### PR TITLE
feat: add data_root -> data_size submodule table

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -4,6 +4,7 @@ serial = { max-threads = 1 }
 
 [profile.default]
 slow-timeout = { period = "60s", terminate-after = 4 }
+threads-required = 1
 
 # serial tests
 [[profile.default.overrides]]

--- a/crates/actors/src/chunk_migration_service.rs
+++ b/crates/actors/src/chunk_migration_service.rs
@@ -168,6 +168,7 @@ fn process_ledger_transactions(
             tx_chunk_range,
             ledger,
             storage_modules,
+            data_size,
         )?;
 
         process_transaction_chunks(
@@ -277,13 +278,14 @@ fn update_storage_module_indexes(
     tx_chunk_range: LedgerChunkRange,
     ledger: DataLedger,
     storage_modules: &[Arc<StorageModule>],
+    data_size: u64,
 ) -> Result<(), ()> {
     let overlapped_modules =
         get_overlapped_storage_modules(storage_modules, ledger, &tx_chunk_range);
 
     for storage_module in overlapped_modules {
         storage_module
-            .index_transaction_data(proof.to_vec(), data_root, tx_chunk_range)
+            .index_transaction_data(proof.to_vec(), data_root, tx_chunk_range, data_size)
             .map_err(|e| {
                 error!(
                     "Failed to add tx path + data_root + start_offset to index: {}",

--- a/crates/actors/src/chunk_migration_service.rs
+++ b/crates/actors/src/chunk_migration_service.rs
@@ -316,7 +316,7 @@ fn find_storage_module(
             .and_then(|pa| pa.ledger_id)
             .filter(|&id| id == ledger as u32)
             // Then check offset range
-            .and_then(|_| module.get_storage_module_range().ok())
+            .and_then(|_| module.get_storage_module_ledger_range().ok())
             .filter(|range| range.contains_point(ledger_offset.into()))
             .map(|_| module)
     })

--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -144,6 +144,8 @@ pub enum ChunkIngressError {
     UnknownTransaction,
     /// Only the last chunk in a `data_root` tree can be less than `CHUNK_SIZE`
     InvalidChunkSize,
+    /// Chunks should have the same data_size field as their parent tx
+    InvalidDataSize,
     /// Some database error occurred when reading or writing the chunk
     DatabaseError,
     /// The service is uninitialized
@@ -322,10 +324,10 @@ impl Handler<ChunkIngressMessage> for MempoolService {
         // recorded in the transaction header.
         if cached_data_root.data_size != chunk.data_size {
             error!(
-                "InvalidChunkSize: expected: {} got:{}",
+                "Invalid data_size for data_root: expected: {} got:{}",
                 cached_data_root.data_size, chunk.data_size
             );
-            return Err(ChunkIngressError::InvalidChunkSize);
+            return Err(ChunkIngressError::InvalidDataSize);
         }
 
         // Use data_size to identify and validate that only the last chunk

--- a/crates/actors/src/mining.rs
+++ b/crates/actors/src/mining.rs
@@ -487,18 +487,19 @@ mod tests {
         let database_provider = DatabaseProvider(Arc::new(db));
 
         let data_root = H256::random();
+        let data_size = chunk_size * chunk_count;
 
         let _ = storage_module.index_transaction_data(
             tx_path.to_vec(),
             data_root,
             LedgerChunkRange(ledger_chunk_offset_ie!(0, chunk_count)),
-            chunk_size,
+            data_size,
         );
 
         for tx_chunk_offset in 0..chunk_count {
             let chunk = UnpackedChunk {
                 data_root,
-                data_size: chunk_size,
+                data_size,
                 data_path: data_path.to_vec().into(),
                 bytes: chunk_data.to_vec().into(),
                 tx_offset: tx_chunk_offset.into(),
@@ -562,7 +563,7 @@ mod tests {
         );
 
         assert!(
-            solution.chunk_offset < chunk_count * 2,
+            solution.chunk_offset < chunk_count as u32 * 2,
             "Not expected offset"
         );
 

--- a/crates/actors/src/mining.rs
+++ b/crates/actors/src/mining.rs
@@ -492,6 +492,7 @@ mod tests {
             tx_path.to_vec(),
             data_root,
             LedgerChunkRange(ledger_chunk_offset_ie!(0, chunk_count)),
+            chunk_size,
         );
 
         for tx_chunk_offset in 0..chunk_count {

--- a/crates/api-server/src/routes/post_chunk.rs
+++ b/crates/api-server/src/routes/post_chunk.rs
@@ -41,6 +41,8 @@ pub async fn post_chunk(
                 .body(format!("Invalid data_hash: {:?}", err))),
             ChunkIngressError::InvalidChunkSize => Ok(HttpResponse::build(StatusCode::BAD_REQUEST)
                 .body(format!("Invalid chunk size: {:?}", err))),
+            ChunkIngressError::InvalidDataSize => Ok(HttpResponse::build(StatusCode::BAD_REQUEST)
+                .body(format!("Invalid data_size field : {:?}", err))),
             ChunkIngressError::UnknownTransaction => {
                 Ok(HttpResponse::build(StatusCode::BAD_REQUEST)
                     .body(format!("Unknown transaction: {:?}", err)))

--- a/crates/database/src/submodule/db.rs
+++ b/crates/database/src/submodule/db.rs
@@ -13,7 +13,8 @@ use crate::open_or_create_db;
 
 use super::tables::{
     ChunkDataPathByPathHash, ChunkOffsetsByPathHash, ChunkPathHashByOffset, ChunkPathHashes,
-    RelativeStartOffsets, StartOffsetsByDataRoot, SubmoduleTables, TxPathByTxPathHash,
+    DataSizeByDataRoot, RelativeStartOffsets, StartOffsetsByDataRoot, SubmoduleTables,
+    TxPathByTxPathHash,
 };
 
 /// Creates or opens a *submodule* MDBX database
@@ -175,6 +176,21 @@ pub fn add_start_offset_to_data_root_index<T: DbTxMut + DbTx>(
     }
     set_start_offsets_by_data_root(tx, data_root, offsets)?;
     Ok(())
+}
+
+pub fn get_data_size_by_data_root<T: DbTx>(
+    tx: &T,
+    data_root: DataRoot,
+) -> eyre::Result<Option<u64>> {
+    Ok(tx.get::<DataSizeByDataRoot>(data_root)?)
+}
+
+pub fn set_data_size_for_data_root<T: DbTxMut>(
+    tx: &T,
+    data_root: DataRoot,
+    data_size: u64,
+) -> eyre::Result<()> {
+    Ok(tx.put::<DataSizeByDataRoot>(data_root, data_size)?)
 }
 
 /// clear db

--- a/crates/database/src/submodule/db.rs
+++ b/crates/database/src/submodule/db.rs
@@ -12,7 +12,7 @@ use reth_db::{
 use crate::open_or_create_db;
 
 use super::tables::{
-    ChunkDataPathByPathHash, ChunkOffsetsByPathHash, ChunkPathHashByOffset, ChunkPathHashes,
+    ChunkDataPathByPathHash, ChunkOffsetsByPathHash, ChunkPathHashes, ChunkPathHashesByOffset,
     DataSizeByDataRoot, RelativeStartOffsets, StartOffsetsByDataRoot, SubmoduleTables,
     TxPathByTxPathHash,
 };
@@ -85,7 +85,7 @@ pub fn get_path_hashes_by_offset<T: DbTx>(
     tx: &T,
     offset: PartitionChunkOffset,
 ) -> eyre::Result<Option<ChunkPathHashes>> {
-    Ok(tx.get::<ChunkPathHashByOffset>(offset)?)
+    Ok(tx.get::<ChunkPathHashesByOffset>(offset)?)
 }
 
 pub fn get_full_data_path<T: DbTx>(
@@ -144,7 +144,7 @@ pub fn set_path_hashes_by_offset<T: DbTxMut>(
     offset: PartitionChunkOffset,
     path_hashes: ChunkPathHashes,
 ) -> eyre::Result<()> {
-    Ok(tx.put::<ChunkPathHashByOffset>(offset, path_hashes)?)
+    Ok(tx.put::<ChunkPathHashesByOffset>(offset, path_hashes)?)
 }
 
 /// get all the start offsets for the `data_root`
@@ -195,7 +195,7 @@ pub fn set_data_size_for_data_root<T: DbTxMut>(
 
 /// clear db
 pub fn clear_submodule_database<T: DbTxMut>(tx: &T) -> eyre::Result<()> {
-    tx.clear::<ChunkPathHashByOffset>()?;
+    tx.clear::<ChunkPathHashesByOffset>()?;
     tx.clear::<ChunkDataPathByPathHash>()?;
     tx.clear::<TxPathByTxPathHash>()?;
     tx.clear::<ChunkOffsetsByPathHash>()?;

--- a/crates/database/src/submodule/tables.rs
+++ b/crates/database/src/submodule/tables.rs
@@ -20,7 +20,7 @@ tables! {
     table ChunkPathHashesByOffset<Key = PartitionChunkOffset, Value = ChunkPathHashes>;
 
     /// Maps a chunk's data path hash to the full data path
-    /// TODO: change how we store these to reduce duplication (use dupsort + tree traversal indicies)
+    /// TODO: change how we store these to reduce duplication (use dupsort + tree traversal indices)
     table ChunkDataPathByPathHash<Key = ChunkPathHash, Value = ChunkDataPath>;
 
     /// Maps a tx path hash to the full tx path

--- a/crates/database/src/submodule/tables.rs
+++ b/crates/database/src/submodule/tables.rs
@@ -30,6 +30,9 @@ tables! {
     /// Maps a data root to the list of submodule-relative start offsets
     table StartOffsetsByDataRoot<Key = DataRoot, Value = RelativeStartOffsets>;
 
+    /// Maps a data root to it's data size (used for validation)
+    table DataSizeByDataRoot<Key = DataRoot, Value = u64>;
+
     /// Table to store various metadata, such as the current db schema version
     table Metadata<Key = MetadataKey, Value = Vec<u8>>;
 

--- a/crates/storage/src/chunk_provider.rs
+++ b/crates/storage/src/chunk_provider.rs
@@ -204,6 +204,7 @@ mod tests {
             tx_path,
             data_root,
             LedgerChunkRange(chunk_range),
+            tx.header.data_size,
         );
 
         let mut unpacked_chunks = vec![];

--- a/crates/storage/src/chunk_provider.rs
+++ b/crates/storage/src/chunk_provider.rs
@@ -74,10 +74,6 @@ impl ChunkProvider {
             let offsets = start_offsets1
                 .0
                 .iter()
-                // .filter_map(|so| {
-                //     checked_add_i32_u64(**so, *sm_range_start) // translate into ledger-relative space
-                //     .map(|mapped_start| mapped_start + (*data_tx_offset as u64))
-                // })
                 .map(|mapped_start| *mapped_start + (*data_tx_offset as i32))
                 .collect::<Vec<_>>();
 
@@ -230,15 +226,7 @@ mod tests {
             let chunk = chunk_provider
                 .get_chunk_by_data_root(DataLedger::Publish, data_root, original_chunk.tx_offset)?
                 .unwrap();
-            // let chunk_size = config.chunk_size as usize;
-            // let start = chunk_offset as usize * chunk_size;
             let packed_chunk = chunk.as_packed().unwrap();
-
-            // let unpacked_chunk = unpack(
-            //     &packed_chunk,
-            //     config.entropy_packing_iterations,
-            //     config.chunk_size.try_into().unwrap(),
-            // );
 
             let unpacked_data = unpack_with_entropy(
                 &packed_chunk,

--- a/crates/storage/src/storage_module.rs
+++ b/crates/storage/src/storage_module.rs
@@ -44,8 +44,8 @@ use irys_database::{
         add_data_path_hash_to_offset_index, add_full_data_path, add_full_tx_path,
         add_start_offset_to_data_root_index, add_tx_path_hash_to_offset_index,
         clear_submodule_database, create_or_open_submodule_db, get_data_path_by_offset,
-        get_start_offsets_by_data_root, get_tx_path_by_offset, set_data_size_for_data_root,
-        tables::RelativeStartOffsets,
+        get_data_size_by_data_root, get_start_offsets_by_data_root, get_tx_path_by_offset,
+        set_data_size_for_data_root, tables::RelativeStartOffsets,
     },
     DataLedger,
 };
@@ -701,7 +701,7 @@ impl StorageModule {
         chunk_range: LedgerChunkRange,
         data_size: u64,
     ) -> eyre::Result<()> {
-        let storage_range = self.get_storage_module_range()?;
+        let storage_range = self.get_storage_module_ledger_range()?;
         let tx_path_hash = H256::from(hash_sha256(&tx_path).unwrap());
 
         let overlap = storage_range
@@ -878,6 +878,15 @@ impl StorageModule {
         Ok(offsets)
     }
 
+    pub fn generate_full_chunk_ledger_offset(
+        &self,
+        ledger_offset: LedgerChunkOffset,
+    ) -> Result<Option<PackedChunk>> {
+        let range = self.get_storage_module_ledger_range()?;
+        let partition_offset = PartitionChunkOffset::from(*(ledger_offset - range.start()));
+        self.generate_full_chunk(partition_offset)
+    }
+
     /// Constructs a Chunk struct for the given ledger offset
     ///
     /// This function:
@@ -888,73 +897,58 @@ impl StorageModule {
     ///
     /// Note: Handles cases where data spans partition boundaries by supporting
     /// negative offsets in the calculation of chunk position
+    /// this is why the input offset is a LedgerOffset and not a PartitionOffset
     pub fn generate_full_chunk(
         &self,
-        ledger_offset: LedgerChunkOffset,
+        partition_offset: PartitionChunkOffset,
     ) -> Result<Option<PackedChunk>> {
         // Get paths and process them
-        let (tx_path, data_path) = self.read_tx_data_path(ledger_offset)?;
+        let (data_root, data_size, data_path, chunk_offset) =
+            self.query_submodule_db_by_offset(partition_offset, |tx| {
+                let tx_path = get_tx_path_by_offset(tx, partition_offset)?
+                    .ok_or(eyre::eyre!("Unable to find a chunk with that tx_path"))?;
 
-        let (data_root, data_size) = match tx_path {
-            Some(tp) => {
-                let path_buff = Base64::from(tp);
+                let path_buff = Base64::from(tx_path);
                 let proof = get_leaf_proof(&path_buff)?;
                 let data_root = proof
                     .hash()
                     .map(H256::from)
-                    .ok_or_eyre("Unable to parse data_root from tx_path ")?;
-                let data_size = proof.offset() as u64;
-                (data_root, data_size)
-            }
-            None => return Err(eyre::eyre!("Unable to find a chunk with that tx_path")),
-        };
+                    .ok_or_eyre("Unable to parse data_root from tx_path")?;
 
-        let (data_path, _offset) = match data_path {
-            Some(dp) => {
-                let path_buff = Base64::from(dp);
+                let data_size = get_data_size_by_data_root(tx, data_root)?.ok_or(eyre!(
+                    "Unable to get data_size for data_root {}",
+                    &data_root
+                ))?;
+
+                let data_path = get_data_path_by_offset(tx, partition_offset)?
+                    .ok_or(eyre::eyre!("Unable to find a chunk for that data_path"))?;
+                let path_buff = Base64::from(data_path);
                 let proof = get_leaf_proof(&path_buff)?;
-                (path_buff, proof.offset() as u64)
-            }
-            None => return Err(eyre::eyre!("Unable to find a chunk for that data_path")),
-        };
+                // -1 as it starts with 0
+                let chunk_offset =
+                    (proof.offset() as u64).div_ceil(self.storage_config.chunk_size) - 1;
 
-        // Get chunk info and calculate index
-        let range = self.get_storage_module_range()?;
-        let partition_offset = PartitionChunkOffset::from(*(ledger_offset - range.start()));
-        let closest_offsets = self.collect_start_offsets(data_root)?;
+                Ok((
+                    data_root,
+                    data_size,
+                    path_buff,
+                    TxChunkOffset(chunk_offset.try_into().unwrap()),
+                ))
+            })?;
 
-        let nearest_start_offset = closest_offsets
-            .0
-            .iter()
-            .filter(|&&offset| *offset <= *partition_offset as i32)
-            .max()
-            .copied()
-            .ok_or_eyre("Could not find nearest_start_offset")?;
-
-        let chunks = self.read_chunks(partition_chunk_offset_ii!(
+        let mut chunks = self.read_chunks(partition_chunk_offset_ii!(
             partition_offset,
             partition_offset
         ))?;
         let chunk_info = chunks
-            .get(&partition_offset)
+            .remove(&partition_offset)
             .ok_or_eyre("Could not find chunk bytes on disk")?;
-
-        // Because nearest_start_offset can be negative (for data_roots that
-        // overlap partition boundaries) we do our calculations with i64s to
-        // account for negative nearest_start_offset
-        let data_root_start_offset: LedgerChunkOffset =
-            LedgerChunkOffset::from(*range.start() as i64 + *nearest_start_offset as i64);
-
-        // Finally the index of the chunk in the transaction can be calculated
-        // using the ledger relative start_offset of the data_root and the
-        // ledger_offset provided by the caller
-        let chunk_offset = TxChunkOffset::from(ledger_offset - data_root_start_offset);
 
         Ok(Some(PackedChunk {
             data_root,
             data_size,
             data_path,
-            bytes: Base64::from(chunk_info.0.clone()),
+            bytes: Base64::from(chunk_info.0),
             partition_offset,
             tx_offset: chunk_offset,
             packing_address: self.storage_config.miner_address,
@@ -967,17 +961,35 @@ impl StorageModule {
         &self,
         chunk_offset: LedgerChunkOffset,
     ) -> eyre::Result<(Option<TxPath>, Option<ChunkDataPath>)> {
-        let (_interval, submodule) = self
-            .submodules
-            .get_key_value_at_point(PartitionChunkOffset::from(chunk_offset))
-            .unwrap();
-
-        submodule.db.view(|tx| {
+        self.query_submodule_db_by_offset(PartitionChunkOffset::from(chunk_offset), |tx| {
             Ok((
                 get_tx_path_by_offset(tx, PartitionChunkOffset::from(chunk_offset))?,
                 get_data_path_by_offset(tx, PartitionChunkOffset::from(chunk_offset))?,
             ))
-        })?
+        })
+    }
+
+    #[inline]
+    pub fn query_submodule_db_by_offset<S, R>(
+        &self,
+        chunk_offset: PartitionChunkOffset,
+        fetch_from_db: S,
+    ) -> eyre::Result<R>
+    where
+        S: FnOnce(&reth_db::mdbx::tx::Tx<reth_db::mdbx::RO>) -> eyre::Result<R>,
+    {
+        let (_, submodule) = self.get_submodule_for_offset(chunk_offset)?;
+        submodule.db.view(fetch_from_db)?
+    }
+
+    #[inline]
+    pub fn get_submodule_for_offset(
+        &self,
+        chunk_offset: PartitionChunkOffset,
+    ) -> eyre::Result<(&Interval<PartitionChunkOffset>, &StorageSubmodule)> {
+        self.submodules
+            .get_key_value_at_point(chunk_offset)
+            .map_err(|e| eyre!("Unable to get submodule for offset {:?}", &e))
     }
 
     /// Writes chunk data to physical storage and updates state tracking
@@ -997,10 +1009,7 @@ impl StorageModule {
     ) -> eyre::Result<()> {
         let chunk_size = self.storage_config.chunk_size;
         // Get the correct submodule reference based on chunk_offset
-        let (interval, submodule) = self
-            .submodules
-            .get_key_value_at_point(chunk_offset)
-            .unwrap();
+        let (interval, submodule) = self.get_submodule_for_offset(chunk_offset).unwrap();
 
         // Get the submodule relative offset of the chunk
         let submodule_offset = chunk_offset - interval.start();
@@ -1028,7 +1037,7 @@ impl StorageModule {
 
     /// Utility method asking the StorageModule to return its chunk range in
     /// ledger relative coordinates
-    pub fn get_storage_module_range(&self) -> eyre::Result<LedgerChunkRange> {
+    pub fn get_storage_module_ledger_range(&self) -> eyre::Result<LedgerChunkRange> {
         if let Some(part_assign) = self.partition_assignment {
             if let Some(slot_index) = part_assign.slot_index {
                 let start = slot_index as u64 * self.storage_config.num_chunks_in_partition;
@@ -1049,7 +1058,7 @@ impl StorageModule {
         &self,
         chunk_range: LedgerChunkRange,
     ) -> eyre::Result<PartitionChunkRange> {
-        let storage_module_range = self.get_storage_module_range()?;
+        let storage_module_range = self.get_storage_module_ledger_range()?;
         let start = chunk_range.start() - storage_module_range.start();
         let end = chunk_range.end() - storage_module_range.start();
         Ok(PartitionChunkRange(ii(
@@ -1065,7 +1074,7 @@ impl StorageModule {
         &self,
         start_offset: LedgerChunkOffset,
     ) -> eyre::Result<i32> {
-        let storage_module_range = self.get_storage_module_range()?;
+        let storage_module_range = self.get_storage_module_ledger_range()?;
         let start = *start_offset as i64 - *storage_module_range.start() as i64;
         Ok(start.try_into()?)
     }
@@ -1181,7 +1190,7 @@ pub fn get_overlapped_storage_modules(
                 .and_then(|pa| pa.ledger_id)
                 .map_or(false, |id| id == ledger as u32)
                 && module
-                    .get_storage_module_range()
+                    .get_storage_module_ledger_range()
                     .map_or(false, |range| range.overlaps(tx_chunk_range))
         })
         .cloned() // Clone the Arc, which is cheap
@@ -1203,7 +1212,7 @@ pub fn get_storage_module_at_offset(
                 .and_then(|pa| pa.ledger_id)
                 .map_or(false, |id| id == ledger as u32)
                 && module
-                    .get_storage_module_range()
+                    .get_storage_module_ledger_range()
                     .map_or(false, |range| range.contains_point(chunk_offset))
         })
         .cloned()

--- a/crates/storage/tests/storage_module_index_tests.rs
+++ b/crates/storage/tests/storage_module_index_tests.rs
@@ -2,7 +2,10 @@ use std::sync::Arc;
 
 use irys_database::{
     cache_chunk, cached_chunk_by_chunk_offset, open_or_create_db,
-    submodule::{get_full_tx_path, get_path_hashes_by_offset, get_start_offsets_by_data_root},
+    submodule::{
+        get_data_size_by_data_root, get_full_tx_path, get_path_hashes_by_offset,
+        get_start_offsets_by_data_root,
+    },
     tables::IrysTables,
 };
 use irys_storage::*;
@@ -163,7 +166,13 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
     );
 
     let data_root = tx_headers[0].data_root;
-    let _ = storage_modules[0].index_transaction_data(tx_path.clone(), data_root, tx_ledger_range);
+    let data_size = tx_headers[0].data_size;
+    let _ = storage_modules[0].index_transaction_data(
+        tx_path.clone(),
+        data_root,
+        tx_ledger_range,
+        data_size,
+    );
 
     // Get the submodule reference
     let submodule = storage_modules[0]
@@ -179,6 +188,8 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
 
     verify_data_root_start_offset(submodule, data_root, 0);
 
+    verify_data_root_data_size(submodule, data_root, data_size);
+
     // Tx:2 - Overlapping case, tx chunks start in one submodule and go to another
     let start_chunk_offset = LedgerChunkOffset::from(num_chunks_in_tx);
     let bytes_in_tx = proofs[1].offset as u64 - proof.offset as u64;
@@ -190,7 +201,14 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
     );
     let tx_path = &proofs[1].proof;
     let data_root = tx_headers[1].data_root;
-    let _ = storage_modules[0].index_transaction_data(tx_path.clone(), data_root, tx_ledger_range);
+    let data_size = tx_headers[1].data_size;
+    assert_eq!(data_size, bytes_in_tx);
+    let _ = storage_modules[0].index_transaction_data(
+        tx_path.clone(),
+        data_root,
+        tx_ledger_range,
+        data_size,
+    );
 
     // Get the both submodule references
     let submodule = storage_modules[0]
@@ -215,11 +233,16 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
     verify_data_root_start_offset(submodule, data_root, 3);
     verify_data_root_start_offset(submodule2, data_root, 3);
 
+    verify_data_root_data_size(submodule, data_root, data_size);
+    verify_data_root_data_size(submodule2, data_root, data_size);
+
     // Tx:3 - Fill up the StorageModule leaving one empty chunk
     let tx_path = &proofs[2].proof;
     let data_root = tx_headers[2].data_root;
     let bytes_in_tx =
         proofs[2].offset as u64 - (*tx_ledger_range.end() * storage_config.chunk_size);
+    let data_size = tx_headers[2].data_size;
+    assert_eq!(bytes_in_tx, data_size);
     let start_chunk_offset = tx_ledger_range.end() + 1u64;
     let (tx_ledger_range, tx_partition_range) = calculate_tx_ranges(
         start_chunk_offset,
@@ -227,7 +250,12 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
         bytes_in_tx,
         chunk_size,
     );
-    let _ = storage_modules[0].index_transaction_data(tx_path.clone(), data_root, tx_ledger_range);
+    let _ = storage_modules[0].index_transaction_data(
+        tx_path.clone(),
+        data_root,
+        tx_ledger_range,
+        data_size,
+    );
 
     let submodule3 = storage_modules[0]
         .get_submodule(tx_partition_range.end())
@@ -255,11 +283,16 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
     verify_data_root_start_offset(submodule2, data_root, 6);
     verify_data_root_start_offset(submodule3, data_root, 6);
 
+    verify_data_root_data_size(submodule2, data_root, data_size);
+    verify_data_root_data_size(submodule3, data_root, data_size);
+
     // Tx:4 - Overlap between StorageModules
     let tx_path = &proofs[3].proof;
     let data_root = tx_headers[3].data_root;
+    let data_size = tx_headers[3].data_size;
     let offset = proofs[3].offset as u64;
     let bytes_in_tx = (offset + 1) - (*(tx_ledger_range.end() + 1u64) * storage_config.chunk_size);
+    assert_eq!(bytes_in_tx, data_size);
     let start_chunk_offset = tx_ledger_range.end() + 1u64;
     let (tx_ledger_range, tx_partition_range) = calculate_tx_ranges(
         start_chunk_offset,
@@ -268,8 +301,18 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
         chunk_size,
     );
     // Update both storage modules with the tx data
-    let _ = storage_modules[0].index_transaction_data(tx_path.clone(), data_root, tx_ledger_range);
-    let _ = storage_modules[1].index_transaction_data(tx_path.clone(), data_root, tx_ledger_range);
+    let _ = storage_modules[0].index_transaction_data(
+        tx_path.clone(),
+        data_root,
+        tx_ledger_range,
+        data_size,
+    );
+    let _ = storage_modules[1].index_transaction_data(
+        tx_path.clone(),
+        data_root,
+        tx_ledger_range,
+        data_size,
+    );
 
     // The first submodule of the second StorageModule/Partition
     let submodule4 = storage_modules[1]
@@ -297,11 +340,16 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
     verify_data_root_start_offset(submodule3, data_root, 19);
     verify_data_root_start_offset(submodule4, data_root, -1); // Offset is from previous Partition
 
+    verify_data_root_data_size(submodule3, data_root, data_size);
+    verify_data_root_data_size(submodule4, data_root, data_size);
+
     // Tx:5 - Perfectly fills the submodule without overlapping
     let tx_path = &proofs[4].proof;
     let data_root = tx_headers[4].data_root;
+    let data_size = tx_headers[4].data_size;
     let offset = proofs[4].offset as u64;
     let bytes_in_tx = (offset + 1) - ((*tx_ledger_range.end() + 1) * storage_config.chunk_size);
+    assert_eq!(bytes_in_tx, data_size);
     let start_chunk_offset = tx_ledger_range.end() + 1u64;
     let (tx_ledger_range, tx_partition_range) = calculate_tx_ranges(
         start_chunk_offset,
@@ -310,12 +358,19 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
         chunk_size,
     );
 
-    let _ = storage_modules[1].index_transaction_data(tx_path.clone(), data_root, tx_ledger_range);
+    let _ = storage_modules[1].index_transaction_data(
+        tx_path.clone(),
+        data_root,
+        tx_ledger_range,
+        data_size,
+    );
 
     let tx_path_hash = H256::from(hash_sha256(tx_path).unwrap());
     verify_tx_path_in_submodule(submodule4, tx_path, tx_path_hash);
 
     verify_tx_path_offsets(submodule4, tx_path_hash, tx_partition_range, &[]);
+
+    verify_data_root_data_size(submodule4, data_root, data_size);
 
     // =========================================================================
     // Post Chunks Tests
@@ -558,4 +613,14 @@ fn verify_data_root_start_offset(
             assert_eq!(relative_start_offsets.0[0], expected_offset.into());
         })
         .unwrap();
+}
+
+fn verify_data_root_data_size(submodule: &StorageSubmodule, data_root: H256, expected_size: u64) {
+    assert_eq!(
+        submodule
+            .db
+            .view_eyre(|tx| get_data_size_by_data_root(tx, data_root))
+            .unwrap(),
+        Some(expected_size)
+    );
 }

--- a/crates/storage/tests/storage_module_index_tests.rs
+++ b/crates/storage/tests/storage_module_index_tests.rs
@@ -239,8 +239,8 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
     // Tx:3 - Fill up the StorageModule leaving one empty chunk
     let tx_path = &proofs[2].proof;
     let data_root = tx_headers[2].data_root;
-    let bytes_in_tx =
-        proofs[2].offset as u64 - (*tx_ledger_range.end() * storage_config.chunk_size);
+    let offset = proofs[2].offset as u64;
+    let bytes_in_tx = (offset + 1) - (*(tx_ledger_range.end() + 1u64) * storage_config.chunk_size);
     let data_size = tx_headers[2].data_size;
     assert_eq!(bytes_in_tx, data_size);
     let start_chunk_offset = tx_ledger_range.end() + 1u64;


### PR DESCRIPTION
**Describe the changes**
This PR:
- Adds a new `DataSizeByDataRoot` submodule table, which stores a data_root -> data_size mapping.
- Adds the appropriate set/get DB helper functions for  `DataSizeByDataRoot`.
- Integrates into `StorageModule::index_transaction_data`, and backpropagates a new data_size arg to tests and the chunk migration service.
- Rennovates StorageModule::generate_full_chunk to fix incorrect logic & move it to use partition relative offsets as inputs.
- Updates ChunkProvider::get_chunk_by_data_root to pass through partition relative offsets.
- Updates appropriate tests, notably the storage module index tx_path_overlap_tests, where new assertion logic is added.
- Adds a threads-required = 1 configuration to all tests by default, to prevent heavy tests from starving & failing.

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.