### PR TITLE
feat: allow chunks to be uploaded ahead of their transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
  "dashmap 6.1.0",
  "futures",
  "futures-utils-wasm",
- "lru",
+ "lru 0.12.5",
  "pin-project",
  "reqwest 0.12.15",
  "serde",
@@ -2753,7 +2753,7 @@ dependencies = [
  "hkdf",
  "lazy_static",
  "libp2p-identity",
- "lru",
+ "lru 0.12.5",
  "more-asserts",
  "multiaddr",
  "parking_lot 0.11.2",
@@ -4085,6 +4085,7 @@ dependencies = [
  "irys-testing-utils",
  "irys-types",
  "irys-vdf",
+ "lru 0.14.0",
  "nodit",
  "openssl",
  "rand",
@@ -5068,6 +5069,15 @@ name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.2",
+]
+
+[[package]]
+name = "lru"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f8cc7106155f10bdf99a6f379688f543ad6596a415375b36a59a054ceda1198"
 dependencies = [
  "hashbrown 0.15.2",
 ]
@@ -6357,7 +6367,7 @@ dependencies = [
  "crossterm",
  "instability",
  "itertools 0.13.0",
- "lru",
+ "lru 0.12.5",
  "paste",
  "strum",
  "strum_macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,26 +62,35 @@ actix-http = "3.9.0"
 awc = "3.5.1"
 base58 = "0.2.0"
 tokio-stream = "0.1"
+lru = "0.14.0"
 alloy-consensus = { path = "./ext/alloy/crates/consensus", default-features = false }
 alloy-core = { path = "./ext/alloy-core/crates/core" }
 alloy-eips = { path = "./ext/alloy/crates/eips", default-features = false }
 alloy-genesis = { path = "./ext/alloy/crates/genesis", default-features = false }
-alloy-primitives = { path = "./ext/alloy-core/crates/primitives", features = ["arbitrary"] }
+alloy-primitives = { path = "./ext/alloy-core/crates/primitives", features = [
+  "arbitrary",
+] }
 rand = "0.8"
 hex = "0.4"
 base64-url = "2"
 alloy-rlp = "0.3.4"
 alloy-rpc-types = { path = "./ext/alloy/crates/rpc-types" }
-alloy-rpc-types-engine = { path = "./ext/alloy/crates/rpc-types-engine", features = ["serde"] }
+alloy-rpc-types-engine = { path = "./ext/alloy/crates/rpc-types-engine", features = [
+  "serde",
+] }
 clap = { version = "4", features = ["derive"] }
 alloy-rpc-types-trace = { path = "./ext/alloy/crates/rpc-types-trace" }
 reth-e2e-test-utils = { path = "./ext/reth/crates/e2e-test-utils" }
 alloy-serde = { path = "./ext/alloy/crates/serde", default-features = false }
 alloy-signer-local = { path = "./ext/alloy/crates/signer-local" }
-alloy-sol-macro = { path = "./ext/alloy-core/crates/sol-macro", features = ["json"] }
+alloy-sol-macro = { path = "./ext/alloy-core/crates/sol-macro", features = [
+  "json",
+] }
 alloy-sol-types = { path = "./ext/alloy-core/crates/sol-types" }
 alloy-contract = { path = "./ext/alloy/crates/contract" }
-alloy-provider = { path = "./ext/alloy/crates/provider", features = ["trace-api"] }
+alloy-provider = { path = "./ext/alloy/crates/provider", features = [
+  "trace-api",
+] }
 
 arbitrary = { version = "1.3", features = ["derive"] }
 rstest = "0.25"
@@ -170,7 +179,12 @@ semver = "1.0"
 syn = { version = "2", features = ["full"] }
 tracing = "0.1.0"
 tracing-error = "0.2"
-tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt", "json", "ansi"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = [
+  "env-filter",
+  "fmt",
+  "json",
+  "ansi",
+] }
 alloy-signer = { path = "./ext/alloy/crates/signer" }
 tempfile = "3"
 csv = "1"
@@ -367,7 +381,7 @@ ignored = ["modular-bitfield", "test-fuzz"]
 # https://github.com/crate-ci/typos/blob/master/docs/reference.md
 [workspace.metadata.typos]
 default.extend-ignore-re = [
-  "(?Rm)^.*(#|//)\\s*spellchecker:disable-line$", # disable a single line: spellchecker:disable-line
+  "(?Rm)^.*(#|//)\\s*spellchecker:disable-line$",                      # disable a single line: spellchecker:disable-line
   "(?s)(#|//)\\s*spellchecker:off.*?\\n\\s*(#|//)\\s*spellchecker:on", # disable blocks of lines: spellchecker:<on|off>
 ]
 files.extend-exclude = ["ext/*", "fixtures/*"]

--- a/crates/actors/Cargo.toml
+++ b/crates/actors/Cargo.toml
@@ -20,6 +20,7 @@ nodit.workspace = true
 actix-rt.workspace = true
 
 tokio.workspace = true
+lru.workspace = true
 reth-db.workspace = true
 irys-primitives.workspace = true
 eyre.workspace = true

--- a/crates/chain/tests/multi_node/mempool_tests.rs
+++ b/crates/chain/tests/multi_node/mempool_tests.rs
@@ -6,7 +6,6 @@ use irys_types::{DataLedger, LedgerChunkOffset, NodeConfig};
 #[actix::test]
 async fn heavy_pending_chunks_test() {
     // Turn on tracing even before the nodes start
-    std::env::set_var("RUST_LOG", "debug");
     initialize_tracing();
 
     // Configure a test network

--- a/crates/chain/tests/multi_node/mempool_tests.rs
+++ b/crates/chain/tests/multi_node/mempool_tests.rs
@@ -1,0 +1,55 @@
+use crate::utils::{get_chunk, post_chunk, post_storage_tx, IrysNodeTest};
+use assert_matches::assert_matches;
+use irys_testing_utils::initialize_tracing;
+use irys_types::{DataLedger, LedgerChunkOffset, NodeConfig};
+
+#[actix::test]
+async fn heavy_pending_chunks_test() {
+    // Turn on tracing even before the nodes start
+    std::env::set_var("RUST_LOG", "debug");
+    initialize_tracing();
+
+    // Configure a test network
+    let mut genesis_config = NodeConfig::testnet();
+    genesis_config.consensus.get_mut().chunk_size = 32;
+
+    // Create a signer (keypair) for transactions and fund it
+    let signer = genesis_config.new_random_signer();
+    genesis_config.fund_genesis_accounts(vec![&signer]);
+
+    // Start the genesis node
+    let genesis_node = IrysNodeTest::new_genesis(genesis_config.clone())
+        .start()
+        .await;
+    let app = genesis_node.start_public_api().await;
+
+    let chunks = vec![[10; 32], [20; 32], [30; 32]];
+    let mut data: Vec<u8> = Vec::new();
+    for chunk in chunks.iter() {
+        data.extend_from_slice(chunk);
+    }
+
+    let tx = signer.create_transaction(data, None).unwrap();
+    let tx = signer.sign_transaction(tx).unwrap();
+
+    // First post the chunks
+    post_chunk(&app, &tx, 0, &chunks).await;
+    post_chunk(&app, &tx, 1, &chunks).await;
+    post_chunk(&app, &tx, 2, &chunks).await;
+
+    // Then post the tx
+    post_storage_tx(&app, &tx).await;
+
+    // Mine some blocks to trigger chunk migration
+    genesis_node.mine_blocks(2).await.unwrap();
+
+    // Finally verify the chunks didn't get dropped
+    let c1 = get_chunk(&app, DataLedger::Submit, LedgerChunkOffset::from(0)).await;
+    let c2 = get_chunk(&app, DataLedger::Submit, LedgerChunkOffset::from(1)).await;
+    let c3 = get_chunk(&app, DataLedger::Submit, LedgerChunkOffset::from(2)).await;
+    assert_matches!(c1, Some(_));
+    assert_matches!(c2, Some(_));
+    assert_matches!(c3, Some(_));
+
+    genesis_node.stop().await;
+}

--- a/crates/chain/tests/multi_node/mod.rs
+++ b/crates/chain/tests/multi_node/mod.rs
@@ -1,3 +1,4 @@
+pub mod mempool_tests;
 pub mod peer_discovery;
 pub mod peer_mining;
 pub mod sync_chain_state;

--- a/crates/types/src/chunk.rs
+++ b/crates/types/src/chunk.rs
@@ -9,6 +9,7 @@ use derive_more::{Add, From, Into};
 use eyre::eyre;
 use reth_codecs::Compact;
 use serde::{Deserialize, Serialize};
+use std::hash::{Hash, Hasher};
 use std::ops::{Add, Deref, DerefMut};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -243,6 +244,12 @@ pub struct TxChunkOffset(pub u32);
 impl TxChunkOffset {
     pub fn from_be_bytes(bytes: [u8; 4]) -> Self {
         TxChunkOffset(u32::from_be_bytes(bytes))
+    }
+}
+
+impl Hash for TxChunkOffset {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
     }
 }
 


### PR DESCRIPTION
**Describe the changes**
* Adds support for uploading chunks ahead of their `data_root` arriving in a transaction.
* Chunks are held in a pending LRU cache
* When the transaction arrives it attempts to flush the cache
* Added some test methods "post_storage_tx()" and made `start_public_api` return its actix app 

**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
