### PR TITLE
chore: reenable nvidia in cargo c and fix warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -69,7 +69,7 @@ jobs:
         run: git submodule update --init --recursive
 
       - name: cargo check
-        run: RUSTFLAGS="-D warnings" cargo xtask check --all-targets --workspace --all-features
+        run: RUSTFLAGS="-D warnings" cargo xtask check -- --all-targets --workspace --all-features
 
   cargo-fmt:
     name: cargo fmt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -69,7 +69,7 @@ jobs:
         run: git submodule update --init --recursive
 
       - name: cargo check
-        run: RUSTFLAGS="-D warnings" cargo check --all-targets --workspace
+        run: RUSTFLAGS="-D warnings" cargo xtask check --all-targets --workspace --all-features
 
   cargo-fmt:
     name: cargo fmt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -69,7 +69,7 @@ jobs:
         run: git submodule update --init --recursive
 
       - name: cargo check
-        run: RUSTFLAGS="-D warnings" cargo xtask check -- --all-targets --workspace --all-features
+        run: RUSTFLAGS="-D warnings" cargo xtask check -- --all-features
 
   cargo-fmt:
     name: cargo fmt

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -191,7 +191,7 @@ pub fn solution_hash_is_valid(block: &IrysBlockHeader) -> eyre::Result<()> {
     let solution_hash = block.solution_hash;
     let solution_diff = hash_to_number(&solution_hash.0);
 
-    let previous_solution_diff=hash_to_number(&block.previous_solution_hash.0);
+    let previous_solution_diff = hash_to_number(&block.previous_solution_hash.0);
 
     if solution_diff >= previous_solution_diff {
         Ok(())

--- a/crates/c/src/capacity_cuda.rs
+++ b/crates/c/src/capacity_cuda.rs
@@ -1,4 +1,4 @@
-#[allow(non_upper_case_globals)]
-#[allow(non_camel_case_types)]
-#[allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
 include!(concat!(env!("OUT_DIR"), "/capacity_bindings_cuda.rs"));

--- a/crates/packing/src/lib.rs
+++ b/crates/packing/src/lib.rs
@@ -122,7 +122,7 @@ pub fn capacity_pack_range_cuda_c(
     let entropy_ptr = entropy.as_ptr() as *mut u8;
     let chain_id: u64 = CONFIG.irys_chain_id;
 
-    let mut result;
+    let result;
     unsafe {
         result = capacity_cuda::compute_entropy_chunks_cuda(
             mining_addr,

--- a/crates/packing/src/lib.rs
+++ b/crates/packing/src/lib.rs
@@ -122,7 +122,7 @@ pub fn capacity_pack_range_cuda_c(
     let entropy_ptr = entropy.as_ptr() as *mut u8;
     let chain_id: u64 = CONFIG.irys_chain_id;
 
-    let mut result: u32 = 1;
+    let mut result;
     unsafe {
         result = capacity_cuda::compute_entropy_chunks_cuda(
             mining_addr,


### PR DESCRIPTION
**Describe the changes**
nvidia checks were disabled in CI. Warnings have been fixed, and nvidia build re-enabled

**Related Issue(s)**
NA

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
