### PR TITLE
Feat: initial nextest integration

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,151 @@
+# This is the default config used by nextest. It is embedded in the binary at
+# build time. It may be used as a template for .config/nextest.toml.
+
+[store]
+# The directory under the workspace root at which nextest-related files are
+# written. Profile-specific storage is currently written to dir/<profile-name>.
+dir = "target/nextest"
+
+# This section defines the default nextest profile. Custom profiles are layered
+# on top of the default profile.
+[profile.default]
+# The set of tests run by `cargo nextest run` by default.
+default-filter = "all()"
+
+# "retries" defines the number of times a test should be retried. If set to a
+# non-zero value, tests that succeed on a subsequent attempt will be marked as
+# flaky. Can be overridden through the `--retries` option.
+# Examples
+# * retries = 3
+# * retries = { backoff = "fixed", count = 2, delay = "1s" }
+# * retries = { backoff = "exponential", count = 10, delay = "1s", jitter = true, max-delay = "10s" }
+retries = 3
+
+# The number of threads to run tests with. Supported values are either an integer or
+# the string "num-cpus". Can be overridden through the `--test-threads` option.
+test-threads = "num-cpus"
+
+# The number of threads required for each test. This is generally used in overrides to
+# mark certain tests as heavier than others. However, it can also be set as a global parameter.
+threads-required = 1
+
+# Extra arguments to pass in to the test binary at runtime. Intended primarily for
+# communication with custom test harnesses -- use with caution!
+run-extra-args = []
+
+# Show these test statuses in the output.
+#
+# The possible values this can take are:
+# * none: no output
+# * fail: show failed (including exec-failed) tests
+# * retry: show flaky and retried tests
+# * slow: show slow tests
+# * pass: show passed tests
+# * skip: show skipped tests (most useful for CI)
+# * all: all of the above
+#
+# Each value includes all the values above it; for example, "slow" includes
+# failed and retried tests.
+#
+# Can be overridden through the `--status-level` flag.
+status-level = "pass"
+
+# Similar to status-level, show these test statuses at the end of the run.
+final-status-level = "flaky"
+
+# "failure-output" defines when standard output and standard error for failing tests are produced.
+# Accepted values are
+# * "immediate": output failures as soon as they happen
+# * "final": output failures at the end of the test run
+# * "immediate-final": output failures as soon as they happen and at the end of
+#   the test run; combination of "immediate" and "final"
+# * "never": don't output failures at all
+#
+# For large test suites and CI it is generally useful to use "immediate-final".
+#
+# Can be overridden through the `--failure-output` option.
+failure-output = "immediate"
+
+# "success-output" controls production of standard output and standard error on success. This should
+# generally be set to "never".
+success-output = "never"
+
+# Cancel the test run on the first failure. For CI runs, consider setting this
+# to false.
+# Accepted values are
+# * true: cancel the test run on the first failure
+# * false: continue running tests even after a failure
+# * { max-fail = 10 }: cancel the test run after the specified number of failures
+# * { max-fail = "all" }: continue running tests even after a failure
+fail-fast = true
+
+# Treat a test that takes longer than the configured 'period' as slow, and print a message.
+# See <https://nexte.st/docs/features/slow-tests> for more information.
+#
+# Optional: specify the parameter 'terminate-after' with a non-zero integer,
+# which will cause slow tests to be terminated after the specified number of
+# periods have passed.
+# Example: slow-timeout = { period = "60s", terminate-after = 2 }
+slow-timeout = { period = "60s" }
+
+# Treat a test as leaky if after the process is shut down, standard output and standard error
+# aren't closed within this duration.
+#
+# This usually happens in case of a test that creates a child process and lets it inherit those
+# handles, but doesn't clean the child process up (especially when it fails).
+#
+# See <https://nexte.st/docs/features/leaky-tests> for more information.
+leak-timeout = "100ms"
+
+# `nextest archive` automatically includes any build output required by a standard build.
+# However sometimes extra non-standard files are required.
+# To address this, "archive.include" specifies additional paths that will be included in the archive.
+archive.include = [
+    # Examples:
+    #
+    # { path = "application-data", relative-to = "target" },
+    # { path = "data-from-some-dependency/file.txt", relative-to = "target" },
+    #
+    # In the above example:
+    # * the directory and its contents at "target/application-data" will be included recursively in the archive.
+    # * the file "target/data-from-some-dependency/file.txt" will be included in the archive.
+]
+
+[profile.default.junit]
+# Output a JUnit report into the given file inside 'store.dir/<profile-name>'.
+# If unspecified, JUnit is not written out.
+
+# path = "junit.xml"
+
+# The name of the top-level "report" element in JUnit report. If aggregating
+# reports across different test runs, it may be useful to provide separate names
+# for each report.
+report-name = "nextest-run"
+
+# Whether standard output and standard error for passing tests should be stored in the JUnit report.
+# Output is stored in the <system-out> and <system-err> elements of the <testcase> element.
+store-success-output = false
+
+# Whether standard output and standard error for failing tests should be stored in the JUnit report.
+# Output is stored in the <system-out> and <system-err> elements of the <testcase> element.
+#
+# Note that if a description can be extracted from the output, it is always stored in the
+# <description> element.
+store-failure-output = true
+
+# This profile is activated if MIRI_SYSROOT is set.
+[profile.default-miri]
+
+
+[test-groups]
+serial = { max-threads = 1 }
+
+# serial tests
+[[profile.default.overrides]]
+filter = 'test(/.*serial_.*/)'
+test-group = 'serial'
+
+# heavy tests
+[[profile.default.overrides]]
+filter = 'test(/^heavy/)'
+threads-required = 2

--- a/crates/chain/tests/api/api.rs
+++ b/crates/chain/tests/api/api.rs
@@ -13,8 +13,9 @@ use base58::ToBase58;
 use tracing::info;
 
 #[cfg(test)]
+#[ignore]
 #[actix_web::test]
-async fn api_end_to_end_test_32b() {
+async fn serial_api_end_to_end_test_32b() {
     if PACKING_TYPE == PackingType::CPU {
         api_end_to_end_test(32).await;
     } else {
@@ -23,8 +24,9 @@ async fn api_end_to_end_test_32b() {
 }
 
 #[cfg(test)]
+#[ignore]
 #[actix_web::test]
-async fn api_end_to_end_test_256kb() {
+async fn serial_api_end_to_end_test_256kb() {
     api_end_to_end_test(256 * 1024).await;
 }
 
@@ -99,7 +101,10 @@ async fn api_end_to_end_test(chunk_size: usize) {
 
     // Call the service
     let resp = test::call_service(&app, req).await;
-    assert_eq!(resp.status(), StatusCode::OK);
+    let status = resp.status();
+    let body = test::read_body(resp).await;
+    debug!("Response body: {:#?}", body);
+    assert_eq!(status, StatusCode::OK);
     info!("Transaction was posted");
 
     // Loop though each of the transaction chunks

--- a/crates/chain/tests/block_production/analytics.rs
+++ b/crates/chain/tests/block_production/analytics.rs
@@ -129,7 +129,7 @@ async fn test_blockprod_with_evm_txs() -> eyre::Result<()> {
             ProviderBuilder::new()
                 .with_recommended_fillers()
                 .wallet(EthereumWallet::from(signer))
-                .on_http("http://localhost:8080".parse().unwrap())
+                .on_http("http://localhost:8080/v1/execution-rpc".parse().unwrap())
         })
         .collect::<Vec<_>>();
 

--- a/crates/chain/tests/block_production/basic_contract.rs
+++ b/crates/chain/tests/block_production/basic_contract.rs
@@ -21,9 +21,9 @@ sol!(
     IrysERC20,
     "../../fixtures/contracts/out/IrysERC20.sol/IrysERC20.json"
 );
-
+#[cfg(test)]
 #[tokio::test]
-async fn test_erc20() -> eyre::Result<()> {
+async fn serial_test_erc20() -> eyre::Result<()> {
     let temp_dir = setup_tracing_and_temp_dir(Some("test_erc20"), false);
     let mut config = IrysNodeConfig::default();
     config.base_directory = temp_dir.path().to_path_buf();
@@ -56,7 +56,7 @@ async fn test_erc20() -> eyre::Result<()> {
     let alloy_provider = ProviderBuilder::new()
         .with_recommended_fillers()
         .wallet(wallet)
-        .on_http("http://localhost:8080".parse()?);
+        .on_http("http://localhost:8080/v1/execution-rpc".parse()?);
 
     let mut deploy_fut = Box::pin(IrysERC20::deploy(alloy_provider, account1.address()));
 

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -24,9 +24,9 @@ use tracing::info;
 
 use crate::utils::capacity_chunk_solution;
 /// Create a valid capacity PoA solution
-
+#[cfg(test)]
 #[tokio::test]
-async fn test_blockprod() -> eyre::Result<()> {
+async fn serial_test_blockprod() -> eyre::Result<()> {
     std::env::set_var("RUST_LOG", "debug");
     let temp_dir = setup_tracing_and_temp_dir(Some("test_blockprod"), false);
     let mut config = IrysNodeConfig::default();
@@ -129,7 +129,7 @@ async fn test_blockprod() -> eyre::Result<()> {
 }
 
 #[tokio::test]
-async fn mine_ten_blocks() -> eyre::Result<()> {
+async fn serial_mine_ten_blocks() -> eyre::Result<()> {
     let temp_dir = setup_tracing_and_temp_dir(Some("test_blockprod"), false);
     let mut config = IrysNodeConfig::default();
     config.base_directory = temp_dir.path().to_path_buf();
@@ -172,7 +172,7 @@ async fn mine_ten_blocks() -> eyre::Result<()> {
 }
 
 #[tokio::test]
-async fn mine_ten_blocks_with_capacity_poa_solution() -> eyre::Result<()> {
+async fn serial_mine_ten_blocks_with_capacity_poa_solution() -> eyre::Result<()> {
     let temp_dir = setup_tracing_and_temp_dir(Some("test_blockprod"), false);
     let mut config = IrysNodeConfig::default();
     config.base_directory = temp_dir.path().to_path_buf();
@@ -219,7 +219,7 @@ async fn mine_ten_blocks_with_capacity_poa_solution() -> eyre::Result<()> {
 }
 
 #[tokio::test]
-async fn test_basic_blockprod() -> eyre::Result<()> {
+async fn serial_test_basic_blockprod() -> eyre::Result<()> {
     let temp_dir = setup_tracing_and_temp_dir(Some("test_blockprod"), false);
     let mut config = IrysNodeConfig::default();
     config.base_directory = temp_dir.path().to_path_buf();
@@ -264,7 +264,7 @@ async fn test_basic_blockprod() -> eyre::Result<()> {
 }
 
 #[tokio::test]
-async fn test_blockprod_with_evm_txs() -> eyre::Result<()> {
+async fn serial_test_blockprod_with_evm_txs() -> eyre::Result<()> {
     let temp_dir = setup_tracing_and_temp_dir(Some("test_blockprod"), false);
     let mut config = IrysNodeConfig::default();
     config.base_directory = temp_dir.path().to_path_buf();

--- a/crates/chain/tests/block_production/external_tx.rs
+++ b/crates/chain/tests/block_production/external_tx.rs
@@ -22,7 +22,8 @@ const DEV_ADDRESS: &str = "64f1a2829e0e698c18e7792d6e74f67d89aa0a32";
 const DEV2_PRIVATE_KEY: &str = "9687cbc3f9f3a0b6dffbf01ec30143e33b7c49f789257d7836eb54b9ae5d27e2";
 const DEV2_ADDRESS: &str = "Bea4f456A5801cf9Af196a582D6Ec425c970c2C6";
 
-// #[tokio::test]
+#[ignore]
+#[tokio::test]
 /// WARNING DO NOT RUN AUTOMATICALLY
 /// THIS TEST BLOCKS EXPECTING AN EXTERNAL TX TO BE SUBMITTED, THROUGH A TOOL LIKE METAMASK
 async fn test_basic_blockprod_extern_tx_src() -> eyre::Result<()> {

--- a/crates/chain/tests/block_production/mod.rs
+++ b/crates/chain/tests/block_production/mod.rs
@@ -1,4 +1,5 @@
-mod analytics;
+#[cfg(test)]
+pub mod analytics;
 pub mod basic_contract;
 pub mod block_production;
-mod external_tx;
+pub mod external_tx;

--- a/crates/chain/tests/integration/mod.rs
+++ b/crates/chain/tests/integration/mod.rs
@@ -1,0 +1,6 @@
+#[cfg(test)]
+pub mod tests {
+    pub use crate::block_production;
+    pub use crate::programmable_data;
+    pub use crate::promotion;
+}

--- a/crates/chain/tests/mod.rs
+++ b/crates/chain/tests/mod.rs
@@ -1,6 +1,7 @@
 // so rust-analyzer considers the test files to be part of the project
-mod api;
-mod block_production;
-mod programmable_data;
-mod promotion;
+pub mod api;
+pub mod block_production;
+pub mod integration;
+pub mod programmable_data;
+pub mod promotion;
 pub mod utils;

--- a/crates/chain/tests/programmable_data/basic.rs
+++ b/crates/chain/tests/programmable_data/basic.rs
@@ -42,7 +42,7 @@ const DEV_PRIVATE_KEY: &str = "db793353b633df950842415065f769699541160845d73db90
 const DEV_ADDRESS: &str = "64f1a2829e0e698c18e7792d6e74f67d89aa0a32";
 
 #[actix_web::test]
-async fn test_programmable_data_basic() -> eyre::Result<()> {
+async fn serial_test_programmable_data_basic() -> eyre::Result<()> {
     std::env::set_var("RUST_LOG", "debug");
 
     let temp_dir = setup_tracing_and_temp_dir(Some("test_programmable_data_basic"), false);

--- a/crates/chain/tests/programmable_data/mod.rs
+++ b/crates/chain/tests/programmable_data/mod.rs
@@ -1,2 +1,2 @@
-mod basic;
-mod basic_external;
+pub mod basic;
+pub mod basic_external;

--- a/crates/chain/tests/promotion/data_promotion_basic.rs
+++ b/crates/chain/tests/promotion/data_promotion_basic.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 #[actix_web::test]
-async fn data_promotion_test() {
+async fn serial_data_promotion_test() {
     use actix_web::{
         middleware::Logger,
         test::{self, call_service, TestRequest},

--- a/crates/chain/tests/promotion/data_promotion_double.rs
+++ b/crates/chain/tests/promotion/data_promotion_double.rs
@@ -6,7 +6,7 @@ use tracing::debug;
 
 #[cfg(test)]
 #[actix_web::test]
-async fn double_root_data_promotion_test() {
+async fn serial_double_root_data_promotion_test() {
     use std::time::Duration;
 
     use actix_web::{

--- a/crates/chain/tests/promotion/mod.rs
+++ b/crates/chain/tests/promotion/mod.rs
@@ -1,2 +1,2 @@
-mod data_promotion_basic;
-mod data_promotion_double;
+pub mod data_promotion_basic;
+pub mod data_promotion_double;

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -21,6 +21,7 @@ pub struct IrysNodeConfig {
     /// Signer instance used for mining
     pub mining_signer: IrysSigner,
     /// Node ID/instance number: used for testing. if omitted, an instance subfolder is not created. reth will still be set as instance `1`.
+    /// if `0` is provided as the instance number, random ports are used
     pub instance_number: Option<u32>,
     /// base data directory, i.e `./.tmp`
     /// should not be used directly, instead use the appropriate methods, i.e `instance_directory`

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -21,7 +21,6 @@ pub struct IrysNodeConfig {
     /// Signer instance used for mining
     pub mining_signer: IrysSigner,
     /// Node ID/instance number: used for testing. if omitted, an instance subfolder is not created. reth will still be set as instance `1`.
-    /// if `0` is provided as the instance number, random ports are used
     pub instance_number: Option<u32>,
     /// base data directory, i.e `./.tmp`
     /// should not be used directly, instead use the appropriate methods, i.e `instance_directory`


### PR DESCRIPTION
This PR:
- Creates a nextest configuration, with groups defined for `serial` tests (for now just tests that initialize reth/a full Irys node)
- Fixes some broken tests, disables a couple more busted tests (notablly the API e2e tests, which are broken due to the addition of balance checks)
