### PR TITLE
fix: explicit service shutdown ordering

### DIFF
--- a/crates/types/src/config.rs
+++ b/crates/types/src/config.rs
@@ -110,7 +110,7 @@ impl Config {
     pub fn testnet() -> Self {
         use k256::ecdsa::SigningKey;
 
-        const DEFAULT_BLOCK_TIME: u64 = 5;
+        const DEFAULT_BLOCK_TIME: u64 = 1;
 
         Config {
             block_time: DEFAULT_BLOCK_TIME,


### PR DESCRIPTION
**Describe the changes**
A very small PR, that adds explicit stop ordering to the Actix services/arbiters
it also reduces the target block time for tests to help speed things along