### PR TITLE
fix:valid solutions based on head-1 difficulty

### DIFF
--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -130,7 +130,17 @@ pub fn difficulty_is_valid(
     );
 
     if diff == block.diff {
-        Ok(())
+        if let Some(stats) = _stats {
+            if stats.is_adjusted && block.diff > previous_block.diff {
+                Ok(())
+            } else {
+                Err(eyre::eyre!(
+                    "Difficulty shoud be greater than previous difficulty."
+                ))
+            }
+        } else {
+            Ok(())
+        }
     } else {
         Err(eyre::eyre!(
             "Invalid difficulty (expected {} got {})",

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -130,17 +130,7 @@ pub fn difficulty_is_valid(
     );
 
     if diff == block.diff {
-        if let Some(stats) = _stats {
-            if stats.is_adjusted && block.diff > previous_block.diff {
-                Ok(())
-            } else {
-                Err(eyre::eyre!(
-                    "Difficulty shoud be greater than previous difficulty."
-                ))
-            }
-        } else {
-            Ok(())
-        }
+        Ok(())
     } else {
         Err(eyre::eyre!(
             "Invalid difficulty (expected {} got {})",
@@ -201,7 +191,9 @@ pub fn solution_hash_is_valid(block: &IrysBlockHeader) -> eyre::Result<()> {
     let solution_hash = block.solution_hash;
     let solution_diff = hash_to_number(&solution_hash.0);
 
-    if solution_diff >= block.diff {
+    let previous_solution_diff=hash_to_number(&block.previous_solution_hash.0);
+
+    if solution_diff >= previous_solution_diff {
         Ok(())
     } else {
         Err(eyre::eyre!(

--- a/crates/types/src/difficulty_adjustment_config.rs
+++ b/crates/types/src/difficulty_adjustment_config.rs
@@ -58,6 +58,9 @@ pub fn calculate_initial_difficulty(
     Ok(initial_difficulty)
 }
 
+/// - if `actual_time_ms` < `target_time_ms`,the difficulty increases i.e. block.difficulty > previous_block.difficulty.
+/// -  if `actual_time_ms` > `target_time_ms`,the difficulty decreases i.e. block.difficulty < previous_block.difficulty.
+/// - if the `percent_diff` < `min_threshold`, the difficulty remains unchanged.
 pub fn adjust_difficulty(current_diff: U256, actual_time_ms: u128, target_time_ms: u128) -> U256 {
     let max_u256 = U256::MAX;
     let scale = U256::from(1000);


### PR DESCRIPTION
Ref #206 

Checks made in `difficulty_is_valid` are in this order now:
- check if difficulty is equal to calculated difficulty, else return error
- if `stats` is some, that implies the difficulty has beed adjusted
- if so, it checks if the block.diff > previousBlock.diff