### PR TITLE
test: change hardcoded ports from 8080/8081 to 8078/8079

### DIFF
--- a/crates/chain/tests/multi_node/sync_chain_state.rs
+++ b/crates/chain/tests/multi_node/sync_chain_state.rs
@@ -620,11 +620,11 @@ fn init_configs() -> (
 ) {
     let mut testnet_config_genesis = NodeConfig {
         http: HttpConfig {
-            port: 8080,
+            port: 8078,
             bind_ip: "127.0.0.1".to_string(),
         },
         gossip: GossipConfig {
-            port: 8081,
+            port: 8079,
             bind_ip: "127.0.0.1".to_string(),
         },
         mining_key: SigningKey::from_slice(
@@ -671,14 +671,14 @@ fn init_configs() -> (
         ..NodeConfig::testnet()
     };
     let trusted_peers = vec![PeerAddress {
-        api: "127.0.0.1:8080".parse().expect("valid SocketAddr expected"),
-        gossip: "127.0.0.1:8081".parse().expect("valid SocketAddr expected"),
+        api: "127.0.0.1:8078".parse().expect("valid SocketAddr expected"),
+        gossip: "127.0.0.1:8079".parse().expect("valid SocketAddr expected"),
         execution: RethPeerInfo::default(),
     }];
     let genesis_trusted_peers = vec![
         PeerAddress {
-            api: "127.0.0.1:8080".parse().expect("valid SocketAddr expected"),
-            gossip: "127.0.0.1:8081".parse().expect("valid SocketAddr expected"),
+            api: "127.0.0.1:8078".parse().expect("valid SocketAddr expected"),
+            gossip: "127.0.0.1:8079".parse().expect("valid SocketAddr expected"),
             execution: RethPeerInfo::default(),
         },
         PeerAddress {


### PR DESCRIPTION
Avoid test networks talking to each other across different tests running in parallel.
Port randomisation will be a more robust solution in future and may also need to apply to some of the gossip tests.


**Describe the changes**
Hard coded test ports changed from 8080/8081 to 8078/8079 for sync_heavy_chain_state test

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Port randomisation will replace this hard coding in future
