### PR TITLE
Clean up configs 

### DIFF
--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -584,7 +584,7 @@ mod tests {
     use assert_matches::assert_matches;
     use irys_database::{open_or_create_db, tables::IrysTables};
     use irys_packing::xor_vec_u8_arrays_in_place;
-    use irys_storage::{ii, initialize_storage_files, ChunkType, StorageModule, StorageModuleInfo};
+    use irys_storage::{ii, ChunkType, StorageModule, StorageModuleInfo};
     use irys_testing_utils::utils::setup_tracing_and_temp_dir;
     use irys_types::{
         irys::IrysSigner,
@@ -626,11 +626,6 @@ mod tests {
                 (ii(0, 4), "hdd0-4TB".into()), // 0 to 4 inclusive
             ],
         };
-        initialize_storage_files(
-            &base_path,
-            &vec![storage_module_info.clone()],
-            &storage_config,
-        )?;
 
         // Override the default StorageModule config for testing
         let config = StorageConfig {

--- a/crates/actors/src/mining.rs
+++ b/crates/actors/src/mining.rs
@@ -314,9 +314,7 @@ mod tests {
     use actix::{Actor, Addr, ArbiterService, Recipient};
     use alloy_rpc_types_engine::ExecutionPayloadEnvelopeV1Irys;
     use irys_database::{open_or_create_db, tables::IrysTables};
-    use irys_storage::{
-        ie, initialize_storage_files, read_info_file, StorageModule, StorageModuleInfo,
-    };
+    use irys_storage::{ie, PackingParams, StorageModule, StorageModuleInfo};
     use irys_testing_utils::utils::{setup_tracing_and_temp_dir, temporary_directory};
     use irys_types::{
         app_state::DatabaseProvider, block_production::SolutionContext, chunk::UnpackedChunk,
@@ -389,16 +387,16 @@ mod tests {
 
         let tmp_dir = setup_tracing_and_temp_dir(Some("storage_module_test"), false);
         let base_path = tmp_dir.path().to_path_buf();
-        let _ = initialize_storage_files(&base_path, &infos, &storage_config);
-
-        // Verify the StorageModuleInfo file was crated in the base path
-        let file_infos = read_info_file(&base_path.join("StorageModule_0.json")).unwrap();
-        assert_eq!(file_infos, infos[0]);
 
         // Create a StorageModule with the specified submodules and config
         let storage_module_info = &infos[0];
         let storage_module =
             Arc::new(StorageModule::new(&base_path, storage_module_info, storage_config).unwrap());
+
+        // Verify the packing params file was crated in the submodule
+        let params_path = base_path.join("hdd0").join("packing_params.toml");
+        let params = PackingParams::from_toml(params_path).expect("packing params to load");
+        assert_eq!(params.partition_hash, Some(partition_hash));
 
         // Pack the storage module
         storage_module.pack_with_zeros();

--- a/crates/actors/src/packing.rs
+++ b/crates/actors/src/packing.rs
@@ -346,7 +346,7 @@ mod tests {
 
     use actix::Actor as _;
     use irys_packing::capacity_single::compute_entropy_chunk;
-    use irys_storage::{ii, initialize_storage_files, ChunkType, StorageModule, StorageModuleInfo};
+    use irys_storage::{ii, ChunkType, StorageModule, StorageModuleInfo};
     use irys_testing_utils::utils::setup_tracing_and_temp_dir;
     use irys_types::{
         partition::{PartitionAssignment, PartitionHash},
@@ -386,7 +386,6 @@ mod tests {
 
         let tmp_dir = setup_tracing_and_temp_dir(Some("test_packing_actor"), false);
         let base_path = tmp_dir.path().to_path_buf();
-        initialize_storage_files(&base_path, &infos, &storage_config)?;
 
         // Create a StorageModule with the specified submodules and config
         let storage_module_info = &infos[0];

--- a/crates/actors/tests/chunk_migration_test.rs
+++ b/crates/actors/tests/chunk_migration_test.rs
@@ -80,7 +80,6 @@ async fn finalize_block_test() -> eyre::Result<()> {
     let tmp_dir = setup_tracing_and_temp_dir(Some("chunk_migration_test"), false);
     let base_path = tmp_dir.path().to_path_buf();
     info!("temp_dir:{:?}\nbase_path:{:?}", tmp_dir, base_path);
-    let _ = initialize_storage_files(&base_path, &storage_module_infos, &storage_config);
 
     // Create a Vec initialized storage modules
     let mut storage_modules: Vec<Arc<StorageModule>> = Vec::new();

--- a/crates/chain/tests/api/external_api.rs
+++ b/crates/chain/tests/api/external_api.rs
@@ -113,7 +113,6 @@ async fn external_api() -> eyre::Result<()> {
     let tmp_dir = setup_tracing_and_temp_dir(Some("chunk_migration_test"), false);
     let base_path = tmp_dir.path().to_path_buf();
     info!("temp_dir:{:?}\nbase_path:{:?}", tmp_dir, base_path);
-    let _ = initialize_storage_files(&base_path, &storage_module_infos, &storage_config);
 
     // Create a Vec initialized storage modules
     let mut storage_modules: Vec<Arc<StorageModule>> = Vec::new();

--- a/crates/storage/src/chunk_provider.rs
+++ b/crates/storage/src/chunk_provider.rs
@@ -142,8 +142,9 @@ impl ChunkProvider {
 
 #[cfg(test)]
 mod tests {
+    use crate::StorageModuleInfo;
+
     use super::*;
-    use crate::{initialize_storage_files, StorageModuleInfo};
     use irys_database::{open_or_create_db, tables::IrysTables};
     use irys_packing::unpack_with_entropy;
     use irys_testing_utils::utils::setup_tracing_and_temp_dir;
@@ -174,8 +175,6 @@ mod tests {
             num_chunks_in_partition: 100,
             ..Default::default()
         };
-
-        initialize_storage_files(&base_path, &infos, &config)?;
 
         // Create a StorageModule with the specified submodules and config
         let storage_module_info = &infos[0];

--- a/crates/storage/src/storage_module.rs
+++ b/crates/storage/src/storage_module.rs
@@ -320,27 +320,6 @@ impl StorageModule {
             ));
         }
 
-        // This is temporary to help migrate testnet to the new config schema
-        // If there are intervals at the StorageModule level, write them to the submodules and delete the global file
-        let json_path: PathBuf = base_path.join(format!(
-            "StorageModule_{}_intervals.json",
-            storage_module_info.id
-        ));
-        match Self::read_global_intervals_file(&json_path) {
-            Ok(intervals) => {
-                let arc_intervals = Arc::new(RwLock::new(intervals));
-                // Split the intervals across submodules
-                if Self::write_intervals_to_submodules(&arc_intervals, &submodule_map).is_err() {
-                    panic!("could not update submodule intervals file");
-                }
-
-                // Remove the global file as it is now deprecated
-                fs::remove_file(json_path)
-                    .expect("to be able to remove deprecated StorageModule intervals file");
-            }
-            Err(_) => {}
-        }
-
         // Attempt to load a global set of intervals from the submodules
         let loaded_intervals = Self::load_intervals_from_submodules(&submodule_map);
 
@@ -488,20 +467,6 @@ impl StorageModule {
             }
         }
         global_intervals
-    }
-
-    #[deprecated(
-        since = "0.1",
-        note = "Intervals now stored per-submodule rather than globally. Use read_submodule_intervals() for new format."
-    )]
-    fn read_global_intervals_file(path: &PathBuf) -> eyre::Result<StorageIntervals> {
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(&path)
-            .wrap_err_with(|| format!("Failed to open intervals file at {}", path.display()))?;
-
-        read_intervals_file(&file)
     }
 
     /// Reads chunks from the specified range and returns their data and storage state

--- a/crates/storage/src/storage_module.rs
+++ b/crates/storage/src/storage_module.rs
@@ -911,27 +911,6 @@ impl StorageModule {
     }
 }
 
-/// Creates required storage directory structure and empty data files
-///
-/// Creates:
-/// - Base directory
-/// - Subdirectories for each range
-/// - Empty chunks.dat files in each subdirectory
-///
-/// Deletes:
-/// - the _intervals.json, resetting the storage module state
-///
-/// Used primarily for testing storage initialization
-pub fn initialize_storage_files(
-    base_path: &PathBuf,
-    infos: &Vec<StorageModuleInfo>,
-    storage_config: &StorageConfig,
-) -> Result<()> {
-    // TODO: Remove this method when ready to update all the tests
-
-    Ok(())
-}
-
 fn ensure_default_intervals(
     submodule_interval: &Interval<u32>,
     mut file: &File,
@@ -1127,8 +1106,6 @@ mod tests {
             num_chunks_in_partition: 20,
             ..Default::default()
         };
-
-        let _ = initialize_storage_files(&base_path, &infos, &config);
 
         // Create a StorageModule with the specified submodules and config
         let storage_module_info = &infos[0];

--- a/crates/storage/tests/storage_module_index_tests.rs
+++ b/crates/storage/tests/storage_module_index_tests.rs
@@ -80,8 +80,6 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
     let base_path = tmp_dir.path().to_path_buf();
     info!("temp_dir:{:?}\nbase_path:{:?}", tmp_dir, base_path);
 
-    let _ = initialize_storage_files(&base_path, &storage_module_infos, &storage_config);
-
     let mut storage_modules: Vec<Arc<StorageModule>> = Vec::new();
 
     // Create a Vec initialized storage modules


### PR DESCRIPTION
This is the promised fixup after testnet migration.

* Remove code related to migrating configs to the new format.
* Remove the now unused `initialize_storage_fies()` function
* patch up the tests that referenced it.

Note: The tests that require a wallet to be funded still fail because of that error.

My favorite part of this PR:

![image](https://github.com/user-attachments/assets/f9f7c0b4-0a59-463e-a4f3-694a0f713f87)

less code!