### PR TITLE
feat: simplify epoch service to not rely on db or block_index

### DIFF
--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -534,17 +534,12 @@ mod tests {
             BlockIndexService::new(block_index.clone(), storage_config.clone()).start();
         SystemRegistry::set(block_index_actor.clone());
 
-        let block_index_guard = block_index_actor
-            .send(GetBlockIndexGuardMessage)
-            .await
-            .unwrap();
-
-        let epoch_service =
-            EpochServiceActor::new(epoch_config.clone(), &testnet_config, block_index_guard);
+        let epoch_service = EpochServiceActor::new(epoch_config.clone(), &testnet_config);
         let epoch_service_addr = epoch_service.start();
 
         // Tell the epoch service to initialize the ledgers
         let msg = NewEpochMessage {
+            previous_epoch_block: None,
             epoch_block: arc_genesis.clone(),
             commitments,
         };

--- a/crates/actors/tests/epoch_service_tests.rs
+++ b/crates/actors/tests/epoch_service_tests.rs
@@ -1,17 +1,19 @@
 use actix::{Actor, Context, Handler};
 use base58::ToBase58;
-use irys_actors::epoch_service::{GetLedgersGuardMessage, GetPartitionAssignmentsGuardMessage};
+use irys_actors::epoch_service::{
+    EpochReplayData, GetLedgersGuardMessage, GetPartitionAssignmentsGuardMessage,
+};
+
 use irys_config::StorageSubmodulesConfig;
 use irys_types::Config;
 use irys_types::{
     partition::PartitionAssignment, DatabaseProvider, IrysBlockHeader, StorageConfig, H256,
 };
 use irys_types::{partition_chunk_offset_ie, Address, PartitionChunkOffset};
-use reth_db::Database;
 use std::collections::VecDeque;
 use std::sync::{Arc, RwLock};
 use tokio::time::sleep;
-use tracing::{debug, info};
+use tracing::{debug, error, info};
 
 use std::{any::Any, sync::atomic::AtomicU64, time::Duration};
 
@@ -28,8 +30,8 @@ use irys_actors::{
 };
 use irys_config::IrysNodeConfig;
 use irys_database::{
-    add_genesis_commitments, add_test_commitments, insert_commitment_tx, open_or_create_db,
-    tables::IrysTables, BlockIndex, DataLedger, Initialized,
+    add_genesis_commitments, add_test_commitments, open_or_create_db, tables::IrysTables,
+    BlockIndex, DataLedger, Initialized,
 };
 use irys_storage::{ie, StorageModule, StorageModuleVec};
 use irys_testing_utils::utils::setup_tracing_and_temp_dir;
@@ -64,19 +66,14 @@ async fn genesis_test() {
         BlockIndexService::new(block_index.clone(), storage_config.clone()).start();
     SystemRegistry::set(block_index_actor.clone());
 
-    let block_index_guard = block_index_actor
-        .send(GetBlockIndexGuardMessage)
-        .await
-        .unwrap();
-
-    let mut epoch_service =
-        EpochServiceActor::new(config.clone(), &testnet_config, block_index_guard);
+    let mut epoch_service = EpochServiceActor::new(config.clone(), &testnet_config);
     let miner_address = config.storage_config.miner_address;
 
     // Process genesis message directly instead of through actor system
     // This allows us to inspect the actor's state after processing
     let _ = epoch_service.handle(
         NewEpochMessage {
+            previous_epoch_block: None,
             epoch_block: genesis_block.into(),
             commitments,
         },
@@ -198,6 +195,7 @@ async fn genesis_test() {
 
 #[actix::test]
 async fn add_slots_test() {
+    std::env::set_var("RUST_LOG", "debug");
     // Initialize genesis block at height 0
     let mut genesis_block = IrysBlockHeader::new_mock_header();
     let testnet_config = Config::testnet();
@@ -229,80 +227,32 @@ async fn add_slots_test() {
     };
     let num_blocks_in_epoch = config.num_blocks_in_epoch;
 
-    let arc_config = Arc::new(IrysNodeConfig {
-        base_directory: base_path.clone(),
-        ..IrysNodeConfig::default()
-    });
-
-    let block_index: Arc<RwLock<BlockIndex<Initialized>>> = Arc::new(RwLock::new(
-        BlockIndex::default()
-            .reset(&arc_config.clone())
-            .unwrap()
-            .init(arc_config.clone())
-            .await
-            .unwrap(),
-    ));
-
-    let block_index_actor = BlockIndexService::new(block_index.clone(), storage_config).start();
-    SystemRegistry::set(block_index_actor.clone());
-
-    let block_index_guard = block_index_actor
-        .send(GetBlockIndexGuardMessage)
-        .await
-        .unwrap();
-
-    let mut epoch_service = EpochServiceActor::new(config, &testnet_config, block_index_guard);
-
-    // Process genesis message directly instead of through actor system
-    // This allows us to inspect the actor's state after processing
+    let mut epoch_service = EpochServiceActor::new(config, &testnet_config);
     let mut ctx = Context::new();
-    let _ = epoch_service.handle(
-        NewEpochMessage {
-            epoch_block: genesis_block.clone().into(),
-            commitments,
-        },
-        &mut ctx,
-    );
+    let storage_submodule_config = StorageSubmodulesConfig::load(base_path.clone()).unwrap();
+    let _ = epoch_service.initialize(genesis_block.clone(), commitments, storage_submodule_config);
 
-    let msg = BlockFinalizedMessage {
-        block_header: Arc::new(genesis_block.clone()),
-        all_txs: Arc::new(vec![]),
-    };
-    match block_index_actor.send(msg).await {
-        Ok(_) => info!("Genesis block indexed"),
-        Err(_) => panic!("Failed to index genesis block"),
-    }
+    let mut mock_header = IrysBlockHeader::new_mock_header();
+    mock_header.data_ledgers[DataLedger::Submit].max_chunk_offset = 0;
 
-    // Now create a new epoch block & give the Submit ledger enough size to add a slot
-    let mut new_epoch_block = IrysBlockHeader::new_mock_header();
-    new_epoch_block.data_ledgers[DataLedger::Submit].max_chunk_offset = 0;
-
-    // index epoch previous blocks
-    let mut height = 1;
-    while height < num_blocks_in_epoch {
-        new_epoch_block.height = height;
-        let msg = BlockFinalizedMessage {
-            block_header: Arc::new(new_epoch_block.clone()),
-            all_txs: Arc::new(vec![]),
-        };
-        match block_index_actor.send(msg).await {
-            Ok(_) => debug!("block indexed"),
-            Err(err) => panic!("Failed to index block {:?}", err),
-        }
-
-        height += 1;
-    }
-
+    // Now create a new epoch block & give the Submit ledger enough size to add one slot
+    let mut new_epoch_block = mock_header.clone();
     new_epoch_block.height = num_blocks_in_epoch;
     new_epoch_block.data_ledgers[DataLedger::Submit].max_chunk_offset = num_chunks_in_partition / 2;
 
+    // Post the new epoch block to the service and let it perform_epoch_tasks()
     let _ = epoch_service.handle(
         NewEpochMessage {
+            previous_epoch_block: Some(genesis_block.clone()),
             epoch_block: new_epoch_block.clone().into(),
             commitments: Vec::new(),
         },
         &mut ctx,
     );
+
+    let ledgers = epoch_service.ledgers.read().unwrap();
+    debug!("{:#?}", ledgers);
+    drop(ledgers);
 
     // Verify each ledger has one slot and the correct number of partitions
     {
@@ -313,24 +263,13 @@ async fn add_slots_test() {
         assert_eq!(sub_slots.len(), 3); // TODO: check 1 expired, 2 new slots added
     }
 
-    // index epoch block up to 2 * num_blocks_in_epoch
-    while height < 2 * num_blocks_in_epoch {
-        new_epoch_block.height = height;
-        let msg = BlockFinalizedMessage {
-            block_header: Arc::new(new_epoch_block.clone()),
-            all_txs: Arc::new(vec![]),
-        };
-        match block_index_actor.send(msg).await {
-            Ok(_) => debug!("block indexed"),
-            Err(_) => panic!("Failed to index block"),
-        }
-
-        height += 1;
-    }
+    let previous_epoch_block = Some(new_epoch_block.clone());
 
     // Simulate a subsequent epoch block that adds multiple ledger slots
     let mut new_epoch_block = IrysBlockHeader::new_mock_header();
     new_epoch_block.height = num_blocks_in_epoch * 2;
+
+    // Increase the Submit ledger by 3 slots  and the Publish ledger by 2 slots
     new_epoch_block.data_ledgers[DataLedger::Submit].max_chunk_offset =
         (num_chunks_in_partition as f64 * 2.5) as u64;
     new_epoch_block.data_ledgers[DataLedger::Publish as usize].max_chunk_offset =
@@ -338,11 +277,16 @@ async fn add_slots_test() {
 
     let _ = epoch_service.handle(
         NewEpochMessage {
+            previous_epoch_block,
             epoch_block: new_epoch_block.clone().into(),
             commitments: Vec::new(),
         },
         &mut ctx,
     );
+
+    let ledgers = epoch_service.ledgers.read().unwrap();
+    debug!("{:#?}", ledgers);
+    drop(ledgers);
 
     // Validate the correct number of ledgers slots were added to each ledger
     {
@@ -372,7 +316,7 @@ async fn capacity_projection_tests() {
 }
 
 #[actix::test]
-async fn partition_expiration_test() {
+async fn partition_expiration_and_repacking_test() {
     std::env::set_var("RUST_LOG", "debug");
     // Initialize genesis block at height 0
     let chunk_size = 32;
@@ -411,74 +355,20 @@ async fn partition_expiration_test() {
         storage_config: storage_config.clone(),
     };
 
-    let arc_config = Arc::new(IrysNodeConfig::default());
-    let block_index: Arc<RwLock<BlockIndex<Initialized>>> = Arc::new(RwLock::new(
-        BlockIndex::default()
-            .reset(&arc_config.clone())
-            .unwrap()
-            .init(arc_config.clone())
-            .await
-            .unwrap(),
-    ));
-
-    let block_index_actor =
-        BlockIndexService::new(block_index.clone(), storage_config.clone()).start();
-    SystemRegistry::set(block_index_actor.clone());
-
-    let block_index_guard = block_index_actor
-        .send(GetBlockIndexGuardMessage)
-        .await
-        .unwrap();
-
     let db_env = open_or_create_db(tmp_dir, IrysTables::ALL, None).unwrap();
     let db = DatabaseProvider(Arc::new(db_env));
 
-    // Make sure the genesis_block is in the DB so the epoch service is initialized
-    // I don't like this dependency, dependencies should be passed into initialize() -DMac
-    {
-        db.update_eyre(|tx| irys_database::insert_block_header(tx, &genesis_block))
-            .expect("to write genesis_block to db");
-
-        db.update_eyre(|tx| {
-            commitments
-                .iter()
-                .map(|commitment| insert_commitment_tx(tx, commitment))
-                .collect::<eyre::Result<()>>()
-        })
-        .expect("inserting commitment tx should succeed");
-    }
-
-    //  You also can't initialize the epoch_service without the genesis block being in the block_index
-    // Need a better way to communicate these dependencies. -DMac
-    let msg = BlockFinalizedMessage {
-        block_header: Arc::new(genesis_block.clone()),
-        all_txs: Arc::new(vec![]),
-    };
-    match block_index_actor.send(msg).await {
-        Ok(_) => info!("Genesis block indexed"),
-        Err(_) => panic!("Failed to index genesis block"),
-    }
-
     let storage_module_config = StorageSubmodulesConfig::load(base_path.clone()).unwrap();
-    let mut epoch_service = EpochServiceActor::new(config, &testnet_config, block_index_guard);
-    let _ = epoch_service
-        .initialize(&db, storage_module_config.clone())
-        .await;
-
-    // Get the genesis storage modules and their assigned partitions
-    let storage_module_infos =
-        epoch_service.map_storage_modules_to_partition_assignments(storage_module_config);
-    let epoch_service_actor = epoch_service.start();
-
-    // Process genesis message directly instead of through actor system
-    // This allows us to inspect the actor's state after processing
-    let _ = epoch_service_actor
-        .send(NewEpochMessage {
-            epoch_block: genesis_block.into(),
+    let mut epoch_service = EpochServiceActor::new(config, &testnet_config);
+    let storage_module_infos = epoch_service
+        .initialize(
+            genesis_block.clone(),
             commitments,
-        })
-        .await
+            storage_module_config.clone(),
+        )
         .unwrap();
+
+    let epoch_service_actor = epoch_service.start();
 
     let mut storage_modules: StorageModuleVec = Vec::new();
     // Create a list of storage modules wrapping the storage files
@@ -610,65 +500,51 @@ async fn partition_expiration_test() {
         capacity_partitions
     };
 
-    let mut genesis_block = IrysBlockHeader::new_mock_header();
-    genesis_block.height = 0;
-
-    let msg = BlockFinalizedMessage {
-        block_header: Arc::new(genesis_block.clone()),
-        all_txs: Arc::new(vec![]),
-    };
-    match block_index_actor.send(msg).await {
-        Ok(_) => info!("Genesis block indexed"),
-        Err(_) => panic!("Failed to index genesis block"),
-    }
-
-    // Now create a new epoch block & give the Submit ledger enough size to add a slot
-    let mut new_epoch_block = IrysBlockHeader::new_mock_header();
-    new_epoch_block.data_ledgers[DataLedger::Submit].max_chunk_offset = 0;
-
-    // index epoch previous blocks
-    let mut height = 1;
-    while height < (testnet_config.submit_ledger_epoch_length + 1) * num_blocks_in_epoch {
-        new_epoch_block.height = height;
-        let msg = BlockFinalizedMessage {
-            block_header: Arc::new(new_epoch_block.clone()),
-            all_txs: Arc::new(vec![]),
-        };
-        match block_index_actor.send(msg).await {
-            Ok(_) => debug!("block indexed {}", height),
-            Err(_) => panic!("Failed to index block {}", height),
-        }
-
-        height += 1;
-    }
-
-    new_epoch_block.height = (testnet_config.submit_ledger_epoch_length + 1) * num_blocks_in_epoch; // next epoch block, next multiple of num_blocks_in epoch,
-    new_epoch_block.data_ledgers[DataLedger::Submit].max_chunk_offset = num_chunks_in_partition / 2;
-
-    let _ = epoch_service_actor
-        .send(NewEpochMessage {
-            epoch_block: new_epoch_block.clone().into(),
-            commitments: Vec::new(),
-        })
-        .await
-        .unwrap();
-
-    new_epoch_block.height = (testnet_config.submit_ledger_epoch_length + 2) * num_blocks_in_epoch;
-    let _ = epoch_service_actor
-        .send(NewEpochMessage {
-            epoch_block: new_epoch_block.into(),
-            commitments: Vec::new(),
-        })
-        .await
-        .unwrap();
-
     let ledgers_guard = epoch_service_actor
         .send(GetLedgersGuardMessage)
         .await
         .unwrap();
-    let ledgers = ledgers_guard.read();
-    debug!("{:#?}", ledgers);
-    drop(ledgers);
+
+    // Simulate enough epoch blocks to compete a Submit ledger storage term, expiring a slot
+    let mut new_epoch_block = IrysBlockHeader::new_mock_header();
+    let mut previous_epoch_block = Some(genesis_block.clone());
+    for i in 0..testnet_config.submit_ledger_epoch_length + 4 {
+        new_epoch_block.height = num_blocks_in_epoch + num_blocks_in_epoch * i;
+
+        if i == 3 {
+            new_epoch_block.data_ledgers[DataLedger::Submit].max_chunk_offset =
+                num_chunks_in_partition / 3;
+        }
+
+        if i == 5 {
+            new_epoch_block.data_ledgers[DataLedger::Submit].max_chunk_offset =
+                num_chunks_in_partition / 2;
+        }
+
+        debug!(
+            "Epoch Block: Submit.max_chunk_offset = {}",
+            new_epoch_block.data_ledgers[DataLedger::Submit].max_chunk_offset
+        );
+
+        let result = epoch_service_actor
+            .send(NewEpochMessage {
+                previous_epoch_block,
+                epoch_block: new_epoch_block.clone().into(),
+                commitments: Vec::new(),
+            })
+            .await
+            .unwrap();
+
+        if let Err(err) = result {
+            error!("Error processing NewEpochMessage: {:?}", err);
+            panic!("Test failed: {:?}", err);
+        }
+
+        previous_epoch_block = Some(new_epoch_block.clone());
+        let ledgers = ledgers_guard.read();
+        debug!("{:#?}", ledgers);
+        drop(ledgers);
+    }
 
     // busypoll the solution context rwlock
     let mut max_pools = 10;
@@ -696,21 +572,16 @@ async fn partition_expiration_test() {
 
     // check a new slots is inserted with a partition assigned to it, and slot 0 expired and its partition was removed
     let (publish_partition, submit_partition, submit_partition2) = {
-        let ledgers = epoch_service_actor
-            .send(GetLedgersGuardMessage)
-            .await
-            .unwrap();
-
-        let pub_slots = ledgers.read().get_slots(DataLedger::Publish).clone();
-        let sub_slots = ledgers.read().get_slots(DataLedger::Submit).clone();
+        let pub_slots = ledgers_guard.read().get_slots(DataLedger::Publish).clone();
+        let sub_slots = ledgers_guard.read().get_slots(DataLedger::Submit).clone();
         assert_eq!(
             pub_slots.len(),
             1,
             "Publish should still have only one slot"
         );
-        debug!("Ledger State: {:#?}", ledgers);
+        debug!("Ledger State: {:#?}", ledgers_guard);
 
-        assert_eq!(sub_slots.len(), 4, "Submit slots should have two new not expired slots with a new fresh partition from available previous capacity ones!");
+        assert_eq!(sub_slots.len(), 3, "Submit slots should have two new not expired slots with a new fresh partition from available previous capacity ones!");
         assert!(
             sub_slots[0].is_expired && sub_slots[0].partitions.len() == 0,
             "Slot 0 should have expired and have no assigned partition!"
@@ -732,14 +603,6 @@ async fn partition_expiration_test() {
         );
 
         println!("{}", serde_json::to_string_pretty(&sub_slots).unwrap());
-
-        assert!(
-            !sub_slots[3].is_expired
-                && sub_slots[3].partitions.len() == 1
-                && (capacity_partitions.contains(&sub_slots[3].partitions[0])
-                    || submit_partition_hash == sub_slots[3].partitions[0]),
-            "Slot 3 should not be expired have a capacity or the just expired partition"
-        );
 
         let publish_partition = pub_slots[0]
             .partitions
@@ -769,7 +632,7 @@ async fn partition_expiration_test() {
 
         assert_eq!(
             partition_assignments_read.read().data_partitions.len(),
-            4,
+            3,
             "Should have four partitions assignments"
         );
 
@@ -868,9 +731,6 @@ async fn epoch_blocks_reinitialization_test() {
     let base_path = tmp_dir.path().to_path_buf();
     let storage_module_config = StorageSubmodulesConfig::load(base_path.clone()).unwrap();
 
-    let db = open_or_create_db(tmp_dir, IrysTables::ALL, None).unwrap();
-    let database_provider = DatabaseProvider(Arc::new(db));
-
     let config = EpochServiceConfig {
         capacity_scalar: testnet_config.capacity_scalar,
         num_blocks_in_epoch: testnet_config.num_blocks_in_epoch,
@@ -897,13 +757,7 @@ async fn epoch_blocks_reinitialization_test() {
         BlockIndexService::new(block_index.clone(), storage_config.clone()).start();
     SystemRegistry::set(block_index_actor.clone());
 
-    let block_index_guard = block_index_actor
-        .send(GetBlockIndexGuardMessage)
-        .await
-        .unwrap();
-
-    let mut epoch_service =
-        EpochServiceActor::new(config.clone(), &testnet_config, block_index_guard.clone());
+    let mut epoch_service = EpochServiceActor::new(config.clone(), &testnet_config);
 
     // Process genesis message directly instead of through actor system
     // This allows us to inspect the actor's state after processing
@@ -913,40 +767,19 @@ async fn epoch_blocks_reinitialization_test() {
     genesis_block.height = 0;
     let pledge_count = config.num_capacity_partitions.unwrap_or(31) as u8;
     let commitments = add_test_commitments(&mut genesis_block, pledge_count, &testnet_config);
-    database_provider
-        .update_eyre(|tx| {
-            commitments
-                .iter()
-                .map(|commitment| insert_commitment_tx(tx, commitment))
-                .collect::<eyre::Result<()>>()
-        })
-        .expect("inserting commitment tx should succeed");
-
-    database_provider
-        .update_eyre(|tx| irys_database::insert_block_header(tx, &genesis_block))
-        .unwrap();
 
     // Get the genesis storage modules and their assigned partitions
     let storage_module_infos = epoch_service
-        .initialize(&database_provider, storage_module_config.clone())
-        .await
+        .initialize(
+            genesis_block.clone(),
+            commitments.clone(),
+            storage_module_config.clone(),
+        )
         .unwrap();
     debug!("{:#?}", storage_module_infos);
 
     genesis_block.block_hash = H256::from_slice(&[0; 32]);
-    let _ = epoch_service.handle(
-        NewEpochMessage {
-            epoch_block: genesis_block.clone().into(),
-            commitments,
-        },
-        &mut ctx,
-    );
-
     let pa_read_guard = epoch_service.handle(GetPartitionAssignmentsGuardMessage, &mut ctx);
-
-    // database_provider
-    //     .update_eyre(|tx| irys_database::insert_block_header(tx, &genesis_block))
-    //     .unwrap();
 
     let msg = BlockFinalizedMessage {
         block_header: Arc::new(genesis_block.clone()),
@@ -990,45 +823,49 @@ async fn epoch_blocks_reinitialization_test() {
     //          |sm2|
     //          +-+-+
 
+    let ledgers = epoch_service.ledgers.read().unwrap();
+    debug!("{:#?}", ledgers);
+    drop(ledgers);
+
     // Now create a new epoch block & give the Submit ledger enough size to add a slot
     let mut new_epoch_block = IrysBlockHeader::new_mock_header();
     new_epoch_block.data_ledgers[DataLedger::Submit].max_chunk_offset = 0;
 
-    // index and store in db blocks
-    let mut height = 1;
-    while height <= (testnet_config.submit_ledger_epoch_length + 2) * num_blocks_in_epoch {
-        new_epoch_block.height = height;
-        new_epoch_block.block_hash = H256::random();
+    let mut epoch_replay_data: Vec<EpochReplayData> = Vec::new();
+    let epochs_in_term = testnet_config.submit_ledger_epoch_length;
+    let mut previous_epoch_block = Some(genesis_block.clone());
 
-        if height == (testnet_config.submit_ledger_epoch_length + 1) * num_blocks_in_epoch {
+    for i in 0..=epochs_in_term {
+        // Simulate blocks up to one before the next epoch boundary
+        let next_epoch_height = num_blocks_in_epoch * (i + 1);
+
+        // For the second to last epoch block in the term, have it resize the submit ledger
+        if i == epochs_in_term - 1 {
             new_epoch_block.data_ledgers[DataLedger::Submit].max_chunk_offset =
                 num_chunks_in_partition / 2;
         }
 
-        let msg = BlockFinalizedMessage {
-            block_header: Arc::new(new_epoch_block.clone()),
-            all_txs: Arc::new(vec![]),
-        };
-        match block_index_actor.send(msg).await {
-            Ok(_) => (), // debug!("block indexed"),
-            Err(err) => panic!("Failed to index block {:?}", err),
+        // Send the epoch message
+        new_epoch_block.height = next_epoch_height;
+        let result = epoch_service.handle(
+            NewEpochMessage {
+                previous_epoch_block,
+                epoch_block: new_epoch_block.clone().into(),
+                commitments: Vec::new(),
+            },
+            &mut ctx,
+        );
+
+        if let Err(err) = result {
+            error!("Error processing NewEpochMessage: {:?}", err);
+            panic!("Test failed: {:?}", err);
         }
 
-        if height % num_blocks_in_epoch == 0 {
-            debug!("epoch block {}", height);
-            let _ = epoch_service.handle(
-                NewEpochMessage {
-                    epoch_block: new_epoch_block.clone().into(),
-                    commitments: Vec::new(),
-                },
-                &mut ctx,
-            );
-        }
-
-        database_provider
-            .update_eyre(|tx| irys_database::insert_block_header(tx, &new_epoch_block))
-            .unwrap();
-        height += 1;
+        epoch_replay_data.push(EpochReplayData {
+            epoch_block: new_epoch_block.clone(),
+            commitments: Vec::new(),
+        });
+        previous_epoch_block = Some(new_epoch_block.clone());
     }
 
     // Verify each ledger has one slot and the correct number of partitions
@@ -1038,7 +875,7 @@ async fn epoch_blocks_reinitialization_test() {
         let pub_slots = ledgers.get_slots(DataLedger::Publish);
         let sub_slots = ledgers.get_slots(DataLedger::Submit);
         assert_eq!(pub_slots.len(), 1);
-        assert_eq!(sub_slots.len(), 4); // TODO: check slot 1 expired, 3 new slots added
+        assert_eq!(sub_slots.len(), 3); // TODO: check slot 1 expired, 2 new slots added
     }
 
     //            +---+
@@ -1047,12 +884,12 @@ async fn epoch_blocks_reinitialization_test() {
     // Publish 0----+----+----+---
     //              |    |    |
     //              0    1    2
-    //                  +---+ +---+ +---+
-    //                  |sm2| |sm1| | ? |
-    //                  +-|-+ +-|-+ +-|-+
-    // Submit 1 +----+----+-----+-----+----+---
-    //          |    |    |     |     |
-    //          0    1    2     3     4
+    //                +---+ +---+
+    //                |sm2| |sm1|
+    //                +-|-+ +-|-+
+    // Submit 1----+----+-----+---
+    //             |    |     |
+    //             0    1     2
     // Capacity
 
     pa_read_guard.read().print_assignments();
@@ -1068,12 +905,21 @@ async fn epoch_blocks_reinitialization_test() {
     );
 
     // Get the genesis storage modules and their assigned partitions
-    let mut epoch_service = EpochServiceActor::new(config, &testnet_config, block_index_guard);
+    let mut epoch_service = EpochServiceActor::new(config, &testnet_config);
     let storage_module_infos = epoch_service
-        .initialize(&database_provider, storage_module_config.clone())
-        .await
+        .initialize(genesis_block, commitments, storage_module_config.clone())
         .unwrap();
+
+    epoch_service
+        .replay_epoch_data(epoch_replay_data, storage_module_config.clone())
+        .expect("to replay the epoch data");
+
     debug!("{:#?}", storage_module_infos);
+
+    let new_sm_infos =
+        epoch_service.map_storage_modules_to_partition_assignments(storage_module_config);
+
+    debug!("{:#?}", new_sm_infos);
 
     // Check partition hashes have not changed in storage modules
     {
@@ -1109,8 +955,6 @@ async fn partitions_assignment_determinism_test() {
     let pledge_count = 20;
     let commitments = add_test_commitments(&mut genesis_block, pledge_count, &testnet_config);
 
-    // TODO: need a test method that pledges X partitions regardless of the storage config
-
     // Create a storage config for testing
     let storage_config = StorageConfig {
         chunk_size: 32,
@@ -1134,53 +978,17 @@ async fn partitions_assignment_determinism_test() {
     };
     let num_blocks_in_epoch = config.num_blocks_in_epoch;
 
-    let tmp_dir = setup_tracing_and_temp_dir(Some("epoch_block_reinitialization_test"), false);
+    let tmp_dir = setup_tracing_and_temp_dir(Some("partitions_assignment_determinism_test"), false);
     let base_path = tmp_dir.path().to_path_buf();
-    let arc_config = Arc::new(IrysNodeConfig {
-        base_directory: base_path.clone(),
-        ..IrysNodeConfig::default()
-    });
+    let storage_module_config = StorageSubmodulesConfig::load(base_path.clone()).unwrap();
 
-    let block_index: Arc<RwLock<BlockIndex<Initialized>>> = Arc::new(RwLock::new(
-        BlockIndex::default()
-            .reset(&arc_config.clone())
-            .unwrap()
-            .init(arc_config.clone())
-            .await
-            .unwrap(),
-    ));
+    let mut epoch_service = EpochServiceActor::new(config.clone(), &testnet_config);
+    let _ = epoch_service.initialize(genesis_block.clone(), commitments, storage_module_config);
 
-    let block_index_actor =
-        BlockIndexService::new(block_index.clone(), storage_config.clone()).start();
-    SystemRegistry::set(block_index_actor.clone());
-
-    let block_index_guard = block_index_actor
-        .send(GetBlockIndexGuardMessage)
-        .await
-        .unwrap();
-
-    let mut epoch_service =
-        EpochServiceActor::new(config.clone(), &testnet_config, block_index_guard.clone());
     let mut ctx = Context::new();
-    let _ = epoch_service.handle(
-        NewEpochMessage {
-            epoch_block: genesis_block.clone().into(),
-            commitments,
-        },
-        &mut ctx,
-    );
 
     let pa_read_guard = epoch_service.handle(GetPartitionAssignmentsGuardMessage, &mut ctx);
     pa_read_guard.read().print_assignments();
-
-    let msg = BlockFinalizedMessage {
-        block_header: Arc::new(genesis_block.clone()),
-        all_txs: Arc::new(vec![]),
-    };
-    match block_index_actor.send(msg).await {
-        Ok(_) => info!("Genesis block indexed"),
-        Err(_) => panic!("Failed to index genesis block"),
-    }
 
     // Now create a new epoch block & give the Submit ledger enough size to add a slot
     let total_epoch_messages = 6;
@@ -1189,39 +997,29 @@ async fn partitions_assignment_determinism_test() {
     new_epoch_block.data_ledgers[DataLedger::Submit].max_chunk_offset = num_chunks_in_partition;
     new_epoch_block.data_ledgers[DataLedger::Publish].max_chunk_offset = num_chunks_in_partition;
 
-    let mut height = 1;
+    let mut previous_epoch_block = Some(genesis_block.clone());
     while epoch_num <= total_epoch_messages {
-        new_epoch_block.height = height;
+        new_epoch_block.height = epoch_num * num_blocks_in_epoch;
         //(testnet_config.submit_ledger_epoch_length * epoch_num) * num_blocks_in_epoch; // next epoch block, next multiple of num_blocks_in epoch,
-        let msg = BlockFinalizedMessage {
-            block_header: Arc::new(new_epoch_block.clone()),
-            all_txs: Arc::new(vec![]),
-        };
-        match block_index_actor.send(msg).await {
-            Ok(_) => (), // debug!("block indexed"),
-            Err(err) => panic!("Failed to index block {:?}", err),
-        }
-
-        if height % num_blocks_in_epoch == 0 {
-            epoch_num += 1;
-            debug!("epoch block {}", height);
-            let _ = epoch_service.handle(
-                NewEpochMessage {
-                    epoch_block: new_epoch_block.clone().into(),
-                    commitments: Vec::new(),
-                },
-                &mut ctx,
-            );
-        }
-        height += 1;
+        epoch_num += 1;
+        debug!("epoch block {}", new_epoch_block.height);
+        let _ = epoch_service.handle(
+            NewEpochMessage {
+                previous_epoch_block,
+                epoch_block: new_epoch_block.clone().into(),
+                commitments: Vec::new(),
+            },
+            &mut ctx,
+        );
+        previous_epoch_block = Some(new_epoch_block.clone());
     }
 
     pa_read_guard.read().print_assignments();
-    // debug!(
-    //     "\nAll Partitions({})\n{}",
-    //     &epoch_service.all_active_partitions.len(),
-    //     serde_json::to_string_pretty(&epoch_service.all_active_partitions).unwrap()
-    // );
+    debug!(
+        "\nAll Partitions({})\n{}",
+        &epoch_service.all_active_partitions.len(),
+        serde_json::to_string_pretty(&epoch_service.all_active_partitions).unwrap()
+    );
 
     // Check determinism in assigned partitions
     let publish_slot_0 = H256::from_base58("2F5eg8FE2VmXGcgpyUKTzBrLzSmVXMKqawUJeDgKC1vW");
@@ -1293,14 +1091,14 @@ async fn partitions_assignment_determinism_test() {
         panic!("Should have an assignment");
     };
 
-    let submit_slot_7 = H256::from_base58("AtGjnuZ1EKmp8sP1FT3aMPbJWCY8tdEoksVFDB6PKXr1");
+    let submit_slot_2 = H256::from_base58("8sRHV12yycwpUSzean97JemQrzAXSSQWMmC4Jx3xUXzQ");
 
     if let Some(submit_assignment) = epoch_service
         .partition_assignments
         .read()
         .unwrap()
         .data_partitions
-        .get(&submit_slot_7)
+        .get(&submit_slot_2)
     {
         assert_eq!(
             submit_assignment.ledger_id,
@@ -1309,8 +1107,8 @@ async fn partitions_assignment_determinism_test() {
         );
         assert_eq!(
             submit_assignment.slot_index,
-            Some(7),
-            "Should be assigned to slot 7"
+            Some(2),
+            "Should be assigned to slot 14"
         );
     } else {
         panic!("Should have an assignment");

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -32,6 +32,7 @@ use irys_database::{
     migration::check_db_version_and_run_migrations_if_needed, tables::IrysTables, BlockIndex,
     Initialized,
 };
+use irys_database::{block_header_by_hash, commitment_tx_by_txid, SystemLedger};
 use irys_gossip_service::ServiceHandleWithShutdownSignal;
 use irys_price_oracle::{mock_oracle::MockOracle, IrysPriceOracle};
 
@@ -728,6 +729,7 @@ impl IrysNode {
         let (block_discovery, block_discovery_arbiter) = self.init_block_discovery_service(
             &irys_db,
             &service_senders,
+            &epoch_service_actor,
             &block_index_guard,
             partition_assignments_guard,
             &vdf_steps_guard,
@@ -1076,6 +1078,7 @@ impl IrysNode {
         &self,
         irys_db: &DatabaseProvider,
         service_senders: &ServiceSenders,
+        epoch_service: &Addr<EpochServiceActor>,
         block_index_guard: &BlockIndexReadGuard,
         partition_assignments_guard: irys_actors::epoch_service::PartitionAssignmentsReadGuard,
         vdf_steps_guard: &VdfStepsReadGuard,
@@ -1091,6 +1094,8 @@ impl IrysNode {
             vdf_steps_guard: vdf_steps_guard.clone(),
             service_senders: service_senders.clone(),
             gossip_sender,
+            epoch_service: epoch_service.clone(),
+            epoch_config: self.epoch_config.clone(),
         };
         let block_discovery_arbiter = Arbiter::new();
         let block_discovery =
@@ -1234,14 +1239,51 @@ impl IrysNode {
         ),
         eyre::Error,
     > {
-        let mut epoch_service = EpochServiceActor::new(
-            self.epoch_config.clone(),
-            &self.config,
-            block_index_guard.clone(),
-        );
-        let storage_module_infos = epoch_service
-            .initialize(irys_db, self.storage_submodule_config.clone())
-            .await?;
+        // TODO: Refactor this function to reduce database queries and block index lookups.
+        // Consider accepting the genesis block and its commitments as direct parameters
+        // rather than retrieving them from storage, especially when these values can
+        // already known by the caller. This would improve efficiency and simplify the
+        // function's responsibilities. -DMac
+
+        // Get the genesis block
+        let genesis_item = block_index_guard
+            .read()
+            .get_item(0)
+            .expect("To read genesis item ")
+            .clone();
+
+        let genesis_block = irys_db
+            .view(|tx| block_header_by_hash(tx, &genesis_item.block_hash, false))
+            .unwrap()
+            .unwrap()
+            .expect("to retrieve genesis block form db");
+
+        // Extract the Commitment ledger from the epoch block
+        let commitments_ledger = genesis_block
+            .system_ledgers
+            .iter()
+            .find(|b| b.ledger_id == SystemLedger::Commitment)
+            .expect("commitments ledger to be present");
+
+        // Get the genesis commitment tx
+        let read_tx = irys_db.tx().expect("to create a database read tx");
+        let commitments = commitments_ledger
+            .tx_ids
+            .iter()
+            .map(|txid| {
+                commitment_tx_by_txid(&read_tx, txid).and_then(|opt| {
+                    opt.ok_or_else(|| eyre::eyre!("No commitment tx found for txid {:?}", txid))
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .expect("to be able to retrieve all of the commitment tx headers locally");
+
+        let mut epoch_service = EpochServiceActor::new(self.epoch_config.clone(), &self.config);
+        let storage_module_infos = epoch_service.initialize(
+            genesis_block,
+            commitments,
+            self.storage_submodule_config.clone(),
+        )?;
         let epoch_service_actor = epoch_service.start();
         Ok((storage_module_infos, epoch_service_actor))
     }

--- a/crates/types/src/block.rs
+++ b/crates/types/src/block.rs
@@ -110,7 +110,7 @@ pub struct IrysBlockHeader {
     /// The solution hash of the previous block in the chain.
     pub previous_solution_hash: H256,
 
-    /// The solution hash of the last epoch block
+    /// The block hash of the last epoch block
     pub last_epoch_hash: H256,
 
     /// `SHA-256` hash of the PoA chunk (unencoded) bytes.


### PR DESCRIPTION
# Refactor: Epoch Service and Block Discovery Flow

## Key Architectural Improvements

- **Relocated NewEpochMessage to block_discovery**:
  - Now properly positioned for processing epoch blocks from all peers
  - Improved messaging flow and responsibility boundaries

- **Enhanced block_producer functionality**:
  - Fixed `last_epoch_hash` population in all blocks
  - Added proper `previous_solution_hash` tracking

- **Simplified Epoch Service API**:
  - Split initialization into two clear phases:
    1. `initialize()` - Takes genesis information
    2. `replay_epoch_data()` - Processes epoch blocks and commitments
  - Removed database and block_index dependencies
  - Streamlined slot growth calculations

- **Introduced EpochReplayData structure**:
```rust
pub struct EpochReplayData {
    pub epoch_block: IrysBlockHeader,
    pub commitments: Vec<CommitmentTransaction>,
}
```

- **Optimized partition management**:
  - Fixed partition expiration sequence (now occurs after new slot allocation)
  - Resolved incorrect slot addition bug (previously added one slot every epoch)
  - Simplified `calculate_additional_slots()` logic for better maintainability

- **Improved testability**:
  - Dramatically reduced test overhead by eliminating need to record intermediate blocks
  - Added specific tests for `replay_epoch_data()` functionality

## Implementation Details

- Moved `print_items()` to `BlockItemReadGuard` for broader accessibility
- Fixed `div_ceil` usage that was causing unnecessary slot allocation
- Updated chain.rs to properly initialize epoch_service from genesis

## Additional Context

The peer initialization path in chain.rs needs updating to create the `EpochReplayData` and call `replay_epoch_data()` for full epoch_service initialization at startup. This will be addressed in a future PR.

## Checklist
- [x] Tests updated
- [ ] Documentation needs updates
- [x] Code follows Rust style guidelines
