### PR TITLE
feat: support > 1 pending writes for StorageModules

### DIFF
--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -375,7 +375,11 @@ impl Handler<ChunkIngressMessage> for MempoolService {
             .map_err(|_| ChunkIngressError::DatabaseError)?;
 
         for sm in &self.storage_modules {
-            if !sm.get_write_offsets(&chunk).unwrap_or(vec![]).is_empty() {
+            if !sm
+                .get_writeable_offsets(&chunk)
+                .unwrap_or_default()
+                .is_empty()
+            {
                 info!(target: "irys::mempool::chunk_ingress", "Writing chunk with offset {} for data_root {} to sm {}", &chunk.tx_offset, &chunk.data_root, &sm.id );
                 sm.write_data_chunk(&chunk)
                     .map_err(|_| ChunkIngressError::Other("Internal error".to_owned()))?;

--- a/crates/storage/src/storage_module.rs
+++ b/crates/storage/src/storage_module.rs
@@ -1269,9 +1269,7 @@ pub fn validate_packing_at_point(sm: &Arc<StorageModule>, point: u32) -> eyre::R
 mod tests {
     use super::*;
     use irys_testing_utils::utils::setup_tracing_and_temp_dir;
-    use irys_types::{
-        chunk, ledger_chunk_offset_ii, partition_chunk_offset_ii, TxChunkOffset, H256,
-    };
+    use irys_types::{ledger_chunk_offset_ii, partition_chunk_offset_ii, TxChunkOffset, H256};
     use nodit::interval::ii;
 
     #[test]

--- a/crates/types/src/chunk.rs
+++ b/crates/types/src/chunk.rs
@@ -54,7 +54,7 @@ pub struct UnpackedChunk {
     /// Raw bytes to be stored, should be CHUNK_SIZE in length unless it is the
     /// last chunk in the transaction
     pub bytes: Base64,
-    // Index of the chunk in the transaction starting with 0
+    /// Index of the chunk in the transaction starting with 0
     pub tx_offset: TxChunkOffset,
 }
 


### PR DESCRIPTION
**Describe the changes**
This feature enhances support for a "pending writes" queue length of > 1, enabling writes to be striped to disk and minimizing fragmentation.

We've updated `read_chunks()`, `write_data_chunk()`, and `get_intervals()` to present the union of the pending writes queue and stored intervals. This makes pending writes transparent to `StorageModule` clients - they simply write chunks and read them back without needing knowledge of the underlying pending writes buffer.

This implementation allows us to experiment with different values for `config.min_writes_before_sync` to optimize for both minimizing fragmentation and maximizing reliability.

**Related Issue(s)**
No issue for this work as it is discovered / unplanned.

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
@antouhou is there a way to make sure we call `storage_module.sync_pending_chunks()` (or similar) to flush all pending chunks to disk during an ordered shutdown?
