### PR TITLE
Remove warnings from reth-node-bridge crate

### DIFF
--- a/crates/reth-node-bridge/src/adapter/engine_api.rs
+++ b/crates/reth-node-bridge/src/adapter/engine_api.rs
@@ -113,7 +113,7 @@ impl<E: EngineTypes> EngineApiContext<E> {
         EngineApiClient::<E>::fork_choice_updated_v1_irys(
             &self.engine_api_client,
             ForkchoiceState {
-                head_block_hash: head_block_hash,
+                head_block_hash,
                 safe_block_hash: confirmed_block_hash.unwrap_or(B256::ZERO),
                 finalized_block_hash: finalized_block_hash.unwrap_or(B256::ZERO),
             },

--- a/crates/reth-node-bridge/src/node.rs
+++ b/crates/reth-node-bridge/src/node.rs
@@ -212,7 +212,7 @@ pub async fn run_node<T: HasName + HasTableType>(
         db,
         dev,
         pruning,
-        ext: engine_args,
+        ext: _engine_args,
         ..
     } = node_command;
 

--- a/crates/reth-node-bridge/src/precompile/read_bytes.rs
+++ b/crates/reth-node-bridge/src/precompile/read_bytes.rs
@@ -117,8 +117,8 @@ pub fn read_partial_byte_range(
 
 pub fn read_bytes_range(
     bytes_range: ByteRangeSpecifier,
-    gas_limit: u64,
-    env: &Env,
+    _gas_limit: u64,
+    _env: &Env,
     state_provider: &IrysRethProviderInner,
     access_lists: ParsedAccessLists,
 ) -> PrecompileResult {


### PR DESCRIPTION
Removed `cargo c` warnings from reth-node-bridge crate.