### PR TITLE
feat: more misc testnet fixes

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -98,8 +98,8 @@ fn backup_accounts() -> eyre::Result<()> {
     let mut read_cursor = read_tx.cursor_read::<PlainAccountState>()?;
 
     let mut walker = read_cursor.walk(None)?;
-
-    let file = File::create(format!("accounts-{}.json", &latest_reth_block))?;
+    let file_name = format!("accounts-{}.json", &latest_reth_block);
+    let file = File::create(&file_name)?;
     let mut writer = BufWriter::new(file);
 
     writer.write_all(b"[\n")?;
@@ -128,7 +128,7 @@ fn backup_accounts() -> eyre::Result<()> {
 
     read_tx.commit()?;
 
-    info!("Accounts saved!");
+    info!("Accounts saved to {}", &file_name);
 
     Ok(())
 }


### PR DESCRIPTION
**Describe the changes**
- adds `yield_now` calls to packing, so that the packing actor (& the node) can shutdown when there are still packing requests
- tweaks the logging for the irys CLI's account dump command to include the filename

**Additional Context**
This is a second small set of changes from testnet I forgot to upstream earlier
