### PR TITLE
Fix/efficient sampling server reinitialization

### DIFF
--- a/crates/actors/src/mining.rs
+++ b/crates/actors/src/mining.rs
@@ -73,7 +73,7 @@ impl PartitionMiningActor {
             debug!("Non consecutive Step {} need to reconstruct ranges", step);
             let reset_step = self.ranges.reset_step(step);
             debug!(
-                "Near reset step is {} num recall ranges in partition {}",
+                "Nearest reset step is {}, num recall ranges in partition: {}",
                 reset_step, self.ranges.num_recall_ranges_in_partition
             );
             let start = if reset_step > self.ranges.last_step_num + 1 {

--- a/crates/actors/src/mining.rs
+++ b/crates/actors/src/mining.rs
@@ -70,10 +70,26 @@ impl PartitionMiningActor {
             debug!("Step {} already processed or next consecutive one", step);
             Ok(self.ranges.get_recall_range(step, seed, partition_hash) as u64)
         } else {
-            // This code is not needed for just one node, but will be needed for multiple nodes
-            warn!("Non consecutive Step {} need to reconstruct ranges", step);
-            let steps = vdf_steps.get_steps(ii(self.ranges.last_step_num + 1, step - 1))?;
-            self.ranges.reconstruct(&steps, partition_hash);
+            debug!("Non consecutive Step {} need to reconstruct ranges", step);
+            let reset_step = self.ranges.reset_step(step);
+            debug!("Near reset step is {} num recall ranges in partition {}", reset_step, self.ranges.num_recall_ranges_in_partition);
+            let start =
+                if reset_step > self.ranges.last_step_num + 1 {
+                    debug!(
+                        "Step {} is too far ahead of last processed step {}, reinitializing ranges ...",
+                        step, self.ranges.last_step_num
+                    );
+                    self.ranges.reinitialize();
+                    self.ranges.last_step_num = reset_step - 1;
+                    reset_step
+                } else {
+                    self.ranges.last_step_num + 1
+                };
+            debug!("Getting stored steps from ({}..={})", start, step - 1);
+            if start <= step - 1 {
+                let steps = vdf_steps.get_steps(ii(start, step - 1))?;
+                self.ranges.reconstruct(&steps, partition_hash);
+            };                
             Ok(self.ranges.get_recall_range(step, seed, partition_hash) as u64)
         }
     }
@@ -310,8 +326,8 @@ mod tests {
     };
     use crate::broadcast_mining_service::{BroadcastMiningSeed, BroadcastMiningService};
     use crate::mining::{PartitionMiningActor, Seed};
-    use crate::vdf_service::{GetVdfStateMessage, VdfService};
-    use actix::{Actor, Addr, ArbiterService, Recipient};
+    use crate::vdf_service::{GetVdfStateMessage, VdfSeed, VdfService};
+    use actix::{Actor, Addr, Recipient};
     use alloy_rpc_types_engine::ExecutionPayloadEnvelopeV1Irys;
     use irys_database::{open_or_create_db, tables::IrysTables};
     use irys_storage::{ie, PackingParams, StorageModule, StorageModuleInfo};
@@ -320,13 +336,31 @@ mod tests {
         app_state::DatabaseProvider, block_production::SolutionContext, chunk::UnpackedChunk,
         partition::PartitionAssignment, storage::LedgerChunkRange, Address, StorageConfig, H256,
     };
-    use irys_types::{H256List, IrysBlockHeader};
-    use irys_vdf::vdf_state::VdfStepsReadGuard;
+    use irys_types::{partition, H256List, IrysBlockHeader};
+    use irys_vdf::vdf_state::{VdfStepsReadGuard, VdfState};
     use std::any::Any;
+    use std::collections::VecDeque;
     use std::sync::atomic::AtomicU64;
     use std::sync::RwLock;
     use std::time::Duration;
     use tokio::time::sleep;
+
+    fn get_mocked_block_producer(closure_arc: Arc<RwLock<Option<SolutionContext>>>) -> BlockProducerMockActor {
+        let closure_arc = closure_arc.clone();
+        BlockProducerMockActor::mock(Box::new(move |msg, _ctx| {
+            let solution_message: SolutionFoundMessage =
+                *msg.downcast::<SolutionFoundMessage>().unwrap();
+            let solution = solution_message.0;
+
+            {
+                let mut lck = closure_arc.write().unwrap();
+                lck.replace(solution);
+            }
+
+            let inner_result = None::<(Arc<IrysBlockHeader>, ExecutionPayloadEnvelopeV1Irys)>;
+            Box::new(Some(inner_result)) as Box<dyn Any>
+        }))
+    }
 
     #[actix_rt::test]
     async fn test_solution() {
@@ -341,19 +375,7 @@ mod tests {
         let arc_rwlock = Arc::new(rwlock);
         let closure_arc = arc_rwlock.clone();
 
-        let mocked_block_producer = BlockProducerMockActor::mock(Box::new(move |msg, _ctx| {
-            let solution_message: SolutionFoundMessage =
-                *msg.downcast::<SolutionFoundMessage>().unwrap();
-            let solution = solution_message.0;
-
-            {
-                let mut lck = closure_arc.write().unwrap();
-                lck.replace(solution);
-            }
-
-            let inner_result = None::<(Arc<IrysBlockHeader>, ExecutionPayloadEnvelopeV1Irys)>;
-            Box::new(Some(inner_result)) as Box<dyn Any>
-        }));
+        let mocked_block_producer = get_mocked_block_producer(closure_arc);
 
         let block_producer_actor_addr: Addr<BlockProducerMockActor> = mocked_block_producer.start();
         let recipient: Recipient<SolutionFoundMessage> = block_producer_actor_addr.recipient();
@@ -501,5 +523,99 @@ mod tests {
             solution.data_path,
             "Not expected partition"
         );
+    }
+
+    #[actix_rt::test]
+    async fn test_recall_range_reinit() {
+        let mining_address = Address::random();
+        
+        let partition_hash = H256::random();
+        
+        let infos = vec![StorageModuleInfo {
+            id: 0,
+            partition_assignment: Some(PartitionAssignment {
+                partition_hash: partition_hash.clone(),
+                miner_address: mining_address,
+                ledger_id: Some(0),
+                slot_index: Some(0), // Submit Ledger Slot 0
+            }),
+            submodules: vec![
+                (ie(0, 10), "hdd0".into()), // 10 chunks
+            ],
+        }];
+
+        let tmp_dir = setup_tracing_and_temp_dir(Some("get_by_data_tx_offset_test"), false);
+        let base_path = tmp_dir.path().to_path_buf();
+        let db = open_or_create_db(tmp_dir, IrysTables::ALL, None).unwrap();
+        let database_provider = DatabaseProvider(Arc::new(db));
+
+        // Override the default StorageModule config for testing
+        let config = StorageConfig {
+            chunk_size: 32,
+            num_chunks_in_partition: 10,
+            num_chunks_in_recall_range: 2, // Recall range size is 5 chunks
+            miner_address: mining_address.clone(),
+            ..Default::default()
+        };
+
+        // Create a StorageModule with the specified submodules and config
+        let storage_module_info = &infos[0];
+        let storage_module = Arc::new(StorageModule::new(&base_path, storage_module_info, config.clone()).unwrap());
+        
+        let rwlock: RwLock<Option<SolutionContext>> = RwLock::new(None);
+        let arc_rwlock = Arc::new(rwlock);
+        let closure_arc = arc_rwlock.clone();
+        let mocked_block_producer = get_mocked_block_producer(closure_arc);
+        let block_producer_actor_addr: Addr<BlockProducerMockActor> = mocked_block_producer.start();
+        let recipient: Recipient<SolutionFoundMessage> = block_producer_actor_addr.recipient();
+        let mocked_addr = MockedBlockProducerAddr(recipient);
+
+        let vdf_state = VdfState {
+            global_step: 0,
+            max_seeds_num: 5,
+            seeds: VecDeque::new(),
+        };
+        
+        let vdf_service = VdfService::from_atomic_state(Arc::new(RwLock::new(vdf_state))).start();
+        let vdf_steps_guard: VdfStepsReadGuard =
+            vdf_service.send(GetVdfStateMessage).await.unwrap();
+
+        let hash: H256 = H256::random();
+        vdf_service.do_send(VdfSeed(Seed(hash)));
+        vdf_service.do_send(VdfSeed(Seed(hash)));
+        vdf_service.do_send(VdfSeed(Seed(hash)));                
+        vdf_service.do_send(VdfSeed(Seed(hash)));                
+        vdf_service.do_send(VdfSeed(Seed(hash))); //5                
+        // reset
+        vdf_service.do_send(VdfSeed(Seed(hash))); //6
+        vdf_service.do_send(VdfSeed(Seed(hash))); //7
+
+        sleep(Duration::from_secs(1)).await;
+
+        let atomic_global_step_number = Arc::new(AtomicU64::new(1));            
+
+        let mut partition_mining_actor = PartitionMiningActor::new(
+            mining_address,
+            database_provider.clone(),
+            mocked_addr.0,
+            storage_module,
+            false,
+            vdf_steps_guard.clone(),
+            atomic_global_step_number,
+        );        
+
+        let range = partition_mining_actor.get_recall_range(7, &hash, &partition_hash).unwrap();
+
+        let mut ranges = Ranges::new(5);
+        ranges.get_recall_range(1, &hash, &partition_hash);
+        ranges.get_recall_range(2, &hash, &partition_hash);
+        ranges.get_recall_range(3, &hash, &partition_hash);
+        ranges.get_recall_range(4, &hash, &partition_hash);
+        ranges.get_recall_range(5, &hash, &partition_hash);
+        // reset
+        ranges.get_recall_range(6, &hash, &partition_hash);
+        let range2 = ranges.get_recall_range(7, &hash, &partition_hash) as u64;
+
+        assert_eq!(range, range2, "Ranges should be equal");
     }
 }

--- a/crates/efficient-sampling/src/lib.rs
+++ b/crates/efficient-sampling/src/lib.rs
@@ -18,7 +18,7 @@ pub struct Ranges {
     /// last recall ranges by step number
     last_recall_ranges: HashMap<u64, usize>,
     /// num recall ranges in a partition, equal to ranges vector capacity
-    num_recall_ranges_in_partition: usize,
+    pub num_recall_ranges_in_partition: usize,
 }
 
 impl Ranges {
@@ -73,7 +73,7 @@ impl Ranges {
         range
     }
 
-    fn reinitialize(&mut self) {
+    pub fn reinitialize(&mut self) {
         info!("Reinitializing ranges");
         self.ranges.clear();
         for i in 0..self.num_recall_ranges_in_partition {
@@ -104,12 +104,16 @@ impl Ranges {
         }
     }
 
-    /// Reconstructs recall ranges from given seeds assuming last step number is the step of the first seed
+    /// Reconstructs recall ranges from given seeds assuming last step number + 1 is the step of the first seed
     pub fn reconstruct(&mut self, next_steps: &H256List, partition_hash: &H256) {
         let step = self.last_step_num;
         next_steps.0.iter().enumerate().for_each(|(i, seed)| {
             self.next_recall_range(step + 1 + i as u64, seed, partition_hash);
         });
+    }
+
+    pub fn reset_step(&mut self, step_num: u64) -> u64{
+        reset_step(step_num, self.num_recall_ranges_in_partition as u64)
     }
 }
 
@@ -151,6 +155,10 @@ pub fn get_recall_range(
 /// Get last step number where ranges were reinitialized
 pub fn reset_step_number(step_num: u64, config: &StorageConfig) -> u64 {
     let num_recall_ranges_in_partition = num_recall_ranges_in_partition(config);
+    reset_step(step_num, num_recall_ranges_in_partition)
+}
+
+pub fn reset_step(step_num: u64, num_recall_ranges_in_partition: u64) -> u64 {
     (step_num - 1) / num_recall_ranges_in_partition * num_recall_ranges_in_partition + 1
 }
 

--- a/crates/efficient-sampling/src/lib.rs
+++ b/crates/efficient-sampling/src/lib.rs
@@ -112,7 +112,7 @@ impl Ranges {
         });
     }
 
-    pub fn reset_step(&mut self, step_num: u64) -> u64{
+    pub fn reset_step(&mut self, step_num: u64) -> u64 {
         reset_step(step_num, self.num_recall_ranges_in_partition as u64)
     }
 }

--- a/crates/efficient-sampling/src/lib.rs
+++ b/crates/efficient-sampling/src/lib.rs
@@ -159,7 +159,7 @@ pub fn reset_step_number(step_num: u64, config: &StorageConfig) -> u64 {
 }
 
 pub fn reset_step(step_num: u64, num_recall_ranges_in_partition: u64) -> u64 {
-    (step_num - 1) / num_recall_ranges_in_partition * num_recall_ranges_in_partition + 1
+((step_num - 1) / num_recall_ranges_in_partition) * num_recall_ranges_in_partition + 1
 }
 
 pub fn num_recall_ranges_in_partition(config: &StorageConfig) -> u64 {


### PR DESCRIPTION
Here is the fix to miner efficient sampling recall ranges reinitialization with a vdf step number grater than cached vdf steps.

The problem was miner was trying to reproduce the hole sequence of recall ranges from step 1 and not from last reset step number, so the error popped up when the node reinits from a  step number is grater than partition's recall ranges (~64000). The previous logic was not prepared for reinitialization and assumed reconstructed steps were always a few of them in this part of the code.

I added a test trying to reproduce the case `test_recall_range_reinit`