### PR TITLE
feat: block rewards for miners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 .vscode/settings.json
 ext/
 config.toml
+emission_simulation.csv

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4058,6 +4058,7 @@ dependencies = [
  "irys-price-oracle",
  "irys-primitives",
  "irys-reth-node-bridge",
+ "irys-reward-curve",
  "irys-storage",
  "irys-testing-utils",
  "irys-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4171,6 +4171,7 @@ dependencies = [
  "irys-packing",
  "irys-price-oracle",
  "irys-reth-node-bridge",
+ "irys-reward-curve",
  "irys-storage",
  "irys-testing-utils",
  "irys-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4429,6 +4429,7 @@ version = "0.1.0"
 dependencies = [
  "eyre",
  "irys-types",
+ "rstest",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4424,6 +4424,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "irys-reward-curve"
+version = "0.1.0"
+
+[[package]]
 name = "irys-storage"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4426,6 +4426,10 @@ dependencies = [
 [[package]]
 name = "irys-reward-curve"
 version = "0.1.0"
+dependencies = [
+ "eyre",
+ "irys-types",
+]
 
 [[package]]
 name = "irys-storage"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2388,6 +2388,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3571,7 +3592,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -4429,6 +4450,8 @@ dependencies = [
 name = "irys-reward-curve"
 version = "0.1.0"
 dependencies = [
+ "clap",
+ "csv",
  "eyre",
  "irys-types",
  "rstest",
@@ -4886,7 +4909,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -11022,7 +11045,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
   "crates/cli",
   "crates/gossip-service",
   "crates/api-client",
+  "crates/reward-curve",
 ]
 resolver = "2"
 
@@ -48,6 +49,7 @@ irys-testing-utils = { path = "./crates/testing-utils" }
 irys-packing = { path = "./crates/packing" }
 irys-chain = { path = "./crates/chain" }
 irys-vdf = { path = "./crates/vdf" }
+irys-rewrd-curve = { path = "./crates/reward-curve" }
 irys-efficient-sampling = { path = "./crates/efficient-sampling" }
 irys-price-oracle = { path = "./crates/price-oracle" }
 irys-gossip-service = { path = "./crates/gossip-service" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ irys-testing-utils = { path = "./crates/testing-utils" }
 irys-packing = { path = "./crates/packing" }
 irys-chain = { path = "./crates/chain" }
 irys-vdf = { path = "./crates/vdf" }
-irys-rewrd-curve = { path = "./crates/reward-curve" }
+irys-reward-curve = { path = "./crates/reward-curve" }
 irys-efficient-sampling = { path = "./crates/efficient-sampling" }
 irys-price-oracle = { path = "./crates/price-oracle" }
 irys-gossip-service = { path = "./crates/gossip-service" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,6 +173,7 @@ tracing-error = "0.2"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt", "json", "ansi"] }
 alloy-signer = { path = "./ext/alloy/crates/signer" }
 tempfile = "3"
+csv = "1"
 jsonrpsee = "0.24"
 jsonrpsee-core = "0.24"
 jsonrpsee-http-client = "0.24"

--- a/crates/actors/Cargo.toml
+++ b/crates/actors/Cargo.toml
@@ -38,6 +38,7 @@ futures.workspace = true
 rust_decimal.workspace = true
 serde_json = { workspace = true, features = ["std", "raw_value"] }
 reqwest = { version = "0.11", features = ["json"] }
+irys-reward-curve.workspace = true
 # serde.workspace = true
 
 [dev-dependencies]

--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -15,7 +15,7 @@ use irys_reth_node_bridge::{adapter::node::RethNodeContext, node::RethNodeProvid
 use irys_reward_curve::HalvingCurve;
 use irys_types::{
     app_state::DatabaseProvider, block_production::SolutionContext, calculate_difficulty,
-    next_cumulative_diff, Address, Base64, Config, DataTransactionLedger, H256List,
+    next_cumulative_diff, Base64, Config, DataTransactionLedger, H256List,
     IngressProofsList, IrysBlockHeader, IrysTransactionCommon, IrysTransactionHeader, PoaData,
     Signature, SystemTransactionLedger, TxIngressProof, VDFLimiterInfo, H256, U256,
 };

--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -125,6 +125,7 @@ impl Handler<SolutionFoundMessage> for BlockProducerActor {
             vdf_steps_guard,
             block_tree_guard,
             price_oracle,
+            reward_curve,
             ..
         } = self.clone();
 
@@ -464,7 +465,7 @@ impl Handler<SolutionFoundMessage> for BlockProducerActor {
                             fee: alloy_primitives::U256::ZERO,
                             address: irys_block.reward_address,
                             tx: ShadowTxType::BlockReward(BlockRewardShadow {
-                                reward: alloy_primitives::U256::from_le_bytes(irys_block.reward_amount.to_le_bytes()),
+                                reward: irys_block.reward_amount.into(),
                             })
                         },
                     ]);

--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -15,9 +15,9 @@ use irys_reth_node_bridge::{adapter::node::RethNodeContext, node::RethNodeProvid
 use irys_reward_curve::HalvingCurve;
 use irys_types::{
     app_state::DatabaseProvider, block_production::SolutionContext, calculate_difficulty,
-    next_cumulative_diff, Base64, Config, DataTransactionLedger, H256List,
-    IngressProofsList, IrysBlockHeader, IrysTransactionCommon, IrysTransactionHeader, PoaData,
-    Signature, SystemTransactionLedger, TxIngressProof, VDFLimiterInfo, H256, U256,
+    next_cumulative_diff, Base64, Config, DataTransactionLedger, H256List, IngressProofsList,
+    IrysBlockHeader, IrysTransactionCommon, IrysTransactionHeader, PoaData, Signature,
+    SystemTransactionLedger, TxIngressProof, VDFLimiterInfo, H256, U256,
 };
 use irys_vdf::vdf_state::VdfStepsReadGuard;
 use nodit::interval::ii;
@@ -386,7 +386,7 @@ impl Handler<SolutionFoundMessage> for BlockProducerActor {
                 prev_block_header.timestamp.saturating_div(1000),
                 current_timestamp.saturating_div(1000)
             )?;
-       
+
             // build a new block header
             let mut irys_block = IrysBlockHeader {
                 block_hash,

--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -384,7 +384,7 @@ impl Handler<SolutionFoundMessage> for BlockProducerActor {
             let ms_since_genesis_block = genesis_block_timestamp.abs_diff(current_timestamp);
             let sec_since_genesis_block = ms_since_genesis_block.saturating_div(1000);
             let reward_amount = reward_curve.block_reward(sec_since_genesis_block)?;
-
+       
             // build a new block header
             let mut irys_block = IrysBlockHeader {
                 block_hash,

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -25,6 +25,7 @@ irys-vdf.workspace = true
 irys-price-oracle.workspace = true
 irys-gossip-service.workspace = true
 irys-api-client.workspace = true
+irys-reward-curve.workspace = true
 
 base58.workspace = true
 color-eyre.workspace = true
@@ -59,10 +60,7 @@ futures.workspace = true
 reth-tracing.workspace = true
 hex.workspace = true
 test-fuzz.workspace = true
-k256 = { version = "0.13", default-features = false, features = [
-    "ecdsa",
-    "serde",
-] }
+k256 = { version = "0.13", default-features = false, features = ["ecdsa", "serde"] }
 alloy-sol-macro = { workspace = true, features = ["json"] }
 alloy-provider.workspace = true
 core_affinity = "0.8.1"

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -773,7 +773,7 @@ impl IrysNode {
         // create the block reward curve
         let reward_curve = irys_reward_curve::HalvingCurve {
             inflation_cap: config.consensus.block_reward_config.inflation_cap,
-            half_life_secs: config.consensus.block_reward_config.half_life_secs,
+            half_life_secs: config.consensus.block_reward_config.half_life_secs.into(),
         };
         let reward_curve = Arc::new(reward_curve);
 

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -667,8 +667,15 @@ impl IrysNode {
         let (broadcast_mining_actor, broadcast_arbiter) = init_broadcaster_service();
 
         // start the epoch service
-        let (storage_module_infos, epoch_service_actor) =
-            Self::init_epoch_service(&config, &irys_db, &block_index_guard).await?;
+        let (genesis_block, commitments, epoch_replay_data) =
+            EpochReplayData::query_replay_data(&irys_db, &block_index_guard, &config)?;
+        let (storage_module_infos, epoch_service_actor) = Self::init_epoch_service(
+            &config,
+            genesis_block.clone(),
+            commitments,
+            epoch_replay_data,
+        )
+        .await?;
 
         // Retrieve Partition assignment
         let partition_assignments_guard = epoch_service_actor
@@ -777,6 +784,7 @@ impl IrysNode {
         // set up the block producer
         let (block_producer_addr, block_producer_arbiter) = Self::init_block_producer(
             &config,
+            &genesis_block,
             &irys_db,
             &reth_node,
             &service_senders,
@@ -1051,6 +1059,7 @@ impl IrysNode {
 
     fn init_block_producer(
         config: &Config,
+        genesis_block: &IrysBlockHeader,
         irys_db: &DatabaseProvider,
         reth_node: &RethNodeProvider,
         service_senders: &ServiceSenders,
@@ -1073,6 +1082,7 @@ impl IrysNode {
             block_tree_guard: block_tree_guard.clone(),
             price_oracle,
             service_senders: service_senders.clone(),
+            genesis_block_timestamp: genesis_block.timestamp,
         };
         let block_producer_addr =
             BlockProducerActor::start_in_arbiter(&block_producer_arbiter.handle(), |_| {
@@ -1244,15 +1254,13 @@ impl IrysNode {
 
     async fn init_epoch_service(
         config: &Config,
-        irys_db: &DatabaseProvider,
-        block_index_guard: &BlockIndexReadGuard,
+        genesis_block: IrysBlockHeader,
+        commitments: Vec<CommitmentTransaction>,
+        epoch_replay_data: Vec<EpochReplayData>,
     ) -> eyre::Result<(
         Vec<irys_storage::StorageModuleInfo>,
         actix::Addr<EpochServiceActor>,
     )> {
-        let (genesis_block, commitments, epoch_replay_data) =
-            EpochReplayData::query_replay_data(irys_db, block_index_guard, &config)?;
-
         let storage_submodule_config =
             StorageSubmodulesConfig::load(config.node_config.base_directory.clone())?;
         let mut epoch_service = EpochServiceActor::new(&config);

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -193,8 +193,6 @@ async fn heavy_test_blockprod_with_evm_txs() -> eyre::Result<()> {
     let account2 = IrysSigner::random_signer(&config.consensus_config());
     let account3 = IrysSigner::random_signer(&config.consensus_config());
     let chain_id = config.consensus_config().chain_id;
-    let mining_signer_addr = config.miner_address();
-    let reward_address = config.reward_address;
     let recipient = IrysSigner::random_signer(&config.consensus_config());
     config.consensus.extend_genesis_accounts(vec![
         (
@@ -221,11 +219,6 @@ async fn heavy_test_blockprod_with_evm_txs() -> eyre::Result<()> {
     ]);
     let node = IrysNodeTest::new_genesis(config).await.start().await;
     let reth_context = RethNodeContext::new(node.node_ctx.reth_handle.clone().into()).await?;
-    let miner_init_balance = reth_context
-        .rpc
-        .get_balance(mining_signer_addr, None)
-        .await?;
-    let reward_init_balance = reth_context.rpc.get_balance(reward_address, None).await?;
     let recipient_init_balance = reth_context
         .rpc
         .get_balance(recipient.address(), None)

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -346,7 +346,7 @@ async fn heavy_rewards_get_calculated_correctly() -> eyre::Result<()> {
     let mut prev_ts: Option<u128> = None;
     let reward_address = node.node_ctx.config.node_config.reward_address;
     let mut init_balance = reth_context.rpc.get_balance(reward_address, None).await?;
-    for iteration in 0..3 {
+    for _ in 0..3 {
         // mine a single block
         let (block, reth_exec_env) = mine_block(&node.node_ctx)
             .await?

--- a/crates/chain/tests/multi_node/sync_chain_state.rs
+++ b/crates/chain/tests/multi_node/sync_chain_state.rs
@@ -292,7 +292,6 @@ async fn heavy_test_p2p_evm_gossip_new_rpc() -> eyre::Result<()> {
 /// 3. mine further blocks on genesis node, and confirm gossip service syncs them to peers
 /// TODO: Mine on peer2 and see if those blocks arrive at genesis via gossip
 #[test_log::test(actix_web::test)]
-#[ignore]
 async fn heavy_sync_chain_state() -> eyre::Result<()> {
     // setup trusted peers connection data and configs for genesis and nodes
     let (

--- a/crates/chain/tests/multi_node/sync_chain_state.rs
+++ b/crates/chain/tests/multi_node/sync_chain_state.rs
@@ -292,6 +292,7 @@ async fn heavy_test_p2p_evm_gossip_new_rpc() -> eyre::Result<()> {
 /// 3. mine further blocks on genesis node, and confirm gossip service syncs them to peers
 /// TODO: Mine on peer2 and see if those blocks arrive at genesis via gossip
 #[test_log::test(actix_web::test)]
+#[ignore]
 async fn heavy_sync_chain_state() -> eyre::Result<()> {
     // setup trusted peers connection data and configs for genesis and nodes
     let (

--- a/crates/reward-curve/Cargo.toml
+++ b/crates/reward-curve/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "irys-reward-curve"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/reward-curve/Cargo.toml
+++ b/crates/reward-curve/Cargo.toml
@@ -12,5 +12,8 @@ authors.workspace = true
 irys-types.workspace = true
 eyre.workspace = true
 
+[dev-dependencies]
+rstest.workspace = true
+
 [lints]
 workspace = true

--- a/crates/reward-curve/Cargo.toml
+++ b/crates/reward-curve/Cargo.toml
@@ -8,9 +8,20 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[[bin]]
+name = "irys-reward-curve-simulation"
+path = "src/main.rs"
+required-features = ["emission-sim"]
+
+[features]
+default = []
+emission-sim = ["csv", "clap"]
+
 [dependencies]
 irys-types.workspace = true
 eyre.workspace = true
+clap = { workspace = true, optional = true }
+csv = { workspace = true, optional = true }
 
 [dev-dependencies]
 rstest.workspace = true

--- a/crates/reward-curve/Cargo.toml
+++ b/crates/reward-curve/Cargo.toml
@@ -9,6 +9,8 @@ repository.workspace = true
 authors.workspace = true
 
 [dependencies]
+irys-types.workspace = true
+eyre.workspace = true
 
 [lints]
 workspace = true

--- a/crates/reward-curve/src/lib.rs
+++ b/crates/reward-curve/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: u64, right: u64) -> u64 {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/crates/reward-curve/src/lib.rs
+++ b/crates/reward-curve/src/lib.rs
@@ -1,14 +1,112 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
+use eyre::{eyre, Result};
+use irys_types::storage_pricing::{mul_div, safe_add, safe_div, safe_sub, TOKEN_SCALE};
+use irys_types::storage_pricing::{phantoms::Irys, Amount};
+use irys_types::U256;
+
+/// 18-decimal fixed-point representation of ln(2).
+/// 0.693147180559945309 × 10¹⁸  ≈  693_147_180_559_945_309
+const LN2_SCALED: U256 = U256([693_147_180_559_945_309u64, 0, 0, 0]);
+
+/// Exponential–decay emission curve:
+///
+/// R(t) = R_max · ln(2)/T½ · 2⁻(t/T½)
+///
+/// Everything is integer / fixed-point.  
+/// `inflation_supply` – asymptotic total emission (atomic units)  
+/// `half_life_secs`   – half-life in **seconds**
+#[derive(Debug, Clone)]
+pub struct LogCurve {
+    pub inflation_supply: Amount<Irys>,
+    pub half_life_secs: u64,
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+impl LogCurve {
+    /// Per-block reward at `block_timestamp` (seconds since genesis).
+    ///
+    /// Returns `Amount<Irys>` in atomic units.
+    pub fn miner_reward(&self, block_timestamp: u64) -> Result<Amount<Irys>> {
+        if self.inflation_supply.amount.is_zero() || self.half_life_secs == 0 {
+            return Ok(Amount::new(U256::zero()));
+        }
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+        //--------------------------------------------------------------------
+        // 1.  R_max · ln(2) / T½   (scaled 1e18)
+        //--------------------------------------------------------------------
+        let r_ln2_scaled = mul_div(
+            self.inflation_supply.amount,
+            LN2_SCALED,
+            U256::from(self.half_life_secs),
+        )?;
+
+        //--------------------------------------------------------------------
+        // 2.  decay = 2^-(t / T½)  (scaled 1e18)
+        //--------------------------------------------------------------------
+        let decay_scaled = pow_half_ratio(block_timestamp, self.half_life_secs)?;
+
+        //--------------------------------------------------------------------
+        // 3.  reward = (r_ln2_scaled · decay_scaled) / 1e18   → atomic units
+        //--------------------------------------------------------------------
+        let reward = mul_div(r_ln2_scaled, decay_scaled, TOKEN_SCALE)?;
+
+        Ok(Amount::new(reward))
     }
+}
+
+/*──────────────────────── helper functions ──────────────────────────*/
+
+/// 2^-(t / half_life)  in 1e18 fixed-point.
+///
+/// Split t / T½  into its integer part  *q*  and fractional part  *f*.
+/// * 2⁻ᵠ  is just a right-shift / division by 2ᵠ.
+/// * 2⁻ᶠ = e^(-ln2·f)  is approximated with a 6-term Taylor series;
+///   f ≤ 1 so the error stays < 10⁻¹² for practical ranges.
+fn pow_half_ratio(timestamp: u64, half_life: u64) -> Result<U256> {
+    if half_life == 0 {
+        return Err(eyre!("half_life cannot be zero"));
+    }
+
+    let whole = timestamp / half_life;
+    let remainder = timestamp % half_life;
+
+    // TOKEN_SCALE / 2^whole
+    let mut result = TOKEN_SCALE;
+    if whole > 0 {
+        // shift >255 would underflow straight to zero – early-out
+        if whole >= 256 {
+            return Ok(U256::zero());
+        }
+        let pow2_whole = U256::one() << whole;
+        result = safe_div(result, pow2_whole)?;
+    }
+
+    // If there is no fractional part we are done.
+    if remainder == 0 {
+        return Ok(result);
+    }
+
+    // x = ln2 * remainder / half_life   (scaled 1e18)
+    let x_scaled = mul_div(LN2_SCALED, U256::from(remainder), U256::from(half_life))?;
+    let exp_frac = exp_neg_fixed(x_scaled)?;
+
+    // combine: 2^-whole * 2^-fraction
+    mul_div(result, exp_frac, TOKEN_SCALE)
+}
+
+/// e^(-x) in 18-dec fixed-point for 0 ≤ x ≤ ~0.7 (covers ln2*fraction).
+/// 6-term alternating Taylor series  ⇒  relative error < 10⁻¹².
+fn exp_neg_fixed(x_scaled: U256) -> Result<U256> {
+    let mut term = TOKEN_SCALE; // current term (starts at 1)
+    let mut sum = TOKEN_SCALE; // running total
+
+    for i in 1..=6u64 {
+        term = mul_div(term, x_scaled, TOKEN_SCALE)?; // term *= x
+        term = safe_div(term, U256::from(i))?; // term /= i
+        if i & 1 == 1 {
+            // alternate signs
+            sum = safe_sub(sum, term)?;
+        } else {
+            sum = safe_add(sum, term)?;
+        }
+    }
+    Ok(sum)
 }

--- a/crates/reward-curve/src/lib.rs
+++ b/crates/reward-curve/src/lib.rs
@@ -218,8 +218,9 @@ mod tests {
         // what the integral says
         let expected = expected_reward(&curve, from_year, to_year)?;
 
-        assert!(
-            (actual.as_u128() as i128 - expected as i128).abs() <= 1,
+        assert_eq!(
+            U256::from(actual),
+            U256::from(expected),
             "Δ[{from_year},{to_year}]: expected {expected}, got {actual}"
         );
         Ok(())

--- a/crates/reward-curve/src/lib.rs
+++ b/crates/reward-curve/src/lib.rs
@@ -1,6 +1,6 @@
 //! Exponential-decay (base-2) emission curve
 //!
-//! R(t) = R_max * ln 2 / T½ * 2^-(t/T½)
+//! R(t) = R_max * ln(2) / T_half * 2^-(t / T_half)
 //!
 //! All arithmetic is 18-decimal fixed-point using 256-bit unsigned integers.
 
@@ -9,14 +9,14 @@ use irys_types::storage_pricing::{mul_div, safe_add, safe_div, safe_sub, TOKEN_S
 use irys_types::storage_pricing::{phantoms::Irys, Amount};
 use irys_types::U256;
 
-/// ln 2 in 18-dec fixed-point:
-/// 0.693 147 180 559 945 309 × 1 e18 ≈ 693 147 180 559 945 309
+/// ln(2) in 18-decimal fixed-point:
+/// Approximately 0.693147180559945309 * 1e18 = 693147180559945309
 const LN2_FP18: U256 = U256([693_147_180_559_945_309u64, 0, 0, 0]);
 
-/// Continuous halving emission curve.
+/// Continuous halving emission curve
 ///
-/// * **inflation_cap** – asymptotic total emission, atomic units (R_max)  
-/// * **half_life_secs** – seconds until the remaining emission halves (T½)
+/// - inflation_cap: maximum total emission, in atomic units (R_max)
+/// - half_life_secs: time in seconds until remaining emission is halved (T_half)
 #[derive(Debug, Clone)]
 pub struct HalvingCurve {
     pub inflation_cap: Amount<Irys>,
@@ -24,10 +24,10 @@ pub struct HalvingCurve {
 }
 
 impl HalvingCurve {
-    /// Reward for the time span *(prev_ts … new_ts]*  (both in seconds since genesis).
+    /// Returns the emitted reward for the time interval (prev_ts ..= new_ts)
     ///
-    /// Guarantees `Ok(0)` when the interval is empty and
-    /// `Err(..)` if `new_ts < prev_ts`.
+    /// Returns Ok(0) if the interval is empty.
+    /// Returns Err if new_ts is earlier than prev_ts.
     pub fn reward_between(&self, prev_ts: u128, new_ts: u128) -> Result<Amount<Irys>> {
         if new_ts < prev_ts {
             return Err(eyre!("new_ts ({new_ts}) < prev_ts ({prev_ts})"));
@@ -36,31 +36,31 @@ impl HalvingCurve {
             return Ok(Amount::new(U256::zero()));
         }
 
-        // Cumulative emission up to each endpoint
+        // Compute total emission up to each timestamp
         let emitted_prev = self.emitted_until(prev_ts)?;
         let emitted_new = self.emitted_until(new_ts)?;
 
-        // Δ-emission is the block reward
+        // Difference in emission is the reward
         let delta = safe_sub(emitted_new, emitted_prev)?;
         Ok(Amount::new(delta))
     }
 
-    /// Tokens emitted from genesis **up to** `t` (seconds).
+    /// Returns total tokens emitted from genesis up to time t (in seconds)
     fn emitted_until(&self, t: u128) -> Result<U256> {
-        // decay = 2^-(t/T½)  (18-dec)
+        // decay = 2^-(t / T_half) in fixed-point
         let decay_fp18 = decay_factor(t, self.half_life_secs)?;
 
-        // emitted = R_max * (1 − decay)
+        // emitted = R_max * (1 - decay)
         let one_minus = safe_sub(TOKEN_SCALE, decay_fp18)?;
         mul_div(self.inflation_cap.amount, one_minus, TOKEN_SCALE)
     }
 }
 
-/// 2^-(t / half_life) in 18-dec fixed-point.
+/// Computes 2^-(t / half_life) in 18-decimal fixed-point
 ///
-/// Split `t / half_life = q + f` into integer `q` and fractional `f`.
-/// * 2^-q => divide by 2^q (bit-shift)  
-/// * 2^-f => e^(-ln 2 * f) via truncated Taylor series
+/// Splits t / half_life into integer part q and fractional part f
+/// - 2^-q is computed by bit-shifting
+/// - 2^-f is approximated using a truncated Taylor expansion of exp(-ln(2) * f)
 fn decay_factor(t_secs: u128, half_life: u128) -> Result<U256> {
     if half_life == 0 {
         return Err(eyre!("half_life cannot be zero"));
@@ -69,44 +69,44 @@ fn decay_factor(t_secs: u128, half_life: u128) -> Result<U256> {
     let q = t_secs / half_life;
     let f_secs = t_secs % half_life;
 
-    // 2^-q
+    // Compute 2^-q
     let decay_q_fp18 = if q == 0 {
         TOKEN_SCALE
     } else if q >= 256 {
-        U256::zero() // underflow
+        U256::zero() // result underflows to zero
     } else {
         safe_div(TOKEN_SCALE, U256::one() << q)?
     };
 
-    // No fractional part? Done.
+    // If no fractional remainder, we are done
     if f_secs == 0 || decay_q_fp18.is_zero() {
         return Ok(decay_q_fp18);
     }
 
-    // x = ln 2 * f / half_life  (18-dec)
+    // Compute ln(2) * f / half_life in fixed-point
     let x_fp18 = mul_div(LN2_FP18, U256::from(f_secs), U256::from(half_life))?;
     let decay_f_fp18 = exp_neg(x_fp18)?;
 
-    // Combine integer and fractional pieces.
+    // Final decay = 2^-q * 2^-f
     mul_div(decay_q_fp18, decay_f_fp18, TOKEN_SCALE)
 }
 
-/// e^(-x) in 18-dec fixed-point using `TAYLOR_TERMS` terms.
+/// Approximates exp(-x) in 18-decimal fixed-point using Taylor series
 fn exp_neg(x_fp18: U256) -> Result<U256> {
-    /// Number of terms kept in the e^(-x) Taylor series.
-    /// 10 → |ε| < 3 × 10⁻¹⁵.
-    const TAYLOR_TERMS: u128 = 10;
+    /// Number of terms in the Taylor series expansion
+    const TAYLOR_TERMS: u128 = 12;
 
-    let mut term = TOKEN_SCALE; // current term (= 1)
-    let mut sum = TOKEN_SCALE; // running total
+    let mut term = TOKEN_SCALE; // first term is 1
+    let mut sum = TOKEN_SCALE; // accumulated sum
 
     for i in 1..=TAYLOR_TERMS {
-        term = mul_div(term, x_fp18, TOKEN_SCALE)?; // term *= x
-        term = safe_div(term, U256::from(i))?; // term /= i
+        term = mul_div(term, x_fp18, TOKEN_SCALE)?; // multiply by x
+        term = safe_div(term, U256::from(i))?; // divide by i
         sum = if i & 1 == 1 {
-            // alternating signs
+            // subtract on odd steps
             safe_sub(sum, term)?
         } else {
+            // add on even steps
             safe_add(sum, term)?
         };
     }
@@ -127,13 +127,13 @@ mod tests {
     /// Cumulative emitted tokens after `t_years`, computed
     /// **with the same integer math** that `LogCurve::miner_reward` uses:
     ///
-    /// S(t) = R_max * (1 − 2^{-t/T½})
+    /// S(t) = R_max * (1 − 2^{-t/T_half})
     fn circulating_supply(curve: &HalvingCurve, t_years: u128) -> Result<u128> {
         use irys_types::storage_pricing::{mul_div, safe_sub, TOKEN_SCALE};
 
         let elapsed_secs = t_years * SECS_PER_YEAR;
 
-        // decay = 2^{-t/T½} (scaled 1e18)
+        // decay = 2^{-t/T_half} (scaled 1e18)
         let decay_scaled = decay_factor(elapsed_secs, curve.half_life_secs)?;
 
         // emitted = R_max * (1 − decay)
@@ -211,6 +211,34 @@ mod tests {
         #[case] to_year: u128,
     ) -> Result<()> {
         let curve = test_curve();
+
+        // what the curve says
+        let actual = curve.reward_between(secs(from_year), secs(to_year))?.amount;
+
+        // what the integral says
+        let expected = expected_reward(&curve, from_year, to_year)?;
+
+        assert_eq!(
+            U256::from(actual),
+            U256::from(expected),
+            "Δ[{from_year},{to_year}]: expected {expected}, got {actual}"
+        );
+        Ok(())
+    }
+
+    /// Golden-path table: reward for each [y, y+1) interval.
+    #[rstest]
+    #[case(0, 1)]
+    #[case(1, 2)]
+    #[case(3, 4)]
+    #[case(7, 8)]
+    #[case(18, 19)]
+    fn sanity_check_with_18_decimals(#[case] from_year: u128, #[case] to_year: u128) -> Result<()> {
+        let curve = HalvingCurve {
+            // this will generate a max cap with 18 decimals
+            inflation_cap: Amount::token(INF_SUPPLY.into()).unwrap(),
+            half_life_secs: HALF_LIFE_YEARS * SECS_PER_YEAR,
+        };
 
         // what the curve says
         let actual = curve.reward_between(secs(from_year), secs(to_year))?.amount;

--- a/crates/reward-curve/src/main.rs
+++ b/crates/reward-curve/src/main.rs
@@ -1,0 +1,94 @@
+use std::fs::File;
+
+use clap::Parser;
+use irys_reward_curve::HalvingCurve;
+use irys_types::{
+    storage_pricing::{safe_add, Amount},
+    U256,
+};
+
+/// Command‑line parameters for the simulation.
+#[derive(Parser, Debug)]
+#[command(name = "Emission Simulator", author, version, about)]
+struct Args {
+    /// Block interval in seconds.
+    #[arg(long = "block-interval-secs", default_value_t = 1200)]
+    block_interval_secs: u128,
+
+    /// Number of whole years to simulate (from genesis).
+    #[arg(long = "years", default_value_t = 20)]
+    years: u128,
+
+    /// Path to the CSV output file.
+    #[arg(long = "output", default_value = "emission_simulation.csv")]
+    output: String,
+}
+
+fn main() -> eyre::Result<()> {
+    let args = Args::parse();
+
+    const INFLATION_CAP_TOKENS: u128 = 100_000_000;
+    const HALF_LIFE_YEARS: u128 = 4;
+    const SECS_PER_YEAR: u128 = 31_557_600;
+
+    let curve = HalvingCurve {
+        inflation_cap: Amount::token(INFLATION_CAP_TOKENS.into()).unwrap(),
+        half_life_secs: HALF_LIFE_YEARS * SECS_PER_YEAR,
+    };
+
+    let total_seconds = args.years * SECS_PER_YEAR;
+    let mut prev_ts: u128 = 0;
+    let mut block_number: u64 = 0;
+    let mut cumulative: U256 = U256::zero();
+
+    let mut wtr = csv::Writer::from_writer(File::create(&args.output)?);
+    wtr.write_record(&[
+        "block_number",
+        "timestamp_secs",
+        "emission_per_block",
+        "cumulative_emission",
+    ])?;
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::scope(move |s| {
+        s.spawn(move || {
+            while prev_ts < total_seconds {
+                let next_ts = (prev_ts + args.block_interval_secs).min(total_seconds);
+                let reward = curve.reward_between(prev_ts, next_ts).unwrap();
+                cumulative = safe_add(cumulative, reward.amount).unwrap();
+
+                tx.send([
+                    block_number.to_string(),
+                    next_ts.to_string(),
+                    reward.token_to_decimal().unwrap().to_string(),
+                    Amount::<()>::new(cumulative)
+                        .token_to_decimal()
+                        .unwrap()
+                        .to_string(),
+                ])
+                .unwrap();
+
+                prev_ts = next_ts;
+                block_number = block_number.saturating_add(1);
+            }
+        });
+
+        let mut last_pct: u8 = 0;
+        while let Ok(res) = rx.recv() {
+            wtr.write_record(&res).unwrap();
+
+            // progress calculation: timestamp_secs is at index 1
+            let ts_secs: u128 = res[1].parse().unwrap();
+            let pct = ((ts_secs * 100) / total_seconds) as u8;
+
+            if pct > last_pct {
+                last_pct = pct;
+                println!("Progress: {pct}%");
+            }
+        }
+        wtr.flush().unwrap();
+    });
+
+    println!("CSV written to {}", args.output);
+    Ok(())
+}

--- a/crates/types/src/block.rs
+++ b/crates/types/src/block.rs
@@ -4,6 +4,7 @@
 //! making them easy to reference and maintain.
 use std::fmt;
 
+use crate::storage_pricing::phantoms::Irys;
 use crate::storage_pricing::{phantoms::IrysPrice, phantoms::Usd, Amount};
 use crate::{
     generate_data_root, generate_leaves_from_data_roots, option_u64_stringify,
@@ -127,6 +128,9 @@ pub struct IrysBlockHeader {
 
     /// The address that the block reward should be sent to
     pub reward_address: Address,
+
+    /// The amount of Irys tokens that must be rewarded to the `self.rewrad_address`
+    pub reward_amount: U256,
 
     /// The address of the block producer - used to validate the block hash/signature & the PoA chunk (as the packing key)
     /// We allow for miners to send rewards to a separate address

--- a/crates/types/src/block.rs
+++ b/crates/types/src/block.rs
@@ -4,7 +4,6 @@
 //! making them easy to reference and maintain.
 use std::fmt;
 
-use crate::storage_pricing::phantoms::Irys;
 use crate::storage_pricing::{phantoms::IrysPrice, phantoms::Usd, Amount};
 use crate::{
     generate_data_root, generate_leaves_from_data_roots, option_u64_stringify,

--- a/crates/types/src/block.rs
+++ b/crates/types/src/block.rs
@@ -128,7 +128,7 @@ pub struct IrysBlockHeader {
     /// The address that the block reward should be sent to
     pub reward_address: Address,
 
-    /// The amount of Irys tokens that must be rewarded to the `self.rewrad_address`
+    /// The amount of Irys tokens that must be rewarded to the `self.reward_address`
     pub reward_amount: U256,
 
     /// The address of the block producer - used to validate the block hash/signature & the PoA chunk (as the packing key)

--- a/crates/types/src/config.rs
+++ b/crates/types/src/config.rs
@@ -147,7 +147,7 @@ pub struct BlockRewradConfig {
         serialize_with = "serde_utils::serializes_token_amount"
     )]
     pub inflation_cap: Amount<Irys>,
-    pub half_life_secs: u128,
+    pub half_life_secs: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -539,7 +539,7 @@ impl ConsensusConfig {
             },
             block_reward_config: BlockRewradConfig {
                 inflation_cap: Amount::token(rust_decimal::Decimal::from(INFLATION_CAP)).unwrap(),
-                half_life_secs: HALF_LIFE_YEARS * SECS_PER_YEAR,
+                half_life_secs: (HALF_LIFE_YEARS * SECS_PER_YEAR).try_into().unwrap(),
             },
         }
     }
@@ -762,6 +762,10 @@ mod tests {
     fn test_deserialize_consensus_config_from_toml() {
         let toml_data = r#"
         chain_id = 1270
+        token_price_safe_range = 1.0
+        genesis_price = 1.0
+        annual_cost_per_gb = 0.01
+        decay_rate = 0.01
         chunk_size = 262144
         chunk_migration_depth = 1
         num_chunks_in_partition = 10
@@ -770,10 +774,6 @@ mod tests {
         entropy_packing_iterations = 1000
         number_of_ingress_proofs = 10
         safe_minimum_number_of_years = 200
-        token_price_safe_range = 1.0
-        genesis_price = 1
-        annual_cost_per_gb = 0.01
-        decay_rate = 0.01
 
         [reth]
         chain = 1270
@@ -798,6 +798,10 @@ mod tests {
         [reth.genesis.alloc.0xa93225cbf141438629f1bd906a31a1c5401ce924]
         balance = "0xd3c21bcecceda1000000"
 
+        [mempool]
+        max_data_txs_per_block = 100
+        anchor_expiry_depth = 10
+
         [difficulty_adjustment]
         block_time = 1
         difficulty_adjustment_interval = 1209600000
@@ -810,6 +814,10 @@ mod tests {
         num_checkpoints_in_vdf_step = 25
         sha_1s_difficulty = 7000
 
+        [block_reward_config]
+        inflation_cap = 100000000
+        half_life_secs = 126144000
+
         [epoch]
         capacity_scalar = 100
         num_blocks_in_epoch = 100
@@ -817,10 +825,6 @@ mod tests {
 
         [ema]
         price_adjustment_interval = 10
-
-        [mempool]
-        max_data_txs_per_block = 100
-        anchor_expiry_depth = 10
         "#;
 
         // Create the expected config
@@ -840,41 +844,19 @@ mod tests {
     #[test]
     fn test_deserialize_config_from_toml() {
         let toml_data = r#"
-        max_data_txs_per_block = 20
-        chunk_size = 262144
-        num_chunks_in_partition = 10
-        num_chunks_in_recall_range = 2
-        num_partitions_per_slot = 1
-        num_writes_before_sync = 5
-        reset_state_on_restart = false
-        chunk_migration_depth = 1
-        num_capacity_partitions = 16
-        anchor_expiry_depth = 10
-        genesis_price_valid_for_n_epochs = 2
-        genesis_token_price = "1.0"
-        token_price_safe_range = "0.25"
-        price_adjustment_interval = 10
-        cpu_packing_concurrency = 4
-        gpu_packing_batch_size = 1024
-        annual_cost_per_gb = "0.01"
-        decay_rate = "0.01"
-        fee_percentage = "0.05"
-        safe_minimum_number_of_years = 200
-        number_of_ingress_proofs = 10
         mode = "Genesis"
         base_directory = "~/.tmp/.irys"
         consensus = "Testnet"
         mining_key = "db793353b633df950842415065f769699541160845d73db902eadee6bc5042d0"
+        reward_address = "0x64f1a2829e0e698c18e7792d6e74f67d89aa0a32"
 
         [[trusted_peers]]
         gossip = "127.0.0.1:8081"
         api = "127.0.0.1:8080"
-      
+
         [trusted_peers.execution]
         peering_tcp_addr = "127.0.0.1:30303"
         peer_id = "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-
-
 
         [oracle]
         type = "mock"
@@ -892,10 +874,6 @@ mod tests {
         bind_ip = "127.0.0.1"
         port = 0
 
-        [reth_peer_info]
-        peering_tcp_addr = "0.0.0.0:0"
-        peer_id = "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-
         [packing]
         cpu_packing_concurrency = 4
         gpu_packing_batch_size = 1024
@@ -906,6 +884,10 @@ mod tests {
         [http]
         bind_ip = "127.0.0.1"
         port = 0
+
+        [reth_peer_info]
+        peering_tcp_addr = "0.0.0.0:0"
+        peer_id = "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
         "#;
         // Create the expected config
         let mut expected_config = NodeConfig::testnet();

--- a/crates/types/src/config.rs
+++ b/crates/types/src/config.rs
@@ -189,6 +189,8 @@ pub struct NodeConfig {
     )]
     pub mining_key: k256::ecdsa::SigningKey,
 
+    pub reward_address: Address,
+
     /// Data storage configuration
     pub storage: StorageSyncConfig,
 
@@ -566,9 +568,16 @@ impl NodeConfig {
 
     #[cfg(any(test, feature = "test-utils"))]
     pub fn testnet() -> Self {
+        use alloy_signer::utils::secret_key_to_address;
         use k256::ecdsa::SigningKey;
         use rust_decimal_macros::dec;
 
+        let mining_key = SigningKey::from_slice(
+            &hex::decode(b"db793353b633df950842415065f769699541160845d73db902eadee6bc5042d0")
+                .expect("valid hex"),
+        )
+        .expect("valid key");
+        let reward_address = secret_key_to_address(&mining_key);
         Self {
             mode: NodeMode::Genesis,
             consensus: ConsensusOptions::Custom(ConsensusConfig::testnet()),
@@ -579,11 +588,8 @@ impl NodeConfig {
                 percent_change: Amount::percentage(dec!(0.01)).expect("valid percentage"),
                 smoothing_interval: 15,
             },
-            mining_key: SigningKey::from_slice(
-                &hex::decode(b"db793353b633df950842415065f769699541160845d73db902eadee6bc5042d0")
-                    .expect("valid hex"),
-            )
-            .expect("valid key"),
+            mining_key,
+            reward_address,
             storage: StorageSyncConfig {
                 num_writes_before_sync: 1,
             },

--- a/crates/types/src/config.rs
+++ b/crates/types/src/config.rs
@@ -105,7 +105,7 @@ pub struct ConsensusConfig {
     pub vdf: VdfConfig,
 
     /// Configuration for block rewards
-    pub block_reward_config: BlockRewradConfig,
+    pub block_reward_config: BlockRewardConfig,
 
     /// Size of each data chunk in bytes
     pub chunk_size: u64,
@@ -141,7 +141,7 @@ pub struct ConsensusConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct BlockRewradConfig {
+pub struct BlockRewardConfig {
     #[serde(
         deserialize_with = "serde_utils::token_amount",
         serialize_with = "serde_utils::serializes_token_amount"
@@ -456,7 +456,7 @@ impl ConsensusConfig {
         const DEFAULT_BLOCK_TIME: u64 = 1;
         const IRYS_TESTNET_CHAIN_ID: u64 = 1270;
 
-        // block rewrad params
+        // block reward params
         const HALF_LIFE_YEARS: u128 = 4;
         const SECS_PER_YEAR: u128 = 365 * 24 * 60 * 60;
         const INFLATION_CAP: u128 = 100_000_000;
@@ -537,7 +537,7 @@ impl ConsensusConfig {
                     ..Default::default()
                 },
             },
-            block_reward_config: BlockRewradConfig {
+            block_reward_config: BlockRewardConfig {
                 inflation_cap: Amount::token(rust_decimal::Decimal::from(INFLATION_CAP)).unwrap(),
                 half_life_secs: (HALF_LIFE_YEARS * SECS_PER_YEAR).try_into().unwrap(),
             },

--- a/crates/types/src/serialization.rs
+++ b/crates/types/src/serialization.rs
@@ -55,6 +55,34 @@ construct_uint! {
     pub struct U256(4);
 }
 
+impl U256 {
+    /// 32-byte *little-endian* encoding (`0x01 == 1`).
+    #[inline]
+    pub fn to_le_bytes(&self) -> [u8; 32] {
+        let mut out = [0u8; 32];
+
+        // limbs are already little-endian *order* (0 = least-significant),
+        // we only have to make sure every limb is written as little-endian bytes.
+        for (i, limb) in self.0.iter().enumerate() {
+            out[i * 8..][..8].copy_from_slice(&limb.to_le_bytes());
+        }
+        out
+    }
+
+    /// 32-byte *big-endian* encoding (`0x01 == 2¹⁵⁵…`).
+    #[inline]
+    pub fn to_be_bytes(&self) -> [u8; 32] {
+        let mut out = [0u8; 32];
+
+        // reverse limb order (MS-limb first) *and*
+        // write each limb itself in big-endian byte order.
+        for (i, limb) in self.0.iter().rev().enumerate() {
+            out[i * 8..][..8].copy_from_slice(&limb.to_be_bytes());
+        }
+        out
+    }
+}
+
 // Manually implement Arbitrary for U256
 impl<'a> Arbitrary<'a> for U256 {
     fn arbitrary(_u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {

--- a/crates/types/src/storage_pricing.rs
+++ b/crates/types/src/storage_pricing.rs
@@ -438,26 +438,26 @@ fn basis_pow(mut base_bps: U256, mut exp: u64) -> Result<U256> {
 
 /// safe addition that errors on overflow.
 #[tracing::instrument(err)]
-fn safe_add(lhs: U256, rhs: U256) -> Result<U256> {
+pub fn safe_add(lhs: U256, rhs: U256) -> Result<U256> {
     lhs.checked_add(rhs).ok_or_else(|| eyre!("overflow in add"))
 }
 
 /// safe subtraction that errors on underflow.
 #[tracing::instrument(err)]
-fn safe_sub(lhs: U256, rhs: U256) -> Result<U256> {
+pub fn safe_sub(lhs: U256, rhs: U256) -> Result<U256> {
     lhs.checked_sub(rhs)
         .ok_or_else(|| eyre!("underflow in sub"))
 }
 
 /// safe multiplication that errors on overflow.
 #[tracing::instrument(err)]
-fn safe_mul(lhs: U256, rhs: U256) -> Result<U256> {
+pub fn safe_mul(lhs: U256, rhs: U256) -> Result<U256> {
     lhs.checked_mul(rhs).ok_or_else(|| eyre!("overflow in mul"))
 }
 
 /// safe division that errors on division-by-zero.
 #[tracing::instrument(err)]
-fn safe_div(lhs: U256, rhs: U256) -> Result<U256> {
+pub fn safe_div(lhs: U256, rhs: U256) -> Result<U256> {
     if rhs.is_zero() {
         Err(eyre!("division by zero"))
     } else {
@@ -466,7 +466,7 @@ fn safe_div(lhs: U256, rhs: U256) -> Result<U256> {
 }
 
 #[tracing::instrument(err)]
-fn safe_mod(lhs: U256, rhs: U256) -> Result<U256> {
+pub fn safe_mod(lhs: U256, rhs: U256) -> Result<U256> {
     if rhs.is_zero() {
         Err(eyre!("module by zero"))
     } else {
@@ -476,7 +476,7 @@ fn safe_mod(lhs: U256, rhs: U256) -> Result<U256> {
 
 /// computes (a * b) / c in 256-bit arithmetic with checks.
 #[tracing::instrument]
-fn mul_div(mul_lhs: U256, mul_rhs: U256, div: U256) -> Result<U256> {
+pub fn mul_div(mul_lhs: U256, mul_rhs: U256, div: U256) -> Result<U256> {
     let prod = safe_mul(mul_lhs, mul_rhs)?;
     safe_div(prod, div)
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -44,6 +44,7 @@ enum Commands {
     },
     Typos,
     UnusedDeps,
+    EmissionSimulation,
 }
 
 fn main() -> eyre::Result<()> {
@@ -151,6 +152,14 @@ fn main() -> eyre::Result<()> {
             println!("unused deps");
             cmd!(sh, "cargo install --locked cargo-machete").run()?;
             cmd!(sh, "cargo-machete").run()?;
+        }
+        Commands::EmissionSimulation => {
+            println!("block reward emission simulation");
+            cmd!(
+                sh,
+                "cargo run --bin irys-reward-curve-simulation --features=emission-sim"
+            )
+            .run()?;
         }
     }
 


### PR DESCRIPTION
**Describe the changes**
- added logarithmic decay block reward function
- block producer & pre-validation will use this block reward curve to calculate the reward
- tests that ensure that the math follows reference implementation
- added executable to simulate block reward emissions, `cargo xtask emission-simulation`:
  - (for plotting purposes)  The goal of this is just to ensure that the emission curve & the generated data match visually of what's expected.
- config has a new parameter to account for "reward address"
- added a block reward shadow that updates the miners balance

 
**Related Issue(s)**
#366

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

