### PR TITLE
Add block_discovery and block_tree actors 

### DIFF
--- a/crates/actors/src/block_discovery.rs
+++ b/crates/actors/src/block_discovery.rs
@@ -1,0 +1,96 @@
+use crate::{block_tree::BlockTreeActor, epoch_service::EpochServiceActor, mempool::MempoolActor};
+use actix::prelude::*;
+use irys_database::{tx_header_by_txid, BlockIndex, Initialized, Ledger};
+use irys_types::{DatabaseProvider, IrysBlockHeader, IrysTransactionHeader};
+use reth_db::Database;
+use std::sync::{Arc, RwLock};
+use tracing::error;
+
+/// BlockDiscoveryActor listens for discovered blocks & validates them.
+#[derive(Debug)]
+pub struct BlockDiscoveryActor {
+    /// Shared access to the block index used for validation.
+    pub block_index: Arc<RwLock<BlockIndex<Initialized>>>,
+    /// Manages forks at the head of the chain before finalization
+    pub block_tree: Addr<BlockTreeActor>,
+    /// Address of the EpochServiceActor for managing epoch-related tasks.
+    pub epoch_service: Addr<EpochServiceActor>,
+    /// Reference to the mempool actor, which maintains the validity of pending transactions.
+    pub mempool: Addr<MempoolActor>,
+    /// Database provider for accessing transaction headers and related data.
+    pub db: DatabaseProvider,
+}
+
+/// When a block is discovered, either produced locally or received from
+/// a network peer, this message is broadcast.
+#[derive(Message, Debug, Clone)]
+#[rtype(result = "()")]
+pub struct BlockDiscoveredMessage(pub Arc<IrysBlockHeader>);
+
+/// Sent when a discovered block is pre-validated
+#[derive(Message, Debug, Clone)]
+#[rtype(result = "()")]
+pub struct BlockPreValidatedMessage(
+    pub Arc<IrysBlockHeader>,
+    pub Arc<Vec<IrysTransactionHeader>>,
+);
+
+impl Actor for BlockDiscoveryActor {
+    type Context = Context<Self>;
+}
+
+impl BlockDiscoveryActor {
+    /// Initializes a new BlockDiscoveryActor
+    pub fn new(
+        block_index: Arc<RwLock<BlockIndex<Initialized>>>,
+        block_tree: Addr<BlockTreeActor>,
+        epoch_service: Addr<EpochServiceActor>,
+        mempool: Addr<MempoolActor>,
+        db: DatabaseProvider,
+    ) -> Self {
+        Self {
+            block_index,
+            block_tree,
+            epoch_service,
+            mempool,
+            db,
+        }
+    }
+}
+
+impl Handler<BlockDiscoveredMessage> for BlockDiscoveryActor {
+    type Result = ();
+    fn handle(&mut self, msg: BlockDiscoveredMessage, _ctx: &mut Context<Self>) -> Self::Result {
+        // Validate discovered block
+        let new_block_header = msg.0;
+
+        // Get all the submit ledger transactions for the new block, error if not found
+        // TODO: in the future we'll retrieve the missing transactions from the block
+        // producer and validate them.
+        let submit_txs = match new_block_header.ledgers[Ledger::Submit]
+            .txids
+            .iter()
+            .map(|txid| {
+                self.db
+                    .view_eyre(|tx| tx_header_by_txid(tx, txid))
+                    .and_then(|opt| {
+                        opt.ok_or_else(|| eyre::eyre!("No tx header found for txid {:?}", txid))
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()
+        {
+            Ok(txs) => txs,
+            Err(e) => {
+                error!("Failed to collect tx headers: {}", e);
+                return;
+            }
+        };
+
+        // TODO: Do pre-validation steps here
+
+        self.block_tree.do_send(BlockPreValidatedMessage(
+            new_block_header,
+            Arc::new(submit_txs),
+        ));
+    }
+}

--- a/crates/actors/src/block_tree.rs
+++ b/crates/actors/src/block_tree.rs
@@ -1,0 +1,67 @@
+use crate::{
+    block_discovery::BlockPreValidatedMessage,
+    block_index::BlockIndexActor,
+    block_producer::{BlockConfirmedMessage, BlockProducerActor, RegisterBlockProducerMessage},
+    mempool::MempoolActor,
+};
+use actix::prelude::*;
+
+/// BlockDiscoveryActor listens for discovered blocks & validates them.
+#[derive(Debug)]
+pub struct BlockTreeActor {
+    /// Shared access to the block index used for validation.
+    pub block_index: Addr<BlockIndexActor>,
+    /// Reference to the mempool actor, which maintains the validity of pending transactions.
+    pub mempool: Addr<MempoolActor>,
+    /// Needs to know the current block to build on
+    block_producer: Option<Addr<BlockProducerActor>>,
+}
+
+impl Actor for BlockTreeActor {
+    type Context = Context<Self>;
+}
+
+impl BlockTreeActor {
+    /// Initializes a BlockTreeActor without a block_producer address
+    pub fn new(block_index: Addr<BlockIndexActor>, mempool: Addr<MempoolActor>) -> Self {
+        Self {
+            block_index,
+            mempool,
+            block_producer: None,
+        }
+    }
+}
+
+impl Handler<RegisterBlockProducerMessage> for BlockTreeActor {
+    type Result = ();
+    fn handle(
+        &mut self,
+        msg: RegisterBlockProducerMessage,
+        _ctx: &mut Context<Self>,
+    ) -> Self::Result {
+        self.block_producer = Some(msg.0);
+    }
+}
+
+impl Handler<BlockPreValidatedMessage> for BlockTreeActor {
+    type Result = ();
+    fn handle(&mut self, msg: BlockPreValidatedMessage, _ctx: &mut Context<Self>) -> Self::Result {
+        let pre_validated_block = msg.0;
+        let txs = msg.1;
+        // TODO: Check and see if this block represents a new head for the canonical chain
+        // or if it should be added to a fork.
+
+        // For now, because there are no forks, we'll just auto confirm the block
+        let block_confirm_message = BlockConfirmedMessage(pre_validated_block, txs);
+
+        self.block_index.do_send(block_confirm_message.clone());
+        if let Some(block_producer) = &self.block_producer {
+            block_producer.do_send(block_confirm_message.clone());
+        }
+        self.mempool.do_send(block_confirm_message.clone());
+
+        // TODO: Kick off a full validation process on the confirmed block that checks the VDF steps
+        // and other heavy validation tasks, so it can be fully validated before we risk producing
+        // a block on top of it.
+    }
+}

--- a/crates/actors/src/broadcast_mining_service.rs
+++ b/crates/actors/src/broadcast_mining_service.rs
@@ -1,6 +1,5 @@
 use crate::mining::{PartitionMiningActor, Seed};
 use actix::prelude::*;
-use dev::ToEnvelope;
 use irys_types::IrysBlockHeader;
 use std::sync::Arc;
 use tracing::info;
@@ -28,13 +27,13 @@ pub struct BroadcastMiningSeed(pub Seed);
 pub struct BroadcastDifficultyUpdate(pub Arc<IrysBlockHeader>);
 
 /// Broadcaster actor
-#[derive(Debug)]
-pub struct MiningBroadcaster {
+#[derive(Debug, Default)]
+pub struct BroadcastMiningService {
     subscribers: Vec<Addr<PartitionMiningActor>>,
 }
 // Actor Definition
 
-impl MiningBroadcaster {
+impl BroadcastMiningService {
     /// Initialize a new MiningBroadcaster
     pub fn new() -> Self {
         Self {
@@ -43,12 +42,21 @@ impl MiningBroadcaster {
     }
 }
 
-impl Actor for MiningBroadcaster {
+impl Actor for BroadcastMiningService {
     type Context = Context<Self>;
 }
 
+/// Adds this actor the the local service registry
+impl Supervised for BroadcastMiningService {}
+
+impl ArbiterService for BroadcastMiningService {
+    fn service_started(&mut self, ctx: &mut Context<Self>) {
+        println!("broadcast_mining service started");
+    }
+}
+
 // Handle subscriptions
-impl Handler<Subscribe> for MiningBroadcaster {
+impl Handler<Subscribe> for BroadcastMiningService {
     type Result = ();
 
     fn handle(&mut self, msg: Subscribe, _: &mut Context<Self>) {
@@ -57,7 +65,7 @@ impl Handler<Subscribe> for MiningBroadcaster {
 }
 
 // Handle unsubscribe
-impl Handler<Unsubscribe> for MiningBroadcaster {
+impl Handler<Unsubscribe> for BroadcastMiningService {
     type Result = ();
 
     fn handle(&mut self, msg: Unsubscribe, _: &mut Context<Self>) {
@@ -66,7 +74,7 @@ impl Handler<Unsubscribe> for MiningBroadcaster {
 }
 
 // Handle broadcasts
-impl Handler<BroadcastMiningSeed> for MiningBroadcaster {
+impl Handler<BroadcastMiningSeed> for BroadcastMiningService {
     type Result = ();
 
     fn handle(&mut self, msg: BroadcastMiningSeed, _: &mut Context<Self>) {
@@ -78,7 +86,7 @@ impl Handler<BroadcastMiningSeed> for MiningBroadcaster {
     }
 }
 
-impl Handler<BroadcastDifficultyUpdate> for MiningBroadcaster {
+impl Handler<BroadcastDifficultyUpdate> for BroadcastMiningService {
     type Result = ();
 
     fn handle(&mut self, msg: BroadcastDifficultyUpdate, _: &mut Context<Self>) {

--- a/crates/actors/src/lib.rs
+++ b/crates/actors/src/lib.rs
@@ -1,12 +1,14 @@
 mod addresses;
+pub mod block_discovery;
 pub mod block_index;
 pub mod block_producer;
+pub mod block_tree;
 pub mod block_validation;
+pub mod broadcast_mining_service;
 pub mod chunk_migration;
 pub mod epoch_service;
 pub mod mempool;
 pub mod mining;
-pub mod mining_broadcaster;
 pub mod packing;
 
 pub use addresses::*;

--- a/crates/actors/src/mining.rs
+++ b/crates/actors/src/mining.rs
@@ -1,6 +1,6 @@
 use crate::block_producer::SolutionFoundMessage;
-use crate::mining_broadcaster::{
-    BroadcastDifficultyUpdate, BroadcastMiningSeed, MiningBroadcaster, Subscribe, Unsubscribe,
+use crate::broadcast_mining_service::{
+    BroadcastDifficultyUpdate, BroadcastMiningSeed, BroadcastMiningService, Subscribe, Unsubscribe,
 };
 use actix::prelude::*;
 use actix::{Actor, Addr, Context, Handler, Message};
@@ -16,7 +16,6 @@ pub struct PartitionMiningActor {
     mining_address: Address,
     database_provider: DatabaseProvider,
     block_producer_actor: Recipient<SolutionFoundMessage>,
-    mining_broadcaster_addr: Addr<MiningBroadcaster>,
     storage_module: Arc<StorageModule>,
     should_mine: bool,
     difficulty: U256,
@@ -27,7 +26,6 @@ impl PartitionMiningActor {
         mining_address: Address,
         database_provider: DatabaseProvider,
         block_producer_addr: Recipient<SolutionFoundMessage>,
-        mining_broadcaster_addr: Addr<MiningBroadcaster>,
         storage_module: Arc<StorageModule>,
         start_mining: bool,
     ) -> Self {
@@ -35,7 +33,6 @@ impl PartitionMiningActor {
             mining_address,
             database_provider,
             block_producer_actor: block_producer_addr,
-            mining_broadcaster_addr,
             storage_module,
             should_mine: start_mining,
             difficulty: U256::zero(),
@@ -144,7 +141,7 @@ impl PartitionMiningActor {
                 // Once solution is sent stop mining and let all other partitions know
                 return Ok(Some(solution));
             } else {
-              //  info!("NO SOLUTION!!!!")
+                //  info!("NO SOLUTION!!!!")
             }
         }
 
@@ -156,12 +153,12 @@ impl Actor for PartitionMiningActor {
     type Context = Context<Self>;
 
     fn started(&mut self, ctx: &mut Context<Self>) {
-        let broadcaster = &self.mining_broadcaster_addr;
+        let broadcaster = BroadcastMiningService::from_registry();
         broadcaster.do_send(Subscribe(ctx.address()));
     }
 
     fn stopping(&mut self, ctx: &mut Context<Self>) -> Running {
-        let broadcaster = &self.mining_broadcaster_addr;
+        let broadcaster = BroadcastMiningService::from_registry();
         broadcaster.do_send(Unsubscribe(ctx.address()));
         Running::Stop
     }
@@ -195,7 +192,7 @@ impl Handler<BroadcastMiningSeed> for PartitionMiningActor {
         match self.mine_partition_with_seed(seed.into_inner()) {
             Ok(Some(s)) => match self.block_producer_actor.try_send(SolutionFoundMessage(s)) {
                 Ok(_) => {
-                   // debug!("Solution sent!");
+                    // debug!("Solution sent!");
                 }
                 Err(err) => error!("Error submitting solution to block producer {:?}", err),
             },
@@ -249,8 +246,8 @@ mod tests {
     use crate::block_producer::{
         BlockProducerMockActor, MockedBlockProducerAddr, SolutionFoundMessage,
     };
+    use crate::broadcast_mining_service::{BroadcastMiningSeed, BroadcastMiningService};
     use crate::mining::{PartitionMiningActor, Seed};
-    use crate::mining_broadcaster::{BroadcastMiningSeed, MiningBroadcaster};
     use actix::{Actor, Addr, Recipient};
     use alloy_rpc_types_engine::ExecutionPayloadEnvelopeV1Irys;
     use irys_database::{open_or_create_db, tables::IrysTables};
@@ -367,14 +364,13 @@ mod tests {
 
         let _ = storage_module.sync_pending_chunks();
 
-        let mining_broadcaster = MiningBroadcaster::new();
+        let mining_broadcaster = BroadcastMiningService::new();
         let mining_broadcaster_addr = mining_broadcaster.start();
 
         let partition_mining_actor = PartitionMiningActor::new(
             mining_address,
             database_provider.clone(),
             mocked_addr.0,
-            mining_broadcaster_addr,
             storage_module,
             true,
         );

--- a/crates/chain/src/vdf.rs
+++ b/crates/chain/src/vdf.rs
@@ -1,7 +1,7 @@
 use actix::Addr;
 use irys_actors::{
+    broadcast_mining_service::{BroadcastMiningSeed, BroadcastMiningService},
     mining::Seed,
-    mining_broadcaster::{BroadcastMiningSeed, MiningBroadcaster},
 };
 use irys_types::{
     vdf_config::VDFStepsConfig, H256, NONCE_LIMITER_RESET_FREQUENCY, NUM_CHECKPOINTS_IN_VDF_STEP,
@@ -51,7 +51,7 @@ pub fn run_vdf(
     config: VDFStepsConfig,
     seed: H256,
     new_seed_listener: Receiver<H256>,
-    mining_broadcaster: Addr<MiningBroadcaster>,
+    broadcast_mining_service: Addr<BroadcastMiningService>,
 ) {
     let mut hasher = Sha256::new();
     let mut hash: H256 = H256::from_slice(seed.as_bytes());


### PR DESCRIPTION
This PR does a few things.

* Renames `mining_broadcaster` to `broadcast_mining_service` and registers it as a local service you can retrieve from anywhere with ` BroadcastMiningService::from_registry();`

* adds 3 new messages `BlockDiscoveredMessage`, `BlockPreValidatedMessage` and `RegisterBlockProducerMessage`

* adds two new actors `block_discovery` and `block_tree`.  I think these are actually services but it's a larger refactor to register them. 

These new actors implement a message flow of:

`SolutionFoundMessage`->`block_producer`->`BlockDiscoveredMessage`->`block_discovery`->`BlockPreValidatedMessage`->`block_tree`->`BlockConfirmedMessage`-> (many actors)

The purpose of adding these actors is to :

1. Stub in the message flow well need for multi node mining
2. Create placeholder actors for the block validation and block reorg logic to live.

Implements Irys #60 