### PR TITLE
Refactor Chunk::offset from a weird byte offset to a chunk_index

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
 		"chainspec",
 		"Deque",
 		"hasher",
+		"ingressed",
 		"Irys",
 		"keccak",
 		"Linearize",

--- a/crates/api-server/src/lib.rs
+++ b/crates/api-server/src/lib.rs
@@ -71,6 +71,7 @@ async fn post_tx_and_chunks_golden_path() {
     let task_manager = TaskManager::current();
     let storage_config = StorageConfig::default();
 
+    // TODO Fixup this test, maybe with some stubs
     let mempool_actor = MempoolActor::new(
         irys_types::app_state::DatabaseProvider(arc_db),
         task_manager.executor(),
@@ -149,7 +150,7 @@ async fn post_tx_and_chunks_golden_path() {
             data_size,
             data_path,
             bytes: Base64(data_bytes[min..max].to_vec()),
-            offset,
+            chunk_index: index as u32,
         };
 
         // Make a POST request with JSON payload

--- a/crates/database/src/db_cache.rs
+++ b/crates/database/src/db_cache.rs
@@ -1,10 +1,7 @@
 use std::ops::Deref;
 
 use arbitrary::Arbitrary;
-use irys_types::{
-    Base64, Chunk, ChunkPathHash, Compact, TxRelativeChunkIndex, TxRelativeChunkOffset, CHUNK_SIZE,
-    H256,
-};
+use irys_types::{Base64, Chunk, ChunkPathHash, Compact, TxRelativeChunkIndex, H256};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, Default, PartialEq, Serialize, Deserialize, Arbitrary, Compact)]
@@ -94,15 +91,6 @@ impl Compact for CachedChunkIndexEntry {
             CachedChunkIndexMetadata::from_compact(&buf[KEY_BYTES..], len - KEY_BYTES);
         (Self { index, meta }, out)
     }
-}
-/// convert a chunk's tx relative offset to a tx relative index (i.e offset 262144 -> index 0, offset 262145 -> index 1)
-/// due to the fact offsets are the end bound, we minus 1 to get the intuitive 0 indexed offsets
-pub fn chunk_offset_to_index(
-    offset: TxRelativeChunkOffset,
-    chunk_size: u64,
-) -> eyre::Result<TxRelativeChunkIndex> {
-    let div: u32 = offset.div_ceil(chunk_size.try_into()?).try_into()?;
-    Ok(div - 1)
 }
 
 /// converts a size (in bytes) to the number of chunks, rounding up (size 0 -> illegal state, size 1 -> 1, size 262144 -> 1, 262145 -> 2 )

--- a/crates/database/src/tables.rs
+++ b/crates/database/src/tables.rs
@@ -100,7 +100,7 @@ tables! {
     table CachedDataRoots<Key = DataRoot, Value = CachedDataRoot>;
 
     /// Index mapping a data root to a set of ordered-by-index index entries, which contain the chunk path hash ('chunk id')
-    table CachedChunksIndex<Key = DataRoot, Value = CachedChunkIndexEntry, SubKey = TxRelativeChunkIndex>;
+    table CachedChunksIndex<Key = DataRoot, Value = CachedChunkIndexEntry, SubKey = u32>;
 
     /// Table mapping a chunk path hash to a cached chunk (with data)
     table CachedChunks<Key =ChunkPathHash , Value = CachedChunk>;


### PR DESCRIPTION
This should clean up a lot of pain.

```Chunk::offset``` is no longer a weird byte offset in the transaction. Instead the value is refactored to `Chunk::chunk_index` which is the 0-based index of the chunk in the transaction.

Chunk now has a `Chunk::byte_offset(chunk_size)` implementation that will retrieve the byte offsets which are only really necessary when validating the merkle proofs (data_path) associated with the Chunk.

Also, removed `chunk_size` from the parameter lists of functions that didn't seem to be using it.