### PR TITLE
feat: add a StopGuard to IrysNodeCtx

### DIFF
--- a/crates/chain/src/arbiter_handle.rs
+++ b/crates/chain/src/arbiter_handle.rs
@@ -5,25 +5,22 @@ use std::thread::{self, JoinHandle};
 #[derive(Debug)]
 pub struct ArbiterHandle {
     inner: Arc<Mutex<Option<Arbiter>>>,
+    pub name: String,
 }
 
 impl Clone for ArbiterHandle {
     fn clone(&self) -> Self {
         Self {
+            name: self.name.clone(),
             inner: Arc::clone(&self.inner),
         }
     }
 }
 
-impl From<Arbiter> for ArbiterHandle {
-    fn from(arbiter: Arbiter) -> Self {
-        Self::new(arbiter)
-    }
-}
-
 impl ArbiterHandle {
-    pub fn new(value: Arbiter) -> Self {
+    pub fn new(value: Arbiter, name: String) -> Self {
         Self {
+            name,
             inner: Arc::new(Mutex::new(Some(value))),
         }
     }

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -95,7 +95,7 @@ pub struct IrysNodeCtx {
     pub reth_shutdown_sender: tokio::sync::mpsc::Sender<()>,
     // Thread handles spawned by the start function
     pub reth_thread_handle: Option<CloneableJoinHandle<()>>,
-    _stop_guard: StopGuard
+    _stop_guard: StopGuard,
 }
 
 impl IrysNodeCtx {
@@ -136,11 +136,11 @@ impl StopGuard {
     fn new() -> Self {
         StopGuard(Arc::new(AtomicBool::new(false)))
     }
-    
+
     fn mark_stopped(&self) {
         self.0.store(true, Ordering::SeqCst);
     }
-    
+
     fn is_stopped(&self) -> bool {
         self.0.load(Ordering::SeqCst)
     }
@@ -1336,7 +1336,7 @@ impl IrysNode {
             reth_shutdown_sender,
             reth_thread_handle: None,
             block_tree_guard: block_tree_guard.clone(),
-            _stop_guard: StopGuard::new()
+            _stop_guard: StopGuard::new(),
         };
         let server = run_server(ApiState {
             mempool: mempool_service,

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -723,7 +723,7 @@ pub async fn start_irys_node(
                 reth_node
             });
             debug!("Main actor thread finished");
-           
+
             reth_node_handle
         })?;
 

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -95,6 +95,7 @@ pub struct IrysNodeCtx {
     pub reth_shutdown_sender: tokio::sync::mpsc::Sender<()>,
     // Thread handles spawned by the start function
     pub reth_thread_handle: Option<CloneableJoinHandle<()>>,
+    _stop_guard: StopGuard
 }
 
 impl IrysNodeCtx {
@@ -104,6 +105,7 @@ impl IrysNodeCtx {
         let _ = self.reth_shutdown_sender.send(()).await;
         let _ = self.reth_thread_handle.unwrap().join();
         debug!("Main actor thread and reth thread stopped");
+        self._stop_guard.mark_stopped();
     }
 
     pub fn start_mining(&self) -> eyre::Result<()> {
@@ -121,6 +123,41 @@ impl IrysNodeCtx {
 
         info!("Sync complete.");
         Ok(())
+    }
+}
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+// Shared stop guard that can be cloned
+#[derive(Debug)]
+struct StopGuard(Arc<AtomicBool>);
+
+impl StopGuard {
+    fn new() -> Self {
+        StopGuard(Arc::new(AtomicBool::new(false)))
+    }
+    
+    fn mark_stopped(&self) {
+        self.0.store(true, Ordering::SeqCst);
+    }
+    
+    fn is_stopped(&self) -> bool {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
+impl Drop for StopGuard {
+    fn drop(&mut self) {
+        // Only check if this is the last reference to the guard
+        if Arc::strong_count(&self.0) == 1 && !self.is_stopped() {
+            panic!("IrysNodeCtx must be stopped before all instances are dropped");
+        }
+    }
+}
+
+impl Clone for StopGuard {
+    fn clone(&self) -> Self {
+        StopGuard(Arc::clone(&self.0))
     }
 }
 
@@ -249,7 +286,7 @@ pub async fn start_irys_node(
                     &reth_arbiter.handle(),
                     |_| reth_service,
                 ));
-                arbiters.push(reth_arbiter.into());
+                arbiters.push(ArbiterHandle::new(reth_arbiter, "reth_arbiter".to_string()));
 
                 debug!(
                     "JESSEDEBUG setting head to block {} ({})",
@@ -389,7 +426,7 @@ pub async fn start_irys_node(
                     |_| block_tree_service,
                 ));
                 let block_tree_service = BlockTreeService::from_registry();
-                arbiters.push(block_tree_arbiter.into());
+                arbiters.push(ArbiterHandle::new(block_tree_arbiter, "block_tree_arbiter".to_string()));
 
                 let block_tree_guard = block_tree_service
                     .send(GetBlockTreeGuardMessage)
@@ -403,7 +440,7 @@ pub async fn start_irys_node(
                     &peer_list_arbiter.handle(),
                     |_| peer_list_service,
                 ));
-                arbiters.push(peer_list_arbiter.into());
+                arbiters.push(ArbiterHandle::new(peer_list_arbiter, "peer_list_arbiter".to_string()));
 
                 let mempool_service = MempoolService::new(
                     irys_db.clone(),
@@ -421,7 +458,7 @@ pub async fn start_irys_node(
                     |_| mempool_service,
                 ));
                 let mempool_addr = MempoolService::from_registry();
-                arbiters.push(mempool_arbiter.into());
+                arbiters.push(ArbiterHandle::new(mempool_arbiter, "mempool_arbiter".to_string()));
 
                 let chunk_migration_service = ChunkMigrationService::new(
                     block_index.clone(),
@@ -451,7 +488,7 @@ pub async fn start_irys_node(
                     &validation_arbiter.handle(),
                     |_| validation_service,
                 ));
-                arbiters.push(validation_arbiter.into());
+                arbiters.push(ArbiterHandle::new(validation_arbiter, "validation_arbiter".to_string()));
 
                 let (global_step_number, seed) = vdf_steps_guard.read().get_last_step_and_seed();
                 info!("Starting at global step number: {}", global_step_number);
@@ -471,7 +508,7 @@ pub async fn start_irys_node(
                     &block_discovery_arbiter.handle(),
                     |_| block_discovery_actor,
                 );
-                arbiters.push(block_discovery_arbiter.into());
+                arbiters.push(ArbiterHandle::new(block_discovery_arbiter, "block_discovery_arbiter".to_string()));
 
                 // set up the price oracle
                 let price_oracle = match config.oracle_config {
@@ -503,7 +540,7 @@ pub async fn start_irys_node(
                     BlockProducerActor::start_in_arbiter(&block_producer_arbiter.handle(), |_| {
                         block_producer_actor
                     });
-                arbiters.push(block_producer_arbiter.into());
+                arbiters.push(ArbiterHandle::new(block_producer_arbiter, "block_producer_arbiter".to_string()));
 
                 let mut part_actors = Vec::new();
 
@@ -535,7 +572,7 @@ pub async fn start_irys_node(
                         &part_arbiter.handle(),
                         |_| partition_mining_actor,
                     ));
-                    arbiters.push(ArbiterHandle::new(part_arbiter));
+                    arbiters.push(ArbiterHandle::new(part_arbiter, "part_arbiter".to_string()));
                 }
 
                 // Yield to let actors process their mailboxes (and subscribe to the mining_broadcaster)
@@ -598,7 +635,8 @@ pub async fn start_irys_node(
                         broadcast_mining_service.clone(),
                         vdf_service.clone(),
                         atomic_global_step_number.clone(),
-                    )
+                    );
+                    debug!("VDF thread exiting...")
                 });
 
                 let actor_addresses = ActorAddresses {
@@ -633,6 +671,7 @@ pub async fn start_irys_node(
                     reth_shutdown_sender,
                     reth_thread_handle: None,
                     block_tree_guard: block_tree_guard.clone(),
+                    _stop_guard: StopGuard::new()
                 });
 
                 let server = run_server(ApiState {
@@ -658,11 +697,18 @@ pub async fn start_irys_node(
                 });
 
                 server.await.unwrap();
+                info!("API server stopped");
                 server_stop_handle.await.unwrap();
 
                 debug!("Stopping actors");
                 for arbiter in arbiters {
+
+                    let name = arbiter.name.clone();
+                    debug!("stopping {}", &name);
+
                     arbiter.stop_and_join();
+                    debug!("stopped {}", &name);
+
                 }
                 debug!("Actors stopped");
 
@@ -674,11 +720,10 @@ pub async fn start_irys_node(
                 vdf_thread_handler.join().unwrap();
 
                 debug!("VDF thread finished");
-
                 reth_node
             });
             debug!("Main actor thread finished");
-
+           
             reth_node_handle
         })?;
 
@@ -981,12 +1026,10 @@ impl IrysNode {
                         server_stop_handle.await.unwrap();
 
                         debug!("Stopping actors");
-                        debug!("Stopping actors");
                         for arbiter in arbiters {
                             arbiter.stop();
                             let _ = arbiter.join();
                         }
-                        debug!("Actors stopped");
                         debug!("Actors stopped");
 
                         // Send shutdown signal
@@ -1293,6 +1336,7 @@ impl IrysNode {
             reth_shutdown_sender,
             reth_thread_handle: None,
             block_tree_guard: block_tree_guard.clone(),
+            _stop_guard: StopGuard::new()
         };
         let server = run_server(ApiState {
             mempool: mempool_service,

--- a/crates/chain/tests/api/external_api.rs
+++ b/crates/chain/tests/api/external_api.rs
@@ -156,6 +156,7 @@ async fn serial_external_api() -> eyre::Result<()> {
         }
     }
 
+    ctx.node.stop().await;
     Ok(())
 }
 

--- a/crates/chain/tests/block_production/basic_contract.rs
+++ b/crates/chain/tests/block_production/basic_contract.rs
@@ -82,7 +82,7 @@ async fn serial_test_erc20() -> eyre::Result<()> {
         node.clone(),
         &mut transfer_receipt_fut,
         Duration::from_millis(2_000),
-        node.vdf_steps_guard,
+        node.vdf_steps_guard.clone(),
         &node.vdf_config,
         &node.storage_config,
     )
@@ -94,6 +94,6 @@ async fn serial_test_erc20() -> eyre::Result<()> {
 
     assert_eq!(addr1_balance, U256::from(10));
     assert_eq!(main_balance2, U256::from(10000000000000000000000 - 10_u128));
-
+    node.stop().await;
     Ok(())
 }

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -124,6 +124,7 @@ async fn serial_test_blockprod() -> eyre::Result<()> {
 
     assert_eq!(db_irys_block.evm_block_hash, reth_block.hash_slow());
 
+    node.stop().await;
     Ok(())
 }
 
@@ -172,6 +173,7 @@ async fn serial_mine_ten_blocks_with_capacity_poa_solution() -> eyre::Result<()>
         // MAGIC: we wait more than 1s so that the block timestamps (evm block timestamps are seconds) don't overlap
         sleep(Duration::from_millis(1500)).await;
     }
+    node.stop().await;
     Ok(())
 }
 
@@ -218,6 +220,7 @@ async fn serial_mine_ten_blocks() -> eyre::Result<()> {
 
         assert_eq!(db_irys_block.evm_block_hash, reth_block.hash_slow());
     }
+    node.stop().await;
     Ok(())
 }
 

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -81,7 +81,7 @@ async fn serial_test_blockprod() -> eyre::Result<()> {
 
     let poa_solution = capacity_chunk_solution(
         node.config.mining_signer.address(),
-        node.vdf_steps_guard,
+        node.vdf_steps_guard.clone(),
         &node.vdf_config,
         &node.storage_config,
     )
@@ -103,7 +103,7 @@ async fn serial_test_blockprod() -> eyre::Result<()> {
         }
     }
 
-    let reth_context = RethNodeContext::new(node.reth_handle.into()).await?;
+    let reth_context = RethNodeContext::new(node.reth_handle.clone().into()).await?;
 
     //check reth for built block
     let reth_block = reth_context
@@ -136,7 +136,7 @@ async fn serial_mine_ten_blocks_with_capacity_poa_solution() -> eyre::Result<()>
     let storage_config = irys_types::StorageConfig::new(&testnet_config);
     let node = start_irys_node(config, storage_config, testnet_config.clone()).await?;
 
-    let reth_context = RethNodeContext::new(node.reth_handle.into()).await?;
+    let reth_context = RethNodeContext::new(node.reth_handle.clone().into()).await?;
 
     for i in 1..10 {
         info!("manually producing block {}", i);
@@ -185,7 +185,7 @@ async fn serial_mine_ten_blocks() -> eyre::Result<()> {
     let node = start_irys_node(config, storage_config, testnet_config.clone()).await?;
     node.actor_addresses.start_mining()?;
 
-    let reth_context = RethNodeContext::new(node.reth_handle.into()).await?;
+    let reth_context = RethNodeContext::new(node.reth_handle.clone().into()).await?;
 
     for i in 1..10 {
         info!("waiting block {}", i);
@@ -234,7 +234,7 @@ async fn serial_test_basic_blockprod() -> eyre::Result<()> {
 
     let poa_solution = capacity_chunk_solution(
         node.config.mining_signer.address(),
-        node.vdf_steps_guard,
+        node.vdf_steps_guard.clone(),
         &node.vdf_config,
         &node.storage_config,
     )
@@ -247,7 +247,7 @@ async fn serial_test_basic_blockprod() -> eyre::Result<()> {
         .await??
         .unwrap();
 
-    let reth_context = RethNodeContext::new(node.reth_handle.into()).await?;
+    let reth_context = RethNodeContext::new(node.reth_handle.clone().into()).await?;
 
     //check reth for built block
     let reth_block = reth_context
@@ -265,7 +265,7 @@ async fn serial_test_basic_blockprod() -> eyre::Result<()> {
         .view_eyre(|tx| irys_database::block_header_by_hash(tx, &block.block_hash, false))?
         .unwrap();
     assert_eq!(db_irys_block.evm_block_hash, reth_block.hash_slow());
-
+    node.stop().await;
     Ok(())
 }
 
@@ -316,7 +316,7 @@ async fn serial_test_blockprod_with_evm_txs() -> eyre::Result<()> {
     ]);
 
     let node = start_irys_node(config, storage_config, testnet_config.clone()).await?;
-    let reth_context = RethNodeContext::new(node.reth_handle.into()).await?;
+    let reth_context = RethNodeContext::new(node.reth_handle.clone().into()).await?;
     let miner_init_balance = reth_context
         .rpc
         .get_balance(mining_signer_addr, None)
@@ -383,7 +383,7 @@ async fn serial_test_blockprod_with_evm_txs() -> eyre::Result<()> {
 
     let poa_solution = capacity_chunk_solution(
         node.config.mining_signer.address(),
-        node.vdf_steps_guard,
+        node.vdf_steps_guard.clone(),
         &node.vdf_config,
         &node.storage_config,
     )
@@ -429,6 +429,6 @@ async fn serial_test_blockprod_with_evm_txs() -> eyre::Result<()> {
         .unwrap();
 
     assert_eq!(db_irys_block.evm_block_hash, reth_block.hash_slow());
-
+    node.stop().await;
     Ok(())
 }

--- a/crates/chain/tests/integration/cache_service.rs
+++ b/crates/chain/tests/integration/cache_service.rs
@@ -185,7 +185,7 @@ async fn serial_test_cache_pruning() -> eyre::Result<()> {
     .unwrap();
 
     // mine a couple blocks
-    let reth_context = RethNodeContext::new(node.reth_handle.into()).await?;
+    let reth_context = RethNodeContext::new(node.reth_handle.clone().into()).await?;
     let (chunk_cache_count, _) = &node
         .db
         .view_eyre(|tx| get_cache_size::<CachedChunks, _>(tx, testnet_config.chunk_size))?;
@@ -240,5 +240,8 @@ async fn serial_test_cache_pruning() -> eyre::Result<()> {
         .unwrap();
 
     assert_eq!(chunk_res.status(), StatusCode::OK);
+
+    node.stop().await;
+
     Ok(())
 }

--- a/crates/chain/tests/multi_node/peer_discovery.rs
+++ b/crates/chain/tests/multi_node/peer_discovery.rs
@@ -64,7 +64,7 @@ async fn serial_peer_discovery() -> eyre::Result<()> {
         block_index: None,
         block_tree: None,
         db: node.db.clone(),
-        mempool: node.actor_addresses.mempool,
+        mempool: node.actor_addresses.mempool.clone(),
         chunk_provider: node.chunk_provider.clone(),
         config: test_config.clone(),
     };
@@ -220,5 +220,7 @@ async fn serial_peer_discovery() -> eyre::Result<()> {
         }),
         "Peer list missing expected addresses"
     );
+
+    node.stop().await;
     Ok(())
 }

--- a/crates/chain/tests/programmable_data/basic.rs
+++ b/crates/chain/tests/programmable_data/basic.rs
@@ -320,7 +320,7 @@ async fn serial_test_programmable_data_basic() -> eyre::Result<()> {
 
     assert_eq!(&message, &stored_message);
 
-    let context = RethNodeContext::new(node.reth_handle.into()).await?;
+    let context = RethNodeContext::new(node.reth_handle.clone().into()).await?;
 
     let latest = context
         .rpc
@@ -345,5 +345,6 @@ async fn serial_test_programmable_data_basic() -> eyre::Result<()> {
 
     dbg!(latest, safe, finalized);
 
+    node.stop().await;
     Ok(())
 }

--- a/crates/chain/tests/promotion/data_promotion_basic.rs
+++ b/crates/chain/tests/promotion/data_promotion_basic.rs
@@ -78,7 +78,7 @@ async fn serial_data_promotion_test() {
         block_index: None,
         block_tree: None,
         db: node_context.db.clone(),
-        mempool: node_context.actor_addresses.mempool,
+        mempool: node_context.actor_addresses.mempool.clone(),
         chunk_provider: node_context.chunk_provider.clone(),
         config: testnet_config,
     };
@@ -372,5 +372,5 @@ async fn serial_data_promotion_test() {
     )
     .await;
 
-    // println!("\n{:?}", unpacked_chunk);
+    node_context.stop().await;
 }

--- a/crates/chain/tests/promotion/data_promotion_double.rs
+++ b/crates/chain/tests/promotion/data_promotion_double.rs
@@ -599,4 +599,6 @@ async fn serial_double_root_data_promotion_test() {
         .unwrap()
         .unwrap();
     assert_eq!(ingress_proofs.len(), 0);
+
+    node_context.stop().await;
 }

--- a/crates/chain/tests/startup/startup.rs
+++ b/crates/chain/tests/startup/startup.rs
@@ -1,7 +1,8 @@
 use crate::utils::mine_block;
 use irys_actors::block_tree_service::get_canonical_chain;
-use irys_chain::IrysNode;
-use irys_testing_utils::utils::temporary_directory;
+use irys_chain::{start_irys_node, IrysNode};
+use irys_config::IrysNodeConfig;
+use irys_testing_utils::utils::{setup_tracing_and_temp_dir, temporary_directory};
 use irys_types::Config;
 use std::time::Duration;
 
@@ -50,4 +51,20 @@ async fn serial_test_can_resume_from_genesis_startup() -> eyre::Result<()> {
 
     ctx.stop().await;
     Ok(())
+}
+
+#[tokio::test]
+#[should_panic(expected = "IrysNodeCtx must be stopped before all instances are dropped")]
+async fn serial_test_drop_guard() -> () {
+    let temp_dir = setup_tracing_and_temp_dir(Some("serial_test_drop_guard"), false);
+
+    let testnet_config = Config::testnet();
+    let mut config = IrysNodeConfig::new(&testnet_config);
+    config.base_directory = temp_dir.path().to_path_buf();
+
+    let storage_config = irys_types::StorageConfig::new(&testnet_config);
+    let _node = start_irys_node(config, storage_config, testnet_config.clone())
+        .await
+        .unwrap();
+    ()
 }

--- a/crates/chain/tests/startup/startup.rs
+++ b/crates/chain/tests/startup/startup.rs
@@ -55,8 +55,8 @@ async fn serial_test_can_resume_from_genesis_startup() -> eyre::Result<()> {
 
 #[tokio::test]
 #[should_panic(expected = "IrysNodeCtx must be stopped before all instances are dropped")]
-async fn serial_test_drop_guard() -> () {
-    let temp_dir = setup_tracing_and_temp_dir(Some("serial_test_drop_guard"), false);
+async fn serial_test_stop_guard() -> () {
+    let temp_dir = setup_tracing_and_temp_dir(Some("serial_test_stop_guard"), false);
 
     let testnet_config = Config::testnet();
     let mut config = IrysNodeConfig::new(&testnet_config);


### PR DESCRIPTION
**Describe the changes**
This PR:
- Adds a `StopGuard` to `IrysNodeCtx`, which will panic if it's dropped when the `IrysNodeCtx.stop()` method hasn't been called/awaited
- Names arbiter handles (this was a change I was using to debug this issue, thought it'd be useful to keep in)

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.


