### PR TITLE
Sign ingress proofs with combined roots and optimize chunk handling

### DIFF
--- a/crates/actors/src/mempool.rs
+++ b/crates/actors/src/mempool.rs
@@ -4,7 +4,6 @@ use irys_database::db_cache::data_size_to_chunk_count;
 use irys_database::tables::{CachedChunks, CachedChunksIndex, IngressProofs};
 use irys_storage::StorageModuleVec;
 use irys_types::irys::IrysSigner;
-use irys_types::DataChunks;
 use irys_types::{
     app_state::DatabaseProvider, chunk::UnpackedChunk, hash_sha256, validate_path,
     IrysTransactionHeader, H256,
@@ -367,15 +366,20 @@ pub fn generate_ingress_proof(
     // TODO: allow for "streaming" the tree chunks, instead of having to read them all into memory
     let ro_tx = db.tx()?;
     let mut dup_cursor = ro_tx.cursor_dup_read::<CachedChunksIndex>()?;
+
     // start from first duplicate entry for this root_hash
     let dup_walker = dup_cursor.walk_dup(Some(data_root), None)?;
+
     // we need to validate that the index is valid
     // we do this by constructing a set over the chunk hashes, checking if we've seen this hash before
     // if we have, we *must* error
     let mut set = HashSet::<H256>::new();
     let expected_chunk_count = data_size_to_chunk_count(size, chunk_size).unwrap();
-    let mut data: DataChunks = Vec::with_capacity(expected_chunk_count as usize);
+
+    let mut chunks = Vec::with_capacity(expected_chunk_count as usize);
+    let mut owned_chunks = Vec::with_capacity(expected_chunk_count as usize);
     let mut data_size: u64 = 0;
+
     for entry in dup_walker {
         let (root_hash2, index_entry) = entry?;
         // make sure we haven't traversed into the wrong key
@@ -401,16 +405,19 @@ pub fn generate_ingress_proof(
                 )
                 .as_str(),
             );
-        // TODO validate chunk length
         let chunk_bin = chunk.chunk.unwrap().0;
         data_size += chunk_bin.len() as u64;
-        data.push(chunk_bin);
+        owned_chunks.push(chunk_bin);
     }
-    assert_eq!(data.len() as u32, expected_chunk_count);
+
+    // Now create the slice references
+    chunks.extend(owned_chunks.iter().map(|c| c.as_slice()));
+
+    assert_eq!(chunks.len() as u32, expected_chunk_count);
     assert_eq!(data_size, size);
 
     // generate the ingress proof hash
-    let proof = irys_types::ingress::generate_ingress_proof(signer, data_root, data)?;
+    let proof = irys_types::ingress::generate_ingress_proof(signer, data_root, &chunks)?;
     info!(
         "generated ingress proof {} for data root {}",
         &proof.proof, &data_root

--- a/crates/types/src/block.rs
+++ b/crates/types/src/block.rs
@@ -199,7 +199,6 @@ impl TransactionLedger {
                 tx_size: h.data_size as usize, // TODO: check this
             })
             .collect::<Vec<DataRootLeave>>();
-        //txs_data_roots.push(&[]); // TODO: check this ? mimics merkle::generate_leaves's push as last chunk has max. capacity 32
         let data_root_leaves = generate_leaves_from_data_roots(&txs_data_roots).unwrap();
         let root = generate_data_root(data_root_leaves.clone()).unwrap();
         let root_id = root.id.clone();

--- a/crates/types/src/chunk.rs
+++ b/crates/types/src/chunk.rs
@@ -197,8 +197,6 @@ pub type DataRoot = H256;
 /// The offset of the chunk relative to the first (0th) chunk of the tx's data tree
 pub type TxRelativeChunkOffset = u32;
 
-pub type DataChunks = Vec<Vec<u8>>;
-
 /// the Block relative chunk offset
 pub type BlockRelativeChunkOffset = u64;
 

--- a/crates/types/src/ingress.rs
+++ b/crates/types/src/ingress.rs
@@ -1,6 +1,7 @@
 use alloy_primitives::{Address, Parity, U256};
 use alloy_signer::Signature;
-use eyre::OptionExt as _;
+use eyre::OptionExt;
+use openssl::sha;
 use reth_codecs::Compact;
 use reth_db::DatabaseError;
 use reth_db_api::table::{Compress, Decompress};
@@ -10,7 +11,8 @@ use serde::{Deserialize, Serialize};
 use crate::irys::IrysSigner;
 
 use crate::{
-    generate_data_root, generate_ingress_leaves, DataChunks, DataRoot, IrysSignature, Node, H256,
+    generate_data_root, generate_ingress_leaves, generate_leaves_from_chunks, DataRoot,
+    IrysSignature, Node, H256, IRYS_CHAIN_ID,
 };
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq, Compact)]
 pub struct IngressProof {
@@ -32,8 +34,8 @@ impl Decompress for IngressProof {
     }
 }
 
-pub fn generate_ingress_proof_tree(chunks: DataChunks, address: Address) -> eyre::Result<Node> {
-    let chunks = generate_ingress_leaves(chunks.clone(), address)?;
+pub fn generate_ingress_proof_tree(chunks: Vec<&[u8]>, address: Address) -> eyre::Result<Node> {
+    let chunks = generate_ingress_leaves(chunks, address)?;
     let root = generate_data_root(chunks.clone())?;
     Ok(root)
 }
@@ -41,11 +43,28 @@ pub fn generate_ingress_proof_tree(chunks: DataChunks, address: Address) -> eyre
 pub fn generate_ingress_proof(
     signer: IrysSigner,
     data_root: DataRoot,
-    chunks: DataChunks,
+    chunks: &Vec<&[u8]>,
 ) -> eyre::Result<IngressProof> {
-    let root = generate_ingress_proof_tree(chunks, signer.address())?;
+    let root = generate_ingress_proof_tree(chunks.clone(), signer.address())?;
     let proof: [u8; 32] = root.id;
-    let signature: Signature = signer.signer.sign_prehash_recoverable(&proof)?.into();
+
+    // Combine proof and data_root into a single digest to sign
+    let mut hasher = sha::Sha256::new();
+    hasher.update(&proof);
+    hasher.update(&data_root.0);
+    let prehash = hasher.finish();
+
+    let mut signature: Signature = signer.signer.sign_prehash_recoverable(&prehash)?.into();
+    signature = signature.with_chain_id(IRYS_CHAIN_ID);
+
+    println!(
+        "\naddr: {}\nsig: {:?}\ndata_root: {}\nproof: {:?}",
+        signer.address(),
+        signature,
+        data_root,
+        root.id
+    );
+
     Ok(IngressProof {
         signature: signature.into(),
         data_root,
@@ -53,25 +72,41 @@ pub fn generate_ingress_proof(
     })
 }
 
-pub fn verify_ingress_proof(proof: IngressProof, chunks: DataChunks) -> eyre::Result<bool> {
-    let prehash = proof.proof.0;
+pub fn verify_ingress_proof(proof: IngressProof, chunks: &Vec<&[u8]>) -> eyre::Result<bool> {
+    let mut hasher = sha::Sha256::new();
+    hasher.update(&proof.proof.0);
+    hasher.update(&proof.data_root.0);
+    let prehash = hasher.finish();
+
     let sig = proof.signature.as_bytes();
 
     let recovered_address = recover_signer(&sig[..].try_into()?, prehash.into())
         .ok_or_eyre("Unable to recover signer")?;
 
     // re-compute the proof
-    let recomputed = generate_ingress_proof_tree(chunks, recovered_address)?;
+    let proof_root = generate_ingress_proof_tree(chunks.clone(), recovered_address)?;
+    let nodes = generate_leaves_from_chunks(chunks)?;
+
+    // re-compute the data_root
+    let root = generate_data_root(nodes.clone())?;
+    let data_root = H256(root.id.clone());
+
+    // re-compute the prehash (combining data_root and proof)
+    let mut hasher = sha::Sha256::new();
+    hasher.update(&proof_root.id);
+    hasher.update(&data_root.0);
+    let new_prehash = hasher.finish();
+
     // make sure they match
-    Ok(recomputed.id == prehash)
+    Ok(new_prehash == prehash)
 }
 
 mod tests {
     use rand::Rng;
 
     use crate::{
-        generate_leaves, hash_sha256, ingress::verify_ingress_proof, irys::IrysSigner, DataChunks,
-        H256, MAX_CHUNK_SIZE,
+        generate_data_root, generate_leaves, hash_sha256, ingress::verify_ingress_proof,
+        irys::IrysSigner, H256, MAX_CHUNK_SIZE,
     };
 
     use super::generate_ingress_proof;
@@ -82,7 +117,7 @@ mod tests {
         let mut data_bytes = vec![0u8; data_size];
         rand::thread_rng().fill(&mut data_bytes[..]);
         let signer = IrysSigner::random_signer();
-        let leaves = generate_leaves(data_bytes.clone(), MAX_CHUNK_SIZE)?;
+        let leaves = generate_leaves(&data_bytes, MAX_CHUNK_SIZE)?;
         let interleave_value = signer.address();
         let interleave_hash = hash_sha256(&interleave_value.0 .0)?;
 
@@ -100,21 +135,26 @@ mod tests {
 
     #[test]
     fn basic() -> eyre::Result<()> {
+        // Create some random data
         let data_size = (MAX_CHUNK_SIZE as f64 * 2.5).round() as usize;
         let mut data_bytes = vec![0u8; data_size];
         rand::thread_rng().fill(&mut data_bytes[..]);
-        let signer = IrysSigner::random_signer();
-        let data_root = H256::random();
-        let chunks: DataChunks = data_bytes
-            .chunks(MAX_CHUNK_SIZE)
-            .map(|c| c.to_vec())
-            .collect();
-        let proof = generate_ingress_proof(signer.clone(), data_root, chunks.clone())?;
 
-        assert!(verify_ingress_proof(proof.clone(), chunks.clone())?);
+        // Build a merkle tree and data_root from the chunks
+        let leaves = generate_leaves(&data_bytes, MAX_CHUNK_SIZE).unwrap();
+        let root = generate_data_root(leaves)?;
+        let data_root = H256(root.id.clone());
+
+        // Generate an ingress proof
+        let signer = IrysSigner::random_signer();
+        let chunks: Vec<&[u8]> = data_bytes.chunks(MAX_CHUNK_SIZE).collect();
+        let proof = generate_ingress_proof(signer.clone(), data_root, &chunks)?;
+
+        // Verify the ingress proof
+        assert!(verify_ingress_proof(proof.clone(), &chunks)?);
         let mut reversed = chunks.clone();
         reversed.reverse();
-        assert!(!verify_ingress_proof(proof, reversed)?);
+        assert!(!verify_ingress_proof(proof, &reversed)?);
 
         Ok(())
     }

--- a/crates/types/src/irys.rs
+++ b/crates/types/src/irys.rs
@@ -89,16 +89,15 @@ impl IrysSigner {
     /// Builds a merkle tree, with a root, including all the proofs for each
     /// chunk.
     fn merklize(&self, data: Vec<u8>, chunk_size: usize) -> Result<IrysTransaction> {
-        let mut chunks = generate_leaves(data.clone(), chunk_size)?;
+        let chunks = generate_leaves(&data, chunk_size)?;
         let root = generate_data_root(chunks.clone())?;
         let data_root = H256(root.id.clone());
-        let mut proofs = resolve_proofs(root, None)?;
+        let proofs = resolve_proofs(root, None)?;
 
-        // Discard the last chunk & proof if it's zero length.
+        // Error if the last chunk or proof is zero length.
         let last_chunk = chunks.last().unwrap();
         if last_chunk.max_byte_range == last_chunk.min_byte_range {
-            chunks.pop();
-            proofs.pop();
+            return Err(eyre::eyre!("Last chunk cannot be zero length"));
         }
 
         Ok(IrysTransaction {


### PR DESCRIPTION
Changes:
1. Updated ingress proof signatures to include both `data_root` and `proof_root` for better security by signing both pieces of data together 
   - This allows nodes to validate the `ingress-proof` signer did indeed generate a `proof` for a specific `data_root`.  If only the `proof` is signed an adversary could pair them with arbitrary `data_roots`, gossip them,  and potentially get the innocent signer blacklisted.
3. Optimized chunk data handling:
   - Removed `DataChunks = Vec<Vec<u8>>` type alias to eliminate unnecessary ownership and cloning
   - Switched to direct `Vec<&[u8]>` instead of a type alias with references, avoiding cascading lifetime annotations throughout the codebase
   - Removed redundant logic that added/stripped empty chunks at merkle tree leaves

This improves validation of tx being promoted and reduces memory overhead by avoiding unnecessary data cloning, while keeping lifetime management simple and localized.