### PR TITLE
feat: Replace unsafe numeric casting

### DIFF
--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -603,8 +603,8 @@ mod tests {
             data_path: Some(Base64(txs[poa_tx_num].proofs[poa_chunk_num].proof.clone())),
             chunk: Base64(poa_chunk.clone()),
             ledger_id: Some(1),
-            partition_chunk_offset: (poa_tx_num * 3 /* 3 chunks in each tx */ + poa_chunk_num)
-                as u32,
+            partition_chunk_offset: (poa_tx_num * 3 /* 3 chunks in each tx */ + poa_chunk_num).try_into()
+            .expect("Value exceeds u32::MAX"),
             recall_chunk_index: 0,
             partition_hash: context.partition_hash,
         };

--- a/crates/actors/src/chunk_migration_service.rs
+++ b/crates/actors/src/chunk_migration_service.rs
@@ -134,7 +134,8 @@ fn process_ledger_transactions(
     let mut prev_chunk_offset = block_range.start();
 
     for ((_txid, tx_path), (data_root, data_size)) in path_pairs {
-        let num_chunks_in_tx = data_size.div_ceil(chunk_size as u64) as u32;
+        let num_chunks_in_tx = TryInto::<u32>::try_into(data_size.div_ceil(chunk_size as u64))
+        .expect("Value exceeds u32::MAX");
         let tx_chunk_range = LedgerChunkRange(ie(
             prev_chunk_offset,
             prev_chunk_offset + num_chunks_in_tx as u64,

--- a/crates/actors/src/epoch_service.rs
+++ b/crates/actors/src/epoch_service.rs
@@ -470,7 +470,8 @@ impl EpochServiceActor {
             let ledgers = self.ledgers.read().unwrap();
             slot_needs = ledgers.get_slot_needs(ledger);
         }
-        let mut capacity_count = capacity_partitions.len() as u32;
+        let mut capacity_count = capacity_partitions.len().try_into()
+        .expect("Value exceeds u32::MAX");
 
         // Iterate over slots that need partitions and assign them
         for (slot_index, num_needed) in slot_needs {
@@ -651,7 +652,8 @@ impl EpochServiceActor {
     /// Configure storage modules for genesis partition assignments
     pub fn get_genesis_storage_module_infos(&self) -> Vec<StorageModuleInfo> {
         let ledgers = self.ledgers.read().unwrap();
-        let num_part_chunks = self.config.storage_config.num_chunks_in_partition as u32;
+        let num_part_chunks = self.config.storage_config.num_chunks_in_partition.try_into()
+        .expect("Value exceeds u32::MAX");
 
         let pa = self.partition_assignments.read().unwrap();
         let sm_paths = &STORAGE_SUBMODULES_CONFIG.submodule_paths;

--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -699,7 +699,8 @@ mod tests {
                 data_size,
                 data_path: data_path.clone(),
                 bytes: chunk_bytes.clone(),
-                tx_offset: tx_chunk_offset as u32,
+                tx_offset: tx_chunk_offset.try_into()
+                .expect("Value exceeds u32::MAX"),
             });
 
             let is_last_chunk = tx_chunk_offset == last_index;
@@ -723,7 +724,8 @@ mod tests {
             let (meta, chunk) = irys_database::cached_chunk_by_chunk_offset(
                 &db_tx,
                 data_root,
-                tx_chunk_offset as u32,
+                tx_chunk_offset.try_into()
+                .expect("Value exceeds u32::MAX"),
             )
             .unwrap()
             .unwrap();
@@ -739,7 +741,8 @@ mod tests {
             if is_last_chunk {
                 // read the set of chunks
                 // only offset 2 (last chunk) should have data
-                let res = storage_module.read_chunks(ii(0, last_index as u32))?;
+                let res = storage_module.read_chunks(ii(0, last_index.try_into()
+                .expect("Value exceeds u32::MAX")))?;
                 let r = res.get(&2).unwrap();
                 let mut packed_bytes = r.0.clone();
                 // unpack the data (packing was all 0's)

--- a/crates/actors/src/mining.rs
+++ b/crates/actors/src/mining.rs
@@ -100,7 +100,7 @@ impl PartitionMiningActor {
 
         // Starting chunk index within partition
         let start_chunk_offset =
-            recall_range_index as u32 * config.num_chunks_in_recall_range as u32;
+            (recall_range_index as u32).saturating_mul(config.num_chunks_in_recall_range as u32);
 
         // info!(
         //     "Recall range index {} start chunk index {}",

--- a/crates/actors/src/packing.rs
+++ b/crates/actors/src/packing.rs
@@ -325,7 +325,13 @@ pub async fn wait_for_packing(
                 // try to get all the semaphore permits - this is how we know that the packing is done
                 let _permit =
                     futures::future::join_all(internals.semaphore.iter().map(|(_, s)| {
-                        s.as_ref().acquire_many(internals.config.concurrency as u32)
+                        s.as_ref().acquire_many(
+                            internals
+                                .config
+                                .concurrency
+                                .try_into()
+                                .expect("Value exceeds u32::MAX"),
+                        )
                     }))
                     .await
                     .iter()

--- a/crates/api-server/src/lib.rs
+++ b/crates/api-server/src/lib.rs
@@ -187,7 +187,7 @@ async fn post_tx_and_chunks_golden_path() {
             data_size,
             data_path,
             bytes: Base64(data_bytes[min..max].to_vec()),
-            tx_offset: tx_chunk_offset as u32,
+            tx_offset: tx_chunk_offset.try_into().expect("Value exceeds u32::MAX"),
         };
 
         // Make a POST request with JSON payload

--- a/crates/chain/tests/api/api.rs
+++ b/crates/chain/tests/api/api.rs
@@ -115,7 +115,7 @@ async fn api_end_to_end_test(chunk_size: usize) {
             data_size,
             data_path,
             bytes: Base64(data_bytes[min..max].to_vec()),
-            tx_offset: index as u32,
+            tx_offset: index.try_into().expect("Value exceeds u32::MAX"),
         };
 
         // Make a POST request with JSON payload

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -97,7 +97,8 @@ pub async fn capacity_chunk_solution(
 
     SolutionContext {
         partition_hash,
-        chunk_offset: recall_range_idx as u32 * storage_config.num_chunks_in_recall_range as u32,
+        chunk_offset: (recall_range_idx as u32)
+            .saturating_mul(storage_config.num_chunks_in_recall_range as u32),
         mining_address: miner_addr,
         chunk: entropy_chunk,
         vdf_step: step_num,

--- a/crates/chain/tests/data_promotion_test.rs
+++ b/crates/chain/tests/data_promotion_test.rs
@@ -384,7 +384,7 @@ where
         data_size: tx.header.data_size,
         data_path: Base64(tx.proofs[chunk_index].proof.to_vec()),
         bytes: Base64(chunks[chunk_index].to_vec()),
-        tx_offset: chunk_index as u32,
+        tx_offset: chunk_index.try_into().expect("Value exceeds u32::MAX"),
     };
 
     let resp = test::call_service(

--- a/crates/efficient-sampling/src/lib.rs
+++ b/crates/efficient-sampling/src/lib.rs
@@ -61,7 +61,10 @@ impl Ranges {
             let rng_seed: u32 = u32::from_be_bytes(hasher.finish()[28..32].try_into().unwrap());
             let mut rng = SimpleRNG::new(rng_seed);
 
-            let next_range_pos = (rng.next() % self.last_range_pos as u32) as usize; // usize (one word in current CPU architecture) to u32 is safe in 32bits of above architectures
+            let next_range_pos = (rng.next()
+                % TryInto::<u32>::try_into(self
+                    .last_range_pos)
+                    .expect("Value exceeds u32::MAX")) as usize; // usize (one word in current CPU architecture) to u32 is safe in 32bits of above architectures
             let range = self.ranges[next_range_pos];
             self.ranges[next_range_pos] = self.ranges[self.last_range_pos]; // overwrite returned range with last one
             self.last_range_pos -= 1;

--- a/crates/storage/src/storage_module.rs
+++ b/crates/storage/src/storage_module.rs
@@ -311,7 +311,13 @@ impl StorageModule {
         let gaps = global_intervals
             .gaps_untrimmed(ii(0, u32::MAX))
             .collect::<Vec<_>>();
-        let expected = vec![ii(storage_config.num_chunks_in_partition as u32, u32::MAX)];
+        let expected = vec![ii(
+            storage_config
+                .num_chunks_in_partition
+                .try_into()
+                .expect("Value exceeds u32::MAX"),
+            u32::MAX,
+        )];
         if &gaps != &expected {
             return Err(eyre!(
                 "Invalid storage module config, expected range {:?}, got range {:?}",
@@ -742,7 +748,7 @@ impl StorageModule {
 
         // Get chunk info and calculate index
         let range = self.get_storage_module_range()?;
-        let partition_offset = (ledger_offset - range.start()) as u32;
+        let partition_offset = (ledger_offset - range.start()).try_into().expect("Value exceeds u32::MAX");
         let closest_offsets = self.collect_start_offsets(data_root)?;
 
         let nearest_start_offset = closest_offsets
@@ -871,7 +877,10 @@ impl StorageModule {
         let storage_module_range = self.get_storage_module_range()?;
         let start = chunk_range.start() - storage_module_range.start();
         let end = chunk_range.end() - storage_module_range.start();
-        Ok(PartitionChunkRange(ii(start as u32, end as u32)))
+        Ok(PartitionChunkRange(ii(
+            start.try_into().expect("Value exceeds u32::MAX"),
+            end.try_into().expect("Value exceeds u32::MAX"),
+        )))
     }
 
     /// utility function to take a ledger relative offset and makes it

--- a/crates/storage/tests/storage_module_index_tests.rs
+++ b/crates/storage/tests/storage_module_index_tests.rs
@@ -340,7 +340,7 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
                 data_size: chunk_bytes.len() as u64,
                 data_path: Base64(proof.proof.clone()),
                 bytes: chunk_bytes,
-                tx_offset: i as u32,
+                tx_offset: i.try_into().expect("Value exceeds u32::MAX"),
             };
 
             let _ = db.update_eyre(|tx| cache_chunk(tx, &chunk));
@@ -353,7 +353,7 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
     let mut ledger_offset: LedgerChunkOffset = 0;
     for tx in &txs {
         let data_root = tx.header.data_root;
-        let num_chunks = (tx.header.data_size / chunk_size) as u32;
+        let num_chunks = (tx.header.data_size / chunk_size).try_into().expect("Value exceeds u32::MAX");
 
         // Retrieve the partition assignments from the data root
         let hashes = db
@@ -537,7 +537,7 @@ fn calculate_tx_ranges(
         num_chunks_in_tx = (num_chunks_in_tx as i64 + partition_start) as u64;
     }
 
-    let partition_start = partition_start.max(0) as u32;
+    let partition_start = partition_start.max(0).try_into().expect("Value exceeds u32::MAX");
 
     let partition_range = PartitionChunkRange(ie(
         partition_start,

--- a/crates/types/src/difficulty_adjustment_config.rs
+++ b/crates/types/src/difficulty_adjustment_config.rs
@@ -114,7 +114,7 @@ pub fn calculate_difficulty(
     // Calculate difference
     let percent_diff = actual_block_time.abs_diff(target_block_time).as_millis() * 100
         / target_block_time.as_millis();
-    let min_threshold = (difficulty_config.min_adjustment_factor * dec![100.0])
+    let min_threshold: u128 = (difficulty_config.min_adjustment_factor * dec![100.0])
         .try_into()
         .unwrap();
 
@@ -122,7 +122,7 @@ pub fn calculate_difficulty(
         actual_block_time,
         target_block_time,
         percent_different: percent_diff as u32,
-        min_threshold: min_threshold as u32,
+        min_threshold: min_threshold.try_into().expect("Value exceeds u32::MAX"),
         is_adjusted: percent_diff > min_threshold,
     };
 


### PR DESCRIPTION
Ref #81 

This PR will break down the unsafe conversions in the following steps(respective commits):
- u32
- u8
- u64
- u128(if any)

Currently, this PR has implemented safe conversion for `u32`. 

Will update this description as progress is made on the other types.