### PR TITLE
Refactor Block Ledger Structure for Future Extensibility

### DIFF
--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -301,11 +301,11 @@ impl Handler<SolutionFoundMessage> for BlockProducerActor {
             let block_hash = hash_sha256(&current_timestamp.to_le_bytes());
 
             // Use the partition hash to figure out what ledger it belongs to
-            let ledger_num = epoch_service_addr
+            let ledger_id = epoch_service_addr
                 .send(GetPartitionAssignmentMessage(solution.partition_hash))
                 .await
                 .unwrap()
-                .and_then(|pa| pa.ledger_num);
+                .and_then(|pa| pa.ledger_id);
 
 
             let poa = PoaData {
@@ -313,7 +313,7 @@ impl Handler<SolutionFoundMessage> for BlockProducerActor {
                 data_path: solution.data_path.map(Base64),
                 chunk: Base64(solution.chunk),
                 recall_chunk_index: solution.recall_chunk_index,
-                ledger_num,
+                ledger_id,
                 partition_chunk_offset: solution.chunk_offset,
                 partition_hash: solution.partition_hash,
             };

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -184,8 +184,8 @@ pub fn poa_is_valid(
 ) -> eyre::Result<()> {
     debug!("PoA validating mining address: {:?} chunk_offset: {} partition hash: {:?} iterations: {} chunk size: {}", miner_address, poa.partition_chunk_offset, poa.partition_hash, config.entropy_packing_iterations, config.chunk_size);
     // data chunk
-    if let (Some(data_path), Some(tx_path), Some(ledger_num)) =
-        (poa.data_path.clone(), poa.tx_path.clone(), poa.ledger_num)
+    if let (Some(data_path), Some(tx_path), Some(ledger_id)) =
+        (poa.data_path.clone(), poa.tx_path.clone(), poa.ledger_id)
     {
         // partition data -> ledger data
         let partition_assignment = partitions_guard
@@ -199,7 +199,7 @@ pub fn poa_is_valid(
             + poa.partition_chunk_offset as u64;
 
         // ledger data -> block
-        let ledger = Ledger::try_from(ledger_num).unwrap();
+        let ledger = Ledger::try_from(ledger_id).unwrap();
 
         let bb = block_index_guard
             .read()
@@ -263,10 +263,10 @@ pub fn poa_is_valid(
 
         if poa_chunk_hash != data_path_result.leaf_hash {
             return Err(eyre::eyre!(
-                "PoA chunk hash mismatch\n{:?}\nleaf_hash: {:?}\nledger_num: {}\nledger_chunk_offset: {}",
+                "PoA chunk hash mismatch\n{:?}\nleaf_hash: {:?}\nledger_id: {}\nledger_chunk_offset: {}",
                 poa_chunk,
                 data_path_result.leaf_hash,
-                ledger_num,
+                ledger_id,
                 ledger_chunk_offset
             ));
         }
@@ -549,7 +549,7 @@ mod tests {
             tx_path: Some(Base64(tx_path[poa_tx_num].proof.clone())),
             data_path: Some(Base64(txs[poa_tx_num].proofs[poa_chunk_num].proof.clone())),
             chunk: Base64(poa_chunk.clone()),
-            ledger_num: Some(1),
+            ledger_id: Some(1),
             partition_chunk_offset: (poa_tx_num * 3 /* 3 chunks in each tx */ + poa_chunk_num)
                 as u32,
             recall_chunk_index: 0,

--- a/crates/actors/src/chunk_migration_service.rs
+++ b/crates/actors/src/chunk_migration_service.rs
@@ -286,8 +286,8 @@ fn find_storage_module(
         module
             .partition_assignment
             .as_ref()
-            .and_then(|pa| pa.ledger_num)
-            .filter(|&num| num == ledger as u64)
+            .and_then(|pa| pa.ledger_id)
+            .filter(|&id| id == ledger as u32)
             // Then check offset range
             .and_then(|_| module.get_storage_module_range().ok())
             .filter(|range| range.contains_point(ledger_offset))

--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -616,7 +616,7 @@ mod tests {
             partition_assignment: Some(PartitionAssignment {
                 partition_hash: PartitionHash::zero(),
                 miner_address: Address::random(),
-                ledger_num: Some(0),
+                ledger_id: Some(0),
                 slot_index: Some(0),
             }),
             submodules: vec![

--- a/crates/actors/src/mining.rs
+++ b/crates/actors/src/mining.rs
@@ -343,7 +343,7 @@ mod tests {
             partition_assignment: Some(PartitionAssignment {
                 partition_hash,
                 miner_address: mining_address,
-                ledger_num: Some(0),
+                ledger_id: Some(0),
                 slot_index: Some(0), // Submit Ledger Slot 0
             }),
             submodules: vec![

--- a/crates/actors/src/packing.rs
+++ b/crates/actors/src/packing.rs
@@ -314,7 +314,7 @@ mod tests {
             partition_assignment: Some(PartitionAssignment {
                 partition_hash,
                 miner_address: mining_address,
-                ledger_num: None,
+                ledger_id: None,
                 slot_index: None,
             }),
             submodules: vec![

--- a/crates/actors/tests/chunk_migration_test.rs
+++ b/crates/actors/tests/chunk_migration_test.rs
@@ -57,7 +57,7 @@ async fn finalize_block_test() -> eyre::Result<()> {
             partition_assignment: Some(PartitionAssignment {
                 partition_hash: H256::random(),
                 miner_address: storage_config.miner_address,
-                ledger_num: Some(1),
+                ledger_id: Some(1),
                 slot_index: Some(0), // Submit Ledger Slot 0
             }),
             submodules: vec![
@@ -69,7 +69,7 @@ async fn finalize_block_test() -> eyre::Result<()> {
             partition_assignment: Some(PartitionAssignment {
                 partition_hash: H256::random(),
                 miner_address: storage_config.miner_address,
-                ledger_num: Some(1),
+                ledger_id: Some(1),
                 slot_index: Some(1), // Submit Ledger Slot 1
             }),
             submodules: vec![
@@ -202,7 +202,7 @@ async fn finalize_block_test() -> eyre::Result<()> {
             tx_path: None,
             data_path: None,
             chunk: Base64::from_str("").unwrap(),
-            ledger_num: None,
+            ledger_id: None,
             partition_chunk_offset: 0,
             recall_chunk_index: 0,
             partition_hash: PartitionHash::zero(),

--- a/crates/api-server/src/lib.rs
+++ b/crates/api-server/src/lib.rs
@@ -33,11 +33,11 @@ pub fn routes() -> impl HttpServiceFactory {
         )
         .route("/block/{block_hash}", web::get().to(block::get_block))
         .route(
-            "/chunk/data_root/{ledger_num}/{data_root}/{offset}",
+            "/chunk/data_root/{ledger_id}/{data_root}/{offset}",
             web::get().to(get_chunk::get_chunk_by_data_root_offset),
         )
         .route(
-            "/chunk/ledger/{ledger_num}/{ledger_offset}",
+            "/chunk/ledger/{ledger_id}/{ledger_offset}",
             web::get().to(get_chunk::get_chunk_by_ledger_offset),
         )
         .route("/chunk", web::post().to(post_chunk::post_chunk))

--- a/crates/api-server/src/routes/get_chunk.rs
+++ b/crates/api-server/src/routes/get_chunk.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 
 #[derive(Deserialize)]
 pub struct LedgerChunkApiPath {
-    ledger_num: u64,
+    ledger_id: u32,
     ledger_offset: u64,
 }
 
@@ -18,11 +18,9 @@ pub async fn get_chunk_by_ledger_offset(
     state: web::Data<ApiState>,
     path: web::Path<LedgerChunkApiPath>,
 ) -> actix_web::Result<HttpResponse> {
-    let ledger = match Ledger::try_from(path.ledger_num) {
+    let ledger = match Ledger::try_from(path.ledger_id) {
         Ok(l) => l,
-        Err(e) => {
-            return Ok(HttpResponse::BadRequest().body(format!("Invalid ledger number: {}", e)))
-        }
+        Err(e) => return Ok(HttpResponse::BadRequest().body(format!("Invalid ledger id: {}", e))),
     };
 
     match state
@@ -39,7 +37,7 @@ pub async fn get_chunk_by_ledger_offset(
 
 #[derive(Deserialize)]
 pub struct DataRootChunkApiPath {
-    ledger_num: u64,
+    ledger_id: u32,
     data_root: H256,
     offset: u32,
 }
@@ -48,11 +46,9 @@ pub async fn get_chunk_by_data_root_offset(
     state: web::Data<ApiState>,
     path: web::Path<DataRootChunkApiPath>,
 ) -> actix_web::Result<HttpResponse> {
-    let ledger = match Ledger::try_from(path.ledger_num) {
+    let ledger = match Ledger::try_from(path.ledger_id) {
         Ok(l) => l,
-        Err(e) => {
-            return Ok(HttpResponse::BadRequest().body(format!("Invalid ledger number: {}", e)))
-        }
+        Err(e) => return Ok(HttpResponse::BadRequest().body(format!("Invalid ledger id: {}", e))),
     };
 
     match state

--- a/crates/api-server/src/routes/tx.rs
+++ b/crates/api-server/src/routes/tx.rs
@@ -89,7 +89,7 @@ pub async fn get_tx_local_start_offset(
     let tx_id: H256 = path.into_inner();
     info!("Get tx data metadata by tx_id: {}", tx_id);
     let tx_header = get_tx_header(&state, tx_id)?;
-    let ledger = Ledger::try_from(tx_header.ledger_num).unwrap();
+    let ledger = Ledger::try_from(tx_header.ledger_id).unwrap();
 
     match state
         .chunk_provider

--- a/crates/chain/tests/api/external_api.rs
+++ b/crates/chain/tests/api/external_api.rs
@@ -89,7 +89,7 @@ async fn external_api() -> eyre::Result<()> {
             partition_assignment: Some(PartitionAssignment {
                 partition_hash: H256::random(),
                 miner_address: storage_config.miner_address,
-                ledger_num: Some(1),
+                ledger_id: Some(1),
                 slot_index: Some(0), // Submit Ledger Slot 0
             }),
             submodules: vec![
@@ -101,7 +101,7 @@ async fn external_api() -> eyre::Result<()> {
             partition_assignment: Some(PartitionAssignment {
                 partition_hash: H256::random(),
                 miner_address: storage_config.miner_address,
-                ledger_num: Some(1),
+                ledger_id: Some(1),
                 slot_index: Some(1), // Submit Ledger Slot 1
             }),
             submodules: vec![
@@ -252,7 +252,7 @@ async fn external_api() -> eyre::Result<()> {
             tx_path: None,
             data_path: None,
             chunk: Base64::from_str("").unwrap(),
-            ledger_num: None,
+            ledger_id: None,
             partition_chunk_offset: 0,
             partition_hash: PartitionHash::zero(),
             recall_chunk_index: 0,

--- a/crates/database/src/data_ledger.rs
+++ b/crates/database/src/data_ledger.rs
@@ -47,7 +47,7 @@ impl Default for PermanentLedger {
 }
 
 impl PermanentLedger {
-    /// Constructs a permanent ledger, always with `ledger_num`: 0
+    /// Constructs a permanent ledger, always with Ledger::Publish as the id
     pub const fn new() -> Self {
         Self {
             slots: Vec::new(),
@@ -196,7 +196,7 @@ impl LedgerCore for TermLedger {
     }
 }
 
-/// Names for each of the ledgers as well as their `ledger_num` discriminant
+/// Names for each of the ledgers as well as their `ledger_id` discriminant
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Compact, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum Ledger {
@@ -242,10 +242,10 @@ impl From<Ledger> for u32 {
     }
 }
 
-impl TryFrom<u64> for Ledger {
+impl TryFrom<u32> for Ledger {
     type Error = &'static str;
 
-    fn try_from(value: u64) -> Result<Self, Self::Error> {
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
         match value {
             0 => Ok(Self::Publish),
             1 => Ok(Self::Submit),
@@ -344,8 +344,8 @@ impl Ledgers {
 impl Index<Ledger> for Ledgers {
     type Output = dyn LedgerCore;
 
-    fn index(&self, ledger_num: Ledger) -> &Self::Output {
-        match ledger_num {
+    fn index(&self, ledger: Ledger) -> &Self::Output {
+        match ledger {
             Ledger::Publish => &self.perm,
             Ledger::Submit => &self.term[0],
         }
@@ -354,8 +354,8 @@ impl Index<Ledger> for Ledgers {
 
 // Implement IndexMut to retrieve a LedgerCore by its Ledger name
 impl IndexMut<Ledger> for Ledgers {
-    fn index_mut(&mut self, ledger_num: Ledger) -> &mut Self::Output {
-        match ledger_num {
+    fn index_mut(&mut self, ledger: Ledger) -> &mut Self::Output {
+        match ledger {
             Ledger::Publish => &mut self.perm,
             Ledger::Submit => &mut self.term[0],
         }

--- a/crates/storage/src/chunk_provider.rs
+++ b/crates/storage/src/chunk_provider.rs
@@ -69,8 +69,8 @@ impl ChunkProvider {
             .iter()
             .filter(|sm| {
                 sm.partition_assignment
-                    .and_then(|sm| sm.ledger_num)
-                    .map_or(false, |ledger_num| ledger_num == ledger as u64)
+                    .and_then(|sm| sm.ledger_id)
+                    .map_or(false, |ledger_id| ledger_id == ledger as u32)
             })
             .collect::<Vec<_>>();
 
@@ -115,8 +115,8 @@ impl ChunkProvider {
             .iter()
             .filter(|sm| {
                 sm.partition_assignment
-                    .and_then(|sm| sm.ledger_num)
-                    .map_or(false, |ledger_num| ledger_num == ledger as u64)
+                    .and_then(|sm| sm.ledger_id)
+                    .map_or(false, |ledger_id| ledger_id == ledger as u32)
             })
             .collect::<Vec<_>>();
 

--- a/crates/storage/src/storage_module.rs
+++ b/crates/storage/src/storage_module.rs
@@ -869,8 +869,8 @@ pub fn get_overlapped_storage_modules(
         .filter(|module| {
             module
                 .partition_assignment
-                .and_then(|pa| pa.ledger_num)
-                .map_or(false, |num| num == ledger as u64)
+                .and_then(|pa| pa.ledger_id)
+                .map_or(false, |id| id == ledger as u32)
                 && module
                     .get_storage_module_range()
                     .map_or(false, |range| range.overlaps(tx_chunk_range))
@@ -891,8 +891,8 @@ pub fn get_storage_module_at_offset(
         .find(|module| {
             module
                 .partition_assignment
-                .and_then(|pa| pa.ledger_num)
-                .map_or(false, |num| num == ledger as u64)
+                .and_then(|pa| pa.ledger_id)
+                .map_or(false, |id| id == ledger as u32)
                 && module
                     .get_storage_module_range()
                     .map_or(false, |range| range.contains_point(chunk_offset))

--- a/crates/storage/tests/storage_module_index_tests.rs
+++ b/crates/storage/tests/storage_module_index_tests.rs
@@ -40,7 +40,7 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
             partition_assignment: Some(PartitionAssignment {
                 partition_hash: H256::random(),
                 miner_address: storage_config.miner_address,
-                ledger_num: Some(1),
+                ledger_id: Some(1),
                 slot_index: Some(0), // Submit Ledger Slot 0
             }),
             submodules: vec![
@@ -54,7 +54,7 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
             partition_assignment: Some(PartitionAssignment {
                 partition_hash: H256::random(),
                 miner_address: storage_config.miner_address,
-                ledger_num: Some(1),
+                ledger_id: Some(1),
                 slot_index: Some(1), // Submit Ledger Slot 1
             }),
             submodules: vec![
@@ -67,7 +67,7 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
             partition_assignment: Some(PartitionAssignment {
                 partition_hash: H256::random(),
                 miner_address: storage_config.miner_address,
-                ledger_num: Some(1),
+                ledger_id: Some(1),
                 slot_index: Some(2), // Submit Ledger Slot 2
             }),
             submodules: vec![

--- a/crates/types/src/block.rs
+++ b/crates/types/src/block.rs
@@ -140,7 +140,7 @@ impl IrysBlockHeader {
                 partition_hash: PartitionHash::zero(),
                 partition_chunk_offset: 0,
                 recall_chunk_index: 0,
-                ledger_num: None,
+                ledger_id: None,
             },
             reward_address: Address::ZERO,
             signature: Signature::test_signature().into(),
@@ -188,7 +188,7 @@ impl IrysBlockHeader {
         write_optional_ref(buf, &self.poa.data_path);
         // we use the chunk hash instead of the data
         buf.extend_from_slice(&hash_sha256(&self.poa.chunk.0)?);
-        write_optional(buf, &self.poa.ledger_num);
+        write_optional(buf, &self.poa.ledger_id);
         buf.extend_from_slice(&self.poa.partition_chunk_offset.to_le_bytes());
         buf.extend_from_slice(self.poa.partition_hash.as_bytes());
         //
@@ -266,6 +266,18 @@ trait WriteBytes {
 }
 
 // Implementation for integer types
+impl WriteBytes for u32 {
+    fn write_bytes(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&self.to_le_bytes());
+    }
+}
+
+impl WriteBytes for &u32 {
+    fn write_bytes(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&(**self).to_le_bytes());
+    }
+}
+
 impl WriteBytes for u64 {
     fn write_bytes(&self, buf: &mut Vec<u8>) {
         buf.extend_from_slice(&self.to_le_bytes());
@@ -300,7 +312,7 @@ pub struct PoaData {
     pub data_path: Option<Base64>,
     pub chunk: Base64,
     pub recall_chunk_index: u32,
-    pub ledger_num: Option<u64>,
+    pub ledger_id: Option<u32>,
     pub partition_chunk_offset: u32,
     pub partition_hash: PartitionHash,
 }
@@ -399,7 +411,7 @@ mod tests {
                 partition_hash: H256::zero(),
                 partition_chunk_offset: 0,
                 recall_chunk_index: 0,
-                ledger_num: None,
+                ledger_id: None,
             },
             reward_address: Address::ZERO,
             signature: Signature::test_signature().into(),
@@ -486,7 +498,7 @@ mod tests {
                 partition_hash: H256::zero(),
                 partition_chunk_offset: 0,
                 recall_chunk_index: 0,
-                ledger_num: None,
+                ledger_id: None,
             },
             reward_address: Address::ZERO,
             signature: Signature::test_signature().into(),

--- a/crates/types/src/partition.rs
+++ b/crates/types/src/partition.rs
@@ -14,7 +14,7 @@ pub struct PartitionAssignment {
     /// Address of the miner pledged to store it
     pub miner_address: Address,
     /// If assigned to a ledger, the ledger number
-    pub ledger_num: Option<u64>,
+    pub ledger_id: Option<u32>,
     /// If assigned to a ledger, the index in the ledger
     pub slot_index: Option<usize>,
 }
@@ -24,7 +24,7 @@ impl Default for PartitionAssignment {
         Self {
             partition_hash: PartitionHash::zero(),
             miner_address: Address::ZERO,
-            ledger_num: Some(0),
+            ledger_id: Some(0),
             slot_index: Some(0),
         }
     }

--- a/crates/types/src/signature.rs
+++ b/crates/types/src/signature.rs
@@ -183,7 +183,7 @@ mod tests {
             data_size: 1024,
             term_fee: 100,
             perm_fee: Some(1),
-            ledger_num: 0,
+            ledger_id: 0,
             bundle_format: Some(0),
             chain_id: CONFIG.irys_chain_id,
             version: 0,

--- a/crates/types/src/transaction.rs
+++ b/crates/types/src/transaction.rs
@@ -56,8 +56,7 @@ pub struct IrysTransactionHeader {
     pub term_fee: u64,
 
     /// Destination ledger for the transaction, default is 0 - Permanent Ledger
-    #[serde(with = "string_u64")]
-    pub ledger_num: u64,
+    pub ledger_id: u32,
 
     /// EVM chain ID - used to prevent cross-chain replays
     #[serde(with = "string_u64")]
@@ -151,7 +150,7 @@ impl Default for IrysTransactionHeader {
             data_size: 0,
             term_fee: 0,
             perm_fee: None,
-            ledger_num: 0,
+            ledger_id: 0,
             bundle_format: None,
             version: 0,
             chain_id: CONFIG.irys_chain_id,
@@ -196,7 +195,7 @@ mod tests {
             data_size: 1024,
             term_fee: 100,
             perm_fee: Some(200),
-            ledger_num: 1,
+            ledger_id: 1,
             bundle_format: None,
             chain_id: CONFIG.irys_chain_id,
             version: 0,
@@ -234,7 +233,7 @@ mod tests {
             term_fee: 100,
             // perm_fee: Some(200),
             perm_fee: None,
-            ledger_num: 0,
+            ledger_id: 0,
             chain_id: CONFIG.irys_chain_id,
             bundle_format: None,
             version: 0,


### PR DESCRIPTION
* Rename `txids` to `tx_ids` in Ledger blocks for naming consistency
* Add explicit `ledger_id` field to each Ledger block
* Decouple ledger indexing from enum discriminant order:
  - Replace direct array indexing with ledger_id matching
  - `ledgers[Ledger::Publish]` now finds first ledger with matching id
  - Enables adding/removing ledgers while preserving existing ids
  - Removes requirement for sequential ledger ids