### PR TITLE
fix: solution validation now checks correct difficulty value

### DIFF
--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -81,7 +81,7 @@ pub async fn prevalidate_block(
     debug!("poa data not expired");
 
     // Check the solution_hash
-    solution_hash_is_valid(&block)?;
+    solution_hash_is_valid(&block, &previous_block)?;
     debug!(
         block_hash = ?block.block_hash.0.to_base58(),
         ?block.height,
@@ -249,22 +249,24 @@ pub fn cumulative_difficulty_is_valid(
 }
 
 /// Checks to see if the `solution_hash` exceeds the difficulty threshold
+/// of the previous block
 ///
 /// Note: Requires valid block difficulty - call `difficulty_is_valid()` first.
-pub fn solution_hash_is_valid(block: &IrysBlockHeader) -> eyre::Result<()> {
+pub fn solution_hash_is_valid(
+    block: &IrysBlockHeader,
+    previous_block: &IrysBlockHeader,
+) -> eyre::Result<()> {
     let solution_hash = block.solution_hash;
     let solution_diff = hash_to_number(&solution_hash.0);
 
-    let previous_solution_diff = hash_to_number(&block.previous_solution_hash.0);
-
-    if solution_diff >= previous_solution_diff {
+    if solution_diff >= previous_block.diff {
         Ok(())
     } else {
         Err(eyre::eyre!(
             "Invalid solution_hash - expected difficulty >={}, got {} (diff: {})",
-            &block.diff,
+            &previous_block.diff,
             &solution_diff,
-            &block.diff.abs_diff(solution_diff)
+            &previous_block.diff.abs_diff(solution_diff)
         ))
     }
 }


### PR DESCRIPTION
**Describe the changes**
This fixes a bug in the `discovery_service.solution_hash_is_valid()` check.

A valid solution is supposed to meet or exceed the difficulty of the previous block's `diff`.

The buggy version of this was referencing `previous_solution_diff` which is the incorrect property and always set to 0 as our block production doesn't set it yet.

**Related Issue(s)**
No issue, just discovered while debugging.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
