### PR TITLE
feat: change storage module APIs to use the correct offset type

### DIFF
--- a/crates/actors/src/chunk_storage.rs
+++ b/crates/actors/src/chunk_storage.rs
@@ -237,7 +237,9 @@ impl Handler<BlockFinalizedMessage> for ChunkStorageActor {
                             let _ = storage_module.add_data_path_to_index(
                                 chunk_info.0.chunk_path_hash,
                                 chunk_info.1.data_path.into(),
-                                ledger_offset,
+                                storage_module
+                                    .make_offset_partition_relative_guarded(ledger_offset)
+                                    .unwrap(),
                             );
                             info!("cached_chunk found: {:?}", chunk_info.0);
                             // TODO: This doesn't yet take into account packing

--- a/crates/types/src/partition.rs
+++ b/crates/types/src/partition.rs
@@ -18,3 +18,14 @@ pub struct PartitionAssignment {
     /// If assigned to a ledger, the index in the ledger
     pub slot_index: Option<usize>,
 }
+
+impl Default for PartitionAssignment {
+    fn default() -> Self {
+        Self {
+            partition_hash: PartitionHash::zero(),
+            miner_address: Address::ZERO,
+            ledger_num: Some(0),
+            slot_index: Some(0),
+        }
+    }
+}


### PR DESCRIPTION
This PR:
- modifies the args to `add_data_path_to_index` to use `PartitionChunkOffset` as it's 'internal'
- modifies `write_data_chunk` to use `add_data_path_to_index` & to take in a `LedgerChunkOffset`
- adds a `make_offset_partition_relative_guarded` utility method, that Err's if the local offset is out of this submodule's range
- fixes `data_path_test`