### PR TITLE
feat: remove the unused PartitionHashesByDataRoot table

### DIFF
--- a/crates/actors/src/mining.rs
+++ b/crates/actors/src/mining.rs
@@ -70,7 +70,10 @@ impl PartitionMiningActor {
             debug!("Step {} already processed or next consecutive one", step);
             Ok(self.ranges.get_recall_range(step, seed, partition_hash) as u64)
         } else {
-            debug!("Non consecutive step {} may need to reconstruct ranges", step);
+            debug!(
+                "Non consecutive step {} may need to reconstruct ranges",
+                step
+            );
             // calculate the nearest step lower or equal to step where recall ranges are reinitialized, as this is the step from where ranges will be recalculated
             let reset_step = self.ranges.reset_step(step);
             debug!(
@@ -89,9 +92,9 @@ impl PartitionMiningActor {
                 next_ranges_step
             };
             // check if we need to reconstruct steps, that is inverval start..=step-1 is not empty
-            if start <= step - 1 {  
+            if start <= step - 1 {
                 debug!("Getting stored steps from ({}..={})", start, step - 1);
-                let vdf_steps = self.steps_guard.read();                
+                let vdf_steps = self.steps_guard.read();
                 let steps = vdf_steps.get_steps(ii(start, step - 1))?; // -1 because last step is calculated in next get_recall_range call, with its corresponding argument seed
                 self.ranges.reconstruct(&steps, partition_hash);
             };

--- a/crates/database/src/tables.rs
+++ b/crates/database/src/tables.rs
@@ -107,10 +107,6 @@ tables! {
     /// Indexes Ingress proofs by their data_root
     table IngressProofs<Key = DataRoot, Value = IngressProof>;
 
-    /// Maps a data root to the partition hashes that store it. Primarily used for chunk ingress.
-    /// Common case is a 1:1, but 1:N is possible
-    table PartitionHashesByDataRoot<Key = DataRoot, Value = PartitionHashes>;
-
     /// Maps an ingress proof (by data_root) to the latest possible height it could be used at, given known transactions.
     /// this value is updated every time we receive a valid to-be-promoted transaction to (<height of anchor block> + ANCHOR_EXPIRY_DEPTH)
     /// and is pruned if value > <current_height>

--- a/crates/efficient-sampling/src/lib.rs
+++ b/crates/efficient-sampling/src/lib.rs
@@ -159,7 +159,7 @@ pub fn reset_step_number(step_num: u64, config: &StorageConfig) -> u64 {
 }
 
 pub fn reset_step(step_num: u64, num_recall_ranges_in_partition: u64) -> u64 {
-((step_num - 1) / num_recall_ranges_in_partition) * num_recall_ranges_in_partition + 1
+    ((step_num - 1) / num_recall_ranges_in_partition) * num_recall_ranges_in_partition + 1
 }
 
 pub fn num_recall_ranges_in_partition(config: &StorageConfig) -> u64 {


### PR DESCRIPTION
This PR removes the unused PartitionHashesByDataRoot table, as well as it's associated DB methods and the one place in the one test that used it (the test passes with these modifications)
closes #85 