### PR TITLE
Update publish ledger's max_chunk_offset in block_index

### DIFF
--- a/crates/actors/src/block_discovery.rs
+++ b/crates/actors/src/block_discovery.rs
@@ -152,9 +152,8 @@ impl Handler<BlockDiscoveredMessage> for BlockDiscoveryActor {
         }
 
         //====================================
-        // PoA validation
+        // Block header pre-validation
         //------------------------------------
-        let poa = new_block_header.poa.clone();
         let block_index_guard = self.block_index_guard.clone();
         let partitions_guard = self.partition_assignments_guard.clone();
         let block_tree_addr = self.block_tree.clone();
@@ -177,9 +176,11 @@ impl Handler<BlockDiscoveredMessage> for BlockDiscoveryActor {
         ) {
             Ok(_) => {
                 info!("Block is valid, sending to block tree");
+                let mut all_txs = submit_txs.clone();
+                all_txs.extend_from_slice(&publish_txs);
                 block_tree_addr.do_send(BlockPreValidatedMessage(
                     new_block_header,
-                    Arc::new(submit_txs),
+                    Arc::new(all_txs),
                 ));
             }
             Err(err) => {

--- a/crates/actors/src/block_tree.rs
+++ b/crates/actors/src/block_tree.rs
@@ -47,12 +47,12 @@ impl Handler<BlockPreValidatedMessage> for BlockTreeActor {
     type Result = ();
     fn handle(&mut self, msg: BlockPreValidatedMessage, _ctx: &mut Context<Self>) -> Self::Result {
         let pre_validated_block = msg.0;
-        let txs = msg.1;
+        let all_txs = msg.1;
         // TODO: Check and see if this block represents a new head for the canonical chain
         // or if it should be added to a fork.
 
         // For now, because there are no forks, we'll just auto confirm the block
-        let block_confirm_message = BlockConfirmedMessage(pre_validated_block, txs);
+        let block_confirm_message = BlockConfirmedMessage(pre_validated_block, all_txs);
 
         self.block_index.do_send(block_confirm_message.clone());
         if let Some(block_producer) = &self.block_producer {

--- a/crates/actors/src/mempool.rs
+++ b/crates/actors/src/mempool.rs
@@ -335,12 +335,11 @@ impl Handler<BlockConfirmedMessage> for MempoolActor {
     fn handle(&mut self, msg: BlockConfirmedMessage, _ctx: &mut Context<Self>) -> Self::Result {
         // Access the block header through msg.0
         let block = &msg.0;
-        let data_tx = &msg.1;
+        let all_txs = &msg.1;
 
-        // Loop through the storage tx in each ledger
-        for tx in data_tx.iter() {
-            // Remove them from the pending valid_tx pool
-            self.valid_tx.remove(&tx.id);
+        for txid in block.ledgers[Ledger::Submit].txids.iter() {
+            // Remove the submit tx from the pending valid_tx pool
+            self.valid_tx.remove(txid);
         }
 
         let published_txids = &block.ledgers[Ledger::Publish].txids.0;
@@ -404,7 +403,7 @@ impl Handler<BlockConfirmedMessage> for MempoolActor {
         info!(
             "Removing confirmed tx - Block height: {} num tx: {}",
             block.height,
-            data_tx.len()
+            all_txs.len()
         );
     }
 }


### PR DESCRIPTION
Track chunk growth for both Submit and Publish ledgers

- Calculate max_chunk_offset for both ledgers
- Require full transaction list in BlockConfirmedMessage
- Clean up transaction set naming

Block validation already requires all transaction headers, so we can  safely use them to calculate chunk counts for each ledger.