### PR TITLE
feat: port randomisation

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -10,4 +10,4 @@ test-group = 'serial'
 # heavy tests
 [[profile.default.overrides]]
 filter = 'test(/.*heavy_.*/)'
-threads-required = 2
+threads-required = 3

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -9,5 +9,5 @@ test-group = 'serial'
 
 # heavy tests
 [[profile.default.overrides]]
-filter = 'test(/^heavy/)'
+filter = 'test(/.*heavy_.*/)'
 threads-required = 2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4042,6 +4042,7 @@ dependencies = [
  "semver 1.0.24",
  "serde",
  "serde_json",
+ "socket2 0.5.8",
  "tracing",
 ]
 

--- a/crates/api-server/Cargo.toml
+++ b/crates/api-server/Cargo.toml
@@ -13,6 +13,7 @@ irys-types.workspace = true
 irys-config.workspace = true
 #
 
+socket2 = "0.5.8"
 awc = "3.5.1"
 base58.workspace = true
 reth.workspace = true

--- a/crates/api-server/src/lib.rs
+++ b/crates/api-server/src/lib.rs
@@ -35,6 +35,7 @@ pub struct ApiState {
     // TODO: slim this down to what we actually use - beware the types!
     // TODO: remove the Option<>
     pub reth_provider: Option<RethNodeProvider>,
+    pub reth_http_url: Option<String>,
     pub block_tree: Option<BlockTreeReadGuard>,
     pub block_index: Option<BlockIndexReadGuard>,
 }
@@ -190,6 +191,7 @@ pub fn create_listener(addr: SocketAddr) -> eyre::Result<TcpListener> {
 //         mempool: mempool_addr,
 //         chunk_provider: Arc::new(chunk_provider),
 //         reth_provider: None,
+//         reth_http_url: None,
 //         block_tree: None,
 //         block_index: None,
 //     };

--- a/crates/api-server/src/lib.rs
+++ b/crates/api-server/src/lib.rs
@@ -1,7 +1,5 @@
 pub mod error;
 pub mod routes;
-use std::{net::SocketAddr, sync::Arc};
-
 use actix::Addr;
 use actix_cors::Cors;
 use actix_web::dev::Server;
@@ -24,6 +22,8 @@ use routes::{
     block, block_index, get_chunk, index, network_config, peer_list, post_chunk, post_version,
     price, proxy::proxy, tx,
 };
+use std::net::TcpListener;
+use std::{net::SocketAddr, sync::Arc};
 use tracing::{debug, info};
 
 #[derive(Clone)]
@@ -94,7 +94,7 @@ pub fn routes() -> impl HttpServiceFactory {
         .route("/version", web::post().to(post_version::post_version))
 }
 
-pub async fn run_server(app_state: ApiState) -> Server {
+pub async fn run_server(app_state: ApiState, listener: TcpListener) -> Server {
     let port = app_state.config.port;
     info!(?port, "Starting API server");
 
@@ -117,9 +117,27 @@ pub async fn run_server(app_state: ApiState) -> Server {
             .route("/", web::get().to(index::info_route))
             .wrap(Cors::permissive())
     })
-    .bind(("0.0.0.0", port))
+    .listen(listener)
     .unwrap()
     .run()
+}
+
+// Adapted from /actix-web-4.9.0/src/server.rs create_listener
+// This is required as we need to access the TcpListener directly to figure out what port we've been assigned
+// if randomisation (requested port 0) is used.
+pub fn create_listener(addr: SocketAddr) -> eyre::Result<TcpListener> {
+    use socket2::{Domain, Protocol, Socket, Type};
+    let backlog = 1024;
+    let domain = Domain::for_address(addr);
+    let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
+    // need this so application restarts can pick back up the same port without suffering from time-wait
+    socket.set_reuse_address(true)?;
+    socket.bind(&addr.into())?;
+    // clamp backlog to max u32 that fits in i32 range
+    let backlog = core::cmp::min(backlog, i32::MAX as u32) as i32;
+    socket.listen(backlog)?;
+    let listener = TcpListener::from(socket);
+    Ok(listener)
 }
 
 //==============================================================================

--- a/crates/api-server/src/routes/block.rs
+++ b/crates/api-server/src/routes/block.rs
@@ -244,6 +244,7 @@ impl FromStr for BlockParam {
 
 //         let app_state = ApiState {
 //             reth_provider: None,
+//             reth_http_url: None,
 //             block_index: None,
 //             block_tree: None,
 //             db: DatabaseProvider(db_arc.clone()),
@@ -300,6 +301,7 @@ impl FromStr for BlockParam {
 
 //         let app_state = ApiState {
 //             reth_provider: None,
+//             reth_http_url: None,
 //             block_index: None,
 //             block_tree: None,
 //             db: DatabaseProvider(db_arc.clone()),

--- a/crates/api-server/src/routes/proxy.rs
+++ b/crates/api-server/src/routes/proxy.rs
@@ -1,8 +1,10 @@
 use actix_web::{
-    web::{Data, Payload},
+    web::{self, Data, Payload},
     HttpRequest, HttpResponse,
 };
 use awc::Client;
+
+use crate::ApiState;
 
 #[derive(Debug)]
 pub enum ProxyError {
@@ -36,9 +38,12 @@ pub async fn proxy(
     req: HttpRequest,
     payload: Payload,
     client: Data<Client>,
+    state: web::Data<ApiState>,
 ) -> Result<HttpResponse, ProxyError> {
-    // TODO: make this configurable!
-    let target_uri = "http://localhost:8545";
+    let target_uri = state
+        .reth_http_url
+        .as_ref()
+        .ok_or(ProxyError::MethodNotAllowed)?;
 
     // Create a new client request
     let mut client_req = match *req.method() {

--- a/crates/api-server/src/routes/tx.rs
+++ b/crates/api-server/src/routes/tx.rs
@@ -189,6 +189,7 @@ pub struct TxOffset {
 
 //         let app_state = ApiState {
 //             reth_provider: None,
+//             reth_http_url: None,
 //             block_index: None,
 //             block_tree: None,
 //             db: DatabaseProvider(arc_db.clone()),
@@ -248,6 +249,7 @@ pub struct TxOffset {
 
 //         let app_state = ApiState {
 //             reth_provider: None,
+//             reth_http_url: None,
 //             block_index: None,
 //             block_tree: None,
 //             db: DatabaseProvider(db_arc.clone()),

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -657,7 +657,7 @@ pub async fn start_irys_node(
                     block_tree_guard: block_tree_guard.clone(),
                     config: Arc::new(config.clone())
                 });
-
+                
                 let server = run_server(ApiState {
                     mempool: mempool_addr,
                     chunk_provider: arc_chunk_provider.clone(),
@@ -665,6 +665,7 @@ pub async fn start_irys_node(
                     reth_provider: Some(reth_node.clone()),
                     block_tree: Some(block_tree_guard.clone()),
                     block_index: Some(block_index_guard.clone()),
+                    reth_http_url: reth_node.rpc_server_handle().http_url(),
                     config: config.clone()
                 }, listener)
                 .await;
@@ -1353,6 +1354,7 @@ impl IrysNode {
                 block_tree: Some(block_tree_guard.clone()),
                 block_index: Some(block_index_guard.clone()),
                 config: self.config.clone(),
+                reth_http_url: reth_node.rpc_server_handle().http_url()
             },
             http_listener,
         )

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -657,7 +657,7 @@ pub async fn start_irys_node(
                     block_tree_guard: block_tree_guard.clone(),
                     config: Arc::new(config.clone())
                 });
-                
+
                 let server = run_server(ApiState {
                     mempool: mempool_addr,
                     chunk_provider: arc_chunk_provider.clone(),

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -66,7 +66,7 @@ use reth_db::{Database as _, HasName, HasTableType};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener};
 use std::path::PathBuf;
 use std::sync::atomic::AtomicU64;
-use std::thread::JoinHandle;
+use std::thread::{self, JoinHandle};
 use std::{
     fs,
     sync::{mpsc, Arc, RwLock},
@@ -155,7 +155,7 @@ impl StopGuard {
 impl Drop for StopGuard {
     fn drop(&mut self) {
         // Only check if this is the last reference to the guard
-        if Arc::strong_count(&self.0) == 1 && !self.is_stopped() {
+        if Arc::strong_count(&self.0) == 1 && !self.is_stopped() && !thread::panicking() {
             panic!("IrysNodeCtx must be stopped before all instances are dropped");
         }
     }

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -642,13 +642,13 @@ pub async fn start_irys_node(
                     // Setup core affinity
                     let mut core_ids = core_affinity::get_core_ids().expect("Failed to get core IDs");
                     
-                    if cfg!(test) {
-                        debug!("In test, checking for spare core...");
-                        // TODO: make this smart lol
+                    if node_config.base_directory.parent().is_some_and(|p| p.ends_with(".tmp")) {
+                        info!("In test, pinning to random core");
+                        // TODO: make this smart lol (co-ordinate with a common file in .tmp)
                         let mut rand = rand::thread_rng();
                         core_ids.shuffle(&mut rand)
                     }
-                    
+
                     for core in core_ids {
                         let success = core_affinity::set_for_current(core);
                         if success {

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -1354,7 +1354,7 @@ impl IrysNode {
                 block_tree: Some(block_tree_guard.clone()),
                 block_index: Some(block_index_guard.clone()),
                 config: self.config.clone(),
-                reth_http_url: reth_node.rpc_server_handle().http_url()
+                reth_http_url: reth_node.rpc_server_handle().http_url(),
             },
             http_listener,
         )

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -54,7 +54,6 @@ use irys_types::{
     Config, DifficultyAdjustmentConfig, IrysBlockHeader, OracleConfig, PartitionChunkRange,
 };
 use irys_vdf::vdf_state::VdfStepsReadGuard;
-use rand::seq::SliceRandom;
 use reth::rpc::eth::EthApiServer as _;
 use reth::{
     builder::FullNode,
@@ -640,7 +639,7 @@ pub async fn start_irys_node(
 
                 // we can't use `cfg!(test)` to detect integration tests, so we check that the path is of form `(...)/.tmp/<random folder>`
                 let is_test = node_config.base_directory.parent().is_some_and(|p| p.ends_with(".tmp"));
-                
+
                 let vdf_thread_handler = std::thread::spawn(move || {
 
                     if !is_test {
@@ -655,7 +654,7 @@ pub async fn start_irys_node(
                             }
                         }
                     }
-                   
+
                     run_vdf(
                         vdf_config2,
                         global_step_number,

--- a/crates/chain/tests/api/api.rs
+++ b/crates/chain/tests/api/api.rs
@@ -70,6 +70,7 @@ async fn api_end_to_end_test(chunk_size: usize) {
 
     let app_state = ApiState {
         reth_provider: None,
+        reth_http_url: None,
         block_index: None,
         block_tree: None,
         db: handle.db,

--- a/crates/chain/tests/api/api.rs
+++ b/crates/chain/tests/api/api.rs
@@ -18,7 +18,7 @@ use tracing::info;
 
 #[ignore]
 #[actix_web::test]
-async fn serial_api_end_to_end_test_32b() {
+async fn heavy_api_end_to_end_test_32b() {
     if PACKING_TYPE == PackingType::CPU {
         api_end_to_end_test(32).await;
     } else {
@@ -28,7 +28,7 @@ async fn serial_api_end_to_end_test_32b() {
 
 #[ignore]
 #[actix_web::test]
-async fn serial_api_end_to_end_test_256kb() {
+async fn heavy_api_end_to_end_test_256kb() {
     api_end_to_end_test(256 * 1024).await;
 }
 

--- a/crates/chain/tests/api/external_api.rs
+++ b/crates/chain/tests/api/external_api.rs
@@ -67,7 +67,7 @@ async fn version_endpoint_request(
 async fn serial_external_api() -> eyre::Result<()> {
     let ctx = setup().await?; // start api service
 
-    let address = "http://127.0.0.1:8080";
+    let address = format!("http://127.0.0.1:{}", ctx.node.config.port);
 
     // FIXME: Test to be updated with future endpoint work
     let mut _response = chunk_endpoint_request(&address).await;

--- a/crates/chain/tests/api/external_api.rs
+++ b/crates/chain/tests/api/external_api.rs
@@ -64,7 +64,7 @@ async fn version_endpoint_request(
 }
 
 #[actix::test]
-async fn serial_external_api() -> eyre::Result<()> {
+async fn heavy_external_api() -> eyre::Result<()> {
     let ctx = setup().await?; // start api service
 
     let address = format!("http://127.0.0.1:{}", ctx.node.config.port);

--- a/crates/chain/tests/block_production/analytics.rs
+++ b/crates/chain/tests/block_production/analytics.rs
@@ -84,7 +84,7 @@ async fn test_blockprod_with_evm_txs() -> eyre::Result<()> {
     .await?;
     let _reth_context = RethNodeContext::new(node.reth_handle.into()).await?;
 
-    let http_url = "http://127.0.0.1:8080";
+    let http_url = format!("http://127.0.0.1:{}", node.config.port);
 
     // server should be running
     // check with request to `/v1/info`
@@ -132,7 +132,11 @@ async fn test_blockprod_with_evm_txs() -> eyre::Result<()> {
             ProviderBuilder::new()
                 .with_recommended_fillers()
                 .wallet(EthereumWallet::from(signer))
-                .on_http("http://localhost:8080/v1/execution-rpc".parse().unwrap())
+                .on_http(
+                    format!("http://127.0.0.1:{}/v1/execution-rpc", node.config.port)
+                        .parse()
+                        .unwrap(),
+                )
         })
         .collect::<Vec<_>>();
 

--- a/crates/chain/tests/block_production/analytics.rs
+++ b/crates/chain/tests/block_production/analytics.rs
@@ -252,7 +252,7 @@ async fn test_blockprod_with_evm_txs() -> eyre::Result<()> {
         }
 
         let poa_solution = capacity_chunk_solution(
-            node.config.mining_signer.address(),
+            node.node_config.mining_signer.address(),
             node.vdf_steps_guard.clone(),
             &node.vdf_config,
             &node.storage_config,

--- a/crates/chain/tests/block_production/basic_contract.rs
+++ b/crates/chain/tests/block_production/basic_contract.rs
@@ -56,7 +56,7 @@ async fn serial_test_erc20() -> eyre::Result<()> {
     let alloy_provider = ProviderBuilder::new()
         .with_recommended_fillers()
         .wallet(EthereumWallet::from(signer))
-        .on_http("http://localhost:8080/v1/execution-rpc".parse()?);
+        .on_http(format!("http://127.0.0.1:{}/v1/execution-rpc", node.config.port).parse()?);
 
     let mut deploy_fut = Box::pin(IrysERC20::deploy(alloy_provider, account1.address()));
 

--- a/crates/chain/tests/block_production/basic_contract.rs
+++ b/crates/chain/tests/block_production/basic_contract.rs
@@ -22,7 +22,7 @@ sol!(
     "../../fixtures/contracts/out/IrysERC20.sol/IrysERC20.json"
 );
 #[tokio::test]
-async fn serial_test_erc20() -> eyre::Result<()> {
+async fn heavy_test_erc20() -> eyre::Result<()> {
     let temp_dir = setup_tracing_and_temp_dir(Some("test_erc20"), false);
     let testnet_config = Config::testnet();
     let mut config = IrysNodeConfig::new(&testnet_config);

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -80,7 +80,7 @@ async fn serial_test_blockprod() -> eyre::Result<()> {
     }
 
     let poa_solution = capacity_chunk_solution(
-        node.config.mining_signer.address(),
+        node.node_config.mining_signer.address(),
         node.vdf_steps_guard,
         &node.vdf_config,
         &node.storage_config,
@@ -141,7 +141,7 @@ async fn serial_mine_ten_blocks_with_capacity_poa_solution() -> eyre::Result<()>
     for i in 1..10 {
         info!("manually producing block {}", i);
         let poa_solution = capacity_chunk_solution(
-            node.config.mining_signer.address(),
+            node.node_config.mining_signer.address(),
             node.vdf_steps_guard.clone(),
             &node.vdf_config,
             &node.storage_config,
@@ -233,7 +233,7 @@ async fn serial_test_basic_blockprod() -> eyre::Result<()> {
     let node = start_irys_node(config, storage_config, testnet_config.clone()).await?;
 
     let poa_solution = capacity_chunk_solution(
-        node.config.mining_signer.address(),
+        node.node_config.mining_signer.address(),
         node.vdf_steps_guard,
         &node.vdf_config,
         &node.storage_config,
@@ -382,7 +382,7 @@ async fn serial_test_blockprod_with_evm_txs() -> eyre::Result<()> {
     }
 
     let poa_solution = capacity_chunk_solution(
-        node.config.mining_signer.address(),
+        node.node_config.mining_signer.address(),
         node.vdf_steps_guard,
         &node.vdf_config,
         &node.storage_config,

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -25,7 +25,7 @@ use crate::utils::capacity_chunk_solution;
 /// Create a valid capacity PoA solution
 
 #[tokio::test]
-async fn serial_test_blockprod() -> eyre::Result<()> {
+async fn heavy_test_blockprod() -> eyre::Result<()> {
     std::env::set_var("RUST_LOG", "debug");
     let temp_dir = setup_tracing_and_temp_dir(Some("test_blockprod"), false);
     let testnet_config = Config::testnet();
@@ -129,7 +129,7 @@ async fn serial_test_blockprod() -> eyre::Result<()> {
 }
 
 #[tokio::test]
-async fn serial_mine_ten_blocks_with_capacity_poa_solution() -> eyre::Result<()> {
+async fn heavy_mine_ten_blocks_with_capacity_poa_solution() -> eyre::Result<()> {
     let temp_dir = setup_tracing_and_temp_dir(Some("test_blockprod"), false);
     let testnet_config = Config::testnet();
     let mut config = IrysNodeConfig::new(&testnet_config);
@@ -178,7 +178,7 @@ async fn serial_mine_ten_blocks_with_capacity_poa_solution() -> eyre::Result<()>
 }
 
 #[tokio::test]
-async fn serial_mine_ten_blocks() -> eyre::Result<()> {
+async fn heavy_mine_ten_blocks() -> eyre::Result<()> {
     let temp_dir = setup_tracing_and_temp_dir(Some("test_blockprod"), false);
     let testnet_config = Config::testnet();
     let mut config = IrysNodeConfig::new(&testnet_config);
@@ -225,7 +225,7 @@ async fn serial_mine_ten_blocks() -> eyre::Result<()> {
 }
 
 #[tokio::test]
-async fn serial_test_basic_blockprod() -> eyre::Result<()> {
+async fn heavy_test_basic_blockprod() -> eyre::Result<()> {
     let temp_dir = setup_tracing_and_temp_dir(Some("test_blockprod"), false);
 
     let testnet_config = Config::testnet();
@@ -273,7 +273,7 @@ async fn serial_test_basic_blockprod() -> eyre::Result<()> {
 }
 
 #[tokio::test]
-async fn serial_test_blockprod_with_evm_txs() -> eyre::Result<()> {
+async fn heavy_test_blockprod_with_evm_txs() -> eyre::Result<()> {
     let temp_dir = setup_tracing_and_temp_dir(Some("test_blockprod"), false);
     let testnet_config = Config {
         chunk_size: 32,

--- a/crates/chain/tests/ema_pricing/ema_pricing.rs
+++ b/crates/chain/tests/ema_pricing/ema_pricing.rs
@@ -11,7 +11,7 @@ use irys_types::{storage_pricing::Amount, Config, OracleConfig};
 use rust_decimal_macros::dec;
 
 #[test_log::test(tokio::test)]
-async fn serial_test_genesis_ema_price_is_respected_for_2_intervals() -> eyre::Result<()> {
+async fn heavy_test_genesis_ema_price_is_respected_for_2_intervals() -> eyre::Result<()> {
     // setup
     let price_adjustment_interval = 3;
     let ctx = setup(price_adjustment_interval).await?;
@@ -48,7 +48,7 @@ async fn serial_test_genesis_ema_price_is_respected_for_2_intervals() -> eyre::R
 }
 
 #[test_log::test(tokio::test)]
-async fn serial_test_genesis_ema_price_updates_after_second_interval() -> eyre::Result<()> {
+async fn heavy_test_genesis_ema_price_updates_after_second_interval() -> eyre::Result<()> {
     // setup
     let price_adjustment_interval = 3;
     let ctx = setup(price_adjustment_interval).await?;
@@ -92,7 +92,7 @@ async fn serial_test_genesis_ema_price_updates_after_second_interval() -> eyre::
 }
 
 #[test_log::test(tokio::test)]
-async fn serial_test_oracle_price_too_high_gets_capped() -> eyre::Result<()> {
+async fn heavy_test_oracle_price_too_high_gets_capped() -> eyre::Result<()> {
     // setup
     let price_adjustment_interval = 3;
     let token_price_safe_range = Amount::percentage(dec!(0.1)).unwrap();

--- a/crates/chain/tests/external/programmable_data_basic.rs
+++ b/crates/chain/tests/external/programmable_data_basic.rs
@@ -216,7 +216,7 @@ async fn test_programmable_data_basic_external() -> eyre::Result<()> {
 
     for _i in 1..10 {
         let poa_solution = capacity_chunk_solution(
-            node.config.mining_signer.address(),
+            node.node_config.mining_signer.address(),
             node.vdf_steps_guard.clone(),
             &node.vdf_config,
             &node.storage_config,

--- a/crates/chain/tests/external/programmable_data_basic.rs
+++ b/crates/chain/tests/external/programmable_data_basic.rs
@@ -100,7 +100,7 @@ async fn test_programmable_data_basic_external() -> eyre::Result<()> {
     let alloy_provider = ProviderBuilder::new()
         .with_recommended_fillers()
         .wallet(wallet)
-        .on_http("http://localhost:8080/v1/execution-rpc".parse()?);
+        .on_http(format!("http://127.0.0.1:{}/v1/execution-rpc", node.config.port).parse()?);
 
     let deploy_builder =
         IrysProgrammableDataBasic::deploy_builder(alloy_provider.clone()).gas(29506173);
@@ -126,7 +126,7 @@ async fn test_programmable_data_basic_external() -> eyre::Result<()> {
         precompile_address
     );
 
-    let http_url = "http://127.0.0.1:8080";
+    let http_url = format!("http://127.0.0.1:{}", node.config.port);
 
     // server should be running
     // check with request to `/v1/info`

--- a/crates/chain/tests/integration/cache_service.rs
+++ b/crates/chain/tests/integration/cache_service.rs
@@ -195,7 +195,7 @@ async fn serial_test_cache_pruning() -> eyre::Result<()> {
     for i in 1..4 {
         info!("manually producing block {}", i);
         let poa_solution = capacity_chunk_solution(
-            node.config.mining_signer.address(),
+            node.node_config.mining_signer.address(),
             node.vdf_steps_guard.clone(),
             &node.vdf_config,
             &node.storage_config,

--- a/crates/chain/tests/integration/cache_service.rs
+++ b/crates/chain/tests/integration/cache_service.rs
@@ -57,7 +57,7 @@ async fn serial_test_cache_pruning() -> eyre::Result<()> {
     )
     .await?;
 
-    let http_url = "http://127.0.0.1:8080";
+    let http_url = format!("http://127.0.0.1:{}", node.config.port);
 
     // server should be running
     // check with request to `/v1/info`

--- a/crates/chain/tests/integration/cache_service.rs
+++ b/crates/chain/tests/integration/cache_service.rs
@@ -21,8 +21,8 @@ use tokio::time::sleep;
 use tracing::{debug, info};
 
 #[actix_web::test]
-async fn serial_test_cache_pruning() -> eyre::Result<()> {
-    let temp_dir = setup_tracing_and_temp_dir(Some("serial_test_cache_pruning"), false);
+async fn heavy_test_cache_pruning() -> eyre::Result<()> {
+    let temp_dir = setup_tracing_and_temp_dir(Some("heavy_test_cache_pruning"), false);
     let mut testnet_config = Config::testnet();
     testnet_config.chunk_size = 32;
     testnet_config.chunk_migration_depth = 2;

--- a/crates/chain/tests/multi_node/peer_discovery.rs
+++ b/crates/chain/tests/multi_node/peer_discovery.rs
@@ -19,7 +19,7 @@ use irys_types::{build_user_agent, irys::IrysSigner, PeerResponse, VersionReques
 use reth_primitives::GenesisAccount;
 
 #[actix_web::test]
-async fn serial_peer_discovery() -> eyre::Result<()> {
+async fn heavy_peer_discovery() -> eyre::Result<()> {
     let chunk_size = 32; // 32Byte chunks
 
     let mut test_config = Config::testnet();

--- a/crates/chain/tests/multi_node/peer_discovery.rs
+++ b/crates/chain/tests/multi_node/peer_discovery.rs
@@ -61,6 +61,7 @@ async fn serial_peer_discovery() -> eyre::Result<()> {
 
     let app_state = ApiState {
         reth_provider: None,
+        reth_http_url: None,
         block_index: None,
         block_tree: None,
         db: node.db.clone(),

--- a/crates/chain/tests/programmable_data/basic.rs
+++ b/crates/chain/tests/programmable_data/basic.rs
@@ -43,7 +43,7 @@ const DEV_PRIVATE_KEY: &str = "db793353b633df950842415065f769699541160845d73db90
 const DEV_ADDRESS: &str = "64f1a2829e0e698c18e7792d6e74f67d89aa0a32";
 
 #[actix_web::test]
-async fn serial_test_programmable_data_basic() -> eyre::Result<()> {
+async fn heavy_test_programmable_data_basic() -> eyre::Result<()> {
     let temp_dir = setup_tracing_and_temp_dir(Some("test_programmable_data_basic"), false);
     let mut testnet_config = Config::testnet();
     testnet_config.chunk_size = 32;

--- a/crates/chain/tests/programmable_data/basic.rs
+++ b/crates/chain/tests/programmable_data/basic.rs
@@ -97,7 +97,7 @@ async fn serial_test_programmable_data_basic() -> eyre::Result<()> {
     let alloy_provider = ProviderBuilder::new()
         .with_recommended_fillers()
         .wallet(wallet)
-        .on_http("http://localhost:8080/v1/execution-rpc".parse()?);
+        .on_http(format!("http://127.0.0.1:{}/v1/execution-rpc", node.config.port).parse()?);
 
     let deploy_builder =
         IrysProgrammableDataBasic::deploy_builder(alloy_provider.clone()).gas(29506173);
@@ -123,7 +123,7 @@ async fn serial_test_programmable_data_basic() -> eyre::Result<()> {
         precompile_address
     );
 
-    let http_url = "http://127.0.0.1:8080";
+    let http_url = format!("http://127.0.0.1:{}", node.config.port);
 
     // server should be running
     // check with request to `/v1/info`

--- a/crates/chain/tests/promotion/data_promotion_basic.rs
+++ b/crates/chain/tests/promotion/data_promotion_basic.rs
@@ -75,6 +75,7 @@ async fn serial_data_promotion_test() {
 
     let app_state = ApiState {
         reth_provider: None,
+        reth_http_url: None,
         block_index: None,
         block_tree: None,
         db: node_context.db.clone(),

--- a/crates/chain/tests/promotion/data_promotion_basic.rs
+++ b/crates/chain/tests/promotion/data_promotion_basic.rs
@@ -3,7 +3,7 @@ use irys_config::IrysNodeConfig;
 use irys_types::Config;
 
 #[actix_web::test]
-async fn serial_data_promotion_test() {
+async fn heavy_data_promotion_test() {
     use actix_web::{
         middleware::Logger,
         test::{self, call_service, TestRequest},

--- a/crates/chain/tests/promotion/data_promotion_double.rs
+++ b/crates/chain/tests/promotion/data_promotion_double.rs
@@ -8,7 +8,7 @@ use irys_types::Config;
 use tracing::debug;
 
 #[actix_web::test]
-async fn serial_double_root_data_promotion_test() {
+async fn heavy_double_root_data_promotion_test() {
     use std::time::Duration;
 
     use actix_web::{

--- a/crates/chain/tests/promotion/data_promotion_double.rs
+++ b/crates/chain/tests/promotion/data_promotion_double.rs
@@ -93,6 +93,7 @@ async fn serial_double_root_data_promotion_test() {
 
     let app_state = ApiState {
         reth_provider: None,
+        reth_http_url: None,
         block_index: None,
         block_tree: None,
         db: node_context.db.clone(),

--- a/crates/chain/tests/startup/startup.rs
+++ b/crates/chain/tests/startup/startup.rs
@@ -7,7 +7,7 @@ use irys_types::Config;
 use std::time::Duration;
 
 #[test_log::test(tokio::test)]
-async fn serial_test_can_resume_from_genesis_startup() -> eyre::Result<()> {
+async fn heavy_test_can_resume_from_genesis_startup() -> eyre::Result<()> {
     // setup
     let temp_dir = temporary_directory(Some("test_startup"), false);
     let config = Config {
@@ -55,8 +55,8 @@ async fn serial_test_can_resume_from_genesis_startup() -> eyre::Result<()> {
 
 #[tokio::test]
 #[should_panic(expected = "IrysNodeCtx must be stopped before all instances are dropped")]
-async fn serial_test_stop_guard() -> () {
-    let temp_dir = setup_tracing_and_temp_dir(Some("serial_test_stop_guard"), false);
+async fn heavy_test_stop_guard() -> () {
+    let temp_dir = setup_tracing_and_temp_dir(Some("heavy_test_stop_guard"), false);
 
     let testnet_config = Config::testnet();
     let mut config = IrysNodeConfig::new(&testnet_config);

--- a/crates/chain/tests/startup/startup.rs
+++ b/crates/chain/tests/startup/startup.rs
@@ -14,8 +14,8 @@ async fn serial_test_can_resume_from_genesis_startup() -> eyre::Result<()> {
         base_directory: temp_dir.path().to_path_buf(),
         ..Config::testnet()
     };
-    let genesis_node = IrysNode::new(config.clone(), true);
-    let non_genesis_node = IrysNode::new(config.clone(), false);
+    let mut genesis_node = IrysNode::new(config.clone(), true);
+    let mut non_genesis_node = IrysNode::new(config.clone(), false);
 
     // action:
     // 1. start the genesis node;

--- a/crates/chain/tests/synchronization/mod.rs
+++ b/crates/chain/tests/synchronization/mod.rs
@@ -58,7 +58,7 @@ async fn serial_should_resume_from_the_same_block() -> eyre::Result<()> {
     )
     .await?;
 
-    let http_url = "http://127.0.0.1:8080";
+    let http_url = format!("http://127.0.0.1:{}", node.config.port);
 
     // server should be running
     // check with request to `/v1/info`

--- a/crates/chain/tests/synchronization/mod.rs
+++ b/crates/chain/tests/synchronization/mod.rs
@@ -17,7 +17,7 @@ use tokio::time::sleep;
 use tracing::{debug, info};
 
 #[actix_web::test]
-async fn serial_should_resume_from_the_same_block() -> eyre::Result<()> {
+async fn heavy_should_resume_from_the_same_block() -> eyre::Result<()> {
     let temp_dir = setup_tracing_and_temp_dir(Some("node_resume_test"), false);
     let mut testnet_config = Config::testnet();
     testnet_config.chunk_size = 32;

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -120,7 +120,7 @@ pub async fn mine_blocks(node_ctx: &IrysNodeCtx, blocks: usize) -> eyre::Result<
     let vdf_steps_guard = node_ctx.vdf_steps_guard.clone();
     for _ in 0..blocks {
         let poa_solution = capacity_chunk_solution(
-            node_ctx.config.mining_signer.address(),
+            node_ctx.node_config.mining_signer.address(),
             vdf_steps_guard.clone(),
             vdf_config,
             storage_config,
@@ -143,7 +143,7 @@ pub async fn mine_block(
     let vdf_config = &node_ctx.vdf_config;
     let vdf_steps_guard = node_ctx.vdf_steps_guard.clone();
     let poa_solution = capacity_chunk_solution(
-        node_ctx.config.mining_signer.address(),
+        node_ctx.node_config.mining_signer.address(),
         vdf_steps_guard.clone(),
         vdf_config,
         storage_config,
@@ -172,7 +172,7 @@ where
 {
     loop {
         let poa_solution = capacity_chunk_solution(
-            node_ctx.config.mining_signer.address(),
+            node_ctx.node_config.mining_signer.address(),
             vdf_steps_guard.clone(),
             vdf_config,
             storage_config,

--- a/crates/testing-utils/src/utils.rs
+++ b/crates/testing-utils/src/utils.rs
@@ -21,11 +21,15 @@ pub fn setup_tracing_and_temp_dir(name: Option<&str>, keep: bool) -> TempDir {
 /// Constant used to make sure .tmp shows up in the right place all the time
 pub const CARGO_MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
 
+pub fn tmp_base_dir() -> PathBuf {
+    PathBuf::from_str(CARGO_MANIFEST_DIR)
+        .unwrap()
+        .join("../../.tmp")
+}
+
 /// Creates a temporary directory
 pub fn temporary_directory(name: Option<&str>, keep: bool) -> TempDir {
-    let tmp_path = PathBuf::from_str(CARGO_MANIFEST_DIR)
-        .unwrap()
-        .join("../../.tmp");
+    let tmp_path = tmp_base_dir();
 
     create_dir_all(&tmp_path).unwrap();
 

--- a/crates/types/src/config.rs
+++ b/crates/types/src/config.rs
@@ -141,7 +141,7 @@ impl Config {
             )
             .expect("valid key"),
             num_capacity_partitions: None,
-            port: 8080,
+            port: 0,
             anchor_expiry_depth: 10,
             genesis_token_price: Amount::token(rust_decimal_macros::dec!(1))
                 .expect("valid token amount"),

--- a/crates/types/src/config.rs
+++ b/crates/types/src/config.rs
@@ -53,6 +53,7 @@ pub struct Config {
     pub mining_key: k256::ecdsa::SigningKey,
     // TODO: enable this after fixing option in toml
     pub num_capacity_partitions: Option<u64>,
+    /// The port that the Node's HTTP server should listen on. Set to 0 for randomisation.
     pub port: u16,
     /// the number of block a given anchor (tx or block hash) is valid for.
     /// The anchor must be included within the last X blocks otherwise the transaction it anchors will drop.


### PR DESCRIPTION
**Describe the changes**
This PR:
- Enables port randomisation for our HttpServer
- Enables port randomisation for Reth
- Changes the RPC proxy to use the appropriate Reth URL
- Exposes `Config` as part of `IrysNodeCtx`
- Disables VDF core pinning for tests
- Assigns `serial` tests to the new `heavy` test group, which enables test parallelisation

**Related Issue(s)**
Closes #256 

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.
