### PR TITLE
feat: vdf sync during node startup

### DIFF
--- a/crates/actors/src/addresses.rs
+++ b/crates/actors/src/addresses.rs
@@ -9,6 +9,7 @@ use crate::{
     packing::PackingActor,
     peer_list_service::PeerListService,
     reth_service::RethServiceActor,
+    vdf_service::VdfService,
     EpochServiceActor,
 };
 
@@ -25,6 +26,7 @@ pub struct ActorAddresses {
     pub epoch_service: Addr<EpochServiceActor>,
     pub peer_list: Addr<PeerListService>,
     pub reth: Addr<RethServiceActor>,
+    pub vdf: Addr<VdfService>,
 }
 
 impl ActorAddresses {

--- a/crates/actors/src/mining.rs
+++ b/crates/actors/src/mining.rs
@@ -513,8 +513,7 @@ mod tests {
         let mining_broadcaster = BroadcastMiningService::new();
         let _mining_broadcaster_addr = mining_broadcaster.start();
 
-        let (new_seed_tx, _) = mpsc::channel::<BroadcastMiningSeed>(1);
-        let vdf_service = VdfService::from_capacity(100, new_seed_tx).start();
+        let vdf_service = VdfService::from_capacity(100).start();
         let vdf_steps_guard: VdfStepsReadGuard =
             vdf_service.send(GetVdfStateMessage).await.unwrap();
 
@@ -639,11 +638,9 @@ mod tests {
             capacity: 5,
             seeds: VecDeque::new(),
         };
-        let (new_seed_tx, _) = mpsc::channel::<BroadcastMiningSeed>(1);
 
         let vdf_service = VdfService {
             vdf_state: Arc::new(RwLock::new(vdf_state)),
-            tx: new_seed_tx,
         }
         .start();
         let vdf_steps_guard: VdfStepsReadGuard =

--- a/crates/actors/src/mining.rs
+++ b/crates/actors/src/mining.rs
@@ -635,7 +635,7 @@ mod tests {
 
         let vdf_state = VdfState {
             global_step: 0,
-            max_seeds_num: 5,
+            capacity: 5,
             seeds: VecDeque::new(),
         };
         let vdf_service = VdfService {

--- a/crates/actors/src/mining.rs
+++ b/crates/actors/src/mining.rs
@@ -394,7 +394,7 @@ mod tests {
     use std::sync::atomic::AtomicU64;
     use std::sync::RwLock;
     use std::time::Duration;
-    use tokio::{sync::mpsc, time::sleep};
+    use tokio::time::sleep;
 
     fn get_mocked_block_producer(
         closure_arc: Arc<RwLock<Option<SolutionContext>>>,

--- a/crates/actors/src/mining.rs
+++ b/crates/actors/src/mining.rs
@@ -513,7 +513,7 @@ mod tests {
         let mining_broadcaster = BroadcastMiningService::new();
         let _mining_broadcaster_addr = mining_broadcaster.start();
 
-        let (new_seed_tx, _) = mpsc::channel::<H256>(1);
+        let (new_seed_tx, _) = mpsc::channel::<BroadcastMiningSeed>(1);
         let vdf_service = VdfService::from_capacity(100, new_seed_tx).start();
         let vdf_steps_guard: VdfStepsReadGuard =
             vdf_service.send(GetVdfStateMessage).await.unwrap();
@@ -639,7 +639,7 @@ mod tests {
             capacity: 5,
             seeds: VecDeque::new(),
         };
-        let (new_seed_tx, _) = mpsc::channel::<H256>(1);
+        let (new_seed_tx, _) = mpsc::channel::<BroadcastMiningSeed>(1);
 
         let vdf_service = VdfService {
             vdf_state: Arc::new(RwLock::new(vdf_state)),

--- a/crates/actors/src/vdf_service.rs
+++ b/crates/actors/src/vdf_service.rs
@@ -34,7 +34,7 @@ impl VdfService {
         VdfService {
             vdf_state: Arc::new(RwLock::new(VdfState {
                 global_step: 0,
-                max_seeds_num: capacity,
+                capacity,
                 seeds: VecDeque::with_capacity(capacity),
             })),
         }
@@ -84,7 +84,7 @@ fn create_state(
         return VdfState {
             global_step: global_step_number,
             seeds,
-            max_seeds_num: capacity,
+            capacity,
         };
     };
 
@@ -92,7 +92,7 @@ fn create_state(
     VdfState {
         global_step: 0,
         seeds: VecDeque::with_capacity(capacity),
-        max_seeds_num: capacity,
+        capacity,
     }
 }
 
@@ -157,7 +157,7 @@ async fn create_state_parallel(
     return VdfState {
         global_step: global_step_number,
         seeds,
-        max_seeds_num: capacity,
+        capacity,
     };
 }
 
@@ -248,7 +248,7 @@ mod tests {
         let testnet_config = NodeConfig::testnet().into();
         let service = VdfService::from_capacity(calc_capacity(&testnet_config));
         service.vdf_state.write().unwrap().seeds = VecDeque::with_capacity(4);
-        service.vdf_state.write().unwrap().max_seeds_num = 4;
+        service.vdf_state.write().unwrap().capacity = 4;
         let addr = service.start();
 
         // Send 8 seeds 1,2..,8 (capacity is 4)
@@ -369,7 +369,7 @@ mod tests {
             elapsed
         );
 
-        assert_eq!(vdf_state.max_seeds_num, vdf_state_parallel.max_seeds_num);
+        assert_eq!(vdf_state.capacity, vdf_state_parallel.capacity);
         assert_eq!(vdf_state.global_step, vdf_state_parallel.global_step);
         assert_eq!(vdf_state.seeds, vdf_state_parallel.seeds);
     }

--- a/crates/actors/src/vdf_service.rs
+++ b/crates/actors/src/vdf_service.rs
@@ -1,14 +1,12 @@
 use actix::prelude::*;
-use futures::future::join_all;
 use irys_database::block_header_by_hash;
-use irys_types::{block_production::Seed, Config, DatabaseProvider, IrysBlockHeader};
+use irys_types::{block_production::Seed, Config, DatabaseProvider};
 use irys_vdf::vdf_state::{AtomicVdfState, VdfState, VdfStepsReadGuard};
 use reth_db::Database;
 use std::{
     collections::VecDeque,
     sync::{Arc, RwLock},
 };
-use tokio::task::{self, JoinHandle};
 use tracing::{info, warn};
 
 use crate::block_index_service::BlockIndexReadGuard;
@@ -96,71 +94,6 @@ fn create_state(
     }
 }
 
-#[allow(dead_code)]
-async fn create_state_parallel(
-    block_index: BlockIndexReadGuard,
-    db: DatabaseProvider,
-    config: &Config,
-) -> VdfState {
-    let capacity = calc_capacity(config);
-
-    let mut height = block_index.read().latest_height();
-    let mut steps_remaining = capacity;
-
-    let mut seeds: VecDeque<Seed> = VecDeque::with_capacity(capacity);
-    let mut global_step_number: u64 = 0;
-    let n = 50; // number of block headers read in parallel
-
-    while steps_remaining > 0 && height > 0 {
-        // get in parallel n blocks
-        info!("reading from {} to {}", height.saturating_sub(n), height);
-        let mut blocks_handles: Vec<JoinHandle<IrysBlockHeader>> = Vec::new();
-        for block in height.saturating_sub(n)..height {
-            let db = db.clone();
-            let block_index = block_index.clone();
-            let join = task::spawn_blocking(move || {
-                let block_hash = block_index
-                    .read()
-                    .get_item(block)
-                    .map(|item| item.block_hash)
-                    .expect("Error getting block hash");
-                db.view_eyre(|tx| block_header_by_hash(tx, &block_hash, false))
-                    .expect("Db error reading block header by hash")
-                    .expect("Block hash not found")
-            });
-            blocks_handles.push(join);
-        }
-
-        // Wait for all tasks to complete
-        let results = join_all(blocks_handles).await;
-
-        'outer: for block in results.iter().rev() {
-            let block = block.as_ref().expect("Error getting block");
-            if global_step_number == 0 {
-                global_step_number = block.vdf_limiter_info.global_step_number;
-            }
-            for step in block.vdf_limiter_info.steps.0.iter().rev() {
-                seeds.push_front(Seed(*step));
-                steps_remaining -= 1;
-                if steps_remaining == 0 {
-                    break 'outer;
-                }
-            }
-        }
-        height = height.saturating_sub(n + 1);
-    }
-    info!(
-        "Initializing vdf service from block's info in step number {} to {}",
-        global_step_number,
-        global_step_number - capacity as u64
-    );
-    return VdfState {
-        global_step: global_step_number,
-        seeds,
-        capacity,
-    };
-}
-
 /// return the larger of MINIMUM_CAPACITY or number of seeds required for (chunks in partition / chunks in recall range)
 /// This ensure the capacity of VecDeqeue is large enough for the partition.
 pub fn calc_capacity(config: &Config) -> usize {
@@ -233,20 +166,8 @@ impl Handler<Stop> for VdfService {
 // Tests
 #[cfg(test)]
 mod tests {
-    use std::time::Instant;
-
-    use actix::SystemRegistry;
-    use irys_database::{open_or_create_db, tables::IrysTables, BlockIndex, DataLedger};
     use irys_storage::ii;
-    use irys_testing_utils::utils::setup_tracing_and_temp_dir;
-    use irys_types::{
-        ConsensusConfig, ConsensusOptions, H256List, IrysBlockHeader, NodeConfig, H256,
-    };
-
-    use crate::{
-        block_index_service::{BlockIndexService, GetBlockIndexGuardMessage},
-        BlockFinalizedMessage,
-    };
+    use irys_types::{H256List, NodeConfig, H256};
 
     use super::*;
 
@@ -296,88 +217,5 @@ mod tests {
             ]),
             get_all
         );
-    }
-
-    #[ignore = "benchmark test"]
-    #[actix_rt::test]
-    async fn test_create_state_performance() {
-        let tmp_dir = setup_tracing_and_temp_dir(Some("create_state_test"), false);
-        let base_path = tmp_dir.path().to_path_buf();
-        let consensus_config = ConsensusConfig {
-            num_chunks_in_partition: 51_872_000, // testnet.toml numbers
-            num_chunks_in_recall_range: 800,
-            ..ConsensusConfig::testnet()
-        };
-        let combined_config = Config::new(NodeConfig {
-            base_directory: base_path,
-            consensus: ConsensusOptions::Custom(consensus_config),
-            ..NodeConfig::testnet()
-        });
-        let db = open_or_create_db(tmp_dir, IrysTables::ALL, None).unwrap();
-        let database_provider = DatabaseProvider(Arc::new(db));
-
-        let block_index: Arc<RwLock<BlockIndex>> = Arc::new(RwLock::new(
-            BlockIndex::new(&combined_config.node_config).await.unwrap(),
-        ));
-
-        let block_index_actor =
-            BlockIndexService::new(block_index.clone(), &combined_config.consensus).start();
-        SystemRegistry::set(block_index_actor.clone());
-
-        let block_index_guard = block_index_actor
-            .send(GetBlockIndexGuardMessage)
-            .await
-            .unwrap();
-
-        let mut new_epoch_block = IrysBlockHeader::new_mock_header();
-        new_epoch_block.data_ledgers[DataLedger::Submit].max_chunk_offset = 0;
-
-        let now = Instant::now();
-        // index and store in db blocks
-        let mut height = 0;
-        let capacity = calc_capacity(&combined_config) as u64;
-        while height <= capacity {
-            new_epoch_block.height = height;
-            new_epoch_block.previous_block_hash = new_epoch_block.block_hash;
-            new_epoch_block.block_hash = H256::random();
-
-            let msg = BlockFinalizedMessage {
-                block_header: Arc::new(new_epoch_block.clone()),
-                all_txs: Arc::new(vec![]),
-            };
-            match block_index_actor.send(msg).await {
-                Ok(_) => (), // debug!("block indexed"),
-                Err(err) => panic!("Failed to index block {:?}", err),
-            }
-
-            database_provider
-                .update_eyre(|tx| irys_database::insert_block_header(tx, &new_epoch_block))
-                .unwrap();
-            height += 1;
-        }
-        let elapsed = now.elapsed();
-        println!("Indexed: {} blocks in {:.2?}", height, elapsed);
-
-        let now = Instant::now();
-        let vdf_state = create_state(
-            block_index_guard.clone(),
-            database_provider.clone(),
-            &combined_config,
-        );
-        let elapsed = now.elapsed();
-        println!("VdfService vdf steps initialization time: {:.2?}", elapsed);
-
-        let now = Instant::now();
-        let vdf_state_parallel =
-            create_state_parallel(block_index_guard, database_provider, &combined_config).await;
-        let elapsed = now.elapsed();
-        println!(
-            "VdfService vdf steps initialization time in parallel: {:.2?}",
-            elapsed
-        );
-
-        assert_eq!(vdf_state.capacity, vdf_state_parallel.capacity);
-        assert_eq!(vdf_state.global_step, vdf_state_parallel.global_step);
-        assert_eq!(vdf_state.seeds, vdf_state_parallel.seeds);
     }
 }

--- a/crates/actors/src/vdf_service.rs
+++ b/crates/actors/src/vdf_service.rs
@@ -41,6 +41,7 @@ impl VdfService {
     }
 }
 
+/// create VDF state using the latest block in db
 fn create_state(
     block_index: BlockIndexReadGuard,
     db: DatabaseProvider,

--- a/crates/actors/src/vdf_service.rs
+++ b/crates/actors/src/vdf_service.rs
@@ -262,7 +262,7 @@ mod tests {
 
         let steps = state.read().seeds.iter().cloned().collect::<Vec<_>>();
 
-        // Should only contain last 3 messages
+        // Should only contain last 4 seeds
         assert_eq!(steps.len(), 4);
 
         // Check last 4 seeds are stored

--- a/crates/actors/src/vdf_service.rs
+++ b/crates/actors/src/vdf_service.rs
@@ -147,16 +147,16 @@ impl Actor for VdfService {
 /// Reset VDF Steps as we have a new block with future steps
 #[derive(Message, Debug, Clone)]
 #[rtype(result = "()")]
-pub struct ResetVdfMessage(pub BroadcastMiningSeed);
+pub struct FastForwardVdfMessage(pub BroadcastMiningSeed);
 
-impl Handler<ResetVdfMessage> for VdfService {
+impl Handler<FastForwardVdfMessage> for VdfService {
     type Result = ();
 
-    fn handle(&mut self, msg: ResetVdfMessage, ctx: &mut Context<Self>) -> Self::Result {
+    fn handle(&mut self, msg: FastForwardVdfMessage, ctx: &mut Context<Self>) -> Self::Result {
         let tx = self.tx.clone();
         let value = msg.0;
 
-        // this to allow using the async fn tx.send() inside an actix context
+        // allow using the async fn tx.send() inside an actix context
         ctx.spawn(
             async move {
                 if let Err(e) = tx.send(value).await {

--- a/crates/actors/src/vdf_service.rs
+++ b/crates/actors/src/vdf_service.rs
@@ -156,11 +156,18 @@ impl Handler<FastForwardVdfMessage> for VdfService {
         let tx = self.tx.clone();
         let value = msg.0;
 
+        self.vdf_state
+            .write()
+            .unwrap()
+            .jump_step(value.seed.clone(), value.global_step.clone());
+
         // allow using the async fn tx.send() inside an actix context
         ctx.spawn(
             async move {
                 if let Err(e) = tx.send(value).await {
                     error!("Error sending to VDF channel: {}", e);
+                } else {
+                    error!("Sent to VDF channel");
                 }
             }
             .into_actor(self),

--- a/crates/actors/tests/epoch_service_tests.rs
+++ b/crates/actors/tests/epoch_service_tests.rs
@@ -385,7 +385,7 @@ async fn partition_expiration_and_repacking_test() {
     }));
 
     let vdf_steps_guard = VdfStepsReadGuard::new(Arc::new(RwLock::new(VdfState {
-        max_seeds_num: 10,
+        capacity: 10,
         global_step: 0,
         seeds: VecDeque::new(),
     })));

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -731,8 +731,7 @@ impl IrysNode {
         let (vdf_sender, new_seed_rx) = mpsc::channel::<BroadcastMiningSeed>(1);
 
         // spawn the vdf service
-        let vdf_service =
-            Self::init_vdf_service(&config, &irys_db, &block_index_guard, vdf_sender.clone());
+        let vdf_service = Self::init_vdf_service(&config, &irys_db, &block_index_guard);
         let vdf_steps_guard = vdf_service.send(GetVdfStateMessage).await?;
 
         // spawn the validation service
@@ -1143,14 +1142,9 @@ impl IrysNode {
         config: &Config,
         irys_db: &DatabaseProvider,
         block_index_guard: &BlockIndexReadGuard,
-        new_seed_tx: mpsc::Sender<BroadcastMiningSeed>,
     ) -> actix::Addr<VdfService> {
-        let vdf_service_actor = VdfService::new(
-            block_index_guard.clone(),
-            irys_db.clone(),
-            &config,
-            new_seed_tx,
-        );
+        let vdf_service_actor =
+            VdfService::new(block_index_guard.clone(), irys_db.clone(), &config);
         let vdf_service = vdf_service_actor.start();
         SystemRegistry::set(vdf_service.clone());
         vdf_service

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -337,7 +337,7 @@ impl IrysNode {
         let (reth_shutdown_sender, reth_shutdown_receiver) = tokio::sync::mpsc::channel::<()>(1);
         let (main_actor_thread_shutdown_tx, main_actor_thread_shutdown_rx) =
             tokio::sync::mpsc::channel::<()>(1);
-        let (vdf_sthutodwn_sender, vdf_sthutodwn_receiver) = mpsc::channel();
+        let (vdf_shutdown_sender, vdf_shutdown_receiver) = mpsc::channel();
         let (reth_handle_sender, reth_handle_receiver) =
             oneshot::channel::<FullNode<RethNode, RethNodeAddOns>>();
         let (irys_node_ctx_tx, irys_node_ctx_rx) = oneshot::channel::<IrysNodeCtx>();
@@ -345,13 +345,14 @@ impl IrysNode {
         let irys_provider = irys_storage::reth_provider::create_provider();
 
         // init the services
+        // vdf gets started here...
         let actor_main_thread_handle = Self::init_services_thread(
             self.config.clone(),
             latest_block_height_tx,
             reth_shutdown_sender,
             main_actor_thread_shutdown_rx,
-            vdf_sthutodwn_sender,
-            vdf_sthutodwn_receiver,
+            vdf_shutdown_sender,
+            vdf_shutdown_receiver,
             reth_handle_receiver,
             irys_node_ctx_tx,
             &irys_provider,
@@ -916,7 +917,7 @@ impl IrysNode {
 
     fn init_vdf_thread(
         config: &Config,
-        vdf_sthutodwn_receiver: mpsc::Receiver<()>,
+        vdf_shutdown_receiver: mpsc::Receiver<()>,
         latest_block: Arc<IrysBlockHeader>,
         seed: H256,
         global_step_number: u64,
@@ -956,7 +957,7 @@ impl IrysNode {
                     seed,
                     vdf_reset_seed,
                     new_seed_rx,
-                    vdf_sthutodwn_receiver,
+                    vdf_shutdown_receiver,
                     broadcast_mining_actor.clone(),
                     vdf_service.clone(),
                     atomic_global_step_number.clone(),

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -790,10 +790,14 @@ impl IrysNode {
             latest_block.diff,
         );
 
+        //TODO: these channels are unused
+        let (_new_seed_tx, new_seed_rx) = mpsc::channel::<H256>();
+
         // set up the vdf thread
         let vdf_thread_handler = Self::init_vdf_thread(
             &config,
             vdf_shutdown_receiver,
+            new_seed_rx,
             latest_block,
             seed,
             global_step_number,
@@ -918,6 +922,7 @@ impl IrysNode {
     fn init_vdf_thread(
         config: &Config,
         vdf_shutdown_receiver: mpsc::Receiver<()>,
+        new_seed_rx: mpsc::Receiver<H256>,
         latest_block: Arc<IrysBlockHeader>,
         seed: H256,
         global_step_number: u64,
@@ -949,8 +954,6 @@ impl IrysNode {
                     }
                 }
 
-                // TODO: these channels are unused
-                let (_new_seed_tx, new_seed_rx) = mpsc::channel::<H256>();
                 run_vdf(
                     &vdf_config,
                     global_step_number,

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -407,6 +407,7 @@ impl IrysNode {
             sync_state_from_peers(
                 ctx.config.node_config.trusted_peers.clone(),
                 ctx.actor_addresses.block_discovery_addr.clone(),
+                ctx.actor_addresses.vdf.clone(),
                 ctx.actor_addresses.mempool.clone(),
                 ctx.actor_addresses.peer_list.clone(),
             )
@@ -803,7 +804,7 @@ impl IrysNode {
             seed,
             global_step_number,
             broadcast_mining_actor,
-            vdf_service,
+            vdf_service.clone(),
             atomic_global_step_number,
         );
 
@@ -822,6 +823,7 @@ impl IrysNode {
                 epoch_service: epoch_service_actor,
                 peer_list: peer_list_service.clone(),
                 reth: reth_service_actor,
+                vdf: vdf_service,
             },
             reth_handle: reth_node.clone(),
             db: irys_db.clone(),

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -412,7 +412,6 @@ impl IrysNode {
             sync_state_from_peers(
                 ctx.config.node_config.trusted_peers.clone(),
                 ctx.actor_addresses.block_discovery_addr.clone(),
-                ctx.actor_addresses.vdf.clone(),
                 ctx.actor_addresses.mempool.clone(),
                 ctx.actor_addresses.peer_list.clone(),
                 ctx.vdf_sender.clone(),

--- a/crates/chain/src/peer_utilities.rs
+++ b/crates/chain/src/peer_utilities.rs
@@ -302,7 +302,7 @@ pub async fn sync_state_from_peers(
                 .await?
             {
                 error!(
-                    "Error sending BlockDiscoveredMessage for block {}: {:?}\nOFFENDING BLOCK evm_block_hash: {}",
+                    "Peer Sync: Error sending BlockDiscoveredMessage for block {}: {:?}\nOFFENDING BLOCK evm_block_hash: {}",
                     block_index_item.block_hash.0.to_base58(),
                     e,
                     block.clone().evm_block_hash,

--- a/crates/chain/src/peer_utilities.rs
+++ b/crates/chain/src/peer_utilities.rs
@@ -5,7 +5,7 @@ use irys_actors::{
     broadcast_mining_service::BroadcastMiningSeed,
     mempool_service::{MempoolService, TxIngressMessage},
     peer_list_service::{AddPeer, PeerListService},
-    vdf_service::{ResetVdfMessage, VdfService},
+    vdf_service::{FastForwardVdfMessage, VdfService},
 };
 use irys_database::{BlockIndexItem, DataLedger};
 use irys_types::{block_production::Seed, Address};
@@ -294,7 +294,9 @@ pub async fn sync_state_from_peers(
                 checkpoints: block.vdf_limiter_info.last_step_checkpoints.clone(),
             };
 
-            vdf_service_addr.send(ResetVdfMessage(mining_seed)).await?;
+            vdf_service_addr
+                .send(FastForwardVdfMessage(mining_seed))
+                .await?;
 
             // allow block to be discovered by block discovery actor
             if let Err(e) = block_discovery_addr

--- a/crates/chain/src/peer_utilities.rs
+++ b/crates/chain/src/peer_utilities.rs
@@ -269,9 +269,6 @@ pub async fn sync_state_from_peers(
         if let Some(irys_block) = fetch_block(&peer.api, &client, &block_index_item).await {
             let block = Arc::new(irys_block);
             let block_discovery_addr = block_discovery_addr.clone();
-            //TODO: temporarily introducing a 2 second pause to allow vdf steps to be created. otherwise vdf steps try to be included that do not exist locally. This helps prevent against the following type of error:
-            //      Error sending BlockDiscoveredMessage for block 3Yy6zT8as2P4n4A4xYtVL4oMfwsAzgBpFMdoUJ6UYKoy: Block validation error Unavailable requested range (6..=10). Stored steps range is (1..=8)
-            sleep(Duration::from_millis(2000));
 
             //add txns from block to txn db
             for tx in block.data_ledgers[DataLedger::Submit].tx_ids.iter() {

--- a/crates/chain/src/peer_utilities.rs
+++ b/crates/chain/src/peer_utilities.rs
@@ -5,7 +5,6 @@ use irys_actors::{
     broadcast_mining_service::BroadcastMiningSeed,
     mempool_service::{MempoolService, TxIngressMessage},
     peer_list_service::{AddPeer, PeerListService},
-    vdf_service::{FastForwardVdfMessage, VdfService},
 };
 use irys_database::{BlockIndexItem, DataLedger};
 use irys_types::{block_production::Seed, Address};
@@ -221,7 +220,6 @@ pub async fn fetch_block_index(
 pub async fn sync_state_from_peers(
     trusted_peers: Vec<PeerAddress>,
     block_discovery_addr: Addr<BlockDiscoveryActor>,
-    vdf_service_addr: Addr<VdfService>,
     mempool_addr: Addr<MempoolService>,
     peer_list_service_addr: Addr<PeerListService>,
     vdf_sender: tokio::sync::mpsc::Sender<BroadcastMiningSeed>,

--- a/crates/chain/src/peer_utilities.rs
+++ b/crates/chain/src/peer_utilities.rs
@@ -224,6 +224,7 @@ pub async fn sync_state_from_peers(
     vdf_service_addr: Addr<VdfService>,
     mempool_addr: Addr<MempoolService>,
     peer_list_service_addr: Addr<PeerListService>,
+    vdf_sender: tokio::sync::mpsc::Sender<BroadcastMiningSeed>,
 ) -> eyre::Result<()> {
     let client = awc::Client::default();
     let peers = Arc::new(Mutex::new(trusted_peers.clone()));

--- a/crates/chain/src/vdf.rs
+++ b/crates/chain/src/vdf.rs
@@ -25,7 +25,8 @@ pub fn run_vdf(
     let mut hash: H256 = seed;
     let mut checkpoints: Vec<H256> = vec![H256::default(); config.num_checkpoints_in_vdf_step];
     let mut global_step_number = global_step_number;
-    let mut reset_seed = initial_reset_seed;
+    // FIXME: The reset seed is the same as the seed... which I suspect is incorrect!
+    let reset_seed = initial_reset_seed;
     info!(
         "VDF thread started at global_step_number: {}",
         global_step_number

--- a/crates/chain/src/vdf.rs
+++ b/crates/chain/src/vdf.rs
@@ -84,7 +84,7 @@ pub fn run_vdf(
                     "Fastforward Step {:?} with Seed {:?}",
                     proposed_ff_to_mining_seed.global_step, proposed_ff_to_mining_seed.seed
                 );
-                reset_seed = proposed_ff_to_mining_seed.seed.0;
+                hash = proposed_ff_to_mining_seed.seed.0;
                 global_step_number = proposed_ff_to_mining_seed.global_step;
             } else {
                 debug!(

--- a/crates/chain/src/vdf.rs
+++ b/crates/chain/src/vdf.rs
@@ -66,6 +66,7 @@ pub fn run_vdf(
         });
 
         if global_step_number % nonce_limiter_reset_frequency == 0 {
+            // FIXME: is there an issue with reset_seed never changing here?
             info!(
                 "Reset seed {:?} applied to step {}",
                 global_step_number, reset_seed

--- a/crates/chain/src/vdf.rs
+++ b/crates/chain/src/vdf.rs
@@ -175,8 +175,8 @@ mod tests {
 
         let broadcast_mining_service = BroadcastMiningService::from_registry();
         let capacity = calc_capacity(&config);
-        let (new_seed_tx, new_seed_rx) = mpsc::channel::<BroadcastMiningSeed>(1);
-        let vdf_service = VdfService::from_capacity(capacity, new_seed_tx).start();
+        let (_, new_seed_rx) = mpsc::channel::<BroadcastMiningSeed>(1);
+        let vdf_service = VdfService::from_capacity(capacity).start();
         SystemRegistry::set(vdf_service.clone());
         let vdf_steps: VdfStepsReadGuard = vdf_service.send(GetVdfStateMessage).await.unwrap();
 

--- a/crates/chain/src/vdf.rs
+++ b/crates/chain/src/vdf.rs
@@ -8,7 +8,7 @@ use irys_vdf::{apply_reset_seed, step_number_to_salt_number, vdf_sha};
 use sha2::{Digest, Sha256};
 use std::time::Instant;
 use tokio::sync::mpsc::Receiver;
-use tracing::{debug, error, info};
+use tracing::{debug, info};
 
 pub fn run_vdf(
     config: &irys_types::VdfConfig,

--- a/crates/chain/tests/multi_node/sync_chain_state.rs
+++ b/crates/chain/tests/multi_node/sync_chain_state.rs
@@ -14,8 +14,10 @@ use tracing::{debug, error};
 #[test_log::test(actix_web::test)]
 async fn heavy_sync_chain_state() -> eyre::Result<()> {
     let required_blocks_height: usize = 5;
+    let expected_block_lag_between_index_and_tree: usize = 2;
     // +2 is so genesis is two blocks ahead of the peer nodes, as currently we check the peers index which lags behind
-    let required_genesis_node_height = required_blocks_height + 2;
+    let required_genesis_node_height =
+        required_blocks_height + expected_block_lag_between_index_and_tree;
     let trusted_peers = vec![PeerAddress {
         api: "127.0.0.1:8080".parse().expect("valid SocketAddr expected"),
         gossip: "127.0.0.1:8081".parse().expect("valid SocketAddr expected"),

--- a/crates/vdf/src/vdf_state.rs
+++ b/crates/vdf/src/vdf_state.rs
@@ -18,7 +18,9 @@ use tokio::time::sleep;
 pub struct VdfState {
     /// last global step stored
     pub global_step: u64,
+    /// maximum number of seeds to store in seeds VecDeque
     pub capacity: usize,
+    /// stored seeds
     pub seeds: VecDeque<Seed>,
 }
 

--- a/crates/vdf/src/vdf_state.rs
+++ b/crates/vdf/src/vdf_state.rs
@@ -18,7 +18,7 @@ use tokio::time::sleep;
 pub struct VdfState {
     /// last global step stored
     pub global_step: u64,
-    pub max_seeds_num: usize,
+    pub capacity: usize,
     pub seeds: VecDeque<Seed>,
 }
 
@@ -29,7 +29,7 @@ impl VdfState {
 
     /// Push new seed, and removing oldest one if is full
     pub fn push_step(&mut self, seed: Seed) {
-        if self.seeds.len() >= self.max_seeds_num {
+        if self.seeds.len() >= self.capacity {
             self.seeds.pop_front();
         }
 

--- a/crates/vdf/src/vdf_state.rs
+++ b/crates/vdf/src/vdf_state.rs
@@ -29,13 +29,25 @@ impl VdfState {
         (self.global_step, self.seeds.back().cloned())
     }
 
-    /// Push new seed, and removing oldest one if is full
+    /// Called when local vdf thread generates a new step and wants to increment vdf step state
     pub fn push_step(&mut self, seed: Seed) {
+        self.update_state(seed, self.global_step + 1);
+    }
+
+    /// Called when vdf step is recieved during peer sync and we need to jump to specified step
+    pub fn jump_step(&mut self, seed: Seed, step: u64) {
+        self.update_state(seed, step);
+    }
+
+    // FIXME: update_state() might not be ok to jump... it might need to fill in the gap too. How to know?
+    //        would that create the recall_range error we see when discovering a block?
+
+    /// Push new seed, removing oldest one if capacity full
+    fn update_state(&mut self, seed: Seed, step: u64) {
         if self.seeds.len() >= self.capacity {
             self.seeds.pop_front();
         }
-
-        self.global_step += 1;
+        self.global_step = step;
         self.seeds.push_back(seed);
         info!(
             "Received seed: {:?} global step: {}",

--- a/crates/vdf/src/vdf_state.rs
+++ b/crates/vdf/src/vdf_state.rs
@@ -61,7 +61,10 @@ impl VdfState {
         let vdf_steps_len = self.seeds.len() as u64;
 
         let last_global_step = self.global_step;
-        let first_global_step = last_global_step - vdf_steps_len + 1;
+
+        // first available global step should be at least one.
+        // TODO: Should this instead panic! as something has gone very wrong?
+        let first_global_step = last_global_step.saturating_sub(vdf_steps_len) + 1;
 
         if first_global_step > last_global_step {
             return Err(eyre::eyre!("No steps stored!"));


### PR DESCRIPTION
**Describe the changes**
VDF steps imported from synced blocks during node sync path.
PRevents the need to wait before importing blocks, i.e. one could never fully catch up with genesis.

**Related Issue(s)**
https://github.com/Irys-xyz/irys/issues/357

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
New new tests. Existing sync test is used with sleeps removed.
