### PR TITLE
feat: Configurable block depth for storage finality

### DIFF
--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -389,6 +389,7 @@ mod tests {
             miner_address,
             min_writes_before_sync: 1,
             entropy_packing_iterations: 1_000,
+            num_confirmations_for_finality: 1, // Testnet / single node config
         };
 
         let config = EpochServiceConfig {

--- a/crates/actors/src/epoch_service.rs
+++ b/crates/actors/src/epoch_service.rs
@@ -759,6 +759,7 @@ mod tests {
             miner_address: Address::random(),
             min_writes_before_sync: 1,
             entropy_packing_iterations: PACKING_SHA_1_5_S,
+            num_confirmations_for_finality: 1, // Testnet / single node config
         };
         let num_chunks_in_partition = storage_config.num_chunks_in_partition;
 

--- a/crates/actors/src/mining.rs
+++ b/crates/actors/src/mining.rs
@@ -327,6 +327,7 @@ mod tests {
             miner_address: mining_address,
             min_writes_before_sync: 1,
             entropy_packing_iterations: 1,
+            num_confirmations_for_finality: 1, // Testnet / single node config
         };
 
         let infos = vec![StorageModuleInfo {

--- a/crates/actors/tests/chunk_migration_test.rs
+++ b/crates/actors/tests/chunk_migration_test.rs
@@ -44,6 +44,7 @@ async fn finalize_block_test() -> eyre::Result<()> {
         miner_address: Address::random(),
         min_writes_before_sync: 1,
         entropy_packing_iterations: 1,
+        num_confirmations_for_finality: 1, // Testnet / single node config
     };
     let chunk_size = storage_config.chunk_size;
 

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -61,6 +61,7 @@ pub async fn start_for_testing(config: IrysNodeConfig) -> eyre::Result<IrysNodeC
         miner_address: config.mining_signer.address(),
         min_writes_before_sync: 1,
         entropy_packing_iterations: 1_000,
+        num_confirmations_for_finality: 1, // Testnet / single node config
     };
 
     start_irys_node(config, storage_config).await
@@ -80,6 +81,7 @@ pub async fn start_for_testing_default(
 
     let storage_config = StorageConfig {
         miner_address: miner_signer.address(), // just in case to keep the same miner address
+        num_confirmations_for_finality: 1,     // Testnet / single node config
         ..storage_config
     };
 

--- a/crates/chain/tests/api/api.rs
+++ b/crates/chain/tests/api/api.rs
@@ -42,6 +42,7 @@ async fn api_end_to_end_test(chunk_size: usize) {
         miner_address: miner_signer.address(),
         min_writes_before_sync: 1,
         entropy_packing_iterations: 1_000,
+        num_confirmations_for_finality: 1, // Testnet / single node config
     };
 
     let handle = start_for_testing_default(

--- a/crates/chain/tests/api/external_api.rs
+++ b/crates/chain/tests/api/external_api.rs
@@ -52,6 +52,7 @@ async fn external_api() -> eyre::Result<()> {
         miner_address: Address::random(),
         min_writes_before_sync: 1,
         entropy_packing_iterations: 1,
+        num_confirmations_for_finality: 1, // Testnet / single node config
     };
     let chunk_size = storage_config.chunk_size;
 

--- a/crates/chain/tests/data_promotion_test.rs
+++ b/crates/chain/tests/data_promotion_test.rs
@@ -45,6 +45,7 @@ async fn data_promotion_test() {
         miner_address: miner_signer.address(),
         min_writes_before_sync: 1,
         entropy_packing_iterations: 1_000,
+        num_confirmations_for_finality: 1, // Testnet / single node config
     };
 
     // This will create 3 storage modules, one for submit, one for publish, and one for capacity

--- a/crates/storage/tests/storage_module_index_tests.rs
+++ b/crates/storage/tests/storage_module_index_tests.rs
@@ -28,6 +28,7 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
         miner_address: Address::random(),
         min_writes_before_sync: 1,
         entropy_packing_iterations: 1,
+        num_confirmations_for_finality: 1, // Testnet / single node config
     };
     let chunk_size = storage_config.chunk_size;
 

--- a/crates/types/src/consensus.rs
+++ b/crates/types/src/consensus.rs
@@ -21,12 +21,12 @@ pub const NUM_CHUNKS_IN_RECALL_RANGE: u64 = 2;
 pub const NUM_RECALL_RANGES_IN_PARTITION: u64 =
     NUM_CHUNKS_IN_PARTITION / NUM_CHUNKS_IN_RECALL_RANGE;
 
-// Reset the nonce limiter (vdf) once every 1200 steps/seconds or every ~20 min
+/// Reset the nonce limiter (vdf) once every 1200 steps/seconds or every ~20 min
 pub const NONCE_LIMITER_RESET_FREQUENCY: usize = 10 * 120;
 
 pub const VDF_PARALLEL_VERIFICATION_THREAD_LIMIT: usize = 4;
 
-// 25 checkpoints 40 ms each = 1000 ms
+/// 25 checkpoints 40 ms each = 1000 ms
 pub const NUM_CHECKPOINTS_IN_VDF_STEP: usize = 25;
 
 pub const VDF_SHA_1S: u64 = 530_000;
@@ -40,3 +40,12 @@ pub const NUM_BLOCKS_IN_EPOCH: u64 = 100;
 pub const SUBMIT_LEDGER_EPOCH_LENGTH: u64 = 5;
 pub const NUM_PARTITIONS_PER_SLOT: u64 = 1;
 pub const NUM_WRITES_BEFORE_SYNC: u64 = 5;
+
+// Longest chain consensus
+/// Number of block confirmations required before considering data final.
+///
+/// In Nakamoto consensus, finality is probabilistic based on chain depth:
+/// - 6 confirmations protects against attackers with <25% hashpower
+/// - 20 confirmations protects against attackers with <40% hashpower
+/// - No number of confirmations is secure against attackers with >50% hashpower
+pub const NUM_CONFIRMATIONS_FOR_FINALITY: u32 = 6;

--- a/crates/types/src/difficulty_adjustment_config.rs
+++ b/crates/types/src/difficulty_adjustment_config.rs
@@ -184,6 +184,7 @@ mod tests {
             miner_address: Address::random(),
             min_writes_before_sync: 1,
             entropy_packing_iterations: PACKING_SHA_1_5_S,
+            num_confirmations_for_finality: 1, // Testnet / single node config
         };
 
         let mut storage_module_count = 3;

--- a/crates/types/src/storage_config.rs
+++ b/crates/types/src/storage_config.rs
@@ -19,6 +19,8 @@ pub struct StorageConfig {
     pub min_writes_before_sync: u64,
     /// Number of sha256 iterations required to pack a chunk
     pub entropy_packing_iterations: u32,
+    /// Number of confirmations before storing tx data in `StorageModule`s
+    pub num_confirmations_for_finality: u32,
 }
 
 impl Default for StorageConfig {
@@ -32,6 +34,7 @@ impl Default for StorageConfig {
             min_writes_before_sync: NUM_WRITES_BEFORE_SYNC,
             // TODO: revert this back
             entropy_packing_iterations: 1_000, /* PACKING_SHA_1_5_S */
+            num_confirmations_for_finality: NUM_CONFIRMATIONS_FOR_FINALITY,
         }
     }
 }


### PR DESCRIPTION
Adding a config value for "storage finality", as in, the number of confirmations we require before moving chunks from the indexes to the storage modules.

It's a noisy but superficial refactor so it's in it's own PR. 