### PR TITLE
fix: api client not returning transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4087,6 +4087,7 @@ name = "irys-api-client"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base58",
  "eyre",
  "irys-types",
  "reqwest 0.12.15",

--- a/crates/actors/src/peer_list_service.rs
+++ b/crates/actors/src/peer_list_service.rs
@@ -928,7 +928,7 @@ mod tests {
     async fn test_announce_yourself_to_all_peers() {
         let calls = Arc::new(Mutex::new(Vec::new()));
         let mock_client = CountingMockClient {
-            calls: calls.clone(),
+            post_version_calls: calls.clone(),
         };
 
         let (_mining1, peer1) = create_test_peer(

--- a/crates/api-client/Cargo.toml
+++ b/crates/api-client/Cargo.toml
@@ -11,6 +11,7 @@ serde.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 async-trait = "0.1"
+base58.workspace = true
 
 [features]
 default = []

--- a/crates/api-client/src/lib.rs
+++ b/crates/api-client/src/lib.rs
@@ -4,7 +4,7 @@ use irys_types::{IrysTransactionHeader, PeerResponse, VersionRequest, H256};
 use reqwest::{Client, StatusCode};
 use serde::{de::DeserializeOwned, Serialize};
 use std::net::SocketAddr;
-use tracing::{debug, error};
+use tracing::error;
 
 /// Trait defining the interface for the API client
 #[async_trait::async_trait]

--- a/crates/api-client/src/lib.rs
+++ b/crates/api-client/src/lib.rs
@@ -1,3 +1,4 @@
+use base58::ToBase58;
 use eyre::Result;
 use irys_types::{IrysTransactionHeader, PeerResponse, VersionRequest, H256};
 use reqwest::{Client, StatusCode};
@@ -15,6 +16,13 @@ pub trait ApiClient: Send + Sync + Clone {
         tx_id: H256,
     ) -> Result<Option<IrysTransactionHeader>>;
 
+    /// Post a transaction header to a node
+    async fn post_transaction(
+        &self,
+        peer: SocketAddr,
+        transaction: IrysTransactionHeader,
+    ) -> Result<()>;
+
     /// Fetch multiple transaction headers by their IDs from a peer
     async fn get_transactions(
         &self,
@@ -22,6 +30,8 @@ pub trait ApiClient: Send + Sync + Clone {
         tx_ids: &[H256],
     ) -> Result<Vec<Option<IrysTransactionHeader>>>;
 
+    /// Post a version request to a peer. Version request contains protocol version and peer
+    /// information.
     async fn post_version(&self, peer: SocketAddr, version: VersionRequest)
         -> Result<PeerResponse>;
 }
@@ -47,7 +57,6 @@ impl IrysApiClient {
         body: Option<&B>,
     ) -> Result<Option<T>> {
         let url = format!("http://{}/v1{}", peer, path);
-        debug!("Making {} request to {}", method, url);
 
         let mut request = match method {
             "GET" => self.client.get(&url),
@@ -64,6 +73,9 @@ impl IrysApiClient {
 
         match status {
             StatusCode::OK => {
+                if response.content_length().unwrap_or(0) == 0 {
+                    return Ok(None);
+                }
                 let body = response.json::<T>().await?;
                 Ok(Some(body))
             }
@@ -91,9 +103,29 @@ impl ApiClient for IrysApiClient {
         peer: SocketAddr,
         tx_id: H256,
     ) -> Result<Option<IrysTransactionHeader>> {
-        debug!("Fetching transaction {} from peer {}", tx_id, peer);
-        let path = format!("/tx/{}", tx_id);
+        // IMPORTANT: You have to keep the debug format here, since normal to_string of H256
+        //  encodes just first 4 and last 4 bytes with a placeholder in the middle
+        let path = format!("/tx/{}", tx_id.0.to_base58());
         self.make_request(peer, "GET", &path, None::<&()>).await
+    }
+
+    async fn post_transaction(
+        &self,
+        peer: SocketAddr,
+        transaction: IrysTransactionHeader,
+    ) -> Result<()> {
+        let path = "/tx";
+        let response = self
+            .make_request::<(), _>(peer, "POST", path, Some(&transaction))
+            .await;
+
+        match response {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                error!("Failed to post transaction: {}", e);
+                Err(e)
+            }
+        }
     }
 
     async fn get_transactions(
@@ -101,7 +133,6 @@ impl ApiClient for IrysApiClient {
         peer: SocketAddr,
         tx_ids: &[H256],
     ) -> Result<Vec<Option<IrysTransactionHeader>>> {
-        debug!("Fetching {} transactions from peer {}", tx_ids.len(), peer);
         let mut results = Vec::with_capacity(tx_ids.len());
 
         for &tx_id in tx_ids {
@@ -142,7 +173,7 @@ pub mod test_utils {
 
     #[derive(Default, Clone)]
     pub struct CountingMockClient {
-        pub calls: Arc<Mutex<Vec<std::net::SocketAddr>>>,
+        pub post_version_calls: Arc<Mutex<Vec<std::net::SocketAddr>>>,
     }
 
     #[async_trait]
@@ -166,9 +197,17 @@ pub mod test_utils {
             peer: std::net::SocketAddr,
             _version: VersionRequest,
         ) -> eyre::Result<PeerResponse> {
-            let mut calls = self.calls.lock().await;
+            let mut calls = self.post_version_calls.lock().await;
             calls.push(peer);
             Ok(PeerResponse::Accepted(AcceptedResponse::default()))
+        }
+
+        async fn post_transaction(
+            &self,
+            _peer: std::net::SocketAddr,
+            _transaction: IrysTransactionHeader,
+        ) -> eyre::Result<()> {
+            Ok(())
         }
     }
 }
@@ -215,6 +254,14 @@ mod tests {
             _version: VersionRequest,
         ) -> Result<PeerResponse> {
             Ok(PeerResponse::Accepted(AcceptedResponse::default())) // Mock response
+        }
+
+        async fn post_transaction(
+            &self,
+            _peer: SocketAddr,
+            _tx: IrysTransactionHeader,
+        ) -> Result<()> {
+            Ok(())
         }
     }
 

--- a/crates/chain/tests/api/client.rs
+++ b/crates/chain/tests/api/client.rs
@@ -1,23 +1,14 @@
 //! api client tests
 
-use crate::utils::IrysNodeTest;
+use crate::utils::{mine_block, IrysNodeTest};
 use irys_api_client::{ApiClient, IrysApiClient};
+use irys_chain::IrysNodeCtx;
 use irys_types::{AcceptedResponse, PeerAddress, PeerResponse, ProtocolVersion, VersionRequest};
 use semver::Version;
 use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 
-#[actix_rt::test]
-async fn heavy_api_client_all_endpoints_should_work() {
-    // POST /version
-    let ctx = IrysNodeTest::default_async().await.start().await;
-
-    let api_address = SocketAddr::new(
-        IpAddr::from_str("127.0.0.1").unwrap(),
-        ctx.node_ctx.config.api_port,
-    );
-    let api_client = IrysApiClient::new();
-
+async fn check_post_version_endpoint(api_client: &IrysApiClient, api_address: SocketAddr) {
     let version_request = VersionRequest::default();
 
     let expected_version_response = AcceptedResponse {
@@ -54,6 +45,70 @@ async fn heavy_api_client_all_endpoints_should_work() {
     );
     assert_eq!(response_data.peers, expected_version_response.peers);
     assert_eq!(response_data.message, expected_version_response.message);
+}
+
+async fn check_transaction_endpoints(
+    api_client: &IrysApiClient,
+    api_address: SocketAddr,
+    ctx: &IrysNodeTest<IrysNodeCtx>,
+) {
+    // advance one block
+    let (_previous_header, _payload) = mine_block(&ctx.node_ctx).await.unwrap().unwrap();
+    // advance one block, finalizing the previous block
+    let (_header, _payload) = mine_block(&ctx.node_ctx).await.unwrap().unwrap();
+
+    let tx = ctx
+        .create_signed_data_tx(&ctx.node_ctx.node_config.mining_signer, vec![1, 2, 3])
+        .unwrap();
+    let tx_id = tx.header.id;
+    let tx_2 = ctx
+        .create_signed_data_tx(&ctx.node_ctx.node_config.mining_signer, vec![4, 5, 6])
+        .unwrap();
+    let tx_2_id = tx_2.header.id;
+
+    // This method doesn't return anything if there's no error
+    api_client
+        .post_transaction(api_address, tx.header.clone())
+        .await
+        .expect("valid post transaction response");
+    api_client
+        .post_transaction(api_address, tx_2.header.clone())
+        .await
+        .expect("valid post transaction response");
+
+    // advance one block to add the transaction to the block
+    let (_header, _payload) = mine_block(&ctx.node_ctx).await.unwrap().unwrap();
+
+    let retrieved_tx = api_client
+        .get_transaction(api_address, tx_id)
+        .await
+        .expect("valid get transaction response")
+        .expect("transaction not found");
+
+    assert_eq!(retrieved_tx, tx.header);
+
+    let txs = api_client
+        .get_transactions(api_address, &[tx_id, tx_2_id])
+        .await
+        .expect("valid get transactions response");
+
+    assert_eq!(txs.len(), 2);
+    assert!(txs.contains(&Some(tx.header)));
+    assert!(txs.contains(&Some(tx_2.header)));
+}
+
+#[actix_rt::test]
+async fn heavy_api_client_all_endpoints_should_work() {
+    let ctx = IrysNodeTest::default_async().await.start().await;
+
+    let api_address = SocketAddr::new(
+        IpAddr::from_str("127.0.0.1").unwrap(),
+        ctx.node_ctx.config.api_port,
+    );
+    let api_client = IrysApiClient::new();
+
+    check_post_version_endpoint(&api_client, api_address).await;
+    check_transaction_endpoints(&api_client, api_address, &ctx).await;
 
     ctx.node_ctx.stop().await;
 }

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -310,6 +310,17 @@ impl IrysNodeTest<IrysNodeCtx> {
         };
     }
 
+    pub fn create_signed_data_tx(
+        &self,
+        account: &IrysSigner,
+        data: Vec<u8>,
+    ) -> Result<IrysTransaction, AddTxError> {
+        let tx = account
+            .create_transaction(data, None)
+            .map_err(AddTxError::CreateTx)?;
+        account.sign_transaction(tx).map_err(AddTxError::CreateTx)
+    }
+
     pub fn get_tx_header(&self, tx_id: &H256) -> eyre::Result<IrysTransactionHeader> {
         match self
             .node_ctx

--- a/crates/gossip-service/tests/util.rs
+++ b/crates/gossip-service/tests/util.rs
@@ -204,6 +204,14 @@ impl ApiClient for StubApiClient {
     ) -> Result<PeerResponse> {
         Ok(PeerResponse::Accepted(AcceptedResponse::default())) // Mock re sponse
     }
+
+    async fn post_transaction(
+        &self,
+        _api_address: SocketAddr,
+        _transaction: IrysTransactionHeader,
+    ) -> Result<()> {
+        Ok(())
+    }
 }
 
 impl Default for StubApiClient {


### PR DESCRIPTION
**Describe the changes**
This PR fixes `IrysApiCleint` not returning a transaction as expected due to wrong encoding used for the request

**Related Issue(s)**

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**