### PR TITLE
Fix block production

### DIFF
--- a/crates/chain/tests/block_production/basic_contract.rs
+++ b/crates/chain/tests/block_production/basic_contract.rs
@@ -122,6 +122,9 @@ where
                 partition_hash: H256::random(),
                 chunk_offset: 0,
                 mining_address: Address::random(),
+                tx_path: None,
+                data_path: None,
+                chunk: Vec::new(),
             }))
             .await?
             .unwrap();

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -85,6 +85,9 @@ async fn test_blockprod() -> eyre::Result<()> {
             partition_hash: H256::random(),
             chunk_offset: 0,
             mining_address: node.config.mining_signer.address(),
+            tx_path: None,
+            data_path: None,
+            chunk: Vec::new(),
         }))
         .await?
         .unwrap();
@@ -141,6 +144,9 @@ async fn mine_ten_blocks() -> eyre::Result<()> {
                 partition_hash: H256::random(),
                 chunk_offset: 0,
                 mining_address: node.config.mining_signer.address(),
+                tx_path: None,
+                data_path: None,
+                chunk: Vec::new(),
             }));
         let (block, reth_exec_env) = fut.await?.unwrap();
 
@@ -181,6 +187,9 @@ async fn test_basic_blockprod() -> eyre::Result<()> {
             partition_hash: H256::random(),
             chunk_offset: 0,
             mining_address: Address::random(),
+            tx_path: None,
+            data_path: None,
+            chunk: Vec::new(),
         }))
         .await?
         .unwrap();
@@ -314,6 +323,9 @@ async fn test_blockprod_with_evm_txs() -> eyre::Result<()> {
             partition_hash: H256::random(),
             chunk_offset: 0,
             mining_address: node.config.mining_signer.address(),
+            tx_path: None,
+            data_path: None,
+            chunk: Vec::new(),
         }))
         .await?
         .unwrap();

--- a/crates/chain/tests/block_production/external_tx.rs
+++ b/crates/chain/tests/block_production/external_tx.rs
@@ -106,6 +106,9 @@ async fn test_basic_blockprod_extern_tx_src() -> eyre::Result<()> {
                 partition_hash: H256::random(),
                 chunk_offset: 0,
                 mining_address: Address::random(),
+                tx_path: None,
+                data_path: None,
+                chunk: Vec::new(),
             }))
             .await?
             .unwrap();

--- a/crates/chain/tests/programmable_data/basic.rs
+++ b/crates/chain/tests/programmable_data/basic.rs
@@ -174,6 +174,9 @@ where
                 partition_hash: H256::random(),
                 chunk_offset: 0,
                 mining_address: Address::random(),
+                tx_path: None,
+                data_path: None,
+                chunk: Vec::new(),
             }))
             .await?
             .unwrap();

--- a/crates/types/src/block.rs
+++ b/crates/types/src/block.rs
@@ -98,12 +98,12 @@ impl IrysBlockHeader {
             previous_block_hash: H256::zero(),
             previous_cumulative_diff: U256::from(4000),
             poa: PoaData {
-                tx_path: Base64::from_str("").unwrap(),
-                data_path: Base64::from_str("").unwrap(),
+                tx_path: None,
+                data_path: None,
                 chunk: Base64::from_str("").unwrap(),
                 partition_hash: PartitionHash::zero(),
                 partition_chunk_offset: 0,
-                ledger_num: 0,
+                ledger_num: None,
             },
             reward_address: Address::ZERO,
             reward_key: Base64::from_str("").unwrap(),
@@ -135,10 +135,10 @@ impl IrysBlockHeader {
 #[derive(Default, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Compact, Arbitrary)]
 /// Stores deserialized fields from a `poa` (Proof of Access) JSON
 pub struct PoaData {
-    pub tx_path: Base64,
-    pub data_path: Base64,
+    pub tx_path: Option<Base64>,
+    pub data_path: Option<Base64>,
     pub chunk: Base64,
-    pub ledger_num: u64,
+    pub ledger_num: Option<u64>,
     pub partition_chunk_offset: u64, // TODO: implement Compact for u32 ?
     pub partition_hash: PartitionHash,
 }
@@ -248,12 +248,12 @@ mod tests {
             previous_block_hash: H256::zero(),
             previous_cumulative_diff: U256::from(4000),
             poa: PoaData {
-                tx_path: Base64::from_str("").unwrap(),
-                data_path: Base64::from_str("").unwrap(),
+                tx_path: None,
+                data_path: None,
                 chunk: Base64::from_str("").unwrap(),
                 partition_hash: H256::zero(),
                 partition_chunk_offset: 0,
-                ledger_num: 0,
+                ledger_num: None,
             },
             reward_address: Address::ZERO,
             reward_key: Base64::from_str("").unwrap(),


### PR DESCRIPTION
Fix block production test

```
successes:
    block_production::block_production::test_basic_blockprod

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.57s
```

