### PR TITLE
feat: storage pricing module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11258,7 +11258,6 @@ name = "storage-pricing"
 version = "0.1.0"
 dependencies = [
  "eyre",
- "irys-types",
  "rust_decimal",
  "rust_decimal_macros",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11256,6 +11256,12 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "storage-pricing"
 version = "0.1.0"
+dependencies = [
+ "eyre",
+ "irys-types",
+ "rust_decimal",
+ "rust_decimal_macros",
+]
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11254,6 +11254,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "storage-pricing"
+version = "0.1.0"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,25 +1,31 @@
 [workspace]
 exclude = ["ext/"]
 members = [
-    "crates/actors",
-    "crates/c",
-    "crates/chain",
-    "crates/primitives",
-    "crates/reth-node-bridge",
-    "crates/types",
-    "crates/packing",
-    "crates/database",
-    "crates/storage",
-    "crates/testing-utils",
-    "crates/config",
-    "crates/efficient-sampling",
-    "crates/macros", "crates/debug-utils",
+  "crates/actors",
+  "crates/c",
+  "crates/chain",
+  "crates/primitives",
+  "crates/reth-node-bridge",
+  "crates/types",
+  "crates/packing",
+  "crates/database",
+  "crates/storage",
+  "crates/testing-utils",
+  "crates/config",
+  "crates/efficient-sampling",
+  "crates/macros",
+  "crates/debug-utils",
+  "crates/storage-pricing",
 ]
 resolver = "2"
 
 [workspace.package]
 edition = "2021"
 rust-version = "1.82"
+homepage = "http://irys.xyz/"
+license = "MIT/Apache-2.0"
+repository = "https://github.com/Irys-xyz/irys"
+authors = []
 
 [workspace.dependencies]
 # Irys
@@ -38,7 +44,6 @@ irys-packing = { path = "./crates/packing" }
 irys-chain = { path = "./crates/chain" }
 irys-vdf = { path = "./crates/vdf" }
 irys-efficient-sampling = { path = "./crates/efficient-sampling" }
-#
 
 ruint = { version = "1.12.3", features = ["alloc", "arbitrary"] }
 actix = "0.13.5"
@@ -50,30 +55,22 @@ alloy-consensus = { path = "./ext/alloy/crates/consensus", default-features = fa
 alloy-core = { path = "./ext/alloy-core/crates/core" }
 alloy-eips = { path = "./ext/alloy/crates/eips", default-features = false }
 alloy-genesis = { path = "./ext/alloy/crates/genesis", default-features = false }
-alloy-primitives = { path = "./ext/alloy-core/crates/primitives", features = [
-    "arbitrary",
-] }
+alloy-primitives = { path = "./ext/alloy-core/crates/primitives", features = ["arbitrary"] }
 rand = "0.8.5"
 hex = "0.4"
 base64-url = "2.0.0"
 alloy-rlp = "0.3.4"
 alloy-rpc-types = { path = "./ext/alloy/crates/rpc-types" }
-alloy-rpc-types-engine = { path = "./ext/alloy/crates/rpc-types-engine", features = [
-    "serde",
-] }
+alloy-rpc-types-engine = { path = "./ext/alloy/crates/rpc-types-engine", features = ["serde"] }
 
 alloy-rpc-types-trace = { path = "./ext/alloy/crates/rpc-types-trace" }
 reth-e2e-test-utils = { path = "./ext/reth/crates/e2e-test-utils" }
 alloy-serde = { path = "./ext/alloy/crates/serde", default-features = false }
 alloy-signer-local = { path = "./ext/alloy/crates/signer-local" }
-alloy-sol-macro = { path = "./ext/alloy-core/crates/sol-macro", features = [
-    "json",
-] }
+alloy-sol-macro = { path = "./ext/alloy-core/crates/sol-macro", features = ["json"] }
 alloy-sol-types = { path = "./ext/alloy-core/crates/sol-types" }
 alloy-contract = { path = "./ext/alloy/crates/contract" }
-alloy-provider = { path = "./ext/alloy/crates/provider", features = [
-    "trace-api",
-] }
+alloy-provider = { path = "./ext/alloy/crates/provider", features = ["trace-api"] }
 
 arbitrary = { version = "1.3", features = ["derive"] }
 once_cell = "1.19.0"
@@ -156,11 +153,7 @@ proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full"] }
 tracing = "0.1.0"
-tracing-subscriber = { version = "0.3", default-features = false, features = [
-    "env-filter",
-    "fmt",
-    "json",
-] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt", "json"] }
 alloy-signer = { path = "./ext/alloy/crates/signer" }
 tempfile = "3.10"
 jsonrpsee = "0.24"
@@ -168,7 +161,6 @@ jsonrpsee-core = "0.24"
 jsonrpsee-http-client = "0.24"
 jsonrpsee-types = "0.24"
 futures-util = "0.3.30"
-
 
 [patch.crates-io]
 revm = { path = "./ext/revm/crates/revm" }
@@ -223,10 +215,50 @@ rust.missing_debug_implementations = "warn"
 rust.rust_2018_idioms = { level = "deny", priority = -1 }
 rust.unreachable_pub = "warn"
 rust.unused_must_use = "deny"
-#rustdoc.all = "warn"
+rust.unused_imports = "warn"
+# rustdoc.all = "warn"
 # rust.unnameable-types = "warn"
 
 [workspace.lints.clippy]
+cargo = { priority = -1, level = "warn" }
+complexity = { priority = -2, level = "warn" }
+perf = { priority = -3, level = "warn" }
+correctness = { priority = -4, level = "warn" }
+restriction = { priority = -5, level = "warn" }
+style = { priority = -6, level = "warn" }
+suspicious = { priority = -7, level = "warn" }
+pedantic = { priority = -8, level = "warn" }
+nursery = { priority = -9, level = "warn" }
+
+cargo_common_metadata = "allow"
+pattern_type_mismatch = "allow"
+missing_docs_in_private_items = "allow"
+blanket_clippy_restriction_lints = "allow"
+implicit_return = "allow"
+dbg_macro = "allow"
+single_call_fn = "allow"
+missing_inline_in_public_items = "allow"
+question_mark_used = "allow"
+absolute_paths = "allow"
+missing_trait_methods = "allow"
+wildcard_imports = "allow"
+shadow_reuse = "allow"
+exhaustive_enums = "allow"
+ref_patterns = "allow"
+pub_use = "allow"
+single_char_lifetime_names = "allow"
+multiple_crate_versions = "allow"
+exhaustive_structs = "allow"
+separated_literal_suffix = "allow"
+mod_module_files = "allow"
+negative_feature_names = "allow"
+std_instead_of_alloc = "allow"
+expect_used = "allow"
+pub_with_shorthand = "allow"
+option_if_let_else = "allow"
+self_named_module_files = "allow"
+shadow_unrelated = "allow"
+
 # These are some of clippy's nursery (i.e., experimental) lints that we like.
 # By default, nursery lints are allowed. Some of the lints below have made good
 # suggestions which we fixed. The others didn't have any findings, so we can

--- a/crates/storage-pricing/Cargo.toml
+++ b/crates/storage-pricing/Cargo.toml
@@ -9,7 +9,6 @@ homepage.workspace = true
 license.workspace = true
 
 [dependencies]
-irys-types.workspace = true
 eyre.workspace = true
 rust_decimal = { workspace = true, features = ["maths"] }
 rust_decimal_macros.workspace = true

--- a/crates/storage-pricing/Cargo.toml
+++ b/crates/storage-pricing/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "storage-pricing"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/storage-pricing/Cargo.toml
+++ b/crates/storage-pricing/Cargo.toml
@@ -9,6 +9,10 @@ homepage.workspace = true
 license.workspace = true
 
 [dependencies]
+irys-types.workspace = true
+eyre.workspace = true
+rust_decimal = { workspace = true, features = ["maths"] }
+rust_decimal_macros.workspace = true
 
 [lints]
 workspace = true

--- a/crates/storage-pricing/src/lib.rs
+++ b/crates/storage-pricing/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: u64, right: u64) -> u64 {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/crates/storage-pricing/src/lib.rs
+++ b/crates/storage-pricing/src/lib.rs
@@ -1,14 +1,132 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
+use std::marker::PhantomData;
+
+use eyre::ContextCompat;
+use rust_decimal::{Decimal, MathematicalOps};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AnnualCostUsd;
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TotalCostUsd;
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct DecayRate;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Amount<T> {
+    amount: Decimal,
+    _t: PhantomData<T>,
+}
+
+/// Calculate the total cost for storage
+///
+/// n = years to pay for storage
+/// r = decay rate
+///
+/// total cost = annual_cost * ((1 - (1-r)^n) / r)
+pub fn total_cost(
+    annual_cost: Amount<AnnualCostUsd>,
+    n: u64,
+    decay_rate: Amount<DecayRate>,
+) -> eyre::Result<Amount<TotalCostUsd>> {
+    // (1 - r)^n
+    let one_minus_r_pow = (Decimal::ONE.saturating_sub(decay_rate.amount))
+        .checked_powu(n)
+        .wrap_err("too many years to pay for")?;
+
+    // fraction = [ 1 - (1-r)^n ] / r
+    let fraction = (Decimal::ONE.saturating_sub(one_minus_r_pow))
+        .checked_div(decay_rate.amount)
+        .wrap_err("decay rate invalid")?;
+
+    // total = annual_cost * fraction
+    let total = annual_cost
+        .amount
+        .checked_mul(fraction)
+        .wrap_err("fraction too large")?;
+
+    Ok(Amount {
+        amount: total,
+        _t: PhantomData,
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use eyre::Result;
+    use rust_decimal::Decimal;
+
+    /// Helper to quickly build Amount<AnnualCostUsd> or Amount<DecayRate> etc.
+    fn annual_cost_usd(value: &str) -> Amount<AnnualCostUsd> {
+        Amount {
+            amount: Decimal::from_str_exact(value).unwrap(),
+            _t: PhantomData,
+        }
+    }
+    fn decay_rate(value: &str) -> Amount<DecayRate> {
+        Amount {
+            amount: Decimal::from_str_exact(value).unwrap(),
+            _t: PhantomData,
+        }
+    }
 
     #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+    fn test_normal_case() -> Result<()> {
+        let annual = annual_cost_usd("0.01");
+        let dec = decay_rate("0.01");
+        let years = 200;
+        let total = total_cost(annual, years, dec)?;
+
+        let expected = Decimal::from_str_exact("0.8661").unwrap();
+        let diff = (total.amount - expected).abs();
+        assert!(diff < Decimal::from_str_exact("0.0001").unwrap());
+        Ok(())
+    }
+
+    #[test]
+    fn test_zero_decay_rate() {
+        // r=0 => division by zero => should Err
+        let annual = annual_cost_usd("1000");
+        let dec = decay_rate("0.0");
+        let result = total_cost(annual, 10, dec);
+        assert!(result.is_err(), "Expected an error for r=0, got Ok(...)");
+    }
+
+    #[test]
+    fn test_full_decay_rate() -> Result<()> {
+        // r=1 => fraction = [1 - (1-1)^n]/1 => [1 - 0^n]/1 => 1
+        // total = annual_cost
+        let annual = annual_cost_usd("500");
+        let dec = decay_rate("1.0");
+        let total = total_cost(annual, 5, dec)?;
+        assert_eq!(total.amount, Decimal::from(500));
+        Ok(())
+    }
+
+    #[test]
+    fn test_decay_rate_above_one() {
+        let annual = annual_cost_usd("0.01");
+        let dec = decay_rate("1.5"); // 150%
+        let years = 200;
+        let result = total_cost(annual, years, dec);
+        assert!(result.is_ok(), "Expected error for decay > 1.0");
+    }
+
+    #[test]
+    fn test_no_years_to_pay() -> Result<()> {
+        let annual = annual_cost_usd("1234.56");
+        let dec = decay_rate("0.05"); // 5%
+        let total = total_cost(annual, 0, dec)?;
+        assert_eq!(total.amount, Decimal::ZERO);
+        Ok(())
+    }
+
+    #[test]
+    fn test_annual_cost_zero() -> Result<()> {
+        // If annual cost=0 => total=0, no matter the decay rate
+        let annual = annual_cost_usd("0");
+        let dec = decay_rate("0.05"); // 5%
+        let total = total_cost(annual, 10, dec)?;
+        assert_eq!(total.amount, Decimal::ZERO);
+        Ok(())
     }
 }

--- a/crates/storage-pricing/src/lib.rs
+++ b/crates/storage-pricing/src/lib.rs
@@ -439,7 +439,7 @@ mod tests {
             let result = current_irys_price.calculate_ema(total_past_blocks, last_block_ema);
 
             // assert
-            result.unwrap();
+            assert!(result.is_ok());
         }
     }
 }

--- a/crates/storage-pricing/src/lib.rs
+++ b/crates/storage-pricing/src/lib.rs
@@ -1,28 +1,77 @@
-use std::{fmt::Debug, marker::PhantomData};
+//! A utility crate fro calculating netwokrk fees, costs for storing different amounts of data, and EMA for blocks.
+//!
+//! Core data types:
+//! - `Amount<(CostPerGb, Usd)>` - Cost in $USD of storing 1GB on irys (per single replica), data part of the config
+//! - `Amount<(IrysPrice, Usd)>` - Cost in $USD of a single $IRYS token, the data retrieved form oracles
+//! - `Amount<(Ema, Usd)>` - Exponential Moving Average for a single $IRYS token, the data to be stored in blocks
+//! - `Amount<(NetworkFee, Irys)>` - The cost in $IRYS that the user will have to pay to store his data on Irys
+use std::{fmt::Debug, marker::PhantomData, ops::Deref};
 
-use eyre::{ensure, ContextCompat, OptionExt};
+use eyre::{ensure, OptionExt};
 pub use phantoms::*;
 use rust_decimal::{Decimal, MathematicalOps};
 use rust_decimal_macros::dec;
 
-mod phantoms {
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-    pub struct CostUsdPerGb;
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-    pub struct DecayRate;
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-    pub struct NetworkFee;
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-    pub struct UsdCostPerGbYearAccounted;
-}
-
+/// A wrapper around [`rust_decimal::Decimal`] that also denominates the value in currency using [`PhantomData`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Amount<T> {
     amount: Decimal,
     _t: PhantomData<T>,
 }
 
-impl Amount<CostUsdPerGb> {
+impl<T> Amount<T> {
+    /// Initialize a new Amount; PhantomData to be inferred from usage
+    pub fn new(amount: Decimal) -> Self {
+        Self {
+            amount,
+            _t: PhantomData,
+        }
+    }
+}
+
+impl<T> Deref for Amount<T> {
+    type Target = Decimal;
+
+    fn deref(&self) -> &Self::Target {
+        &self.amount
+    }
+}
+
+mod phantoms {
+    /// The cost of storing a single GB of data.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct CostPerGb;
+
+    /// Currency denomintator util type.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct Usd;
+
+    /// Currency denominator util type.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct Irys;
+
+    /// Exponential Moving Average.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct Ema;
+
+    /// Decay rate to account for storage hardware getting cheaper.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct DecayRate;
+
+    /// The network fee, that the user would have to pay for storing his data on Irys.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct NetworkFee;
+
+    /// Price of the $IRYS token.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct IrysPrice;
+
+    /// Cost per storing 1GB, of data. Includes adjustment for storage duration.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct CostPerGbYearAdjusted;
+}
+
+impl Amount<(CostPerGb, Usd)> {
     /// Calculate the total cost for storage.
     /// The price is for storing a single replica.
     ///
@@ -34,23 +83,23 @@ impl Amount<CostUsdPerGb> {
         self,
         years_to_pay_for_storage: u64,
         decay_rate: Amount<DecayRate>,
-    ) -> eyre::Result<Amount<UsdCostPerGbYearAccounted>> {
+    ) -> eyre::Result<Amount<(CostPerGbYearAdjusted, Usd)>> {
         let annual_cost_per_byte = self.amount;
 
         // (1 - r)^n
-        let one_minus_r_pow = (Decimal::ONE.saturating_sub(decay_rate.amount))
+        let one_minus_r_pow = (Decimal::ONE.saturating_sub(*decay_rate))
             .checked_powu(years_to_pay_for_storage)
-            .wrap_err("too many years to pay for")?;
+            .ok_or_eyre("too many years to pay for")?;
 
         // fraction = [ 1 - (1-r)^n ] / r
         let fraction = (Decimal::ONE.saturating_sub(one_minus_r_pow))
             .checked_div(decay_rate.amount)
-            .wrap_err("decay rate invalid")?;
+            .ok_or_eyre("decay rate invalid")?;
 
         // total = annual_cost * fraction
         let total = annual_cost_per_byte
             .checked_mul(fraction)
-            .wrap_err("fraction too large")?;
+            .ok_or_eyre("fraction too large")?;
 
         Ok(Amount {
             amount: total,
@@ -59,19 +108,22 @@ impl Amount<CostUsdPerGb> {
     }
 }
 
-impl Amount<UsdCostPerGbYearAccounted> {
+impl Amount<(CostPerGbYearAdjusted, Usd)> {
+    /// Apply a multiplier of how much would storing the data cost fro `n` replicas.
     pub fn replica_count(self, replicas: u64) -> eyre::Result<Self> {
         let amount = self
             .amount
             .checked_mul(replicas.into())
-            .wrap_err("overflow during replica multiplication")?;
+            .ok_or_eyre("overflow during replica multiplication")?;
         Ok(Self { amount, ..self })
     }
+
+    /// calculate the network fee, denominated in $IRYS tokens
     pub fn base_network_fee(
         self,
         bytes_to_store: Decimal,
-        irys_token_price: Decimal,
-    ) -> eyre::Result<Amount<NetworkFee>> {
+        irys_token_price: Amount<(IrysPrice, Usd)>,
+    ) -> eyre::Result<Amount<(NetworkFee, Irys)>> {
         // divide by the ratio
         let bytes_in_gb = dec!(1_073_741_824); // 1024 * 1024 * 1024
         let price_ratio = bytes_to_store.checked_div(bytes_in_gb).unwrap();
@@ -80,7 +132,7 @@ impl Amount<UsdCostPerGbYearAccounted> {
         let usd_fee = self.amount.checked_mul(price_ratio.into()).unwrap();
 
         // converted to $IRYS
-        let network_fee = usd_fee.checked_div(irys_token_price).unwrap();
+        let network_fee = usd_fee.checked_div(*irys_token_price).unwrap();
 
         Ok(Amount {
             amount: network_fee,
@@ -89,13 +141,13 @@ impl Amount<UsdCostPerGbYearAccounted> {
     }
 }
 
-impl Amount<NetworkFee> {
+impl Amount<(NetworkFee, Irys)> {
     /// Add additional network fee for storing data to incerace incentivisation.
     ///
     /// 0.05 => 5%
     /// 1.00 => 100%
     /// 0.50 => 50%
-    pub fn add_multiplier(self, percentage: Decimal) -> eyre::Result<Amount<NetworkFee>> {
+    pub fn add_multiplier(self, percentage: Decimal) -> eyre::Result<Amount<(NetworkFee, Irys)>> {
         // amount * (100% + x%)
         let amount = self
             .amount
@@ -104,7 +156,7 @@ impl Amount<NetworkFee> {
                     .checked_add(dec!(1))
                     .expect("rewarad percentage too large"),
             )
-            .wrap_err("reward percentage too large")?;
+            .ok_or_eyre("reward percentage too large")?;
         Ok(Self {
             amount,
             _t: PhantomData,
@@ -112,55 +164,59 @@ impl Amount<NetworkFee> {
     }
 }
 
-/// The EMA can be calculated using the following formula:
-///
-/// `EMA b = α ⋅ Pb + (1 - α) ⋅ EMAb-1`
-///
-/// Where:
-/// - `EMAb` is the Exponential Moving Average at block b.
-/// - `α` is the smoothing factor, calculated as `α = 2 / (n+1)`, where n is the number of block prices.
-/// - `Pb` is the price at block b.
-/// - `EMAb-1` is the EMA at the previous block.
-pub fn calculate_ema(
-    total_past_blocks: u64,
-    current_block_price: Amount<NetworkFee>,
-    previous_block_ema: Amount<NetworkFee>,
-) -> eyre::Result<Decimal> {
-    // Safely convert `total_blocks_in_epoch + 1` to Decimal
-    let denominator = Decimal::from(total_past_blocks)
-        .checked_add(dec!(1))
-        .ok_or_eyre("failed to compute total_past_blocks + 1")?;
+impl Amount<(IrysPrice, Usd)> {
+    /// Calculate the Exponential Moving Average for the current Irys Price (denominaed in $USD).
+    ///
+    /// The EMA can be calculated using the following formula:
+    ///
+    /// `EMA b = α ⋅ Pb + (1 - α) ⋅ EMAb-1`
+    ///
+    /// Where:
+    /// - `EMAb` is the Exponential Moving Average at block b.
+    /// - `α` is the smoothing factor, calculated as `α = 2 / (n+1)`, where n is the number of block prices.
+    /// - `Pb` is the price at block b.
+    /// - `EMAb-1` is the EMA at the previous block.
+    pub fn calculate_ema(
+        self,
+        total_past_blocks: u64,
+        previous_block_ema: Amount<(Ema, Usd)>,
+    ) -> eyre::Result<Amount<(Ema, Usd)>> {
+        // Safely convert `total_blocks_in_epoch + 1` to Decimal
+        let denominator = Decimal::from(total_past_blocks)
+            .checked_add(dec!(1))
+            .ok_or_eyre("failed to compute total_past_blocks + 1")?;
 
-    // Calculate alpha = 2 / (n+1)
-    let alpha = dec!(2)
-        .checked_div(denominator)
-        .ok_or_eyre("failed to compute smoothing factor alpha")?;
-    ensure!(
-        alpha > dec!(0) || alpha <= dec!(1),
-        "computed alpha={alpha} is out of the valid range (0,1]"
-    );
+        // Calculate alpha = 2 / (n+1)
+        let alpha = dec!(2)
+            .checked_div(denominator)
+            .ok_or_eyre("failed to compute smoothing factor alpha")?;
+        ensure!(
+            alpha > dec!(0) || alpha <= dec!(1),
+            "computed alpha={alpha} is out of the valid range (0,1]"
+        );
 
-    // Calculate (1 - alpha)
-    let one_minus_alpha = dec!(1)
-        .checked_sub(alpha)
-        .ok_or_eyre("failed to compute (1 - alpha)")?;
+        // Calculate (1 - alpha)
+        let one_minus_alpha = dec!(1)
+            .checked_sub(alpha)
+            .ok_or_eyre("failed to compute (1 - alpha)")?;
 
-    // alpha * current_block_price
-    let scaled_current_price = alpha
-        .checked_mul(current_block_price.amount)
-        .ok_or_eyre("failed to multiply alpha by current_block_price")?;
+        // alpha * current_irys_price
+        let scaled_current_price = alpha
+            .checked_mul(self.amount)
+            .ok_or_eyre("failed to multiply alpha by current_irys_price")?;
 
-    // (1 - alpha) * last_block_ema
-    let scaled_last_ema = one_minus_alpha
-        .checked_mul(previous_block_ema.amount)
-        .ok_or_eyre("failed to multiply (1 - alpha) by last_block_ema")?;
+        // (1 - alpha) * last_block_ema
+        let scaled_last_ema = one_minus_alpha
+            .checked_mul(*previous_block_ema)
+            .ok_or_eyre("failed to multiply (1 - alpha) by last_block_ema")?;
 
-    // alpha * price + (1 - alpha) * previous_ema
-    let current_block_ema = scaled_current_price
-        .checked_add(scaled_last_ema)
-        .ok_or_eyre("failed to add scaled current block price to scaled last block EMA")?;
+        // alpha * price + (1 - alpha) * previous_ema
+        let current_block_ema = scaled_current_price
+            .checked_add(scaled_last_ema)
+            .ok_or_eyre("failed to add scaled current block price to scaled last block EMA")?;
 
-    Ok(current_block_ema)
+        Ok(Amount::new(current_block_ema))
+    }
 }
 
 #[cfg(test)]
@@ -169,28 +225,14 @@ mod tests {
     use eyre::Result;
     use rust_decimal::Decimal;
 
-    /// Helper to quickly build Amount<AnnualCostUsd> or Amount<DecayRate> etc.
-    fn annual_cost_usd(value: &str) -> Amount<CostUsdPerGb> {
-        Amount {
-            amount: Decimal::from_str_exact(value).unwrap(),
-            _t: PhantomData,
-        }
-    }
-    fn decay_rate(value: &str) -> Amount<DecayRate> {
-        Amount {
-            amount: Decimal::from_str_exact(value).unwrap(),
-            _t: PhantomData,
-        }
-    }
-
     mod cost_per_byte {
         use super::*;
 
         #[test]
         fn test_normal_case() -> Result<()> {
             // Setup
-            let annual = annual_cost_usd("0.01");
-            let dec = decay_rate("0.01");
+            let annual = Amount::new(dec!(0.01));
+            let dec = Amount::new(dec!(0.01));
             let years = 200;
 
             // Action
@@ -213,8 +255,8 @@ mod tests {
         // r=0 => division by zero => should Err
         fn test_zero_decay_rate() {
             // setup
-            let annual = annual_cost_usd("1000");
-            let dec = decay_rate("0.0");
+            let annual = Amount::new(dec!(1000));
+            let dec = Amount::new(dec!(0.0));
             let years = 10;
 
             // actoin
@@ -228,8 +270,8 @@ mod tests {
         // r=1 => fraction = (1 - (1-1)^n)/1 => (1 - 0^n)/1 => 1
         fn test_full_decay_rate() -> Result<()> {
             // setup
-            let annual = annual_cost_usd("500");
-            let dec = decay_rate("1.0");
+            let annual = Amount::new(dec!(500));
+            let dec = Amount::new(dec!(1.0));
             let years_to_pay_for_storage = 5;
 
             // action
@@ -246,8 +288,8 @@ mod tests {
         #[test]
         fn test_decay_rate_above_one() {
             // setup
-            let annual = annual_cost_usd("0.01");
-            let dec = decay_rate("1.5"); // 150%
+            let annual = Amount::new(dec!(0.01));
+            let dec = Amount::new(dec!(1.5)); // 150%
             let years = 200;
 
             // actoin
@@ -263,8 +305,8 @@ mod tests {
         #[test]
         fn test_no_years_to_pay() -> Result<()> {
             // setup
-            let annual = annual_cost_usd("1234.56");
-            let dec = decay_rate("0.05"); // 5%
+            let annual = Amount::new(dec!(1234.56));
+            let dec = Amount::new(dec!(0.05)); // 5%
             let years = 0;
 
             // action
@@ -282,8 +324,8 @@ mod tests {
         // If annual cost=0 => total=0, no matter the decay rate
         fn test_annual_cost_zero() -> Result<()> {
             // setup
-            let annual = annual_cost_usd("0");
-            let dec = decay_rate("0.05"); // 5%
+            let annual = Amount::new(dec!(0));
+            let dec = Amount::new(dec!(0.05)); // 5%
             let years = 10;
 
             // action
@@ -305,7 +347,7 @@ mod tests {
         fn test_normal_case() -> Result<()> {
             // Setup
             let cost_per_gb_10_replicas_200_years = dec!(8.65);
-            let price_irys = dec!(1.09);
+            let price_irys = Amount::new(dec!(1.09));
             let bytes_to_store = 1024 * 1024 * 200; // 200mb
             let fee_percentage = dec!(0.05);
 
@@ -338,28 +380,18 @@ mod tests {
         fn test_calculate_ema_valid() -> Result<()> {
             // setup
             let total_past_blocks = 10;
-            let ema_0 = Amount {
-                amount: dec!(1.00),
-                _t: std::marker::PhantomData,
-            };
-            let current_price = dec!(1.01);
+            let ema_0 = Amount::new(dec!(1.00));
+            let current_price = Amount::new(dec!(1.01));
 
             // action
-            let ema_1 = calculate_ema(
-                total_past_blocks,
-                Amount {
-                    amount: current_price,
-                    _t: PhantomData,
-                },
-                ema_0,
-            )?;
+            let ema_1 = current_price.calculate_ema(total_past_blocks, ema_0)?;
 
             // assert
             let expected = dec!(1.00181818181818);
             assert!(
-                (ema_1 - expected).abs() < dec!(0.00000001),
+                (ema_1.amount - expected).abs() < dec!(0.00000001),
                 "EMA is {}, expected around {}",
-                ema_1,
+                ema_1.amount,
                 expected
             );
             Ok(())
@@ -370,17 +402,11 @@ mod tests {
         fn test_calculate_ema_huge_epoch() {
             // setup
             let total_past_blocks = u64::MAX;
-            let current_block_price = Amount {
-                amount: dec!(123.456),
-                _t: std::marker::PhantomData,
-            };
-            let last_block_ema = Amount {
-                amount: dec!(1000.0),
-                _t: std::marker::PhantomData,
-            };
+            let current_irys_price = Amount::new(dec!(123.456));
+            let last_block_ema = Amount::new(dec!(1000.0));
 
             // action
-            let result = calculate_ema(total_past_blocks, current_block_price, last_block_ema);
+            let result = current_irys_price.calculate_ema(total_past_blocks, last_block_ema);
 
             // assert
             assert!(result.is_ok());

--- a/crates/storage-pricing/src/lib.rs
+++ b/crates/storage-pricing/src/lib.rs
@@ -1,14 +1,19 @@
-use std::marker::PhantomData;
+use std::{fmt::Debug, marker::PhantomData};
 
 use eyre::ContextCompat;
 use rust_decimal::{Decimal, MathematicalOps};
+use rust_decimal_macros::dec;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct AnnualCostUsd;
+pub struct AnnualCostUsdPerGb;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct TotalCostUsd;
+pub struct AnnualCostUsdPerByte;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct DecayRate;
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct NetworkFee;
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AnnualUsdCostPerReplicaPerByte;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Amount<T> {
@@ -16,37 +21,93 @@ pub struct Amount<T> {
     _t: PhantomData<T>,
 }
 
-/// Calculate the total cost for storage
-///
-/// n = years to pay for storage
-/// r = decay rate
-///
-/// total cost = annual_cost * ((1 - (1-r)^n) / r)
-pub fn total_cost(
-    annual_cost: Amount<AnnualCostUsd>,
-    n: u64,
-    decay_rate: Amount<DecayRate>,
-) -> eyre::Result<Amount<TotalCostUsd>> {
-    // (1 - r)^n
-    let one_minus_r_pow = (Decimal::ONE.saturating_sub(decay_rate.amount))
-        .checked_powu(n)
-        .wrap_err("too many years to pay for")?;
+impl Amount<AnnualCostUsdPerGb> {
+    pub fn cost_per_byte(self) -> Amount<AnnualCostUsdPerByte> {
+        let amount = self
+            .amount
+            .checked_div(dec!(1024.0))
+            .expect("cost per byte must always be derrivable");
 
-    // fraction = [ 1 - (1-r)^n ] / r
-    let fraction = (Decimal::ONE.saturating_sub(one_minus_r_pow))
-        .checked_div(decay_rate.amount)
-        .wrap_err("decay rate invalid")?;
+        Amount {
+            amount,
+            _t: PhantomData,
+        }
+    }
+}
 
-    // total = annual_cost * fraction
-    let total = annual_cost
-        .amount
-        .checked_mul(fraction)
-        .wrap_err("fraction too large")?;
+impl Amount<AnnualCostUsdPerByte> {
+    /// Calculate the total cost for storage.
+    /// The price is for storing a single replica.
+    ///
+    /// n = years to pay for storage
+    /// r = decay rate
+    ///
+    /// total cost = annual_cost * ((1 - (1-r)^n) / r)
+    pub fn cost_per_replica(
+        self,
+        years_to_pay_for_storage: u64,
+        decay_rate: Amount<DecayRate>,
+    ) -> eyre::Result<Amount<AnnualUsdCostPerReplicaPerByte>> {
+        let annual_cost_per_byte = self.amount;
 
-    Ok(Amount {
-        amount: total,
-        _t: PhantomData,
-    })
+        // (1 - r)^n
+        let one_minus_r_pow = (Decimal::ONE.saturating_sub(decay_rate.amount))
+            .checked_powu(years_to_pay_for_storage)
+            .wrap_err("too many years to pay for")?;
+
+        // fraction = [ 1 - (1-r)^n ] / r
+        let fraction = (Decimal::ONE.saturating_sub(one_minus_r_pow))
+            .checked_div(decay_rate.amount)
+            .wrap_err("decay rate invalid")?;
+
+        // total = annual_cost * fraction
+        let total = annual_cost_per_byte
+            .checked_mul(fraction)
+            .wrap_err("fraction too large")?;
+
+        Ok(Amount {
+            amount: total,
+            _t: PhantomData,
+        })
+    }
+}
+
+impl Amount<AnnualUsdCostPerReplicaPerByte> {
+    pub fn replica_count(self, replicas: u64) -> eyre::Result<Self> {
+        let amount = self
+            .amount
+            .checked_mul(replicas.into())
+            .wrap_err("overflow during replica multiplication")?;
+        Ok(Self { amount, ..self })
+    }
+    pub fn base_network_fee(
+        self,
+        bytes_to_store: u128,
+        irys_token_price: Decimal,
+    ) -> eyre::Result<Amount<NetworkFee>> {
+        // annual cost per replica per byte in usd
+        let usd_fee = self.amount.checked_mul(bytes_to_store.into()).unwrap();
+        // converted to $IRYS
+        let network_fee = usd_fee.checked_div(irys_token_price).unwrap();
+        Ok(Amount {
+            amount: network_fee,
+            _t: PhantomData,
+        })
+    }
+}
+
+impl Amount<NetworkFee> {
+    /// Add additional network fee for storing data to incerace incentivisation.
+    ///
+    /// 0.05 => 5%
+    /// 1.00 => 100%
+    /// 0.50 => 50%
+    pub fn add_multiplier(self, percentage: Decimal) -> Amount<NetworkFee> {
+        Self {
+            amount: self.amount.saturating_mul(percentage),
+            _t: PhantomData,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -56,7 +117,7 @@ mod tests {
     use rust_decimal::Decimal;
 
     /// Helper to quickly build Amount<AnnualCostUsd> or Amount<DecayRate> etc.
-    fn annual_cost_usd(value: &str) -> Amount<AnnualCostUsd> {
+    fn annual_cost_usd(value: &str) -> Amount<AnnualCostUsdPerGb> {
         Amount {
             amount: Decimal::from_str_exact(value).unwrap(),
             _t: PhantomData,
@@ -71,61 +132,121 @@ mod tests {
 
     #[test]
     fn test_normal_case() -> Result<()> {
+        // Setup
         let annual = annual_cost_usd("0.01");
         let dec = decay_rate("0.01");
         let years = 200;
-        let total = total_cost(annual, years, dec)?;
 
-        let expected = Decimal::from_str_exact("0.8661").unwrap();
-        let diff = (total.amount - expected).abs();
-        assert!(diff < Decimal::from_str_exact("0.0001").unwrap());
+        // Action
+        let cost_per_replica = annual
+            .cost_per_byte()
+            .cost_per_replica(years, dec)?
+            .replica_count(1)?;
+        let cost_per_gb = cost_per_replica.amount * dec!(1024.0);
+
+        // Assert - cost per gb / single replica
+        let expected = Decimal::from_str_exact("0.8661")?;
+        let diff = (cost_per_gb - expected).abs();
+        assert!(diff < Decimal::from_str_exact("0.0001")?);
+
+        // Assert - cost per gb / 10 replicas
+        let cost_per_10_replicas = cost_per_replica.replica_count(10)?;
+        let cost_per_10_in_gb = cost_per_10_replicas.amount * dec!(1024.0);
+        let expected = Decimal::from_str_exact("8.66")?;
+        let diff = (cost_per_10_in_gb - expected).abs();
+        assert!(diff < Decimal::from_str_exact("0.001")?);
         Ok(())
     }
 
     #[test]
+    // r=0 => division by zero => should Err
     fn test_zero_decay_rate() {
-        // r=0 => division by zero => should Err
+        // setup
         let annual = annual_cost_usd("1000");
         let dec = decay_rate("0.0");
-        let result = total_cost(annual, 10, dec);
+        let years = 10;
+
+        // actoin
+        let result = annual.cost_per_byte().cost_per_replica(years, dec);
+
+        // assert
         assert!(result.is_err(), "Expected an error for r=0, got Ok(...)");
     }
 
     #[test]
+    // r=1 => fraction = (1 - (1-1)^n)/1 => (1 - 0^n)/1 => 1
     fn test_full_decay_rate() -> Result<()> {
-        // r=1 => fraction = [1 - (1-1)^n]/1 => [1 - 0^n]/1 => 1
-        // total = annual_cost
+        // setup
         let annual = annual_cost_usd("500");
         let dec = decay_rate("1.0");
-        let total = total_cost(annual, 5, dec)?;
-        assert_eq!(total.amount, Decimal::from(500));
+        let years_to_pay_for_storage = 5;
+
+        // action
+        let total = annual
+            .cost_per_byte()
+            .cost_per_replica(years_to_pay_for_storage, dec)
+            .unwrap()
+            .replica_count(1)?;
+        let per_gb = total.amount * dec!(1024.0);
+
+        // assert
+        assert_eq!(per_gb, Decimal::from(500));
         Ok(())
     }
 
     #[test]
     fn test_decay_rate_above_one() {
+        // setup
         let annual = annual_cost_usd("0.01");
         let dec = decay_rate("1.5"); // 150%
         let years = 200;
-        let result = total_cost(annual, years, dec);
+
+        // actoin
+        let result = annual
+            .cost_per_byte()
+            .cost_per_replica(years, dec)
+            .unwrap()
+            .replica_count(1);
+
+        // assert
         assert!(result.is_ok(), "Expected error for decay > 1.0");
     }
 
     #[test]
     fn test_no_years_to_pay() -> Result<()> {
+        // setup
         let annual = annual_cost_usd("1234.56");
         let dec = decay_rate("0.05"); // 5%
-        let total = total_cost(annual, 0, dec)?;
+        let years = 0;
+
+        // action
+        let total = annual
+            .cost_per_byte()
+            .cost_per_replica(years, dec)
+            .unwrap()
+            .replica_count(1)?;
+
+        // assert
         assert_eq!(total.amount, Decimal::ZERO);
         Ok(())
     }
 
     #[test]
+    // If annual cost=0 => total=0, no matter the decay rate
     fn test_annual_cost_zero() -> Result<()> {
-        // If annual cost=0 => total=0, no matter the decay rate
+        // setup
         let annual = annual_cost_usd("0");
         let dec = decay_rate("0.05"); // 5%
-        let total = total_cost(annual, 10, dec)?;
+        let years = 10;
+
+        // action
+        let total = annual
+            .cost_per_byte()
+            .cost_per_replica(years, dec)
+            .unwrap()
+            .replica_count(1)?;
+
+        // assert
         assert_eq!(total.amount, Decimal::ZERO);
         Ok(())
     }


### PR DESCRIPTION
## Related issues

#180 

## Changes

This PR adds a standalone crate under `/crates/storage-pricing` for doing all the necessary calculations for:
- the operational cost of storing _n_ bytes of data
- network fees for storing data that the user has to pay
- EMA for the Irys token price (denominated in USD) that are to be stored in the block headers (storing this data will be added in a future PR)
- piggybacking extra lints that have been added to the root Cargo.toml 🙈 

This PR **does not** add any functionality to the node itself. 

## Linter

All linter checks pass for `cargo clippy -p storage-pricing`