### PR TITLE
Difficulty based mining

### DIFF
--- a/crates/actors/src/block_index.rs
+++ b/crates/actors/src/block_index.rs
@@ -95,16 +95,14 @@ impl BlockIndexActor {
 
         if self.block_log.len() % 10 == 0 {
             let mut prev_entry: Option<&BlockLogEntry> = None;
+            println!("block_height, block_time(ms)");
             for entry in &self.block_log {
                 let duration = if let Some(ref pe) = prev_entry {
                     Duration::from_millis(entry.timestamp - pe.timestamp)
                 } else {
                     Duration::from_millis(0)
                 };
-                println!(
-                    "block - height: {} timestamp: {} duration: {:?} diff: {}",
-                    entry.height, entry.timestamp, duration, entry.difficulty
-                );
+                println!("{},{:?}", entry.height, duration.as_millis(),);
                 prev_entry = Some(entry);
             }
         }

--- a/crates/actors/src/mining_broadcaster.rs
+++ b/crates/actors/src/mining_broadcaster.rs
@@ -69,6 +69,7 @@ impl Handler<BroadcastMiningSeed> for MiningBroadcaster {
     type Result = ();
 
     fn handle(&mut self, msg: BroadcastMiningSeed, _: &mut Context<Self>) {
+        println!("Mining: {:?}", msg.0);
         self.subscribers.retain(|addr| addr.connected());
         for subscriber in &self.subscribers {
             subscriber.do_send(msg.clone());

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -26,7 +26,7 @@ pub const NUM_CHECKPOINTS_IN_VDF_STEP: usize = 25;
 
 // Typical ryzen 5900X iterations for 1 sec
 // pub const VDF_SHA_1S: u64 = 15_000_000;
-pub const VDF_SHA_1S: u64 = 350_000;
+pub const VDF_SHA_1S: u64 = 250_000; // We go way slow with openssl sha for now
 pub const PACKING_SHA_1_5_S: u32 = 22_500_000;
 
 pub const HASHES_PER_CHECKPOINT: u64 = VDF_SHA_1S / NUM_CHECKPOINTS_IN_VDF_STEP as u64;


### PR DESCRIPTION
ok, using the new `mining_broadcaster` actor, the partition miners now learn about difficulty.

It is VERY streaky right now because we don't have good entropy.

The chunks are always packed with zeros, and the only other entropy is the mining seed and chunk offset, which it looks like often end up being the same across partitions for a particular seed.

So we need both property entropy packing and property random/efficient sampling to smooth it out.