### PR TITLE
more robust epoch_service replay tests

### DIFF
--- a/crates/actors/src/epoch_service/epoch_replay_data.rs
+++ b/crates/actors/src/epoch_service/epoch_replay_data.rs
@@ -41,7 +41,7 @@ impl EpochReplayData {
         // Calculate how many epoch blocks should exist in the chain
         let num_blocks_in_epoch = config.consensus.epoch.num_blocks_in_epoch;
         let num_blocks = block_index.num_blocks();
-        let num_epoch_blocks = (num_blocks / num_blocks_in_epoch) as u64 + 1;
+        let num_epoch_blocks = (num_blocks / num_blocks_in_epoch).max(1) as u64;
         let mut replay_data: VecDeque<EpochReplayData> = VecDeque::new();
 
         // Process each epoch block from genesis to the latest
@@ -49,9 +49,10 @@ impl EpochReplayData {
             let block_height = i * num_blocks_in_epoch;
 
             // Get the block hash from the block index
-            let block_item = block_index
-                .get_item(block_height)
-                .expect("Expected block index to contain an item at the epoch block height");
+            let block_item = block_index.get_item(block_height).expect(&format!(
+                "Expected block index to contain an item at the epoch block height: {}",
+                block_height
+            ));
 
             // Retrieve the block header from the database
             let block = db

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -399,10 +399,7 @@ impl IrysNodeTest<IrysNodeCtx> {
 
     pub async fn stop(self) -> IrysNodeTest<()> {
         self.node_ctx.stop().await;
-        let cfg = NodeConfig {
-            mode: NodeMode::PeerSync,
-            ..self.cfg
-        };
+        let cfg = NodeConfig { ..self.cfg };
         IrysNodeTest {
             node_ctx: (),
             cfg,

--- a/crates/database/src/db.rs
+++ b/crates/database/src/db.rs
@@ -3,6 +3,7 @@ use reth_db::DatabaseEnv;
 use reth_db_api::database_metrics::{DatabaseMetadata, DatabaseMetadataValue, DatabaseMetrics};
 use std::sync::RwLock;
 use std::sync::{Arc, PoisonError, RwLockReadGuard};
+use tracing::info;
 
 /// In the reth library, there's a nested circular Arc reference. This circular dependency prevents
 /// the DB connection from being dropped even when external references are removed, thereby making
@@ -32,9 +33,11 @@ impl RethDbWrapper {
 
     /// Close underlying DB connection
     pub fn close(&self) {
+        info!("Closing underlying DB connection");
         if let Ok(mut db) = self.db.write() {
             db.take();
         }
+        info!("Connection Closed");
     }
 }
 


### PR DESCRIPTION
**Describe the changes**
Adds a more robust epoch block replay test that validates that a node can be restarted and the epoch state deterministically recreated.

**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
