### PR TITLE
Feat: Overhaul Reth forkchoice logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5191,6 +5191,7 @@ dependencies = [
  "base64-url",
  "env_logger",
  "eyre",
+ "futures",
  "irys-config",
  "irys-database",
  "irys-efficient-sampling",

--- a/crates/actors/src/block_index_service.rs
+++ b/crates/actors/src/block_index_service.rs
@@ -211,7 +211,7 @@ impl BlockIndexService {
 }
 
 impl Handler<BlockFinalizedMessage> for BlockIndexService {
-    type Result = Result<(), ()>;
+    type Result = eyre::Result<()>;
     fn handle(&mut self, msg: BlockFinalizedMessage, _: &mut Context<Self>) -> Self::Result {
         // Collect working variables to move into the closure
         let block = msg.block_header;

--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -434,13 +434,13 @@ impl Handler<SolutionFoundMessage> for BlockProducerActor {
                 }
             }?;
 
-            // make this the new head, add the parent as confirmed.
-            // we also update head, confirmed, and finalized as part of block validation.
-            context
-                .engine_api
-                .update_forkchoice_full(block_hash, Some(v1_payload.parent_hash), None)
-                .await
-                .unwrap();
+            // make this the new head
+            // note: also update head, confirmed, and finalized as part of the block validation -> block tree system
+            // context
+            //     .engine_api
+            //     .update_forkchoice_full(block_hash, None, None)
+            //     .await
+            //     .unwrap();
 
             if is_difficulty_updated {
                 mining_broadcaster_addr.do_send(BroadcastDifficultyUpdate(block.clone()));

--- a/crates/actors/src/lib.rs
+++ b/crates/actors/src/lib.rs
@@ -10,6 +10,7 @@ pub mod epoch_service;
 pub mod mempool_service;
 pub mod mining;
 pub mod packing;
+pub mod reth_service;
 pub mod validation_service;
 pub mod vdf_service;
 

--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -408,11 +408,11 @@ impl Handler<GetBestMempoolTxs> for MempoolService {
 }
 
 impl Handler<BlockConfirmedMessage> for MempoolService {
-    type Result = ();
+    type Result = eyre::Result<()>;
     fn handle(&mut self, msg: BlockConfirmedMessage, _ctx: &mut Context<Self>) -> Self::Result {
         if self.db.is_none() {
             error!("mempool_service is uninitialized");
-            return;
+            return Err(eyre!("mempool_service is uninitialized"));
         }
 
         // Access the block header through msg.0
@@ -489,6 +489,7 @@ impl Handler<BlockConfirmedMessage> for MempoolService {
             block.height,
             all_txs.len()
         );
+        Ok(())
     }
 }
 

--- a/crates/actors/src/packing.rs
+++ b/crates/actors/src/packing.rs
@@ -17,7 +17,7 @@ use {
 
 use irys_storage::{ChunkType, InclusiveInterval, StorageModule};
 use irys_types::{PartitionChunkRange, StorageConfig};
-use reth::{tasks::TaskExecutor};
+use reth::tasks::TaskExecutor;
 use tokio::{runtime::Handle, sync::Semaphore, time::sleep};
 use tracing::{debug, warn};
 
@@ -85,7 +85,6 @@ impl PackingActor {
             .iter()
             .map(|s| (*s, Arc::new(RwLock::new(VecDeque::with_capacity(32)))))
             .collect();
-
 
         Self {
             actix_runtime_handle,
@@ -196,7 +195,12 @@ impl PackingActor {
                         let storage_module = storage_module.clone();
                         let chunk_range_split = chunk_range_split.clone();
 
-                        let semaphore = self.semaphore.clone().as_ref().get(&storage_module_id).unwrap().clone();
+                        let semaphore = self
+                            .semaphore
+                            .clone()
+                            .get(&storage_module_id)
+                            .unwrap()
+                            .clone();
                         // wait for the permit before spawning the thread
                         let permit = semaphore.acquire_owned().await.unwrap();
 
@@ -255,8 +259,11 @@ impl Actor for PackingActor {
     fn start(self) -> actix::Addr<Self> {
         let keys = self.pending_jobs.keys().cloned().collect::<Vec<usize>>();
         for key in keys {
-            self.actix_runtime_handle
-                .spawn(Self::process_jobs(self.clone(), key, self.pending_jobs.get(&key).unwrap().clone()));
+            self.actix_runtime_handle.spawn(Self::process_jobs(
+                self.clone(),
+                key,
+                self.pending_jobs.get(&key).unwrap().clone(),
+            ));
         }
 
         Context::new().run(self)
@@ -272,7 +279,13 @@ impl Handler<PackingRequest> for PackingActor {
 
     fn handle(&mut self, msg: PackingRequest, _ctx: &mut Self::Context) -> Self::Result {
         debug!(target: "irys::packing", "Received packing request for range {}-{} for SM {}", &msg.chunk_range.start(), &msg.chunk_range.end(), &msg.storage_module.id);
-        self.pending_jobs.get(&msg.storage_module.id).unwrap().as_ref().write().unwrap().push_back(msg);
+        self.pending_jobs
+            .get(&msg.storage_module.id)
+            .unwrap()
+            .as_ref()
+            .write()
+            .unwrap()
+            .push_back(msg);
     }
 }
 
@@ -308,14 +321,20 @@ pub async fn wait_for_packing(
     tokio::time::timeout(timeout.unwrap_or(Duration::from_secs(10)), async {
         loop {
             // Counts all jobs in all job queues
-            if internals.pending_jobs.values().fold(0, |acc, x| acc + x.as_ref().read().unwrap().len()) == 0 {
+            if internals
+                .pending_jobs
+                .values()
+                .fold(0, |acc, x| acc + x.as_ref().read().unwrap().len())
+                == 0
+            {
                 // try to get all the semaphore permits - this is how we know that the packing is done
-                let _permit = futures::future::join_all(internals
-                    .semaphore
-                    .iter()
-                    .map(|(_, s)| s.as_ref().acquire_many(internals.config.concurrency as u32)))
+                let _permit =
+                    futures::future::join_all(internals.semaphore.iter().map(|(_, s)| {
+                        s.as_ref().acquire_many(internals.config.concurrency as u32)
+                    }))
                     .await
-                    .iter().map(|r| r.as_ref().unwrap());
+                    .iter()
+                    .map(|r| r.as_ref().unwrap());
                 break Some(());
             } else {
                 sleep(Duration::from_millis(100)).await
@@ -390,7 +409,6 @@ mod tests {
         let task_manager = TaskManager::current();
 
         let sm_ids = vec![storage_module.id];
-
 
         let packing = PackingActor::new(Handle::current(), task_manager.executor(), sm_ids, None);
 

--- a/crates/actors/src/reth_service.rs
+++ b/crates/actors/src/reth_service.rs
@@ -1,0 +1,170 @@
+use actix::{Actor, Context, Handler, Message, ResponseFuture, Supervised, SystemService};
+use eyre::{eyre, OptionExt};
+use futures::TryFutureExt;
+use irys_database::database;
+use irys_reth_node_bridge::{adapter::node::RethNodeContext, node::RethNodeProvider};
+use irys_types::{DatabaseProvider, H256};
+use reth::revm::primitives::B256;
+use reth_db::Database as _;
+use tracing::{error, info};
+
+#[derive(Debug, Default)]
+pub struct RethServiceActor {
+    pub handle: Option<RethNodeProvider>,
+    pub db: Option<DatabaseProvider>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ForkChoiceUpdate {
+    pub head_hash: B256,
+    pub confirmed_hash: Option<B256>,
+    pub finalized_hash: Option<B256>,
+}
+
+// todo: move the entire reth process in here
+impl RethServiceActor {
+    pub fn new(handle: RethNodeProvider, database_provider: DatabaseProvider) -> Self {
+        Self {
+            handle: Some(handle),
+            db: Some(database_provider),
+        }
+    }
+
+    pub fn resolve_irys_block_hashes(
+        db: DatabaseProvider,
+        fcu: ForkChoiceUpdateMessage,
+    ) -> eyre::Result<ForkChoiceUpdate> {
+        let ForkChoiceUpdateMessage {
+            head_hash,
+            confirmed_hash,
+            finalized_hash,
+        } = fcu;
+
+        let evm_head_hash = match head_hash {
+            BlockHashType::Irys(irys_hash) => {
+                let irys_header =
+                    db.view_eyre(|tx| database::block_header_by_hash(tx, &irys_hash))?;
+                let h = irys_header
+                    .ok_or(eyre!("Missing irys block {} in DB!", &irys_hash))?
+                    .evm_block_hash;
+                h
+            }
+            BlockHashType::Evm(v) => v,
+        };
+
+        let evm_confirmed_hash = match confirmed_hash {
+            Some(confirmed_hash) => Some(match confirmed_hash {
+                BlockHashType::Irys(irys_hash) => {
+                    let irys_header =
+                        db.view_eyre(|tx| database::block_header_by_hash(tx, &irys_hash))?;
+                    irys_header
+                        .ok_or(eyre!("Missing irys block {} in DB!", &irys_hash))?
+                        .evm_block_hash
+                }
+                BlockHashType::Evm(v) => v,
+            }),
+            None => None,
+        };
+
+        let evm_finalized_hash = match finalized_hash {
+            Some(finalized_hash) => Some(match finalized_hash {
+                BlockHashType::Irys(irys_hash) => {
+                    let irys_header =
+                        db.view_eyre(|tx| database::block_header_by_hash(tx, &irys_hash))?;
+                    irys_header
+                        .ok_or(eyre!("Missing irys block {} in DB!", &irys_hash))?
+                        .evm_block_hash
+                }
+                BlockHashType::Evm(v) => v,
+            }),
+            None => None,
+        };
+
+        Ok(ForkChoiceUpdate {
+            head_hash: evm_head_hash,
+            confirmed_hash: evm_confirmed_hash,
+            finalized_hash: evm_finalized_hash,
+        })
+    }
+}
+
+impl Actor for RethServiceActor {
+    type Context = Context<Self>;
+}
+
+impl Supervised for RethServiceActor {}
+
+impl SystemService for RethServiceActor {
+    fn service_started(&mut self, _ctx: &mut Context<Self>) {
+        println!("RethServiceActor started");
+    }
+}
+
+#[derive(Message, Debug, Clone)]
+#[rtype(result = "Option<RethNodeProvider>")]
+pub struct GetRethProvider(pub Option<RethNodeProvider>);
+
+impl Handler<GetRethProvider> for RethServiceActor {
+    type Result = Option<RethNodeProvider>;
+
+    fn handle(&mut self, _msg: GetRethProvider, _ctx: &mut Self::Context) -> Self::Result {
+        self.handle.clone()
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum BlockHashType {
+    Irys(H256),
+    Evm(B256),
+}
+
+#[derive(Message, Debug, Clone, Copy)]
+#[rtype(result = "eyre::Result<()>")]
+pub struct ForkChoiceUpdateMessage {
+    pub head_hash: BlockHashType,
+    pub confirmed_hash: Option<BlockHashType>,
+    pub finalized_hash: Option<BlockHashType>,
+}
+
+impl Handler<ForkChoiceUpdateMessage> for RethServiceActor {
+    type Result = ResponseFuture<eyre::Result<()>>;
+
+    fn handle(&mut self, msg: ForkChoiceUpdateMessage, _ctx: &mut Self::Context) -> Self::Result {
+        let handle = self.handle.clone();
+        let db = self.db.clone();
+        return Box::pin(
+            async move {
+                let handle = handle.ok_or_eyre("Reth service is uninitialized!")?;
+                let db = db.ok_or_eyre("Reth service is uninitialized!")?;
+
+                let ForkChoiceUpdate {
+                    head_hash,
+                    confirmed_hash,
+                    finalized_hash,
+                } = RethServiceActor::resolve_irys_block_hashes(db, msg).map_err(|e| {
+                    error!("Error updating reth forkchoice - {}", &e);
+                    e
+                })?;
+
+                info!(
+                    "Updating reth forkchoice: head: {:?}, conf: {:?}, final: {:?}",
+                    &head_hash, &confirmed_hash, &finalized_hash
+                );
+
+                let context = RethNodeContext::new(handle.into())
+                    .await
+                    .map_err(|e| eyre!("Error connecting to Reth - {}", e))?;
+
+                context
+                    .engine_api
+                    .update_forkchoice_full(head_hash, confirmed_hash, finalized_hash)
+                    .await?;
+                Ok(())
+            }
+            .map_err(|e| {
+                error!("Error updating reth forkchoice: {}", &e);
+                e
+            }),
+        );
+    }
+}

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -111,6 +111,7 @@ pub async fn capacity_chunk_solution(
 
 #[tokio::test]
 async fn test_blockprod() -> eyre::Result<()> {
+    std::env::set_var("RUST_LOG", "debug");
     let temp_dir = setup_tracing_and_temp_dir(Some("test_blockprod"), false);
     let mut config = IrysNodeConfig::default();
     config.base_directory = temp_dir.path().to_path_buf();

--- a/crates/chain/tests/programmable_data/basic.rs
+++ b/crates/chain/tests/programmable_data/basic.rs
@@ -92,7 +92,7 @@ async fn test_programmable_data_basic() -> eyre::Result<()> {
     let alloy_provider = ProviderBuilder::new()
         .with_recommended_fillers()
         .wallet(wallet)
-        .on_http("http://localhost:8080".parse()?);
+        .on_http("http://localhost:8080/v1/execution-rpc".parse()?);
 
     let deploy_builder =
         IrysProgrammableDataBasic::deploy_builder(alloy_provider.clone()).gas(29506173);

--- a/crates/chain/tests/programmable_data/basic.rs
+++ b/crates/chain/tests/programmable_data/basic.rs
@@ -3,6 +3,7 @@ use actix_http::StatusCode;
 use alloy_core::primitives::aliases::U200;
 use alloy_core::primitives::U256;
 use alloy_eips::eip2930::AccessListItem;
+use alloy_eips::BlockNumberOrTag;
 use alloy_network::EthereumWallet;
 use alloy_provider::ProviderBuilder;
 use alloy_signer_local::PrivateKeySigner;
@@ -11,11 +12,13 @@ use base58::ToBase58;
 use irys_actors::packing::wait_for_packing;
 use irys_api_server::routes::tx::TxOffset;
 use irys_chain::chain::start_for_testing;
+use irys_reth_node_bridge::adapter::node::RethNodeContext;
 use irys_testing_utils::utils::setup_tracing_and_temp_dir;
 use irys_types::{irys::IrysSigner, Address};
 use irys_types::{Base64, IrysTransactionHeader, UnpackedChunk};
 
 use k256::ecdsa::SigningKey;
+use reth::rpc::eth::EthApiServer;
 use reth_primitives::irys_primitives::precompile::IrysPrecompileOffsets;
 use reth_primitives::irys_primitives::range_specifier::{
     ByteRangeSpecifier, PdAccessListArgSerde, U18, U34,
@@ -303,6 +306,31 @@ async fn test_programmable_data_basic() -> eyre::Result<()> {
     );
 
     assert_eq!(&message, &stored_message);
+
+    let context = RethNodeContext::new(node.reth_handle.into()).await?;
+
+    let latest = context
+        .rpc
+        .inner
+        .eth_api()
+        .block_by_number(BlockNumberOrTag::Latest, false)
+        .await?;
+
+    let safe = context
+        .rpc
+        .inner
+        .eth_api()
+        .block_by_number(BlockNumberOrTag::Safe, false)
+        .await?;
+
+    let finalized = context
+        .rpc
+        .inner
+        .eth_api()
+        .block_by_number(BlockNumberOrTag::Finalized, false)
+        .await?;
+
+    dbg!(latest, safe, finalized);
 
     Ok(())
 }

--- a/crates/config/src/chain/chainspec.rs
+++ b/crates/config/src/chain/chainspec.rs
@@ -1,6 +1,7 @@
 use irys_primitives::GenesisAccount;
 use irys_types::{Address, IrysBlockHeader};
-use reth_chainspec::ChainSpecBuilder;
+use reth_chainspec::{ChainSpec, ChainSpecBuilder};
+use tracing::debug;
 
 use super::chain::IRYS_MAINNET;
 
@@ -26,8 +27,13 @@ impl IrysChainSpecBuilder {
         }
     }
 
-    pub fn genesis(&self) -> IrysBlockHeader {
-        self.genesis.clone()
+    // build the chainspec and the Irys genesis block
+    pub fn build(&self) -> (ChainSpec, IrysBlockHeader) {
+        let cs = self.reth_builder.clone().build();
+        let mut genesis = self.genesis.clone();
+        genesis.evm_block_hash = cs.genesis_hash();
+        debug!("EVM genesis block hash: {}", &genesis.evm_block_hash);
+        (cs, genesis)
     }
 
     pub fn new() -> Self {

--- a/crates/reth-node-bridge/src/adapter/engine_api.rs
+++ b/crates/reth-node-bridge/src/adapter/engine_api.rs
@@ -101,24 +101,28 @@ impl<E: EngineTypes> EngineApiContext<E> {
     }
 
     /// Sends forkchoice update to the engine api
+    // we can set safe or finalized to ZERO to skip updating them, but head is mandatory.
+    // safe (confirmed) we update in the block confirmed handler
+    // finalized we update in the block finalized handler
     pub async fn update_forkchoice_full(
         &self,
-        current_head: B256,
-        new_safe_head: B256,
-        finalized: Option<B256>,
+        head_block_hash: B256,
+        confirmed_block_hash: Option<B256>,
+        finalized_block_hash: Option<B256>,
     ) -> eyre::Result<()> {
         EngineApiClient::<E>::fork_choice_updated_v1_irys(
             &self.engine_api_client,
             ForkchoiceState {
-                head_block_hash: new_safe_head,
-                safe_block_hash: current_head,
-                finalized_block_hash: finalized.unwrap_or(B256::ZERO),
+                head_block_hash: head_block_hash,
+                safe_block_hash: confirmed_block_hash.unwrap_or(B256::ZERO),
+                finalized_block_hash: finalized_block_hash.unwrap_or(B256::ZERO),
             },
             None,
         )
         .await?;
         Ok(())
     }
+
     pub async fn update_forkchoice_payload_attr(
         &self,
         current_head: B256,

--- a/crates/reth-node-bridge/src/node.rs
+++ b/crates/reth-node-bridge/src/node.rs
@@ -266,8 +266,8 @@ pub async fn run_node<T: HasName + HasTableType>(
     // from ext/reth/bin/reth/src/main.rs
 
     let engine_tree_config = TreeConfig::default()
-        .with_persistence_threshold(engine_args.persistence_threshold)
-        .with_memory_block_buffer_target(engine_args.memory_block_buffer_target);
+        .with_persistence_threshold(0 /* engine_args.persistence_threshold */) // always persist to disk
+        .with_memory_block_buffer_target(0 /* engine_args.memory_block_buffer_target */);
 
     let handle =
         builder


### PR DESCRIPTION
This PR:
- Adds a new `RethServiceActor`, which handles forwarding fork choice updates to Reth.
- Improves error logging & _**adds code to cause critical actors to stop the process if they error**_ (block production and Reth).
- Hooks into block tree logic to update Reth in lockstep.
- Fixes a process restart losing head blocks (tweaks Reth side persistence values).
- Improves error logs.

