### PR TITLE
feat: rename ledgers->data_ledgers for consistency

### DIFF
--- a/crates/actors/src/block_discovery.rs
+++ b/crates/actors/src/block_discovery.rs
@@ -111,7 +111,7 @@ impl Handler<BlockDiscoveredMessage> for BlockDiscoveryActor {
         // to retrieve and validate them from the block producer.
         // TODO: in the future we'll retrieve the missing transactions from the block
         // producer and validate them.
-        let submit_txs = match new_block_header.ledgers[Ledger::Submit]
+        let submit_txs = match new_block_header.storage_ledgers[Ledger::Submit]
             .tx_ids
             .iter()
             .map(|txid| {
@@ -139,7 +139,7 @@ impl Handler<BlockDiscoveredMessage> for BlockDiscoveryActor {
         // 3. Update the local tx headers index so include the ingress- proof.
         //    This keeps the transaction from getting re-promoted each block.
         //    (this last step performed in mempool after the block is confirmed)
-        let publish_txs = match new_block_header.ledgers[Ledger::Publish]
+        let publish_txs = match new_block_header.storage_ledgers[Ledger::Publish]
             .tx_ids
             .iter()
             .map(|txid| {
@@ -160,7 +160,7 @@ impl Handler<BlockDiscoveredMessage> for BlockDiscoveryActor {
         };
 
         if !publish_txs.is_empty() {
-            let publish_proofs = match &new_block_header.ledgers[Ledger::Publish].proofs {
+            let publish_proofs = match &new_block_header.storage_ledgers[Ledger::Publish].proofs {
                 Some(proofs) => proofs,
                 None => {
                     return Box::pin(async move { Err(eyre::eyre!("Ingress proofs missing")) });

--- a/crates/actors/src/block_discovery.rs
+++ b/crates/actors/src/block_discovery.rs
@@ -4,7 +4,7 @@ use crate::{
     services::ServiceSenders,
 };
 use actix::prelude::*;
-use irys_database::{block_header_by_hash, tx_header_by_txid, Ledger};
+use irys_database::{block_header_by_hash, tx_header_by_txid, DataLedger};
 use irys_types::{
     DatabaseProvider, DifficultyAdjustmentConfig, IrysBlockHeader, IrysTransactionHeader,
     StorageConfig, VDFStepsConfig,
@@ -111,7 +111,7 @@ impl Handler<BlockDiscoveredMessage> for BlockDiscoveryActor {
         // to retrieve and validate them from the block producer.
         // TODO: in the future we'll retrieve the missing transactions from the block
         // producer and validate them.
-        let submit_txs = match new_block_header.storage_ledgers[Ledger::Submit]
+        let submit_txs = match new_block_header.data_ledgers[DataLedger::Submit]
             .tx_ids
             .iter()
             .map(|txid| {
@@ -139,7 +139,7 @@ impl Handler<BlockDiscoveredMessage> for BlockDiscoveryActor {
         // 3. Update the local tx headers index so include the ingress- proof.
         //    This keeps the transaction from getting re-promoted each block.
         //    (this last step performed in mempool after the block is confirmed)
-        let publish_txs = match new_block_header.storage_ledgers[Ledger::Publish]
+        let publish_txs = match new_block_header.data_ledgers[DataLedger::Publish]
             .tx_ids
             .iter()
             .map(|txid| {
@@ -160,7 +160,7 @@ impl Handler<BlockDiscoveredMessage> for BlockDiscoveryActor {
         };
 
         if !publish_txs.is_empty() {
-            let publish_proofs = match &new_block_header.storage_ledgers[Ledger::Publish].proofs {
+            let publish_proofs = match &new_block_header.data_ledgers[DataLedger::Publish].proofs {
                 Some(proofs) => proofs,
                 None => {
                     return Box::pin(async move { Err(eyre::eyre!("Ingress proofs missing")) });

--- a/crates/actors/src/block_index_service.rs
+++ b/crates/actors/src/block_index_service.rs
@@ -1,6 +1,6 @@
 use crate::{calculate_chunks_added, BlockFinalizedMessage};
 use actix::prelude::*;
-use irys_database::{BlockIndex, BlockIndexItem, Initialized, DataLedger, LedgerIndexItem};
+use irys_database::{BlockIndex, BlockIndexItem, DataLedger, Initialized, LedgerIndexItem};
 use irys_types::{IrysBlockHeader, IrysTransactionHeader, StorageConfig, H256, U256};
 use std::{
     sync::{Arc, RwLock, RwLockReadGuard},

--- a/crates/actors/src/block_index_service.rs
+++ b/crates/actors/src/block_index_service.rs
@@ -133,7 +133,7 @@ impl BlockIndexService {
         let chunk_size = self.storage_config.chunk_size;
 
         // Extract just the transactions referenced in the submit ledger
-        let submit_tx_count = block.ledgers[Ledger::Submit].tx_ids.len();
+        let submit_tx_count = block.storage_ledgers[Ledger::Submit].tx_ids.len();
         let submit_txs = &all_txs[..submit_tx_count];
 
         // Extract just the transactions referenced in the publish ledger
@@ -166,11 +166,11 @@ impl BlockIndexService {
             ledgers: vec![
                 LedgerIndexItem {
                     max_chunk_offset: max_publish_chunks,
-                    tx_root: block.ledgers[Ledger::Publish].tx_root,
+                    tx_root: block.storage_ledgers[Ledger::Publish].tx_root,
                 },
                 LedgerIndexItem {
                     max_chunk_offset: max_submit_chunks,
-                    tx_root: block.ledgers[Ledger::Submit].tx_root,
+                    tx_root: block.storage_ledgers[Ledger::Submit].tx_root,
                 },
             ],
         };

--- a/crates/actors/src/block_index_service.rs
+++ b/crates/actors/src/block_index_service.rs
@@ -1,6 +1,6 @@
 use crate::{calculate_chunks_added, BlockFinalizedMessage};
 use actix::prelude::*;
-use irys_database::{BlockIndex, BlockIndexItem, Initialized, Ledger, LedgerIndexItem};
+use irys_database::{BlockIndex, BlockIndexItem, Initialized, DataLedger, LedgerIndexItem};
 use irys_types::{IrysBlockHeader, IrysTransactionHeader, StorageConfig, H256, U256};
 use std::{
     sync::{Arc, RwLock, RwLockReadGuard},
@@ -133,7 +133,7 @@ impl BlockIndexService {
         let chunk_size = self.storage_config.chunk_size;
 
         // Extract just the transactions referenced in the submit ledger
-        let submit_tx_count = block.storage_ledgers[Ledger::Submit].tx_ids.len();
+        let submit_tx_count = block.data_ledgers[DataLedger::Submit].tx_ids.len();
         let submit_txs = &all_txs[..submit_tx_count];
 
         // Extract just the transactions referenced in the publish ledger
@@ -155,8 +155,8 @@ impl BlockIndexService {
                     .get_item((block.height.saturating_sub(1)) as usize)
                     .unwrap();
                 (
-                    prev_block.ledgers[Ledger::Publish].max_chunk_offset + pub_chunks_added,
-                    prev_block.ledgers[Ledger::Submit].max_chunk_offset + sub_chunks_added,
+                    prev_block.ledgers[DataLedger::Publish].max_chunk_offset + pub_chunks_added,
+                    prev_block.ledgers[DataLedger::Submit].max_chunk_offset + sub_chunks_added,
                 )
             };
 
@@ -166,11 +166,11 @@ impl BlockIndexService {
             ledgers: vec![
                 LedgerIndexItem {
                     max_chunk_offset: max_publish_chunks,
-                    tx_root: block.storage_ledgers[Ledger::Publish].tx_root,
+                    tx_root: block.data_ledgers[DataLedger::Publish].tx_root,
                 },
                 LedgerIndexItem {
                     max_chunk_offset: max_submit_chunks,
-                    tx_root: block.storage_ledgers[Ledger::Submit].tx_root,
+                    tx_root: block.data_ledgers[DataLedger::Submit].tx_root,
                 },
             ],
         };

--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -232,7 +232,7 @@ impl Handler<SolutionFoundMessage> for BlockProducerActor {
 
             // Publish Ledger Transactions
             let publish_chunks_added = calculate_chunks_added(&publish_txs, chunk_size);
-            let publish_max_chunk_offset =  prev_block_header.ledgers[Ledger::Publish].max_chunk_offset + publish_chunks_added;
+            let publish_max_chunk_offset =  prev_block_header.storage_ledgers[Ledger::Publish].max_chunk_offset + publish_chunks_added;
             let opt_proofs = (!proofs.is_empty()).then(|| IngressProofsList::from(proofs));
 
             // Submit Ledger Transactions    
@@ -240,7 +240,7 @@ impl Handler<SolutionFoundMessage> for BlockProducerActor {
                 mempool_addr.send(GetBestMempoolTxs).await.unwrap();
 
             let submit_chunks_added = calculate_chunks_added(&submit_txs, chunk_size);
-            let submit_max_chunk_offset = prev_block_header.ledgers[Ledger::Submit].max_chunk_offset + submit_chunks_added;
+            let submit_max_chunk_offset = prev_block_header.storage_ledgers[Ledger::Submit].max_chunk_offset + submit_chunks_added;
 
             let submit_txids = submit_txs.iter().map(|h| h.id).collect::<Vec<H256>>();
             let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
@@ -324,7 +324,7 @@ impl Handler<SolutionFoundMessage> for BlockProducerActor {
                 signature: Signature::test_signature().into(),
                 timestamp: current_timestamp,
                 system_ledgers: vec![],
-                ledgers: vec![
+                storage_ledgers: vec![
                     // Permanent Publish Ledger
                     StorageTransactionLedger {
                         ledger_id: Ledger::Publish.into(),

--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -11,7 +11,7 @@ use base58::ToBase58;
 use eyre::eyre;
 use irys_database::{
     block_header_by_hash, cached_data_root_by_data_root, tables::IngressProofs, tx_header_by_txid,
-    Ledger,
+    DataLedger,
 };
 use irys_price_oracle::IrysPriceOracle;
 use irys_primitives::{DataShadow, IrysTxId, ShadowTx, ShadowTxType, Shadows};
@@ -19,9 +19,9 @@ use irys_reth_node_bridge::{adapter::node::RethNodeContext, node::RethNodeProvid
 use irys_types::{
     app_state::DatabaseProvider, block_production::SolutionContext, calculate_difficulty,
     next_cumulative_diff, storage_config::StorageConfig, vdf_config::VDFStepsConfig, Address,
-    Base64, DifficultyAdjustmentConfig, H256List, IngressProofsList, IrysBlockHeader,
-    IrysTransactionHeader, PoaData, Signature, StorageTransactionLedger, TxIngressProof,
-    VDFLimiterInfo, H256, U256,
+    Base64, DataTransactionLedger, DifficultyAdjustmentConfig, H256List, IngressProofsList,
+    IrysBlockHeader, IrysTransactionHeader, PoaData, Signature, TxIngressProof, VDFLimiterInfo,
+    H256, U256,
 };
 use irys_vdf::vdf_state::VdfStepsReadGuard;
 use nodit::interval::ii;
@@ -232,7 +232,7 @@ impl Handler<SolutionFoundMessage> for BlockProducerActor {
 
             // Publish Ledger Transactions
             let publish_chunks_added = calculate_chunks_added(&publish_txs, chunk_size);
-            let publish_max_chunk_offset =  prev_block_header.storage_ledgers[Ledger::Publish].max_chunk_offset + publish_chunks_added;
+            let publish_max_chunk_offset =  prev_block_header.data_ledgers[DataLedger::Publish].max_chunk_offset + publish_chunks_added;
             let opt_proofs = (!proofs.is_empty()).then(|| IngressProofsList::from(proofs));
 
             // Submit Ledger Transactions    
@@ -240,7 +240,7 @@ impl Handler<SolutionFoundMessage> for BlockProducerActor {
                 mempool_addr.send(GetBestMempoolTxs).await.unwrap();
 
             let submit_chunks_added = calculate_chunks_added(&submit_txs, chunk_size);
-            let submit_max_chunk_offset = prev_block_header.storage_ledgers[Ledger::Submit].max_chunk_offset + submit_chunks_added;
+            let submit_max_chunk_offset = prev_block_header.data_ledgers[DataLedger::Submit].max_chunk_offset + submit_chunks_added;
 
             let submit_txids = submit_txs.iter().map(|h| h.id).collect::<Vec<H256>>();
             let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
@@ -324,20 +324,20 @@ impl Handler<SolutionFoundMessage> for BlockProducerActor {
                 signature: Signature::test_signature().into(),
                 timestamp: current_timestamp,
                 system_ledgers: vec![],
-                storage_ledgers: vec![
+                data_ledgers: vec![
                     // Permanent Publish Ledger
-                    StorageTransactionLedger {
-                        ledger_id: Ledger::Publish.into(),
-                        tx_root: StorageTransactionLedger::merklize_tx_root(&publish_txs).0,
+                    DataTransactionLedger {
+                        ledger_id: DataLedger::Publish.into(),
+                        tx_root: DataTransactionLedger::merklize_tx_root(&publish_txs).0,
                         tx_ids: H256List(publish_txs.iter().map(|t| t.id).collect::<Vec<_>>()),
                         max_chunk_offset: publish_max_chunk_offset,
                         expires: None,
                         proofs: opt_proofs,
                     },
                     // Term Submit Ledger
-                    StorageTransactionLedger {
-                        ledger_id: Ledger::Submit.into(),
-                        tx_root: StorageTransactionLedger::merklize_tx_root(&submit_txs).0,
+                    DataTransactionLedger {
+                        ledger_id: DataLedger::Submit.into(),
+                        tx_root: DataTransactionLedger::merklize_tx_root(&submit_txs).0,
                         tx_ids: H256List(submit_txids.clone()),
                         max_chunk_offset: submit_max_chunk_offset,
                         expires: Some(1622543200),

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -19,7 +19,7 @@ use crate::{
 use actix::prelude::*;
 use base58::ToBase58 as _;
 use eyre::ensure;
-use irys_database::{block_header_by_hash, tx_header_by_txid, BlockIndex, Initialized, DataLedger};
+use irys_database::{block_header_by_hash, tx_header_by_txid, BlockIndex, DataLedger, Initialized};
 use irys_types::{
     Address, BlockHash, DatabaseProvider, IrysBlockHeader, IrysTransactionHeader,
     IrysTransactionId, StorageConfig, H256, U256,
@@ -857,7 +857,10 @@ impl BlockTreeCache {
                         .tx_ids
                         .0
                         .clone();
-                    let submit_txs = entry.block.data_ledgers[DataLedger::Submit].tx_ids.0.clone();
+                    let submit_txs = entry.block.data_ledgers[DataLedger::Submit]
+                        .tx_ids
+                        .0
+                        .clone();
                     pairs.push((current, entry.block.height, publish_txs, submit_txs));
 
                     if blocks_to_collect == 0 {
@@ -872,7 +875,10 @@ impl BlockTreeCache {
                         .tx_ids
                         .0
                         .clone();
-                    let submit_txs = entry.block.data_ledgers[DataLedger::Submit].tx_ids.0.clone();
+                    let submit_txs = entry.block.data_ledgers[DataLedger::Submit]
+                        .tx_ids
+                        .0
+                        .clone();
                     pairs.push((current, entry.block.height, publish_txs, submit_txs));
                     not_onchain_count += 1;
 

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -1291,12 +1291,12 @@ mod tests {
         // Adding `b1` again shouldn't change the state because it is confirmed
         // onchain
         let mut b1_test = b1.clone();
-        b1_test.storage_ledgers[DataLedger::Submit]
+        b1_test.data_ledgers[DataLedger::Submit]
             .tx_ids
             .push(H256::random());
         assert_matches!(cache.add_block(&b1_test, all_tx.clone()), Ok(_));
         assert_eq!(
-            cache.get_block(&b1.block_hash).unwrap().storage_ledgers[Ledger::Submit]
+            cache.get_block(&b1.block_hash).unwrap().data_ledgers[DataLedger::Submit]
                 .tx_ids
                 .len(),
             0
@@ -1305,7 +1305,7 @@ mod tests {
             cache
                 .get_by_solution_hash(&b1.solution_hash, &H256::random(), U256::one(), U256::one())
                 .unwrap()
-                .storage_ledgers[Ledger::Submit]
+                .data_ledgers[DataLedger::Submit]
                 .tx_ids
                 .len(),
             0
@@ -1334,17 +1334,17 @@ mod tests {
 
         // Add a TXID to b2, and re-add it to the cache, but still don't mark as validated
         let txid = H256::random();
-        b2.storage_ledgers[DataLedger::Submit].tx_ids.push(txid);
+        b2.data_ledgers[DataLedger::Submit].tx_ids.push(txid);
         assert_matches!(cache.add_block(&b2, all_tx.clone()), Ok(_));
         assert_eq!(
-            cache.get_block(&b2.block_hash).unwrap().storage_ledgers[Ledger::Submit].tx_ids[0],
+            cache.get_block(&b2.block_hash).unwrap().data_ledgers[DataLedger::Submit].tx_ids[0],
             txid
         );
         assert_eq!(
             cache
                 .get_by_solution_hash(&b2.solution_hash, &H256::random(), U256::one(), U256::one())
                 .unwrap()
-                .storage_ledgers[Ledger::Submit]
+                .data_ledgers[DataLedger::Submit]
                 .tx_ids[0],
             txid
         );
@@ -1352,7 +1352,7 @@ mod tests {
             cache
                 .get_by_solution_hash(&b2.solution_hash, &b1.block_hash, U256::one(), U256::one())
                 .unwrap()
-                .storage_ledgers[Ledger::Submit]
+                .data_ledgers[DataLedger::Submit]
                 .tx_ids[0],
             txid
         );

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -19,7 +19,7 @@ use crate::{
 use actix::prelude::*;
 use base58::ToBase58 as _;
 use eyre::ensure;
-use irys_database::{block_header_by_hash, tx_header_by_txid, BlockIndex, Initialized, Ledger};
+use irys_database::{block_header_by_hash, tx_header_by_txid, BlockIndex, Initialized, DataLedger};
 use irys_types::{
     Address, BlockHash, DatabaseProvider, IrysBlockHeader, IrysTransactionHeader,
     IrysTransactionId, StorageConfig, H256, U256,
@@ -149,8 +149,8 @@ impl BlockTreeService {
 
         // Get all the transactions for the finalized block, error if not found
         // TODO: Eventually abstract this for support of `n` ledgers
-        let submit_txs = get_ledger_tx_headers(&tx, &block_header, Ledger::Submit);
-        let publish_txs = get_ledger_tx_headers(&tx, &block_header, Ledger::Publish);
+        let submit_txs = get_ledger_tx_headers(&tx, &block_header, DataLedger::Submit);
+        let publish_txs = get_ledger_tx_headers(&tx, &block_header, DataLedger::Publish);
 
         let all_txs = {
             let mut combined = submit_txs.unwrap_or_default();
@@ -395,9 +395,9 @@ impl Handler<ValidationResultMessage> for BlockTreeService {
 fn get_ledger_tx_headers<T: DbTx>(
     tx: &T,
     block_header: &IrysBlockHeader,
-    ledger: Ledger,
+    ledger: DataLedger,
 ) -> Option<Vec<IrysTransactionHeader>> {
-    match block_header.storage_ledgers[ledger]
+    match block_header.data_ledgers[ledger]
         .tx_ids
         .iter()
         .map(|txid| {
@@ -522,8 +522,8 @@ impl BlockTreeCache {
             vec![(
                 block_hash,
                 height,
-                block.storage_ledgers[Ledger::Publish].tx_ids.0.clone(), // Publish ledger txs
-                block.storage_ledgers[Ledger::Submit].tx_ids.0.clone(),  // Submit ledger txs
+                block.data_ledgers[DataLedger::Publish].tx_ids.0.clone(), // Publish ledger txs
+                block.data_ledgers[DataLedger::Submit].tx_ids.0.clone(),  // Submit ledger txs
             )],
             0,
         );
@@ -602,7 +602,7 @@ impl BlockTreeCache {
         db: DatabaseProvider,
     ) -> Result<Vec<IrysTransactionHeader>, eyre::Report> {
         // Collect submit transactions
-        let submit_txs = block.storage_ledgers[Ledger::Submit]
+        let submit_txs = block.data_ledgers[DataLedger::Submit]
             .tx_ids
             .iter()
             .map(|txid| {
@@ -618,7 +618,7 @@ impl BlockTreeCache {
             })?;
 
         // Collect publish transactions
-        let publish_txs = block.storage_ledgers[Ledger::Publish]
+        let publish_txs = block.data_ledgers[DataLedger::Publish]
             .tx_ids
             .iter()
             .map(|txid| {
@@ -853,11 +853,11 @@ impl BlockTreeCache {
 
                 ChainState::Onchain => {
                     // Include OnChain blocks in pairs
-                    let publish_txs = entry.block.storage_ledgers[Ledger::Publish]
+                    let publish_txs = entry.block.data_ledgers[DataLedger::Publish]
                         .tx_ids
                         .0
                         .clone();
-                    let submit_txs = entry.block.storage_ledgers[Ledger::Submit].tx_ids.0.clone();
+                    let submit_txs = entry.block.data_ledgers[DataLedger::Submit].tx_ids.0.clone();
                     pairs.push((current, entry.block.height, publish_txs, submit_txs));
 
                     if blocks_to_collect == 0 {
@@ -868,11 +868,11 @@ impl BlockTreeCache {
 
                 // For Validated or other NotOnchain states
                 ChainState::Validated(_) | ChainState::NotOnchain(_) => {
-                    let publish_txs = entry.block.storage_ledgers[Ledger::Publish]
+                    let publish_txs = entry.block.data_ledgers[DataLedger::Publish]
                         .tx_ids
                         .0
                         .clone();
-                    let submit_txs = entry.block.storage_ledgers[Ledger::Submit].tx_ids.0.clone();
+                    let submit_txs = entry.block.data_ledgers[DataLedger::Submit].tx_ids.0.clone();
                     pairs.push((current, entry.block.height, publish_txs, submit_txs));
                     not_onchain_count += 1;
 
@@ -1243,7 +1243,7 @@ mod tests {
     use super::*;
     use assert_matches::assert_matches;
     use eyre::ensure;
-    use irys_database::Ledger;
+    use irys_database::DataLedger;
 
     #[actix::test]
     async fn test_block_cache() {
@@ -1285,7 +1285,7 @@ mod tests {
         // Adding `b1` again shouldn't change the state because it is confirmed
         // onchain
         let mut b1_test = b1.clone();
-        b1_test.storage_ledgers[Ledger::Submit]
+        b1_test.storage_ledgers[DataLedger::Submit]
             .tx_ids
             .push(H256::random());
         assert_matches!(cache.add_block(&b1_test, all_tx.clone()), Ok(_));
@@ -1328,7 +1328,7 @@ mod tests {
 
         // Add a TXID to b2, and re-add it to the cache, but still don't mark as validated
         let txid = H256::random();
-        b2.storage_ledgers[Ledger::Submit].tx_ids.push(txid);
+        b2.storage_ledgers[DataLedger::Submit].tx_ids.push(txid);
         assert_matches!(cache.add_block(&b2, all_tx.clone()), Ok(_));
         assert_eq!(
             cache.get_block(&b2.block_hash).unwrap().storage_ledgers[Ledger::Submit].tx_ids[0],

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use base58::ToBase58;
 use eyre::ensure;
-use irys_database::Ledger;
+use irys_database::DataLedger;
 use irys_packing::{capacity_single::compute_entropy_chunk, xor_vec_u8_arrays_in_place};
 use irys_storage::ii;
 use irys_types::{
@@ -346,7 +346,7 @@ pub fn poa_is_valid(
             + poa.partition_chunk_offset as u64;
 
         // ledger data -> block
-        let ledger = Ledger::try_from(ledger_id).unwrap();
+        let ledger = DataLedger::try_from(ledger_id).unwrap();
 
         let bb = block_index_guard
             .read()
@@ -459,8 +459,9 @@ mod tests {
     use irys_database::{BlockIndex, Initialized};
     use irys_testing_utils::utils::temporary_directory;
     use irys_types::{
-        irys::IrysSigner, partition::PartitionAssignment, Address, Base64, Config, H256List,
-        IrysTransaction, IrysTransactionHeader, Signature, StorageTransactionLedger, H256, U256,
+        irys::IrysSigner, partition::PartitionAssignment, Address, Base64, Config,
+        DataTransactionLedger, H256List, IrysTransaction, IrysTransactionHeader, Signature, H256,
+        U256,
     };
     use std::sync::{Arc, RwLock};
     use tempfile::TempDir;
@@ -557,7 +558,7 @@ mod tests {
         let ledgers = ledgers_guard.read();
         debug!("ledgers: {:?}", ledgers);
 
-        let sub_slots = ledgers.get_slots(Ledger::Submit);
+        let sub_slots = ledgers.get_slots(DataLedger::Submit);
 
         let partition_hash = sub_slots[0].partitions[0];
         let msg = BlockFinalizedMessage {
@@ -701,7 +702,7 @@ mod tests {
 
         let data_tx_ids = tx_headers.iter().map(|h| h.id).collect::<Vec<H256>>();
 
-        let (tx_root, tx_path) = StorageTransactionLedger::merklize_tx_root(&tx_headers);
+        let (tx_root, tx_path) = DataTransactionLedger::merklize_tx_root(&tx_headers);
 
         let poa = PoaData {
             tx_path: Some(Base64(tx_path[poa_tx_num].proof.clone())),
@@ -725,10 +726,10 @@ mod tests {
             miner_address: context.miner_address,
             signature: Signature::test_signature().into(),
             timestamp: 1000,
-            storage_ledgers: vec![
+            data_ledgers: vec![
                 // Permanent Publish Ledger
-                StorageTransactionLedger {
-                    ledger_id: Ledger::Publish.into(),
+                DataTransactionLedger {
+                    ledger_id: DataLedger::Publish.into(),
                     tx_root: H256::zero(),
                     tx_ids: H256List(Vec::new()),
                     max_chunk_offset: 0,
@@ -736,8 +737,8 @@ mod tests {
                     proofs: None,
                 },
                 // Term Submit Ledger
-                StorageTransactionLedger {
-                    ledger_id: Ledger::Submit.into(),
+                DataTransactionLedger {
+                    ledger_id: DataLedger::Submit.into(),
                     tx_root,
                     tx_ids: H256List(data_tx_ids.clone()),
                     max_chunk_offset: 9,
@@ -785,7 +786,7 @@ mod tests {
         // ledger data -> block
         let bb = block_index_guard
             .read()
-            .get_block_bounds(Ledger::Submit, ledger_chunk_offset);
+            .get_block_bounds(DataLedger::Submit, ledger_chunk_offset);
         info!("block bounds: {:?}", bb);
 
         assert_eq!(bb.start_chunk_offset, 0, "start_chunk_offset should be 0");

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -725,7 +725,7 @@ mod tests {
             miner_address: context.miner_address,
             signature: Signature::test_signature().into(),
             timestamp: 1000,
-            ledgers: vec![
+            storage_ledgers: vec![
                 // Permanent Publish Ledger
                 StorageTransactionLedger {
                     ledger_id: Ledger::Publish.into(),

--- a/crates/actors/src/chunk_migration_service.rs
+++ b/crates/actors/src/chunk_migration_service.rs
@@ -94,7 +94,7 @@ impl Handler<BlockFinalizedMessage> for ChunkMigrationService {
         let service_senders = self.service_senders.clone().unwrap();
 
         // Extract transactions for each ledger
-        let submit_tx_count = block.ledgers[Ledger::Submit].tx_ids.len();
+        let submit_tx_count = block.storage_ledgers[Ledger::Submit].tx_ids.len();
         let submit_txs = all_txs[..submit_tx_count].to_vec();
         let publish_txs = all_txs[submit_tx_count..].to_vec();
         let block_height = block.height;
@@ -250,7 +250,7 @@ fn get_block_range(
 
     LedgerChunkRange(ii(
         LedgerChunkOffset::from(start_chunk_offset),
-        LedgerChunkOffset::from(block.ledgers[ledger].max_chunk_offset),
+        LedgerChunkOffset::from(block.storage_ledgers[ledger].max_chunk_offset),
     ))
 }
 fn get_tx_path_pairs(
@@ -260,7 +260,7 @@ fn get_tx_path_pairs(
 ) -> eyre::Result<Vec<((H256, Proof), (DataRoot, u64))>> {
     let (tx_root, proofs) = StorageTransactionLedger::merklize_tx_root(txs);
 
-    if tx_root != block.ledgers[ledger].tx_root {
+    if tx_root != block.storage_ledgers[ledger].tx_root {
         return Err(eyre::eyre!("Invalid tx_root"));
     }
 

--- a/crates/actors/src/chunk_migration_service.rs
+++ b/crates/actors/src/chunk_migration_service.rs
@@ -3,12 +3,12 @@ use eyre::eyre;
 use irys_database::{
     cached_chunk_by_chunk_offset,
     db_cache::{CachedChunk, CachedChunkIndexMetadata},
-    BlockIndex, Initialized, Ledger,
+    BlockIndex, DataLedger, Initialized,
 };
 use irys_storage::{get_overlapped_storage_modules, ie, ii, InclusiveInterval, StorageModule};
 use irys_types::{
-    app_state::DatabaseProvider, Base64, DataRoot, IrysBlockHeader, IrysTransactionHeader,
-    LedgerChunkOffset, LedgerChunkRange, Proof, StorageConfig, StorageTransactionLedger,
+    app_state::DatabaseProvider, Base64, DataRoot, DataTransactionLedger, IrysBlockHeader,
+    IrysTransactionHeader, LedgerChunkOffset, LedgerChunkRange, Proof, StorageConfig,
     TxChunkOffset, UnpackedChunk, H256,
 };
 use reth_db::Database;
@@ -94,7 +94,7 @@ impl Handler<BlockFinalizedMessage> for ChunkMigrationService {
         let service_senders = self.service_senders.clone().unwrap();
 
         // Extract transactions for each ledger
-        let submit_tx_count = block.storage_ledgers[Ledger::Submit].tx_ids.len();
+        let submit_tx_count = block.data_ledgers[DataLedger::Submit].tx_ids.len();
         let submit_txs = all_txs[..submit_tx_count].to_vec();
         let publish_txs = all_txs[submit_tx_count..].to_vec();
         let block_height = block.height;
@@ -102,7 +102,7 @@ impl Handler<BlockFinalizedMessage> for ChunkMigrationService {
             // Process Submit ledger transactions
             process_ledger_transactions(
                 &block,
-                Ledger::Submit,
+                DataLedger::Submit,
                 &submit_txs,
                 &block_index,
                 chunk_size,
@@ -115,7 +115,7 @@ impl Handler<BlockFinalizedMessage> for ChunkMigrationService {
             // Process Publish ledger transactions
             process_ledger_transactions(
                 &block,
-                Ledger::Publish,
+                DataLedger::Publish,
                 &publish_txs,
                 &block_index,
                 chunk_size,
@@ -144,7 +144,7 @@ impl Handler<Stop> for ChunkMigrationService {
 
 fn process_ledger_transactions(
     block: &Arc<IrysBlockHeader>,
-    ledger: Ledger,
+    ledger: DataLedger,
     txs: &[IrysTransactionHeader],
     block_index: &Arc<RwLock<BlockIndex<Initialized>>>,
     chunk_size: usize,
@@ -195,7 +195,7 @@ fn process_transaction_chunks(
     data_root: DataRoot,
     data_size: u64,
     tx_chunk_range: LedgerChunkRange,
-    ledger: Ledger,
+    ledger: DataLedger,
     storage_modules: &[Arc<StorageModule>],
     db: &DatabaseProvider,
 ) -> Result<(), ()> {
@@ -235,7 +235,7 @@ fn process_transaction_chunks(
 /// added to the ledger by the specified block.
 fn get_block_range(
     block: &IrysBlockHeader,
-    ledger: Ledger,
+    ledger: DataLedger,
     block_index: Arc<RwLock<BlockIndex<Initialized>>>,
 ) -> LedgerChunkRange {
     // Use the block index to get the ledger relative chunk offset of the
@@ -250,17 +250,17 @@ fn get_block_range(
 
     LedgerChunkRange(ii(
         LedgerChunkOffset::from(start_chunk_offset),
-        LedgerChunkOffset::from(block.storage_ledgers[ledger].max_chunk_offset),
+        LedgerChunkOffset::from(block.data_ledgers[ledger].max_chunk_offset),
     ))
 }
 fn get_tx_path_pairs(
     block: &IrysBlockHeader,
-    ledger: Ledger,
+    ledger: DataLedger,
     txs: &[IrysTransactionHeader],
 ) -> eyre::Result<Vec<((H256, Proof), (DataRoot, u64))>> {
-    let (tx_root, proofs) = StorageTransactionLedger::merklize_tx_root(txs);
+    let (tx_root, proofs) = DataTransactionLedger::merklize_tx_root(txs);
 
-    if tx_root != block.storage_ledgers[ledger].tx_root {
+    if tx_root != block.data_ledgers[ledger].tx_root {
         return Err(eyre::eyre!("Invalid tx_root"));
     }
 
@@ -275,7 +275,7 @@ fn update_storage_module_indexes(
     proof: &[u8],
     data_root: DataRoot,
     tx_chunk_range: LedgerChunkRange,
-    ledger: Ledger,
+    ledger: DataLedger,
     storage_modules: &[Arc<StorageModule>],
 ) -> Result<(), ()> {
     let overlapped_modules =
@@ -303,7 +303,7 @@ fn get_cached_chunk(
 
 fn find_storage_module(
     storage_modules: &[Arc<StorageModule>],
-    ledger: Ledger,
+    ledger: DataLedger,
     ledger_offset: u64,
 ) -> Option<&Arc<StorageModule>> {
     storage_modules.iter().find_map(|module| {

--- a/crates/actors/src/epoch_service.rs
+++ b/crates/actors/src/epoch_service.rs
@@ -1049,7 +1049,7 @@ mod tests {
 
         // Now create a new epoch block & give the Submit ledger enough size to add a slot
         let mut new_epoch_block = IrysBlockHeader::new_mock_header();
-        new_epoch_block.storage_ledgers[DataLedger::Submit].max_chunk_offset = 0;
+        new_epoch_block.data_ledgers[DataLedger::Submit].max_chunk_offset = 0;
 
         // index epoch previous blocks
         let mut height = 1;
@@ -1068,7 +1068,7 @@ mod tests {
         }
 
         new_epoch_block.height = num_blocks_in_epoch;
-        new_epoch_block.storage_ledgers[DataLedger::Submit].max_chunk_offset =
+        new_epoch_block.data_ledgers[DataLedger::Submit].max_chunk_offset =
             num_chunks_in_partition / 2;
 
         let _ = epoch_service.handle(NewEpochMessage(new_epoch_block.clone().into()), &mut ctx);
@@ -1100,9 +1100,9 @@ mod tests {
         // Simulate a subsequent epoch block that adds multiple ledger slots
         let mut new_epoch_block = IrysBlockHeader::new_mock_header();
         new_epoch_block.height = num_blocks_in_epoch * 2;
-        new_epoch_block.storage_ledgers[DataLedger::Submit].max_chunk_offset =
+        new_epoch_block.data_ledgers[DataLedger::Submit].max_chunk_offset =
             (num_chunks_in_partition as f64 * 2.5) as u64;
-        new_epoch_block.storage_ledgers[DataLedger::Publish as usize].max_chunk_offset =
+        new_epoch_block.data_ledgers[DataLedger::Publish as usize].max_chunk_offset =
             (num_chunks_in_partition as f64 * 0.75) as u64;
 
         let _ = epoch_service.handle(NewEpochMessage(new_epoch_block.into()), &mut ctx);
@@ -1357,7 +1357,7 @@ mod tests {
 
         // Now create a new epoch block & give the Submit ledger enough size to add a slot
         let mut new_epoch_block = IrysBlockHeader::new_mock_header();
-        new_epoch_block.storage_ledgers[DataLedger::Submit].max_chunk_offset = 0;
+        new_epoch_block.data_ledgers[DataLedger::Submit].max_chunk_offset = 0;
 
         // index epoch previous blocks
         let mut height = 1;
@@ -1377,7 +1377,7 @@ mod tests {
 
         new_epoch_block.height =
             (testnet_config.submit_ledger_epoch_length + 1) * num_blocks_in_epoch; // next epoch block, next multiple of num_blocks_in epoch,
-        new_epoch_block.storage_ledgers[DataLedger::Submit].max_chunk_offset =
+        new_epoch_block.data_ledgers[DataLedger::Submit].max_chunk_offset =
             num_chunks_in_partition / 2;
 
         let _ = epoch_service_actor
@@ -1492,7 +1492,7 @@ mod tests {
             {
                 assert_eq!(
                     publish_assignment.ledger_id,
-                    Some(Ledger::Publish.get_id()),
+                    Some(DataLedger::Publish.get_id()),
                     "Should be assigned to publish ledger"
                 );
                 assert_eq!(
@@ -1511,7 +1511,7 @@ mod tests {
             {
                 assert_eq!(
                     submit_assignment.ledger_id,
-                    Some(Ledger::Submit.get_id()),
+                    Some(DataLedger::Submit.get_id()),
                     "Should be assigned to submit ledger"
                 );
                 assert_eq!(
@@ -1530,7 +1530,7 @@ mod tests {
             {
                 assert_eq!(
                     submit_assignment.ledger_id,
-                    Some(Ledger::Submit.get_id()),
+                    Some(DataLedger::Submit.get_id()),
                     "Should be assigned to submit ledger"
                 );
                 assert_eq!(
@@ -1680,7 +1680,7 @@ mod tests {
 
         // Now create a new epoch block & give the Submit ledger enough size to add a slot
         let mut new_epoch_block = IrysBlockHeader::new_mock_header();
-        new_epoch_block.storage_ledgers[DataLedger::Submit].max_chunk_offset = 0;
+        new_epoch_block.data_ledgers[DataLedger::Submit].max_chunk_offset = 0;
 
         // index and store in db blocks
         let mut height = 1;
@@ -1689,7 +1689,7 @@ mod tests {
             new_epoch_block.block_hash = H256::random();
 
             if height == (testnet_config.submit_ledger_epoch_length + 1) * num_blocks_in_epoch {
-                new_epoch_block.storage_ledgers[DataLedger::Submit].max_chunk_offset =
+                new_epoch_block.data_ledgers[DataLedger::Submit].max_chunk_offset =
                     num_chunks_in_partition / 2;
             }
 
@@ -1843,9 +1843,8 @@ mod tests {
         let total_epoch_messages = 6;
         let mut epoch_num = 1;
         let mut new_epoch_block = IrysBlockHeader::new_mock_header();
-        new_epoch_block.storage_ledgers[DataLedger::Submit].max_chunk_offset =
-            num_chunks_in_partition;
-        new_epoch_block.storage_ledgers[DataLedger::Publish].max_chunk_offset =
+        new_epoch_block.data_ledgers[DataLedger::Submit].max_chunk_offset = num_chunks_in_partition;
+        new_epoch_block.data_ledgers[DataLedger::Publish].max_chunk_offset =
             num_chunks_in_partition;
 
         let mut height = 1;
@@ -1887,7 +1886,7 @@ mod tests {
         {
             assert_eq!(
                 publish_assignment.ledger_id,
-                Some(Ledger::Publish.get_id()),
+                Some(DataLedger::Publish.get_id()),
                 "Should be assigned to publish ledger"
             );
             assert_eq!(
@@ -1915,7 +1914,7 @@ mod tests {
         {
             assert_eq!(
                 publish_assignment.ledger_id,
-                Some(Ledger::Publish.get_id()),
+                Some(DataLedger::Publish.get_id()),
                 "Should be assigned to publish ledger"
             );
             assert_eq!(
@@ -1943,7 +1942,7 @@ mod tests {
         {
             assert_eq!(
                 submit_assignment.ledger_id,
-                Some(Ledger::Publish.get_id()),
+                Some(DataLedger::Publish.get_id()),
                 "Should be assigned to publish ledger"
             );
             assert_eq!(
@@ -1971,7 +1970,7 @@ mod tests {
         {
             assert_eq!(
                 submit_assignment.ledger_id,
-                Some(Ledger::Submit.get_id()),
+                Some(DataLedger::Submit.get_id()),
                 "Should be assigned to submit ledger"
             );
             assert_eq!(

--- a/crates/actors/src/epoch_service.rs
+++ b/crates/actors/src/epoch_service.rs
@@ -667,7 +667,7 @@ impl EpochServiceActor {
         }
         let partition_chunk_count = self.config.storage_config.num_chunks_in_partition;
         let max_chunk_capacity = num_slots * partition_chunk_count;
-        let ledger_size = new_epoch_block.ledgers[ledger].max_chunk_offset;
+        let ledger_size = new_epoch_block.storage_ledgers[ledger].max_chunk_offset;
 
         // Add capacity slots if ledger usage exceeds 50% of partition size from max capacity
         let add_capacity_threshold = max_chunk_capacity.saturating_sub(partition_chunk_count / 2);
@@ -1039,7 +1039,7 @@ mod tests {
 
         // Now create a new epoch block & give the Submit ledger enough size to add a slot
         let mut new_epoch_block = IrysBlockHeader::new_mock_header();
-        new_epoch_block.ledgers[Ledger::Submit].max_chunk_offset = 0;
+        new_epoch_block.storage_ledgers[Ledger::Submit].max_chunk_offset = 0;
 
         // index epoch previous blocks
         let mut height = 1;
@@ -1058,7 +1058,7 @@ mod tests {
         }
 
         new_epoch_block.height = num_blocks_in_epoch;
-        new_epoch_block.ledgers[Ledger::Submit].max_chunk_offset = num_chunks_in_partition / 2;
+        new_epoch_block.storage_ledgers[Ledger::Submit].max_chunk_offset = num_chunks_in_partition / 2;
 
         let _ = epoch_service.handle(NewEpochMessage(new_epoch_block.clone().into()), &mut ctx);
 
@@ -1089,9 +1089,9 @@ mod tests {
         // Simulate a subsequent epoch block that adds multiple ledger slots
         let mut new_epoch_block = IrysBlockHeader::new_mock_header();
         new_epoch_block.height = num_blocks_in_epoch * 2;
-        new_epoch_block.ledgers[Ledger::Submit].max_chunk_offset =
+        new_epoch_block.storage_ledgers[Ledger::Submit].max_chunk_offset =
             (num_chunks_in_partition as f64 * 2.5) as u64;
-        new_epoch_block.ledgers[Ledger::Publish as usize].max_chunk_offset =
+        new_epoch_block.storage_ledgers[Ledger::Publish as usize].max_chunk_offset =
             (num_chunks_in_partition as f64 * 0.75) as u64;
 
         let _ = epoch_service.handle(NewEpochMessage(new_epoch_block.into()), &mut ctx);
@@ -1344,7 +1344,7 @@ mod tests {
 
         // Now create a new epoch block & give the Submit ledger enough size to add a slot
         let mut new_epoch_block = IrysBlockHeader::new_mock_header();
-        new_epoch_block.ledgers[Ledger::Submit].max_chunk_offset = 0;
+        new_epoch_block.storage_ledgers[Ledger::Submit].max_chunk_offset = 0;
 
         // index epoch previous blocks
         let mut height = 1;
@@ -1364,7 +1364,7 @@ mod tests {
 
         new_epoch_block.height =
             (testnet_config.submit_ledger_epoch_length + 1) * num_blocks_in_epoch; // next epoch block, next multiple of num_blocks_in epoch,
-        new_epoch_block.ledgers[Ledger::Submit].max_chunk_offset = num_chunks_in_partition / 2;
+        new_epoch_block.storage_ledgers[Ledger::Submit].max_chunk_offset = num_chunks_in_partition / 2;
 
         let _ = epoch_service_actor
             .send(NewEpochMessage(new_epoch_block.into()))
@@ -1666,7 +1666,7 @@ mod tests {
 
         // Now create a new epoch block & give the Submit ledger enough size to add a slot
         let mut new_epoch_block = IrysBlockHeader::new_mock_header();
-        new_epoch_block.ledgers[Ledger::Submit].max_chunk_offset = 0;
+        new_epoch_block.storage_ledgers[Ledger::Submit].max_chunk_offset = 0;
 
         // index and store in db blocks
         let mut height = 1;
@@ -1675,7 +1675,7 @@ mod tests {
             new_epoch_block.block_hash = H256::random();
 
             if height == (testnet_config.submit_ledger_epoch_length + 1) * num_blocks_in_epoch {
-                new_epoch_block.ledgers[Ledger::Submit].max_chunk_offset =
+                new_epoch_block.storage_ledgers[Ledger::Submit].max_chunk_offset =
                     num_chunks_in_partition / 2;
             }
 
@@ -1829,8 +1829,8 @@ mod tests {
         let total_epoch_messages = 6;
         let mut epoch_num = 1;
         let mut new_epoch_block = IrysBlockHeader::new_mock_header();
-        new_epoch_block.ledgers[Ledger::Submit].max_chunk_offset = num_chunks_in_partition;
-        new_epoch_block.ledgers[Ledger::Publish].max_chunk_offset = num_chunks_in_partition;
+        new_epoch_block.storage_ledgers[Ledger::Submit].max_chunk_offset = num_chunks_in_partition;
+        new_epoch_block.storage_ledgers[Ledger::Publish].max_chunk_offset = num_chunks_in_partition;
 
         let mut height = 1;
         while epoch_num <= total_epoch_messages {

--- a/crates/actors/src/epoch_service.rs
+++ b/crates/actors/src/epoch_service.rs
@@ -622,7 +622,8 @@ impl EpochServiceActor {
         if let Some(mut assignment) = pa.data_partitions.remove(&partition_hash) {
             {
                 // Remove the partition hash from the slots state
-                let ledger: DataLedger = DataLedger::try_from(assignment.ledger_id.unwrap()).unwrap();
+                let ledger: DataLedger =
+                    DataLedger::try_from(assignment.ledger_id.unwrap()).unwrap();
                 let partition_hash = assignment.partition_hash;
                 let slot_index = assignment.slot_index.unwrap();
                 let mut write = self.ledgers.write().unwrap();
@@ -640,7 +641,12 @@ impl EpochServiceActor {
 
     /// Takes a capacity partition hash and updates its `PartitionAssignment`
     /// state to indicate it is part of a data ledger
-    fn assign_partition_to_slot(&self, partition_hash: H256, ledger: DataLedger, slot_index: usize) {
+    fn assign_partition_to_slot(
+        &self,
+        partition_hash: H256,
+        ledger: DataLedger,
+        slot_index: usize,
+    ) {
         debug!(
             "Assigning partition {} to slot {} of ledger {:?}",
             &partition_hash.0.to_base58(),
@@ -658,7 +664,11 @@ impl EpochServiceActor {
     /// For a given ledger indicated by `Ledger`, calculate the number of
     /// partition slots to add to the ledger based on remaining capacity
     /// and data ingress this epoch
-    fn calculate_additional_slots(&self, new_epoch_block: &IrysBlockHeader, ledger: DataLedger) -> u64 {
+    fn calculate_additional_slots(
+        &self,
+        new_epoch_block: &IrysBlockHeader,
+        ledger: DataLedger,
+    ) -> u64 {
         let num_slots: u64;
         {
             let ledgers = self.ledgers.read().unwrap();
@@ -1058,7 +1068,8 @@ mod tests {
         }
 
         new_epoch_block.height = num_blocks_in_epoch;
-        new_epoch_block.storage_ledgers[DataLedger::Submit].max_chunk_offset = num_chunks_in_partition / 2;
+        new_epoch_block.storage_ledgers[DataLedger::Submit].max_chunk_offset =
+            num_chunks_in_partition / 2;
 
         let _ = epoch_service.handle(NewEpochMessage(new_epoch_block.clone().into()), &mut ctx);
 
@@ -1281,7 +1292,9 @@ mod tests {
                 .read()
                 .data_partitions
                 .iter()
-                .find(|(_hash, assignment)| assignment.ledger_id == Some(DataLedger::Submit.get_id()))
+                .find(|(_hash, assignment)| {
+                    assignment.ledger_id == Some(DataLedger::Submit.get_id())
+                })
                 .map(|(hash, _)| hash.clone())
                 .expect("There should be a partition assigned to submit ledger");
 
@@ -1364,7 +1377,8 @@ mod tests {
 
         new_epoch_block.height =
             (testnet_config.submit_ledger_epoch_length + 1) * num_blocks_in_epoch; // next epoch block, next multiple of num_blocks_in epoch,
-        new_epoch_block.storage_ledgers[DataLedger::Submit].max_chunk_offset = num_chunks_in_partition / 2;
+        new_epoch_block.storage_ledgers[DataLedger::Submit].max_chunk_offset =
+            num_chunks_in_partition / 2;
 
         let _ = epoch_service_actor
             .send(NewEpochMessage(new_epoch_block.into()))
@@ -1829,8 +1843,10 @@ mod tests {
         let total_epoch_messages = 6;
         let mut epoch_num = 1;
         let mut new_epoch_block = IrysBlockHeader::new_mock_header();
-        new_epoch_block.storage_ledgers[DataLedger::Submit].max_chunk_offset = num_chunks_in_partition;
-        new_epoch_block.storage_ledgers[DataLedger::Publish].max_chunk_offset = num_chunks_in_partition;
+        new_epoch_block.storage_ledgers[DataLedger::Submit].max_chunk_offset =
+            num_chunks_in_partition;
+        new_epoch_block.storage_ledgers[DataLedger::Publish].max_chunk_offset =
+            num_chunks_in_partition;
 
         let mut height = 1;
         while epoch_num <= total_epoch_messages {

--- a/crates/actors/src/epoch_service.rs
+++ b/crates/actors/src/epoch_service.rs
@@ -405,7 +405,7 @@ impl EpochServiceActor {
             // Create a scope for the write lock to expire with
             {
                 let mut ledgers = self.ledgers.write().unwrap();
-                for ledger in Ledger::iter() {
+                for ledger in DataLedger::iter() {
                     debug!("Allocating 1 slot for {:?}", &ledger);
                     num_data_partitions += ledgers[ledger].allocate_slots(1);
                 }
@@ -454,7 +454,7 @@ impl EpochServiceActor {
     /// Loops though all the ledgers both perm and term, checking to see if any
     /// require additional ledger slots added to accommodate data ingress.
     fn allocate_additional_ledger_slots(&self, new_epoch_block: &IrysBlockHeader) {
-        for ledger in Ledger::iter() {
+        for ledger in DataLedger::iter() {
             let part_slots = self.calculate_additional_slots(new_epoch_block, ledger);
             {
                 let mut ledgers = self.ledgers.write().unwrap();
@@ -506,7 +506,7 @@ impl EpochServiceActor {
         let mut rng = SimpleRNG::new(seed);
 
         // Loop though all of the ledgers processing their slot needs
-        for ledger in Ledger::iter() {
+        for ledger in DataLedger::iter() {
             self.process_slot_needs(ledger, &mut capacity_partitions, &mut rng);
         }
     }
@@ -515,7 +515,7 @@ impl EpochServiceActor {
     /// as needed.
     pub fn process_slot_needs(
         &mut self,
-        ledger: Ledger,
+        ledger: DataLedger,
         capacity_partitions: &mut Vec<H256>,
         rng: &mut SimpleRNG,
     ) {
@@ -566,7 +566,7 @@ impl EpochServiceActor {
     /// data partitions and scaling factor
     fn get_num_capacity_partitions(num_data_partitions: u64, config: &EpochServiceConfig) -> u64 {
         // Every ledger needs at least one slot filled with data partitions
-        let min_count = Ledger::ALL.len() as u64 * config.storage_config.num_partitions_in_slot;
+        let min_count = DataLedger::ALL.len() as u64 * config.storage_config.num_partitions_in_slot;
         let base_count = std::cmp::max(num_data_partitions, min_count);
         let log_10 = (base_count as f64).log10();
         let trunc = truncate_to_3_decimals(log_10);
@@ -622,7 +622,7 @@ impl EpochServiceActor {
         if let Some(mut assignment) = pa.data_partitions.remove(&partition_hash) {
             {
                 // Remove the partition hash from the slots state
-                let ledger: Ledger = Ledger::try_from(assignment.ledger_id.unwrap()).unwrap();
+                let ledger: DataLedger = DataLedger::try_from(assignment.ledger_id.unwrap()).unwrap();
                 let partition_hash = assignment.partition_hash;
                 let slot_index = assignment.slot_index.unwrap();
                 let mut write = self.ledgers.write().unwrap();
@@ -640,7 +640,7 @@ impl EpochServiceActor {
 
     /// Takes a capacity partition hash and updates its `PartitionAssignment`
     /// state to indicate it is part of a data ledger
-    fn assign_partition_to_slot(&self, partition_hash: H256, ledger: Ledger, slot_index: usize) {
+    fn assign_partition_to_slot(&self, partition_hash: H256, ledger: DataLedger, slot_index: usize) {
         debug!(
             "Assigning partition {} to slot {} of ledger {:?}",
             &partition_hash.0.to_base58(),
@@ -658,7 +658,7 @@ impl EpochServiceActor {
     /// For a given ledger indicated by `Ledger`, calculate the number of
     /// partition slots to add to the ledger based on remaining capacity
     /// and data ingress this epoch
-    fn calculate_additional_slots(&self, new_epoch_block: &IrysBlockHeader, ledger: Ledger) -> u64 {
+    fn calculate_additional_slots(&self, new_epoch_block: &IrysBlockHeader, ledger: DataLedger) -> u64 {
         let num_slots: u64;
         {
             let ledgers = self.ledgers.read().unwrap();
@@ -667,7 +667,7 @@ impl EpochServiceActor {
         }
         let partition_chunk_count = self.config.storage_config.num_chunks_in_partition;
         let max_chunk_capacity = num_slots * partition_chunk_count;
-        let ledger_size = new_epoch_block.storage_ledgers[ledger].max_chunk_offset;
+        let ledger_size = new_epoch_block.data_ledgers[ledger].max_chunk_offset;
 
         // Add capacity slots if ledger usage exceeds 50% of partition size from max capacity
         let add_capacity_threshold = max_chunk_capacity.saturating_sub(partition_chunk_count / 2);
@@ -718,7 +718,7 @@ impl EpochServiceActor {
         let sm_paths = storage_module_config.submodule_paths;
         // Configure publish ledger storage
         let mut module_infos = ledgers
-            .get_slots(Ledger::Publish)
+            .get_slots(DataLedger::Publish)
             .iter()
             .flat_map(|slot| &slot.partitions)
             .enumerate()
@@ -736,7 +736,7 @@ impl EpochServiceActor {
 
         // Configure submit ledger storage
         let submit_infos = ledgers
-            .get_slots(Ledger::Submit)
+            .get_slots(DataLedger::Submit)
             .iter()
             .flat_map(|slot| &slot.partitions)
             .enumerate()
@@ -858,12 +858,12 @@ mod tests {
         {
             // Verify the correct number of ledgers have been added
             let ledgers = epoch_service.ledgers.read().unwrap();
-            let expected_ledger_count = Ledger::ALL.len();
+            let expected_ledger_count = DataLedger::ALL.len();
             assert_eq!(ledgers.len(), expected_ledger_count);
 
             // Verify each ledger has one slot and the correct number of partitions
-            let pub_slots = ledgers.get_slots(Ledger::Publish);
-            let sub_slots = ledgers.get_slots(Ledger::Submit);
+            let pub_slots = ledgers.get_slots(DataLedger::Publish);
+            let sub_slots = ledgers.get_slots(DataLedger::Submit);
 
             assert_eq!(pub_slots.len(), 1);
             assert_eq!(sub_slots.len(), 1);
@@ -890,7 +890,7 @@ mod tests {
                         assignment,
                         &PartitionAssignment {
                             partition_hash,
-                            ledger_id: Some(Ledger::Publish.into()),
+                            ledger_id: Some(DataLedger::Publish.into()),
                             slot_index: Some(slot_idx),
                             miner_address,
                         }
@@ -915,7 +915,7 @@ mod tests {
                         assignment,
                         &PartitionAssignment {
                             partition_hash,
-                            ledger_id: Some(Ledger::Submit.into()),
+                            ledger_id: Some(DataLedger::Submit.into()),
                             slot_index: Some(slot_idx),
                             miner_address,
                         }
@@ -1039,7 +1039,7 @@ mod tests {
 
         // Now create a new epoch block & give the Submit ledger enough size to add a slot
         let mut new_epoch_block = IrysBlockHeader::new_mock_header();
-        new_epoch_block.storage_ledgers[Ledger::Submit].max_chunk_offset = 0;
+        new_epoch_block.storage_ledgers[DataLedger::Submit].max_chunk_offset = 0;
 
         // index epoch previous blocks
         let mut height = 1;
@@ -1058,15 +1058,15 @@ mod tests {
         }
 
         new_epoch_block.height = num_blocks_in_epoch;
-        new_epoch_block.storage_ledgers[Ledger::Submit].max_chunk_offset = num_chunks_in_partition / 2;
+        new_epoch_block.storage_ledgers[DataLedger::Submit].max_chunk_offset = num_chunks_in_partition / 2;
 
         let _ = epoch_service.handle(NewEpochMessage(new_epoch_block.clone().into()), &mut ctx);
 
         // Verify each ledger has one slot and the correct number of partitions
         {
             let ledgers = epoch_service.ledgers.read().unwrap();
-            let pub_slots = ledgers.get_slots(Ledger::Publish);
-            let sub_slots = ledgers.get_slots(Ledger::Submit);
+            let pub_slots = ledgers.get_slots(DataLedger::Publish);
+            let sub_slots = ledgers.get_slots(DataLedger::Submit);
             assert_eq!(pub_slots.len(), 1);
             assert_eq!(sub_slots.len(), 3); // TODO: check 1 expired, 2 new slots added
         }
@@ -1089,9 +1089,9 @@ mod tests {
         // Simulate a subsequent epoch block that adds multiple ledger slots
         let mut new_epoch_block = IrysBlockHeader::new_mock_header();
         new_epoch_block.height = num_blocks_in_epoch * 2;
-        new_epoch_block.storage_ledgers[Ledger::Submit].max_chunk_offset =
+        new_epoch_block.storage_ledgers[DataLedger::Submit].max_chunk_offset =
             (num_chunks_in_partition as f64 * 2.5) as u64;
-        new_epoch_block.storage_ledgers[Ledger::Publish as usize].max_chunk_offset =
+        new_epoch_block.storage_ledgers[DataLedger::Publish as usize].max_chunk_offset =
             (num_chunks_in_partition as f64 * 0.75) as u64;
 
         let _ = epoch_service.handle(NewEpochMessage(new_epoch_block.into()), &mut ctx);
@@ -1099,8 +1099,8 @@ mod tests {
         // Validate the correct number of ledgers slots were added to each ledger
         {
             let ledgers = epoch_service.ledgers.read().unwrap();
-            let pub_slots = ledgers.get_slots(Ledger::Publish);
-            let sub_slots = ledgers.get_slots(Ledger::Submit);
+            let pub_slots = ledgers.get_slots(DataLedger::Publish);
+            let sub_slots = ledgers.get_slots(DataLedger::Submit);
             assert_eq!(pub_slots.len(), 3);
             assert_eq!(sub_slots.len(), 7);
             println!("Ledger State: {:#?}", ledgers);
@@ -1281,7 +1281,7 @@ mod tests {
                 .read()
                 .data_partitions
                 .iter()
-                .find(|(_hash, assignment)| assignment.ledger_id == Some(Ledger::Submit.get_id()))
+                .find(|(_hash, assignment)| assignment.ledger_id == Some(DataLedger::Submit.get_id()))
                 .map(|(hash, _)| hash.clone())
                 .expect("There should be a partition assigned to submit ledger");
 
@@ -1294,8 +1294,8 @@ mod tests {
                 .await
                 .unwrap();
 
-            let pub_slots = ledgers.read().get_slots(Ledger::Publish).clone();
-            let sub_slots = ledgers.read().get_slots(Ledger::Submit).clone();
+            let pub_slots = ledgers.read().get_slots(DataLedger::Publish).clone();
+            let sub_slots = ledgers.read().get_slots(DataLedger::Submit).clone();
             assert_eq!(pub_slots.len(), 1);
             assert_eq!(sub_slots.len(), 1);
 
@@ -1344,7 +1344,7 @@ mod tests {
 
         // Now create a new epoch block & give the Submit ledger enough size to add a slot
         let mut new_epoch_block = IrysBlockHeader::new_mock_header();
-        new_epoch_block.storage_ledgers[Ledger::Submit].max_chunk_offset = 0;
+        new_epoch_block.storage_ledgers[DataLedger::Submit].max_chunk_offset = 0;
 
         // index epoch previous blocks
         let mut height = 1;
@@ -1364,7 +1364,7 @@ mod tests {
 
         new_epoch_block.height =
             (testnet_config.submit_ledger_epoch_length + 1) * num_blocks_in_epoch; // next epoch block, next multiple of num_blocks_in epoch,
-        new_epoch_block.storage_ledgers[Ledger::Submit].max_chunk_offset = num_chunks_in_partition / 2;
+        new_epoch_block.storage_ledgers[DataLedger::Submit].max_chunk_offset = num_chunks_in_partition / 2;
 
         let _ = epoch_service_actor
             .send(NewEpochMessage(new_epoch_block.into()))
@@ -1402,8 +1402,8 @@ mod tests {
                 .await
                 .unwrap();
 
-            let pub_slots = ledgers.read().get_slots(Ledger::Publish).clone();
-            let sub_slots = ledgers.read().get_slots(Ledger::Submit).clone();
+            let pub_slots = ledgers.read().get_slots(DataLedger::Publish).clone();
+            let sub_slots = ledgers.read().get_slots(DataLedger::Submit).clone();
             assert_eq!(
                 pub_slots.len(),
                 1,
@@ -1666,7 +1666,7 @@ mod tests {
 
         // Now create a new epoch block & give the Submit ledger enough size to add a slot
         let mut new_epoch_block = IrysBlockHeader::new_mock_header();
-        new_epoch_block.storage_ledgers[Ledger::Submit].max_chunk_offset = 0;
+        new_epoch_block.storage_ledgers[DataLedger::Submit].max_chunk_offset = 0;
 
         // index and store in db blocks
         let mut height = 1;
@@ -1675,7 +1675,7 @@ mod tests {
             new_epoch_block.block_hash = H256::random();
 
             if height == (testnet_config.submit_ledger_epoch_length + 1) * num_blocks_in_epoch {
-                new_epoch_block.storage_ledgers[Ledger::Submit].max_chunk_offset =
+                new_epoch_block.storage_ledgers[DataLedger::Submit].max_chunk_offset =
                     num_chunks_in_partition / 2;
             }
 
@@ -1704,8 +1704,8 @@ mod tests {
         {
             let ledgers = epoch_service.ledgers.read().unwrap();
             debug!("{:#?}", ledgers);
-            let pub_slots = ledgers.get_slots(Ledger::Publish);
-            let sub_slots = ledgers.get_slots(Ledger::Submit);
+            let pub_slots = ledgers.get_slots(DataLedger::Publish);
+            let sub_slots = ledgers.get_slots(DataLedger::Submit);
             assert_eq!(pub_slots.len(), 1);
             assert_eq!(sub_slots.len(), 5); // TODO: check slot 2 expired, 3 new slots added
         }
@@ -1829,8 +1829,8 @@ mod tests {
         let total_epoch_messages = 6;
         let mut epoch_num = 1;
         let mut new_epoch_block = IrysBlockHeader::new_mock_header();
-        new_epoch_block.storage_ledgers[Ledger::Submit].max_chunk_offset = num_chunks_in_partition;
-        new_epoch_block.storage_ledgers[Ledger::Publish].max_chunk_offset = num_chunks_in_partition;
+        new_epoch_block.storage_ledgers[DataLedger::Submit].max_chunk_offset = num_chunks_in_partition;
+        new_epoch_block.storage_ledgers[DataLedger::Publish].max_chunk_offset = num_chunks_in_partition;
 
         let mut height = 1;
         while epoch_num <= total_epoch_messages {

--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -9,7 +9,7 @@ use irys_database::db_cache::data_size_to_chunk_count;
 use irys_database::db_cache::DataRootLRUEntry;
 use irys_database::tables::DataRootLRU;
 use irys_database::tables::{CachedChunks, CachedChunksIndex, IngressProofs};
-use irys_database::{insert_tx_header, tx_header_by_txid, Ledger};
+use irys_database::{insert_tx_header, tx_header_by_txid, DataLedger};
 use irys_storage::StorageModuleVec;
 use irys_types::irys::IrysSigner;
 use irys_types::{
@@ -521,12 +521,12 @@ impl Handler<BlockConfirmedMessage> for MempoolService {
             let block = &msg.0;
             let all_txs = &msg.1;
 
-            for txid in block.storage_ledgers[Ledger::Submit].tx_ids.iter() {
+            for txid in block.data_ledgers[DataLedger::Submit].tx_ids.iter() {
                 // Remove the submit tx from the pending valid_tx pool
                 self.valid_tx.remove(txid);
             }
 
-            let published_txids = &block.storage_ledgers[Ledger::Publish].tx_ids.0;
+            let published_txids = &block.data_ledgers[DataLedger::Publish].tx_ids.0;
 
             // Loop though the promoted transactions and remove their ingress proofs
             // from the mempool. In the future on a multi node network we may keep
@@ -540,7 +540,7 @@ impl Handler<BlockConfirmedMessage> for MempoolService {
                     })
                     .unwrap();
 
-                for (i, txid) in block.storage_ledgers[Ledger::Publish].tx_ids.0.iter().enumerate() {
+                for (i, txid) in block.data_ledgers[DataLedger::Publish].tx_ids.0.iter().enumerate() {
                     // Retrieve the promoted transactions header
                     let mut tx_header = match tx_header_by_txid(&mut_tx, txid) {
                         Ok(Some(header)) => header,
@@ -556,7 +556,7 @@ impl Handler<BlockConfirmedMessage> for MempoolService {
 
                     // TODO: In a single node world there is only one ingress proof
                     // per promoted tx, but in the future there will be multiple proofs.
-                    let proofs = block.storage_ledgers[Ledger::Publish].proofs.as_ref().unwrap();
+                    let proofs = block.data_ledgers[DataLedger::Publish].proofs.as_ref().unwrap();
                     let proof = proofs.0[i].clone();
                     tx_header.ingress_proofs = Some(proof);
 

--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -540,7 +540,12 @@ impl Handler<BlockConfirmedMessage> for MempoolService {
                     })
                     .unwrap();
 
-                for (i, txid) in block.data_ledgers[DataLedger::Publish].tx_ids.0.iter().enumerate() {
+                for (i, txid) in block.data_ledgers[DataLedger::Publish]
+                    .tx_ids
+                    .0
+                    .iter()
+                    .enumerate()
+                {
                     // Retrieve the promoted transactions header
                     let mut tx_header = match tx_header_by_txid(&mut_tx, txid) {
                         Ok(Some(header)) => header,
@@ -556,7 +561,10 @@ impl Handler<BlockConfirmedMessage> for MempoolService {
 
                     // TODO: In a single node world there is only one ingress proof
                     // per promoted tx, but in the future there will be multiple proofs.
-                    let proofs = block.data_ledgers[DataLedger::Publish].proofs.as_ref().unwrap();
+                    let proofs = block.data_ledgers[DataLedger::Publish]
+                        .proofs
+                        .as_ref()
+                        .unwrap();
                     let proof = proofs.0[i].clone();
                     tx_header.ingress_proofs = Some(proof);
 

--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -521,12 +521,12 @@ impl Handler<BlockConfirmedMessage> for MempoolService {
             let block = &msg.0;
             let all_txs = &msg.1;
 
-            for txid in block.ledgers[Ledger::Submit].tx_ids.iter() {
+            for txid in block.storage_ledgers[Ledger::Submit].tx_ids.iter() {
                 // Remove the submit tx from the pending valid_tx pool
                 self.valid_tx.remove(txid);
             }
 
-            let published_txids = &block.ledgers[Ledger::Publish].tx_ids.0;
+            let published_txids = &block.storage_ledgers[Ledger::Publish].tx_ids.0;
 
             // Loop though the promoted transactions and remove their ingress proofs
             // from the mempool. In the future on a multi node network we may keep
@@ -540,7 +540,7 @@ impl Handler<BlockConfirmedMessage> for MempoolService {
                     })
                     .unwrap();
 
-                for (i, txid) in block.ledgers[Ledger::Publish].tx_ids.0.iter().enumerate() {
+                for (i, txid) in block.storage_ledgers[Ledger::Publish].tx_ids.0.iter().enumerate() {
                     // Retrieve the promoted transactions header
                     let mut tx_header = match tx_header_by_txid(&mut_tx, txid) {
                         Ok(Some(header)) => header,
@@ -556,7 +556,7 @@ impl Handler<BlockConfirmedMessage> for MempoolService {
 
                     // TODO: In a single node world there is only one ingress proof
                     // per promoted tx, but in the future there will be multiple proofs.
-                    let proofs = block.ledgers[Ledger::Publish].proofs.as_ref().unwrap();
+                    let proofs = block.storage_ledgers[Ledger::Publish].proofs.as_ref().unwrap();
                     let proof = proofs.0[i].clone();
                     tx_header.ingress_proofs = Some(proof);
 

--- a/crates/actors/src/vdf_service.rs
+++ b/crates/actors/src/vdf_service.rs
@@ -163,7 +163,9 @@ mod tests {
 
     use actix::SystemRegistry;
     use irys_config::IrysNodeConfig;
-    use irys_database::{open_or_create_db, tables::IrysTables, BlockIndex, Initialized, DataLedger};
+    use irys_database::{
+        open_or_create_db, tables::IrysTables, BlockIndex, DataLedger, Initialized,
+    };
     use irys_storage::ii;
     use irys_testing_utils::utils::setup_tracing_and_temp_dir;
     use irys_types::{H256List, IrysBlockHeader, StorageConfig, H256};

--- a/crates/actors/src/vdf_service.rs
+++ b/crates/actors/src/vdf_service.rs
@@ -163,7 +163,7 @@ mod tests {
 
     use actix::SystemRegistry;
     use irys_config::IrysNodeConfig;
-    use irys_database::{open_or_create_db, tables::IrysTables, BlockIndex, Initialized, Ledger};
+    use irys_database::{open_or_create_db, tables::IrysTables, BlockIndex, Initialized, DataLedger};
     use irys_storage::ii;
     use irys_testing_utils::utils::setup_tracing_and_temp_dir;
     use irys_types::{H256List, IrysBlockHeader, StorageConfig, H256};
@@ -265,7 +265,7 @@ mod tests {
             .unwrap();
 
         let mut new_epoch_block = IrysBlockHeader::new_mock_header();
-        new_epoch_block.storage_ledgers[Ledger::Submit].max_chunk_offset = 0;
+        new_epoch_block.storage_ledgers[DataLedger::Submit].max_chunk_offset = 0;
 
         let now = Instant::now();
         // index and store in db blocks

--- a/crates/actors/src/vdf_service.rs
+++ b/crates/actors/src/vdf_service.rs
@@ -265,7 +265,7 @@ mod tests {
             .unwrap();
 
         let mut new_epoch_block = IrysBlockHeader::new_mock_header();
-        new_epoch_block.ledgers[Ledger::Submit].max_chunk_offset = 0;
+        new_epoch_block.storage_ledgers[Ledger::Submit].max_chunk_offset = 0;
 
         let now = Instant::now();
         // index and store in db blocks

--- a/crates/actors/src/vdf_service.rs
+++ b/crates/actors/src/vdf_service.rs
@@ -267,7 +267,7 @@ mod tests {
             .unwrap();
 
         let mut new_epoch_block = IrysBlockHeader::new_mock_header();
-        new_epoch_block.storage_ledgers[DataLedger::Submit].max_chunk_offset = 0;
+        new_epoch_block.data_ledgers[DataLedger::Submit].max_chunk_offset = 0;
 
         let now = Instant::now();
         // index and store in db blocks

--- a/crates/api-server/src/routes/get_chunk.rs
+++ b/crates/api-server/src/routes/get_chunk.rs
@@ -5,7 +5,7 @@ use actix_web::{
     HttpResponse,
 };
 
-use irys_database::Ledger;
+use irys_database::DataLedger;
 use irys_types::{ChunkFormat, H256};
 use serde::Deserialize;
 
@@ -19,7 +19,7 @@ pub async fn get_chunk_by_ledger_offset(
     state: web::Data<ApiState>,
     path: web::Path<LedgerChunkApiPath>,
 ) -> actix_web::Result<HttpResponse> {
-    let ledger = match Ledger::try_from(path.ledger_id) {
+    let ledger = match DataLedger::try_from(path.ledger_id) {
         Ok(l) => l,
         Err(e) => return Ok(HttpResponse::BadRequest().body(format!("Invalid ledger id: {}", e))),
     };
@@ -49,7 +49,7 @@ pub async fn get_chunk_by_data_root_offset(
     state: web::Data<ApiState>,
     path: web::Path<DataRootChunkApiPath>,
 ) -> actix_web::Result<HttpResponse> {
-    let ledger = match Ledger::try_from(path.ledger_id) {
+    let ledger = match DataLedger::try_from(path.ledger_id) {
         Ok(l) => l,
         Err(e) => return Ok(HttpResponse::BadRequest().body(format!("Invalid ledger id: {}", e))),
     };

--- a/crates/api-server/src/routes/price.rs
+++ b/crates/api-server/src/routes/price.rs
@@ -3,7 +3,7 @@ use actix_web::{
     HttpResponse,
 };
 use irys_config::{PRICE_PER_CHUNK_5_EPOCH, PRICE_PER_CHUNK_PERM};
-use irys_database::Ledger;
+use irys_database::DataLedger;
 
 use crate::ApiState;
 
@@ -12,7 +12,7 @@ pub async fn get_price(
     state: web::Data<ApiState>,
 ) -> actix_web::Result<HttpResponse> {
     let size = path.1;
-    let ledger = Ledger::from_url(&path.0);
+    let ledger = DataLedger::from_url(&path.0);
 
     let num_of_chunks = if size < state.config.chunk_size {
         1u128
@@ -23,8 +23,8 @@ pub async fn get_price(
 
     if let Ok(l) = ledger {
         let final_price = match l {
-            Ledger::Publish => PRICE_PER_CHUNK_PERM,
-            Ledger::Submit => PRICE_PER_CHUNK_5_EPOCH,
+            DataLedger::Publish => PRICE_PER_CHUNK_PERM,
+            DataLedger::Submit => PRICE_PER_CHUNK_5_EPOCH,
         } * num_of_chunks;
 
         Ok(HttpResponse::Ok().body(final_price.to_string()))

--- a/crates/api-server/src/routes/tx.rs
+++ b/crates/api-server/src/routes/tx.rs
@@ -6,7 +6,7 @@ use actix_web::{
 };
 use awc::http::StatusCode;
 use irys_actors::mempool_service::{TxIngressError, TxIngressMessage};
-use irys_database::{database, Ledger};
+use irys_database::{database, DataLedger};
 use irys_types::{u64_stringify, IrysTransactionHeader, H256};
 use reth_db::Database;
 use serde::{Deserialize, Serialize};
@@ -99,7 +99,7 @@ pub async fn get_tx_local_start_offset(
     let tx_id: H256 = path.into_inner();
     info!("Get tx data metadata by tx_id: {}", tx_id);
     let tx_header = get_tx_header(&state, tx_id)?;
-    let ledger = Ledger::try_from(tx_header.ledger_id).unwrap();
+    let ledger = DataLedger::try_from(tx_header.ledger_id).unwrap();
 
     match state
         .chunk_provider

--- a/crates/chain/tests/promotion/data_promotion_basic.rs
+++ b/crates/chain/tests/promotion/data_promotion_basic.rs
@@ -15,7 +15,7 @@ async fn heavy_data_promotion_test() {
     use base58::ToBase58;
     use irys_actors::packing::wait_for_packing;
     use irys_api_server::{routes, ApiState};
-    use irys_database::Ledger;
+    use irys_database::DataLedger;
     use irys_testing_utils::utils::setup_tracing_and_temp_dir;
     use irys_types::{
         irys::IrysSigner, IrysTransaction, IrysTransactionHeader, LedgerChunkOffset, StorageConfig,

--- a/crates/chain/tests/promotion/data_promotion_basic.rs
+++ b/crates/chain/tests/promotion/data_promotion_basic.rs
@@ -283,21 +283,21 @@ async fn heavy_data_promotion_test() {
 
     if block_tx1.block_hash == block_tx2.block_hash {
         // Extract the transaction order
-        let txid_1 = block_tx1.ledgers[Ledger::Publish].tx_ids.0[0];
-        let txid_2 = block_tx1.ledgers[Ledger::Publish].tx_ids.0[1];
+        let txid_1 = block_tx1.storage_ledgers[Ledger::Publish].tx_ids.0[0];
+        let txid_2 = block_tx1.storage_ledgers[Ledger::Publish].tx_ids.0[1];
         first_tx_index = txs.iter().position(|tx| tx.header.id == txid_1).unwrap();
         next_tx_index = txs.iter().position(|tx| tx.header.id == txid_2).unwrap();
         println!("1:{}", block_tx1);
     } else if block_tx1.height > block_tx2.height {
-        let txid_1 = block_tx2.ledgers[Ledger::Publish].tx_ids.0[0];
-        let txid_2 = block_tx1.ledgers[Ledger::Publish].tx_ids.0[0];
+        let txid_1 = block_tx2.storage_ledgers[Ledger::Publish].tx_ids.0[0];
+        let txid_2 = block_tx1.storage_ledgers[Ledger::Publish].tx_ids.0[0];
         first_tx_index = txs.iter().position(|tx| tx.header.id == txid_1).unwrap();
         next_tx_index = txs.iter().position(|tx| tx.header.id == txid_2).unwrap();
         println!("1:{}", block_tx2);
         println!("2:{}", block_tx1);
     } else {
-        let txid_1 = block_tx1.ledgers[Ledger::Publish].tx_ids.0[0];
-        let txid_2 = block_tx2.ledgers[Ledger::Publish].tx_ids.0[0];
+        let txid_1 = block_tx1.storage_ledgers[Ledger::Publish].tx_ids.0[0];
+        let txid_2 = block_tx2.storage_ledgers[Ledger::Publish].tx_ids.0[0];
         first_tx_index = txs.iter().position(|tx| tx.header.id == txid_1).unwrap();
         next_tx_index = txs.iter().position(|tx| tx.header.id == txid_2).unwrap();
         println!("1:{}", block_tx1);

--- a/crates/chain/tests/promotion/data_promotion_basic.rs
+++ b/crates/chain/tests/promotion/data_promotion_basic.rs
@@ -255,7 +255,7 @@ async fn heavy_data_promotion_test() {
     // wait for the first set of chunks chunk to appear in the publish ledger
     for _attempts in 1..20 {
         if let Some(_packed_chunk) =
-            get_chunk(&app, Ledger::Publish, LedgerChunkOffset::from(0)).await
+            get_chunk(&app, DataLedger::Publish, LedgerChunkOffset::from(0)).await
         {
             println!("First set of chunks found!");
             break;
@@ -266,7 +266,7 @@ async fn heavy_data_promotion_test() {
     // wait for the second set of chunks to appear in the publish ledger
     for _attempts in 1..20 {
         if let Some(_packed_chunk) =
-            get_chunk(&app, Ledger::Publish, LedgerChunkOffset::from(3)).await
+            get_chunk(&app, DataLedger::Publish, LedgerChunkOffset::from(3)).await
         {
             println!("Second set of chunks found!");
             break;
@@ -275,29 +275,29 @@ async fn heavy_data_promotion_test() {
     }
 
     let db = &node_context.db.clone();
-    let block_tx1 = get_block_parent(txs[0].header.id, Ledger::Publish, db).unwrap();
-    let block_tx2 = get_block_parent(txs[2].header.id, Ledger::Publish, db).unwrap();
+    let block_tx1 = get_block_parent(txs[0].header.id, DataLedger::Publish, db).unwrap();
+    let block_tx2 = get_block_parent(txs[2].header.id, DataLedger::Publish, db).unwrap();
 
     let first_tx_index: usize;
     let next_tx_index: usize;
 
     if block_tx1.block_hash == block_tx2.block_hash {
         // Extract the transaction order
-        let txid_1 = block_tx1.storage_ledgers[Ledger::Publish].tx_ids.0[0];
-        let txid_2 = block_tx1.storage_ledgers[Ledger::Publish].tx_ids.0[1];
+        let txid_1 = block_tx1.data_ledgers[DataLedger::Publish].tx_ids.0[0];
+        let txid_2 = block_tx1.data_ledgers[DataLedger::Publish].tx_ids.0[1];
         first_tx_index = txs.iter().position(|tx| tx.header.id == txid_1).unwrap();
         next_tx_index = txs.iter().position(|tx| tx.header.id == txid_2).unwrap();
         println!("1:{}", block_tx1);
     } else if block_tx1.height > block_tx2.height {
-        let txid_1 = block_tx2.storage_ledgers[Ledger::Publish].tx_ids.0[0];
-        let txid_2 = block_tx1.storage_ledgers[Ledger::Publish].tx_ids.0[0];
+        let txid_1 = block_tx2.data_ledgers[DataLedger::Publish].tx_ids.0[0];
+        let txid_2 = block_tx1.data_ledgers[DataLedger::Publish].tx_ids.0[0];
         first_tx_index = txs.iter().position(|tx| tx.header.id == txid_1).unwrap();
         next_tx_index = txs.iter().position(|tx| tx.header.id == txid_2).unwrap();
         println!("1:{}", block_tx2);
         println!("2:{}", block_tx1);
     } else {
-        let txid_1 = block_tx1.storage_ledgers[Ledger::Publish].tx_ids.0[0];
-        let txid_2 = block_tx2.storage_ledgers[Ledger::Publish].tx_ids.0[0];
+        let txid_1 = block_tx1.data_ledgers[DataLedger::Publish].tx_ids.0[0];
+        let txid_2 = block_tx2.data_ledgers[DataLedger::Publish].tx_ids.0[0];
         first_tx_index = txs.iter().position(|tx| tx.header.id == txid_1).unwrap();
         next_tx_index = txs.iter().position(|tx| tx.header.id == txid_2).unwrap();
         println!("1:{}", block_tx1);

--- a/crates/chain/tests/promotion/data_promotion_double.rs
+++ b/crates/chain/tests/promotion/data_promotion_double.rs
@@ -325,7 +325,7 @@ async fn heavy_double_root_data_promotion_test() {
     //     println!("2:{}", block_tx2);
     // }
 
-    let txid_1 = block_tx1.storage_ledgers[DataLedger::Publish].tx_ids.0[0];
+    let txid_1 = block_tx1.data_ledgers[DataLedger::Publish].tx_ids.0[0];
     //     let txid_2 = block_tx2.ledgers[Ledger::Publish].tx_ids.0[0];
     first_tx_index = txs.iter().position(|tx| tx.header.id == txid_1).unwrap();
     //     next_tx_index = txs.iter().position(|tx| tx.header.id == txid_2).unwrap();
@@ -533,7 +533,7 @@ async fn heavy_double_root_data_promotion_test() {
 
     let first_tx_index: usize;
 
-    let txid_1 = block_tx1.storage_ledgers[DataLedger::Publish].tx_ids.0[0];
+    let txid_1 = block_tx1.data_ledgers[DataLedger::Publish].tx_ids.0[0];
     //     let txid_2 = block_tx2.ledgers[Ledger::Publish].tx_ids.0[0];
     first_tx_index = txs.iter().position(|tx| tx.header.id == txid_1).unwrap();
     //     next_tx_index = txs.iter().position(|tx| tx.header.id == txid_2).unwrap();

--- a/crates/chain/tests/promotion/data_promotion_double.rs
+++ b/crates/chain/tests/promotion/data_promotion_double.rs
@@ -2,7 +2,7 @@ use crate::utils::{mine_blocks, post_chunk};
 use awc::http::StatusCode;
 use irys_chain::start_irys_node;
 use irys_config::IrysNodeConfig;
-use irys_database::Ledger;
+use irys_database::DataLedger;
 
 use irys_types::Config;
 use tracing::debug;
@@ -276,7 +276,7 @@ async fn heavy_double_root_data_promotion_test() {
     // wait for the first set of chunks chunk to appear in the publish ledger
     for _attempts in 1..20 {
         if let Some(_packed_chunk) =
-            get_chunk(&app, Ledger::Publish, LedgerChunkOffset::from(0)).await
+            get_chunk(&app, DataLedger::Publish, LedgerChunkOffset::from(0)).await
         {
             println!("First set of chunks found!");
             break;
@@ -287,7 +287,7 @@ async fn heavy_double_root_data_promotion_test() {
     // wait for the second set of chunks to appear in the publish ledger
     for _attempts in 1..20 {
         if let Some(_packed_chunk) =
-            get_chunk(&app, Ledger::Publish, LedgerChunkOffset::from(3)).await
+            get_chunk(&app, DataLedger::Publish, LedgerChunkOffset::from(3)).await
         {
             println!("Second set of chunks found!");
             break;
@@ -296,7 +296,7 @@ async fn heavy_double_root_data_promotion_test() {
     }
 
     let db = &node_context.db.clone();
-    let block_tx1 = get_block_parent(txs[0].header.id, Ledger::Publish, db).unwrap();
+    let block_tx1 = get_block_parent(txs[0].header.id, DataLedger::Publish, db).unwrap();
     // let block_tx2 = get_block_parent(txs[2].header.id, Ledger::Publish, db).unwrap();
 
     let first_tx_index: usize;
@@ -325,7 +325,7 @@ async fn heavy_double_root_data_promotion_test() {
     //     println!("2:{}", block_tx2);
     // }
 
-    let txid_1 = block_tx1.storage_ledgers[Ledger::Publish].tx_ids.0[0];
+    let txid_1 = block_tx1.storage_ledgers[DataLedger::Publish].tx_ids.0[0];
     //     let txid_2 = block_tx2.ledgers[Ledger::Publish].tx_ids.0[0];
     first_tx_index = txs.iter().position(|tx| tx.header.id == txid_1).unwrap();
     //     next_tx_index = txs.iter().position(|tx| tx.header.id == txid_2).unwrap();
@@ -519,7 +519,7 @@ async fn heavy_double_root_data_promotion_test() {
     // wait for the second set of chunks to appear in the publish ledger
     for _attempts in 1..20 {
         if let Some(_packed_chunk) =
-            get_chunk(&app, Ledger::Publish, LedgerChunkOffset::from(3)).await
+            get_chunk(&app, DataLedger::Publish, LedgerChunkOffset::from(3)).await
         {
             println!("Second set of chunks found!");
             break;
@@ -528,12 +528,12 @@ async fn heavy_double_root_data_promotion_test() {
     }
 
     let db = &node_context.db.clone();
-    let block_tx1 = get_block_parent(txs[0].header.id, Ledger::Publish, db).unwrap();
+    let block_tx1 = get_block_parent(txs[0].header.id, DataLedger::Publish, db).unwrap();
     // let block_tx2 = get_block_parent(txs[2].header.id, Ledger::Publish, db).unwrap();
 
     let first_tx_index: usize;
 
-    let txid_1 = block_tx1.storage_ledgers[Ledger::Publish].tx_ids.0[0];
+    let txid_1 = block_tx1.storage_ledgers[DataLedger::Publish].tx_ids.0[0];
     //     let txid_2 = block_tx2.ledgers[Ledger::Publish].tx_ids.0[0];
     first_tx_index = txs.iter().position(|tx| tx.header.id == txid_1).unwrap();
     //     next_tx_index = txs.iter().position(|tx| tx.header.id == txid_2).unwrap();

--- a/crates/chain/tests/promotion/data_promotion_double.rs
+++ b/crates/chain/tests/promotion/data_promotion_double.rs
@@ -325,7 +325,7 @@ async fn heavy_double_root_data_promotion_test() {
     //     println!("2:{}", block_tx2);
     // }
 
-    let txid_1 = block_tx1.ledgers[Ledger::Publish].tx_ids.0[0];
+    let txid_1 = block_tx1.storage_ledgers[Ledger::Publish].tx_ids.0[0];
     //     let txid_2 = block_tx2.ledgers[Ledger::Publish].tx_ids.0[0];
     first_tx_index = txs.iter().position(|tx| tx.header.id == txid_1).unwrap();
     //     next_tx_index = txs.iter().position(|tx| tx.header.id == txid_2).unwrap();
@@ -533,7 +533,7 @@ async fn heavy_double_root_data_promotion_test() {
 
     let first_tx_index: usize;
 
-    let txid_1 = block_tx1.ledgers[Ledger::Publish].tx_ids.0[0];
+    let txid_1 = block_tx1.storage_ledgers[Ledger::Publish].tx_ids.0[0];
     //     let txid_2 = block_tx2.ledgers[Ledger::Publish].tx_ids.0[0];
     first_tx_index = txs.iter().position(|tx| tx.header.id == txid_1).unwrap();
     //     next_tx_index = txs.iter().position(|tx| tx.header.id == txid_2).unwrap();

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -299,7 +299,11 @@ pub fn get_block_parent(
 
     // Loop tough all the blocks and find the one that contains the txid
     for block_header in block_headers.values() {
-        if block_header.ledgers[ledger].tx_ids.0.contains(&txid) {
+        if block_header.storage_ledgers[ledger]
+            .tx_ids
+            .0
+            .contains(&txid)
+        {
             return Some(IrysBlockHeader::from(block_header.clone()));
         }
     }

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -26,7 +26,7 @@ use actix_web::{
     test,
 };
 use awc::{body::MessageBody, http::StatusCode};
-use irys_database::{tables::IrysBlockHeaders, Ledger};
+use irys_database::{tables::IrysBlockHeaders, DataLedger};
 use irys_types::{
     Base64, DatabaseProvider, IrysBlockHeader, IrysTransaction, LedgerChunkOffset, PackedChunk,
     UnpackedChunk,
@@ -237,7 +237,7 @@ pub async fn post_chunk<T, B>(
 /// Returns `Some(PackedChunk)` if found (HTTP 200), `None` otherwise.
 pub async fn get_chunk<T, B>(
     app: &T,
-    ledger: Ledger,
+    ledger: DataLedger,
     chunk_offset: LedgerChunkOffset,
 ) -> Option<PackedChunk>
 where
@@ -266,7 +266,7 @@ where
 /// Returns None if the transaction isn't found in any block.
 pub fn get_block_parent(
     txid: H256,
-    ledger: Ledger,
+    ledger: DataLedger,
     db: &DatabaseProvider,
 ) -> Option<IrysBlockHeader> {
     let read_tx = db
@@ -299,7 +299,7 @@ pub fn get_block_parent(
 
     // Loop tough all the blocks and find the one that contains the txid
     for block_header in block_headers.values() {
-        if block_header.storage_ledgers[ledger]
+        if block_header.data_ledgers[ledger]
             .tx_ids
             .0
             .contains(&txid)
@@ -323,7 +323,7 @@ pub async fn verify_published_chunk<T, B>(
     T: Service<actix_http::Request, Response = ServiceResponse<B>, Error = actix_web::Error>,
     B: MessageBody,
 {
-    if let Some(packed_chunk) = get_chunk(&app, Ledger::Publish, chunk_offset).await {
+    if let Some(packed_chunk) = get_chunk(&app, DataLedger::Publish, chunk_offset).await {
         let unpacked_chunk = unpack(
             &packed_chunk,
             storage_config.entropy_packing_iterations,

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -299,11 +299,7 @@ pub fn get_block_parent(
 
     // Loop tough all the blocks and find the one that contains the txid
     for block_header in block_headers.values() {
-        if block_header.data_ledgers[ledger]
-            .tx_ids
-            .0
-            .contains(&txid)
-        {
+        if block_header.data_ledgers[ledger].tx_ids.0.contains(&txid) {
             return Some(IrysBlockHeader::from(block_header.clone()));
         }
     }

--- a/crates/database/src/block_index_data.rs
+++ b/crates/database/src/block_index_data.rs
@@ -1,6 +1,6 @@
 //! Manages a list of `{block_hash, weave_size, tx_root}`entries, indexed by
 //! block height.
-use crate::data_ledger::Ledger;
+use crate::data_ledger::DataLedger;
 use actix::dev::MessageResponse;
 use base58::ToBase58;
 use eyre::Result;
@@ -139,7 +139,7 @@ impl BlockIndex<Initialized> {
 
     /// For a given byte offset in a ledger, what block was responsible for adding
     /// that byte to the data ledger?
-    pub fn get_block_bounds(&self, ledger: Ledger, chunk_offset: u64) -> BlockBounds {
+    pub fn get_block_bounds(&self, ledger: DataLedger, chunk_offset: u64) -> BlockBounds {
         let mut block_bounds: BlockBounds = Default::default();
         block_bounds.ledger = ledger;
 
@@ -157,7 +157,7 @@ impl BlockIndex<Initialized> {
 
     pub fn get_block_index_item(
         &self,
-        ledger: Ledger,
+        ledger: DataLedger,
         chunk_offset: u64,
     ) -> Result<(usize, &BlockIndexItem)> {
         let result = self.items.binary_search_by(|item| {
@@ -197,7 +197,7 @@ pub struct BlockBounds {
     /// Block height where these bounds apply
     pub height: u128,
     /// Target ledger (Publish or Submit)
-    pub ledger: Ledger,
+    pub ledger: DataLedger,
     /// First chunk offset included in this block (inclusive)
     pub start_chunk_offset: u64,
     /// Final chunk offset after processing block transactions
@@ -240,16 +240,16 @@ impl LedgerIndexItem {
     }
 }
 
-impl Index<Ledger> for Vec<LedgerIndexItem> {
+impl Index<DataLedger> for Vec<LedgerIndexItem> {
     type Output = LedgerIndexItem;
 
-    fn index(&self, ledger: Ledger) -> &Self::Output {
+    fn index(&self, ledger: DataLedger) -> &Self::Output {
         &self[ledger as usize]
     }
 }
 
-impl IndexMut<Ledger> for Vec<LedgerIndexItem> {
-    fn index_mut(&mut self, ledger: Ledger) -> &mut Self::Output {
+impl IndexMut<DataLedger> for Vec<LedgerIndexItem> {
+    fn index_mut(&mut self, ledger: DataLedger) -> &mut Self::Output {
         &mut self[ledger as usize]
     }
 }
@@ -393,7 +393,7 @@ mod tests {
     use super::BlockIndex;
     use crate::{
         block_index_data::{ensure_path_exists, save_block_index},
-        data_ledger::Ledger,
+        data_ledger::DataLedger,
         BlockBounds, BlockIndexItem, LedgerIndexItem,
     };
     use irys_config::IrysNodeConfig;
@@ -466,27 +466,27 @@ mod tests {
         assert_eq!(*block_index.get_item(1).unwrap(), block_items[1]);
         assert_eq!(*block_index.get_item(2).unwrap(), block_items[2]);
 
-        let block_bounds = block_index.get_block_bounds(Ledger::Publish, 150);
+        let block_bounds = block_index.get_block_bounds(DataLedger::Publish, 150);
         assert_eq!(
             block_bounds,
             BlockBounds {
                 height: 1,
-                ledger: Ledger::Publish,
+                ledger: DataLedger::Publish,
                 start_chunk_offset: 100,
                 end_chunk_offset: 200,
-                tx_root: block_items[1].ledgers[Ledger::Publish].tx_root
+                tx_root: block_items[1].ledgers[DataLedger::Publish].tx_root
             }
         );
 
-        let block_bounds = block_index.get_block_bounds(Ledger::Submit, 1000);
+        let block_bounds = block_index.get_block_bounds(DataLedger::Submit, 1000);
         assert_eq!(
             block_bounds,
             BlockBounds {
                 height: 1,
-                ledger: Ledger::Submit,
+                ledger: DataLedger::Submit,
                 start_chunk_offset: 1000,
                 end_chunk_offset: 2000,
-                tx_root: block_items[1].ledgers[Ledger::Submit].tx_root
+                tx_root: block_items[1].ledgers[DataLedger::Submit].tx_root
             }
         );
 

--- a/crates/reth-node-bridge/src/precompile/read_bytes.rs
+++ b/crates/reth-node-bridge/src/precompile/read_bytes.rs
@@ -168,7 +168,7 @@ pub fn read_bytes_range(
     for i in translated_chunks_start_offset..translated_chunks_end_offset {
         let chunk = state_provider
             .chunk_provider
-            .get_chunk_by_ledger_offset(irys_database::Ledger::Publish, i.into())
+            .get_chunk_by_ledger_offset(irys_database::DataLedger::Publish, i.into())
             .map_err(|e| {
                 PrecompileErrors::Error(PrecompileError::Other(format!(
                     "Error reading chunk with part offset {} - {}",

--- a/crates/storage/src/chunk_provider.rs
+++ b/crates/storage/src/chunk_provider.rs
@@ -1,5 +1,5 @@
 use eyre::OptionExt;
-use irys_database::Ledger;
+use irys_database::DataLedger;
 use irys_types::{
     ChunkFormat, DataRoot, LedgerChunkOffset, PackedChunk, StorageConfig, TxChunkOffset,
 };
@@ -34,7 +34,7 @@ impl ChunkProvider {
     /// Retrieves a chunk from a ledger
     pub fn get_chunk_by_ledger_offset(
         &self,
-        ledger: Ledger,
+        ledger: DataLedger,
         ledger_offset: LedgerChunkOffset,
     ) -> eyre::Result<Option<PackedChunk>> {
         // Get basic chunk info
@@ -46,7 +46,7 @@ impl ChunkProvider {
     /// Retrieves a chunk by [`DataRoot`]
     pub fn get_chunk_by_data_root(
         &self,
-        ledger: Ledger,
+        ledger: DataLedger,
         data_root: DataRoot,
         data_tx_offset: TxChunkOffset,
     ) -> eyre::Result<Option<ChunkFormat>> {
@@ -97,7 +97,7 @@ impl ChunkProvider {
 
     pub fn get_ledger_offsets_for_data_root(
         &self,
-        ledger: Ledger,
+        ledger: DataLedger,
         data_root: DataRoot,
     ) -> eyre::Result<Option<Vec<u64>>> {
         debug!(
@@ -146,8 +146,8 @@ mod tests {
     use irys_testing_utils::utils::setup_tracing_and_temp_dir;
     use irys_types::{
         irys::IrysSigner, ledger_chunk_offset_ii, partition::PartitionAssignment,
-        partition_chunk_offset_ie, Base64, Config, LedgerChunkRange, PartitionChunkOffset,
-        StorageTransactionLedger, UnpackedChunk,
+        partition_chunk_offset_ie, Base64, Config, DataTransactionLedger, LedgerChunkRange,
+        PartitionChunkOffset, UnpackedChunk,
     };
     use nodit::interval::{ie, ii};
     use rand::Rng as _;
@@ -189,8 +189,7 @@ mod tests {
 
         // fake the tx_path
         // Create a tx_root (and paths) from the tx
-        let (_tx_root, proofs) =
-            StorageTransactionLedger::merklize_tx_root(&vec![tx.header.clone()]);
+        let (_tx_root, proofs) = DataTransactionLedger::merklize_tx_root(&vec![tx.header.clone()]);
 
         let tx_path = proofs[0].proof.clone();
 
@@ -231,7 +230,7 @@ mod tests {
 
         for original_chunk in unpacked_chunks {
             let chunk = chunk_provider
-                .get_chunk_by_data_root(Ledger::Publish, data_root, original_chunk.tx_offset)?
+                .get_chunk_by_data_root(DataLedger::Publish, data_root, original_chunk.tx_offset)?
                 .unwrap();
             // let chunk_size = config.chunk_size as usize;
             // let start = chunk_offset as usize * chunk_size;

--- a/crates/storage/src/storage_module.rs
+++ b/crates/storage/src/storage_module.rs
@@ -46,7 +46,7 @@ use irys_database::{
         clear_submodule_database, create_or_open_submodule_db, get_data_path_by_offset,
         get_start_offsets_by_data_root, get_tx_path_by_offset, tables::RelativeStartOffsets,
     },
-    Ledger,
+    DataLedger,
 };
 use irys_packing::{capacity_single::compute_entropy_chunk, packing_xor_vec_u8};
 use irys_types::{
@@ -1168,7 +1168,7 @@ fn hash_sha256(message: &[u8]) -> Result<[u8; 32], eyre::Error> {
 /// Retrieves all the storage modules overlapped by a range in a given ledger
 pub fn get_overlapped_storage_modules(
     storage_modules: &[Arc<StorageModule>],
-    ledger: Ledger,
+    ledger: DataLedger,
     tx_chunk_range: &LedgerChunkRange,
 ) -> Vec<Arc<StorageModule>> {
     storage_modules
@@ -1190,7 +1190,7 @@ pub fn get_overlapped_storage_modules(
 /// a storage module that overlaps the offset
 pub fn get_storage_module_at_offset(
     storage_modules: &[Arc<StorageModule>],
-    ledger: Ledger,
+    ledger: DataLedger,
     chunk_offset: LedgerChunkOffset,
 ) -> Option<Arc<StorageModule>> {
     storage_modules

--- a/crates/storage/tests/storage_module_index_tests.rs
+++ b/crates/storage/tests/storage_module_index_tests.rs
@@ -11,7 +11,7 @@ use irys_types::{
     irys::IrysSigner, ledger_chunk_offset_ii, partition::PartitionAssignment,
     partition_chunk_offset_ie, partition_chunk_offset_ii, Base64, Config, IrysTransaction,
     IrysTransactionHeader, LedgerChunkOffset, LedgerChunkRange, PartitionChunkOffset,
-    PartitionChunkRange, StorageConfig, StorageTransactionLedger, TxChunkOffset, UnpackedChunk,
+    PartitionChunkRange, StorageConfig, DataTransactionLedger, TxChunkOffset, UnpackedChunk,
     H256,
 };
 use openssl::sha;
@@ -148,7 +148,7 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
     let tx_headers: Vec<IrysTransactionHeader> = txs.iter().map(|tx| tx.header.clone()).collect();
 
     // Create a tx_root (and paths) from the tx
-    let (_tx_root, proofs) = StorageTransactionLedger::merklize_tx_root(&tx_headers);
+    let (_tx_root, proofs) = DataTransactionLedger::merklize_tx_root(&tx_headers);
 
     // Assume this is the first block in the blockchain
     let proof = &proofs[0];

--- a/crates/storage/tests/storage_module_index_tests.rs
+++ b/crates/storage/tests/storage_module_index_tests.rs
@@ -9,10 +9,9 @@ use irys_storage::*;
 use irys_testing_utils::utils::setup_tracing_and_temp_dir;
 use irys_types::{
     irys::IrysSigner, ledger_chunk_offset_ii, partition::PartitionAssignment,
-    partition_chunk_offset_ie, partition_chunk_offset_ii, Base64, Config, IrysTransaction,
-    IrysTransactionHeader, LedgerChunkOffset, LedgerChunkRange, PartitionChunkOffset,
-    PartitionChunkRange, StorageConfig, DataTransactionLedger, TxChunkOffset, UnpackedChunk,
-    H256,
+    partition_chunk_offset_ie, partition_chunk_offset_ii, Base64, Config, DataTransactionLedger,
+    IrysTransaction, IrysTransactionHeader, LedgerChunkOffset, LedgerChunkRange,
+    PartitionChunkOffset, PartitionChunkRange, StorageConfig, TxChunkOffset, UnpackedChunk, H256,
 };
 use openssl::sha;
 use reth_db::Database;

--- a/crates/types/src/block.rs
+++ b/crates/types/src/block.rs
@@ -141,7 +141,7 @@ pub struct IrysBlockHeader {
     /// A list of storage transaction ledgers, one for each active data ledger
     /// Maintains the block->tx_root->data_root relationship for each block
     /// and ledger.
-    pub storage_ledgers: Vec<StorageTransactionLedger>,
+    pub data_ledgers: Vec<DataTransactionLedger>,
 
     /// Evm block hash (32 bytes)
     pub evm_block_hash: B256,
@@ -301,7 +301,7 @@ pub type TxRoot = H256;
 )]
 #[rlp(trailing)]
 #[serde(rename_all = "camelCase")]
-pub struct StorageTransactionLedger {
+pub struct DataTransactionLedger {
     /// Unique identifier for this ledger, maps to discriminant in `Ledger` enum
     pub ledger_id: u32,
     /// Root of the merkle tree built from the ledger transaction data_roots
@@ -319,7 +319,7 @@ pub struct StorageTransactionLedger {
     pub proofs: Option<IngressProofsList>,
 }
 
-impl StorageTransactionLedger {
+impl DataTransactionLedger {
     /// Computes the tx_root and tx_paths. The TX Root is composed of taking the data_roots of each of the storage
     /// transactions included, in order, and building a merkle tree out of them. The root of this tree is the tx_root.
     pub fn merklize_tx_root(data_txs: &[IrysTransactionHeader]) -> (H256, Vec<Proof>) {
@@ -410,9 +410,9 @@ impl IrysBlockHeader {
                 ledger_id: 0, // SystemLedger::Commitment
                 tx_ids: H256List(vec![H256::random(), H256::random()]),
             }],
-            storage_ledgers: vec![
+            data_ledgers: vec![
                 // Permanent Publish Ledger
-                StorageTransactionLedger {
+                DataTransactionLedger {
                     ledger_id: 0, // Publish ledger_id
                     tx_root: H256::zero(),
                     tx_ids,
@@ -421,7 +421,7 @@ impl IrysBlockHeader {
                     proofs: None,
                 },
                 // Term Submit Ledger
-                StorageTransactionLedger {
+                DataTransactionLedger {
                     ledger_id: 1, // Submit ledger_id
                     tx_root: H256::zero(),
                     tx_ids: H256List::new(),
@@ -524,7 +524,7 @@ mod tests {
     #[test]
     fn test_storage_transaction_ledger_rlp_round_trip() {
         // setup
-        let data = StorageTransactionLedger {
+        let data = DataTransactionLedger {
             ledger_id: 1,
             tx_root: H256::random(),
             tx_ids: H256List(vec![]),
@@ -679,7 +679,7 @@ mod tests {
             tx.data_size = 64
         }
 
-        let (tx_root, proofs) = StorageTransactionLedger::merklize_tx_root(&txs);
+        let (tx_root, proofs) = DataTransactionLedger::merklize_tx_root(&txs);
 
         for proof in proofs {
             let encoded_proof = Base64(proof.proof.to_vec());
@@ -716,8 +716,8 @@ mod tests {
             |h: &mut IrysBlockHeader| h.reward_address.as_mut_bytes(),
             |h: &mut IrysBlockHeader| h.miner_address.as_mut_bytes(),
             |h: &mut IrysBlockHeader| h.timestamp.as_mut_bytes(),
-            |h: &mut IrysBlockHeader| h.storage_ledgers[0].ledger_id.as_mut_bytes(),
-            |h: &mut IrysBlockHeader| h.storage_ledgers[0].max_chunk_offset.as_mut_bytes(),
+            |h: &mut IrysBlockHeader| h.data_ledgers[0].ledger_id.as_mut_bytes(),
+            |h: &mut IrysBlockHeader| h.data_ledgers[0].max_chunk_offset.as_mut_bytes(),
             |h: &mut IrysBlockHeader| h.evm_block_hash.as_mut_bytes(),
             |h: &mut IrysBlockHeader| h.vdf_limiter_info.global_step_number.as_mut_bytes(),
         ];

--- a/crates/types/src/block.rs
+++ b/crates/types/src/block.rs
@@ -141,7 +141,7 @@ pub struct IrysBlockHeader {
     /// A list of storage transaction ledgers, one for each active data ledger
     /// Maintains the block->tx_root->data_root relationship for each block
     /// and ledger.
-    pub ledgers: Vec<StorageTransactionLedger>,
+    pub storage_ledgers: Vec<StorageTransactionLedger>,
 
     /// Evm block hash (32 bytes)
     pub evm_block_hash: B256,
@@ -410,7 +410,7 @@ impl IrysBlockHeader {
                 ledger_id: 0, // SystemLedger::Commitment
                 tx_ids: H256List(vec![H256::random(), H256::random()]),
             }],
-            ledgers: vec![
+            storage_ledgers: vec![
                 // Permanent Publish Ledger
                 StorageTransactionLedger {
                     ledger_id: 0, // Publish ledger_id
@@ -716,8 +716,8 @@ mod tests {
             |h: &mut IrysBlockHeader| h.reward_address.as_mut_bytes(),
             |h: &mut IrysBlockHeader| h.miner_address.as_mut_bytes(),
             |h: &mut IrysBlockHeader| h.timestamp.as_mut_bytes(),
-            |h: &mut IrysBlockHeader| h.ledgers[0].ledger_id.as_mut_bytes(),
-            |h: &mut IrysBlockHeader| h.ledgers[0].max_chunk_offset.as_mut_bytes(),
+            |h: &mut IrysBlockHeader| h.storage_ledgers[0].ledger_id.as_mut_bytes(),
+            |h: &mut IrysBlockHeader| h.storage_ledgers[0].max_chunk_offset.as_mut_bytes(),
             |h: &mut IrysBlockHeader| h.evm_block_hash.as_mut_bytes(),
             |h: &mut IrysBlockHeader| h.vdf_limiter_info.global_step_number.as_mut_bytes(),
         ];


### PR DESCRIPTION
**Describe the changes**
Renaming the `ledgers` attribute of the `IrysBlockHeader` struct to `data_ledgers` for consistency with `system_ledgers`. Also rename the `Ledger` enum to `DataLedger`

**Related Issue(s)**
None

**Checklist**

- [] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.


