### PR TITLE
fix: StorageSubmoduleConfig initialisation

### DIFF
--- a/crates/actors/src/mining.rs
+++ b/crates/actors/src/mining.rs
@@ -344,7 +344,7 @@ mod tests {
         app_state::DatabaseProvider, block_production::SolutionContext, chunk::UnpackedChunk,
         partition::PartitionAssignment, storage::LedgerChunkRange, Address, StorageConfig, H256,
     };
-    use irys_types::{partition, H256List, IrysBlockHeader};
+    use irys_types::{H256List, IrysBlockHeader};
     use irys_vdf::vdf_state::{VdfState, VdfStepsReadGuard};
     use std::any::Any;
     use std::collections::VecDeque;

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -147,7 +147,7 @@ pub async fn start_irys_node(
     }
 
     // Autogenerates the ".irys_submodules.toml" in dev mode
-    StorageSubmodulesConfig::load();
+    let storage_module_config = StorageSubmodulesConfig::load(base_dir.clone()).unwrap();
 
     if PACKING_TYPE != PackingType::CPU && storage_config.chunk_size != CHUNK_SIZE {
         error!("GPU packing only supports chunk size {}!", CHUNK_SIZE)
@@ -354,7 +354,7 @@ pub async fn start_irys_node(
 
                 // Get the genesis storage modules and their assigned partitions
                 let storage_module_infos = epoch_service_actor_addr
-                    .send(GetGenesisStorageModulesMessage)
+                    .send(GetGenesisStorageModulesMessage(storage_module_config))
                     .await
                     .unwrap();
 

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -293,7 +293,7 @@ pub async fn start_irys_node(
                     if latest.unwrap().unwrap().header.number != latest_block.height {
                         error!("Reth is out of sync with Irys block index! recovery will be attempted.")
                     };
-                    
+
                 }
 
                 RethServiceActor::from_registry()
@@ -532,7 +532,7 @@ pub async fn start_irys_node(
                         })
                         .collect::<Vec<()>>();
                 }
-                
+
                 // let _ = wait_for_packing(packing_actor_addr.clone(), None).await;
                 // debug!("Packing complete");
 

--- a/crates/chain/tests/block_production/basic_contract.rs
+++ b/crates/chain/tests/block_production/basic_contract.rs
@@ -1,19 +1,15 @@
-use std::{future::Future, time::Duration};
+use std::time::Duration;
 
 use alloy_core::primitives::U256;
 use alloy_network::EthereumWallet;
 use alloy_provider::ProviderBuilder;
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_macro::sol;
-use futures::future::select;
-use irys_actors::block_producer::SolutionFoundMessage;
-use irys_chain::{chain::start_for_testing, IrysNodeCtx};
+use irys_chain::chain::start_for_testing;
 use irys_config::IrysNodeConfig;
 use irys_testing_utils::utils::setup_tracing_and_temp_dir;
-use irys_types::{irys::IrysSigner, StorageConfig, VDFStepsConfig};
-use irys_vdf::vdf_state::VdfStepsReadGuard;
+use irys_types::irys::IrysSigner;
 use reth_primitives::GenesisAccount;
-use tokio::time::sleep;
 use tracing::info;
 
 use crate::utils::future_or_mine_on_timeout;

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -5,20 +5,12 @@ use alloy_core::primitives::{ruint::aliases::U256, Bytes, TxKind, B256};
 use alloy_eips::eip2718::Encodable2718;
 use alloy_signer_local::LocalSigner;
 use eyre::eyre;
-use irys_actors::{
-    block_producer::SolutionFoundMessage, block_validation, mempool_service::TxIngressMessage,
-};
+use irys_actors::{block_producer::SolutionFoundMessage, mempool_service::TxIngressMessage};
 use irys_chain::chain::start_for_testing;
 use irys_config::IrysNodeConfig;
-use irys_packing::capacity_single::compute_entropy_chunk;
 use irys_reth_node_bridge::adapter::{node::RethNodeContext, transaction::TransactionTestContext};
-use irys_storage::ii;
 use irys_testing_utils::utils::setup_tracing_and_temp_dir;
-use irys_types::{
-    block_production::Seed, block_production::SolutionContext, irys::IrysSigner,
-    vdf_config::VDFStepsConfig, Address, H256List, IrysTransaction, StorageConfig, CONFIG, H256,
-};
-use irys_vdf::{step_number_to_salt_number, vdf_sha, vdf_state::VdfStepsReadGuard};
+use irys_types::{irys::IrysSigner, IrysTransaction, CONFIG};
 use k256::ecdsa::SigningKey;
 use reth::{providers::BlockReader, rpc::types::TransactionRequest};
 use reth_db::Database;
@@ -26,9 +18,9 @@ use reth_primitives::{
     irys_primitives::{IrysTxId, ShadowResult},
     GenesisAccount,
 };
-use sha2::{Digest, Sha256};
+use sha2::Digest;
 use tokio::time::sleep;
-use tracing::{debug, info};
+use tracing::info;
 
 use crate::utils::capacity_chunk_solution;
 /// Create a valid capacity PoA solution

--- a/crates/chain/tests/block_production/mod.rs
+++ b/crates/chain/tests/block_production/mod.rs
@@ -2,4 +2,3 @@ mod analytics;
 pub mod basic_contract;
 pub mod block_production;
 mod external_tx;
-use block_production::*;

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -4,7 +4,6 @@ use std::{
     fs,
     num::ParseIntError,
     path::{Path, PathBuf},
-    str::FromStr as _,
 };
 
 use chain::chainspec::IrysChainSpecBuilder;

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -182,6 +182,8 @@ pub struct StorageSubmodulesConfig {
     pub submodule_paths: Vec<PathBuf>,
 }
 
+const FILENAME: &str = ".irys_submodules.toml";
+
 impl StorageSubmodulesConfig {
     /// Loads the [`StorageSubmodulesConfig`] from a TOML file at the given path
     pub fn from_toml(path: impl AsRef<Path>) -> eyre::Result<Self> {
@@ -201,29 +203,7 @@ impl StorageSubmodulesConfig {
         Ok(config)
     }
 
-    /// Forces the lazy loading of the [`STORAGE_SUBMODULES_CONFIG`]
-    pub fn load() {
-        let _ = STORAGE_SUBMODULES_CONFIG.submodule_paths.len();
-    }
-}
-
-/// Constant used to make sure .irys shows up in the right place all the time
-pub const CARGO_MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
-
-/// Configure storage submodule paths:
-/// - In deployed envs (IRYS_ENV set): Try HOME/.irys_submodules.toml first
-/// - Otherwise: Use/create .irys/<instance id>/.irys_submodules.toml
-/// - Default: Create config with hardcoded submodule paths in .irys
-pub static STORAGE_SUBMODULES_CONFIG: once_cell::sync::Lazy<StorageSubmodulesConfig> =
-    once_cell::sync::Lazy::new(|| {
-        const FILENAME: &str = ".irys_submodules.toml";
-        // let node_config = IrysNodeConfig::default();
-        // let instance_dir = node_config.instance_directory();
-
-        // hack for now until I can rework this entire thing
-        let instance_dir = PathBuf::from_str(CARGO_MANIFEST_DIR)
-            .unwrap()
-            .join("../../.irys/1");
+    pub fn load(instance_dir: PathBuf) -> eyre::Result<Self> {
         let home_dir = env::var("HOME").expect("Failed to get home directory");
 
         let is_deployed = env::var("IRYS_ENV").is_ok();
@@ -277,13 +257,13 @@ pub static STORAGE_SUBMODULES_CONFIG: once_cell::sync::Lazy<StorageSubmodulesCon
                     }
                 }
 
-                return config;
+                return Ok(config);
             }
         }
 
         // Try .irys directory config in dev/local environment
         if config_path_local.exists() {
-            return StorageSubmodulesConfig::from_toml(config_path_local).unwrap();
+            return StorageSubmodulesConfig::from_toml(config_path_local);
         } else {
             // Create default config with hardcoded paths in dev if none exists
             tracing::info!("Creating default config at {:?}", config_path_local);
@@ -309,6 +289,8 @@ pub static STORAGE_SUBMODULES_CONFIG: once_cell::sync::Lazy<StorageSubmodulesCon
             }
 
             // Load the config to verify it parses
-            StorageSubmodulesConfig::from_toml(config_path_local).unwrap()
+            StorageSubmodulesConfig::from_toml(config_path_local)
         }
-    });
+        // let _ = STORAGE_SUBMODULES_CONFIG.submodule_paths.len();
+    }
+}

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -5,10 +5,8 @@ use crate::db_cache::{
 };
 use crate::tables::{
     CachedChunks, CachedChunksIndex, CachedDataRoots, IrysBlockHeaders, IrysTxHeaders,
-    PartitionHashes,
 };
 
-use irys_types::partition::PartitionHash;
 use irys_types::{
     Address, BlockHash, ChunkPathHash, DataRoot, IrysBlockHeader, IrysTransactionHeader,
     IrysTransactionId, TxRelativeChunkOffset, UnpackedChunk, MEGABYTE, U256,

--- a/crates/debug-utils/src/db.rs
+++ b/crates/debug-utils/src/db.rs
@@ -1,12 +1,6 @@
 use irys_database::{
     open_or_create_db,
-    reth_db::{
-        cursor::*,
-        mdbx::{tx::Tx, RO},
-        table::Table,
-        transaction::DbTx,
-        Database as _, DatabaseEnv, HasName, HasTableType,
-    },
+    reth_db::{Database as _, DatabaseEnv},
     tables::{IngressProofs, IrysTables, IrysTxHeaders},
     walk_all,
 };
@@ -16,7 +10,6 @@ pub fn load_db() -> DatabaseEnv {
     open_or_create_db(path, IrysTables::ALL, None).unwrap()
 }
 
-#[test]
 fn promotion_debug() -> eyre::Result<()> {
     let db = load_db();
     let read_tx = db.tx()?;

--- a/crates/reth-node-bridge/src/launcher.rs
+++ b/crates/reth-node-bridge/src/launcher.rs
@@ -39,8 +39,7 @@ use reth_provider::ChainStateBlockReader;
 use reth_provider::ChainStateBlockWriter;
 use reth_provider::{
     providers::{BlockchainProvider2, ProviderNodeTypes},
-    writer::UnifiedStorageWriter,
-    BlockHashReader as _, DatabaseProviderFactory as _, StaticFileProviderFactory as _,
+    StaticFileProviderFactory as _,
 };
 use reth_rpc_engine_api::{capabilities::EngineCapabilities, EngineApi};
 use reth_tasks::TaskExecutor;
@@ -181,7 +180,7 @@ where
             .with_metrics_task()
             // passing FullNodeTypes as type parameter here so that we can build
             // later the components.
-            .with_blockchain_db::<T, _>(move |provider_factory| {            
+            .with_blockchain_db::<T, _>(move |provider_factory| {
                 Ok(BlockchainProvider2::new(provider_factory)?)
             }, tree_config, canon_state_notification_sender)?
             // "inspect" fn to unwind blocks that are out of sync with Irys
@@ -195,7 +194,7 @@ where
                 let last = provider.last_block_number()?;
 
                 let target = latest_irys_block_height;
-                
+
                 if target >= last {
                     warn!("requesting to prune reth block ({}) ahead (or equal to) of current state ({})", &target, &last);
                     return Ok(false)
@@ -217,7 +216,7 @@ where
                    /*  if self.offline {
                         info!(target: "reth::cli", "Performing an unwind for offline-only data!");
                     } */
-        
+
                     if let Some(highest_static_file_block) = highest_static_file_block {
                         info!(target: "reth::cli", ?range, ?highest_static_file_block, "Executing a pipeline unwind.");
                     } else {
@@ -226,19 +225,19 @@ where
 
                     let mut pipeline = crate::prune_pipeline::build_pipeline(false, config.stages.clone(), config.prune.clone(), provider_factory.clone())?;
 
-        
+
                     // Move all applicable data from database to static files.
                     pipeline.move_to_static_files()?;
-        
+
                     pipeline.unwind((*range.start()).saturating_sub(1), None)?;
                 } else {
                     info!(target: "reth::cli", ?range, "Executing a database unwind.");
                     let provider = provider_factory.provider_rw()?;
-        
+
                     let _ = provider
                         .take_block_and_execution_range(range.clone())
                         .map_err(|err| eyre::eyre!("Transaction error on unwind: {err}"))?;
-        
+
                     // update finalized block if needed
                     let last_saved_finalized_block_number = provider.last_finalized_block_number()?;
                     let range_min =
@@ -248,13 +247,13 @@ where
                     {
                         provider.save_finalized_block_number(BlockNumber::from(range_min))?;
                     }
-        
+
                     provider.commit()?;
                 }
                 Ok(true)
             }();
-            
-        match result 
+
+        match result
             {
                 Err(e) => {
                     error!("Error pruning: {}", &e);
@@ -268,7 +267,7 @@ where
                   ()
                 }
             };
-            })          
+            })
             .with_components(components_builder, on_component_initialized, Some(irys_ext.clone())).await?;
 
         // spawn exexs

--- a/crates/storage/src/storage_module.rs
+++ b/crates/storage/src/storage_module.rs
@@ -147,6 +147,8 @@ impl PackingParams {
 pub struct StorageSubmodule {
     /// Persistent database env
     pub db: DatabaseProvider,
+    /// path to this Submodule
+    pub path: PathBuf,
     /// Persistent storage handle
     file: Arc<Mutex<File>>,
     /// Intervals file handle
@@ -199,7 +201,7 @@ impl StorageModule {
 
         // Initialize the submodules from the StorageModuleInfo
         for (submodule_interval, dir) in storage_module_info.submodules.clone() {
-            let sub_base_path = base_path.join(dir);
+            let sub_base_path = base_path.join(dir.clone());
 
             println!("{:?}", sub_base_path);
             fs::create_dir_all(&sub_base_path)?; // Ensure the directory exists (for component tests)
@@ -286,6 +288,7 @@ impl StorageModule {
                 .insert_strict(
                     submodule_interval.clone(),
                     StorageSubmodule {
+                        path: dir,
                         file: chunks_file,
                         db: DatabaseProvider(Arc::new(submodule_db)),
                         intervals_file: Arc::new(Mutex::new(submodules_intervals_file)),

--- a/crates/vdf/src/lib.rs
+++ b/crates/vdf/src/lib.rs
@@ -382,7 +382,6 @@ fn warn_mismatches(a: &H256List, b: &H256List) {
 #[cfg(test)]
 mod tests {
     use base58::{FromBase58, ToBase58};
-    use irys_types::CONFIG;
 
     use super::*;
     #[test]
@@ -394,7 +393,7 @@ mod tests {
                 .unwrap(),
         );
 
-        let mut reset_seed = H256([0; 32]);
+        let reset_seed = H256([0; 32]);
         print!("seed: {:?}\n", seed);
 
         let start_step_number = 44399;


### PR DESCRIPTION
This PR:
- "demotes" StorageSubmoduleConfig from a LazyStatic to a regular struct, this is so we can reliably pass through the instance directory.
Closes #196 