### PR TITLE
Fix: flaky block production test

### DIFF
--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -18,7 +18,6 @@ use reth_primitives::{
     irys_primitives::{IrysTxId, ShadowResult},
     GenesisAccount,
 };
-use sha2::Digest;
 use tokio::time::sleep;
 use tracing::info;
 
@@ -190,11 +189,11 @@ async fn serial_mine_ten_blocks() -> eyre::Result<()> {
         info!("waiting block {}", i);
 
         let mut retries = 0;
-        while node.block_index_guard.read().num_blocks() < i + 1 && retries < 20_u64 {
+        while node.block_index_guard.read().num_blocks() < i + 1 {
             sleep(Duration::from_secs(1)).await;
             retries += 1;
         }
-
+        info!("got block after {} retries", &retries);
         let block = node
             .block_index_guard
             .read()

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -129,49 +129,6 @@ async fn serial_test_blockprod() -> eyre::Result<()> {
 }
 
 #[tokio::test]
-async fn serial_mine_ten_blocks() -> eyre::Result<()> {
-    let temp_dir = setup_tracing_and_temp_dir(Some("test_blockprod"), false);
-    let mut config = IrysNodeConfig::default();
-    config.base_directory = temp_dir.path().to_path_buf();
-
-    let node = start_for_testing(config).await?;
-    node.actor_addresses.start_mining()?;
-
-    let reth_context = RethNodeContext::new(node.reth_handle.into()).await?;
-
-    for i in 1..10 {
-        info!("waiting block {}", i);
-
-        let mut retries = 0;
-        while node.block_index_guard.read().num_blocks() < i + 1 && retries < 20_u64 {
-            sleep(Duration::from_secs(1)).await;
-            retries += 1;
-        }
-
-        let block = node
-            .block_index_guard
-            .read()
-            .get_item(i as usize)
-            .unwrap()
-            .clone();
-
-        //check reth for built block
-        let reth_block = reth_context.inner.provider.block_by_number(i)?.unwrap();
-        assert_eq!(i, reth_block.header.number);
-        assert_eq!(i, reth_block.number);
-
-        // check irys DB for built block
-        let db_irys_block = &node
-            .db
-            .view_eyre(|tx| irys_database::block_header_by_hash(tx, &block.block_hash))?
-            .unwrap();
-
-        assert_eq!(db_irys_block.evm_block_hash, reth_block.hash_slow());
-    }
-    Ok(())
-}
-
-#[tokio::test]
 async fn serial_mine_ten_blocks_with_capacity_poa_solution() -> eyre::Result<()> {
     let temp_dir = setup_tracing_and_temp_dir(Some("test_blockprod"), false);
     let mut config = IrysNodeConfig::default();
@@ -214,6 +171,49 @@ async fn serial_mine_ten_blocks_with_capacity_poa_solution() -> eyre::Result<()>
         assert_eq!(db_irys_block.evm_block_hash, reth_block.hash_slow());
         // MAGIC: we wait more than 1s so that the block timestamps (evm block timestamps are seconds) don't overlap
         sleep(Duration::from_millis(1500)).await;
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn serial_mine_ten_blocks() -> eyre::Result<()> {
+    let temp_dir = setup_tracing_and_temp_dir(Some("test_blockprod"), false);
+    let mut config = IrysNodeConfig::default();
+    config.base_directory = temp_dir.path().to_path_buf();
+
+    let node = start_for_testing(config).await?;
+    node.actor_addresses.start_mining()?;
+
+    let reth_context = RethNodeContext::new(node.reth_handle.into()).await?;
+
+    for i in 1..10 {
+        info!("waiting block {}", i);
+
+        let mut retries = 0;
+        while node.block_index_guard.read().num_blocks() < i + 1 && retries < 20_u64 {
+            sleep(Duration::from_secs(1)).await;
+            retries += 1;
+        }
+
+        let block = node
+            .block_index_guard
+            .read()
+            .get_item(i as usize)
+            .unwrap()
+            .clone();
+
+        //check reth for built block
+        let reth_block = reth_context.inner.provider.block_by_number(i)?.unwrap();
+        assert_eq!(i, reth_block.header.number);
+        assert_eq!(i, reth_block.number);
+
+        // check irys DB for built block
+        let db_irys_block = &node
+            .db
+            .view_eyre(|tx| irys_database::block_header_by_hash(tx, &block.block_hash))?
+            .unwrap();
+
+        assert_eq!(db_irys_block.evm_block_hash, reth_block.hash_slow());
     }
     Ok(())
 }

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -189,11 +189,13 @@ async fn serial_mine_ten_blocks() -> eyre::Result<()> {
         info!("waiting block {}", i);
 
         let mut retries = 0;
-        while node.block_index_guard.read().num_blocks() < i + 1 {
+        while node.block_index_guard.read().num_blocks() < i + 1 && retries < 60_u64 {
             sleep(Duration::from_secs(1)).await;
             retries += 1;
         }
-        info!("got block after {} retries", &retries);
+
+        info!("got block after {} seconds/retries", &retries);
+
         let block = node
             .block_index_guard
             .read()


### PR DESCRIPTION
This PR aims to resolve the flaky serial_mine_ten_blocks test by increasing the wait timeout for new solutions. This is required due to the CI server having lower than expected single thread performance, which limits mining solution generation speeds vs the timeout, which is wall clock time based.
This PR is also coupled with a small tweak to the CI container configuration, so that each container has an enforced equal claim to the host's CPU time.