### PR TITLE
fix: refactor BlockIndex.get_item method signature

### DIFF
--- a/crates/actors/src/block_discovery.rs
+++ b/crates/actors/src/block_discovery.rs
@@ -290,8 +290,8 @@ impl Handler<BlockDiscoveredMessage> for BlockDiscoveryActor {
                         .await??;
 
                     // Is this an epoch block?
-                    let block_height = new_block_header.height as usize;
-                    let blocks_in_epoch = epoch_config.num_blocks_in_epoch as usize;
+                    let block_height = new_block_header.height;
+                    let blocks_in_epoch = epoch_config.num_blocks_in_epoch;
                     if block_height > 0 && block_height % blocks_in_epoch == 0 {
                         // Look up the previous epoch block
                         let block_item = block_index_guard2

--- a/crates/actors/src/block_index_service.rs
+++ b/crates/actors/src/block_index_service.rs
@@ -44,7 +44,7 @@ impl BlockIndexReadGuard {
         let rg = self.read();
         let tx = db.tx().unwrap();
         for i in 0..rg.num_blocks() {
-            let item = rg.get_item(i as usize).unwrap();
+            let item = rg.get_item(i).unwrap();
             let block_hash = item.block_hash;
             let block = block_header_by_hash(&tx, &block_hash, false)
                 .unwrap()
@@ -185,9 +185,7 @@ impl BlockIndexService {
             if index.num_blocks() == 0 && block.height == 0 {
                 (0, sub_chunks_added)
             } else {
-                let prev_block = index
-                    .get_item((block.height.saturating_sub(1)) as usize)
-                    .unwrap();
+                let prev_block = index.get_item(block.height.saturating_sub(1)).unwrap();
                 (
                     prev_block.ledgers[DataLedger::Publish].max_chunk_offset + pub_chunks_added,
                     prev_block.ledgers[DataLedger::Submit].max_chunk_offset + sub_chunks_added,
@@ -279,7 +277,7 @@ impl Handler<GetLatestBlockIndexMessage> for BlockIndexService {
 
         let binding = self.block_index.clone().unwrap();
         let bi = binding.read().unwrap();
-        let block_height = bi.num_blocks().max(1) as usize - 1;
+        let block_height = bi.num_blocks().max(1) - 1;
         Some(bi.get_item(block_height)?.clone())
     }
 }

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -246,7 +246,7 @@ impl BlockTreeService {
         let binding = self.block_index_guard.clone().unwrap();
         let bi = binding.read();
         if bi.num_blocks() > finalized_height && bi.num_blocks() > finalized_height {
-            let finalized = bi.get_item(finalized_height as usize).unwrap();
+            let finalized = bi.get_item(finalized_height).unwrap();
             if finalized.block_hash == finalized_hash {
                 return;
             }
@@ -572,7 +572,7 @@ impl BlockTreeCache {
         let end = block_index.num_blocks();
 
         // Initialize cache with the start block
-        let start_block_hash = block_index.get_item(start as usize).unwrap().block_hash;
+        let start_block_hash = block_index.get_item(start).unwrap().block_hash;
         let start_block = block_header_by_hash(&tx, &start_block_hash, false)
             .unwrap()
             .unwrap();
@@ -585,10 +585,7 @@ impl BlockTreeCache {
 
         // Add remaining blocks
         for block_height in (start + 1)..end {
-            let block_hash = block_index
-                .get_item(block_height as usize)
-                .unwrap()
-                .block_hash;
+            let block_hash = block_index.get_item(block_height).unwrap().block_hash;
             let block = block_header_by_hash(&tx, &block_hash, false)
                 .unwrap()
                 .unwrap();

--- a/crates/actors/src/chunk_migration_service.rs
+++ b/crates/actors/src/chunk_migration_service.rs
@@ -246,7 +246,7 @@ fn get_block_range(
     // start of this new block from the previous block.
     let index_reader = block_index.read().unwrap();
     let start_chunk_offset = if block.height > 0 {
-        let prev_item = index_reader.get_item(block.height as usize - 1).unwrap();
+        let prev_item = index_reader.get_item(block.height - 1).unwrap();
         prev_item.ledgers[ledger].max_chunk_offset
     } else {
         0

--- a/crates/actors/src/epoch_service/epoch_replay_data.rs
+++ b/crates/actors/src/epoch_service/epoch_replay_data.rs
@@ -52,7 +52,7 @@ impl EpochReplayData {
 
             // Get the block hash from the block index
             let block_item = block_index
-                .get_item(block_height as usize)
+                .get_item(block_height)
                 .expect("Expected block index to contain an item at the epoch block height");
 
             // Retrieve the block header from the database

--- a/crates/actors/src/vdf_service.rs
+++ b/crates/actors/src/vdf_service.rs
@@ -120,7 +120,7 @@ async fn create_state_parallel(
             let join = task::spawn_blocking(move || {
                 let block_hash = block_index
                     .read()
-                    .get_item(block.try_into().expect("usize overflow"))
+                    .get_item(block)
                     .map(|item| item.block_hash)
                     .expect("Error getting block hash");
                 db.view_eyre(|tx| block_header_by_hash(tx, &block_hash, false))

--- a/crates/api-server/src/routes/block.rs
+++ b/crates/api-server/src/routes/block.rs
@@ -42,9 +42,7 @@ pub async fn get_block(
             state
                 .block_index
                 .read()
-                .get_item(height.try_into().map_err(|_| ApiError::Internal {
-                    err: String::from("Block height out of range"),
-                })?)
+                .get_item(height)
                 .ok_or(ApiError::ErrNoId {
                     id: path.to_string(),
                     err: String::from("Invalid block height"),

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -341,7 +341,7 @@ impl IrysNodeTest<IrysNodeCtx> {
         self.node_ctx
             .block_index_guard
             .read()
-            .get_item(height as usize)
+            .get_item(height)
             .ok_or_else(|| eyre::eyre!("Block at height {} not found", height))
             .and_then(|block| {
                 self.node_ctx


### PR DESCRIPTION
# Refactor BlockIndex.get_item Method Signature

## Changes
- Modified `block_index.get_item()` to accept `u64` parameters instead of `usize`
- Implemented safe internal type conversion with overflow handling
- Eliminated repetitive casting at call sites throughout the codebase

## Benefits
- Improves code readability by removing numerous explicit casts
- Centralizes conversion logic in one location
- Adds safety checks to prevent silent truncation on platforms where usize < u64
- Maintains API consistency with block heights represented as u64 elsewhere

## Implementation
```rust
// Before:
pub fn get_item(&self, index: usize) -> Option<&BlockIndexItem> {
    self.items.get(index)
}

// After:
pub fn get_item(&self, block_height: u64) -> Option<&BlockIndexItem> {
    // Check if block_height can fit into a usize
    let index = if block_height <= usize::MAX as u64 {
        block_height as usize
    } else {
        return None; // Block height too large for this platform
    };
    self.items.get(index)
}
```