### PR TITLE
fix: rename checkpoints field to steps

### DIFF
--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -306,7 +306,7 @@ impl Handler<SolutionFoundMessage> for BlockProducerActor {
                 partition_hash: solution.partition_hash,
             };
 
-            let mut checkpoints = if prev_block_header.vdf_limiter_info.global_step_number + 1 > solution.vdf_step - 1 {
+            let mut steps = if prev_block_header.vdf_limiter_info.global_step_number + 1 > solution.vdf_step - 1 {
                 H256List::new()
             } else {
                     match vdf_steps.get_steps(ii(prev_block_header.vdf_limiter_info.global_step_number + 1, solution.vdf_step - 1)).await {
@@ -317,7 +317,7 @@ impl Handler<SolutionFoundMessage> for BlockProducerActor {
                         }
                     }
             };
-            checkpoints.push(solution.seed.0);
+            steps.push(solution.seed.0);
 
             let mut irys_block = IrysBlockHeader {
                 block_hash,
@@ -361,7 +361,7 @@ impl Handler<SolutionFoundMessage> for BlockProducerActor {
                     last_step_checkpoints: solution.checkpoints,
                     prev_output: prev_block_header.vdf_limiter_info.output,
                     seed: prev_block_header.vdf_limiter_info.seed,
-                    checkpoints,
+                    steps,
                     ..Default::default()
                 },
             };

--- a/crates/chain/src/vdf.rs
+++ b/crates/chain/src/vdf.rs
@@ -203,7 +203,7 @@ mod tests {
             global_step_number: step_num,
             output: steps[3],
             prev_output: steps[0],
-            checkpoints: H256List(steps.0[1..=3].into()),
+            steps: H256List(steps.0[1..=3].into()),
             last_step_checkpoints: H256List(checkpoints),
             seed: reset_seed,
             ..VDFLimiterInfo::default()

--- a/crates/types/src/block.rs
+++ b/crates/types/src/block.rs
@@ -40,7 +40,7 @@ pub struct VDFLimiterInfo {
     /// A list of the output of each step of the nonce limiting process. Note: each step
     /// has VDF_CHECKPOINT_COUNT_IN_STEP checkpoints, the last of which is that step's output.
     /// This field would be more accurately named "steps" as checkpoints are between steps.
-    pub checkpoints: H256List,
+    pub steps: H256List,
     /// The number of SHA2-256 iterations in a single VDF checkpoint. The protocol aims to keep the
     /// checkpoint calculation time to around 40ms by varying this parameter. Note: there are
     /// 25 checkpoints in a single VDF step - so the protocol aims to keep the step calculation at
@@ -213,7 +213,7 @@ impl IrysBlockHeader {
 
         let _ = &self
             .vdf_limiter_info
-            .checkpoints
+            .steps
             .iter()
             .for_each(|c| buf.extend_from_slice(&c.0));
 

--- a/crates/vdf/src/lib.rs
+++ b/crates/vdf/src/lib.rs
@@ -137,7 +137,7 @@ pub fn checkpoints_are_valid(
 
     let reset_seed = vdf_info.seed;
 
-    let mut step_hashes = vdf_info.checkpoints.clone();
+    let mut step_hashes = vdf_info.steps.clone();
 
     // Add the seed from the previous nonce info to the steps
     let previous_seed = vdf_info.prev_output;
@@ -147,7 +147,7 @@ pub fn checkpoints_are_valid(
     let steps = step_hashes.clone();
 
     // Calculate the step number of the first step in the blocks sequence
-    let start_step_number: u64 = vdf_info.global_step_number - vdf_info.checkpoints.len() as u64;
+    let start_step_number: u64 = vdf_info.global_step_number - vdf_info.steps.len() as u64;
 
     // We must calculate the checkpoint iterations for each step sequentially
     // because we only have the first and last checkpoint of each step, but we
@@ -205,11 +205,11 @@ pub fn checkpoints_are_valid(
     let last_step_checkpoints = test.last().unwrap().1.clone();
     let test: H256List = H256List(test.into_iter().map(|par| par.0).collect());
 
-    let checkpoints_are_valid = test == vdf_info.checkpoints;
+    let steps_are_valid = test == vdf_info.steps;
 
-    if !checkpoints_are_valid {
+    if !steps_are_valid {
         // Compare the original list with the calculated one
-        warn_mismatches(&test, &vdf_info.checkpoints);
+        warn_mismatches(&test, &vdf_info.steps);
         return Err(eyre::eyre!("VDF checkpoints are invalid!"));
     }
 


### PR DESCRIPTION
in the `VDFLimiterInfo` we were calling the step hashes `checkpoints` this PR renames them to `steps` for clarity as there are no checkpoints in the list, only step hashes.