### PR TITLE
feat: add commitment tx gossip and improve testing framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4485,6 +4485,7 @@ name = "irys-testing-utils"
 version = "0.1.0"
 dependencies = [
  "tempfile",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -9,6 +9,7 @@ path = "src/main.rs"
 
 [features]
 nvidia = ["irys-actors/nvidia"]
+test-utils = []
 
 [dependencies]
 # Irys
@@ -60,7 +61,10 @@ futures.workspace = true
 reth-tracing.workspace = true
 hex.workspace = true
 test-fuzz.workspace = true
-k256 = { version = "0.13", default-features = false, features = ["ecdsa", "serde"] }
+k256 = { version = "0.13", default-features = false, features = [
+	"ecdsa",
+	"serde",
+] }
 alloy-sol-macro = { workspace = true, features = ["json"] }
 alloy-provider.workspace = true
 core_affinity = "0.8.1"

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -234,7 +234,6 @@ pub struct IrysNode {
 impl IrysNode {
     /// Creates a new node builder instance.
     pub async fn new(mut node_config: NodeConfig) -> eyre::Result<Self> {
-        debug!("{:#?}", node_config.http);
         // we create the listener here so we know the port before we start passing around `config`
         let http_listener = create_listener(
             format!(
@@ -462,7 +461,6 @@ impl IrysNode {
 
         // Log startup information
         debug!("NODE STARTUP: {:?}", node_mode);
-        debug!("Trusted Peers:\n {:#?}", config.node_config.trusted_peers);
 
         // In all startup modes, irys_db and block_index are prerequisites
         let irys_db = init_irys_db(&config).expect("could not open irys db");

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -234,6 +234,7 @@ pub struct IrysNode {
 impl IrysNode {
     /// Creates a new node builder instance.
     pub async fn new(mut node_config: NodeConfig) -> eyre::Result<Self> {
+        debug!("{:#?}", node_config.http);
         // we create the listener here so we know the port before we start passing around `config`
         let http_listener = create_listener(
             format!(
@@ -461,6 +462,7 @@ impl IrysNode {
 
         // Log startup information
         debug!("NODE STARTUP: {:?}", node_mode);
+        debug!("Trusted Peers:\n {:#?}", config.node_config.trusted_peers);
 
         // In all startup modes, irys_db and block_index are prerequisites
         let irys_db = init_irys_db(&config).expect("could not open irys db");

--- a/crates/chain/tests/api/api.rs
+++ b/crates/chain/tests/api/api.rs
@@ -53,10 +53,7 @@ async fn api_end_to_end_test(chunk_size: usize) {
         },
     )]);
     let chain_id = config.consensus_config().chain_id;
-    let node = IrysNodeTest::new_genesis(config.clone())
-        .await
-        .start()
-        .await;
+    let node = IrysNodeTest::new_genesis(config.clone()).start().await;
 
     // FIXME: The node startup already spins up an internal actix-web API service.
     // Is there any reason for spawning another one here?

--- a/crates/chain/tests/api/tx.rs
+++ b/crates/chain/tests/api/tx.rs
@@ -28,10 +28,7 @@ async fn test_get_tx() -> eyre::Result<()> {
             ..Default::default()
         },
     )]);
-    let node = IrysNodeTest::new_genesis(config.clone())
-        .await
-        .start()
-        .await;
+    let node = IrysNodeTest::new_genesis(config.clone()).start().await;
     wait_for_packing(
         node.node_ctx.actor_addresses.packing.clone(),
         Some(Duration::from_secs(10)),

--- a/crates/chain/tests/block_production/analytics.rs
+++ b/crates/chain/tests/block_production/analytics.rs
@@ -64,10 +64,7 @@ async fn test_blockprod_with_evm_txs() -> eyre::Result<()> {
             },
         ),
     ]);
-    let node = IrysNodeTest::new_genesis(config.clone())
-        .await
-        .start()
-        .await;
+    let node = IrysNodeTest::new_genesis(config.clone()).start().await;
     let _reth_context = RethNodeContext::new(node.node_ctx.reth_handle.clone().into()).await?;
 
     let http_url = format!(

--- a/crates/chain/tests/block_production/basic_contract.rs
+++ b/crates/chain/tests/block_production/basic_contract.rs
@@ -39,10 +39,7 @@ async fn heavy_test_erc20() -> eyre::Result<()> {
             },
         ),
     ]);
-    let node = IrysNodeTest::new_genesis(config.clone())
-        .await
-        .start()
-        .await;
+    let node = IrysNodeTest::new_genesis(config.clone()).start().await;
 
     let signer: PrivateKeySigner = node.cfg.mining_key.clone().into();
 

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -217,7 +217,7 @@ async fn heavy_test_blockprod_with_evm_txs() -> eyre::Result<()> {
             },
         ),
     ]);
-    let node = IrysNodeTest::new_genesis(config).await.start().await;
+    let node = IrysNodeTest::new_genesis(config).start().await;
     let reth_context = RethNodeContext::new(node.node_ctx.reth_handle.clone().into()).await?;
     let recipient_init_balance = reth_context
         .rpc

--- a/crates/chain/tests/block_production/testing_primitives.rs
+++ b/crates/chain/tests/block_production/testing_primitives.rs
@@ -47,10 +47,7 @@ async fn heavy_test_mine_tx() {
             ..Default::default()
         },
     )]);
-    let irys_node = IrysNodeTest::new_genesis(config.clone())
-        .await
-        .start()
-        .await;
+    let irys_node = IrysNodeTest::new_genesis(config.clone()).start().await;
 
     let height = irys_node.get_height().await;
     let data = "Hello, world!".as_bytes().to_vec();

--- a/crates/chain/tests/ema_pricing/ema_pricing.rs
+++ b/crates/chain/tests/ema_pricing/ema_pricing.rs
@@ -14,7 +14,7 @@ async fn heavy_test_genesis_ema_price_is_respected_for_2_intervals() -> eyre::Re
     let price_adjustment_interval = 3;
     let mut config = NodeConfig::testnet();
     config.consensus.get_mut().ema.price_adjustment_interval = price_adjustment_interval;
-    let ctx = IrysNodeTest::new_genesis(config).await.start().await;
+    let ctx = IrysNodeTest::new_genesis(config).start().await;
 
     // action
     // we start at 1 because the genesis block is already mined
@@ -53,7 +53,7 @@ async fn heavy_test_genesis_ema_price_updates_after_second_interval() -> eyre::R
     let price_adjustment_interval = 3;
     let mut config = NodeConfig::testnet();
     config.consensus.get_mut().ema.price_adjustment_interval = price_adjustment_interval;
-    let ctx = IrysNodeTest::new_genesis(config).await.start().await;
+    let ctx = IrysNodeTest::new_genesis(config).start().await;
     // (oracle price, EMA price)
     let mut registered_prices = vec![(
         ctx.node_ctx.config.consensus.genesis_price,
@@ -108,7 +108,7 @@ async fn heavy_test_oracle_price_too_high_gets_capped() -> eyre::Result<()> {
         smoothing_interval: 10,
     };
 
-    let ctx = IrysNodeTest::new_genesis(config).await.start().await;
+    let ctx = IrysNodeTest::new_genesis(config).start().await;
 
     // mine 3 blocks
     let (header_1, _payload) = mine_block(&ctx.node_ctx).await?.unwrap();

--- a/crates/chain/tests/external/api.rs
+++ b/crates/chain/tests/external/api.rs
@@ -32,7 +32,7 @@ async fn external_api() -> eyre::Result<()> {
     testnet_config.http.bind_port = 8080; // external test, should never be run concurrently
 
     let account1 = IrysSigner::random_signer(&testnet_config.consensus_config());
-    let mut node = IrysNodeTest::new_genesis(testnet_config.clone()).await;
+    let mut node = IrysNodeTest::new_genesis(testnet_config.clone());
     let main_address = node.cfg.miner_address();
     node.cfg.consensus.extend_genesis_accounts(vec![
         (

--- a/crates/chain/tests/external/block_production.rs
+++ b/crates/chain/tests/external/block_production.rs
@@ -47,7 +47,7 @@ async fn continuous_blockprod_evm_tx() -> eyre::Result<()> {
         ),
     ]);
 
-    let node = IrysNodeTest::new_genesis(config).await.start().await;
+    let node = IrysNodeTest::new_genesis(config).start().await;
 
     assert_eq!(
         node.node_ctx.config.node_config.miner_address(),

--- a/crates/chain/tests/external/programmable_data_basic.rs
+++ b/crates/chain/tests/external/programmable_data_basic.rs
@@ -69,10 +69,7 @@ async fn test_programmable_data_basic_external() -> eyre::Result<()> {
             },
         ),
     ]);
-    let node = IrysNodeTest::new_genesis(config.clone())
-        .await
-        .start()
-        .await;
+    let node = IrysNodeTest::new_genesis(config.clone()).start().await;
     node.node_ctx.actor_addresses.stop_mining()?;
     wait_for_packing(
         node.node_ctx.actor_addresses.packing.clone(),

--- a/crates/chain/tests/integration/cache_service.rs
+++ b/crates/chain/tests/integration/cache_service.rs
@@ -39,7 +39,7 @@ async fn heavy_test_cache_pruning() -> eyre::Result<()> {
             },
         ),
     ]);
-    let node = IrysNodeTest::new_genesis(config).await;
+    let node = IrysNodeTest::new_genesis(config);
     let node = node.start().await;
 
     wait_for_packing(

--- a/crates/chain/tests/multi_node/mod.rs
+++ b/crates/chain/tests/multi_node/mod.rs
@@ -1,2 +1,3 @@
 pub mod peer_discovery;
+pub mod peer_mining;
 pub mod sync_chain_state;

--- a/crates/chain/tests/multi_node/peer_discovery.rs
+++ b/crates/chain/tests/multi_node/peer_discovery.rs
@@ -40,7 +40,7 @@ async fn heavy_peer_discovery() -> eyre::Result<()> {
             ..Default::default()
         },
     )]);
-    let node = IrysNodeTest::new_genesis(config.clone()).await;
+    let node = IrysNodeTest::new_genesis(config.clone());
     let node = node.start().await;
     wait_for_packing(
         node.node_ctx.actor_addresses.packing.clone(),

--- a/crates/chain/tests/multi_node/peer_mining.rs
+++ b/crates/chain/tests/multi_node/peer_mining.rs
@@ -1,0 +1,47 @@
+use irys_testing_utils::*;
+use irys_types::{NodeConfig, H256};
+use tracing::debug;
+
+use crate::utils::IrysNodeTest;
+
+#[actix_web::test]
+async fn heavy_peer_mining_test() -> eyre::Result<()> {
+    // Turn on tracing even before the nodes start
+    std::env::set_var("RUST_LOG", "debug");
+    initialize_tracing();
+
+    // Configure a test network with accelerated epochs (2 blocks per epoch)
+    let num_blocks_in_epoch = 2;
+    let mut genesis_config = NodeConfig::testnet_with_epochs(num_blocks_in_epoch);
+
+    // Create a signer (keypair) for the peer and fund it
+    let peer_signer = genesis_config.new_random_signer();
+    genesis_config.fund_genesis_accounts(vec![&peer_signer]);
+
+    // Start the genesis node and wait for packing
+    let genesis_node = IrysNodeTest::new_genesis(genesis_config.clone())
+        .start_and_wait_for_packing(10)
+        .await;
+    genesis_node.start_public_api().await;
+
+    // Initialize the peer with our keypair/signer
+    let peer_config = genesis_node.testnet_peer_with_signer(&peer_signer);
+
+    // Start the peer: No packing on the peer, it doesn't have partition assignments yet
+    let peer_node = IrysNodeTest::new(peer_config.clone()).start().await;
+    peer_node.start_public_api().await;
+    debug!("{:#?}", peer_node.node_ctx.config.node_config);
+
+    let _stake_tx = peer_node.post_stake_commitment(H256::zero()).await; // zero() is the genesis block hash
+    let _pledge_tx = peer_node.post_pledge_commitment(H256::zero()).await;
+    let _ = tokio_sleep(3).await;
+
+    genesis_node.mine_block().await.unwrap();
+    let block = genesis_node.get_block_by_height(1).await.unwrap();
+    debug!("SystemLedgers: {:#?}", block.system_ledgers);
+
+    genesis_node.stop().await;
+    peer_node.stop().await;
+
+    Ok(())
+}

--- a/crates/chain/tests/multi_node/sync_chain_state.rs
+++ b/crates/chain/tests/multi_node/sync_chain_state.rs
@@ -651,6 +651,8 @@ fn init_configs() -> (
     let http_port_peer2 = get_available_port();
     let gossip_port_peer2 = get_available_port();
 
+    info!("Ports:\n genesis:http = {}\n genesis:gossip = {}\n peer1:http = {}\n peer1:gossip = {}\n peer2:http = {}\n peer2:gossip = {}", http_port_genesis, gossip_port_genesis, http_port_peer1, gossip_port_peer1, http_port_peer2, gossip_port_peer2);
+
     let mut testnet_config_genesis = NodeConfig {
         http: HttpConfig {
             public_ip: "127.0.0.1".to_string(),
@@ -789,7 +791,7 @@ async fn start_genesis_node(
     account: &IrysSigner, // account with balance at genesis
 ) -> IrysNodeTest<IrysNodeCtx> {
     // init genesis node
-    let mut genesis_node = IrysNodeTest::new_genesis(testnet_config_genesis.clone()).await;
+    let mut genesis_node = IrysNodeTest::new_genesis(testnet_config_genesis.clone());
     // add accounts with balances to genesis node
     add_account_to_config(&mut genesis_node.cfg, &account);
     // start genesis node
@@ -803,10 +805,10 @@ async fn start_peer_nodes(
     testnet_config_peer2: &Config,
     account: &IrysSigner, // account with balance at genesis
 ) -> (IrysNodeTest<IrysNodeCtx>, IrysNodeTest<IrysNodeCtx>) {
-    let mut peer1_node = IrysNodeTest::new(testnet_config_peer1.node_config.clone()).await;
+    let mut peer1_node = IrysNodeTest::new(testnet_config_peer1.node_config.clone());
     add_account_to_config(&mut peer1_node.cfg, &account);
     let ctx_peer1_node = peer1_node.start().await;
-    let mut peer2_node = IrysNodeTest::new(testnet_config_peer2.node_config.clone()).await;
+    let mut peer2_node = IrysNodeTest::new(testnet_config_peer2.node_config.clone());
     add_account_to_config(&mut peer2_node.cfg, &account);
     let ctx_peer2_node = peer2_node.start().await;
     (ctx_peer1_node, ctx_peer2_node)

--- a/crates/chain/tests/programmable_data/basic.rs
+++ b/crates/chain/tests/programmable_data/basic.rs
@@ -69,10 +69,7 @@ async fn heavy_test_programmable_data_basic() -> eyre::Result<()> {
             },
         ),
     ]);
-    let node = IrysNodeTest::new_genesis(testnet_config)
-        .await
-        .start()
-        .await;
+    let node = IrysNodeTest::new_genesis(testnet_config).start().await;
     wait_for_packing(
         node.node_ctx.actor_addresses.packing.clone(),
         Some(Duration::from_secs(10)),

--- a/crates/chain/tests/promotion/data_promotion_basic.rs
+++ b/crates/chain/tests/promotion/data_promotion_basic.rs
@@ -38,10 +38,7 @@ async fn heavy_data_promotion_test() {
             ..Default::default()
         },
     )]);
-    let node = IrysNodeTest::new_genesis(config.clone())
-        .await
-        .start()
-        .await;
+    let node = IrysNodeTest::new_genesis(config.clone()).start().await;
 
     wait_for_packing(
         node.node_ctx.actor_addresses.packing.clone(),

--- a/crates/chain/tests/promotion/data_promotion_double.rs
+++ b/crates/chain/tests/promotion/data_promotion_double.rs
@@ -51,10 +51,7 @@ async fn heavy_double_root_data_promotion_test() {
             },
         ),
     ]);
-    let node = IrysNodeTest::new_genesis(config.clone())
-        .await
-        .start()
-        .await;
+    let node = IrysNodeTest::new_genesis(config.clone()).start().await;
 
     wait_for_packing(
         node.node_ctx.actor_addresses.packing.clone(),

--- a/crates/chain/tests/startup/startup.rs
+++ b/crates/chain/tests/startup/startup.rs
@@ -52,7 +52,7 @@ async fn heavy_test_can_resume_from_genesis_startup_no_ctx() -> eyre::Result<()>
 
     let config = NodeConfig::testnet();
 
-    let mut node = IrysNodeTest::new_genesis(config.clone()).await;
+    let mut node = IrysNodeTest::new_genesis(config.clone());
     node.cfg.base_directory = test_dir.clone();
 
     // action:
@@ -68,7 +68,7 @@ async fn heavy_test_can_resume_from_genesis_startup_no_ctx() -> eyre::Result<()>
 
     // start a new instance to take over from the old one that has been completely stopped
     // i.e. it's important this test runs stop() run start() on a new instance with no context transferred via self.
-    let mut node = IrysNodeTest::new_genesis(config.clone()).await;
+    let mut node = IrysNodeTest::new_genesis(config.clone());
     node.cfg.base_directory = test_dir;
     let ctx = node.start().await;
 

--- a/crates/chain/tests/synchronization/mod.rs
+++ b/crates/chain/tests/synchronization/mod.rs
@@ -34,10 +34,7 @@ async fn heavy_should_resume_from_the_same_block() -> eyre::Result<()> {
             },
         ),
     ]);
-    let node = IrysNodeTest::new_genesis(config.clone())
-        .await
-        .start()
-        .await;
+    let node = IrysNodeTest::new_genesis(config.clone()).start().await;
 
     wait_for_packing(
         node.node_ctx.actor_addresses.packing.clone(),

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -1,10 +1,14 @@
 use actix::MailboxError;
+use actix_web::middleware::Logger;
+use actix_web::App;
+use base58::ToBase58;
 use futures::future::select;
 use irys_actors::block_producer::SolutionFoundMessage;
 use irys_actors::block_tree_service::get_canonical_chain;
 use irys_actors::mempool_service::{TxIngressError, TxIngressMessage};
+use irys_actors::packing::wait_for_packing;
 use irys_actors::{block_validation, SetTestBlocksRemainingMessage};
-use irys_api_server::create_listener;
+use irys_api_server::{create_listener, routes};
 use irys_chain::{IrysNode, IrysNodeCtx};
 use irys_database::tx_header_by_txid;
 use irys_packing::capacity_single::compute_entropy_chunk;
@@ -16,17 +20,20 @@ use irys_types::irys::IrysSigner;
 use irys_types::{
     block_production::Seed, block_production::SolutionContext, Address, DataLedger, H256List, H256,
 };
-use irys_types::{Config, IrysTransactionHeader, NodeConfig, NodeMode, TxChunkOffset};
+use irys_types::{
+    CommitmentTransaction, Config, IrysTransactionHeader, NodeConfig, NodeMode, TxChunkOffset,
+};
 use irys_vdf::vdf_state::VdfStepsReadGuard;
 use irys_vdf::{step_number_to_salt_number, vdf_sha};
 use reth::rpc::types::engine::ExecutionPayloadEnvelopeV1Irys;
+use reth_primitives::irys_primitives::CommitmentType;
 use sha2::{Digest, Sha256};
 use std::net::SocketAddr;
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 use std::{future::Future, time::Duration};
 use tokio::time::sleep;
-use tracing::info;
+use tracing::{debug, info};
 
 use std::collections::HashMap;
 
@@ -163,25 +170,26 @@ pub struct IrysNodeTest<T = ()> {
 impl IrysNodeTest<()> {
     pub async fn default_async() -> Self {
         let config = NodeConfig::testnet();
-        Self::new_genesis(config).await
+        Self::new_genesis(config)
     }
 
     /// Start a new test node in peer-sync mode
-    pub async fn new(mut config: NodeConfig) -> Self {
+    pub fn new(mut config: NodeConfig) -> Self {
+        debug!("{:#?}", config.http);
         config.mode = NodeMode::PeerSync;
-        Self::new_inner(config).await
+        Self::new_inner(config)
     }
 
     /// Start a new test node in genesis mode
-    pub async fn new_genesis(mut config: NodeConfig) -> Self {
+    pub fn new_genesis(mut config: NodeConfig) -> Self {
         config.mode = NodeMode::Genesis;
-        Self::new_inner(config).await
+        Self::new_inner(config)
     }
 
-    async fn new_inner(mut config: NodeConfig) -> Self {
+    fn new_inner(mut config: NodeConfig) -> Self {
         let temp_dir = temporary_directory(None, false);
         config.base_directory = temp_dir.path().to_path_buf();
-
+        debug!("{:#?}", config.http);
         Self {
             cfg: config,
             temp_dir,
@@ -190,6 +198,7 @@ impl IrysNodeTest<()> {
     }
 
     pub async fn start(self) -> IrysNodeTest<IrysNodeCtx> {
+        debug!("{:#?}", self.cfg.http);
         let node = IrysNode::new(self.cfg.clone()).await.unwrap();
         let node_ctx = node.start().await.expect("node cannot be initialized");
         IrysNodeTest {
@@ -198,9 +207,72 @@ impl IrysNodeTest<()> {
             temp_dir: self.temp_dir,
         }
     }
+
+    pub async fn start_and_wait_for_packing(
+        self,
+        seconds_to_wait: u64,
+    ) -> IrysNodeTest<IrysNodeCtx> {
+        let node = self.start().await;
+        node.wait_for_packing(seconds_to_wait).await;
+        node
+    }
 }
 
 impl IrysNodeTest<IrysNodeCtx> {
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn testnet_peer(&self) -> NodeConfig {
+        let node_config = &self.node_ctx.config.node_config;
+        let peer_signer = IrysSigner::random_signer(&node_config.consensus_config());
+        self.testnet_peer_with_signer(&peer_signer)
+    }
+
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn testnet_peer_with_signer(&self, peer_signer: &IrysSigner) -> NodeConfig {
+        use irys_types::{PeerAddress, RethPeerInfo};
+        use tracing::debug;
+
+        let node_config = &self.node_ctx.config.node_config;
+
+        if node_config.mode == NodeMode::PeerSync {
+            panic!("Can only create a peer from a genesis config");
+        }
+
+        // Initialize the peer with a random signer, copying the genesis config
+
+        let mut peer_config = node_config.clone();
+        peer_config.mining_key = peer_signer.signer.clone();
+        peer_config.reward_address = peer_signer.address();
+
+        // Make sure this peer does port randomization instead of copying the genesis ports
+        peer_config.http.bind_port = 0;
+        peer_config.http.public_port = 0;
+        peer_config.gossip.bind_port = 0;
+        peer_config.gossip.public_port = 0;
+
+        // Make sure to mark this config as a peer
+        peer_config.mode = NodeMode::PeerSync;
+
+        // Add the genesis node details as a trusted peer
+        peer_config.trusted_peers = vec![
+            (PeerAddress {
+                api: format!(
+                    "{}:{}",
+                    node_config.http.public_ip, node_config.http.public_port
+                )
+                .parse()
+                .expect("valid SocketAddr expected"),
+                gossip: format!(
+                    "{}:{}",
+                    node_config.http.bind_ip, node_config.http.bind_port
+                )
+                .parse()
+                .expect("valid SocketAddr expected"),
+                execution: RethPeerInfo::default(),
+            }),
+        ];
+        debug!("{:#?}", peer_config);
+        peer_config
+    }
     pub async fn wait_until_height_on_chain(
         &self,
         target_height: u64,
@@ -226,6 +298,40 @@ impl IrysNodeTest<IrysNodeCtx> {
             );
             Ok(())
         }
+    }
+
+    pub async fn wait_for_packing(&self, seconds_to_wait: u64) {
+        wait_for_packing(
+            self.node_ctx.actor_addresses.packing.clone(),
+            Some(Duration::from_secs(seconds_to_wait)),
+        )
+        .await
+        .expect("for packing to complete in the wait period");
+    }
+
+    pub fn start_mining(&self) {
+        if self.node_ctx.actor_addresses.start_mining().is_err() {
+            panic!("Expected to start mining")
+        }
+    }
+
+    pub fn stop_mining(&self) {
+        if self.node_ctx.actor_addresses.stop_mining().is_err() {
+            panic!("Expected to stop mining")
+        }
+    }
+
+    pub async fn start_public_api(&self) {
+        let (ema_tx, _ema_rx) = tokio::sync::mpsc::unbounded_channel();
+        let api_state = self.node_ctx.get_api_state(ema_tx);
+
+        let _app = actix_web::test::init_service(
+            App::new()
+                .wrap(Logger::default())
+                .app_data(actix_web::web::Data::new(api_state))
+                .service(routes()),
+        )
+        .await;
     }
 
     pub async fn wait_until_height(
@@ -412,6 +518,79 @@ impl IrysNodeTest<IrysNodeCtx> {
             node_ctx: (),
             cfg,
             temp_dir: self.temp_dir,
+        }
+    }
+
+    pub async fn post_pledge_commitment(&self, anchor: H256) -> CommitmentTransaction {
+        let pledge_tx = CommitmentTransaction {
+            commitment_type: CommitmentType::Pledge,
+            anchor,
+            fee: 1,
+            ..Default::default()
+        };
+        let signer = self.cfg.signer();
+        let pledge_tx = signer.sign_commitment(pledge_tx).unwrap();
+        info!("Generated pledge_tx.id: {}", pledge_tx.id.0.to_base58());
+
+        // Submit pledge commitment via API
+        let api_uri = self.node_ctx.config.node_config.api_uri();
+        self.post_commitment_tx_request(&api_uri, &pledge_tx).await;
+
+        pledge_tx
+    }
+
+    pub async fn post_stake_commitment(&self, anchor: H256) -> CommitmentTransaction {
+        let stake_tx = CommitmentTransaction {
+            commitment_type: CommitmentType::Stake,
+            // TODO: real staking amounts
+            fee: 1,
+            anchor,
+            ..Default::default()
+        };
+
+        let signer = self.cfg.signer();
+        let stake_tx = signer.sign_commitment(stake_tx).unwrap();
+        info!("Generated stake_tx.id: {}", stake_tx.id.0.to_base58());
+
+        // Submit stake commitment via public API
+        let api_uri = self.node_ctx.config.node_config.api_uri();
+        self.post_commitment_tx_request(&api_uri, &stake_tx).await;
+
+        stake_tx
+    }
+
+    async fn post_commitment_tx_request(
+        &self,
+        api_uri: &str,
+        commitment_tx: &CommitmentTransaction,
+    ) {
+        info!("Posting Commitment TX: {}", commitment_tx.id.0.to_base58());
+
+        let client = awc::Client::default();
+        let url = format!("{}/v1/commitment_tx", api_uri);
+        let mut response = client
+            .post(url)
+            .send_json(commitment_tx) // Send the commitment_tx as JSON in the request body
+            .await
+            .expect("client post failed");
+
+        if response.status() != StatusCode::OK {
+            // Read the response body
+            let body_bytes = response.body().await.expect("Failed to read response body");
+            let body_str = String::from_utf8_lossy(&body_bytes);
+
+            panic!(
+                "Response status: {} - {}\nRequest Body: {}",
+                response.status(),
+                body_str,
+                serde_json::to_string_pretty(&commitment_tx).unwrap(),
+            );
+        } else {
+            info!(
+                "Response status: {}\n{}",
+                response.status(),
+                serde_json::to_string_pretty(&commitment_tx).unwrap()
+            );
         }
     }
 }

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -33,7 +33,7 @@ use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 use std::{future::Future, time::Duration};
 use tokio::time::sleep;
-use tracing::{debug, info};
+use tracing::info;
 
 use std::collections::HashMap;
 
@@ -226,7 +226,6 @@ impl IrysNodeTest<IrysNodeCtx> {
     #[cfg(any(test, feature = "test-utils"))]
     pub fn testnet_peer_with_signer(&self, peer_signer: &IrysSigner) -> NodeConfig {
         use irys_types::{PeerAddress, RethPeerInfo};
-        use tracing::debug;
 
         let node_config = &self.node_ctx.config.node_config;
 

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -175,7 +175,6 @@ impl IrysNodeTest<()> {
 
     /// Start a new test node in peer-sync mode
     pub fn new(mut config: NodeConfig) -> Self {
-        debug!("{:#?}", config.http);
         config.mode = NodeMode::PeerSync;
         Self::new_inner(config)
     }
@@ -189,7 +188,6 @@ impl IrysNodeTest<()> {
     fn new_inner(mut config: NodeConfig) -> Self {
         let temp_dir = temporary_directory(None, false);
         config.base_directory = temp_dir.path().to_path_buf();
-        debug!("{:#?}", config.http);
         Self {
             cfg: config,
             temp_dir,
@@ -198,7 +196,6 @@ impl IrysNodeTest<()> {
     }
 
     pub async fn start(self) -> IrysNodeTest<IrysNodeCtx> {
-        debug!("{:#?}", self.cfg.http);
         let node = IrysNode::new(self.cfg.clone()).await.unwrap();
         let node_ctx = node.start().await.expect("node cannot be initialized");
         IrysNodeTest {
@@ -270,7 +267,6 @@ impl IrysNodeTest<IrysNodeCtx> {
                 execution: RethPeerInfo::default(),
             }),
         ];
-        debug!("{:#?}", peer_config);
         peer_config
     }
     pub async fn wait_until_height_on_chain(

--- a/crates/p2p/src/cache.rs
+++ b/crates/p2p/src/cache.rs
@@ -34,6 +34,7 @@ impl From<&GossipData> for GossipCacheKey {
         match data {
             GossipData::Chunk(chunk) => GossipCacheKey::Chunk(chunk.chunk_path_hash()),
             GossipData::Transaction(transaction) => GossipCacheKey::Transaction(transaction.id),
+            GossipData::CommitmentTransaction(comm_tx) => GossipCacheKey::Transaction(comm_tx.id),
             GossipData::Block(block) => GossipCacheKey::Block(block.block_hash),
         }
     }
@@ -122,6 +123,13 @@ impl GossipCache {
                     .read()
                     .map_err(|error| GossipError::Cache(error.to_string()))?;
                 txs.get(&transaction.id).cloned().unwrap_or_default()
+            }
+            GossipData::CommitmentTransaction(commitment_tx) => {
+                let txs = self
+                    .transactions
+                    .read()
+                    .map_err(|error| GossipError::Cache(error.to_string()))?;
+                txs.get(&commitment_tx.id).cloned().unwrap_or_default()
             }
             GossipData::Block(block) => {
                 let blocks = self

--- a/crates/p2p/src/gossip_client.rs
+++ b/crates/p2p/src/gossip_client.rs
@@ -55,6 +55,13 @@ impl GossipClient {
                 )
                 .await?;
             }
+            GossipData::CommitmentTransaction(commitment_tx) => {
+                self.send_data_internal(
+                    format!("http://{}/gossip/commitment_tx", peer.address.gossip),
+                    commitment_tx,
+                )
+                .await?;
+            }
             GossipData::Block(irys_block_header) => {
                 self.send_data_internal(
                     format!("http://{}/gossip/block", peer.address.gossip),

--- a/crates/p2p/src/server.rs
+++ b/crates/p2p/src/server.rs
@@ -18,8 +18,8 @@ use irys_actors::block_discovery::BlockDiscoveryFacade;
 use irys_actors::mempool_service::MempoolFacade;
 use irys_api_client::ApiClient;
 use irys_types::{
-    Address, GossipRequest, IrysBlockHeader, IrysTransactionHeader, PeerListItem, RethPeerInfo,
-    UnpackedChunk,
+    Address, CommitmentTransaction, GossipRequest, IrysBlockHeader, IrysTransactionHeader,
+    PeerListItem, RethPeerInfo, UnpackedChunk,
 };
 use std::net::TcpListener;
 use tracing::{debug, error, info};
@@ -191,6 +191,33 @@ where
         HttpResponse::Ok().finish()
     }
 
+    async fn handle_commitment_tx(
+        server: Data<Self>,
+        commitment_tx_json: web::Json<GossipRequest<CommitmentTransaction>>,
+        req: actix_web::HttpRequest,
+    ) -> HttpResponse {
+        let gossip_request = commitment_tx_json.0;
+        let source_miner_address = gossip_request.miner_address;
+
+        match Self::check_peer(&server.peer_list, &req, gossip_request.miner_address).await {
+            Ok(peer_address) => peer_address,
+            Err(error_response) => return error_response,
+        };
+
+        if let Err(error) = server
+            .data_handler
+            .handle_commitment_tx(gossip_request)
+            .await
+        {
+            Self::handle_invalid_data(&source_miner_address, &error, &server.peer_list).await;
+            error!("Failed to send transaction: {}", error);
+            return HttpResponse::InternalServerError().finish();
+        }
+
+        debug!("Gossip data handled");
+        HttpResponse::Ok().finish()
+    }
+
     async fn handle_health_check(server: Data<Self>, req: actix_web::HttpRequest) -> HttpResponse {
         let Some(peer_addr) = req.peer_addr() else {
             return HttpResponse::BadRequest().finish();
@@ -259,6 +286,7 @@ where
                 .service(
                     web::scope("/gossip")
                         .route("/transaction", web::post().to(Self::handle_transaction))
+                        .route("/commitment_tx", web::post().to(Self::handle_commitment_tx))
                         .route("/chunk", web::post().to(Self::handle_chunk))
                         .route("/block", web::post().to(Self::handle_block))
                         .route("/get_data", web::post().to(Self::handle_get_data))

--- a/crates/testing-utils/Cargo.toml
+++ b/crates/testing-utils/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 tempfile.workspace = true
+tokio.workspace = true
 
 [lints]
 workspace = true

--- a/crates/testing-utils/src/lib.rs
+++ b/crates/testing-utils/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod utils;
+pub use utils::*;

--- a/crates/testing-utils/src/utils.rs
+++ b/crates/testing-utils/src/utils.rs
@@ -1,8 +1,20 @@
-use std::{fs::create_dir_all, path::PathBuf, str::FromStr as _};
+use std::{fs::create_dir_all, path::PathBuf, str::FromStr as _, time::Duration};
 pub use tempfile;
 use tempfile::TempDir;
+use tokio::time::Sleep;
 use tracing::debug;
 use tracing_subscriber::{fmt::SubscriberBuilder, util::SubscriberInitExt, EnvFilter};
+
+pub fn initialize_tracing() {
+    let _ = SubscriberBuilder::default()
+        .with_env_filter(EnvFilter::from_default_env())
+        .finish()
+        .try_init();
+}
+
+pub async fn tokio_sleep(seconds: u64) -> Sleep {
+    tokio::time::sleep(Duration::from_secs(seconds))
+}
 
 /// Configures support for logging `Tracing` macros to console, and creates a temporary directory in ./<`project_dir>/.tmp`.  
 /// The temp directory is prefixed by <name> (default: "irys-test-"), and automatically deletes itself on test completion -

--- a/crates/types/src/gossip.rs
+++ b/crates/types/src/gossip.rs
@@ -1,4 +1,4 @@
-use crate::{IrysBlockHeader, IrysTransactionHeader, UnpackedChunk};
+use crate::{CommitmentTransaction, IrysBlockHeader, IrysTransactionHeader, UnpackedChunk};
 use alloy_primitives::Address;
 use base58::ToBase58;
 use serde::{Deserialize, Serialize};
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 pub enum GossipData {
     Chunk(UnpackedChunk),
     Transaction(IrysTransactionHeader),
+    CommitmentTransaction(CommitmentTransaction),
     Block(IrysBlockHeader),
 }
 
@@ -18,6 +19,9 @@ impl GossipData {
             }
             GossipData::Transaction(tx) => {
                 format!("transaction {}", tx.id.0.to_base58())
+            }
+            GossipData::CommitmentTransaction(commitment_tx) => {
+                format!("commitment transaction {}", commitment_tx.id.0.to_base58())
             }
             GossipData::Block(block) => {
                 format!("block {}", block.block_hash.0.to_base58())


### PR DESCRIPTION
**Describe the changes**
* Adds support to the gossip service for `CommitmentTransaction` type
* Simplifies test framework for setting up multi-node tests
  * Initialize a peer_config from a genesis_config
  * generate new signers using a genesis_config (for peers and accounts)
  * simplify method for funding genesis accounts to have less boilerplate for typical scenario
  * simplify starting a node, remove unused async from start()
  * add helper methods for a peer to create and post commitment transactions
 * add a `peer_mining` example test, WIP
 
![image](https://github.com/user-attachments/assets/ca140614-9d3a-4673-ad84-f905fb71681a)

 

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
