### PR TITLE
feat: is_promoted HTTP route

### DIFF
--- a/crates/api-server/src/lib.rs
+++ b/crates/api-server/src/lib.rs
@@ -78,6 +78,10 @@ pub fn routes() -> impl HttpServiceFactory {
         .route("/tx", web::post().to(tx::post_tx))
         .route("/tx/{tx_id}", web::get().to(tx::get_transaction_api))
         .route(
+            "/tx/{tx_id}/is_promoted",
+            web::get().to(tx::get_tx_is_promoted),
+        )
+        .route(
             "/tx/{tx_id}/local/data_start_offset",
             web::get().to(tx::get_tx_local_start_offset),
         )

--- a/crates/api-server/src/routes/tx.rs
+++ b/crates/api-server/src/routes/tx.rs
@@ -191,7 +191,7 @@ pub async fn get_tx_is_promoted(
     path: web::Path<H256>,
 ) -> Result<Json<IsPromoted>, ApiError> {
     let tx_id: H256 = path.into_inner();
-    info!("Get tx by tx_id: {}", tx_id);
+    info!("Get tx_is_promoted by tx_id: {}", tx_id);
     let tx_header = get_storage_transaction(&state, tx_id)?;
 
     Ok(web::Json(IsPromoted {

--- a/crates/api-server/src/routes/tx.rs
+++ b/crates/api-server/src/routes/tx.rs
@@ -176,12 +176,6 @@ pub async fn get_tx_local_start_offset(
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
-pub struct IsPromoted {
-    promoted: bool,
-}
-
 // TODO: REMOVE ME ONCE WE HAVE A GATEWAY
 /// Returns whether or not a transaction has been promoted
 /// by checking if the ingress_proofs field of the tx's header is `Some`,
@@ -189,12 +183,10 @@ pub struct IsPromoted {
 pub async fn get_tx_is_promoted(
     state: web::Data<ApiState>,
     path: web::Path<H256>,
-) -> Result<Json<IsPromoted>, ApiError> {
+) -> Result<Json<bool>, ApiError> {
     let tx_id: H256 = path.into_inner();
     info!("Get tx_is_promoted by tx_id: {}", tx_id);
     let tx_header = get_storage_transaction(&state, tx_id)?;
 
-    Ok(web::Json(IsPromoted {
-        promoted: tx_header.ingress_proofs.is_some(),
-    }))
+    Ok(web::Json(tx_header.ingress_proofs.is_some()))
 }

--- a/crates/api-server/src/routes/tx.rs
+++ b/crates/api-server/src/routes/tx.rs
@@ -135,6 +135,13 @@ pub fn get_transaction(
         })
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct TxOffset {
+    #[serde(default, with = "u64_stringify")]
+    pub data_start_offset: u64,
+}
+
 // Modified to work only with storage transactions
 pub async fn get_tx_local_start_offset(
     state: web::Data<ApiState>,
@@ -171,7 +178,27 @@ pub async fn get_tx_local_start_offset(
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
-pub struct TxOffset {
+pub struct TxStatus {
     #[serde(default, with = "u64_stringify")]
-    pub data_start_offset: u64,
+    pub confirmations: u64,
+}
+
+pub async fn get_tx_status(
+    state: web::Data<ApiState>,
+    path: web::Path<H256>,
+) -> Result<Json<TxStatus>, ApiError> {
+    let tx_id: H256 = path.into_inner();
+    info!("Get tx by tx_id: {}", tx_id);
+    get_tx_status_internal(&state, tx_id).map(web::Json)
+}
+
+pub fn get_tx_status_internal(
+    _state: &web::Data<ApiState>,
+    _tx_id: H256,
+) -> Result<TxStatus, ApiError> {
+    // let block_index_read = state.block_index.read();
+    // block_index_read.items.iter().find(|i| i.ledgers.iter().find(|li| li.tx_root));
+
+    // todo!();
+    Ok(TxStatus { confirmations: 50 })
 }


### PR DESCRIPTION
**Describe the changes**
This is a small PR that adds a (temporary until we have a gateway) `/tx/<txId>/is_promoted` route that signals if a given transaction a.) exists (by response code, 404 or 200) and b.) if it's promoted (by response body)
The primary use case for this is the Bundler node, which needs a mechanism for quickly checking on transaction status.


