### PR TITLE
feat: add block_index height to default "node info" endpoint

### DIFF
--- a/crates/api-server/src/lib.rs
+++ b/crates/api-server/src/lib.rs
@@ -109,6 +109,7 @@ pub async fn run_server(app_state: ApiState) -> Server {
                     }),
             )
             .service(routes())
+            //FIXME this default route is not behind a api version, should it be before 1.0 release?
             .route("/", web::get().to(index::info_route))
             .wrap(Cors::permissive())
     })

--- a/crates/api-server/src/routes/index.rs
+++ b/crates/api-server/src/routes/index.rs
@@ -13,6 +13,7 @@ struct NodeInfo {
     pub chain_id: u64,
     pub height: u64,
     pub block_hash: H256,
+    pub block_index_height: u64,
     pub blocks: u64,
 }
 
@@ -24,6 +25,7 @@ pub async fn info_route(state: web::Data<ApiState>) -> HttpResponse {
         chain_id: state.config.chain_id,
         height: 0,
         block_hash: H256::zero(),
+        block_index_height: 0,
         blocks: 0,
     };
     HttpResponse::Ok().body(serde_json::to_string_pretty(&node_info).unwrap())

--- a/crates/api-server/src/routes/index.rs
+++ b/crates/api-server/src/routes/index.rs
@@ -18,6 +18,12 @@ struct NodeInfo {
 }
 
 pub async fn info_route(state: web::Data<ApiState>) -> HttpResponse {
+    let block_index_height = state
+        .block_index
+        .as_ref()
+        .expect("block index")
+        .read()
+        .latest_height();
     // TODO: populate this response struct with real values
     let node_info = NodeInfo {
         version: "0.0.1".into(),
@@ -25,7 +31,7 @@ pub async fn info_route(state: web::Data<ApiState>) -> HttpResponse {
         chain_id: state.config.chain_id,
         height: 0,
         block_hash: H256::zero(),
-        block_index_height: 0,
+        block_index_height,
         blocks: 0,
     };
     HttpResponse::Ok().body(serde_json::to_string_pretty(&node_info).unwrap())

--- a/crates/api-server/src/routes/index.rs
+++ b/crates/api-server/src/routes/index.rs
@@ -1,13 +1,14 @@
 use crate::ApiState;
 use actix_web::{
+    http::header::ContentType,
     web::{self},
     HttpResponse,
 };
 use irys_types::H256;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Default, Serialize)]
-struct NodeInfo {
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct NodeInfo {
     pub version: String,
     pub peer_count: u32,
     pub chain_id: u64,
@@ -34,5 +35,8 @@ pub async fn info_route(state: web::Data<ApiState>) -> HttpResponse {
         block_index_height,
         blocks: 0,
     };
-    HttpResponse::Ok().body(serde_json::to_string_pretty(&node_info).unwrap())
+
+    HttpResponse::Ok()
+        .content_type(ContentType::json())
+        .body(serde_json::to_string_pretty(&node_info).unwrap())
 }

--- a/crates/chain/tests/api/external_api.rs
+++ b/crates/chain/tests/api/external_api.rs
@@ -12,25 +12,9 @@ use tracing::info;
 
 #[actix::test]
 async fn external_api() -> eyre::Result<()> {
-    let temp_dir = setup_tracing_and_temp_dir(Some("external_api"), false);
-    info!("tracing enabled");
-    let mut node_config = IrysNodeConfig::default();
-    node_config.base_directory = temp_dir.path().to_path_buf();
-
-    let testnet_config = Config::testnet();
-    let mut storage_config = StorageConfig::new(&testnet_config);
-    storage_config.num_chunks_in_partition = 6;
-
-    let _chunk_size = storage_config.chunk_size;
-
-    let ctx = setup().await?;
+    let _ctx = setup().await?;
 
     let address = "http://127.0.0.1:8080";
-    // TODO: remove this delay and use proper probing to check if the server is active
-    sleep(Duration::from_millis(500)).await;
-
-    // server should be running
-    // check with request to `/v1/info`
     let client = awc::Client::default();
 
     let response = client

--- a/crates/chain/tests/api/external_api.rs
+++ b/crates/chain/tests/api/external_api.rs
@@ -1,5 +1,6 @@
 //! endpoint tests
 use actix_web::HttpMessage;
+use irys_api_server::routes::index::NodeInfo;
 use irys_chain::{start_irys_node, IrysNodeCtx};
 use irys_config::IrysNodeConfig;
 use irys_testing_utils::utils::{tempfile::TempDir, temporary_directory};
@@ -24,8 +25,6 @@ async fn external_api() -> eyre::Result<()> {
 
     // confirm we are recieving the correct content type
     assert_eq!(response.content_type(), "application/json");
-
-    use irys_api_server::routes::index::NodeInfo;
 
     // deserialize the response into NodeInfo struct
     let json_response: NodeInfo = response.json().await.expect("valid NodeInfo");

--- a/crates/chain/tests/api/external_api.rs
+++ b/crates/chain/tests/api/external_api.rs
@@ -50,7 +50,7 @@ async fn external_api() -> eyre::Result<()> {
 
     let mut node_config = IrysNodeConfig::default();
     node_config.base_directory = temp_dir.path().to_path_buf();
-    let arc_config = Arc::new(node_config);
+    let arc_config = Arc::new(node_config.clone());
 
     let irys_db_env =
         open_or_create_irys_consensus_data_db(&arc_config.irys_consensus_data_dir()).unwrap();

--- a/crates/chain/tests/api/external_api.rs
+++ b/crates/chain/tests/api/external_api.rs
@@ -13,7 +13,9 @@ use irys_actors::{
 use actix::prelude::*;
 use dev::SystemRegistry;
 use irys_actors::{
-    block_producer::BlockFinalizedMessage, chunk_migration_service::ChunkMigrationService,
+    block_producer::BlockFinalizedMessage,
+    block_tree_service::{BlockTreeService, GetBlockTreeGuardMessage},
+    chunk_migration_service::ChunkMigrationService,
     mempool_service::GetBestMempoolTxs,
 };
 use irys_api_server::{run_server, ApiState};
@@ -23,16 +25,19 @@ use irys_database::{
     tables::{IngressProofs, IrysTables},
     BlockIndex, Initialized, Ledger,
 };
+use irys_reth_node_bridge::node::{RethNode, RethNodeAddOns, RethNodeProvider};
 use irys_storage::*;
 use irys_testing_utils::utils::setup_tracing_and_temp_dir;
 use irys_types::{
-    app_state::DatabaseProvider, partition::*, partition_chunk_offset_ii, Address, Base64, Config,
-    H256List, IrysBlockHeader, PartitionChunkOffset, PoaData, Signature, StorageConfig,
-    TransactionLedger, VDFLimiterInfo, H256, U256,
+    app_state::DatabaseProvider, partition::*, partition_chunk_offset_ii,
+    vdf_config::VDFStepsConfig, Address, Base64, Config, H256List, IrysBlockHeader,
+    PartitionChunkOffset, PoaData, Signature, StorageConfig, TransactionLedger, VDFLimiterInfo,
+    H256, U256,
 };
 use reth::{revm::primitives::B256, tasks::TaskManager};
 use reth_db::transaction::DbTx;
 use reth_db::Database as _;
+use tokio::sync::oneshot::{self};
 use tokio::{task, time::sleep};
 use tracing::info;
 

--- a/crates/chain/tests/api/external_api.rs
+++ b/crates/chain/tests/api/external_api.rs
@@ -13,7 +13,7 @@ use tokio::time::{sleep, Duration};
 use tracing::info;
 
 #[actix::test]
-async fn external_api() -> eyre::Result<()> {
+async fn serial_external_api() -> eyre::Result<()> {
     let ctx = setup().await?;
 
     let address = "http://127.0.0.1:8080";

--- a/crates/chain/tests/api/external_api.rs
+++ b/crates/chain/tests/api/external_api.rs
@@ -255,54 +255,7 @@ async fn external_api() -> eyre::Result<()> {
     }
 
     // Create a block from the tx
-    let irys_block = IrysBlockHeader {
-        diff: U256::from(1000),
-        cumulative_diff: U256::from(5000),
-        last_diff_timestamp: 1622543200,
-        solution_hash: H256::zero(),
-        previous_solution_hash: H256::zero(),
-        last_epoch_hash: H256::random(),
-        chunk_hash: H256::zero(),
-        height,
-        block_hash: H256::zero(),
-        previous_block_hash: H256::zero(),
-        previous_cumulative_diff: U256::from(4000),
-        poa: PoaData {
-            tx_path: None,
-            data_path: None,
-            chunk: Base64::from_str("").unwrap(),
-            ledger_id: None,
-            partition_chunk_offset: 0,
-            partition_hash: PartitionHash::zero(),
-            recall_chunk_index: 0,
-        },
-        reward_address: Address::ZERO,
-        miner_address: Address::ZERO,
-        signature: Signature::test_signature().into(),
-        timestamp: now.as_millis(),
-        ledgers: vec![
-            // Permanent Publish Ledger
-            TransactionLedger {
-                ledger_id: Ledger::Publish.into(),
-                tx_root: H256::zero(),
-                tx_ids: H256List(Vec::new()),
-                max_chunk_offset: 0,
-                expires: None,
-                proofs: None,
-            },
-            // Term Submit Ledger
-            TransactionLedger {
-                ledger_id: Ledger::Submit.into(),
-                tx_root: TransactionLedger::merklize_tx_root(&tx_headers).0,
-                tx_ids: H256List(data_tx_ids.clone()),
-                max_chunk_offset: 0,
-                expires: Some(1622543200),
-                proofs: None,
-            },
-        ],
-        evm_block_hash: B256::ZERO,
-        vdf_limiter_info: VDFLimiterInfo::default(),
-    };
+    let irys_block = IrysBlockHeader::new_mock_header();
 
     // Send the block confirmed message
     let block = Arc::new(irys_block);

--- a/crates/chain/tests/api/external_api.rs
+++ b/crates/chain/tests/api/external_api.rs
@@ -151,11 +151,7 @@ async fn external_api() -> eyre::Result<()> {
             .unwrap(),
     ));
 
-    let chunk_provider = ChunkProvider::new(
-        storage_config.clone(),
-        storage_modules.clone(),
-        arc_db.clone(),
-    );
+    let chunk_provider = ChunkProvider::new(storage_config.clone(), storage_modules.clone());
 
     let app_state = ApiState {
         reth_provider: None,

--- a/crates/chain/tests/api/external_api.rs
+++ b/crates/chain/tests/api/external_api.rs
@@ -38,6 +38,8 @@ async fn external_api() -> eyre::Result<()> {
 
     // advance one block
     let (header, _payload) = mine_block(&ctx.node).await?.unwrap();
+    // advance one block, finalizing the previous block
+    let (header, _payload) = mine_block(&ctx.node).await?.unwrap();
 
     let mock_header = IrysTransactionHeader {
         id: H256::from([255u8; 32]),
@@ -60,7 +62,8 @@ async fn external_api() -> eyre::Result<()> {
         all_txs: Arc::new(vec![mock_header]),
     };
 
-    sleep(Duration::from_millis(5000)).await;
+    //FIXME: magic number could be a constant e.g. 3 blocks worth of time?
+    sleep(Duration::from_millis(10000)).await;
 
     let _ = ctx
         .node
@@ -77,7 +80,7 @@ async fn external_api() -> eyre::Result<()> {
     // deserialize the response into NodeInfo struct
     let json_response: NodeInfo = response.json().await.expect("valid NodeInfo");
 
-    // check the api endpoint again
+    // check the api endpoint again, and it should now show 1 block in the index
     assert_eq!(json_response.block_index_height, 1);
 
     Ok(())

--- a/crates/chain/tests/api/external_api.rs
+++ b/crates/chain/tests/api/external_api.rs
@@ -55,7 +55,8 @@ async fn external_api() -> eyre::Result<()> {
         open_or_create_irys_consensus_data_db(&arc_config.irys_consensus_data_dir()).unwrap();
 
     let testnet_config = Config::testnet();
-    let storage_config = StorageConfig::new(&testnet_config);
+    let mut storage_config = StorageConfig::new(&testnet_config);
+    storage_config.num_chunks_in_partition = 6;
 
     let _chunk_size = storage_config.chunk_size;
 

--- a/crates/chain/tests/api/external_api.rs
+++ b/crates/chain/tests/api/external_api.rs
@@ -156,6 +156,7 @@ async fn external_api() -> eyre::Result<()> {
         db: arc_db.clone(),
         mempool: mempool_addr.clone(),
         chunk_provider: Arc::new(chunk_provider),
+        config: testnet_config,
     };
 
     // spawn server in a separate thread

--- a/crates/chain/tests/api/external_api.rs
+++ b/crates/chain/tests/api/external_api.rs
@@ -28,7 +28,7 @@ async fn external_api() -> eyre::Result<()> {
     assert_eq!(response.status(), 200);
     info!("HTTP server started");
 
-    // confirm we are recieving the correct content type
+    // confirm we are receiving the correct content type
     assert_eq!(response.content_type(), "application/json");
 
     // deserialize the response into NodeInfo struct

--- a/crates/chain/tests/api/external_api.rs
+++ b/crates/chain/tests/api/external_api.rs
@@ -43,7 +43,6 @@ use tokio::sync::oneshot::{self};
 use tokio::{task, time::sleep};
 use tracing::info;
 
-#[ignore]
 #[actix::test]
 async fn external_api() -> eyre::Result<()> {
     let temp_dir = setup_tracing_and_temp_dir(Some("external_api"), false);

--- a/crates/chain/tests/api/external_api.rs
+++ b/crates/chain/tests/api/external_api.rs
@@ -130,11 +130,14 @@ async fn external_api() -> eyre::Result<()> {
 
     // Create an instance of the mempool actor
     let mempool_service = MempoolService::new(
-        arc_db.clone(),
-        task_manager.executor(),
-        arc_config.mining_signer.clone(),
+        irys_db.clone(),
+        reth_db.clone(),
+        reth_node.task_executor.clone(),
+        node_config.mining_signer.clone(),
         storage_config.clone(),
         storage_modules.clone(),
+        block_tree_guard.clone(),
+        &testnet_config,
     );
     SystemRegistry::set(mempool_service.start());
     let mempool_addr = MempoolService::from_registry();

--- a/crates/chain/tests/api/external_api.rs
+++ b/crates/chain/tests/api/external_api.rs
@@ -26,7 +26,7 @@ use irys_database::{
 use irys_storage::*;
 use irys_testing_utils::utils::setup_tracing_and_temp_dir;
 use irys_types::{
-    app_state::DatabaseProvider, partition::*, Address, Base64, H256List, IrysBlockHeader,
+    app_state::DatabaseProvider, partition::*, Address, Base64, Config, H256List, IrysBlockHeader,
     PartitionChunkOffset, PoaData, Signature, StorageConfig, TransactionLedger, VDFLimiterInfo,
     H256, U256,
 };
@@ -45,18 +45,9 @@ async fn external_api() -> eyre::Result<()> {
     node_config.base_directory = temp_dir.path().to_path_buf();
     let arc_config = Arc::new(node_config);
 
-    // Create a storage config for testing
-    let storage_config = StorageConfig {
-        chunk_size: 32,
-        num_chunks_in_partition: 6,
-        num_chunks_in_recall_range: 2,
-        num_partitions_in_slot: 1,
-        miner_address: Address::random(),
-        min_writes_before_sync: 1,
-        entropy_packing_iterations: 1,
-        chunk_migration_depth: 1, // Testnet / single node config
-        chain_id: 333,            //FIXME should this be a specific chain id?
-    };
+    let testnet_config = Config::testnet();
+    let storage_config = StorageConfig::new(&testnet_config);
+
     let _chunk_size = storage_config.chunk_size;
 
     // Create StorageModules for testing

--- a/crates/chain/tests/api/external_api.rs
+++ b/crates/chain/tests/api/external_api.rs
@@ -37,7 +37,7 @@ async fn external_api() -> eyre::Result<()> {
     assert_eq!(json_response.block_index_height, 0);
 
     // advance one block
-    let (header, _payload) = mine_block(&ctx.node).await?.unwrap();
+    let (_header, _payload) = mine_block(&ctx.node).await?.unwrap();
     // advance one block, finalizing the previous block
     let (header, _payload) = mine_block(&ctx.node).await?.unwrap();
 

--- a/crates/chain/tests/api/external_api.rs
+++ b/crates/chain/tests/api/external_api.rs
@@ -1,46 +1,13 @@
 //! chunk migration tests
-use std::{
-    str::FromStr,
-    sync::{Arc, RwLock},
-    time::{Duration, SystemTime, UNIX_EPOCH},
-};
+use std::time::Duration;
 
-use irys_actors::{
-    block_index_service::BlockIndexService, mempool_service::MempoolService,
-    services::ServiceSenders,
-};
-
-use actix::prelude::*;
-use dev::SystemRegistry;
-use irys_actors::{
-    block_producer::BlockFinalizedMessage,
-    block_tree_service::{BlockTreeService, GetBlockTreeGuardMessage},
-    chunk_migration_service::ChunkMigrationService,
-    mempool_service::GetBestMempoolTxs,
-};
-use irys_api_server::{run_server, ApiState};
+use irys_chain::{start_irys_node, IrysNodeCtx};
 use irys_config::IrysNodeConfig;
-use irys_database::{
-    open_or_create_db,
-    tables::{IngressProofs, IrysTables},
-    BlockIndex, Initialized, Ledger,
+use irys_testing_utils::utils::{
+    setup_tracing_and_temp_dir, tempfile::TempDir, temporary_directory,
 };
-use irys_reth_node_bridge::node::{RethNode, RethNodeAddOns, RethNodeProvider};
-use irys_storage::irys_consensus_data_db::open_or_create_irys_consensus_data_db;
-use irys_storage::*;
-use irys_testing_utils::utils::setup_tracing_and_temp_dir;
-use irys_types::{
-    app_state::DatabaseProvider, partition::*, partition_chunk_offset_ii,
-    vdf_config::VDFStepsConfig, Address, Base64, Config, H256List, IrysBlockHeader,
-    PartitionChunkOffset, PoaData, Signature, StorageConfig, TransactionLedger, VDFLimiterInfo,
-    H256, U256,
-};
-use reth::builder::FullNode;
-use reth::{revm::primitives::B256, tasks::TaskManager};
-use reth_db::transaction::DbTx;
-use reth_db::Database as _;
-use tokio::sync::oneshot::{self};
-use tokio::{task, time::sleep};
+use irys_types::{Config, StorageConfig};
+use tokio::time::sleep;
 use tracing::info;
 
 #[actix::test]
@@ -49,10 +16,6 @@ async fn external_api() -> eyre::Result<()> {
     info!("tracing enabled");
     let mut node_config = IrysNodeConfig::default();
     node_config.base_directory = temp_dir.path().to_path_buf();
-    let arc_config = Arc::new(node_config.clone());
-
-    let irys_db_env =
-        open_or_create_irys_consensus_data_db(&arc_config.irys_consensus_data_dir()).unwrap();
 
     let testnet_config = Config::testnet();
     let mut storage_config = StorageConfig::new(&testnet_config);
@@ -60,140 +23,7 @@ async fn external_api() -> eyre::Result<()> {
 
     let _chunk_size = storage_config.chunk_size;
 
-    // Create StorageModules for testing
-    // TODO: once @DanMacDonald fixes promotion, switch back configs & ledger_num in JS test
-    let storage_module_infos = vec![
-        // StorageModuleInfo {
-        //     id: 0,
-        //     partition_assignment: Some(PartitionAssignment {
-        //         partition_hash: H256::random(),
-        //         miner_address: storage_config.miner_address,
-        //         ledger_num: Some(0),
-        //         slot_index: Some(0), // Publish Ledger Slot 0
-        //     }),
-        //     submodules: vec![
-        //         (ii(0, 5), "sm1".to_string()), // 0 to 5 inclusive
-        //     ],
-        // },
-        // StorageModuleInfo {
-        //     id: 1,
-        //     partition_assignment: Some(PartitionAssignment {
-        //         partition_hash: H256::random(),
-        //         miner_address: storage_config.miner_address,
-        //         ledger_num: Some(1),
-        //         slot_index: Some(0), // Submit Ledger Slot 0
-        //     }),
-        //     submodules: vec![
-        //         (ii(0, 5), "sm2".to_string()), // 0 to 5 inclusive
-        //     ],
-        // },
-        StorageModuleInfo {
-            id: 0,
-            partition_assignment: Some(PartitionAssignment {
-                partition_hash: H256::random(),
-                miner_address: storage_config.miner_address,
-                ledger_id: Some(1),
-                slot_index: Some(0), // Submit Ledger Slot 0
-            }),
-            submodules: vec![
-                (partition_chunk_offset_ii!(0, 5), "sm1".into()), // 0 to 5 inclusive
-            ],
-        },
-        StorageModuleInfo {
-            id: 1,
-            partition_assignment: Some(PartitionAssignment {
-                partition_hash: H256::random(),
-                miner_address: storage_config.miner_address,
-                ledger_id: Some(1),
-                slot_index: Some(1), // Submit Ledger Slot 1
-            }),
-            submodules: vec![
-                (partition_chunk_offset_ii!(0, 5), "sm2".into()), // 0 to 5 inclusive
-            ],
-        },
-    ];
-
-    let tmp_dir = setup_tracing_and_temp_dir(Some("chunk_migration_test"), false);
-    let base_path = tmp_dir.path().to_path_buf();
-    info!("temp_dir:{:?}\nbase_path:{:?}", tmp_dir, base_path);
-
-    // Create a Vec initialized storage modules
-    let mut storage_modules: Vec<Arc<StorageModule>> = Vec::new();
-    for info in storage_module_infos {
-        let arc_module = Arc::new(StorageModule::new(
-            &base_path,
-            &info,
-            storage_config.clone(),
-        )?);
-        storage_modules.push(arc_module.clone());
-        arc_module.pack_with_zeros();
-    }
-
-    info!("task manager");
-    let task_manager = TaskManager::current();
-    let db = open_or_create_db(tmp_dir, IrysTables::ALL, None).unwrap();
-    let arc_db = DatabaseProvider(Arc::new(db));
-    info!("db opened/created");
-
-    let (reth_handle_sender, reth_handle_receiver) =
-        oneshot::channel::<FullNode<RethNode, RethNodeAddOns>>();
-
-    info!("setup start: reth node");
-    let reth_node = RethNodeProvider(Arc::new(reth_handle_receiver.await.unwrap()));
-    info!("setup start: reth_db");
-    let reth_db = reth_node.provider.database.db.clone();
-    info!("setup start: irys_db");
-    let irys_db = DatabaseProvider(Arc::new(irys_db_env));
-    info!("setup start: vdf_config");
-    let vdf_config = VDFStepsConfig::new(&testnet_config);
-
-    info!("setup: block tree service");
-    let block_tree_service = BlockTreeService::from_registry();
-    let block_tree_guard = block_tree_service
-        .send(GetBlockTreeGuardMessage)
-        .await
-        .unwrap();
-
-    info!("creating: mempool service");
-    // Create an instance of the mempool actor
-    let mempool_service = MempoolService::new(
-        irys_db.clone(),
-        reth_db.clone(),
-        reth_node.task_executor.clone(),
-        node_config.mining_signer.clone(),
-        storage_config.clone(),
-        storage_modules.clone(),
-        block_tree_guard.clone(),
-        &testnet_config,
-    );
-    SystemRegistry::set(mempool_service.start());
-    let mempool_addr = MempoolService::from_registry();
-
-    // Create a block_index
-    let block_index: Arc<RwLock<BlockIndex<Initialized>>> = Arc::new(RwLock::new(
-        BlockIndex::default()
-            .reset(&arc_config.clone())?
-            .init(arc_config.clone())
-            .await
-            .unwrap(),
-    ));
-
-    info!("creating: chunk provider");
-    let chunk_provider = ChunkProvider::new(storage_config.clone(), storage_modules.clone());
-
-    let app_state = ApiState {
-        reth_provider: None,
-        block_index: None,
-        block_tree: None,
-        db: arc_db.clone(),
-        mempool: mempool_addr.clone(),
-        chunk_provider: Arc::new(chunk_provider),
-        config: testnet_config,
-    };
-
-    // spawn server in a separate thread
-    info!("spawn server in new thread");
-    task::spawn(run_server(app_state));
+    let ctx = setup().await?;
 
     let address = "http://127.0.0.1:8080";
     // TODO: remove this delay and use proper probing to check if the server is active
@@ -212,95 +42,36 @@ async fn external_api() -> eyre::Result<()> {
     assert_eq!(response.status(), 200);
     info!("HTTP server started");
 
-    info!("waiting for tx header...");
-
-    let recv_tx = loop {
-        let txs = mempool_addr.send(GetBestMempoolTxs).await;
-        match txs {
-            Ok(transactions) if !transactions.is_empty() => {
-                break transactions[0].clone();
-            }
-            _ => {
-                sleep(Duration::from_millis(100)).await;
-            }
-        }
-    };
-    info!(
-        "got tx {:?}- waiting for chunks & ingress proof generation...",
-        &recv_tx.id
-    );
-    // now we wait for an ingress proof to be generated for this tx (automatic once all chunks have been uploaded)
-
-    let ingress_proof = loop {
-        // don't reuse the tx! it has read isolation (won't see anything committed after it's creation)
-        let ro_tx = &arc_db.tx().unwrap();
-        match ro_tx.get::<IngressProofs>(recv_tx.data_root).unwrap() {
-            Some(ip) => break ip,
-            None => sleep(Duration::from_millis(100)).await,
-        }
-    };
-
-    info!(
-        "got ingress proof for data root {}",
-        &ingress_proof.data_root
-    );
-    assert_eq!(&ingress_proof.data_root, &recv_tx.data_root);
-
-    info!("mining block");
-
-    let tx_headers = vec![recv_tx];
-
-    let data_tx_ids = tx_headers.iter().map(|h| h.id).collect::<Vec<H256>>();
-
-    let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-
-    // Create a block_index actor
-    let block_index_actor = BlockIndexService::new(block_index.clone(), storage_config.clone());
-    SystemRegistry::set(block_index_actor.start());
-    let block_index_addr = BlockIndexService::from_registry();
-
-    let height: u64;
-    {
-        height = block_index.read().unwrap().num_blocks().max(1) - 1;
-    }
-
-    // Create a block from the tx
-    let irys_block = IrysBlockHeader::new_mock_header();
-
-    // Send the block confirmed message
-    let block = Arc::new(irys_block);
-    let txs: Arc<Vec<irys_types::IrysTransactionHeader>> = Arc::new(tx_headers);
-    let block_finalized_message = BlockFinalizedMessage {
-        block_header: block.clone(),
-        all_txs: Arc::clone(&txs),
-    };
-
-    block_index_addr.do_send(block_finalized_message.clone());
-
-    let (service_senders, receivers) = ServiceSenders::new();
-    // Send the block finalized message
-    let chunk_migration_service = ChunkMigrationService::new(
-        block_index.clone(),
-        storage_config.clone(),
-        storage_modules.clone(),
-        arc_db.clone(),
-        service_senders.clone(),
-    );
-    SystemRegistry::set(chunk_migration_service.start());
-    let block_finalized_message = BlockFinalizedMessage {
-        block_header: block.clone(),
-        all_txs: txs.clone(),
-    };
-    let chunk_migration_addr = ChunkMigrationService::from_registry();
-    let _res = chunk_migration_addr.send(block_finalized_message).await?;
-
-    // Check to see if the chunks are in the StorageModules
-    for sm in storage_modules.iter() {
-        let _ = sm.sync_pending_chunks();
-    }
-    info!("mined block!");
-    // sleep so the client has a chance to read the chunks
-    sleep(Duration::from_millis(10_000)).await;
-
     Ok(())
+}
+
+struct TestCtx {
+    config: Config,
+    node: IrysNodeCtx,
+    #[expect(
+        dead_code,
+        reason = "to prevent drop() being called and cleaning up resources"
+    )]
+    temp_dir: TempDir,
+}
+
+async fn setup() -> eyre::Result<TestCtx> {
+    let testnet_config = Config {
+        // add any overrides here
+        ..Config::testnet()
+    };
+    setup_with_config(testnet_config).await
+}
+
+async fn setup_with_config(testnet_config: Config) -> eyre::Result<TestCtx> {
+    let temp_dir = temporary_directory(Some("external_api"), false);
+    let mut config = IrysNodeConfig::new(&testnet_config);
+    config.base_directory = temp_dir.path().to_path_buf();
+    let storage_config = irys_types::StorageConfig::new(&testnet_config);
+    let node = start_irys_node(config, storage_config, testnet_config.clone()).await?;
+    Ok(TestCtx {
+        config: testnet_config,
+        node,
+        temp_dir,
+    })
 }

--- a/crates/chain/tests/api/external_api.rs
+++ b/crates/chain/tests/api/external_api.rs
@@ -26,6 +26,7 @@ use irys_database::{
     BlockIndex, Initialized, Ledger,
 };
 use irys_reth_node_bridge::node::{RethNode, RethNodeAddOns, RethNodeProvider};
+use irys_storage::irys_consensus_data_db::open_or_create_irys_consensus_data_db;
 use irys_storage::*;
 use irys_testing_utils::utils::setup_tracing_and_temp_dir;
 use irys_types::{
@@ -50,6 +51,9 @@ async fn external_api() -> eyre::Result<()> {
     let mut node_config = IrysNodeConfig::default();
     node_config.base_directory = temp_dir.path().to_path_buf();
     let arc_config = Arc::new(node_config);
+
+    let irys_db_env =
+        open_or_create_irys_consensus_data_db(&arc_config.irys_consensus_data_dir()).unwrap();
 
     let testnet_config = Config::testnet();
     let storage_config = StorageConfig::new(&testnet_config);

--- a/crates/chain/tests/api/external_api.rs
+++ b/crates/chain/tests/api/external_api.rs
@@ -26,9 +26,9 @@ use irys_database::{
 use irys_storage::*;
 use irys_testing_utils::utils::setup_tracing_and_temp_dir;
 use irys_types::{
-    app_state::DatabaseProvider, partition::*, Address, Base64, Config, H256List, IrysBlockHeader,
-    PartitionChunkOffset, PoaData, Signature, StorageConfig, TransactionLedger, VDFLimiterInfo,
-    H256, U256,
+    app_state::DatabaseProvider, partition::*, partition_chunk_offset_ii, Address, Base64, Config,
+    H256List, IrysBlockHeader, PartitionChunkOffset, PoaData, Signature, StorageConfig,
+    TransactionLedger, VDFLimiterInfo, H256, U256,
 };
 use reth::{revm::primitives::B256, tasks::TaskManager};
 use reth_db::transaction::DbTx;

--- a/crates/chain/tests/api/mod.rs
+++ b/crates/chain/tests/api/mod.rs
@@ -1,2 +1,2 @@
 mod api;
-// mod external_api;
+mod external_api;


### PR DESCRIPTION
**Describe the changes**
Test now runs local node. Checks:
 1) /v1/info endpoint returns 200
 2) /v1/info endpoint content-type is of type json
 3) /v1/info endpoint contains the new block_index_height field
 4) advance blocks, /v1/info endpoint contains an increased block_index_height

**Related Issue(s)**
https://github.com/Irys-xyz/irys/issues/285

**Checklist**

- [x] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
 - I added json content-type to the endpoint. I can update the other endpoints as a small separate PR.