### PR TITLE
feat: replace unsafe as u32 cast with safe conversions

### DIFF
--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -709,8 +709,8 @@ mod tests {
             data_path: Some(Base64(txs[poa_tx_num].proofs[poa_chunk_num].proof.clone())),
             chunk: Some(Base64(poa_chunk.clone())),
             ledger_id: Some(1),
-            partition_chunk_offset: (poa_tx_num * 3 /* 3 chunks in each tx */ + poa_chunk_num)
-                as u32,
+            partition_chunk_offset: (poa_tx_num * 3 /* 3 chunks in each tx */ + poa_chunk_num).try_into()
+            .expect("Value exceeds u32::MAX"),
             recall_chunk_index: 0,
             partition_hash: context.partition_hash,
         };

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -709,8 +709,9 @@ mod tests {
             data_path: Some(Base64(txs[poa_tx_num].proofs[poa_chunk_num].proof.clone())),
             chunk: Some(Base64(poa_chunk.clone())),
             ledger_id: Some(1),
-            partition_chunk_offset: (poa_tx_num * 3 /* 3 chunks in each tx */ + poa_chunk_num).try_into()
-            .expect("Value exceeds u32::MAX"),
+            partition_chunk_offset: (poa_tx_num * 3 /* 3 chunks in each tx */ + poa_chunk_num)
+                .try_into()
+                .expect("Value exceeds u32::MAX"),
             recall_chunk_index: 0,
             partition_hash: context.partition_hash,
         };

--- a/crates/actors/src/chunk_migration_service.rs
+++ b/crates/actors/src/chunk_migration_service.rs
@@ -156,7 +156,8 @@ fn process_ledger_transactions(
     let mut prev_chunk_offset = block_range.start();
 
     for ((_txid, tx_path), (data_root, data_size)) in path_pairs {
-        let num_chunks_in_tx = data_size.div_ceil(chunk_size as u64) as u32;
+        let num_chunks_in_tx = TryInto::<u32>::try_into(data_size.div_ceil(chunk_size as u64))
+        .expect("Value exceeds u32::MAX");
         let tx_chunk_range = LedgerChunkRange(ie(
             prev_chunk_offset,
             prev_chunk_offset + num_chunks_in_tx as u64,

--- a/crates/actors/src/chunk_migration_service.rs
+++ b/crates/actors/src/chunk_migration_service.rs
@@ -156,8 +156,10 @@ fn process_ledger_transactions(
     let mut prev_chunk_offset = block_range.start();
 
     for ((_txid, tx_path), (data_root, data_size)) in path_pairs {
-        let num_chunks_in_tx = TryInto::<u32>::try_into(data_size.div_ceil(chunk_size as u64))
-        .expect("Value exceeds u32::MAX");
+        let num_chunks_in_tx: u32 = data_size
+            .div_ceil(chunk_size as u64)
+            .try_into()
+            .expect("Value exceeds u32::MAX");
         let tx_chunk_range = LedgerChunkRange(ie(
             prev_chunk_offset,
             prev_chunk_offset + num_chunks_in_tx as u64,

--- a/crates/actors/src/epoch_service.rs
+++ b/crates/actors/src/epoch_service.rs
@@ -526,7 +526,10 @@ impl EpochServiceActor {
             let ledgers = self.ledgers.read().unwrap();
             slot_needs = ledgers.get_slot_needs(ledger);
         }
-        let mut capacity_count = capacity_partitions.len() as u32;
+        let mut capacity_count: u32 = capacity_partitions
+            .len()
+            .try_into()
+            .expect("Value exceeds u32::MAX");
 
         // Iterate over slots that need partitions and assign them
         for (slot_index, num_needed) in slot_needs {
@@ -721,7 +724,12 @@ impl EpochServiceActor {
         storage_module_config: StorageSubmodulesConfig,
     ) -> Vec<StorageModuleInfo> {
         let ledgers = self.ledgers.read().unwrap();
-        let num_part_chunks = self.config.storage_config.num_chunks_in_partition as u32;
+        let num_part_chunks: u32 = self
+            .config
+            .storage_config
+            .num_chunks_in_partition
+            .try_into()
+            .expect("Value exceeds u32::MAX");
 
         let pa = self.partition_assignments.read().unwrap();
 

--- a/crates/actors/src/mining.rs
+++ b/crates/actors/src/mining.rs
@@ -135,7 +135,7 @@ impl PartitionMiningActor {
 
         // Starting chunk index within partition
         let start_chunk_offset =
-            recall_range_index as u32 * config.num_chunks_in_recall_range as u32;
+            (recall_range_index as u32).saturating_mul(config.num_chunks_in_recall_range as u32);
 
         // info!(
         //     "Recall range index {} start chunk index {}",

--- a/crates/actors/src/packing.rs
+++ b/crates/actors/src/packing.rs
@@ -338,7 +338,13 @@ pub async fn wait_for_packing(
                 // try to get all the semaphore permits - this is how we know that the packing is done
                 let _permit =
                     futures::future::join_all(internals.semaphore.iter().map(|(_, s)| {
-                        s.as_ref().acquire_many(internals.config.concurrency as u32)
+                        s.as_ref().acquire_many(
+                            internals
+                                .config
+                                .concurrency
+                                .try_into()
+                                .expect("Value exceeds u32::MAX"),
+                        )
                     }))
                     .await
                     .iter()

--- a/crates/api-server/src/lib.rs
+++ b/crates/api-server/src/lib.rs
@@ -241,7 +241,7 @@ pub fn create_listener(addr: SocketAddr) -> eyre::Result<TcpListener> {
 //             data_size,
 //             data_path,
 //             bytes: Base64(data_bytes[min..max].to_vec()),
-//             tx_offset: tx_chunk_offset as u32,
+//             tx_offset: tx_chunk_offset.try_into().expect("Value exceeds u32::MAX"),
 //         };
 
 //         // Make a POST request with JSON payload

--- a/crates/chain/tests/api/api.rs
+++ b/crates/chain/tests/api/api.rs
@@ -128,7 +128,7 @@ async fn api_end_to_end_test(chunk_size: usize) {
             data_size,
             data_path,
             bytes: Base64(data_bytes[min..max].to_vec()),
-            tx_offset: TxChunkOffset::from(index as u32),
+            tx_offset: TxChunkOffset::from(index.try_into().expect("Value exceeds u32::MAX")),
         };
 
         // Make a POST request with JSON payload

--- a/crates/chain/tests/api/api.rs
+++ b/crates/chain/tests/api/api.rs
@@ -128,7 +128,9 @@ async fn api_end_to_end_test(chunk_size: usize) {
             data_size,
             data_path,
             bytes: Base64(data_bytes[min..max].to_vec()),
-            tx_offset: TxChunkOffset::from(index.try_into().expect("Value exceeds u32::MAX")),
+            tx_offset: TxChunkOffset::from(
+                TryInto::<u32>::try_into(index).expect("Value exceeds u32::MAX"),
+            ),
         };
 
         // Make a POST request with JSON payload

--- a/crates/chain/tests/block_production/analytics.rs
+++ b/crates/chain/tests/block_production/analytics.rs
@@ -202,7 +202,9 @@ async fn test_blockprod_with_evm_txs() -> eyre::Result<()> {
                     data_size,
                     data_path,
                     bytes: Base64(data_bytes[min..max].to_vec()),
-                    tx_offset: TxChunkOffset::from(tx_chunk_offset as u32),
+                    tx_offset: TxChunkOffset::from(
+                        TryInto::<u32>::try_into(tx_chunk_offset).expect("Value exceeds u32::MAX"),
+                    ),
                 };
 
                 // Make a POST request with JSON payload

--- a/crates/chain/tests/integration/cache_service.rs
+++ b/crates/chain/tests/integration/cache_service.rs
@@ -134,7 +134,9 @@ async fn heavy_test_cache_pruning() -> eyre::Result<()> {
             data_size,
             data_path,
             bytes: Base64(data_bytes[min..max].to_vec()),
-            tx_offset: TxChunkOffset::from(tx_chunk_offset as u32),
+            tx_offset: TxChunkOffset::from(
+                TryInto::<u32>::try_into(tx_chunk_offset).expect("Value exceeds u32::MAX"),
+            ),
         };
 
         // Make a POST request with JSON payload

--- a/crates/chain/tests/programmable_data/basic.rs
+++ b/crates/chain/tests/programmable_data/basic.rs
@@ -207,7 +207,9 @@ async fn heavy_test_programmable_data_basic() -> eyre::Result<()> {
             data_size,
             data_path,
             bytes: Base64(data_bytes[min..max].to_vec()),
-            tx_offset: TxChunkOffset::from(tx_chunk_offset as u32),
+            tx_offset: TxChunkOffset::from(
+                TryInto::<u32>::try_into(tx_chunk_offset).expect("Value exceeds u32::MAX"),
+            ),
         };
 
         // Make a POST request with JSON payload

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -103,6 +103,10 @@ pub async fn capacity_chunk_solution(
 
     SolutionContext {
         partition_hash,
+        // FIXME: SolutionContext should in future use PartitionChunkOffset::from()
+        // chunk_offset appears to be the end byte rather than the start byte that gets read
+        // therefore a saturating_mul is fine as it will read all data up to that point
+        // this is also a test util fn, and so less of a concern than a "domain logic" fn
         chunk_offset: TryInto::<u32>::try_into(recall_range_idx)
             .expect("Value exceeds u32::MAX")
             .saturating_mul(

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -81,7 +81,7 @@ pub async fn capacity_chunk_solution(
         &vdf_steps_guard,
         &partition_hash,
     )
-    .unwrap();
+    .expect("valid recall range");
 
     let mut entropy_chunk = Vec::<u8>::with_capacity(storage_config.chunk_size as usize);
     compute_entropy_chunk(

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -75,7 +75,7 @@ pub async fn capacity_chunk_solution(
     );
 
     let partition_hash = H256::zero();
-    let recall_range_idx: u64 = block_validation::get_recall_range(
+    let recall_range_idx = block_validation::get_recall_range(
         step_num,
         storage_config,
         &vdf_steps_guard,
@@ -103,8 +103,7 @@ pub async fn capacity_chunk_solution(
 
     SolutionContext {
         partition_hash,
-        chunk_offset: recall_range_idx
-            .try_into()
+        chunk_offset: TryInto::<u32>::try_into(recall_range_idx)
             .expect("Value exceeds u32::MAX")
             .saturating_mul(
                 storage_config

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -103,7 +103,8 @@ pub async fn capacity_chunk_solution(
 
     SolutionContext {
         partition_hash,
-        chunk_offset: recall_range_idx as u32 * storage_config.num_chunks_in_recall_range as u32,
+        chunk_offset: (recall_range_idx as u32)
+            .saturating_mul(storage_config.num_chunks_in_recall_range as u32),
         mining_address: miner_addr,
         chunk: entropy_chunk,
         vdf_step: step_num,

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -75,7 +75,7 @@ pub async fn capacity_chunk_solution(
     );
 
     let partition_hash = H256::zero();
-    let recall_range_idx = block_validation::get_recall_range(
+    let recall_range_idx: u64 = block_validation::get_recall_range(
         step_num,
         storage_config,
         &vdf_steps_guard,
@@ -103,8 +103,15 @@ pub async fn capacity_chunk_solution(
 
     SolutionContext {
         partition_hash,
-        chunk_offset: (recall_range_idx as u32)
-            .saturating_mul(storage_config.num_chunks_in_recall_range as u32),
+        chunk_offset: recall_range_idx
+            .try_into()
+            .expect("Value exceeds u32::MAX")
+            .saturating_mul(
+                storage_config
+                    .num_chunks_in_recall_range
+                    .try_into()
+                    .expect("Value exceeds u32::MAX"),
+            ),
         mining_address: miner_addr,
         chunk: entropy_chunk,
         vdf_step: step_num,

--- a/crates/efficient-sampling/src/lib.rs
+++ b/crates/efficient-sampling/src/lib.rs
@@ -66,9 +66,8 @@ impl Ranges {
             let mut rng = SimpleRNG::new(rng_seed);
 
             let next_range_pos = (rng.next()
-                % TryInto::<u32>::try_into(self
-                    .last_range_pos)
-                    .expect("Value exceeds u32::MAX")) as usize; // usize (one word in current CPU architecture) to u32 is safe in 32bits of above architectures
+                % TryInto::<u32>::try_into(self.last_range_pos).expect("Value exceeds u32::MAX"))
+                as usize; // usize (one word in current CPU architecture) to u32 is safe in 32bits of above architectures
             let range = self.ranges[next_range_pos];
             self.ranges[next_range_pos] = self.ranges[self.last_range_pos]; // overwrite returned range with last one
             self.last_range_pos -= 1;

--- a/crates/efficient-sampling/src/lib.rs
+++ b/crates/efficient-sampling/src/lib.rs
@@ -65,7 +65,10 @@ impl Ranges {
             let rng_seed: u32 = u32::from_be_bytes(hasher.finish()[28..32].try_into().unwrap());
             let mut rng = SimpleRNG::new(rng_seed);
 
-            let next_range_pos = (rng.next() % self.last_range_pos as u32) as usize; // usize (one word in current CPU architecture) to u32 is safe in 32bits of above architectures
+            let next_range_pos = (rng.next()
+                % TryInto::<u32>::try_into(self
+                    .last_range_pos)
+                    .expect("Value exceeds u32::MAX")) as usize; // usize (one word in current CPU architecture) to u32 is safe in 32bits of above architectures
             let range = self.ranges[next_range_pos];
             self.ranges[next_range_pos] = self.ranges[self.last_range_pos]; // overwrite returned range with last one
             self.last_range_pos -= 1;

--- a/crates/storage/src/chunk_provider.rs
+++ b/crates/storage/src/chunk_provider.rs
@@ -219,7 +219,9 @@ mod tests {
                 data_size: data_size as u64,
                 data_path: data_path.clone(),
                 bytes: chunk_bytes.clone(),
-                tx_offset: TxChunkOffset::from(tx_chunk_offset as u32),
+                tx_offset: TxChunkOffset::from(
+                    TryInto::<u32>::try_into(tx_chunk_offset).expect("Value exceeds u32::MAX"),
+                ),
             };
             storage_module.write_data_chunk(&chunk)?;
             unpacked_chunks.push(chunk);

--- a/crates/storage/src/storage_module.rs
+++ b/crates/storage/src/storage_module.rs
@@ -316,7 +316,8 @@ impl StorageModule {
             .gaps_untrimmed(partition_chunk_offset_ii!(0, u32::MAX))
             .collect::<Vec<_>>();
         let expected = vec![partition_chunk_offset_ii!(
-            storage_config.num_chunks_in_partition as u32,
+            TryInto::<u32>::try_into(storage_config.num_chunks_in_partition)
+                .expect("Value exceeds u32::MAX"),
             u32::MAX
         )];
         if &gaps != &expected {
@@ -918,7 +919,9 @@ impl StorageModule {
 
         // Get chunk info and calculate index
         let range = self.get_storage_module_range()?;
-        let partition_offset = PartitionChunkOffset::from(*(ledger_offset - range.start()));
+        let partition_offset = PartitionChunkOffset::from(
+            *(ledger_offset - range.start().try_into().expect("Value exceeds u32::MAX")),
+        );
         let closest_offsets = self.collect_start_offsets(data_root)?;
 
         let nearest_start_offset = closest_offsets

--- a/crates/storage/tests/storage_module_index_tests.rs
+++ b/crates/storage/tests/storage_module_index_tests.rs
@@ -536,7 +536,7 @@ fn calculate_tx_ranges(
         num_chunks_in_tx = (num_chunks_in_tx as i64 + partition_start) as u64;
     }
 
-    let partition_start = partition_start
+    let partition_start: u32 = partition_start
         .max(0)
         .try_into()
         .expect("Value exceeds u32::MAX");

--- a/crates/storage/tests/storage_module_index_tests.rs
+++ b/crates/storage/tests/storage_module_index_tests.rs
@@ -345,7 +345,9 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
                 data_size: chunk_bytes.len() as u64,
                 data_path: Base64(proof.proof.clone()),
                 bytes: chunk_bytes,
-                tx_offset: TxChunkOffset::from(i.try_into().expect("Value exceeds u32::MAX")),
+                tx_offset: TxChunkOffset::from(
+                    TryInto::<u32>::try_into(i).expect("Value exceeds u32::MAX"),
+                ),
             };
 
             let _ = db.update_eyre(|tx| cache_chunk(tx, &chunk));

--- a/crates/storage/tests/storage_module_index_tests.rs
+++ b/crates/storage/tests/storage_module_index_tests.rs
@@ -345,7 +345,7 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
                 data_size: chunk_bytes.len() as u64,
                 data_path: Base64(proof.proof.clone()),
                 bytes: chunk_bytes,
-                tx_offset: TxChunkOffset::from(i as u32),
+                tx_offset: TxChunkOffset::from(i.try_into().expect("Value exceeds u32::MAX")),
             };
 
             let _ = db.update_eyre(|tx| cache_chunk(tx, &chunk));
@@ -358,7 +358,9 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
     let mut ledger_offset: LedgerChunkOffset = LedgerChunkOffset::from(0);
     for tx in &txs {
         let data_root = tx.header.data_root;
-        let num_chunks = (tx.header.data_size / chunk_size) as u32;
+        let num_chunks = (tx.header.data_size / chunk_size)
+            .try_into()
+            .expect("Value exceeds u32::MAX");
 
         let mut chunks_added = 0;
         // loop though the assigned partitions
@@ -534,7 +536,10 @@ fn calculate_tx_ranges(
         num_chunks_in_tx = (num_chunks_in_tx as i64 + partition_start) as u64;
     }
 
-    let partition_start = partition_start.max(0) as u32;
+    let partition_start = partition_start
+        .max(0)
+        .try_into()
+        .expect("Value exceeds u32::MAX");
 
     let partition_range = PartitionChunkRange(partition_chunk_offset_ie!(
         partition_start,

--- a/crates/types/src/difficulty_adjustment_config.rs
+++ b/crates/types/src/difficulty_adjustment_config.rs
@@ -125,7 +125,7 @@ pub fn calculate_difficulty(
     // Calculate difference
     let percent_diff = actual_block_time.abs_diff(target_block_time).as_millis() * 100
         / target_block_time.as_millis();
-    let min_threshold = (difficulty_config.min_adjustment_factor * dec![100.0])
+    let min_threshold: u128 = (difficulty_config.min_adjustment_factor * dec![100.0])
         .try_into()
         .unwrap();
 
@@ -133,7 +133,7 @@ pub fn calculate_difficulty(
         actual_block_time,
         target_block_time,
         percent_different: percent_diff as u32,
-        min_threshold: min_threshold as u32,
+        min_threshold: min_threshold.try_into().expect("Value exceeds u32::MAX"),
         is_adjusted: percent_diff > min_threshold,
     };
 


### PR DESCRIPTION
**Describe the changes**
Continue on prior works to improve safety of type casting.

**Related Issue(s)**
https://github.com/Irys-xyz/irys/issues/81

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Supersedes and closes https://github.com/Irys-xyz/irys/pull/237
