### PR TITLE
test: reduce test run time for heavy_sync_chain_state

### DIFF
--- a/crates/chain/tests/multi_node/sync_chain_state.rs
+++ b/crates/chain/tests/multi_node/sync_chain_state.rs
@@ -600,9 +600,11 @@ async fn heavy_sync_chain_state() -> eyre::Result<()> {
     tracing::debug!("COMPLETED FINAL PEER2 ASSERTS");
 
     // shut down peer nodes and then genesis node, we have what we need
-    ctx_peer1_node.stop().await;
-    ctx_peer2_node.stop().await;
-    ctx_genesis_node.stop().await;
+    tokio::join!(
+        ctx_peer1_node.stop(),
+        ctx_peer2_node.stop(),
+        ctx_genesis_node.stop(),
+    );
 
     Ok(())
 }

--- a/crates/chain/tests/multi_node/sync_chain_state.rs
+++ b/crates/chain/tests/multi_node/sync_chain_state.rs
@@ -296,9 +296,9 @@ async fn heavy_sync_chain_state() -> eyre::Result<()> {
     // setup trusted peers connection data and configs for genesis and nodes
     let (
         testnet_config_genesis,
-        mut testnet_config_peer1,
+        testnet_config_peer1,
         testnet_config_peer2,
-        trusted_peers,
+        _trusted_peers,
         genesis_trusted_peers,
     ) = init_configs();
     // setup a funded account at genesis block
@@ -331,8 +331,6 @@ async fn heavy_sync_chain_state() -> eyre::Result<()> {
     //     genesis_trusted_peers[0].api.ip(),
     //     peer_list_items[0].api.ip()
     // );
-
-    testnet_config_peer1.trusted_peers = trusted_peers.clone();
 
     // start additional nodes (after we have mined some blocks on genesis node)
     let (ctx_peer1_node, ctx_peer2_node) = start_peer_nodes(

--- a/crates/chain/tests/multi_node/sync_chain_state.rs
+++ b/crates/chain/tests/multi_node/sync_chain_state.rs
@@ -306,7 +306,7 @@ async fn heavy_sync_chain_state() -> eyre::Result<()> {
 
     let ctx_genesis_node = start_genesis_node(&testnet_config_genesis, &account1).await;
 
-    let required_blocks_height: usize = 5;
+    let required_blocks_height: usize = 2;
     let expected_block_lag_between_index_and_tree: usize = 2;
     // +2 is so genesis is two blocks ahead of the peer nodes, as currently we check the peers index which lags behind
     let required_genesis_node_height =


### PR DESCRIPTION
**Describe the changes**
Reduces `heavy_sync_chain_state` test run time by ~15%. Achieved by mining less block and node shutdown in parallel.

**Related Issue(s)**
N/A

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
