### PR TITLE
fix: never expire the last partition in a ledger, and only expired ones.

### DIFF
--- a/crates/actors/src/epoch_service.rs
+++ b/crates/actors/src/epoch_service.rs
@@ -535,7 +535,8 @@ impl EpochServiceActor {
                 let mut ledgers = self.ledgers.write().unwrap();
                 for ledger in DataLedger::iter() {
                     debug!("Allocating 1 slot for {:?}", &ledger);
-                    num_data_partitions += ledgers[ledger].allocate_slots(1);
+                    num_data_partitions +=
+                        ledgers[ledger].allocate_slots(1, new_epoch_block.height);
                 }
             }
 
@@ -598,7 +599,7 @@ impl EpochServiceActor {
             {
                 let mut ledgers = self.ledgers.write().unwrap();
                 debug!("Allocating {} slots for ledger {:?}", &part_slots, &ledger);
-                ledgers[ledger].allocate_slots(part_slots);
+                ledgers[ledger].allocate_slots(part_slots, new_epoch_block.height);
             }
         }
     }

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -776,6 +776,10 @@ impl IrysNode {
             &atomic_global_step_number,
             &packing_actor_addr,
         );
+
+        // Yield to let actors process their mailboxes (and subscribe to the mining_broadcaster)
+        tokio::task::yield_now().await;
+
         broadcast_mining_actor
             .send(BroadcastDifficultyUpdate(latest_block.clone()))
             .await?;


### PR DESCRIPTION
# Fix: Submit Ledger Partition Expiration Logic

## Issue Summary
Fixed critical bug where submit ledger terms completion would incorrectly expire ALL partitions instead of only eligible ones.

## Root Cause
https://github.com/Irys-xyz/irys/blob/ca1368fa530332951e5f83bc9884089a33b08c65/crates/database/src/data_ledger.rs#L85-L90
- The `slot.last_height` field (used to determine partition age) was never being set.
- As a result all slots had default `last_height` of 0, causing them to expire simultaneously.
- This included expiring the last active slot in the ledger.

## Changes Made
- Added  recording of the epoch blocks height in `last_height` during slot allocation
- Implemented protection to prevent expiration of the last slot in a term ledger
- Updated tests to verify proper partition retention

## Implementation Details
```rust
// Collect indices of slots to expire
for (idx, slot) in self.slots.iter().enumerate() {
    if idx == self.slots.len() - 1 {
        // Never expire the last slot in a ledger
        continue;
    }    
   //...
```

## Current Status
- Draft PR for team collaboration
- These fixes break mining process, causing invalid block solutions
- Reproducible with `heavy_api_end_to_end_test_256kb()` test
![image](https://github.com/user-attachments/assets/8392170a-0d0c-4c3e-a22b-44347fa4b57a)

## Additional Findings
Discovered secondary bug in `allocate_additional_ledger_slots()` where the publish ledger continually grows in each epoch. even though no data is being added. Will address in separate PR.
![image](https://github.com/user-attachments/assets/5b24a34d-0942-4b3c-9576-91f6c1b0bf58)


## Related
- Issue #290
- Chunk migration update needed to set a slots `last_height` when migrating chunks. (planned as separate PR)

## Checklist
- [x] Tests updated
- [ ] Documentation updates needed
- [x] Code follows Rust style guidelines