### PR TITLE
feat: commitment tx ingress, validation and caching

### DIFF
--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -59,7 +59,7 @@ pub struct BlockProducerActor {
     pub block_discovery_addr: Addr<BlockDiscoveryActor>,
     /// Tracks the global state of partition assignments on the protocol
     pub epoch_service: Addr<EpochServiceActor>,
-    /// Tracks the global state of partition assignments on the protocol
+    /// Reference to all the services we can send messages to
     pub service_senders: ServiceSenders,
     /// Reference to the VM node
     pub reth_provider: RethNodeProvider,

--- a/crates/actors/src/commitment_cache.rs
+++ b/crates/actors/src/commitment_cache.rs
@@ -29,7 +29,6 @@ pub enum CommitmentCacheMessage {
 pub enum CommitmentStatus {
     Accepted,        // The commitment is valid and was added to the cache
     Invalid(String), // The commitment failed validation with specific reason
-    Skipped,         // The commitment was skipped
     Unknown,         // The commitment is unknown to the cache & has no status
 }
 
@@ -221,7 +220,9 @@ impl Inner {
 
         // Early return for non-supported commitment types
         if !matches!(tx_type, CommitmentType::Stake | CommitmentType::Pledge) {
-            return send_status(CommitmentStatus::Skipped);
+            return send_status(CommitmentStatus::Invalid(
+                "unsupported commitment type".into(),
+            ));
         }
 
         // Get or create miner commitments entry

--- a/crates/actors/src/commitment_cache.rs
+++ b/crates/actors/src/commitment_cache.rs
@@ -1,0 +1,255 @@
+use std::collections::BTreeMap;
+
+use futures::future::Either;
+use irys_primitives::CommitmentType;
+use irys_types::{Address, CommitmentTransaction, Config};
+use reth::tasks::{shutdown::GracefulShutdown, TaskExecutor};
+use std::pin::pin;
+use tokio::{
+    sync::{mpsc::UnboundedReceiver, oneshot},
+    task::JoinHandle,
+};
+use tracing::debug;
+
+use crate::CommitmentStateReadGuard;
+// Messages that the CommitmentCache service supports
+#[derive(Debug)]
+pub enum CommitmentCacheMessage {
+    GetCommitmentStatus {
+        commitment_tx: CommitmentTransaction,
+        response: oneshot::Sender<CommitmentStatus>,
+    },
+    AddCommitment {
+        commitment_tx: CommitmentTransaction,
+        response: oneshot::Sender<CommitmentStatus>,
+    },
+}
+
+#[derive(Debug, PartialEq)]
+pub enum CommitmentStatus {
+    Accepted,        // The commitment is valid and was added to the cache
+    Invalid(String), // The commitment failed validation with specific reason
+    Skipped,         // The commitment was skipped
+    Unknown,         // The commitment is unknown to the cache & has no status
+}
+
+#[derive(Default, Debug)]
+struct MinerCommitments {
+    stake: Option<CommitmentTransaction>,
+    pledges: Vec<CommitmentTransaction>,
+}
+
+#[derive(Debug)]
+pub struct CommitmentCache {
+    shutdown: GracefulShutdown,
+    msg_rx: UnboundedReceiver<CommitmentCacheMessage>,
+    inner: Inner,
+}
+
+#[derive(Debug)]
+struct Inner {
+    cache: BTreeMap<Address, MinerCommitments>,
+    commitment_state_guard: CommitmentStateReadGuard,
+}
+
+impl CommitmentCache {
+    /// Spawn a new CommitmentCache service
+    pub fn spawn_service(
+        exec: &TaskExecutor,
+        rx: UnboundedReceiver<CommitmentCacheMessage>,
+        commitment_state_guard: CommitmentStateReadGuard,
+        _config: &Config,
+    ) -> JoinHandle<()> {
+        exec.spawn_critical_with_graceful_shutdown_signal(
+            "CommitmentCache Service",
+            |shutdown| async move {
+                let pending_commitments_cache = Self {
+                    shutdown,
+                    msg_rx: rx,
+                    inner: Inner {
+                        cache: BTreeMap::new(),
+                        commitment_state_guard,
+                    },
+                };
+                pending_commitments_cache
+                    .start()
+                    .await
+                    .expect("CommitmentCache encountered an irrecoverable error")
+            },
+        )
+    }
+
+    async fn start(mut self) -> eyre::Result<()> {
+        tracing::info!("starting CommitmentCache service");
+
+        let mut shutdown_future = pin!(self.shutdown);
+        let shutdown_guard = loop {
+            let mut msg_rx = pin!(self.msg_rx.recv());
+            match futures::future::select(&mut msg_rx, &mut shutdown_future).await {
+                Either::Left((Some(msg), _)) => {
+                    self.inner.handle_message(msg).await?;
+                }
+                Either::Left((None, _)) => {
+                    tracing::warn!("receiver channel closed");
+                    break None;
+                }
+                Either::Right((shutdown, _)) => {
+                    tracing::warn!("shutdown signal received");
+                    break Some(shutdown);
+                }
+            }
+        };
+
+        tracing::debug!(amount_of_messages = ?self.msg_rx.len(), "processing last in-bound messages before shutdwon");
+        while let Ok(msg) = self.msg_rx.try_recv() {
+            self.inner.handle_message(msg).await?;
+        }
+
+        // explicitly inform the TaskManager that we're shutting down
+        drop(shutdown_guard);
+
+        tracing::info!("shutting down CommitmentCache service");
+        Ok(())
+    }
+}
+
+impl Inner {
+    #[tracing::instrument(skip_all, err)]
+    async fn handle_message(&mut self, msg: CommitmentCacheMessage) -> eyre::Result<()> {
+        match msg {
+            CommitmentCacheMessage::GetCommitmentStatus {
+                commitment_tx,
+                response,
+            } => {
+                self.get_commitment_status(commitment_tx, response);
+            }
+            CommitmentCacheMessage::AddCommitment {
+                commitment_tx,
+                response,
+            } => {
+                self.add_commitment(commitment_tx, response);
+            }
+        }
+        Ok(())
+    }
+
+    fn get_commitment_status(
+        &self,
+        commitment_tx: CommitmentTransaction,
+        response: oneshot::Sender<CommitmentStatus>,
+    ) {
+        debug!("GetCommitmentStatus message received");
+
+        let commitment_type = commitment_tx.commitment_type;
+        let txid = commitment_tx.id;
+        let signer = &commitment_tx.signer;
+
+        // First handle unsupported commitment types
+        if !matches!(
+            commitment_type,
+            CommitmentType::Stake | CommitmentType::Pledge
+        ) {
+            debug!(
+                "CommitmentStatus is Rejected: unsupported type: {:?}",
+                commitment_type
+            );
+            let _ = response
+                .send(CommitmentStatus::Invalid(
+                    "Unsupported commitment action".into(),
+                ))
+                .inspect_err(|_| tracing::warn!("Response send failed, channel dropped"));
+            return;
+        }
+
+        // Check if we have commitments for this miner address
+        let commitments = self.cache.get(signer);
+
+        // Handle by the input values commitment type
+        let status = match commitment_type {
+            CommitmentType::Stake => {
+                if let Some(commitments) = &commitments {
+                    // Check for duplicate stake transaction
+                    if commitments.stake.as_ref().is_some_and(|s| s.id == txid) {
+                        CommitmentStatus::Accepted
+                    } else {
+                        CommitmentStatus::Unknown
+                    }
+                } else {
+                    // No commitments for this address yet
+                    CommitmentStatus::Unknown
+                }
+            }
+            CommitmentType::Pledge => {
+                if let Some(commitments) = &commitments {
+                    // Check for duplicate pledge transaction
+                    if commitments.pledges.iter().any(|p| p.id == txid) {
+                        CommitmentStatus::Accepted
+                    } else if commitments.stake.is_none() {
+                        // Require existing stake for pledges
+                        CommitmentStatus::Invalid("pledge address not staked".into())
+                    } else {
+                        CommitmentStatus::Unknown
+                    }
+                } else {
+                    // No commitments for this address, so no stake exists
+                    CommitmentStatus::Invalid("pledge address not staked".into())
+                }
+            }
+            _ => unreachable!(), // We already handled unsupported types
+        };
+
+        debug!("CommitmentStatus is {:?}", status);
+        let _ = response.send(status).inspect_err(|_| {
+            tracing::warn!("CommitmentStatus could not be returned, sender has dropped its half of the channel")
+        });
+    }
+
+    fn add_commitment(
+        &mut self,
+        commitment_tx: CommitmentTransaction,
+        response: oneshot::Sender<CommitmentStatus>,
+    ) {
+        debug!("AddCommitment message received");
+        let signer = &commitment_tx.signer;
+        let tx_type = commitment_tx.commitment_type;
+        let send_status = |status| {
+            debug!("AddCommitment response: {:?}", status);
+            let _ = response.send(status).inspect_err(|_| {
+                tracing::warn!("CommitmentStatus could not be returned, sender dropped their half of the channel")
+            });
+        };
+
+        // Early return for non-supported commitment types
+        if !matches!(tx_type, CommitmentType::Stake | CommitmentType::Pledge) {
+            return send_status(CommitmentStatus::Skipped);
+        }
+
+        // Get or create miner commitments entry
+        let miner_commitments = self
+            .cache
+            .entry(signer.clone())
+            .or_insert_with(MinerCommitments::default);
+
+        // Handle stake commitments
+        if matches!(tx_type, CommitmentType::Stake) {
+            // Check existing commitments in epoch service
+            if self
+                .commitment_state_guard
+                .read()
+                .stake_commitments
+                .contains_key(signer)
+                || miner_commitments.stake.is_some()
+            {
+                return send_status(CommitmentStatus::Accepted);
+            }
+
+            // Store new stake commitment
+            miner_commitments.stake = Some(commitment_tx.clone());
+        } else {
+            // Add pledge commitment
+            miner_commitments.pledges.push(commitment_tx.clone());
+        }
+
+        send_status(CommitmentStatus::Accepted);
+    }
+}

--- a/crates/actors/src/lib.rs
+++ b/crates/actors/src/lib.rs
@@ -7,6 +7,7 @@ pub mod block_validation;
 pub mod broadcast_mining_service;
 pub mod cache_service;
 pub mod chunk_migration_service;
+pub mod commitment_cache;
 pub mod ema_service;
 pub mod epoch_service;
 pub mod mempool_service;
@@ -20,4 +21,5 @@ pub mod vdf_service;
 
 pub use addresses::*;
 pub use block_producer::*;
+pub use commitment_cache::*;
 pub use epoch_service::*;

--- a/crates/actors/src/services.rs
+++ b/crates/actors/src/services.rs
@@ -32,7 +32,7 @@ impl ServiceSenders {
 pub struct ServiceReceivers {
     pub chunk_cache: UnboundedReceiver<CacheServiceAction>,
     pub ema: UnboundedReceiver<EmaServiceMessage>,
-    pub pending_commitments_cache: UnboundedReceiver<CommitmentCacheMessage>,
+    pub commitments_cache: UnboundedReceiver<CommitmentCacheMessage>,
 }
 
 #[derive(Debug)]
@@ -47,18 +47,18 @@ impl ServiceSendersInner {
     pub fn init() -> (Self, ServiceReceivers) {
         let (chunk_cache_sender, chunk_cache_receiver) = unbounded_channel::<CacheServiceAction>();
         let (ema_sender, ema_receiver) = unbounded_channel::<EmaServiceMessage>();
-        let (pending_commitments_cache_sender, pending_commitments_cached_receiver) =
+        let (commitments_cache_sender, commitments_cached_receiver) =
             unbounded_channel::<CommitmentCacheMessage>();
 
         let senders = Self {
             chunk_cache: chunk_cache_sender,
             ema: ema_sender,
-            commitment_cache: pending_commitments_cache_sender,
+            commitment_cache: commitments_cache_sender,
         };
         let receivers = ServiceReceivers {
             chunk_cache: chunk_cache_receiver,
             ema: ema_receiver,
-            pending_commitments_cache: pending_commitments_cached_receiver,
+            commitments_cache: commitments_cached_receiver,
         };
         (senders, receivers)
     }

--- a/crates/actors/src/services.rs
+++ b/crates/actors/src/services.rs
@@ -3,7 +3,9 @@ use core::ops::Deref;
 use std::sync::Arc;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
-use crate::{cache_service::CacheServiceAction, ema_service::EmaServiceMessage};
+use crate::{
+    cache_service::CacheServiceAction, ema_service::EmaServiceMessage, CommitmentCacheMessage,
+};
 
 // Only contains senders, thread-safe to clone and share
 #[derive(Debug, Clone)]
@@ -30,12 +32,14 @@ impl ServiceSenders {
 pub struct ServiceReceivers {
     pub chunk_cache: UnboundedReceiver<CacheServiceAction>,
     pub ema: UnboundedReceiver<EmaServiceMessage>,
+    pub pending_commitments_cache: UnboundedReceiver<CommitmentCacheMessage>,
 }
 
 #[derive(Debug)]
 pub struct ServiceSendersInner {
     pub chunk_cache: UnboundedSender<CacheServiceAction>,
     pub ema: UnboundedSender<EmaServiceMessage>,
+    pub commitment_cache: UnboundedSender<CommitmentCacheMessage>,
 }
 
 impl ServiceSendersInner {
@@ -43,14 +47,18 @@ impl ServiceSendersInner {
     pub fn init() -> (Self, ServiceReceivers) {
         let (chunk_cache_sender, chunk_cache_receiver) = unbounded_channel::<CacheServiceAction>();
         let (ema_sender, ema_receiver) = unbounded_channel::<EmaServiceMessage>();
+        let (pending_commitments_cache_sender, pending_commitments_cached_receiver) =
+            unbounded_channel::<CommitmentCacheMessage>();
 
         let senders = Self {
             chunk_cache: chunk_cache_sender,
             ema: ema_sender,
+            commitment_cache: pending_commitments_cache_sender,
         };
         let receivers = ServiceReceivers {
             chunk_cache: chunk_cache_receiver,
             ema: ema_receiver,
+            pending_commitments_cache: pending_commitments_cached_receiver,
         };
         (senders, receivers)
     }

--- a/crates/api-server/src/lib.rs
+++ b/crates/api-server/src/lib.rs
@@ -18,6 +18,7 @@ use irys_actors::{
 use irys_reth_node_bridge::node::RethNodeProvider;
 use irys_storage::ChunkProvider;
 use irys_types::{app_state::DatabaseProvider, Config, PeerAddress};
+use routes::commitment;
 use routes::{
     block, block_index, get_chunk, index, network_config, peer_list, post_chunk, post_version,
     price, proxy::proxy, tx,
@@ -57,6 +58,10 @@ pub fn routes() -> impl HttpServiceFactory {
         .route(
             "/block_index",
             web::get().to(block_index::block_index_route),
+        )
+        .route(
+            "/commitment_tx",
+            web::post().to(commitment::post_commitment_tx),
         )
         .route("/chunk", web::post().to(post_chunk::post_chunk))
         .route(

--- a/crates/api-server/src/routes/commitment.rs
+++ b/crates/api-server/src/routes/commitment.rs
@@ -1,0 +1,60 @@
+use crate::ApiState;
+use actix_web::{
+    web::{self, Json},
+    HttpResponse,
+};
+use awc::http::StatusCode;
+use irys_actors::mempool_service::{CommitmentTxIngressMessage, TxIngressError};
+use irys_types::CommitmentTransaction;
+
+/// Handles the HTTP POST request for adding a transaction to the mempool.
+/// This function takes in a JSON payload of a `CommitmentTransaction` type,
+/// encapsulates it into a `CommitmentTxIngressMessage` for further processing by the
+/// mempool actor, and manages error handling based on the results of message
+/// delivery and transaction validation.
+pub async fn post_commitment_tx(
+    state: web::Data<ApiState>,
+    body: Json<CommitmentTransaction>,
+) -> actix_web::Result<HttpResponse> {
+    let tx = body.into_inner();
+
+    // Validate transaction is valid. Check balances etc etc.
+    let tx_ingress_msg = CommitmentTxIngressMessage(tx);
+    let msg_result = state.mempool.send(tx_ingress_msg).await;
+
+    // Handle failure to deliver the message (e.g., actor unresponsive or unavailable)
+    if let Err(err) = msg_result {
+        return Ok(HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
+            .body(format!("Failed to deliver transaction: {:?}", err)));
+    }
+
+    // If message delivery succeeded, check for validation errors within the response
+    let inner_result = msg_result.unwrap();
+    if let Err(err) = inner_result {
+        return match err {
+            TxIngressError::InvalidSignature => Ok(HttpResponse::build(StatusCode::BAD_REQUEST)
+                .body(format!("Invalid Signature: {:?}", err))),
+            TxIngressError::Unfunded => Ok(HttpResponse::build(StatusCode::PAYMENT_REQUIRED)
+                .body(format!("Unfunded: {:?}", err))),
+            TxIngressError::Skipped => Ok(HttpResponse::Ok()
+                .body("Already processed: the transaction was previously handled")),
+            TxIngressError::Other(err) => {
+                Ok(HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
+                    .body(format!("Failed to deliver transaction: {:?}", err)))
+            }
+            TxIngressError::InvalidAnchor => Ok(HttpResponse::build(StatusCode::BAD_REQUEST)
+                .body(format!("Invalid Anchor: {:?}", err))),
+            TxIngressError::DatabaseError => {
+                Ok(HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
+                    .body(format!("Internal database error: {:?}", err)))
+            }
+            TxIngressError::ServiceUninitialized => {
+                Ok(HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
+                    .body(format!("Internal service error: {:?}", err)))
+            }
+        };
+    }
+
+    // If everything succeeded, return an HTTP 200 OK response
+    Ok(HttpResponse::Ok().finish())
+}

--- a/crates/api-server/src/routes/mod.rs
+++ b/crates/api-server/src/routes/mod.rs
@@ -1,5 +1,6 @@
 pub mod block;
 pub mod block_index;
+pub mod commitment;
 pub mod get_chunk;
 pub mod index;
 pub mod network_config;

--- a/crates/api-server/src/routes/tx.rs
+++ b/crates/api-server/src/routes/tx.rs
@@ -48,7 +48,7 @@ pub async fn post_tx(
                     .body(format!("Failed to deliver transaction: {:?}", err)))
             }
             TxIngressError::InvalidAnchor => Ok(HttpResponse::build(StatusCode::BAD_REQUEST)
-                .body(format!("Invalid Signature: {:?}", err))),
+                .body(format!("Invalid Anchor: {:?}", err))),
             TxIngressError::DatabaseError => {
                 Ok(HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
                     .body(format!("Internal database error: {:?}", err)))

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -691,7 +691,7 @@ impl IrysNode {
         // Spawn the CommitmentCache service
         let _handle = CommitmentCache::spawn_service(
             &task_exec,
-            receivers.pending_commitments_cache,
+            receivers.commitments_cache,
             commitment_state_guard,
             &config,
         );

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -3,8 +3,8 @@ use crate::peer_utilities::{fetch_genesis_block, sync_state_from_peers};
 use crate::vdf::run_vdf;
 use actix::{Actor, Addr, Arbiter, System, SystemRegistry};
 use actix_web::dev::Server;
+use irys_actors::ema_service::EmaServiceMessage;
 use irys_actors::packing::PackingConfig;
-use irys_actors::EpochReplayData;
 use irys_actors::{
     block_discovery::BlockDiscoveryActor,
     block_index_service::{BlockIndexReadGuard, BlockIndexService, GetBlockIndexGuardMessage},
@@ -26,6 +26,7 @@ use irys_actors::{
     vdf_service::{GetVdfStateMessage, VdfService},
     ActorAddresses, BlockFinalizedMessage,
 };
+use irys_actors::{CommitmentCache, EpochReplayData, GetCommitmentStateGuardMessage};
 use irys_api_server::{create_listener, run_server, ApiState};
 use irys_config::chain::chainspec::IrysChainSpecBuilder;
 use irys_config::StorageSubmodulesConfig;
@@ -70,6 +71,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 use tokio::runtime::Runtime;
+use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::oneshot::{self};
 use tracing::{debug, error, info, warn};
 
@@ -92,6 +94,21 @@ pub struct IrysNodeCtx {
 }
 
 impl IrysNodeCtx {
+    pub fn get_api_state(&self, ema_service: UnboundedSender<EmaServiceMessage>) -> ApiState {
+        ApiState {
+            mempool: self.actor_addresses.mempool.clone(),
+            chunk_provider: self.chunk_provider.clone(),
+            ema_service: ema_service,
+            peer_list: self.actor_addresses.peer_list.clone(),
+            db: self.db.clone(),
+            config: self.config.clone(),
+            reth_provider: self.reth_handle.clone(),
+            reth_http_url: self.reth_handle.rpc_server_handle().http_url().unwrap(),
+            block_tree: self.block_tree_guard.clone(),
+            block_index: self.block_index_guard.clone(),
+        }
+    }
+
     pub async fn stop(self) {
         let _ = self.actor_addresses.stop_mining();
         debug!("Sending shutdown signal to reth thread");
@@ -647,6 +664,11 @@ impl IrysNode {
             .await?;
         let storage_modules = Self::init_storage_modules(&config, storage_module_infos)?;
 
+        // Retrieve Commitment State
+        let commitment_state_guard = epoch_service_actor
+            .send(GetCommitmentStateGuardMessage)
+            .await?;
+
         let (gossip_service, gossip_tx) = irys_gossip_service::GossipService::new(
             &config.node_config.gossip.bind_ip,
             config.node_config.gossip.port,
@@ -666,6 +688,14 @@ impl IrysNode {
         let _handle =
             EmaService::spawn_service(&task_exec, block_tree_guard.clone(), receivers.ema, &config);
 
+        // Spawn the CommitmentCache service
+        let _handle = CommitmentCache::spawn_service(
+            &task_exec,
+            receivers.pending_commitments_cache,
+            commitment_state_guard,
+            &config,
+        );
+
         // Spawn peer list service
         let (peer_list_service, peer_list_arbiter) = init_peer_list_service(&irys_db, &config);
 
@@ -677,6 +707,7 @@ impl IrysNode {
             reth_db,
             &storage_modules,
             &block_tree_guard,
+            &service_senders,
             gossip_tx.clone(),
         );
 
@@ -1131,6 +1162,7 @@ impl IrysNode {
         reth_db: irys_database::db::RethDbWrapper,
         storage_modules: &Vec<Arc<StorageModule>>,
         block_tree_guard: &BlockTreeReadGuard,
+        service_senders: &ServiceSenders,
         gossip_tx: tokio::sync::mpsc::Sender<GossipData>,
     ) -> (actix::Addr<MempoolService>, Arbiter) {
         let mempool_service = MempoolService::new(
@@ -1140,6 +1172,7 @@ impl IrysNode {
             storage_modules.clone(),
             block_tree_guard.clone(),
             &config,
+            service_senders.clone(),
             gossip_tx,
         );
         let mempool_arbiter = Arbiter::new();

--- a/crates/chain/tests/api/mod.rs
+++ b/crates/chain/tests/api/mod.rs
@@ -1,10 +1,14 @@
+use base58::ToBase58;
 use irys_database::DataLedger;
+use irys_types::CommitmentTransaction;
+use tracing::info;
 
 mod api;
 mod client;
 mod external_api;
 mod pricing_endpoint;
 mod tx;
+mod tx_commitments;
 
 pub async fn client_request(
     url: &str,
@@ -63,4 +67,21 @@ pub async fn version_endpoint_request(
     address: &str,
 ) -> awc::ClientResponse<actix_web::dev::Decompress<actix_http::Payload>> {
     client_request(&format!("{}{}", &address, "/v1/version")).await
+}
+
+pub async fn post_commitment_tx_request(address: &str, commitment_tx: &CommitmentTransaction) {
+    info!("Posting Commitment TX: {}", commitment_tx.id.0.to_base58());
+
+    let client = awc::Client::default();
+    let response = client
+        .post(format!("{}/v1/commitment_tx", address))
+        .send_json(commitment_tx) // Send the commitment_tx as JSON in the request body
+        .await
+        .expect("client post failed");
+
+    info!(
+        "Response status: {}\n{}",
+        response.status(),
+        serde_json::to_string_pretty(&commitment_tx).unwrap()
+    );
 }

--- a/crates/chain/tests/api/tx_commitments.rs
+++ b/crates/chain/tests/api/tx_commitments.rs
@@ -1,0 +1,155 @@
+use crate::{api::post_commitment_tx_request, utils::IrysNodeTest};
+use actix_web::{middleware::Logger, App};
+use alloy_core::primitives::U256;
+use irys_actors::{packing::wait_for_packing, CommitmentCacheMessage, CommitmentStatus};
+use irys_api_server::routes;
+use irys_chain::IrysNodeCtx;
+use irys_types::{irys::IrysSigner, CommitmentTransaction, NodeConfig, H256};
+use reth_primitives::{irys_primitives::CommitmentType, GenesisAccount};
+use tokio::time::Duration;
+use tracing::info;
+
+#[actix_web::test]
+async fn test_commitments_basic_test() -> eyre::Result<()> {
+    let (ema_tx, _ema_rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut config = NodeConfig::testnet();
+    let signer = IrysSigner::random_signer(&config.consensus_config());
+    config.consensus.extend_genesis_accounts(vec![(
+        signer.address(),
+        GenesisAccount {
+            balance: U256::from(690000000000000000_u128),
+            ..Default::default()
+        },
+    )]);
+    let node = IrysNodeTest::new_genesis(config.clone())
+        .await
+        .start()
+        .await;
+
+    let uri = format!(
+        "http://127.0.0.1:{}",
+        node.node_ctx.config.node_config.http.port
+    );
+
+    wait_for_packing(
+        node.node_ctx.actor_addresses.packing.clone(),
+        Some(Duration::from_secs(10)),
+    )
+    .await?;
+
+    node.node_ctx.actor_addresses.start_mining().unwrap();
+    let api_state = node.node_ctx.get_api_state(ema_tx);
+    let _db = api_state.db.clone();
+
+    // Start the actix web server
+    let _app = actix_web::test::init_service(
+        App::new()
+            .wrap(Logger::default())
+            .app_data(actix_web::web::Data::new(api_state))
+            .service(routes()),
+    )
+    .await;
+
+    // Create a Stake commitment transaction
+    let stake_tx = CommitmentTransaction {
+        id: H256::random(),
+        commitment_type: CommitmentType::Stake,
+        fee: 1,
+        ..Default::default()
+    };
+    let stake_tx = signer.sign_commitment(stake_tx).unwrap();
+    info!("Generated stake_tx.id: {}", stake_tx.id);
+
+    // Verify the transaction is not in the commitment state ahead of time
+    let status = get_commitment_status(&stake_tx, &node.node_ctx).await;
+    assert_eq!(status, CommitmentStatus::Unknown);
+
+    // Make a POST request with commitment tx JSON payload
+    post_commitment_tx_request(&uri, &stake_tx).await;
+
+    // Verify the status in the CommitmentCache
+    let status = get_commitment_status(&stake_tx, &node.node_ctx).await;
+    assert_eq!(status, CommitmentStatus::Accepted);
+
+    // Create a Pledge commitment for the soon to be staked address
+    let pledge_tx = CommitmentTransaction {
+        id: H256::random(),
+        commitment_type: CommitmentType::Pledge,
+        fee: 1,
+        ..Default::default()
+    };
+    let pledge_tx = signer.sign_commitment(pledge_tx).unwrap();
+    info!("Generated pledge_tx.id: {}", pledge_tx.id);
+
+    // Verify the transaction is not in the commitment state ahead of time
+    let status = get_commitment_status(&pledge_tx, &node.node_ctx).await;
+    assert_eq!(status, CommitmentStatus::Unknown);
+
+    // Make a POST request with commitment tx JSON payload
+    post_commitment_tx_request(&uri, &pledge_tx).await;
+
+    // Verify the status in the CommitmentCache
+    let status = get_commitment_status(&pledge_tx, &node.node_ctx).await;
+    assert_eq!(status, CommitmentStatus::Accepted);
+
+    // Verify the stake commitment is already accepted
+    let status = get_commitment_status(&stake_tx, &node.node_ctx).await;
+    assert_eq!(status, CommitmentStatus::Accepted);
+
+    // Make a POST request with commitment tx JSON payload
+    post_commitment_tx_request(&uri, &stake_tx).await;
+
+    // Verify the stake commitment is still accepted after reposting it
+    let status = get_commitment_status(&stake_tx, &node.node_ctx).await;
+    assert_eq!(status, CommitmentStatus::Accepted);
+
+    // Create a new signer and send a pledge without stake
+    let signer2 = IrysSigner::random_signer(&config.consensus_config());
+
+    let pledge_tx = CommitmentTransaction {
+        id: H256::random(),
+        commitment_type: CommitmentType::Pledge,
+        fee: 1,
+        ..Default::default()
+    };
+    let pledge_tx = signer2.sign_commitment(pledge_tx).unwrap();
+    info!("Generated pledge_tx.id: {}", pledge_tx.id);
+
+    // Verify the pledge is not in the commitment state ahead of time
+    let status = get_commitment_status(&pledge_tx, &node.node_ctx).await;
+    assert_eq!(
+        status,
+        CommitmentStatus::Invalid("pledge address not staked".into())
+    );
+
+    // Make a POST request with commitment tx JSON payload
+    post_commitment_tx_request(&uri, &pledge_tx).await;
+
+    // Verify the pledge is STILL not in the commitment state
+    let status = get_commitment_status(&pledge_tx, &node.node_ctx).await;
+    assert_eq!(
+        status,
+        CommitmentStatus::Invalid("pledge address not staked".into())
+    );
+
+    node.node_ctx.stop().await;
+    Ok(())
+}
+
+async fn get_commitment_status(
+    commitment_tx: &CommitmentTransaction,
+    node_context: &IrysNodeCtx,
+) -> CommitmentStatus {
+    let commitment_cache = &node_context.service_senders.commitment_cache;
+    let (oneshot_tx, oneshot_rx) = tokio::sync::oneshot::channel();
+
+    let _ = commitment_cache.send(CommitmentCacheMessage::GetCommitmentStatus {
+        commitment_tx: commitment_tx.clone(),
+        response: oneshot_tx,
+    });
+
+    let status = oneshot_rx
+        .await
+        .expect("to receive CommitmentStatus from GetCommitmentStatus message");
+    status
+}

--- a/crates/types/src/transaction.rs
+++ b/crates/types/src/transaction.rs
@@ -212,6 +212,10 @@ pub struct CommitmentTransaction {
     #[serde(with = "string_u64")]
     pub chain_id: u64,
 
+    /// Pay the fee required to mitigate tx spam
+    #[serde(with = "string_u64")]
+    pub fee: u64,
+
     /// Transaction signature bytes
     #[rlp(skip)]
     #[rlp(default)]
@@ -237,6 +241,32 @@ impl CommitmentTransaction {
     pub fn is_signature_valid(&self) -> bool {
         self.signature
             .validate_signature(self.signature_hash(), self.signer)
+    }
+}
+
+// Trait to abstract common behavior
+pub trait SignatureValidation {
+    fn is_signature_valid(&self) -> bool;
+    fn id(&self) -> IrysTransactionId;
+}
+
+impl SignatureValidation for IrysTransactionHeader {
+    fn is_signature_valid(&self) -> bool {
+        self.is_signature_valid()
+    }
+
+    fn id(&self) -> IrysTransactionId {
+        self.id
+    }
+}
+
+impl SignatureValidation for CommitmentTransaction {
+    fn is_signature_valid(&self) -> bool {
+        self.is_signature_valid()
+    }
+
+    fn id(&self) -> IrysTransactionId {
+        self.id
     }
 }
 
@@ -401,6 +431,7 @@ mod tests {
             signer: Address::default(),
             commitment_type: CommitmentType::Stake,
             version: 0,
+            fee: 1,
             chain_id: config.chain_id,
             signature: Signature::test_signature().into(),
         };


### PR DESCRIPTION
# Commitment Transaction Support and Caching System

## Describe the changes
This PR introduces commitment transaction ingress handling to the node:

* Creates a dedicated `CommitmentCache` service for tracking stakes and pledges, implementing the "new style" channel-based architecture
* Adds complete API support via the `/commitment_tx` route
* Implements the `CommitmentTxIngress` message handler for broadcasting new commitment transactions to the mempool
* Refactors shared validation logic between transaction handlers into helper functions to reduce duplication
* Provides basic test automation covering both happy path and expected failure scenarios

## Technical Details
* The `CommitmentCache` tracks commitment status and maintains stake/pledge relationships
* Added the cache service to `service_senders` for node-wide accessibility
* Extracted common validation logic between `TxIngressMessage` and `CommitmentTxIngress` handlers
* Implemented common traits for signature verification and ID generation across transaction types

## Related Issue(s)
Implements 1-3 of #293

## Checklist
- [x] Tests have been added/updated for the changes
- [ ] Documentation has been updated (if applicable)
- [x] Code follows Rust's style guidelines

## Additional Context
This is the first implementation using the new channel-based service pattern. The integration with `mempool_service` which is style synchronous is a little ugly.  It spawns a thread for the async interactions with the `commitment_cache`.

Depending on how extensive the `commitment_cache` implementation becomes, it might make sense to incorporate it into `cache_service`.