### PR TITLE
feat: add storage config validation for storage modules

### DIFF
--- a/crates/actors/src/epoch_service.rs
+++ b/crates/actors/src/epoch_service.rs
@@ -1,7 +1,7 @@
 use actix::{Actor, Context, Handler, Message, MessageResponse};
 use eyre::{Error, Result};
 use irys_database::data_ledger::*;
-use irys_storage::{ii, InclusiveInterval, StorageModuleInfo};
+use irys_storage::{ie, ii, InclusiveInterval, StorageModuleInfo};
 use irys_types::{
     partition::{PartitionAssignment, PartitionHash},
     IrysBlockHeader, LedgerChunkRange, SimpleRNG, StorageConfig, CAPACITY_SCALAR, H256,
@@ -519,7 +519,7 @@ impl EpochServiceActor {
             .map(|(idx, partition)| StorageModuleInfo {
                 id: idx,
                 partition_assignment: Some(*self.data_partitions.get(partition).unwrap()),
-                submodules: vec![(ii(0, num_part_chunks), format!("submodule_{}", idx))],
+                submodules: vec![(ie(0, num_part_chunks), format!("submodule_{}", idx))],
             })
             .collect::<Vec<_>>();
 
@@ -535,7 +535,7 @@ impl EpochServiceActor {
                 id: idx_start + idx,
                 partition_assignment: Some(*self.data_partitions.get(partition).unwrap()),
                 submodules: vec![(
-                    ii(0, num_part_chunks),
+                    ie(0, num_part_chunks),
                     format!("submodule_{}", idx_start + idx),
                 )],
             })
@@ -552,7 +552,7 @@ impl EpochServiceActor {
         let cap_info = StorageModuleInfo {
             id: idx,
             partition_assignment: Some(*self.capacity_partitions.get(cap_part).unwrap()),
-            submodules: vec![(ii(0, num_part_chunks), format!("submodule_{}", idx))],
+            submodules: vec![(ie(0, num_part_chunks), format!("submodule_{}", idx))],
         };
 
         module_infos.push(cap_info);

--- a/crates/actors/src/mempool.rs
+++ b/crates/actors/src/mempool.rs
@@ -476,10 +476,15 @@ mod tests {
         let config = StorageConfig {
             min_writes_before_sync: 1,
             chunk_size,
+            num_chunks_in_partition: 5,
             ..Default::default()
         };
 
-        let storage_module = Arc::new(StorageModule::new(&base_path, &storage_module_info, config));
+        let storage_module = Arc::new(StorageModule::new(
+            &base_path,
+            &storage_module_info,
+            config,
+        )?);
 
         storage_module.pack_with_zeros();
 

--- a/crates/actors/src/mining.rs
+++ b/crates/actors/src/mining.rs
@@ -254,7 +254,7 @@ mod tests {
     async fn test_solution() {
         let partition_hash = H256::random();
         let mining_address = Address::random();
-        let chunks_number = 1;
+        let chunks_number = 4;
         let chunk_size = 32;
         let chunk_data = [0; 32];
         let data_path = [4, 3, 2, 1];
@@ -300,7 +300,7 @@ mod tests {
         // Set up the storage geometry for this test
         let storage_config = StorageConfig {
             chunk_size,
-            num_chunks_in_partition: 4,
+            num_chunks_in_partition: chunks_number.try_into().unwrap(),
             num_chunks_in_recall_range: 2,
             num_partitions_in_slot: 1,
             miner_address: mining_address,
@@ -331,11 +331,8 @@ mod tests {
 
         // Create a StorageModule with the specified submodules and config
         let storage_module_info = &infos[0];
-        let mut storage_module = Arc::new(StorageModule::new(
-            &base_path,
-            storage_module_info,
-            storage_config,
-        ));
+        let storage_module =
+            Arc::new(StorageModule::new(&base_path, storage_module_info, storage_config).unwrap());
 
         // Pack the storage module
         storage_module.pack_with_zeros();

--- a/crates/actors/src/packing.rs
+++ b/crates/actors/src/packing.rs
@@ -261,6 +261,8 @@ async fn test_packing_actor() -> eyre::Result<()> {
     // Override the default StorageModule config for testing
     let storage_config = StorageConfig {
         min_writes_before_sync: 1,
+        entropy_packing_iterations: 1_000,
+        num_chunks_in_partition: 5,
         ..Default::default()
     };
 
@@ -270,7 +272,7 @@ async fn test_packing_actor() -> eyre::Result<()> {
         &base_path,
         storage_module_info,
         storage_config.clone(),
-    ));
+    )?);
 
     let request = PackingRequest {
         storage_module: storage_module.clone(),

--- a/crates/actors/tests/chunk_storage_test.rs
+++ b/crates/actors/tests/chunk_storage_test.rs
@@ -87,7 +87,7 @@ async fn finalize_block_test() -> eyre::Result<()> {
             &base_path,
             &info,
             storage_config.clone(),
-        ));
+        )?);
         storage_modules.push(arc_module.clone());
         arc_module.pack_with_zeros();
     }

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -192,11 +192,15 @@ pub async fn start_irys_node(node_config: IrysNodeConfig) -> eyre::Result<IrysNo
 
                 // Create a list of storage modules wrapping the storage files
                 for info in storage_module_infos {
-                    let arc_module = Arc::new(StorageModule::new(
-                        &arc_config.storage_module_dir(),
-                        &info,
-                        (*arc_storage_config).clone(),
-                    ));
+                    let arc_module = Arc::new(
+                        StorageModule::new(
+                            &arc_config.storage_module_dir(),
+                            &info,
+                            (*arc_storage_config).clone(),
+                        )
+                        // TODO: remove this unwrap
+                        .unwrap(),
+                    );
                     storage_modules.push(arc_module.clone());
                     arc_module.pack_with_zeros();
                 }

--- a/crates/storage/tests/storage_module_index_tests.rs
+++ b/crates/storage/tests/storage_module_index_tests.rs
@@ -18,7 +18,7 @@ use reth_db::Database;
 use tracing::{error, info};
 
 #[test]
-fn tx_path_overlap_tests() {
+fn tx_path_overlap_tests() -> eyre::Result<()> {
     // Set up the storage geometry for this test
     let storage_config = StorageConfig {
         chunk_size: 32,
@@ -89,7 +89,7 @@ fn tx_path_overlap_tests() {
             &base_path,
             &info,
             storage_config.clone(),
-        ));
+        )?);
         storage_modules.push(arc_module.clone());
         arc_module.pack_with_zeros();
     }
@@ -467,6 +467,7 @@ fn tx_path_overlap_tests() {
             println!("read[sm1]: {:?}", chunk);
         }
     }
+    Ok(())
 }
 
 fn hash_sha256(message: &[u8]) -> Result<[u8; 32], eyre::Error> {


### PR DESCRIPTION
This PR:
- Adds strict submodule interval gap detection & overall size validation for storage modules
     This enforces 1.) no gaps between submodules, and 2.) that the storage module must have exactly the capacity 
  specified in the storage_config

- Updates StorageModule::new() to return a Result
- Updates & validates all affected test cases

While validating, I managed to catch a few cases where the wrong interval type was being used, which caused partitions to be an unexpected length - fixes are included in this PR.