### PR TITLE
fix: introduce unbiased clamping logic

### DIFF
--- a/crates/types/src/simple_rng.rs
+++ b/crates/types/src/simple_rng.rs
@@ -23,7 +23,16 @@ impl SimpleRNG {
     }
 
     /// Generates random number between 0 and max (exclusive)
+    /// NOTE: max values that approach u32::MAX will take a lot of time, due to the bias logic used!
     pub fn next_range(&mut self, max: u32) -> u32 {
-        self.next() % max
+        // prevent clamping/modulo bias
+        let threshold = u32::MAX - (u32::MAX % max);
+        let mut rand = self.next();
+        // Keep generating new values until we get one below the threshold
+        while rand >= threshold {
+            rand = self.next(); // Get a new random value
+        }
+        // Now clamp it
+        rand % max
     }
 }


### PR DESCRIPTION
**Describe the changes**
This PR adds [unbiased RNG clamping logic](https://stackoverflow.com/a/10984975) to the SimpleRNG used for partition assignments

**Additional Context**
This means genesis initialisations with the same last epoch hash and different storage module counts will no longer have the strange behaviour of having identical hashes for most storage module counts.
