### PR TITLE
 actix web tests running

### DIFF
--- a/crates/api-server/src/routes/chunks.rs
+++ b/crates/api-server/src/routes/chunks.rs
@@ -3,18 +3,17 @@ use actix_web::{
     HttpResponse,
 };
 use awc::http::StatusCode;
-use irys_actors::{
-    mempool::{ChunkIngressError, ChunkIngressMessage},
-    ActorAddresses,
-};
+use irys_actors::mempool::{ChunkIngressError, ChunkIngressMessage};
 use irys_types::Chunk;
+
+use crate::ApiState;
 
 /// Handles the HTTP POST request for adding a chunk to the mempool.
 /// This function takes in a JSON payload of a `Chunk` type, encapsulates it
 /// into a `ChunkIngressMessage` for further processing by the mempool actor,
 /// and manages error handling based on the results of message delivery and validation.
 pub async fn post_chunk(
-    state: web::Data<ActorAddresses>,
+    state: web::Data<ApiState>,
     body: Json<Chunk>,
 ) -> actix_web::Result<HttpResponse> {
     let chunk = body.into_inner();

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -234,7 +234,7 @@ pub async fn start_irys_node(node_config: IrysNodeConfig) -> eyre::Result<IrysNo
                     partitions: part_actors_clone,
                     block_producer: block_producer_addr,
                     packing: packing_actor_addr,
-                    mempool: mempool_actor_addr,
+                    mempool: mempool_actor_addr.clone(),
                     block_index: block_index_actor_addr,
                     epoch_service: epoch_service_actor_addr,
                 };
@@ -247,8 +247,8 @@ pub async fn start_irys_node(node_config: IrysNodeConfig) -> eyre::Result<IrysNo
                 });
 
                 run_server(ApiState {
-                    actors: actor_addresses,
                     db,
+                    mempool: mempool_actor_addr,
                 })
                 .await;
             });


### PR DESCRIPTION
The fix here is to only require the mempool actor address to be passed into the ActixWeb context.

Prior to this fix it was requireing a whole ActorAddresses struct that required stubbing out every actor address to set up a test environment.

The reasoning here is that everything the web context does should be interfacing the mempool actor, it should not be reaching deeper into the node internals.