### PR TITLE
feat: restrict MAX_CHUNK_SIZE to only in merkle

### DIFF
--- a/crates/chain/tests/external/block_production.rs
+++ b/crates/chain/tests/external/block_production.rs
@@ -7,7 +7,7 @@ use irys_config::IrysNodeConfig;
 use irys_reth_node_bridge::adapter::node::RethNodeContext;
 use irys_testing_utils::utils::setup_tracing_and_temp_dir;
 use irys_types::{
-    block_production::SolutionContext, irys::IrysSigner, Address, Config, MAX_CHUNK_SIZE,
+    block_production::SolutionContext, irys::IrysSigner, Address, Config,
 };
 use k256::ecdsa::SigningKey;
 use reth::{providers::BlockReader, transaction_pool::TransactionPool as _};
@@ -35,7 +35,7 @@ async fn continuous_blockprod_evm_tx() -> eyre::Result<()> {
     config.mining_signer = IrysSigner {
         signer: SigningKey::from_slice(dev_wallet.as_slice())?,
         chain_id: testnet_config.chain_id,
-        chunk_size: MAX_CHUNK_SIZE,
+        chunk_size: testnet_config.chunk_size as usize,
     };
     config.base_directory = temp_dir.path().to_path_buf();
     let storage_config = irys_types::StorageConfig::new(&testnet_config);
@@ -49,7 +49,7 @@ async fn continuous_blockprod_evm_tx() -> eyre::Result<()> {
     let account1 = IrysSigner {
         signer: SigningKey::from_slice(hex::decode(DEV2_PRIVATE_KEY)?.as_slice())?,
         chain_id: testnet_config.chain_id,
-        chunk_size: MAX_CHUNK_SIZE,
+        chunk_size: testnet_config.chunk_size as usize,
     };
     assert_eq!(
         account1.address(),

--- a/crates/chain/tests/external/block_production.rs
+++ b/crates/chain/tests/external/block_production.rs
@@ -6,9 +6,7 @@ use irys_chain::start_irys_node;
 use irys_config::IrysNodeConfig;
 use irys_reth_node_bridge::adapter::node::RethNodeContext;
 use irys_testing_utils::utils::setup_tracing_and_temp_dir;
-use irys_types::{
-    block_production::SolutionContext, irys::IrysSigner, Address, Config,
-};
+use irys_types::{block_production::SolutionContext, irys::IrysSigner, Address, Config};
 use k256::ecdsa::SigningKey;
 use reth::{providers::BlockReader, transaction_pool::TransactionPool as _};
 use reth_db::Database as _;

--- a/crates/types/src/ingress.rs
+++ b/crates/types/src/ingress.rs
@@ -98,7 +98,7 @@ mod tests {
 
     use crate::{
         generate_data_root, generate_leaves, hash_sha256, ingress::verify_ingress_proof,
-        irys::IrysSigner, Config, H256, MAX_CHUNK_SIZE,
+        irys::IrysSigner, Config, H256,
     };
 
     use super::generate_ingress_proof;
@@ -106,11 +106,11 @@ mod tests {
     #[test]
     fn interleave_test() -> eyre::Result<()> {
         let testnet_config = Config::testnet();
-        let data_size = (MAX_CHUNK_SIZE as f64 * 2.5).round() as usize;
+        let data_size = (testnet_config.chunk_size as f64 * 2.5).round() as usize;
         let mut data_bytes = vec![0u8; data_size];
         rand::thread_rng().fill(&mut data_bytes[..]);
         let signer = IrysSigner::random_signer(&testnet_config);
-        let leaves = generate_leaves(&data_bytes, MAX_CHUNK_SIZE)?;
+        let leaves = generate_leaves(&data_bytes, testnet_config.chunk_size as usize)?;
         let interleave_value = signer.address();
         let interleave_hash = hash_sha256(&interleave_value.0 .0)?;
 
@@ -130,18 +130,18 @@ mod tests {
     fn basic() -> eyre::Result<()> {
         // Create some random data
         let testnet_config = Config::testnet();
-        let data_size = (MAX_CHUNK_SIZE as f64 * 2.5).round() as usize;
+        let data_size = (testnet_config.chunk_size as f64 * 2.5).round() as usize;
         let mut data_bytes = vec![0u8; data_size];
         rand::thread_rng().fill(&mut data_bytes[..]);
 
         // Build a merkle tree and data_root from the chunks
-        let leaves = generate_leaves(&data_bytes, MAX_CHUNK_SIZE).unwrap();
+        let leaves = generate_leaves(&data_bytes, testnet_config.chunk_size as usize).unwrap();
         let root = generate_data_root(leaves)?;
         let data_root = H256(root.id);
 
         // Generate an ingress proof
         let signer = IrysSigner::random_signer(&testnet_config);
-        let chunks: Vec<&[u8]> = data_bytes.chunks(MAX_CHUNK_SIZE).collect();
+        let chunks: Vec<&[u8]> = data_bytes.chunks(testnet_config.chunk_size as usize).collect();
         let proof = generate_ingress_proof(signer.clone(), data_root, &chunks)?;
 
         // Verify the ingress proof

--- a/crates/types/src/ingress.rs
+++ b/crates/types/src/ingress.rs
@@ -141,7 +141,9 @@ mod tests {
 
         // Generate an ingress proof
         let signer = IrysSigner::random_signer(&testnet_config);
-        let chunks: Vec<&[u8]> = data_bytes.chunks(testnet_config.chunk_size as usize).collect();
+        let chunks: Vec<&[u8]> = data_bytes
+            .chunks(testnet_config.chunk_size as usize)
+            .collect();
         let proof = generate_ingress_proof(signer.clone(), data_root, &chunks)?;
 
         // Verify the ingress proof

--- a/crates/types/src/irys.rs
+++ b/crates/types/src/irys.rs
@@ -145,7 +145,7 @@ impl From<IrysSigner> for LocalSigner<SigningKey> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{hash_sha256, validate_chunk, MAX_CHUNK_SIZE};
+    use crate::{hash_sha256, validate_chunk};
     use rand::Rng;
     use reth_primitives::transaction::recover_signer;
 
@@ -155,7 +155,7 @@ mod tests {
     async fn create_and_sign_transaction() {
         // Create 2.5 chunks worth of data *  fill the data with random bytes
         let config = crate::Config::testnet();
-        let data_size = (MAX_CHUNK_SIZE as f64 * 2.5).round() as usize;
+        let data_size = (config.chunk_size as f64 * 2.5).round() as usize;
         let mut data_bytes = vec![0u8; data_size];
         rand::thread_rng().fill(&mut data_bytes[..]);
 
@@ -183,7 +183,7 @@ mod tests {
         // after chunking the rest of the data at MAX_CHUNK_SIZE intervals.
         let last_chunk = tx.chunks.last().unwrap();
         assert_eq!(
-            data_size % MAX_CHUNK_SIZE,
+            data_size % config.chunk_size as usize,
             last_chunk.max_byte_range - last_chunk.min_byte_range
         );
 

--- a/crates/types/src/signature.rs
+++ b/crates/types/src/signature.rs
@@ -150,7 +150,7 @@ mod tests {
     use super::*;
 
     use crate::{
-        irys::IrysSigner, Config, IrysTransaction, IrysTransactionHeader, H256, MAX_CHUNK_SIZE,
+        irys::IrysSigner, Config, IrysTransaction, IrysTransactionHeader, H256,
     };
     use alloy_core::hex::{self};
     use alloy_primitives::Address;
@@ -173,7 +173,7 @@ mod tests {
             signer: SigningKey::from_slice(hex::decode(DEV_PRIVATE_KEY).unwrap().as_slice())
                 .unwrap(),
             chain_id: testnet_config.chain_id,
-            chunk_size: MAX_CHUNK_SIZE,
+            chunk_size: testnet_config.chunk_size as usize,
         };
 
         let original_header = IrysTransactionHeader {

--- a/crates/types/src/signature.rs
+++ b/crates/types/src/signature.rs
@@ -149,9 +149,7 @@ impl<'de> Deserialize<'de> for IrysSignature {
 mod tests {
     use super::*;
 
-    use crate::{
-        irys::IrysSigner, Config, IrysTransaction, IrysTransactionHeader, H256,
-    };
+    use crate::{irys::IrysSigner, Config, IrysTransaction, IrysTransactionHeader, H256};
     use alloy_core::hex::{self};
     use alloy_primitives::Address;
     use k256::ecdsa::SigningKey;

--- a/crates/types/src/transaction.rs
+++ b/crates/types/src/transaction.rs
@@ -172,7 +172,7 @@ pub type TxPathHash = H256;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{irys::IrysSigner, MAX_CHUNK_SIZE};
+    use crate::irys::IrysSigner;
 
     use alloy_rlp::Decodable;
 
@@ -229,7 +229,7 @@ mod tests {
         let signer = IrysSigner {
             signer: SigningKey::random(&mut rand::thread_rng()),
             chain_id: config.chain_id,
-            chunk_size: MAX_CHUNK_SIZE,
+            chunk_size: config.chunk_size as usize,
         };
         let tx = IrysTransaction {
             header: dec,


### PR DESCRIPTION
**Describe the changes**

Restricts `MAX_CHUNK_SIZE` to only inside `merkle`

**Related Issue(s)**
#244 

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
