### PR TITLE
feat: add system_ledgers to the IrysBlockHeader

### DIFF
--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -20,8 +20,8 @@ use irys_types::{
     app_state::DatabaseProvider, block_production::SolutionContext, calculate_difficulty,
     next_cumulative_diff, storage_config::StorageConfig, vdf_config::VDFStepsConfig, Address,
     Base64, DifficultyAdjustmentConfig, H256List, IngressProofsList, IrysBlockHeader,
-    IrysTransactionHeader, PoaData, Signature, TransactionLedger, TxIngressProof, VDFLimiterInfo,
-    H256, U256,
+    IrysTransactionHeader, PoaData, Signature, StorageTransactionLedger, TxIngressProof,
+    VDFLimiterInfo, H256, U256,
 };
 use irys_vdf::vdf_state::VdfStepsReadGuard;
 use nodit::interval::ii;
@@ -323,20 +323,21 @@ impl Handler<SolutionFoundMessage> for BlockProducerActor {
                 miner_address: solution.mining_address,
                 signature: Signature::test_signature().into(),
                 timestamp: current_timestamp,
+                system_ledgers: vec![],
                 ledgers: vec![
                     // Permanent Publish Ledger
-                    TransactionLedger {
+                    StorageTransactionLedger {
                         ledger_id: Ledger::Publish.into(),
-                        tx_root: TransactionLedger::merklize_tx_root(&publish_txs).0,
+                        tx_root: StorageTransactionLedger::merklize_tx_root(&publish_txs).0,
                         tx_ids: H256List(publish_txs.iter().map(|t| t.id).collect::<Vec<_>>()),
                         max_chunk_offset: publish_max_chunk_offset,
                         expires: None,
                         proofs: opt_proofs,
                     },
                     // Term Submit Ledger
-                    TransactionLedger {
+                    StorageTransactionLedger {
                         ledger_id: Ledger::Submit.into(),
-                        tx_root: TransactionLedger::merklize_tx_root(&submit_txs).0,
+                        tx_root: StorageTransactionLedger::merklize_tx_root(&submit_txs).0,
                         tx_ids: H256List(submit_txids.clone()),
                         max_chunk_offset: submit_max_chunk_offset,
                         expires: Some(1622543200),

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -460,7 +460,7 @@ mod tests {
     use irys_testing_utils::utils::temporary_directory;
     use irys_types::{
         irys::IrysSigner, partition::PartitionAssignment, Address, Base64, Config, H256List,
-        IrysTransaction, IrysTransactionHeader, Signature, TransactionLedger, H256, U256,
+        IrysTransaction, IrysTransactionHeader, Signature, StorageTransactionLedger, H256, U256,
     };
     use std::sync::{Arc, RwLock};
     use tempfile::TempDir;
@@ -701,7 +701,7 @@ mod tests {
 
         let data_tx_ids = tx_headers.iter().map(|h| h.id).collect::<Vec<H256>>();
 
-        let (tx_root, tx_path) = TransactionLedger::merklize_tx_root(&tx_headers);
+        let (tx_root, tx_path) = StorageTransactionLedger::merklize_tx_root(&tx_headers);
 
         let poa = PoaData {
             tx_path: Some(Base64(tx_path[poa_tx_num].proof.clone())),
@@ -727,7 +727,7 @@ mod tests {
             timestamp: 1000,
             ledgers: vec![
                 // Permanent Publish Ledger
-                TransactionLedger {
+                StorageTransactionLedger {
                     ledger_id: Ledger::Publish.into(),
                     tx_root: H256::zero(),
                     tx_ids: H256List(Vec::new()),
@@ -736,7 +736,7 @@ mod tests {
                     proofs: None,
                 },
                 // Term Submit Ledger
-                TransactionLedger {
+                StorageTransactionLedger {
                     ledger_id: Ledger::Submit.into(),
                     tx_root,
                     tx_ids: H256List(data_tx_ids.clone()),

--- a/crates/actors/src/chunk_migration_service.rs
+++ b/crates/actors/src/chunk_migration_service.rs
@@ -8,8 +8,8 @@ use irys_database::{
 use irys_storage::{get_overlapped_storage_modules, ie, ii, InclusiveInterval, StorageModule};
 use irys_types::{
     app_state::DatabaseProvider, Base64, DataRoot, IrysBlockHeader, IrysTransactionHeader,
-    LedgerChunkOffset, LedgerChunkRange, Proof, StorageConfig, TransactionLedger, TxChunkOffset,
-    UnpackedChunk, H256,
+    LedgerChunkOffset, LedgerChunkRange, Proof, StorageConfig, StorageTransactionLedger,
+    TxChunkOffset, UnpackedChunk, H256,
 };
 use reth_db::Database;
 use std::sync::{Arc, RwLock};
@@ -258,7 +258,7 @@ fn get_tx_path_pairs(
     ledger: Ledger,
     txs: &[IrysTransactionHeader],
 ) -> eyre::Result<Vec<((H256, Proof), (DataRoot, u64))>> {
-    let (tx_root, proofs) = TransactionLedger::merklize_tx_root(txs);
+    let (tx_root, proofs) = StorageTransactionLedger::merklize_tx_root(txs);
 
     if tx_root != block.ledgers[ledger].tx_root {
         return Err(eyre::eyre!("Invalid tx_root"));

--- a/crates/database/src/data_ledger.rs
+++ b/crates/database/src/data_ledger.rs
@@ -1,4 +1,4 @@
-use irys_types::{Compact, Config, TransactionLedger, H256};
+use irys_types::{Compact, Config, StorageTransactionLedger, H256};
 use serde::{Deserialize, Serialize};
 use std::ops::{Index, IndexMut};
 /// Manages the global ledger state within the epoch service, tracking:
@@ -398,8 +398,8 @@ impl IndexMut<Ledger> for Ledgers {
     }
 }
 
-impl Index<Ledger> for Vec<TransactionLedger> {
-    type Output = TransactionLedger;
+impl Index<Ledger> for Vec<StorageTransactionLedger> {
+    type Output = StorageTransactionLedger;
 
     fn index(&self, ledger: Ledger) -> &Self::Output {
         self.iter()
@@ -408,7 +408,7 @@ impl Index<Ledger> for Vec<TransactionLedger> {
     }
 }
 
-impl IndexMut<Ledger> for Vec<TransactionLedger> {
+impl IndexMut<Ledger> for Vec<StorageTransactionLedger> {
     fn index_mut(&mut self, ledger: Ledger) -> &mut Self::Output {
         self.iter_mut()
             .find(|tx_ledger| tx_ledger.ledger_id == ledger as u32)

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -11,6 +11,7 @@ pub mod database;
 /// Data in the caches can be pending or in a block still subject to re-org so
 /// it is not suitable for mining.
 pub mod db_cache;
+pub mod system_ledger;
 
 pub mod db;
 /// Data in the indexes is confirmed data
@@ -25,6 +26,7 @@ pub mod tables;
 pub use block_index_data::*;
 pub use data_ledger::*;
 pub use database::*;
+pub use system_ledger::*;
 
 pub mod reth_db {
     pub use reth_db::*;

--- a/crates/database/src/system_ledger.rs
+++ b/crates/database/src/system_ledger.rs
@@ -1,0 +1,47 @@
+use irys_types::Compact;
+use serde::{Deserialize, Serialize};
+
+/// Names for each of the system ledgers as well as their `ledger_id` discriminant
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Compact, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum SystemLedger {
+    /// The commitments ledger, for pledging and staking related transactions
+    Commitment = 0,
+}
+
+impl Default for SystemLedger {
+    fn default() -> Self {
+        Self::Commitment
+    }
+}
+
+impl SystemLedger {
+    /// An array of all the System Ledgers, suitable for enumeration
+    pub const ALL: [Self; 1] = [Self::Commitment];
+
+    /// Make it possible to iterate over all the System ledgers in order
+    pub fn iter() -> impl Iterator<Item = Self> {
+        Self::ALL.iter().copied()
+    }
+    /// get the associated numeric SystemLedger ID
+    pub const fn get_id(&self) -> u32 {
+        *self as u32
+    }
+}
+
+impl From<SystemLedger> for u32 {
+    fn from(system_ledger: SystemLedger) -> Self {
+        system_ledger as Self
+    }
+}
+
+impl TryFrom<u32> for SystemLedger {
+    type Error = &'static str;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Commitment),
+            _ => Err("Invalid ledger number"),
+        }
+    }
+}

--- a/crates/storage/src/chunk_provider.rs
+++ b/crates/storage/src/chunk_provider.rs
@@ -147,7 +147,7 @@ mod tests {
     use irys_types::{
         irys::IrysSigner, ledger_chunk_offset_ii, partition::PartitionAssignment,
         partition_chunk_offset_ie, Base64, Config, LedgerChunkRange, PartitionChunkOffset,
-        TransactionLedger, UnpackedChunk,
+        StorageTransactionLedger, UnpackedChunk,
     };
     use nodit::interval::{ie, ii};
     use rand::Rng as _;
@@ -189,7 +189,8 @@ mod tests {
 
         // fake the tx_path
         // Create a tx_root (and paths) from the tx
-        let (_tx_root, proofs) = TransactionLedger::merklize_tx_root(&vec![tx.header.clone()]);
+        let (_tx_root, proofs) =
+            StorageTransactionLedger::merklize_tx_root(&vec![tx.header.clone()]);
 
         let tx_path = proofs[0].proof.clone();
 

--- a/crates/storage/tests/storage_module_index_tests.rs
+++ b/crates/storage/tests/storage_module_index_tests.rs
@@ -11,7 +11,7 @@ use irys_types::{
     irys::IrysSigner, ledger_chunk_offset_ii, partition::PartitionAssignment,
     partition_chunk_offset_ie, partition_chunk_offset_ii, Base64, Config, IrysTransaction,
     IrysTransactionHeader, LedgerChunkOffset, LedgerChunkRange, PartitionChunkOffset,
-    PartitionChunkRange, StorageConfig, TransactionLedger, TxChunkOffset, UnpackedChunk, H256,
+    PartitionChunkRange, StorageConfig, StorageTransactionLedger, TxChunkOffset, UnpackedChunk, H256,
 };
 use openssl::sha;
 use reth_db::Database;
@@ -147,7 +147,7 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
     let tx_headers: Vec<IrysTransactionHeader> = txs.iter().map(|tx| tx.header.clone()).collect();
 
     // Create a tx_root (and paths) from the tx
-    let (_tx_root, proofs) = TransactionLedger::merklize_tx_root(&tx_headers);
+    let (_tx_root, proofs) = StorageTransactionLedger::merklize_tx_root(&tx_headers);
 
     // Assume this is the first block in the blockchain
     let proof = &proofs[0];

--- a/crates/storage/tests/storage_module_index_tests.rs
+++ b/crates/storage/tests/storage_module_index_tests.rs
@@ -11,7 +11,8 @@ use irys_types::{
     irys::IrysSigner, ledger_chunk_offset_ii, partition::PartitionAssignment,
     partition_chunk_offset_ie, partition_chunk_offset_ii, Base64, Config, IrysTransaction,
     IrysTransactionHeader, LedgerChunkOffset, LedgerChunkRange, PartitionChunkOffset,
-    PartitionChunkRange, StorageConfig, StorageTransactionLedger, TxChunkOffset, UnpackedChunk, H256,
+    PartitionChunkRange, StorageConfig, StorageTransactionLedger, TxChunkOffset, UnpackedChunk,
+    H256,
 };
 use openssl::sha;
 use reth_db::Database;


### PR DESCRIPTION
**Describe the changes**
Adds a `system_ledgers` section to the `IrysBlockHeader` above the existing storage `ledgers` section. The `system_ledgers` list contains one or more system ledgers, including a `Commitment` ledger defined in this PR

**Related Issue(s)**
This resolves [#291](https://github.com/Irys-xyz/irys/issues/291)

**Checklist**

- [x] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
Next up, populating the genesis block with the correct genesis commitments.
