### PR TITLE
test: mining height control testing primitives

### DIFF
--- a/crates/chain/tests/api/api.rs
+++ b/crates/chain/tests/api/api.rs
@@ -36,7 +36,7 @@ async fn serial_api_end_to_end_test_256kb() {
 
 async fn api_end_to_end_test(chunk_size: usize) {
     use irys_types::{
-        irys::IrysSigner, Base64, IrysTransactionHeader, PackedChunk, StorageConfig, UnpackedChunk,
+        irys::IrysSigner, Base64, IrysTransactionHeader, PackedChunk, UnpackedChunk,
     };
     use rand::Rng;
     use std::time::Duration;

--- a/crates/chain/tests/api/api.rs
+++ b/crates/chain/tests/api/api.rs
@@ -35,9 +35,7 @@ async fn heavy_api_end_to_end_test_256kb() {
 }
 
 async fn api_end_to_end_test(chunk_size: usize) {
-    use irys_types::{
-        irys::IrysSigner, Base64, IrysTransactionHeader, PackedChunk, UnpackedChunk,
-    };
+    use irys_types::{irys::IrysSigner, Base64, IrysTransactionHeader, PackedChunk, UnpackedChunk};
     use rand::Rng;
     use std::time::Duration;
     use tokio::time::sleep;

--- a/crates/chain/tests/api/api.rs
+++ b/crates/chain/tests/api/api.rs
@@ -50,17 +50,15 @@ async fn api_end_to_end_test(chunk_size: usize) {
     };
     let chain_id = testnet_config.chain_id;
     let mut node_config = IrysNodeConfig::new(&testnet_config);
-    
+
     let irys = IrysSigner::random_signer(&testnet_config);
-    node_config.extend_genesis_accounts(vec![
-        (
-            irys.address(),
-            GenesisAccount {
-                balance: U256::from(1000),
-                ..Default::default()
-            },
-        ),
-    ]);
+    node_config.extend_genesis_accounts(vec![(
+        irys.address(),
+        GenesisAccount {
+            balance: U256::from(1000),
+            ..Default::default()
+        },
+    )]);
 
     let (handle, _tmp_dir) = start_node_config(
         &format!("api_end_to_end_{}_test_", chunk_size),
@@ -104,7 +102,7 @@ async fn api_end_to_end_test(chunk_size: usize) {
     rand::thread_rng().fill(&mut data_bytes[..]);
 
     // Create a new Irys API instance & a signed transaction
-    
+
     let tx = irys.create_transaction(data_bytes.clone(), None).unwrap();
     let tx = irys.sign_transaction(tx).unwrap();
 

--- a/crates/chain/tests/api/api.rs
+++ b/crates/chain/tests/api/api.rs
@@ -151,7 +151,7 @@ async fn api_end_to_end_test(chunk_size: usize) {
     }
     let id: String = tx.header.id.as_bytes().to_base58();
     let mut attempts = 1;
-    let max_attempts = 20;
+    let max_attempts = 40;
 
     let delay = Duration::from_secs(1);
 

--- a/crates/chain/tests/api/api.rs
+++ b/crates/chain/tests/api/api.rs
@@ -72,8 +72,8 @@ async fn api_end_to_end_test(chunk_size: usize) {
         reth_http_url: None,
         block_index: None,
         block_tree: None,
-        db: handle.db,
-        mempool: handle.actor_addresses.mempool,
+        db: handle.db.clone(),
+        mempool: handle.actor_addresses.mempool.clone(),
         chunk_provider: handle.chunk_provider.clone(),
         config: testnet_config.clone(),
     };
@@ -236,4 +236,6 @@ async fn api_end_to_end_test(chunk_size: usize) {
         "Chunk could not be retrieved after {} attempts",
         attempts
     );
+
+    handle.stop().await;
 }

--- a/crates/chain/tests/api/api.rs
+++ b/crates/chain/tests/api/api.rs
@@ -1,8 +1,9 @@
 // todo delete the whole module. the tests are ignored anyway. They can be restored in the future
 
 use actix_http::StatusCode;
+use alloy_core::primitives::U256;
+use irys_actors::packing::wait_for_packing;
 use irys_api_server::{routes, ApiState};
-use irys_chain::start_irys_node;
 use irys_config::IrysNodeConfig;
 use irys_packing::{unpack, PackingType, PACKING_TYPE};
 
@@ -14,9 +15,11 @@ use actix_web::{
 };
 use base58::ToBase58;
 use irys_types::{Config, TxChunkOffset};
+use reth_primitives::GenesisAccount;
 use tracing::info;
 
-#[ignore]
+use crate::utils::start_node_config;
+
 #[actix_web::test]
 async fn serial_api_end_to_end_test_32b() {
     if PACKING_TYPE == PackingType::CPU {
@@ -26,7 +29,6 @@ async fn serial_api_end_to_end_test_32b() {
     }
 }
 
-#[ignore]
 #[actix_web::test]
 async fn serial_api_end_to_end_test_256kb() {
     api_end_to_end_test(256 * 1024).await;
@@ -40,32 +42,33 @@ async fn api_end_to_end_test(chunk_size: usize) {
     use std::time::Duration;
     use tokio::time::sleep;
     use tracing::{debug, info};
+    let entropy_packing_iterations = 1_000;
     let testnet_config = Config {
         chunk_size: chunk_size.try_into().unwrap(),
+        entropy_packing_iterations,
         ..Config::testnet()
     };
-    let miner_signer = IrysSigner::from_config(&testnet_config);
+    let chain_id = testnet_config.chain_id;
+    let mut node_config = IrysNodeConfig::new(&testnet_config);
+    
+    let irys = IrysSigner::random_signer(&testnet_config);
+    node_config.extend_genesis_accounts(vec![
+        (
+            irys.address(),
+            GenesisAccount {
+                balance: U256::from(1000),
+                ..Default::default()
+            },
+        ),
+    ]);
 
-    let storage_config = StorageConfig {
-        chunk_size: chunk_size as u64,
-        num_chunks_in_partition: 10,
-        num_chunks_in_recall_range: 2,
-        num_partitions_in_slot: 1,
-        miner_address: miner_signer.address(),
-        min_writes_before_sync: 1,
-        entropy_packing_iterations: 1_000,
-        chunk_migration_depth: 1, // Testnet / single node config
-        chain_id: testnet_config.chain_id,
-    };
-    let entropy_packing_iterations = storage_config.entropy_packing_iterations;
-
-    let handle = start_irys_node(
-        IrysNodeConfig::new(&testnet_config),
-        storage_config,
-        testnet_config.clone(),
+    let (handle, _tmp_dir) = start_node_config(
+        &format!("api_end_to_end_{}_test_", chunk_size),
+        Some(testnet_config.clone()),
+        Some(node_config),
     )
-    .await
-    .unwrap();
+    .await;
+
     handle.actor_addresses.start_mining().unwrap();
 
     let app_state = ApiState {
@@ -88,13 +91,20 @@ async fn api_end_to_end_test(chunk_size: usize) {
     )
     .await;
 
+    wait_for_packing(
+        handle.actor_addresses.packing.clone(),
+        Some(Duration::from_secs(10)),
+    )
+    .await
+    .unwrap();
+
     // Create 2.5 chunks worth of data *  fill the data with random bytes
     let data_size = chunk_size * 2_usize;
     let mut data_bytes = vec![0u8; data_size];
     rand::thread_rng().fill(&mut data_bytes[..]);
 
     // Create a new Irys API instance & a signed transaction
-    let irys = IrysSigner::random_signer(&testnet_config);
+    
     let tx = irys.create_transaction(data_bytes.clone(), None).unwrap();
     let tx = irys.sign_transaction(tx).unwrap();
 
@@ -199,7 +209,7 @@ async fn api_end_to_end_test(chunk_size: usize) {
                 &packed_chunk,
                 entropy_packing_iterations,
                 chunk_size,
-                testnet_config.chain_id,
+                chain_id,
             );
             assert_eq!(
                 unpacked_chunk.bytes.0,

--- a/crates/chain/tests/block_production/analytics.rs
+++ b/crates/chain/tests/block_production/analytics.rs
@@ -24,7 +24,7 @@ use k256::ecdsa::SigningKey;
 use reth::rpc::types::TransactionRequest;
 use reth_primitives::GenesisAccount;
 use tokio::time::sleep;
-use tracing::{debug, info};
+use tracing::info;
 
 // network simulation test for analytics
 #[ignore]

--- a/crates/chain/tests/block_production/analytics.rs
+++ b/crates/chain/tests/block_production/analytics.rs
@@ -14,6 +14,7 @@ use irys_types::TxChunkOffset;
 use irys_types::UnpackedChunk;
 use rand::Rng;
 
+use crate::utils::mine_block;
 use irys_chain::start_irys_node;
 use irys_config::IrysNodeConfig;
 use irys_reth_node_bridge::adapter::{node::RethNodeContext, transaction::TransactionTestContext};
@@ -24,7 +25,6 @@ use reth::rpc::types::TransactionRequest;
 use reth_primitives::GenesisAccount;
 use tokio::time::sleep;
 use tracing::{debug, info};
-use crate::utils::mine_block;
 
 // network simulation test for analytics
 #[ignore]

--- a/crates/chain/tests/block_production/analytics.rs
+++ b/crates/chain/tests/block_production/analytics.rs
@@ -14,7 +14,6 @@ use irys_types::TxChunkOffset;
 use irys_types::UnpackedChunk;
 use rand::Rng;
 
-use irys_actors::block_producer::SolutionFoundMessage;
 use irys_chain::start_irys_node;
 use irys_config::IrysNodeConfig;
 use irys_reth_node_bridge::adapter::{node::RethNodeContext, transaction::TransactionTestContext};
@@ -25,8 +24,7 @@ use reth::rpc::types::TransactionRequest;
 use reth_primitives::GenesisAccount;
 use tokio::time::sleep;
 use tracing::{debug, info};
-
-use crate::utils::capacity_chunk_solution;
+use crate::utils::mine_block;
 
 // network simulation test for analytics
 #[ignore]
@@ -82,7 +80,7 @@ async fn test_blockprod_with_evm_txs() -> eyre::Result<()> {
         testnet_config.clone(),
     )
     .await?;
-    let _reth_context = RethNodeContext::new(node.reth_handle.into()).await?;
+    let _reth_context = RethNodeContext::new(node.reth_handle.clone().into()).await?;
 
     let http_url = format!("http://127.0.0.1:{}", node.config.port);
 
@@ -255,25 +253,10 @@ async fn test_blockprod_with_evm_txs() -> eyre::Result<()> {
             }
         }
 
-        let poa_solution = capacity_chunk_solution(
-            node.node_config.mining_signer.address(),
-            node.vdf_steps_guard.clone(),
-            &node.vdf_config,
-            &node.storage_config,
-        )
-        .await;
-
-        let (_block, _reth_exec_env) = node
-            .actor_addresses
-            .block_producer
-            .send(SolutionFoundMessage(poa_solution))
-            .await?
-            .unwrap()
-            .unwrap();
+        mine_block(&node).await?;
         info!("Finished step {}", &i);
     }
 
-    debug!("JESSEDEBUG DONE");
     sleep(Duration::from_secs(u64::MAX)).await;
 
     Ok(())

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -5,11 +5,9 @@ use alloy_core::primitives::{ruint::aliases::U256, Bytes, TxKind, B256};
 use alloy_eips::eip2718::Encodable2718;
 use alloy_signer_local::LocalSigner;
 use eyre::eyre;
-use irys_actors::{block_producer::SolutionFoundMessage, mempool_service::TxIngressMessage};
-use irys_chain::start_irys_node;
+use irys_actors::{block_producer::SolutionFoundMessage, mempool_service::TxIngressError};
 use irys_config::IrysNodeConfig;
 use irys_reth_node_bridge::adapter::{node::RethNodeContext, transaction::TransactionTestContext};
-use irys_testing_utils::utils::setup_tracing_and_temp_dir;
 use irys_types::{irys::IrysSigner, Config, IrysTransaction};
 use k256::ecdsa::SigningKey;
 use reth::{providers::BlockReader, rpc::types::TransactionRequest};
@@ -21,16 +19,13 @@ use reth_primitives::{
 use tokio::time::sleep;
 use tracing::info;
 
-use crate::utils::capacity_chunk_solution;
+use crate::utils::{add_tx, capacity_chunk_solution, start_node, start_node_config, wait_until_height, AddTxError};
 /// Create a valid capacity PoA solution
 
 #[tokio::test]
 async fn serial_test_blockprod() -> eyre::Result<()> {
-    std::env::set_var("RUST_LOG", "debug");
-    let temp_dir = setup_tracing_and_temp_dir(Some("test_blockprod"), false);
     let testnet_config = Config::testnet();
     let mut config = IrysNodeConfig::new(&testnet_config);
-    config.base_directory = temp_dir.path().to_path_buf();
 
     let account1 = IrysSigner::random_signer(&testnet_config);
     let account2 = IrysSigner::random_signer(&testnet_config);
@@ -59,24 +54,22 @@ async fn serial_test_blockprod() -> eyre::Result<()> {
             },
         ),
     ]);
-
-    let storage_config = irys_types::StorageConfig::new(&testnet_config);
-    let node = start_irys_node(config, storage_config, testnet_config.clone()).await?;
+    
+    let (node, _) = start_node_config("test_blockprod", Some(testnet_config), Some(config)).await;
 
     let mut txs: HashMap<IrysTxId, IrysTransaction> = HashMap::new();
     for a in [&account1, &account2, &account3] {
         let data_bytes = "Hello, world!".as_bytes().to_vec();
-        let tx = a.create_transaction(data_bytes, None).unwrap();
-        let tx = a.sign_transaction(tx).unwrap();
-        // submit to mempool
-        let _tx_res = node
-            .actor_addresses
-            .mempool
-            .send(TxIngressMessage(tx.header.clone()))
-            .await
-            .unwrap();
-        txs.insert(IrysTxId::from_slice(tx.header.id.as_bytes()), tx);
-        // txs.push(tx);
+        match add_tx(&node, &a, data_bytes).await {
+            Ok(tx) => {
+                txs.insert(IrysTxId::from_slice(tx.header.id.as_bytes()), tx);
+            },
+            Err(AddTxError::TxIngress(TxIngressError::Unfunded)) => {
+                assert_eq!(a.address(), account1.address(), "account1 should fail");
+            },
+            Err(e) =>
+                panic!("unexpected error {:?}", e)
+        }
     }
 
     let poa_solution = capacity_chunk_solution(
@@ -95,11 +88,10 @@ async fn serial_test_blockprod() -> eyre::Result<()> {
         .unwrap();
 
     for receipt in reth_exec_env.shadow_receipts {
-        let og_tx = txs.get(&receipt.tx_id).unwrap();
-        if og_tx.header.signer == account1.address() {
-            assert_eq!(receipt.result, ShadowResult::OutOfFunds)
-        } else {
+        if let Some(og_tx) = txs.get(&receipt.tx_id) {
             assert_eq!(receipt.result, ShadowResult::Success)
+        } else {
+            assert_eq!(receipt.result, ShadowResult::OutOfFunds)
         }
     }
 
@@ -129,14 +121,9 @@ async fn serial_test_blockprod() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn serial_mine_ten_blocks_with_capacity_poa_solution() -> eyre::Result<()> {
-    let temp_dir = setup_tracing_and_temp_dir(Some("test_blockprod"), false);
-    let testnet_config = Config::testnet();
-    let mut config = IrysNodeConfig::new(&testnet_config);
-    config.base_directory = temp_dir.path().to_path_buf();
-    let storage_config = irys_types::StorageConfig::new(&testnet_config);
-    let node = start_irys_node(config, storage_config, testnet_config.clone()).await?;
 
-    let reth_context = RethNodeContext::new(node.reth_handle.into()).await?;
+    let (node, _tmp_dir) = start_node("test_mine_ten_blocks_with_capacity_poa_solution").await;
+    let reth_context = RethNodeContext::new(node.reth_handle.clone().into()).await?;
 
     for i in 1..10 {
         info!("manually producing block {}", i);
@@ -177,26 +164,13 @@ async fn serial_mine_ten_blocks_with_capacity_poa_solution() -> eyre::Result<()>
 
 #[tokio::test]
 async fn serial_mine_ten_blocks() -> eyre::Result<()> {
-    let temp_dir = setup_tracing_and_temp_dir(Some("test_blockprod"), false);
-    let testnet_config = Config::testnet();
-    let mut config = IrysNodeConfig::new(&testnet_config);
-    config.base_directory = temp_dir.path().to_path_buf();
-    let storage_config = irys_types::StorageConfig::new(&testnet_config);
-    let node = start_irys_node(config, storage_config, testnet_config.clone()).await?;
-    node.actor_addresses.start_mining()?;
+    let (node, _tmp_dir) = start_node("test_mine_ten_blocks").await;
 
-    let reth_context = RethNodeContext::new(node.reth_handle.into()).await?;
+    node.actor_addresses.start_mining()?;
+    let reth_context = RethNodeContext::new(node.reth_handle.clone().into()).await?;
 
     for i in 1..10 {
-        info!("waiting block {}", i);
-
-        let mut retries = 0;
-        while node.block_index_guard.read().num_blocks() < i + 1 && retries < 60_u64 {
-            sleep(Duration::from_secs(1)).await;
-            retries += 1;
-        }
-
-        info!("got block after {} seconds/retries", &retries);
+        wait_until_height(&node, i + 1, 30).await;
 
         let block = node
             .block_index_guard
@@ -223,14 +197,7 @@ async fn serial_mine_ten_blocks() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn serial_test_basic_blockprod() -> eyre::Result<()> {
-    let temp_dir = setup_tracing_and_temp_dir(Some("test_blockprod"), false);
-
-    let testnet_config = Config::testnet();
-    let mut config = IrysNodeConfig::new(&testnet_config);
-    config.base_directory = temp_dir.path().to_path_buf();
-
-    let storage_config = irys_types::StorageConfig::new(&testnet_config);
-    let node = start_irys_node(config, storage_config, testnet_config.clone()).await?;
+    let (node, _tmp_dir) = start_node("test_blockprod").await;
 
     let poa_solution = capacity_chunk_solution(
         node.config.mining_signer.address(),
@@ -271,7 +238,6 @@ async fn serial_test_basic_blockprod() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn serial_test_blockprod_with_evm_txs() -> eyre::Result<()> {
-    let temp_dir = setup_tracing_and_temp_dir(Some("test_blockprod"), false);
     let testnet_config = Config {
         chunk_size: 32,
         num_chunks_in_partition: 10,
@@ -283,8 +249,6 @@ async fn serial_test_blockprod_with_evm_txs() -> eyre::Result<()> {
         ..Config::testnet()
     };
     let mut config = IrysNodeConfig::new(&testnet_config);
-    config.base_directory = temp_dir.path().to_path_buf();
-    let storage_config = irys_types::StorageConfig::new(&testnet_config);
 
     let mining_signer_addr = config.mining_signer.address();
     let account1 = IrysSigner::random_signer(&testnet_config);
@@ -315,8 +279,9 @@ async fn serial_test_blockprod_with_evm_txs() -> eyre::Result<()> {
         ),
     ]);
 
-    let node = start_irys_node(config, storage_config, testnet_config.clone()).await?;
-    let reth_context = RethNodeContext::new(node.reth_handle.into()).await?;
+    let chain_id = testnet_config.chain_id;
+    let (node, _) =  start_node_config("test_serial_blockprod", Some(testnet_config), Some(config)).await;
+    let reth_context = RethNodeContext::new(node.reth_handle.clone().into()).await?;
     let miner_init_balance = reth_context
         .rpc
         .get_balance(mining_signer_addr, None)
@@ -333,7 +298,7 @@ async fn serial_test_blockprod_with_evm_txs() -> eyre::Result<()> {
             gas: Some(21000),
             value: Some(U256::from(1)),
             nonce: Some(0),
-            chain_id: Some(testnet_config.chain_id),
+            chain_id: Some(chain_id),
             ..Default::default()
         };
         let tx_env = TransactionTestContext::sign_tx(es, evm_tx_req).await;
@@ -369,16 +334,16 @@ async fn serial_test_blockprod_with_evm_txs() -> eyre::Result<()> {
         evm_txs.insert(*tx_env.tx_hash(), tx_env.clone());
 
         let data_bytes = "Hello, world!".as_bytes().to_vec();
-        let tx = a.create_transaction(data_bytes, None).unwrap();
-        let tx = a.sign_transaction(tx).unwrap();
-        // submit to mempool
-        let _tx_res = node
-            .actor_addresses
-            .mempool
-            .send(TxIngressMessage(tx.header.clone()))
-            .await
-            .unwrap();
-        irys_txs.insert(IrysTxId::from_slice(tx.header.id.as_bytes()), tx);
+        match add_tx(&node, &a, data_bytes).await {
+            Ok(tx) => {
+                irys_txs.insert(IrysTxId::from_slice(tx.header.id.as_bytes()), tx);
+            },
+            Err(AddTxError::TxIngress(TxIngressError::Unfunded)) => {
+                assert_eq!(a.address(), account1.address(), "account1 should be unfunded");
+            },
+            Err(e) =>
+                panic!("unexpected error {:?}", e)
+        }
     }
 
     let poa_solution = capacity_chunk_solution(
@@ -397,11 +362,10 @@ async fn serial_test_blockprod_with_evm_txs() -> eyre::Result<()> {
         .unwrap();
 
     for receipt in reth_exec_env.shadow_receipts {
-        let og_tx = irys_txs.get(&receipt.tx_id).unwrap();
-        if og_tx.header.signer == account1.address() {
-            assert_eq!(receipt.result, ShadowResult::OutOfFunds)
-        } else {
+        if let Some(og_tx ) = irys_txs.get(&receipt.tx_id) {
             assert_eq!(receipt.result, ShadowResult::Success)
+        } else {
+            assert_eq!(receipt.result, ShadowResult::OutOfFunds)
         }
     }
 

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -140,7 +140,7 @@ async fn heavy_mine_ten_blocks() -> eyre::Result<()> {
     let reth_context = RethNodeContext::new(node.node_ctx.reth_handle.clone().into()).await?;
 
     for i in 1..10 {
-        node.wait_until_height(i + 1, 60).await;
+        node.wait_until_height(i + 1, 60).await?;
 
         //check reth for built block
         let reth_block = reth_context.inner.provider.block_by_number(i)?.unwrap();

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -89,10 +89,12 @@ async fn serial_test_blockprod() -> eyre::Result<()> {
         .unwrap();
 
     for receipt in reth_exec_env.shadow_receipts {
-        if let Some(_og_tx) = txs.get(&receipt.tx_id) {
-            assert_eq!(receipt.result, ShadowResult::Success)
+        if let Some(og_tx) = txs.get(&receipt.tx_id) {
+            assert_eq!(receipt.result, ShadowResult::Success);
+            assert_ne!(og_tx.header.signer, account1.address()); // account1 has no funds
         } else {
             assert_eq!(receipt.result, ShadowResult::OutOfFunds)
+            
         }
     }
 
@@ -366,10 +368,11 @@ async fn serial_test_blockprod_with_evm_txs() -> eyre::Result<()> {
         .unwrap();
 
     for receipt in reth_exec_env.shadow_receipts {
-        if let Some(_og_tx) = irys_txs.get(&receipt.tx_id) {
-            assert_eq!(receipt.result, ShadowResult::Success)
+        if let Some(og_tx) = irys_txs.get(&receipt.tx_id) {
+            assert_eq!(receipt.result, ShadowResult::Success);
+            assert_ne!(og_tx.header.signer, account1.address()); // account1 has no funds            
         } else {
-            assert_eq!(receipt.result, ShadowResult::OutOfFunds)
+            assert_eq!(receipt.result, ShadowResult::OutOfFunds);
         }
     }
 

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -94,7 +94,6 @@ async fn heavy_test_blockprod() -> eyre::Result<()> {
             assert_ne!(og_tx.header.signer, account1.address()); // account1 has no funds
         } else {
             assert_eq!(receipt.result, ShadowResult::OutOfFunds)
-            
         }
     }
 
@@ -373,7 +372,7 @@ async fn heavy_test_blockprod_with_evm_txs() -> eyre::Result<()> {
     for receipt in reth_exec_env.shadow_receipts {
         if let Some(og_tx) = irys_txs.get(&receipt.tx_id) {
             assert_eq!(receipt.result, ShadowResult::Success);
-            assert_ne!(og_tx.header.signer, account1.address()); // account1 has no funds            
+            assert_ne!(og_tx.header.signer, account1.address()); // account1 has no funds
         } else {
             assert_eq!(receipt.result, ShadowResult::OutOfFunds);
         }

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -20,7 +20,7 @@ use tokio::time::sleep;
 use tracing::info;
 
 use crate::utils::{
-    add_tx, capacity_chunk_solution, get_block_height, start_node, start_node_config,
+    create_submit_data_tx, capacity_chunk_solution, get_block_by_height, start_node, start_node_config,
     wait_until_height, AddTxError,
 };
 /// Create a valid capacity PoA solution
@@ -63,7 +63,7 @@ async fn heavy_test_blockprod() -> eyre::Result<()> {
     let mut txs: HashMap<IrysTxId, IrysTransaction> = HashMap::new();
     for a in [&account1, &account2, &account3] {
         let data_bytes = "Hello, world!".as_bytes().to_vec();
-        match add_tx(&node, &a, data_bytes).await {
+        match create_submit_data_tx(&node, &a, data_bytes).await {
             Ok(tx) => {
                 txs.insert(IrysTxId::from_slice(tx.header.id.as_bytes()), tx);
             }
@@ -181,7 +181,7 @@ async fn heavy_mine_ten_blocks() -> eyre::Result<()> {
         assert_eq!(i, reth_block.header.number);
         assert_eq!(i, reth_block.number);
 
-        let db_irys_block = get_block_height(&node, i as u64, false).unwrap();
+        let db_irys_block = get_block_by_height(&node, i as u64, false).unwrap();
 
         assert_eq!(db_irys_block.evm_block_hash, reth_block.hash_slow());
     }
@@ -329,7 +329,7 @@ async fn heavy_test_blockprod_with_evm_txs() -> eyre::Result<()> {
         evm_txs.insert(*tx_env.tx_hash(), tx_env.clone());
 
         let data_bytes = "Hello, world!".as_bytes().to_vec();
-        match add_tx(&node, &a, data_bytes).await {
+        match create_submit_data_tx(&node, &a, data_bytes).await {
             Ok(tx) => {
                 irys_txs.insert(IrysTxId::from_slice(tx.header.id.as_bytes()), tx);
             }

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -5,7 +5,7 @@ use alloy_core::primitives::{ruint::aliases::U256, Bytes, TxKind, B256};
 use alloy_eips::eip2718::Encodable2718;
 use alloy_signer_local::LocalSigner;
 use eyre::eyre;
-use irys_actors::{mempool_service::TxIngressError};
+use irys_actors::mempool_service::TxIngressError;
 use irys_config::IrysNodeConfig;
 use irys_reth_node_bridge::adapter::{node::RethNodeContext, transaction::TransactionTestContext};
 use irys_types::{irys::IrysSigner, Config, IrysTransaction};
@@ -18,9 +18,7 @@ use reth_primitives::{
 use tokio::time::sleep;
 use tracing::info;
 
-use crate::utils::{
-    mine_block, AddTxError, IrysNodeTest
-};
+use crate::utils::{mine_block, AddTxError, IrysNodeTest};
 
 #[tokio::test]
 async fn heavy_test_blockprod() -> eyre::Result<()> {
@@ -55,7 +53,8 @@ async fn heavy_test_blockprod() -> eyre::Result<()> {
         ),
     ]);
 
-    let irys_node = IrysNodeTest::new_with_config("test_blockprod", Some(testnet_config), Some(config)).await;
+    let irys_node =
+        IrysNodeTest::new_with_config("test_blockprod", Some(testnet_config), Some(config)).await;
 
     let mut txs: HashMap<IrysTxId, IrysTransaction> = HashMap::new();
     for a in [&account1, &account2, &account3] {
@@ -95,7 +94,9 @@ async fn heavy_test_blockprod() -> eyre::Result<()> {
     // assert_eq!(reth_block.number, block.height);
 
     // check irys DB for built block
-    let db_irys_block = irys_node.get_block_by_hash(&block.block_hash, false).unwrap();
+    let db_irys_block = irys_node
+        .get_block_by_hash(&block.block_hash, false)
+        .unwrap();
     assert_eq!(db_irys_block.evm_block_hash, reth_block.hash_slow());
 
     irys_node.stop().await;
@@ -158,7 +159,7 @@ async fn heavy_mine_ten_blocks() -> eyre::Result<()> {
 async fn heavy_test_basic_blockprod() -> eyre::Result<()> {
     let node = IrysNodeTest::new("test_basic_blockprod").await;
 
-    let (block, _ ) = mine_block(&node.node_ctx).await?.unwrap();
+    let (block, _) = mine_block(&node.node_ctx).await?.unwrap();
 
     let reth_context = RethNodeContext::new(node.node_ctx.reth_handle.clone().into()).await?;
 
@@ -223,7 +224,9 @@ async fn heavy_test_blockprod_with_evm_txs() -> eyre::Result<()> {
     ]);
 
     let chain_id = testnet_config.chain_id;
-    let node= IrysNodeTest::new_with_config("test_serial_blockprod", Some(testnet_config), Some(config)).await;
+    let node =
+        IrysNodeTest::new_with_config("test_serial_blockprod", Some(testnet_config), Some(config))
+            .await;
     let reth_context = RethNodeContext::new(node.node_ctx.reth_handle.clone().into()).await?;
     let miner_init_balance = reth_context
         .rpc

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -19,7 +19,9 @@ use reth_primitives::{
 use tokio::time::sleep;
 use tracing::info;
 
-use crate::utils::{add_tx, capacity_chunk_solution, start_node, start_node_config, wait_until_height, AddTxError};
+use crate::utils::{
+    add_tx, capacity_chunk_solution, start_node, start_node_config, wait_until_height, AddTxError,
+};
 /// Create a valid capacity PoA solution
 
 #[tokio::test]
@@ -54,7 +56,7 @@ async fn serial_test_blockprod() -> eyre::Result<()> {
             },
         ),
     ]);
-    
+
     let (node, _) = start_node_config("test_blockprod", Some(testnet_config), Some(config)).await;
 
     let mut txs: HashMap<IrysTxId, IrysTransaction> = HashMap::new();
@@ -63,12 +65,11 @@ async fn serial_test_blockprod() -> eyre::Result<()> {
         match add_tx(&node, &a, data_bytes).await {
             Ok(tx) => {
                 txs.insert(IrysTxId::from_slice(tx.header.id.as_bytes()), tx);
-            },
+            }
             Err(AddTxError::TxIngress(TxIngressError::Unfunded)) => {
                 assert_eq!(a.address(), account1.address(), "account1 should fail");
-            },
-            Err(e) =>
-                panic!("unexpected error {:?}", e)
+            }
+            Err(e) => panic!("unexpected error {:?}", e),
         }
     }
 
@@ -121,7 +122,6 @@ async fn serial_test_blockprod() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn serial_mine_ten_blocks_with_capacity_poa_solution() -> eyre::Result<()> {
-
     let (node, _tmp_dir) = start_node("test_mine_ten_blocks_with_capacity_poa_solution").await;
     let reth_context = RethNodeContext::new(node.reth_handle.clone().into()).await?;
 
@@ -280,7 +280,8 @@ async fn serial_test_blockprod_with_evm_txs() -> eyre::Result<()> {
     ]);
 
     let chain_id = testnet_config.chain_id;
-    let (node, _) =  start_node_config("test_serial_blockprod", Some(testnet_config), Some(config)).await;
+    let (node, _) =
+        start_node_config("test_serial_blockprod", Some(testnet_config), Some(config)).await;
     let reth_context = RethNodeContext::new(node.reth_handle.clone().into()).await?;
     let miner_init_balance = reth_context
         .rpc
@@ -337,12 +338,15 @@ async fn serial_test_blockprod_with_evm_txs() -> eyre::Result<()> {
         match add_tx(&node, &a, data_bytes).await {
             Ok(tx) => {
                 irys_txs.insert(IrysTxId::from_slice(tx.header.id.as_bytes()), tx);
-            },
+            }
             Err(AddTxError::TxIngress(TxIngressError::Unfunded)) => {
-                assert_eq!(a.address(), account1.address(), "account1 should be unfunded");
-            },
-            Err(e) =>
-                panic!("unexpected error {:?}", e)
+                assert_eq!(
+                    a.address(),
+                    account1.address(),
+                    "account1 should be unfunded"
+                );
+            }
+            Err(e) => panic!("unexpected error {:?}", e),
         }
     }
 
@@ -362,7 +366,7 @@ async fn serial_test_blockprod_with_evm_txs() -> eyre::Result<()> {
         .unwrap();
 
     for receipt in reth_exec_env.shadow_receipts {
-        if let Some(og_tx ) = irys_txs.get(&receipt.tx_id) {
+        if let Some(og_tx) = irys_txs.get(&receipt.tx_id) {
             assert_eq!(receipt.result, ShadowResult::Success)
         } else {
             assert_eq!(receipt.result, ShadowResult::OutOfFunds)

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -89,7 +89,7 @@ async fn serial_test_blockprod() -> eyre::Result<()> {
         .unwrap();
 
     for receipt in reth_exec_env.shadow_receipts {
-        if let Some(og_tx) = txs.get(&receipt.tx_id) {
+        if let Some(_og_tx) = txs.get(&receipt.tx_id) {
             assert_eq!(receipt.result, ShadowResult::Success)
         } else {
             assert_eq!(receipt.result, ShadowResult::OutOfFunds)
@@ -366,7 +366,7 @@ async fn serial_test_blockprod_with_evm_txs() -> eyre::Result<()> {
         .unwrap();
 
     for receipt in reth_exec_env.shadow_receipts {
-        if let Some(og_tx) = irys_txs.get(&receipt.tx_id) {
+        if let Some(_og_tx) = irys_txs.get(&receipt.tx_id) {
             assert_eq!(receipt.result, ShadowResult::Success)
         } else {
             assert_eq!(receipt.result, ShadowResult::OutOfFunds)

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -20,7 +20,8 @@ use tokio::time::sleep;
 use tracing::info;
 
 use crate::utils::{
-    add_tx, capacity_chunk_solution, get_block_height, start_node, start_node_config, wait_until_height, AddTxError
+    add_tx, capacity_chunk_solution, get_block_height, start_node, start_node_config,
+    wait_until_height, AddTxError,
 };
 /// Create a valid capacity PoA solution
 
@@ -181,7 +182,7 @@ async fn heavy_mine_ten_blocks() -> eyre::Result<()> {
         assert_eq!(i, reth_block.number);
 
         let db_irys_block = get_block_height(&node, i as u64, false).unwrap();
-        
+
         assert_eq!(db_irys_block.evm_block_hash, reth_block.hash_slow());
     }
     node.stop().await;

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -174,7 +174,7 @@ async fn heavy_mine_ten_blocks() -> eyre::Result<()> {
     let reth_context = RethNodeContext::new(node.reth_handle.clone().into()).await?;
 
     for i in 1..10 {
-        wait_until_height(&node, i + 1, 30).await;
+        wait_until_height(&node, i + 1, 60).await;
 
         //check reth for built block
         let reth_block = reth_context.inner.provider.block_by_number(i)?.unwrap();

--- a/crates/chain/tests/block_production/mod.rs
+++ b/crates/chain/tests/block_production/mod.rs
@@ -1,3 +1,4 @@
 pub mod analytics;
 pub mod basic_contract;
 pub mod block_production;
+pub mod testing_primitives;

--- a/crates/chain/tests/block_production/testing_primitives.rs
+++ b/crates/chain/tests/block_production/testing_primitives.rs
@@ -5,8 +5,7 @@ use reth_primitives::GenesisAccount;
 use tracing::info;
 
 use crate::utils::{
-    add_tx, get_height, get_tx_header, mine, mine_one, start_node, start_node_config,
-    wait_until_height,
+    add_tx, get_block_height, get_height, get_tx_header, mine, mine_one, start_node, start_node_config, wait_until_height
 };
 
 #[actix::test]
@@ -32,6 +31,8 @@ async fn test_mine() {
     mine(&node_ctx, blocks).await.unwrap();
     let next_height = get_height(&node_ctx);
     assert_eq!(next_height, height + blocks as u64);
+    let block = get_block_height(&node_ctx, next_height, false).unwrap();
+    assert_eq!(block.height, next_height);
     node_ctx.stop().await;
 }
 

--- a/crates/chain/tests/block_production/testing_primitives.rs
+++ b/crates/chain/tests/block_production/testing_primitives.rs
@@ -14,7 +14,7 @@ async fn heavy_test_wait_until_height() {
     let steps = 2;
     let seconds = 60;
     irys_node.node_ctx.actor_addresses.set_mining(true).unwrap();
-    irys_node.wait_until_height(height + steps, seconds).await;
+    irys_node.wait_until_height(height + steps, seconds).await.unwrap();
     let height5 = irys_node.get_height();
     assert_eq!(height5, height + steps);
     irys_node.stop().await;

--- a/crates/chain/tests/block_production/testing_primitives.rs
+++ b/crates/chain/tests/block_production/testing_primitives.rs
@@ -10,12 +10,12 @@ use crate::utils::{
 };
 
 #[actix::test]
-async fn test_wait_until_height() {
+async fn heavy_test_wait_until_height() {
     let (node_ctx, _tmp_dir) = start_node("test_wait_until_height").await;
     let height = get_height(&node_ctx);
     info!("height: {}", height);
     let steps = 2;
-    let seconds = 20;
+    let seconds = 40;
     node_ctx.actor_addresses.set_mining(true).unwrap();
     wait_until_height(&node_ctx, height + steps, seconds).await;
     let height5 = get_height(&node_ctx);
@@ -24,7 +24,7 @@ async fn test_wait_until_height() {
 }
 
 #[actix::test]
-async fn test_mine() {
+async fn heavy_test_mine() {
     let (node_ctx, _tmp_dir) = start_node("test_mine").await;
     let height = get_height(&node_ctx);
     info!("height: {}", height);
@@ -38,7 +38,7 @@ async fn test_mine() {
 }
 
 #[actix::test]
-async fn test_mine_tx() {
+async fn heavy_test_mine_tx() {
     let testnet_config = Config::testnet();
     let mut node_config = IrysNodeConfig::new(&testnet_config);
     let account = IrysSigner::random_signer(&testnet_config);

--- a/crates/chain/tests/block_production/testing_primitives.rs
+++ b/crates/chain/tests/block_production/testing_primitives.rs
@@ -4,11 +4,14 @@ use irys_types::{irys::IrysSigner, Config};
 use reth_primitives::GenesisAccount;
 use tracing::info;
 
-use crate::utils::{add_tx, get_height, get_tx_header, mine, mine_one, start_node, start_node_config, wait_until_height};
+use crate::utils::{
+    add_tx, get_height, get_tx_header, mine, mine_one, start_node, start_node_config,
+    wait_until_height,
+};
 
 #[actix::test]
 async fn test_wait_until_height() {
-    let (node_ctx, _tmp_dir) = start_node("test_wait_until_height").await;    
+    let (node_ctx, _tmp_dir) = start_node("test_wait_until_height").await;
     let height = get_height(&node_ctx);
     info!("height: {}", height);
     let steps = 2;
@@ -21,7 +24,7 @@ async fn test_wait_until_height() {
 
 #[actix::test]
 async fn test_mine() {
-    let (node_ctx, _tmp_dir) = start_node("test_mine").await;    
+    let (node_ctx, _tmp_dir) = start_node("test_mine").await;
     let height = get_height(&node_ctx);
     info!("height: {}", height);
     let blocks = 4;
@@ -30,21 +33,18 @@ async fn test_mine() {
     assert_eq!(next_height, height + blocks as u64);
 }
 
-
 #[actix::test]
 async fn test_mine_tx() {
     let testnet_config = Config::testnet();
     let mut node_config = IrysNodeConfig::new(&testnet_config);
     let account = IrysSigner::random_signer(&testnet_config);
-    node_config.extend_genesis_accounts(vec![
-        (
-            account.address(),
-            GenesisAccount {
-                balance: U256::from(1000),
-                ..Default::default()
-            },
-        ),
-    ]);
+    node_config.extend_genesis_accounts(vec![(
+        account.address(),
+        GenesisAccount {
+            balance: U256::from(1000),
+            ..Default::default()
+        },
+    )]);
 
     let (node_ctx, _tmp_dir) = start_node_config(
         "test_mine_tx",
@@ -62,4 +62,3 @@ async fn test_mine_tx() {
     let tx_header = get_tx_header(&node_ctx, &tx.header.id).unwrap();
     assert_eq!(tx_header, tx.header);
 }
-

--- a/crates/chain/tests/block_production/testing_primitives.rs
+++ b/crates/chain/tests/block_production/testing_primitives.rs
@@ -32,7 +32,7 @@ async fn test_mine() {
     mine(&node_ctx, blocks).await.unwrap();
     let next_height = get_height(&node_ctx);
     assert_eq!(next_height, height + blocks as u64);
-    node_ctx.stop().await;    
+    node_ctx.stop().await;
 }
 
 #[actix::test]

--- a/crates/chain/tests/block_production/testing_primitives.rs
+++ b/crates/chain/tests/block_production/testing_primitives.rs
@@ -1,0 +1,65 @@
+use alloy_core::primitives::U256;
+use irys_config::IrysNodeConfig;
+use irys_types::{irys::IrysSigner, Config};
+use reth_primitives::GenesisAccount;
+use tracing::info;
+
+use crate::utils::{add_tx, get_height, get_tx_header, mine, mine_one, start_node, start_node_config, wait_until_height};
+
+#[actix::test]
+async fn test_wait_until_height() {
+    let (node_ctx, _tmp_dir) = start_node("test_wait_until_height").await;    
+    let height = get_height(&node_ctx);
+    info!("height: {}", height);
+    let steps = 2;
+    let seconds = 20;
+    node_ctx.actor_addresses.set_mining(true).unwrap();
+    wait_until_height(&node_ctx, height + steps, seconds).await;
+    let height5 = get_height(&node_ctx);
+    assert_eq!(height5, height + steps);
+}
+
+#[actix::test]
+async fn test_mine() {
+    let (node_ctx, _tmp_dir) = start_node("test_mine").await;    
+    let height = get_height(&node_ctx);
+    info!("height: {}", height);
+    let blocks = 4;
+    mine(&node_ctx, blocks).await.unwrap();
+    let next_height = get_height(&node_ctx);
+    assert_eq!(next_height, height + blocks as u64);
+}
+
+
+#[actix::test]
+async fn test_mine_tx() {
+    let testnet_config = Config::testnet();
+    let mut node_config = IrysNodeConfig::new(&testnet_config);
+    let account = IrysSigner::random_signer(&testnet_config);
+    node_config.extend_genesis_accounts(vec![
+        (
+            account.address(),
+            GenesisAccount {
+                balance: U256::from(1000),
+                ..Default::default()
+            },
+        ),
+    ]);
+
+    let (node_ctx, _tmp_dir) = start_node_config(
+        "test_mine_tx",
+        Some(testnet_config.clone()),
+        Some(node_config),
+    )
+    .await;
+    let height = get_height(&node_ctx);
+    let data = "Hello, world!".as_bytes().to_vec();
+    info!("height: {}", height);
+    let tx = add_tx(&node_ctx, &account, data).await.unwrap();
+    mine_one(&node_ctx).await.unwrap();
+    let next_height = get_height(&node_ctx);
+    assert_eq!(next_height, height + 1 as u64);
+    let tx_header = get_tx_header(&node_ctx, &tx.header.id).unwrap();
+    assert_eq!(tx_header, tx.header);
+}
+

--- a/crates/chain/tests/block_production/testing_primitives.rs
+++ b/crates/chain/tests/block_production/testing_primitives.rs
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 use alloy_core::primitives::U256;
 use irys_config::IrysNodeConfig;
 use irys_types::{irys::IrysSigner, Config};
@@ -68,53 +67,3 @@ async fn heavy_test_mine_tx() {
     assert_eq!(tx_header, tx.header);
     irys_node.stop().await;
 }
-=======
-use irys_chain::{start_irys_node, IrysNodeCtx};
-use irys_config::IrysNodeConfig;
-use irys_testing_utils::utils::setup_tracing_and_temp_dir;
-use irys_types::{Config, StorageConfig};
-use tracing::info;
-
-use crate::utils::{get_height, mine, wait_until_height};
-
-
-async fn start_node() -> IrysNodeCtx {
-    let temp_dir = setup_tracing_and_temp_dir(Some("test"), false);
-    let testnet_config = Config::testnet();
-    let storage_config = StorageConfig::new(&testnet_config);
-    let mut config = IrysNodeConfig::new(&testnet_config);
-    config.base_directory = temp_dir.path().to_path_buf();
-    start_irys_node(
-        config,
-        storage_config,
-        testnet_config.clone(),
-    )
-    .await
-    .unwrap()
-}
-
-#[actix::test]
-async fn test_wait_until_height() {
-    let node_ctx = start_node().await;    
-    let height = get_height(&node_ctx);
-    info!("height: {}", height);
-    let steps = 2;
-    let seconds = 10;
-    node_ctx.actor_addresses.set_mining(true).unwrap();
-    wait_until_height(&node_ctx, height + steps, seconds).await;
-    let height5 = get_height(&node_ctx);
-    assert_eq!(height5, height + steps);
-}
-
-#[actix::test]
-async fn test_mine() {
-    let node_ctx = start_node().await;    
-    let height = get_height(&node_ctx);
-    info!("height: {}", height);
-    let blocks = 2;
-    mine(&node_ctx, blocks).await;
-    let height5 = get_height(&node_ctx);
-    assert_eq!(height5, height + blocks as u64);
-}
-
->>>>>>> master

--- a/crates/chain/tests/block_production/testing_primitives.rs
+++ b/crates/chain/tests/block_production/testing_primitives.rs
@@ -20,6 +20,7 @@ async fn test_wait_until_height() {
     wait_until_height(&node_ctx, height + steps, seconds).await;
     let height5 = get_height(&node_ctx);
     assert_eq!(height5, height + steps);
+    node_ctx.stop().await;
 }
 
 #[actix::test]
@@ -31,6 +32,7 @@ async fn test_mine() {
     mine(&node_ctx, blocks).await.unwrap();
     let next_height = get_height(&node_ctx);
     assert_eq!(next_height, height + blocks as u64);
+    node_ctx.stop().await;    
 }
 
 #[actix::test]
@@ -61,4 +63,5 @@ async fn test_mine_tx() {
     assert_eq!(next_height, height + 1 as u64);
     let tx_header = get_tx_header(&node_ctx, &tx.header.id).unwrap();
     assert_eq!(tx_header, tx.header);
+    node_ctx.stop().await;
 }

--- a/crates/chain/tests/block_production/testing_primitives.rs
+++ b/crates/chain/tests/block_production/testing_primitives.rs
@@ -5,7 +5,7 @@ use reth_primitives::GenesisAccount;
 use tracing::info;
 
 use crate::utils::{
-    add_tx, get_block_height, get_height, get_tx_header, mine, mine_one, start_node,
+    create_submit_data_tx, get_block_by_height, get_height, get_tx_header, mine_blocks, mine_block, start_node,
     start_node_config, wait_until_height,
 };
 
@@ -29,10 +29,10 @@ async fn heavy_test_mine() {
     let height = get_height(&node_ctx);
     info!("height: {}", height);
     let blocks = 4;
-    mine(&node_ctx, blocks).await.unwrap();
+    mine_blocks(&node_ctx, blocks).await.unwrap();
     let next_height = get_height(&node_ctx);
     assert_eq!(next_height, height + blocks as u64);
-    let block = get_block_height(&node_ctx, next_height, false).unwrap();
+    let block = get_block_by_height(&node_ctx, next_height, false).unwrap();
     assert_eq!(block.height, next_height);
     node_ctx.stop().await;
 }
@@ -59,8 +59,8 @@ async fn heavy_test_mine_tx() {
     let height = get_height(&node_ctx);
     let data = "Hello, world!".as_bytes().to_vec();
     info!("height: {}", height);
-    let tx = add_tx(&node_ctx, &account, data).await.unwrap();
-    mine_one(&node_ctx).await.unwrap();
+    let tx = create_submit_data_tx(&node_ctx, &account, data).await.unwrap();
+    mine_block(&node_ctx).await.unwrap();
     let next_height = get_height(&node_ctx);
     assert_eq!(next_height, height + 1 as u64);
     let tx_header = get_tx_header(&node_ctx, &tx.header.id).unwrap();

--- a/crates/chain/tests/block_production/testing_primitives.rs
+++ b/crates/chain/tests/block_production/testing_primitives.rs
@@ -5,7 +5,8 @@ use reth_primitives::GenesisAccount;
 use tracing::info;
 
 use crate::utils::{
-    add_tx, get_block_height, get_height, get_tx_header, mine, mine_one, start_node, start_node_config, wait_until_height
+    add_tx, get_block_height, get_height, get_tx_header, mine, mine_one, start_node,
+    start_node_config, wait_until_height,
 };
 
 #[actix::test]

--- a/crates/chain/tests/block_production/testing_primitives.rs
+++ b/crates/chain/tests/block_production/testing_primitives.rs
@@ -14,7 +14,10 @@ async fn heavy_test_wait_until_height() {
     let steps = 2;
     let seconds = 60;
     irys_node.node_ctx.actor_addresses.set_mining(true).unwrap();
-    irys_node.wait_until_height(height + steps, seconds).await.unwrap();
+    irys_node
+        .wait_until_height(height + steps, seconds)
+        .await
+        .unwrap();
     let height5 = irys_node.get_height();
     assert_eq!(height5, height + steps);
     irys_node.stop().await;

--- a/crates/chain/tests/block_production/testing_primitives.rs
+++ b/crates/chain/tests/block_production/testing_primitives.rs
@@ -15,7 +15,7 @@ async fn heavy_test_wait_until_height() {
     let height = get_height(&node_ctx);
     info!("height: {}", height);
     let steps = 2;
-    let seconds = 40;
+    let seconds = 60;
     node_ctx.actor_addresses.set_mining(true).unwrap();
     wait_until_height(&node_ctx, height + steps, seconds).await;
     let height5 = get_height(&node_ctx);

--- a/crates/chain/tests/block_production/testing_primitives.rs
+++ b/crates/chain/tests/block_production/testing_primitives.rs
@@ -4,9 +4,7 @@ use irys_types::{irys::IrysSigner, Config};
 use reth_primitives::GenesisAccount;
 use tracing::info;
 
-use crate::utils::{
-    IrysNodeTest
-};
+use crate::utils::IrysNodeTest;
 
 #[actix::test]
 async fn heavy_test_wait_until_height() {
@@ -49,11 +47,19 @@ async fn heavy_test_mine_tx() {
         },
     )]);
 
-    let irys_node = IrysNodeTest::new_with_config("test_mine_tx", Some(testnet_config.clone()), Some(node_config)).await;
+    let irys_node = IrysNodeTest::new_with_config(
+        "test_mine_tx",
+        Some(testnet_config.clone()),
+        Some(node_config),
+    )
+    .await;
     let height = irys_node.get_height();
     let data = "Hello, world!".as_bytes().to_vec();
     info!("height: {}", height);
-    let tx = irys_node.create_submit_data_tx(&account, data).await.unwrap();
+    let tx = irys_node
+        .create_submit_data_tx(&account, data)
+        .await
+        .unwrap();
     irys_node.mine_block().await.unwrap();
     let next_height = irys_node.get_height();
     assert_eq!(next_height, height + 1 as u64);

--- a/crates/chain/tests/external/programmable_data_basic.rs
+++ b/crates/chain/tests/external/programmable_data_basic.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 use tokio::time::sleep;
 use tracing::{debug, info};
 
-use crate::utils::{capacity_chunk_solution, future_or_mine_on_timeout};
+use crate::utils::{future_or_mine_on_timeout, mine_blocks};
 
 // Codegen from artifact.
 // taken from https://github.com/alloy-rs/examples/blob/main/examples/contracts/examples/deploy_from_artifact.rs
@@ -214,22 +214,7 @@ async fn test_programmable_data_basic_external() -> eyre::Result<()> {
     .await?
     .unwrap();
 
-    for _i in 1..10 {
-        let poa_solution = capacity_chunk_solution(
-            node.node_config.mining_signer.address(),
-            node.vdf_steps_guard.clone(),
-            &node.vdf_config,
-            &node.storage_config,
-        )
-        .await;
-
-        let _ = node
-            .actor_addresses
-            .block_producer
-            .send(SolutionFoundMessage(poa_solution.clone()))
-            .await?
-            .unwrap();
-    }
+    mine_blocks(&node, 10).await?;
 
     // sleep so the client has a chance to read the chunks
     sleep(Duration::from_millis(100_000)).await;

--- a/crates/chain/tests/external/programmable_data_basic.rs
+++ b/crates/chain/tests/external/programmable_data_basic.rs
@@ -7,7 +7,6 @@ use alloy_sol_macro::sol;
 use base58::ToBase58;
 use irys_actors::mempool_service::GetBestMempoolTxs;
 use irys_actors::packing::wait_for_packing;
-use irys_actors::SolutionFoundMessage;
 use irys_api_server::routes::tx::TxOffset;
 use irys_chain::start_irys_node;
 use irys_config::IrysNodeConfig;

--- a/crates/chain/tests/integration/cache_service.rs
+++ b/crates/chain/tests/integration/cache_service.rs
@@ -3,7 +3,6 @@ use actix_http::StatusCode;
 use alloy_core::primitives::U256;
 use base58::ToBase58;
 use irys_actors::packing::wait_for_packing;
-use irys_actors::SolutionFoundMessage;
 use irys_api_server::routes::tx::TxOffset;
 use irys_chain::start_irys_node;
 use irys_config::IrysNodeConfig;

--- a/crates/chain/tests/integration/cache_service.rs
+++ b/crates/chain/tests/integration/cache_service.rs
@@ -1,4 +1,4 @@
-use crate::utils::{capacity_chunk_solution, future_or_mine_on_timeout};
+use crate::utils::{future_or_mine_on_timeout, mine_block};
 use actix_http::StatusCode;
 use alloy_core::primitives::U256;
 use base58::ToBase58;
@@ -194,18 +194,7 @@ async fn heavy_test_cache_pruning() -> eyre::Result<()> {
 
     for i in 1..4 {
         info!("manually producing block {}", i);
-        let poa_solution = capacity_chunk_solution(
-            node.node_config.mining_signer.address(),
-            node.vdf_steps_guard.clone(),
-            &node.vdf_config,
-            &node.storage_config,
-        )
-        .await;
-        let fut = node
-            .actor_addresses
-            .block_producer
-            .send(SolutionFoundMessage(poa_solution.clone()));
-        let (block, _reth_exec_env) = fut.await??.unwrap();
+        let (block, _reth_exec_env) = mine_block(&node).await?.unwrap();
 
         //check reth for built block
         let reth_block = reth_context

--- a/crates/chain/tests/promotion/data_promotion_basic.rs
+++ b/crates/chain/tests/promotion/data_promotion_basic.rs
@@ -1,6 +1,7 @@
-use irys_chain::start_irys_node;
 use irys_config::IrysNodeConfig;
 use irys_types::Config;
+
+use crate::utils::start_node_config;
 
 #[actix_web::test]
 async fn serial_data_promotion_test() {
@@ -40,11 +41,7 @@ async fn serial_data_promotion_test() {
         ..Config::testnet()
     };
     testnet_config.chunk_size = chunk_size;
-    let storage_config = StorageConfig::new(&testnet_config);
-
-    let temp_dir = setup_tracing_and_temp_dir(Some("data_promotion_test"), false);
     let mut config = IrysNodeConfig::new(&testnet_config);
-    config.base_directory = temp_dir.path().to_path_buf();
     let signer = IrysSigner::random_signer(&testnet_config);
 
     config.extend_genesis_accounts(vec![(
@@ -55,14 +52,9 @@ async fn serial_data_promotion_test() {
         },
     )]);
 
+
     // This will create 3 storage modules, one for submit, one for publish, and one for capacity
-    let node_context = start_irys_node(
-        config.clone(),
-        storage_config.clone(),
-        testnet_config.clone(),
-    )
-    .await
-    .unwrap();
+    let (node_context, _tmp_dir) =  start_node_config("serial_data_promotion_test", Some(testnet_config.clone()), Some(config)).await;
 
     wait_for_packing(
         node_context.actor_addresses.packing.clone(),
@@ -315,7 +307,7 @@ async fn serial_data_promotion_test() {
         &app,
         LedgerChunkOffset::from(chunk_offset),
         expected_bytes,
-        &storage_config,
+        &node_context.storage_config,
     )
     .await;
 
@@ -325,7 +317,7 @@ async fn serial_data_promotion_test() {
         &app,
         LedgerChunkOffset::from(chunk_offset),
         expected_bytes,
-        &storage_config,
+        &node_context.storage_config,
     )
     .await;
 
@@ -335,7 +327,7 @@ async fn serial_data_promotion_test() {
         &app,
         LedgerChunkOffset::from(chunk_offset),
         expected_bytes,
-        &storage_config,
+        &node_context.storage_config,
     )
     .await;
 
@@ -348,7 +340,7 @@ async fn serial_data_promotion_test() {
         &app,
         LedgerChunkOffset::from(chunk_offset),
         expected_bytes,
-        &storage_config,
+        &node_context.storage_config,
     )
     .await;
 
@@ -358,7 +350,7 @@ async fn serial_data_promotion_test() {
         &app,
         LedgerChunkOffset::from(chunk_offset),
         expected_bytes,
-        &storage_config,
+        &node_context.storage_config,
     )
     .await;
 
@@ -368,7 +360,7 @@ async fn serial_data_promotion_test() {
         &app,
         LedgerChunkOffset::from(chunk_offset),
         expected_bytes,
-        &storage_config,
+        &node_context.storage_config,
     )
     .await;
 

--- a/crates/chain/tests/promotion/data_promotion_basic.rs
+++ b/crates/chain/tests/promotion/data_promotion_basic.rs
@@ -17,9 +17,9 @@ async fn heavy_data_promotion_test() {
     use irys_actors::packing::wait_for_packing;
     use irys_api_server::{routes, ApiState};
     use irys_database::DataLedger;
-    use irys_testing_utils::utils::setup_tracing_and_temp_dir;
+    
     use irys_types::{
-        irys::IrysSigner, IrysTransaction, IrysTransactionHeader, LedgerChunkOffset, StorageConfig,
+        irys::IrysSigner, IrysTransaction, IrysTransactionHeader, LedgerChunkOffset,
     };
     use reth_primitives::GenesisAccount;
     use std::time::Duration;

--- a/crates/chain/tests/promotion/data_promotion_basic.rs
+++ b/crates/chain/tests/promotion/data_promotion_basic.rs
@@ -17,9 +17,9 @@ async fn serial_data_promotion_test() {
     use irys_actors::packing::wait_for_packing;
     use irys_api_server::{routes, ApiState};
     use irys_database::Ledger;
-    use irys_testing_utils::utils::setup_tracing_and_temp_dir;
+    
     use irys_types::{
-        irys::IrysSigner, IrysTransaction, IrysTransactionHeader, LedgerChunkOffset, StorageConfig,
+        irys::IrysSigner, IrysTransaction, IrysTransactionHeader, LedgerChunkOffset,
     };
     use reth_primitives::GenesisAccount;
     use std::time::Duration;

--- a/crates/chain/tests/promotion/data_promotion_basic.rs
+++ b/crates/chain/tests/promotion/data_promotion_basic.rs
@@ -17,10 +17,8 @@ async fn heavy_data_promotion_test() {
     use irys_actors::packing::wait_for_packing;
     use irys_api_server::{routes, ApiState};
     use irys_database::DataLedger;
-    
-    use irys_types::{
-        irys::IrysSigner, IrysTransaction, IrysTransactionHeader, LedgerChunkOffset,
-    };
+
+    use irys_types::{irys::IrysSigner, IrysTransaction, IrysTransactionHeader, LedgerChunkOffset};
     use reth_primitives::GenesisAccount;
     use std::time::Duration;
     use tokio::time::sleep;

--- a/crates/chain/tests/promotion/data_promotion_basic.rs
+++ b/crates/chain/tests/promotion/data_promotion_basic.rs
@@ -52,9 +52,13 @@ async fn serial_data_promotion_test() {
         },
     )]);
 
-
     // This will create 3 storage modules, one for submit, one for publish, and one for capacity
-    let (node_context, _tmp_dir) =  start_node_config("serial_data_promotion_test", Some(testnet_config.clone()), Some(config)).await;
+    let (node_context, _tmp_dir) = start_node_config(
+        "serial_data_promotion_test",
+        Some(testnet_config.clone()),
+        Some(config),
+    )
+    .await;
 
     wait_for_packing(
         node_context.actor_addresses.packing.clone(),

--- a/crates/chain/tests/promotion/data_promotion_basic.rs
+++ b/crates/chain/tests/promotion/data_promotion_basic.rs
@@ -17,10 +17,8 @@ async fn heavy_data_promotion_test() {
     use irys_actors::packing::wait_for_packing;
     use irys_api_server::{routes, ApiState};
     use irys_database::Ledger;
-    
-    use irys_types::{
-        irys::IrysSigner, IrysTransaction, IrysTransactionHeader, LedgerChunkOffset,
-    };
+
+    use irys_types::{irys::IrysSigner, IrysTransaction, IrysTransactionHeader, LedgerChunkOffset};
     use reth_primitives::GenesisAccount;
     use std::time::Duration;
     use tokio::time::sleep;

--- a/crates/chain/tests/promotion/data_promotion_double.rs
+++ b/crates/chain/tests/promotion/data_promotion_double.rs
@@ -21,9 +21,7 @@ async fn heavy_double_root_data_promotion_test() {
     use irys_actors::packing::wait_for_packing;
     use irys_api_server::{routes, ApiState};
     use irys_database::{tables::IngressProofs, walk_all};
-    use irys_types::{
-        irys::IrysSigner, IrysTransaction, IrysTransactionHeader, LedgerChunkOffset,
-    };
+    use irys_types::{irys::IrysSigner, IrysTransaction, IrysTransactionHeader, LedgerChunkOffset};
     use reth_db::Database as _;
     use reth_primitives::GenesisAccount;
     use tokio::time::sleep;

--- a/crates/chain/tests/promotion/data_promotion_double.rs
+++ b/crates/chain/tests/promotion/data_promotion_double.rs
@@ -64,7 +64,12 @@ async fn serial_double_root_data_promotion_test() {
         ),
     ]);
     // This will create 3 storage modules, one for submit, one for publish, and one for capacity
-    let (node_context, _tmp_dir) =  start_node_config("serial_double_root_data_promotion_test", Some(testnet_config.clone()), Some(config)).await;
+    let (node_context, _tmp_dir) = start_node_config(
+        "serial_double_root_data_promotion_test",
+        Some(testnet_config.clone()),
+        Some(config),
+    )
+    .await;
 
     wait_for_packing(
         node_context.actor_addresses.packing.clone(),

--- a/crates/chain/tests/promotion/data_promotion_double.rs
+++ b/crates/chain/tests/promotion/data_promotion_double.rs
@@ -22,7 +22,7 @@ async fn serial_double_root_data_promotion_test() {
     use irys_api_server::{routes, ApiState};
     use irys_database::{tables::IngressProofs, walk_all};
     use irys_types::{
-        irys::IrysSigner, IrysTransaction, IrysTransactionHeader, LedgerChunkOffset, StorageConfig,
+        irys::IrysSigner, IrysTransaction, IrysTransactionHeader, LedgerChunkOffset,
     };
     use reth_db::Database as _;
     use reth_primitives::GenesisAccount;
@@ -32,7 +32,7 @@ async fn serial_double_root_data_promotion_test() {
     use crate::utils::{get_block_parent, get_chunk, mine_block, verify_published_chunk};
 
     let chunk_size = 32; // 32 byte chunks
-    let mut testnet_config = Config {
+    let testnet_config = Config {
         chunk_size: chunk_size as u64,
         num_chunks_in_partition: 10,
         num_chunks_in_recall_range: 2,

--- a/crates/chain/tests/synchronization/mod.rs
+++ b/crates/chain/tests/synchronization/mod.rs
@@ -140,7 +140,7 @@ async fn heavy_should_resume_from_the_same_block() -> eyre::Result<()> {
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     debug!("Stopping node");
-    let node_config = (*node.config).clone();
+    let node_config = (*node.node_config).clone();
     let storage_config = node.storage_config.clone();
     node.stop().await;
 

--- a/crates/chain/tests/synchronization/mod.rs
+++ b/crates/chain/tests/synchronization/mod.rs
@@ -5,11 +5,10 @@ use irys_actors::packing::wait_for_packing;
 use irys_chain::start_irys_node;
 use irys_config::IrysNodeConfig;
 use irys_reth_node_bridge::adapter::node::RethNodeContext;
-use irys_testing_utils::utils::setup_tracing_and_temp_dir;
 use irys_types::irys::IrysSigner;
 use irys_types::{Config, IrysTransactionHeader};
 
-use crate::utils::{future_or_mine_on_timeout, mine_blocks};
+use crate::utils::{future_or_mine_on_timeout, mine_blocks, start_node_config};
 use reth::rpc::eth::EthApiServer;
 use reth_primitives::GenesisAccount;
 use std::time::Duration;
@@ -18,16 +17,13 @@ use tracing::{debug, info};
 
 #[actix_web::test]
 async fn serial_should_resume_from_the_same_block() -> eyre::Result<()> {
-    let temp_dir = setup_tracing_and_temp_dir(Some("node_resume_test"), false);
     let mut testnet_config = Config::testnet();
     testnet_config.chunk_size = 32;
 
     let main_address = testnet_config.miner_address();
     let account1 = IrysSigner::random_signer(&testnet_config);
-    let mut config = IrysNodeConfig {
-        base_directory: temp_dir.path().to_path_buf(),
-        ..IrysNodeConfig::new(&testnet_config)
-    };
+    let mut config = IrysNodeConfig::new(&testnet_config);
+    
     config.extend_genesis_accounts(vec![
         (
             main_address,
@@ -44,14 +40,9 @@ async fn serial_should_resume_from_the_same_block() -> eyre::Result<()> {
             },
         ),
     ]);
-    let storage_config = irys_types::StorageConfig::new(&testnet_config);
 
-    let node = start_irys_node(
-        config.clone(),
-        storage_config.clone(),
-        testnet_config.clone(),
-    )
-    .await?;
+    let (node, _tmp_dir) =  start_node_config("serial_data_promotion_test", Some(testnet_config.clone()), Some(config.clone())).await;
+
     wait_for_packing(
         node.actor_addresses.packing.clone(),
         Some(Duration::from_secs(10)),
@@ -144,6 +135,8 @@ async fn serial_should_resume_from_the_same_block() -> eyre::Result<()> {
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     debug!("Stopping node");
+    let node_config = (*node.config).clone();
+    let storage_config = node.storage_config.clone();
     node.stop().await;
 
     // That shouldn't be necessary, but just in case
@@ -151,7 +144,7 @@ async fn serial_should_resume_from_the_same_block() -> eyre::Result<()> {
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     debug!("Restarting node");
-    let restarted_node = start_irys_node(config, storage_config, testnet_config.clone()).await?;
+    let restarted_node = start_irys_node(node_config, storage_config, testnet_config).await?;
 
     let (latest_block_right_after_restart, earliest_block) = {
         let context = RethNodeContext::new(restarted_node.reth_handle.clone().into()).await?;

--- a/crates/chain/tests/synchronization/mod.rs
+++ b/crates/chain/tests/synchronization/mod.rs
@@ -23,7 +23,7 @@ async fn serial_should_resume_from_the_same_block() -> eyre::Result<()> {
     let main_address = testnet_config.miner_address();
     let account1 = IrysSigner::random_signer(&testnet_config);
     let mut config = IrysNodeConfig::new(&testnet_config);
-    
+
     config.extend_genesis_accounts(vec![
         (
             main_address,
@@ -41,7 +41,12 @@ async fn serial_should_resume_from_the_same_block() -> eyre::Result<()> {
         ),
     ]);
 
-    let (node, _tmp_dir) =  start_node_config("serial_data_promotion_test", Some(testnet_config.clone()), Some(config.clone())).await;
+    let (node, _tmp_dir) = start_node_config(
+        "serial_data_promotion_test",
+        Some(testnet_config.clone()),
+        Some(config.clone()),
+    )
+    .await;
 
     wait_for_packing(
         node.actor_addresses.packing.clone(),

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -217,7 +217,7 @@ pub async fn mine_one(node_ctx: &IrysNodeCtx) -> eyre::Result<()> {
 pub async fn mine(node_ctx: &IrysNodeCtx, num_blocks: usize) -> eyre::Result<()> {
     let height = get_height(node_ctx);
     node_ctx.actor_addresses.set_mining(true)?;
-    wait_until_height(node_ctx, height + num_blocks as u64, 15 * num_blocks).await;
+    wait_until_height(node_ctx, height + num_blocks as u64, 20 * num_blocks).await;
     node_ctx.actor_addresses.set_mining(false)?;
     Ok(())
 }

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -260,6 +260,27 @@ pub fn get_tx_header(node_ctx: &IrysNodeCtx, tx_id: &H256) -> eyre::Result<IrysT
     }
 }
 
+pub fn get_block_height(node_ctx: &IrysNodeCtx, height: u64, include_chunk: bool) -> eyre::Result<IrysBlockHeader> {
+    if let Some(block) = node_ctx
+        .block_index_guard
+        .read()
+        .get_item(height as usize) {
+
+        match &node_ctx
+            .db
+            .view_eyre(|tx| irys_database::block_header_by_hash(tx, &block.block_hash, include_chunk))? {
+            Some(db_irys_block) => {
+                Ok(db_irys_block.clone())
+            }
+            None => {
+                Err(eyre::eyre!("Block at height {} not found", height))
+            }
+        }
+    } else {
+        Err(eyre::eyre!("Block item not found at height {}", height))
+    }
+}
+
 /// Waits for the provided future to resolve, and if it doesn't after `timeout_duration`,
 /// triggers the building/mining of a block, and then waits again.
 /// designed for use with calls that expect to be able to send and confirm a tx in a single exposed future

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -149,7 +149,11 @@ impl IrysNodeTest {
         Self { node_ctx, temp_dir }
     }
 
-    pub async fn wait_until_height(&self, target_height: u64, max_seconds: usize) -> eyre::Result<()>{
+    pub async fn wait_until_height(
+        &self,
+        target_height: u64,
+        max_seconds: usize,
+    ) -> eyre::Result<()> {
         let mut retries = 0;
         let max_retries = max_seconds; // 1 second per retry
         while self.node_ctx.block_index_guard.read().latest_height() < target_height
@@ -159,7 +163,10 @@ impl IrysNodeTest {
             retries += 1;
         }
         if retries == max_retries {
-            Err(eyre::eyre!("Failed to reach target height after {} retries", retries))
+            Err(eyre::eyre!(
+                "Failed to reach target height after {} retries",
+                retries
+            ))
         } else {
             info!(
                 "got block after {} seconds and {} retries",
@@ -237,9 +244,9 @@ impl IrysNodeTest {
                         irys_database::block_header_by_hash(tx, &block.block_hash, include_chunk)
                     })?
                     .ok_or_else(|| eyre::eyre!("Block at height {} not found", height))
-                })
+            })
     }
-        
+
     pub fn get_block_by_hash(
         &self,
         hash: &H256,

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -1,5 +1,4 @@
 use actix::MailboxError;
-use eyre::Error;
 use futures::future::select;
 use irys_actors::block_producer::SolutionFoundMessage;
 use irys_actors::block_validation;
@@ -20,7 +19,6 @@ use irys_types::{Config, IrysTransactionHeader, StorageConfig, TxChunkOffset, VD
 use irys_vdf::vdf_state::VdfStepsReadGuard;
 use irys_vdf::{step_number_to_salt_number, vdf_sha};
 use reth::rpc::types::engine::ExecutionPayloadEnvelopeV1Irys;
-use reth_primitives::irys_primitives::IrysTxId;
 use sha2::{Digest, Sha256};
 use std::sync::Arc;
 use std::{future::Future, time::Duration};

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -121,46 +121,119 @@ pub async fn capacity_chunk_solution(
     }
 }
 
-pub async fn mine_blocks(node_ctx: &IrysNodeCtx, blocks: usize) -> eyre::Result<()> {
-    let storage_config = &node_ctx.storage_config;
-    let vdf_config = &node_ctx.vdf_config;
-    let vdf_steps_guard = node_ctx.vdf_steps_guard.clone();
-    for _ in 0..blocks {
-        let poa_solution = capacity_chunk_solution(
-            node_ctx.node_config.mining_signer.address(),
-            vdf_steps_guard.clone(),
-            vdf_config,
-            storage_config,
-        )
-        .await;
-        let _ = node_ctx
-            .actor_addresses
-            .block_producer
-            .send(SolutionFoundMessage(poa_solution.clone()))
-            .await?
-            .unwrap();
-    }
-    Ok(())
+pub struct IrysNodeTest {
+    pub node_ctx: IrysNodeCtx,
+    pub temp_dir: TempDir,
 }
 
-pub async fn mine_block(
-    node_ctx: &IrysNodeCtx,
-) -> eyre::Result<Option<(Arc<IrysBlockHeader>, ExecutionPayloadEnvelopeV1Irys)>> {
-    let storage_config = &node_ctx.storage_config;
-    let vdf_config = &node_ctx.vdf_config;
-    let vdf_steps_guard = node_ctx.vdf_steps_guard.clone();
-    let poa_solution = capacity_chunk_solution(
-        node_ctx.node_config.mining_signer.address(),
-        vdf_steps_guard.clone(),
-        vdf_config,
-        storage_config,
-    )
-    .await;
-    node_ctx
-        .actor_addresses
-        .block_producer
-        .send(SolutionFoundMessage(poa_solution.clone()))
-        .await?
+// Reasons tx could fail to be added to mempool
+#[derive(Debug)]
+pub enum AddTxError {
+    CreateTx(eyre::Report),
+    TxIngress(TxIngressError),
+    Mailbox(MailboxError),
+}
+
+impl IrysNodeTest {
+    pub async fn new(name: &str) -> Self {
+        let (node_ctx, temp_dir) = start_node(name).await;
+        Self { node_ctx, temp_dir }
+    }
+
+    pub async fn new_with_config(
+        name: &str,
+        config: Option<Config>,
+        node_config: Option<IrysNodeConfig>,
+    ) -> Self {
+        let (node_ctx, temp_dir) = start_node_config(name, config, node_config).await;
+        Self { node_ctx, temp_dir }
+    }
+
+    pub async fn wait_until_height(&self, target_height: u64, max_seconds: usize) {
+        let mut retries = 0;
+        let max_retries = max_seconds; // 1 second per retry
+        while self.node_ctx.block_index_guard.read().latest_height() < target_height && retries < max_retries
+        {
+            sleep(Duration::from_secs(1)).await;
+            retries += 1;
+        }
+        if retries == max_retries {
+            panic!("Failed to reach target height after {} retries", retries);
+        } else {
+            info!(
+                "got block after {} seconds and {} retries",
+                max_seconds, &retries
+            );
+        }
+    }
+    
+    pub fn get_height(&self) -> u64 {
+        self.node_ctx.block_index_guard.read().latest_height()
+    }
+    
+    pub async fn mine_block(&self) -> eyre::Result<()> {
+        self.mine_blocks(1).await?;
+        Ok(())
+    }
+    
+    pub async fn mine_blocks(&self, num_blocks: usize) -> eyre::Result<()> {
+        let height = self.get_height();
+        self.node_ctx.actor_addresses.set_mining(true)?;
+        self.wait_until_height( height + num_blocks as u64, 60 * num_blocks).await;
+        self.node_ctx.actor_addresses.set_mining(false)?;
+        Ok(())
+    }
+
+    pub async fn create_submit_data_tx(
+        &self,
+        account: &IrysSigner,
+        data: Vec<u8>,
+    ) -> Result<IrysTransaction, AddTxError> {
+        let tx = account
+            .create_transaction(data, None)
+            .map_err(AddTxError::CreateTx)?;
+        let tx = account.sign_transaction(tx).map_err(AddTxError::CreateTx)?;
+    
+        match self.node_ctx
+            .actor_addresses
+            .mempool
+            .send(TxIngressMessage(tx.header.clone()))
+            .await
+        {
+            Ok(Ok(())) => return Ok(tx),
+            Ok(Err(tx_error)) => return Err(AddTxError::TxIngress(tx_error)),
+            Err(e) => return Err(AddTxError::Mailbox(e)),
+        };
+    }
+    
+    pub fn get_tx_header(&self, tx_id: &H256) -> eyre::Result<IrysTransactionHeader> {
+        match self.node_ctx.db.view_eyre(|tx| tx_header_by_txid(tx, tx_id)) {
+            Ok(Some(tx_header)) => Ok(tx_header),
+            Ok(None) => Err(eyre::eyre!("No tx header found for txid {:?}", tx_id)),
+            Err(e) => Err(eyre::eyre!("Failed to collect tx header: {}", e)),
+        }
+    }
+    
+    pub fn get_block_by_height(
+        &self,
+        height: u64,
+        include_chunk: bool,
+    ) -> eyre::Result<IrysBlockHeader> {
+        if let Some(block) = self.node_ctx.block_index_guard.read().get_item(height as usize) {
+            match &self.node_ctx.db.view_eyre(|tx| {
+                irys_database::block_header_by_hash(tx, &block.block_hash, include_chunk)
+            })? {
+                Some(db_irys_block) => Ok(db_irys_block.clone()),
+                None => Err(eyre::eyre!("Block at height {} not found", height)),
+            }
+        } else {
+            Err(eyre::eyre!("Block item not found at height {}", height))
+        }
+    }    
+
+    pub async fn stop(self) {
+        self.node_ctx.stop().await;
+    }
 }
 
 pub async fn start_node(name: &str) -> (IrysNodeCtx, TempDir) {
@@ -187,94 +260,31 @@ pub async fn start_node_config(
     )
 }
 
-pub async fn wait_until_height(node_ctx: &IrysNodeCtx, target_height: u64, max_seconds: usize) {
-    let mut retries = 0;
-    let max_retries = max_seconds; // 1 second per retry
-    while node_ctx.block_index_guard.read().latest_height() < target_height && retries < max_retries
-    {
-        sleep(Duration::from_secs(1)).await;
-        retries += 1;
+pub async fn mine_blocks(node_ctx: &IrysNodeCtx, blocks: usize) -> eyre::Result<()> {
+    for _ in 0..blocks {
+        mine_block(node_ctx).await?.unwrap();
     }
-    if retries == max_retries {
-        panic!("Failed to reach target height after {} retries", retries);
-    } else {
-        info!(
-            "got block after {} seconds and {} retries",
-            max_seconds, &retries
-        );
-    }
-}
-
-pub fn get_height(node_ctx: &IrysNodeCtx) -> u64 {
-    node_ctx.block_index_guard.read().latest_height()
-}
-
-pub async fn mine_block(node_ctx: &IrysNodeCtx) -> eyre::Result<()> {
-    mine_blocks(node_ctx, 1).await?;
     Ok(())
 }
 
-pub async fn mine_blocks(node_ctx: &IrysNodeCtx, num_blocks: usize) -> eyre::Result<()> {
-    let height = get_height(node_ctx);
-    node_ctx.actor_addresses.set_mining(true)?;
-    wait_until_height(node_ctx, height + num_blocks as u64, 60 * num_blocks).await;
-    node_ctx.actor_addresses.set_mining(false)?;
-    Ok(())
-}
-
-// Reasons tx could fail to be added to mempool
-#[derive(Debug)]
-pub enum AddTxError {
-    CreateTx(eyre::Report),
-    TxIngress(TxIngressError),
-    Mailbox(MailboxError),
-}
-
-pub async fn create_submit_data_tx(
+pub async fn mine_block(
     node_ctx: &IrysNodeCtx,
-    account: &IrysSigner,
-    data: Vec<u8>,
-) -> Result<IrysTransaction, AddTxError> {
-    let tx = account
-        .create_transaction(data, None)
-        .map_err(AddTxError::CreateTx)?;
-    let tx = account.sign_transaction(tx).map_err(AddTxError::CreateTx)?;
-
-    match node_ctx
+) -> eyre::Result<Option<(Arc<IrysBlockHeader>, ExecutionPayloadEnvelopeV1Irys)>> {
+    let storage_config = &node_ctx.storage_config;
+    let vdf_config = &node_ctx.vdf_config;
+    let vdf_steps_guard = node_ctx.vdf_steps_guard.clone();
+    let poa_solution = capacity_chunk_solution(
+        node_ctx.node_config.mining_signer.address(),
+        vdf_steps_guard.clone(),
+        vdf_config,
+        storage_config,
+    )
+    .await;
+    node_ctx
         .actor_addresses
-        .mempool
-        .send(TxIngressMessage(tx.header.clone()))
-        .await
-    {
-        Ok(Ok(())) => return Ok(tx),
-        Ok(Err(tx_error)) => return Err(AddTxError::TxIngress(tx_error)),
-        Err(e) => return Err(AddTxError::Mailbox(e)),
-    };
-}
-
-pub fn get_tx_header(node_ctx: &IrysNodeCtx, tx_id: &H256) -> eyre::Result<IrysTransactionHeader> {
-    match node_ctx.db.view_eyre(|tx| tx_header_by_txid(tx, tx_id)) {
-        Ok(Some(tx_header)) => Ok(tx_header),
-        Ok(None) => Err(eyre::eyre!("No tx header found for txid {:?}", tx_id)),
-        Err(e) => Err(eyre::eyre!("Failed to collect tx header: {}", e)),
-    }
-}
-
-pub fn get_block_by_height(
-    node_ctx: &IrysNodeCtx,
-    height: u64,
-    include_chunk: bool,
-) -> eyre::Result<IrysBlockHeader> {
-    if let Some(block) = node_ctx.block_index_guard.read().get_item(height as usize) {
-        match &node_ctx.db.view_eyre(|tx| {
-            irys_database::block_header_by_hash(tx, &block.block_hash, include_chunk)
-        })? {
-            Some(db_irys_block) => Ok(db_irys_block.clone()),
-            None => Err(eyre::eyre!("Block at height {} not found", height)),
-        }
-    } else {
-        Err(eyre::eyre!("Block item not found at height {}", height))
-    }
+        .block_producer
+        .send(SolutionFoundMessage(poa_solution.clone()))
+        .await?
 }
 
 /// Waits for the provided future to resolve, and if it doesn't after `timeout_duration`,

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -231,6 +231,19 @@ impl IrysNodeTest {
         }
     }    
 
+    pub fn get_block_by_hash(
+        &self,
+        hash: &H256,
+        include_chunk: bool,
+    ) -> eyre::Result<IrysBlockHeader> {
+        match &self.node_ctx.db.view_eyre(|tx| {
+            irys_database::block_header_by_hash(tx, hash, include_chunk)
+        })? {
+            Some(db_irys_block) => Ok(db_irys_block.clone()),
+            None => Err(eyre::eyre!("Block with hash {} not found", hash)),
+        }
+    }    
+
     pub async fn stop(self) {
         self.node_ctx.stop().await;
     }

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -209,12 +209,12 @@ pub fn get_height(node_ctx: &IrysNodeCtx) -> u64 {
     node_ctx.block_index_guard.read().latest_height()
 }
 
-pub async fn mine_one(node_ctx: &IrysNodeCtx) -> eyre::Result<()> {
-    mine(node_ctx, 1).await?;
+pub async fn mine_block(node_ctx: &IrysNodeCtx) -> eyre::Result<()> {
+    mine_blocks(node_ctx, 1).await?;
     Ok(())
 }
 
-pub async fn mine(node_ctx: &IrysNodeCtx, num_blocks: usize) -> eyre::Result<()> {
+pub async fn mine_blocks(node_ctx: &IrysNodeCtx, num_blocks: usize) -> eyre::Result<()> {
     let height = get_height(node_ctx);
     node_ctx.actor_addresses.set_mining(true)?;
     wait_until_height(node_ctx, height + num_blocks as u64, 60 * num_blocks).await;
@@ -230,7 +230,7 @@ pub enum AddTxError {
     Mailbox(MailboxError),
 }
 
-pub async fn add_tx(
+pub async fn create_submit_data_tx(
     node_ctx: &IrysNodeCtx,
     account: &IrysSigner,
     data: Vec<u8>,
@@ -260,7 +260,7 @@ pub fn get_tx_header(node_ctx: &IrysNodeCtx, tx_id: &H256) -> eyre::Result<IrysT
     }
 }
 
-pub fn get_block_height(
+pub fn get_block_by_height(
     node_ctx: &IrysNodeCtx,
     height: u64,
     include_chunk: bool,

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -217,7 +217,7 @@ pub async fn mine_one(node_ctx: &IrysNodeCtx) -> eyre::Result<()> {
 pub async fn mine(node_ctx: &IrysNodeCtx, num_blocks: usize) -> eyre::Result<()> {
     let height = get_height(node_ctx);
     node_ctx.actor_addresses.set_mining(true)?;
-    wait_until_height(node_ctx, height + num_blocks as u64, 20 * num_blocks).await;
+    wait_until_height(node_ctx, height + num_blocks as u64, 60 * num_blocks).await;
     node_ctx.actor_addresses.set_mining(false)?;
     Ok(())
 }

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -260,21 +260,17 @@ pub fn get_tx_header(node_ctx: &IrysNodeCtx, tx_id: &H256) -> eyre::Result<IrysT
     }
 }
 
-pub fn get_block_height(node_ctx: &IrysNodeCtx, height: u64, include_chunk: bool) -> eyre::Result<IrysBlockHeader> {
-    if let Some(block) = node_ctx
-        .block_index_guard
-        .read()
-        .get_item(height as usize) {
-
-        match &node_ctx
-            .db
-            .view_eyre(|tx| irys_database::block_header_by_hash(tx, &block.block_hash, include_chunk))? {
-            Some(db_irys_block) => {
-                Ok(db_irys_block.clone())
-            }
-            None => {
-                Err(eyre::eyre!("Block at height {} not found", height))
-            }
+pub fn get_block_height(
+    node_ctx: &IrysNodeCtx,
+    height: u64,
+    include_chunk: bool,
+) -> eyre::Result<IrysBlockHeader> {
+    if let Some(block) = node_ctx.block_index_guard.read().get_item(height as usize) {
+        match &node_ctx.db.view_eyre(|tx| {
+            irys_database::block_header_by_hash(tx, &block.block_hash, include_chunk)
+        })? {
+            Some(db_irys_block) => Ok(db_irys_block.clone()),
+            None => Err(eyre::eyre!("Block at height {} not found", height)),
         }
     } else {
         Err(eyre::eyre!("Block item not found at height {}", height))

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -188,7 +188,7 @@ impl IrysNodeTest {
         let height = self.get_height();
         self.node_ctx.actor_addresses.set_mining(true)?;
         self.wait_until_height(height + num_blocks as u64, 60 * num_blocks)
-            .await;
+            .await?;
         self.node_ctx.actor_addresses.set_mining(false)
     }
 

--- a/crates/database/src/block_index_data.rs
+++ b/crates/database/src/block_index_data.rs
@@ -10,7 +10,7 @@ use std::fs::{self, remove_file, File, OpenOptions};
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::ops::{Index, IndexMut};
 use std::sync::Arc;
-use tracing::{error, info};
+use tracing::error;
 
 /// This struct represents the `Uninitialized` `block_index` type state.
 #[derive(Debug)]

--- a/crates/database/src/block_index_data.rs
+++ b/crates/database/src/block_index_data.rs
@@ -6,11 +6,11 @@ use base58::ToBase58;
 use eyre::Result;
 use irys_config::IrysNodeConfig;
 use irys_types::H256;
-use tracing::{error, info};
 use std::fs::{self, remove_file, File, OpenOptions};
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::ops::{Index, IndexMut};
 use std::sync::Arc;
+use tracing::{error, info};
 
 /// This struct represents the `Uninitialized` `block_index` type state.
 #[derive(Debug)]
@@ -336,8 +336,12 @@ fn append_item(item: &BlockIndexItem, config: &IrysNodeConfig) -> eyre::Result<(
         Ok(mut file) => {
             file.write_all(&item.to_bytes())?;
             Ok(())
-        },
-        Err(err) => Err(eyre::eyre!("While trying to open file :{:?} got error: {}", path, err))
+        }
+        Err(err) => Err(eyre::eyre!(
+            "While trying to open file :{:?} got error: {}",
+            path,
+            err
+        )),
     }
 }
 

--- a/crates/database/src/block_index_data.rs
+++ b/crates/database/src/block_index_data.rs
@@ -96,7 +96,6 @@ impl BlockIndex<Uninitialized> {
         // Ensure the path exists
         let path = self.config.clone().unwrap().block_index_dir();
         fs::create_dir_all(&path)?;
-        println!("ensure_path_exists {}", path.display());
         Ok(())
     }
 }


### PR DESCRIPTION
**Describe the changes**
Starts to add basic testing primitives, and tries to refactor some of our tests following those primitives.
Renables [api end to end](https://github.com/Irys-xyz/irys/blob/00614f16b43ad6c4103df4437b95f845541207b4/crates/chain/tests/api/api.rs#L33) tests that are fixed and refactored.
Also add simple test just to show these primitives working together, for example in [async fn test_mine() {](https://github.com/Irys-xyz/irys/blob/00614f16b43ad6c4103df4437b95f845541207b4/crates/chain/tests/block_production/testing_primitives.rs#L27)

**Related Issue(s)**
#270

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**

