### PR TITLE
change StoragePath to be std::path::Path instead of String

### DIFF
--- a/crates/actors/src/epoch_service.rs
+++ b/crates/actors/src/epoch_service.rs
@@ -587,7 +587,7 @@ impl EpochServiceActor {
             .map(|(idx, partition)| StorageModuleInfo {
                 id: idx,
                 partition_assignment: Some(*pa.data_partitions.get(partition).unwrap()),
-                submodules: vec![(ie(0, num_part_chunks), format!("submodule_{}", idx))],
+                submodules: vec![(ie(0, num_part_chunks), format!("submodule_{}", idx).into())],
             })
             .collect::<Vec<_>>();
 
@@ -604,7 +604,7 @@ impl EpochServiceActor {
                 partition_assignment: Some(*pa.data_partitions.get(partition).unwrap()),
                 submodules: vec![(
                     ie(0, num_part_chunks),
-                    format!("submodule_{}", idx_start + idx),
+                    format!("submodule_{}", idx_start + idx).into(),
                 )],
             })
             .collect::<Vec<_>>();
@@ -621,7 +621,7 @@ impl EpochServiceActor {
         let cap_info = StorageModuleInfo {
             id: idx,
             partition_assignment: Some(*pa.capacity_partitions.get(cap_part).unwrap()),
-            submodules: vec![(ie(0, num_part_chunks), format!("submodule_{}", idx))],
+            submodules: vec![(ie(0, num_part_chunks), format!("submodule_{}", idx).into())],
         };
 
         module_infos.push(cap_info);

--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -620,7 +620,7 @@ mod tests {
                 slot_index: Some(0),
             }),
             submodules: vec![
-                (ii(0, 4), "hdd0-4TB".to_string()), // 0 to 4 inclusive
+                (ii(0, 4), "hdd0-4TB".into()), // 0 to 4 inclusive
             ],
         };
         initialize_storage_files(&base_path, &vec![storage_module_info.clone()])?;

--- a/crates/actors/src/mining.rs
+++ b/crates/actors/src/mining.rs
@@ -347,7 +347,7 @@ mod tests {
                 slot_index: Some(0), // Submit Ledger Slot 0
             }),
             submodules: vec![
-                (ie(0, chunk_count), "hdd0".to_string()), // 0 to 3 inclusive, 4 chunks
+                (ie(0, chunk_count), "hdd0".into()), // 0 to 3 inclusive, 4 chunks
             ],
         }];
 

--- a/crates/actors/src/packing.rs
+++ b/crates/actors/src/packing.rs
@@ -318,7 +318,7 @@ mod tests {
                 slot_index: None,
             }),
             submodules: vec![
-                (ii(0, 4), "hdd0-4TB".to_string()), // 0 to 4 inclusive
+                (ii(0, 4), "hdd0-4TB".into()), // 0 to 4 inclusive
             ],
         }];
 

--- a/crates/actors/tests/chunk_migration_test.rs
+++ b/crates/actors/tests/chunk_migration_test.rs
@@ -61,7 +61,7 @@ async fn finalize_block_test() -> eyre::Result<()> {
                 slot_index: Some(0), // Submit Ledger Slot 0
             }),
             submodules: vec![
-                (ii(0, 5), "sm1".to_string()), // 0 to 5 inclusive
+                (ii(0, 5), "sm1".into()), // 0 to 5 inclusive
             ],
         },
         StorageModuleInfo {
@@ -73,7 +73,7 @@ async fn finalize_block_test() -> eyre::Result<()> {
                 slot_index: Some(1), // Submit Ledger Slot 1
             }),
             submodules: vec![
-                (ii(0, 5), "sm2".to_string()), // 0 to 5 inclusive
+                (ii(0, 5), "sm2".into()), // 0 to 5 inclusive
             ],
         },
     ];

--- a/crates/chain/tests/api/external_api.rs
+++ b/crates/chain/tests/api/external_api.rs
@@ -93,7 +93,7 @@ async fn external_api() -> eyre::Result<()> {
                 slot_index: Some(0), // Submit Ledger Slot 0
             }),
             submodules: vec![
-                (ii(0, 5), "sm1".to_string()), // 0 to 5 inclusive
+                (ii(0, 5), "sm1".into()), // 0 to 5 inclusive
             ],
         },
         StorageModuleInfo {
@@ -105,7 +105,7 @@ async fn external_api() -> eyre::Result<()> {
                 slot_index: Some(1), // Submit Ledger Slot 1
             }),
             submodules: vec![
-                (ii(0, 5), "sm2".to_string()), // 0 to 5 inclusive
+                (ii(0, 5), "sm2".into()), // 0 to 5 inclusive
             ],
         },
     ];

--- a/crates/storage/src/chunk_provider.rs
+++ b/crates/storage/src/chunk_provider.rs
@@ -159,10 +159,7 @@ mod tests {
         let infos = vec![StorageModuleInfo {
             id: 0,
             partition_assignment: Some(PartitionAssignment::default()),
-            submodules: vec![
-                (ie(0, 50), "hdd0".to_string()),
-                (ie(50, 100), "hdd1".to_string()),
-            ],
+            submodules: vec![(ie(0, 50), "hdd0".into()), (ie(50, 100), "hdd1".into())],
         }];
 
         let tmp_dir = setup_tracing_and_temp_dir(Some("get_by_data_tx_offset_test"), false);

--- a/crates/storage/src/storage_module.rs
+++ b/crates/storage/src/storage_module.rs
@@ -34,7 +34,7 @@ use std::{
 };
 use tracing::{debug, info};
 
-type SubmodulePath = String;
+type SubmodulePath = PathBuf;
 
 // In-memory chunk data indexed by offset within partition
 type ChunkMap = BTreeMap<PartitionChunkOffset, (ChunkBytes, ChunkType)>;
@@ -928,9 +928,9 @@ mod tests {
             id: 0,
             partition_assignment: None,
             submodules: vec![
-                (ii(0, 4), "hdd0-4TB".to_string()),  // 0 to 4 inclusive
-                (ii(5, 9), "hdd1-4TB".to_string()),  // 5 to 9 inclusive
-                (ii(10, 19), "hdd-8TB".to_string()), // 10 to 19 inclusive
+                (ii(0, 4), "hdd0-4TB".into()),  // 0 to 4 inclusive
+                (ii(5, 9), "hdd1-4TB".into()),  // 5 to 9 inclusive
+                (ii(10, 19), "hdd-8TB".into()), // 10 to 19 inclusive
             ],
         }];
 
@@ -1049,7 +1049,7 @@ mod tests {
             id: 0,
             partition_assignment: Some(PartitionAssignment::default()),
             submodules: vec![
-                (ii(0, 4), "hdd0-4TB".to_string()), // 0 to 4 inclusive
+                (ii(0, 4), "hdd0-4TB".into()), // 0 to 4 inclusive
             ],
         }];
 

--- a/crates/storage/tests/storage_module_index_tests.rs
+++ b/crates/storage/tests/storage_module_index_tests.rs
@@ -44,9 +44,9 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
                 slot_index: Some(0), // Submit Ledger Slot 0
             }),
             submodules: vec![
-                (ii(0, 4), "hdd0".to_string()),   // 0 to 4 inclusive
-                (ii(5, 9), "hdd1".to_string()),   // 5 to 9 inclusive
-                (ii(10, 19), "hdd2".to_string()), // 10 to 19 inclusive
+                (ii(0, 4), "hdd0".into()),   // 0 to 4 inclusive
+                (ii(5, 9), "hdd1".into()),   // 5 to 9 inclusive
+                (ii(10, 19), "hdd2".into()), // 10 to 19 inclusive
             ],
         },
         StorageModuleInfo {
@@ -58,8 +58,8 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
                 slot_index: Some(1), // Submit Ledger Slot 1
             }),
             submodules: vec![
-                (ii(0, 9), "hdd3".to_string()),   // 0 to 9 inclusive
-                (ii(10, 19), "hdd4".to_string()), // 10 to 19 inclusive
+                (ii(0, 9), "hdd3".into()),   // 0 to 9 inclusive
+                (ii(10, 19), "hdd4".into()), // 10 to 19 inclusive
             ],
         },
         StorageModuleInfo {
@@ -71,7 +71,7 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
                 slot_index: Some(2), // Submit Ledger Slot 2
             }),
             submodules: vec![
-                (ii(0, 19), "hdd5".to_string()), // 0 to 19 inclusive
+                (ii(0, 19), "hdd5".into()), // 0 to 19 inclusive
             ],
         },
     ];


### PR DESCRIPTION
much safer

upgrade note: can use `"my_string".into()` instead of `"my_string".to_string()` for places where we have existing string literals