### PR TITLE
feat: allow for transaction data to be an Iterator

### DIFF
--- a/crates/storage/tests/storage_module_index_tests.rs
+++ b/crates/storage/tests/storage_module_index_tests.rs
@@ -386,7 +386,9 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
         let mut prev_byte_offset: u64 = 0;
         info!("num chunks in tx: {:?}", tx.proofs.len());
         for (i, proof) in tx.proofs.iter().enumerate() {
-            let chunk_bytes = Base64(tx.data.0[prev_byte_offset as usize..=proof.offset].to_vec());
+            let chunk_bytes = Base64(
+                tx.data.clone().unwrap().0[prev_byte_offset as usize..=proof.offset].to_vec(),
+            );
 
             // verify the chunk length
             assert_eq!(chunk_bytes.len(), chunk_size as usize);

--- a/crates/types/src/chunk.rs
+++ b/crates/types/src/chunk.rs
@@ -211,7 +211,7 @@ impl TryInto<PackedChunk> for PartialChunk {
 //     println!("{:?}", serde_json::to_string_pretty(&wrapped));
 // }
 
-/// a chunk binary
+/// An (unpacked) chunk's raw bytes
 /// this type is unsized (i.e not a [u8; N]) as chunks can have variable sizes
 /// either for testing or due to it being the last unpadded chunk
 pub type ChunkBytes = Vec<u8>;

--- a/crates/types/src/chunked.rs
+++ b/crates/types/src/chunked.rs
@@ -1,0 +1,133 @@
+use eyre::Result;
+
+pub struct ChunkedIterator<I>
+where
+    I: Iterator<Item = Result<Vec<u8>>>,
+{
+    source: I,
+    buffer: Vec<u8>,
+    chunk_size: usize,
+    finished: bool,
+}
+
+impl<I> ChunkedIterator<I>
+where
+    I: Iterator<Item = Result<Vec<u8>>>,
+{
+    pub fn new(source: I, chunk_size: usize) -> Self {
+        Self {
+            source,
+            buffer: Vec::new(),
+            chunk_size,
+            finished: false,
+        }
+    }
+}
+
+impl<I> Iterator for ChunkedIterator<I>
+where
+    I: Iterator<Item = Result<Vec<u8>>>,
+{
+    type Item = Result<Vec<u8>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.finished && self.buffer.is_empty() {
+            return None;
+        }
+
+        // Fill the buffer until we have enough for a chunk
+        while self.buffer.len() < self.chunk_size {
+            match self.source.next() {
+                Some(Ok(bytes)) => self.buffer.extend(bytes),
+                Some(Err(e)) => {
+                    self.finished = true;
+                    return Some(Err(e));
+                }
+                None => {
+                    self.finished = true;
+                    break;
+                }
+            }
+        }
+
+        if self.buffer.is_empty() {
+            None
+        } else {
+            let chunk_size = if self.finished {
+                self.buffer.len()
+            } else {
+                self.chunk_size.min(self.buffer.len())
+            };
+
+            Some(Ok(self.buffer.drain(..chunk_size).collect()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use eyre::eyre;
+
+    #[test]
+    fn test_exact_chunks() -> Result<()> {
+        let data = vec![Ok(vec![1, 2]), Ok(vec![3, 4]), Ok(vec![5, 6])];
+        let mut iter = ChunkedIterator::new(data.into_iter(), 3);
+
+        assert_eq!(iter.next().transpose()?, Some(vec![1, 2, 3]));
+        assert_eq!(iter.next().transpose()?, Some(vec![4, 5, 6]));
+        assert!(iter.next().is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn test_partial_final_chunk() -> Result<()> {
+        let data = vec![Ok(vec![1, 2]), Ok(vec![3, 4]), Ok(vec![5])];
+        let mut iter = ChunkedIterator::new(data.into_iter(), 3);
+
+        assert_eq!(iter.next().transpose()?, Some(vec![1, 2, 3]));
+        assert_eq!(iter.next().transpose()?, Some(vec![4, 5]));
+        assert!(iter.next().is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn test_error_propagation() {
+        let data = vec![Ok(vec![1, 2]), Err(eyre!("test error")), Ok(vec![3, 4])];
+        let mut iter = ChunkedIterator::new(data.into_iter(), 2);
+
+        assert!(iter.next().unwrap().is_ok());
+        assert!(iter.next().unwrap().is_err());
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_empty_input() {
+        let data: Vec<Result<Vec<u8>>> = vec![];
+        let mut iter = ChunkedIterator::new(data.into_iter(), 2);
+
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_variable_input_sizes() -> Result<()> {
+        let data = vec![Ok(vec![1]), Ok(vec![2, 3, 4]), Ok(vec![5, 6])];
+        let mut iter = ChunkedIterator::new(data.into_iter(), 2);
+
+        assert_eq!(iter.next().transpose()?, Some(vec![1, 2]));
+        assert_eq!(iter.next().transpose()?, Some(vec![3, 4]));
+        assert_eq!(iter.next().transpose()?, Some(vec![5, 6]));
+        assert!(iter.next().is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn test_chunk_size_larger_than_total_input() -> Result<()> {
+        let data = vec![Ok(vec![1]), Ok(vec![2, 3])];
+        let mut iter = ChunkedIterator::new(data.into_iter(), 5);
+
+        assert_eq!(iter.next().transpose()?, Some(vec![1, 2, 3]));
+        assert!(iter.next().is_none());
+        Ok(())
+    }
+}

--- a/crates/types/src/irys.rs
+++ b/crates/types/src/irys.rs
@@ -133,7 +133,8 @@ impl IrysSigner {
     /// Builds a merkle tree, with a root, including all the proofs for each
     /// chunk.
     fn merklize(&self, data: Vec<u8>, chunk_size: usize) -> Result<IrysTransaction> {
-        let chunks = generate_leaves(&data, chunk_size)?;
+        // TODO: fix the `data` field so we can use "streaming" data sources & remove the clone
+        let chunks = generate_leaves(vec![data.clone()].into_iter().map(Ok), chunk_size)?;
         let root = generate_data_root(chunks.clone())?;
         let data_root = H256(root.id);
         let proofs = resolve_proofs(root, None)?;
@@ -150,7 +151,7 @@ impl IrysSigner {
                 data_root,
                 ..Default::default()
             },
-            data: Base64(data),
+            data: Some(Base64(data)),
             chunks,
             proofs,
             ..Default::default()

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -6,6 +6,7 @@ pub mod app_state;
 pub mod block;
 pub mod block_production;
 pub mod chunk;
+pub mod chunked;
 pub mod config;
 pub mod difficulty_adjustment_config;
 pub mod gossip;

--- a/crates/types/src/transaction.rs
+++ b/crates/types/src/transaction.rs
@@ -132,7 +132,8 @@ impl IrysTransactionHeader {
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq)]
 pub struct IrysTransaction {
     pub header: IrysTransactionHeader,
-    pub data: Base64,
+    // TODO: make this compatible with stream/iterator data sources
+    pub data: Option<Base64>,
     #[serde(skip)]
     pub chunks: Vec<Node>,
     #[serde(skip)]


### PR DESCRIPTION
**Describe the changes**
This PR mirrors the changes previously made to Ingress proof generation to support an error-passing iterator as a data source

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
The logic to "bridge" a Vec<u8> data source into the expected Result<Vec<u8>> iterator (and the fact it takes ownership) isn't great, so I'd appreciate any ideas on how to make it better.
