### PR TITLE
Give StorageModules access to their PartitionAssignments

### DIFF
--- a/crates/actors/src/mining.rs
+++ b/crates/actors/src/mining.rs
@@ -78,7 +78,7 @@ impl PartitionMiningActor {
             if solution_number >= difficulty {
                 dbg!("SOLUTION FOUND!!!!!!!!!");
                 let solution = SolutionContext {
-                    partition_hash: self.storage_module.partition_hash.unwrap(),
+                    partition_hash: self.storage_module.partition_hash().unwrap(),
                     chunk_offset: (start_chunk_index + index) as u32,
                     mining_address: self.mining_address,
                 };
@@ -121,7 +121,7 @@ impl Handler<Seed> for PartitionMiningActor {
 
         debug!(
             "Partition {} -- looking for solution with difficulty >= {}",
-            self.storage_module.partition_hash.unwrap(),
+            self.storage_module.partition_hash().unwrap(),
             difficulty
         );
 

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -77,6 +77,7 @@ pub async fn start_irys_node(node_config: IrysNodeConfig) -> eyre::Result<IrysNo
         num_chunks_in_partition: 10,
         num_chunks_in_recall_range: 2,
         num_partitions_in_slot: 1,
+        miner_address: arc_config.mining_signer.address(),
     };
     let arc_storage_config = Arc::new(storage_config_for_testing);
     let mut storage_modules: Vec<Arc<StorageModule>> = Vec::new();
@@ -124,7 +125,7 @@ pub async fn start_irys_node(node_config: IrysNodeConfig) -> eyre::Result<IrysNo
                 };
 
                 let miner_address = node_config.mining_signer.address();
-                let epoch_service = EpochServiceActor::new(miner_address, Some(config));
+                let epoch_service = EpochServiceActor::new(Some(config));
                 let epoch_service_actor_addr = epoch_service.start();
 
                 // Initialize the block index actor and tell it about the genesis block

--- a/crates/chain/src/partitions.rs
+++ b/crates/chain/src/partitions.rs
@@ -62,7 +62,7 @@ pub fn mine_storage_module(
             if solution_number >= difficulty {
                 dbg!("SOLUTION FOUND!!!!!!!!!");
                 let solution = SolutionContext {
-                    partition_hash: storage_module.partition_hash.unwrap(),
+                    partition_hash: storage_module.partition_hash().unwrap(),
                     // TODO: Fix
                     chunk_offset: 0,
                     mining_address: mining_address,

--- a/crates/config/src/chain/storage_config.rs
+++ b/crates/config/src/chain/storage_config.rs
@@ -1,5 +1,6 @@
 use irys_types::{
-    CHUNK_SIZE, NUM_CHUNKS_IN_PARTITION, NUM_CHUNKS_IN_RECALL_RANGE, NUM_PARTITIONS_PER_SLOT,
+    Address, CHUNK_SIZE, NUM_CHUNKS_IN_PARTITION, NUM_CHUNKS_IN_RECALL_RANGE,
+    NUM_PARTITIONS_PER_SLOT,
 };
 
 /// Protocol storage sizing configuration
@@ -13,6 +14,8 @@ pub struct StorageConfig {
     pub num_chunks_in_recall_range: u64,
     /// Number of partition replicas in a ledger slot
     pub num_partitions_in_slot: u64,
+    /// Local mining address
+    pub miner_address: Address,
 }
 
 impl Default for StorageConfig {
@@ -22,6 +25,7 @@ impl Default for StorageConfig {
             num_chunks_in_partition: NUM_CHUNKS_IN_PARTITION,
             num_chunks_in_recall_range: NUM_CHUNKS_IN_RECALL_RANGE,
             num_partitions_in_slot: NUM_PARTITIONS_PER_SLOT,
+            miner_address: Address::random(),
         }
     }
 }

--- a/crates/types/src/partition.rs
+++ b/crates/types/src/partition.rs
@@ -1,4 +1,20 @@
-use crate::H256;
+use actix::MessageResponse;
+use serde::{Deserialize, Serialize};
+
+use crate::{Address, H256};
 
 /// A H256 hash that uniquely identifies a partition
 pub type PartitionHash = H256;
+
+/// Temporary struct tracking partition assignments to miners - will be moved to database
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, MessageResponse, Clone, Copy)]
+pub struct PartitionAssignment {
+    /// Hash of the partition
+    pub partition_hash: PartitionHash,
+    /// Address of the miner pledged to store it
+    pub miner_address: Address,
+    /// If assigned to a ledger, the ledger number
+    pub ledger_num: Option<u64>,
+    /// If assigned to a ledger, the index in the ledger
+    pub slot_index: Option<usize>,
+}


### PR DESCRIPTION
Instead of just storing their `PartitionHash`, `StorageModule`s now store a copy of their `PartitionAssignment`. 

The `PartitionAssignment` tells the `StorageModule` what ledger it is in, and what its `slot_index` is. Having this information the `StorageModule` now has the context to convert ledger relative offsets to Partition/StorageModule relative offsets. 

This enables `StorageModules` to encapsulate Ledger->Module coordinate transformations so the rest of the Node does not need to perform these transformations every time it interacts with storage modules.