### PR TITLE
Remove warnings from Irys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
- "proptest-derive 0.5.1",
+ "proptest-derive",
  "rand",
  "ruint",
  "rustc-hash 2.1.0",
@@ -5490,7 +5490,7 @@ dependencies = [
  "derive_more 1.0.0",
  "eyre",
  "modular-bitfield",
- "proptest-derive 0.5.1",
+ "proptest-derive",
  "reth-codecs",
  "ruint",
  "serde",
@@ -6119,7 +6119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -7591,17 +7591,6 @@ dependencies = [
 
 [[package]]
 name = "proptest-derive"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf16337405ca084e9c78985114633b6827711d22b9e6ef6c6c0d665eb3f0b6e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "proptest-derive"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee1c9ac207483d5e7db4940700de86a9aae46ef90c48b57f99fe7edb8345e49"
@@ -8225,7 +8214,6 @@ dependencies = [
  "reth-primitives",
  "reth-primitives-traits",
  "reth-trie-common",
- "revm-primitives",
  "serde",
  "serde_json",
 ]
@@ -8234,7 +8222,6 @@ dependencies = [
 name = "reth-cli"
 version = "1.1.0"
 dependencies = [
- "alloy-genesis",
  "clap",
  "eyre",
  "irys-primitives",
@@ -8399,7 +8386,6 @@ dependencies = [
  "futures",
  "reqwest",
  "reth-node-api",
- "reth-rpc-api",
  "reth-rpc-builder",
  "reth-tracing",
  "ringbuffer",
@@ -8443,7 +8429,6 @@ dependencies = [
 name = "reth-db-api"
 version = "1.1.0"
 dependencies = [
- "alloy-genesis",
  "alloy-primitives",
  "arbitrary",
  "bytes",
@@ -8468,7 +8453,6 @@ dependencies = [
 name = "reth-db-common"
 version = "1.1.0"
 dependencies = [
- "alloy-genesis",
  "alloy-primitives",
  "boyer-moore-magiclen",
  "eyre",
@@ -8873,7 +8857,7 @@ dependencies = [
  "dyn-clone",
  "once_cell",
  "proptest",
- "proptest-derive 0.5.1",
+ "proptest-derive",
  "rustc-hash 2.1.0",
  "serde",
  "thiserror-no-std",
@@ -9363,7 +9347,6 @@ dependencies = [
  "futures",
  "humantime",
  "irys-storage",
- "irys-types",
  "rand",
  "reth-chainspec",
  "reth-cli-util",
@@ -9569,7 +9552,6 @@ version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
@@ -9815,7 +9797,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "async-trait",
- "eyre",
  "jsonrpsee-core",
  "jsonrpsee-types",
  "metrics 0.23.0",
@@ -9833,7 +9814,6 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "serde",
- "serde_json",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -9959,7 +9939,6 @@ dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-serde",
- "irys-primitives",
  "reth-primitives",
  "reth-trie-common",
 ]
@@ -10199,7 +10178,6 @@ name = "reth-trie-common"
 version = "1.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
@@ -10325,25 +10303,16 @@ dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
  "alloy-primitives",
- "arbitrary",
  "auto_impl",
  "bitflags 2.6.0",
  "bitvec",
- "bytes",
  "c-kzg",
  "cfg-if",
- "derive_more 1.0.0",
  "dyn-clone",
  "enumn",
  "hex",
  "irys-primitives",
- "modular-bitfield",
- "proptest",
- "proptest-derive 0.4.0",
- "reth-codecs",
  "serde",
- "test-fuzz",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -12517,7 +12486,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/actors/src/epoch_service.rs
+++ b/crates/actors/src/epoch_service.rs
@@ -1042,7 +1042,7 @@ mod tests {
         let arc_rwlock = Arc::new(rwlock);
         let closure_arc = arc_rwlock.clone();
 
-        let mocked_block_producer = BlockProducerMockActor::mock(Box::new(move |msg, _ctx| {
+        let mocked_block_producer = BlockProducerMockActor::mock(Box::new(move |_msg, _ctx| {
             let inner_result: eyre::Result<
                 Option<(Arc<IrysBlockHeader>, ExecutionPayloadEnvelopeV1Irys)>,
             > = Ok(None);

--- a/crates/actors/src/mining.rs
+++ b/crates/actors/src/mining.rs
@@ -429,7 +429,7 @@ mod tests {
 
         let mocked_block_producer = get_mocked_block_producer(closure_arc);
 
-        let packing = Mocker::<PackingActor>::mock(Box::new(move |msg, _ctx| {
+        let packing = Mocker::<PackingActor>::mock(Box::new(move |_msg, _ctx| {
             Box::new(Some(())) as Box<dyn Any>
         }));
 
@@ -652,7 +652,7 @@ mod tests {
 
         let atomic_global_step_number = Arc::new(AtomicU64::new(1));
 
-        let packing = Mocker::<PackingActor>::mock(Box::new(move |msg, _ctx| {
+        let packing = Mocker::<PackingActor>::mock(Box::new(move |_msg, _ctx| {
             Box::new(Some(())) as Box<dyn Any>
         }));
 

--- a/crates/actors/src/packing.rs
+++ b/crates/actors/src/packing.rs
@@ -15,7 +15,7 @@ use {
     irys_types::{split_interval, CHUNK_SIZE},
 };
 
-use irys_storage::{ChunkType, InclusiveInterval, StorageModule};
+use irys_storage::{ChunkType, StorageModule};
 use irys_types::{PartitionChunkOffset, PartitionChunkRange, StorageConfig};
 use reth::tasks::TaskExecutor;
 use tokio::{runtime::Handle, sync::Semaphore, time::sleep};
@@ -465,6 +465,6 @@ mod tests {
     #[should_panic(expected = "wrong input N 3")]
     fn test_casting_error() {
         let v: Vec<u8> = (1..=10).collect();
-        let c2 = cast_vec_u8_to_vec_u8_array::<3>(v);
+        let _c2 = cast_vec_u8_to_vec_u8_array::<3>(v);
     }
 }

--- a/crates/c/build/capacity.rs
+++ b/crates/c/build/capacity.rs
@@ -41,7 +41,7 @@ pub(crate) fn bind_capacity(c_src: &PathBuf) {
         .expect("Couldn't write bindings!");
 }
 
-pub(crate) fn build_capacity_cuda(c_src: &PathBuf, ssl_inc_dir: &PathBuf) {
+pub(crate) fn build_capacity_cuda(c_src: &PathBuf, _ssl_inc_dir: &PathBuf) {
     let mut cc = cc::Build::new();
 
     cc.cuda(true);

--- a/crates/c/c_src/capacity_single.c
+++ b/crates/c/c_src/capacity_single.c
@@ -6,7 +6,7 @@
 #include "capacity.h"
 
 entropy_chunk_errors compute_seed_hash(const unsigned char *mining_addr, size_t mining_addr_size, unsigned long int chunk_offset,  unsigned long int chain_id, const unsigned char *partition_hash, size_t partition_hash_size, unsigned char *seed_hash) {
-    int input_len = mining_addr_size + partition_hash_size + sizeof(uint64_t) + sizeof(uint64_t);
+    // int input_len = mining_addr_size + partition_hash_size + sizeof(uint64_t) + sizeof(uint64_t);
     uint64_t chunk_offset_u64 = (uint64_t) chunk_offset;
     uint64_t chain_id_u64 = (uint64_t) chain_id;
 
@@ -95,7 +95,7 @@ entropy_chunk_errors compute_entropy_chunk2(const unsigned char *segment, const 
         return HASH_COMPUTATION_ERROR;
     }
 
-    for (int hash_count = HASH_ITERATIONS_PER_BLOCK; hash_count < packing_sha_1_5_s; ++hash_count) {
+    for (unsigned int hash_count = HASH_ITERATIONS_PER_BLOCK; hash_count < packing_sha_1_5_s; ++hash_count) {
         //printf("compute_entropy_chunk2 hash count %d iterations %d\n", hash_count, packing_sha_1_5_s);
         size_t start_offset = (hash_count % HASH_ITERATIONS_PER_BLOCK) * PACKING_HASH_SIZE;
 

--- a/crates/c/c_src/vdf.cpp
+++ b/crates/c/c_src/vdf.cpp
@@ -2,6 +2,7 @@
 #include <cstring>
 #include <vector>
 #include <mutex>
+#include <openssl/evp.h>
 #include <openssl/sha.h>
 #include <gmp.h>
 #include <cstdlib>
@@ -58,6 +59,24 @@ void long_add(unsigned char* saltBuffer, int checkpointIdx) {
 	}
 }
 
+// todo: Currently the two size args (count1: SALT_SIZE, count2: VDF_SHA_HASH_SIZE) are the same. Can they be merged down to one and eliminated as arguments?
+void calculate(const unsigned char* saltBuffer, const unsigned char* locIn, unsigned char* tempOut, size_t count1, size_t count2) {
+	#if OPENSSL_VERSION_NUMBER < 0x30000000L
+		SHA256_CTX sha256;
+		SHA256_Init(&sha256);
+		SHA256_Update(&sha256, saltBuffer, SALT_SIZE);
+		SHA256_Update(&sha256, locIn, VDF_SHA_HASH_SIZE); // -1 memcpy
+		SHA256_Final(tempOut, &sha256);
+	#else
+		EVP_MD_CTX* ctx = EVP_MD_CTX_new();
+		EVP_DigestInit_ex(ctx, EVP_sha256(), NULL);
+		EVP_DigestUpdate(ctx, saltBuffer, count1);
+		EVP_DigestUpdate(ctx, locIn, count2);
+		EVP_DigestFinal_ex(ctx, tempOut, NULL);
+		EVP_MD_CTX_free(ctx);
+	#endif
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //    SHA
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -71,25 +90,13 @@ void _vdf_sha2(unsigned char* saltBuffer, unsigned char* seed, unsigned char* ou
 			unsigned char* locOut = checkpointIdx == checkpointCount ? out  : (outCheckpoint + VDF_SHA_HASH_SIZE*checkpointIdx);
 			
 			{
-				SHA256_CTX sha256;
-				SHA256_Init(&sha256);
-				SHA256_Update(&sha256, saltBuffer, SALT_SIZE);
-				SHA256_Update(&sha256, locIn, VDF_SHA_HASH_SIZE); // -1 memcpy
-				SHA256_Final(tempOut, &sha256);
+				calculate(saltBuffer, locIn, tempOut, SALT_SIZE, VDF_SHA_HASH_SIZE);
 			}
 			for(int i = 2; i < hashingIterations; i++) {
-				SHA256_CTX sha256;
-				SHA256_Init(&sha256);
-				SHA256_Update(&sha256, saltBuffer, SALT_SIZE);
-				SHA256_Update(&sha256, tempOut, VDF_SHA_HASH_SIZE);
-				SHA256_Final(tempOut, &sha256);
+				calculate(saltBuffer, tempOut, tempOut, SALT_SIZE, VDF_SHA_HASH_SIZE);
 			}
 			{
-				SHA256_CTX sha256;
-				SHA256_Init(&sha256);
-				SHA256_Update(&sha256, saltBuffer, SALT_SIZE);
-				SHA256_Update(&sha256, tempOut, VDF_SHA_HASH_SIZE);
-				SHA256_Final(locOut, &sha256);
+				calculate(saltBuffer, tempOut, locOut, SALT_SIZE, VDF_SHA_HASH_SIZE);
 			}
 			long_add(saltBuffer, 1);
 		}
@@ -99,46 +106,26 @@ void _vdf_sha2(unsigned char* saltBuffer, unsigned char* seed, unsigned char* ou
 			unsigned char* locOut = checkpointIdx == checkpointCount ? out  : (outCheckpoint + VDF_SHA_HASH_SIZE*checkpointIdx);
 			
 			{
-				SHA256_CTX sha256;
-				SHA256_Init(&sha256);
-				SHA256_Update(&sha256, saltBuffer, SALT_SIZE);
-				SHA256_Update(&sha256, locIn, VDF_SHA_HASH_SIZE); // -1 memcpy
-				SHA256_Final(tempOut, &sha256);
+				calculate(saltBuffer, locIn, tempOut, SALT_SIZE, VDF_SHA_HASH_SIZE);
 			}
 			// 1 skip on start
 			for(int i = 1; i < hashingIterations; i++) {
-				SHA256_CTX sha256;
-				SHA256_Init(&sha256);
-				SHA256_Update(&sha256, saltBuffer, SALT_SIZE);
-				SHA256_Update(&sha256, tempOut, VDF_SHA_HASH_SIZE);
-				SHA256_Final(tempOut, &sha256);
+				calculate(saltBuffer, tempOut, tempOut, SALT_SIZE, VDF_SHA_HASH_SIZE);
 			}
 			long_add(saltBuffer, 1);
 			for(int j = 1; j < skipCheckpointCount; j++) {
 				// no skips
 				for(int i = 0; i < hashingIterations; i++) {
-					SHA256_CTX sha256;
-					SHA256_Init(&sha256);
-					SHA256_Update(&sha256, saltBuffer, SALT_SIZE);
-					SHA256_Update(&sha256, tempOut, VDF_SHA_HASH_SIZE);
-					SHA256_Final(tempOut, &sha256);
+					calculate(saltBuffer, tempOut, tempOut, SALT_SIZE, VDF_SHA_HASH_SIZE);
 				}
 				long_add(saltBuffer, 1);
 			}
 			// 1 skip on end
 			for(int i = 1; i < hashingIterations; i++) {
-				SHA256_CTX sha256;
-				SHA256_Init(&sha256);
-				SHA256_Update(&sha256, saltBuffer, SALT_SIZE);
-				SHA256_Update(&sha256, tempOut, VDF_SHA_HASH_SIZE);
-				SHA256_Final(tempOut, &sha256);
+				calculate(saltBuffer, tempOut, tempOut, SALT_SIZE, VDF_SHA_HASH_SIZE);
 			}
 			{
-				SHA256_CTX sha256;
-				SHA256_Init(&sha256);
-				SHA256_Update(&sha256, saltBuffer, SALT_SIZE);
-				SHA256_Update(&sha256, tempOut, VDF_SHA_HASH_SIZE);
-				SHA256_Final(locOut, &sha256);
+				calculate(saltBuffer, tempOut, locOut, SALT_SIZE, VDF_SHA_HASH_SIZE);
 			}
 			long_add(saltBuffer, 1);
 		}
@@ -296,11 +283,7 @@ bool vdf_parallel_sha_verify(unsigned char* startSaltBuffer, unsigned char* seed
 }
 
 void reset_mix(unsigned char* res, unsigned char* prevOutput, unsigned char* resetSeed) {
-	SHA256_CTX sha256;
-	SHA256_Init(&sha256);
-	SHA256_Update(&sha256, prevOutput, VDF_SHA_HASH_SIZE);
-	SHA256_Update(&sha256, resetSeed, VDF_SHA_HASH_SIZE);
-	SHA256_Final(res, &sha256);
+	calculate(prevOutput, resetSeed, res, VDF_SHA_HASH_SIZE, VDF_SHA_HASH_SIZE);
 }
 
 bool fast_rev_cmp256(unsigned char* a, unsigned char* b) {

--- a/crates/c/src/capacity.rs
+++ b/crates/c/src/capacity.rs
@@ -1,4 +1,4 @@
-#[allow(non_upper_case_globals)]
-#[allow(non_camel_case_types)]
-#[allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
 include!(concat!(env!("OUT_DIR"), "/capacity_bindings.rs"));

--- a/crates/c/src/vdf.rs
+++ b/crates/c/src/vdf.rs
@@ -1,4 +1,4 @@
-#[allow(non_upper_case_globals)]
-#[allow(non_camel_case_types)]
-#[allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
 include!(concat!(env!("OUT_DIR"), "/vdf_bindings.rs"));

--- a/crates/chain/tests/api/api.rs
+++ b/crates/chain/tests/api/api.rs
@@ -149,7 +149,7 @@ async fn api_end_to_end_test(chunk_size: usize) {
         let resp = test::call_service(&app, req).await;
 
         if resp.status() == StatusCode::OK {
-            let result: IrysTransactionHeader = test::read_body_json(resp).await;
+            let _result: IrysTransactionHeader = test::read_body_json(resp).await;
             //assert_eq!(tx.header, result); TODO: uncomment this after fixing IrysSignature serialization issue with chain id Dan described
             info!("Transaction was retrieved ok after {} attempts", attempts);
             break;

--- a/crates/chain/tests/block_production/analytics.rs
+++ b/crates/chain/tests/block_production/analytics.rs
@@ -80,7 +80,7 @@ async fn test_blockprod_with_evm_txs() -> eyre::Result<()> {
         },
     )
     .await?;
-    let reth_context = RethNodeContext::new(node.reth_handle.into()).await?;
+    let _reth_context = RethNodeContext::new(node.reth_handle.into()).await?;
 
     let http_url = "http://127.0.0.1:8080";
 
@@ -90,7 +90,7 @@ async fn test_blockprod_with_evm_txs() -> eyre::Result<()> {
         .timeout(Duration::from_secs(10_000))
         .finish();
 
-    let response = client
+    let _response = client
         .get(format!("{}/v1/info", http_url))
         .send()
         .await
@@ -257,7 +257,7 @@ async fn test_blockprod_with_evm_txs() -> eyre::Result<()> {
         )
         .await;
 
-        let (block, reth_exec_env) = node
+        let (_block, _reth_exec_env) = node
             .actor_addresses
             .block_producer
             .send(SolutionFoundMessage(poa_solution))

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -69,7 +69,7 @@ async fn serial_test_blockprod() -> eyre::Result<()> {
         let tx = a.create_transaction(data_bytes, None).unwrap();
         let tx = a.sign_transaction(tx).unwrap();
         // submit to mempool
-        let tx_res = node
+        let _tx_res = node
             .actor_addresses
             .mempool
             .send(TxIngressMessage(tx.header.clone()))
@@ -150,7 +150,7 @@ async fn serial_mine_ten_blocks_with_capacity_poa_solution() -> eyre::Result<()>
             .actor_addresses
             .block_producer
             .send(SolutionFoundMessage(poa_solution.clone()));
-        let (block, reth_exec_env) = fut.await??.unwrap();
+        let (block, _reth_exec_env) = fut.await??.unwrap();
 
         //check reth for built block
         let reth_block = reth_context
@@ -351,7 +351,7 @@ async fn serial_test_blockprod_with_evm_txs() -> eyre::Result<()> {
         let tx = a.create_transaction(data_bytes, None).unwrap();
         let tx = a.sign_transaction(tx).unwrap();
         // submit to mempool
-        let tx_res = node
+        let _tx_res = node
             .actor_addresses
             .mempool
             .send(TxIngressMessage(tx.header.clone()))

--- a/crates/chain/tests/external/block_production.rs
+++ b/crates/chain/tests/external/block_production.rs
@@ -121,5 +121,6 @@ async fn continuous_blockprod_evm_tx() -> eyre::Result<()> {
         sleep(Duration::from_millis(10_000)).await;
     }
 
+    #[allow(unreachable_code)]
     Ok(())
 }

--- a/crates/chain/tests/external/programmable_data_basic.rs
+++ b/crates/chain/tests/external/programmable_data_basic.rs
@@ -202,7 +202,7 @@ async fn test_programmable_data_basic_external() -> eyre::Result<()> {
         None
     });
 
-    let start_offset = future_or_mine_on_timeout(
+    let _start_offset = future_or_mine_on_timeout(
         node.clone(),
         &mut start_offset_fut,
         Duration::from_millis(500),
@@ -213,7 +213,7 @@ async fn test_programmable_data_basic_external() -> eyre::Result<()> {
     .await?
     .unwrap();
 
-    for i in 1..10 {
+    for _i in 1..10 {
         let poa_solution = capacity_chunk_solution(
             node.config.mining_signer.address(),
             node.vdf_steps_guard.clone(),

--- a/crates/chain/tests/promotion/data_promotion_double.rs
+++ b/crates/chain/tests/promotion/data_promotion_double.rs
@@ -184,7 +184,7 @@ async fn serial_double_root_data_promotion_test() {
     // ==============================
     // Post Tx chunks out of order
     // ------------------------------
-    let tx_index = 2;
+    let _tx_index = 2;
 
     // // Last Tx, last chunk
     // let chunk_index = 2;
@@ -294,7 +294,7 @@ async fn serial_double_root_data_promotion_test() {
     // let block_tx2 = get_block_parent(txs[2].header.id, Ledger::Publish, db).unwrap();
 
     let first_tx_index: usize;
-    let next_tx_index: usize;
+    let _next_tx_index: usize;
 
     // if block_tx1.block_hash == block_tx2.block_hash {
     //     // Extract the transaction order
@@ -384,7 +384,7 @@ async fn serial_double_root_data_promotion_test() {
 
     let mut txs: Vec<IrysTransaction> = Vec::new();
 
-    for (i, chunks) in data_chunks.iter().enumerate() {
+    for (_i, chunks) in data_chunks.iter().enumerate() {
         let mut data: Vec<u8> = Vec::new();
         for chunk in chunks {
             data.extend_from_slice(chunk);

--- a/crates/config/src/chain/chain.rs
+++ b/crates/config/src/chain/chain.rs
@@ -94,7 +94,7 @@ pub struct IrysChainSpec {
 }
 
 impl IrysChainSpec {
-    fn new() -> Self {
+    fn _new() -> Self {
         Self {
             irys_genesis: IrysBlockHeader::new(),
         }

--- a/crates/database/src/submodule/tables.rs
+++ b/crates/database/src/submodule/tables.rs
@@ -8,7 +8,7 @@ use reth_db::{HasName, HasTableType, TableType, TableViewer};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-/// Per-submodule database tables
+// Per-submodule database tables
 tables! {
     SubmoduleTables;
 

--- a/crates/debug-utils/src/db.rs
+++ b/crates/debug-utils/src/db.rs
@@ -10,7 +10,7 @@ pub fn load_db() -> DatabaseEnv {
     open_or_create_db(path, IrysTables::ALL, None).unwrap()
 }
 
-fn promotion_debug() -> eyre::Result<()> {
+fn _promotion_debug() -> eyre::Result<()> {
     let db = load_db();
     let read_tx = db.tx()?;
     let ingress_proofs = walk_all::<IngressProofs>(&read_tx)?;

--- a/crates/primitives/src/commitment.rs
+++ b/crates/primitives/src/commitment.rs
@@ -3,7 +3,6 @@ use alloy_rlp::{
     Decodable, Encodable, Error as RlpError, RlpDecodable, RlpDecodableWrapper, RlpEncodable,
     RlpEncodableWrapper,
 };
-use arbitrary::Arbitrary as PledgeArbitrary;
 use bytes::Buf;
 use reth_codecs::Compact;
 

--- a/crates/primitives/src/last_tx.rs
+++ b/crates/primitives/src/last_tx.rs
@@ -1,5 +1,4 @@
 use alloy_rlp::{Decodable, Encodable, Error as RlpError};
-use arbitrary::Arbitrary as PledgeArbitrary;
 use bytes::Buf;
 use reth_codecs::Compact;
 

--- a/crates/storage/tests/storage_module_index_tests.rs
+++ b/crates/storage/tests/storage_module_index_tests.rs
@@ -322,8 +322,8 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
 
     // Manually update the data_root -> partition_hash index
     let db = open_or_create_db(tmp_dir, IrysTables::ALL, None).unwrap();
-    let part_hash_0 = storage_modules[0].partition_hash().unwrap();
-    let part_hash_1 = storage_modules[1].partition_hash().unwrap();
+    let _part_hash_0 = storage_modules[0].partition_hash().unwrap();
+    let _part_hash_1 = storage_modules[1].partition_hash().unwrap();
 
     // Loop though all the transactions and add their chunks to the cache
     for tx in &txs {

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -3,6 +3,9 @@ edition = "2021"
 name = "irys-types"
 version = "0.1.0"
 
+[features]
+dev = []
+
 [dependencies]
 chrono = "0.4"
 uint = "0.9.5"

--- a/crates/types/src/block.rs
+++ b/crates/types/src/block.rs
@@ -474,7 +474,7 @@ mod tests {
 
     const DEV_PRIVATE_KEY: &str =
         "db793353b633df950842415065f769699541160845d73db902eadee6bc5042d0";
-    const DEV_ADDRESS: &str = "64f1a2829e0e698c18e7792d6e74f67d89aa0a32";
+    const _DEV_ADDRESS: &str = "64f1a2829e0e698c18e7792d6e74f67d89aa0a32";
 
     #[test]
     fn test_irys_block_header_signing() {

--- a/crates/types/src/serialization.rs
+++ b/crates/types/src/serialization.rs
@@ -100,7 +100,7 @@ impl Compact for U256 {
 // H256 Type
 //------------------------------------------------------------------------------
 construct_fixed_hash! {
-    /// A 256-bit hash type (32 bytes)
+    /// A 256-bit hash type (32 bytes).
     pub struct H256(32);
 }
 

--- a/crates/types/src/storage.rs
+++ b/crates/types/src/storage.rs
@@ -1,6 +1,6 @@
 use std::{
     fmt,
-    ops::{Add, AddAssign, Deref, DerefMut, Rem, Sub},
+    ops::{Add, AddAssign, Deref, DerefMut, Rem},
     path::PathBuf,
 };
 

--- a/crates/types/src/transaction.rs
+++ b/crates/types/src/transaction.rs
@@ -220,7 +220,7 @@ mod tests {
 
     const DEV_PRIVATE_KEY: &str =
         "db793353b633df950842415065f769699541160845d73db902eadee6bc5042d0";
-    const DEV_ADDRESS: &str = "64f1a2829e0e698c18e7792d6e74f67d89aa0a32";
+    const _DEV_ADDRESS: &str = "64f1a2829e0e698c18e7792d6e74f67d89aa0a32";
 
     #[test]
     fn test_tx_encode_and_signing() {

--- a/crates/vdf/src/lib.rs
+++ b/crates/vdf/src/lib.rs
@@ -388,7 +388,7 @@ mod tests {
     use base58::{FromBase58, ToBase58};
 
     use super::*;
-    fn generate_next_vdf_step() {
+    fn _generate_next_vdf_step() {
         let mut seed = H256(
             hex::decode("ca4d22678f78b87ee7f1c80229133ecbf57c99533d9a708e6d86d2f51ccfcb41")
                 .unwrap()


### PR DESCRIPTION
Removed all warnings found in Irys.

Testing vs main proves same results, 228/229 passed.

This will require updating the following sub-modules:
- alloy
- reth
- revm

for warning-free build.

Can update CI to now use `RUSTFLAGS="-D warnings" cargo c`
