### PR TITLE
feat: allow production instances to forego the instance subdirectory

### DIFF
--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -107,7 +107,7 @@ pub async fn start_for_testing_default(
     let config = IrysNodeConfig {
         base_directory: setup_tracing_and_temp_dir(name, keep).into_path(),
         mining_signer: miner_signer.clone(),
-        ..Default::default()
+        ..IrysNodeConfig::default()
     };
 
     let storage_config = StorageConfig {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -21,9 +21,8 @@ pub mod chain;
 pub struct IrysNodeConfig {
     /// Signer instance used for mining
     pub mining_signer: IrysSigner,
-    /// Node ID/instance number: used for testing
-    pub instance_number: u32,
-
+    /// Node ID/instance number: used for testing. if omitted, an instance subfolder is not created. reth will still be set as instance `1`.
+    pub instance_number: Option<u32>,
     /// base data directory, i.e `./.tmp`
     /// should not be used directly, instead use the appropriate methods, i.e `instance_directory`
     pub base_directory: PathBuf,
@@ -41,7 +40,7 @@ impl Default for IrysNodeConfig {
         Self {
             chainspec_builder: IrysChainSpecBuilder::mainnet(),
             mining_signer: IrysSigner::random_signer(),
-            instance_number: 1,
+            instance_number: Some(1),
             base_directory: base_dir,
         }
     }
@@ -58,7 +57,7 @@ impl IrysNodeConfig {
     pub fn mainnet() -> Self {
         Self {
             mining_signer: IrysSigner::mainnet_from_slice(&decode_hex(CONFIG.mining_key).unwrap()),
-            instance_number: 1,
+            instance_number: None,
             base_directory: env::current_dir()
                 .expect("Unable to determine working dir, aborting")
                 .join(".irys"),
@@ -67,8 +66,12 @@ impl IrysNodeConfig {
     }
 
     /// get the instance-specific directory path
+    /// this will return the base directory if instance_number is not `Some`
     pub fn instance_directory(&self) -> PathBuf {
-        self.base_directory.join(self.instance_number.to_string())
+        self.instance_number
+            .map_or(self.base_directory.clone(), |i| {
+                self.base_directory.join(i.to_string())
+            })
     }
     /// get the instance-specific storage module directory path
     pub fn storage_module_dir(&self) -> PathBuf {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -39,7 +39,7 @@ impl Default for IrysNodeConfig {
         Self {
             chainspec_builder: IrysChainSpecBuilder::mainnet(),
             mining_signer: IrysSigner::random_signer(),
-            instance_number: Some(1),
+            instance_number: None, // no instance dir
             base_directory: base_dir,
         }
     }

--- a/crates/reth-node-bridge/src/node.rs
+++ b/crates/reth-node-bridge/src/node.rs
@@ -144,7 +144,7 @@ pub async fn run_node<T: HasName + HasTableType>(
         "node",
         "-vvvvv",
         "--instance",
-        format!("{}", irys_config.instance_number),
+        format!("{}", irys_config.instance_number.unwrap_or(1)),
         "--disable-discovery",
         "--http",
         "--http.api",


### PR DESCRIPTION
This PR is a small tweak to how instance directories work - instance_number is now optional, and a none value will forego creating a subdirectory at all.