### PR TITLE
feat: make storage_modules list updateable behind RwLock

### DIFF
--- a/crates/actors/src/commitment_cache.rs
+++ b/crates/actors/src/commitment_cache.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashSet};
 
 use futures::future::Either;
 use irys_primitives::CommitmentType;
-use irys_types::{Address, CommitmentTransaction, Config, H256List, H256};
+use irys_types::{Address, CommitmentTransaction, H256List, H256};
 use reth::tasks::{shutdown::GracefulShutdown, TaskExecutor};
 use std::pin::pin;
 use tokio::{
@@ -322,7 +322,6 @@ impl CommitmentCache {
         exec: &TaskExecutor,
         rx: UnboundedReceiver<CommitmentCacheMessage>,
         commitment_state_guard: CommitmentStateReadGuard,
-        _config: &Config,
     ) -> JoinHandle<()> {
         exec.spawn_critical_with_graceful_shutdown_signal(
             "CommitmentCache Service",

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -43,6 +43,7 @@ use irys_price_oracle::{mock_oracle::MockOracle, IrysPriceOracle};
 use irys_reth_node_bridge::node::RethNode;
 pub use irys_reth_node_bridge::node::{RethNodeAddOns, RethNodeProvider};
 use irys_reward_curve::HalvingCurve;
+use irys_storage::StorageModulesReadGuard;
 use irys_storage::{
     irys_consensus_data_db::open_or_create_irys_consensus_data_db,
     reth_provider::{IrysRethProvider, IrysRethProviderInner},
@@ -619,7 +620,7 @@ impl IrysNode {
                                 gossip_listener
                             )
                             .await
-                            .expect("initializng services should not fail");
+                            .expect("initializing services should not fail");
                         irys_node_ctx_tx
                             .send(irys_node)
                             .expect("irys node ctx sender should not be dropped. Is the reth node thread down?");
@@ -750,14 +751,14 @@ impl IrysNode {
     )> {
         // initialize the databases
         let (reth_node, reth_db) = init_reth_db(reth_handle_receiver).await?;
-        debug!("Reth DB initiailsed");
+        debug!("Reth DB initialized");
 
         // start services
         let (service_senders, receivers) = ServiceSenders::new();
 
         // start reth service
         let (reth_service_actor, reth_arbiter) = init_reth_service(&irys_db, &reth_node);
-        debug!("Reth Service Actor initiailsed");
+        debug!("Reth Service Actor initialized");
         // Get the correct Reth peer info
         let reth_peering = reth_service_actor.send(GetPeeringInfoMessage {}).await??;
 
@@ -783,13 +784,13 @@ impl IrysNode {
             receivers.chunk_cache,
             config.clone(),
         );
-        debug!("Chunk cache initiailsed");
+        debug!("Chunk cache initialized");
 
         let block_index_guard = block_index_service_actor
             .send(GetBlockIndexGuardMessage)
             .await?;
 
-        // start the broadcast mimning service
+        // start the broadcast mining service
         let (broadcast_mining_actor, broadcast_arbiter) = init_broadcaster_service();
 
         // start the epoch service
@@ -801,6 +802,7 @@ impl IrysNode {
             .send(GetPartitionAssignmentsGuardMessage)
             .await?;
         let storage_modules = Self::init_storage_modules(&config, storage_module_infos)?;
+        let storage_modules_guard = StorageModulesReadGuard::new(storage_modules.clone());
 
         // Retrieve Commitment State
         let commitment_state_guard = epoch_service_actor
@@ -829,7 +831,6 @@ impl IrysNode {
             &task_exec,
             receivers.commitments_cache,
             commitment_state_guard.clone(),
-            &config,
         );
 
         // Spawn peer list service
@@ -842,7 +843,7 @@ impl IrysNode {
             &irys_db,
             &reth_node,
             reth_db,
-            &storage_modules,
+            &storage_modules_guard,
             &block_tree_guard,
             &commitment_state_guard,
             &service_senders,
@@ -856,7 +857,7 @@ impl IrysNode {
             block_index,
             &irys_db,
             &service_senders,
-            &storage_modules,
+            &storage_modules_guard,
         );
 
         let (vdf_sender, new_seed_rx) = mpsc::channel::<BroadcastMiningSeed>(1);
@@ -936,13 +937,17 @@ impl IrysNode {
             .unwrap_or(latest_block.vdf_limiter_info.seed);
 
         // set up packing actor
-        let (atomic_global_step_number, packing_actor_addr) =
-            Self::init_packing_actor(&config, global_step_number, &reth_node, &storage_modules);
+        let (atomic_global_step_number, packing_actor_addr) = Self::init_packing_actor(
+            &config,
+            global_step_number,
+            &reth_node,
+            &storage_modules_guard,
+        );
 
         // set up storage modules
         let (part_actors, part_arbiters) = Self::init_partition_mining_actor(
             &config,
-            &storage_modules,
+            &storage_modules_guard,
             &vdf_steps_guard,
             &block_producer_addr,
             &atomic_global_step_number,
@@ -965,7 +970,7 @@ impl IrysNode {
         );
 
         // set up chunk provider
-        let chunk_provider = Self::init_chunk_provider(&config, storage_modules);
+        let chunk_provider = Self::init_chunk_provider(&config, storage_modules_guard);
 
         // set up IrysNodeCtx
         let irys_node_ctx = IrysNodeCtx {
@@ -1073,9 +1078,9 @@ impl IrysNode {
 
     fn init_chunk_provider(
         config: &Config,
-        storage_modules: Vec<Arc<StorageModule>>,
+        storage_modules_guard: StorageModulesReadGuard,
     ) -> Arc<ChunkProvider> {
-        let chunk_provider = ChunkProvider::new(config.clone(), storage_modules.clone());
+        let chunk_provider = ChunkProvider::new(config.clone(), storage_modules_guard.clone());
         let chunk_provider = Arc::new(chunk_provider);
         chunk_provider
     }
@@ -1135,7 +1140,7 @@ impl IrysNode {
 
     fn init_partition_mining_actor(
         config: &Config,
-        storage_modules: &Vec<Arc<StorageModule>>,
+        storage_modules_guard: &StorageModulesReadGuard,
         vdf_steps_guard: &VdfStepsReadGuard,
         block_producer_addr: &actix::Addr<BlockProducerActor>,
         atomic_global_step_number: &Arc<AtomicU64>,
@@ -1144,7 +1149,7 @@ impl IrysNode {
     ) -> (Vec<actix::Addr<PartitionMiningActor>>, Vec<Arbiter>) {
         let mut part_actors = Vec::new();
         let mut arbiters = Vec::new();
-        for sm in storage_modules {
+        for sm in storage_modules_guard.read().iter() {
             let partition_mining_actor = PartitionMiningActor::new(
                 &config,
                 block_producer_addr.clone().recipient(),
@@ -1165,7 +1170,7 @@ impl IrysNode {
         }
 
         // request packing for uninitialized ranges
-        for sm in storage_modules {
+        for sm in storage_modules_guard.read().iter() {
             let uninitialized = sm.get_intervals(ChunkType::Uninitialized);
             for interval in uninitialized {
                 packing_actor_addr.do_send(PackingRequest {
@@ -1181,10 +1186,14 @@ impl IrysNode {
         config: &Config,
         global_step_number: u64,
         reth_node: &RethNodeProvider,
-        storage_modules: &Vec<Arc<StorageModule>>,
+        storage_modules_guard: &StorageModulesReadGuard,
     ) -> (Arc<AtomicU64>, actix::Addr<PackingActor>) {
         let atomic_global_step_number = Arc::new(AtomicU64::new(global_step_number));
-        let sm_ids = storage_modules.iter().map(|s| (*s).id).collect();
+        let sm_ids = storage_modules_guard
+            .read()
+            .iter()
+            .map(|s| (*s).id)
+            .collect();
         let packing_config = PackingConfig::new(&config);
         let packing_actor_addr = PackingActor::new(
             reth_node.task_executor.clone(),
@@ -1320,12 +1329,12 @@ impl IrysNode {
         block_index: Arc<RwLock<BlockIndex>>,
         irys_db: &DatabaseProvider,
         service_senders: &ServiceSenders,
-        storage_modules: &Vec<Arc<StorageModule>>,
+        storage_modules_guard: &StorageModulesReadGuard,
     ) {
         let chunk_migration_service = ChunkMigrationService::new(
             block_index.clone(),
             config.clone(),
-            storage_modules.clone(),
+            storage_modules_guard,
             irys_db.clone(),
             service_senders.clone(),
         );
@@ -1337,7 +1346,7 @@ impl IrysNode {
         irys_db: &DatabaseProvider,
         reth_node: &RethNodeProvider,
         reth_db: irys_database::db::RethDbWrapper,
-        storage_modules: &Vec<Arc<StorageModule>>,
+        storage_modules_guard: &StorageModulesReadGuard,
         block_tree_guard: &BlockTreeReadGuard,
         commitment_state_guard: &CommitmentStateReadGuard,
         service_senders: &ServiceSenders,
@@ -1347,7 +1356,7 @@ impl IrysNode {
             irys_db.clone(),
             reth_db.clone(),
             reth_node.task_executor.clone(),
-            storage_modules.clone(),
+            storage_modules_guard.clone(),
             block_tree_guard.clone(),
             commitment_state_guard.clone(),
             &config,
@@ -1388,14 +1397,14 @@ impl IrysNode {
     fn init_storage_modules(
         config: &Config,
         storage_module_infos: Vec<irys_storage::StorageModuleInfo>,
-    ) -> eyre::Result<Vec<Arc<StorageModule>>> {
+    ) -> eyre::Result<Arc<RwLock<Vec<Arc<StorageModule>>>>> {
         let mut storage_modules = Vec::new();
         for info in storage_module_infos {
             let arc_module = Arc::new(StorageModule::new(&info, &config)?);
             storage_modules.push(arc_module.clone());
         }
 
-        Ok(storage_modules)
+        Ok(Arc::new(RwLock::new(storage_modules)))
     }
 
     async fn init_epoch_service(

--- a/crates/storage/src/storage_module.rs
+++ b/crates/storage/src/storage_module.rs
@@ -69,7 +69,7 @@ use std::{
     fs::{self, File, OpenOptions},
     io::{Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
-    sync::{Arc, Mutex, RwLock},
+    sync::{Arc, Mutex, RwLock, RwLockReadGuard},
 };
 use tracing::{debug, error, info};
 
@@ -182,6 +182,26 @@ pub enum ChunkType {
 pub struct StorageModules(pub StorageModuleVec);
 
 pub type StorageModuleVec = Vec<Arc<StorageModule>>;
+
+/// Wraps the internal Arc<`RwLock`<>> to make the reference readonly
+#[derive(Debug, Clone)]
+pub struct StorageModulesReadGuard {
+    storage_module_data: Arc<RwLock<Vec<Arc<StorageModule>>>>,
+}
+
+impl StorageModulesReadGuard {
+    /// Creates a new `ReadGuard` for Ledgers
+    pub const fn new(storage_module_data: Arc<RwLock<Vec<Arc<StorageModule>>>>) -> Self {
+        Self {
+            storage_module_data,
+        }
+    }
+
+    /// Accessor method to get a read guard for Ledgers
+    pub fn read(&self) -> RwLockReadGuard<'_, Vec<Arc<StorageModule>>> {
+        self.storage_module_data.read().unwrap()
+    }
+}
 
 impl StorageModules {
     pub fn inner(self) -> StorageModuleVec {
@@ -1222,11 +1242,12 @@ fn hash_sha256(message: &[u8]) -> Result<[u8; 32], eyre::Error> {
 
 /// Retrieves all the storage modules overlapped by a range in a given ledger
 pub fn get_overlapped_storage_modules(
-    storage_modules: &[Arc<StorageModule>],
+    storage_modules_guard: &StorageModulesReadGuard,
     ledger: DataLedger,
     tx_chunk_range: &LedgerChunkRange,
 ) -> Vec<Arc<StorageModule>> {
-    storage_modules
+    storage_modules_guard
+        .read()
         .iter()
         .filter(|module| {
             module
@@ -1244,11 +1265,12 @@ pub fn get_overlapped_storage_modules(
 /// For a given ledger and ledger offset this function attempts to find
 /// a storage module that overlaps the offset
 pub fn get_storage_module_at_offset(
-    storage_modules: &[Arc<StorageModule>],
+    storage_modules_guard: &StorageModulesReadGuard,
     ledger: DataLedger,
     chunk_offset: LedgerChunkOffset,
 ) -> Option<Arc<StorageModule>> {
-    storage_modules
+    storage_modules_guard
+        .read()
         .iter()
         .find(|module| {
             module

--- a/crates/storage/src/storage_module.rs
+++ b/crates/storage/src/storage_module.rs
@@ -190,14 +190,14 @@ pub struct StorageModulesReadGuard {
 }
 
 impl StorageModulesReadGuard {
-    /// Creates a new `ReadGuard` for Ledgers
+    /// Creates a new `ReadGuard` for StorageModules list
     pub const fn new(storage_module_data: Arc<RwLock<Vec<Arc<StorageModule>>>>) -> Self {
         Self {
             storage_module_data,
         }
     }
 
-    /// Accessor method to get a read guard for Ledgers
+    /// Accessor method to get a read guard for the StorageModules list
     pub fn read(&self) -> RwLockReadGuard<'_, Vec<Arc<StorageModule>>> {
         self.storage_module_data.read().unwrap()
     }


### PR DESCRIPTION
# Global Storage Module Management with Read Guards

## Describe the changes
This PR refactors how we handle storage modules to enable runtime modifications:

* Replaces the current approach of cloning `Vec<Arc<StorageModule>>` to different actors/services with a global `ReadGuard` pattern
* Introduces `StorageModulesReadGuard` to:
  * Clearly communicate code locations with permission to update the global storage module list
  * Simplify parameter types from complex nested generics (`Arc<RwLock<Vec<Arc<StorageModule>>>>` or `RwLockReadGuard<'_, Vec<Arc<StorageModule>>>`) to a single readable type
* Centralizes ownership of storage module membership into a single global list that can be modified at runtime

## Related Issue(s)
Addresses #[issue-number] (please update with actual issue number)

## Checklist
- [ ] Tests have been added/updated for the changes
- [ ] Documentation has been updated for the changes (if applicable)
- [ ] The code follows Rust's style guidelines

## Additional Context
This PR is part of a larger effort to enable dynamic storage module management:

* A companion `StorageModuleService` will be added in an upcoming PR
* The service will listen to events from the `EpochService` to determine when storage modules need to be updated
* This architecture is critical for supporting peers staking/pledging and attaching partition assignments to storage modules at runtime

## Implementation Notes
* This is an incremental PR focused solely on the read guard pattern and global storage module list
* No functional changes to existing behavior - just architectural groundwork for future features