### PR TITLE
perf: wait for desired vdf step + test speed improvements

### DIFF
--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -578,6 +578,7 @@ impl IrysNode {
                 ctx.actor_addresses.mempool.clone(),
                 ctx.peer_list.clone(),
                 ctx.service_senders.vdf_seed.clone(),
+                ctx.service_senders.vdf.clone(),
             )
             .await?;
         }

--- a/crates/chain/src/peer_utilities.rs
+++ b/crates/chain/src/peer_utilities.rs
@@ -245,8 +245,12 @@ pub async fn sync_state_from_peers(
     let client = awc::Client::default();
     let peers = Arc::new(Mutex::new(trusted_peers.clone()));
 
-    // lets give the local api a few second to load...
-    sleep(Duration::from_millis(15000));
+    // orignal comment "lets give the local api a few second to load..."
+    // I think this pause is actually to allow a few vdf steps to have occured...as it's removal causes the following types of errors:
+    //
+    //     Block validation error Unavailable requested range (1..=2). Stored steps range is (1..=1)
+    //     Block validation error No steps stored!
+    sleep(Duration::from_millis(2000));
 
     //initialize queue
     let block_queue: Arc<tokio::sync::Mutex<VecDeque<BlockIndexItem>>> =

--- a/crates/chain/src/peer_utilities.rs
+++ b/crates/chain/src/peer_utilities.rs
@@ -23,9 +23,14 @@ use std::{
     collections::{HashSet, VecDeque},
     net::SocketAddr,
     sync::Arc,
-    thread::sleep,
 };
-use tokio::{sync::Mutex, time::Duration};
+use tokio::{
+    sync::{
+        mpsc::{Sender, UnboundedSender},
+        Mutex,
+    },
+    time::{sleep, Duration},
+};
 use tracing::{error, info, warn};
 
 pub async fn client_request(
@@ -241,8 +246,8 @@ pub async fn sync_state_from_peers(
     block_discovery_addr: Addr<BlockDiscoveryActor>,
     mempool_addr: Addr<MempoolService>,
     peer_service_addr: PeerListServiceFacade,
-    vdf_seed_sender: tokio::sync::mpsc::Sender<BroadcastMiningSeed>,
-    vdf_service_sender: tokio::sync::mpsc::UnboundedSender<VdfServiceMessage>,
+    vdf_seed_sender: Sender<BroadcastMiningSeed>,
+    vdf_service_sender: UnboundedSender<VdfServiceMessage>,
 ) -> eyre::Result<()> {
     let client = awc::Client::default();
     let peers = Arc::new(Mutex::new(trusted_peers.clone()));
@@ -303,24 +308,8 @@ pub async fn sync_state_from_peers(
 
             // wait to be sure the FF steps are saved to VdfState before we try to discover the block that requires them
             let desired_step = block.vdf_limiter_info.global_step_number;
-            loop {
-                tracing::error!("looping waiting for step {}", desired_step);
-                let (oneshot_tx, oneshot_rx) = tokio::sync::oneshot::channel();
-                if let Err(e) = vdf_service_sender.send(VdfServiceMessage::GetVdfStateMessage {
-                    response: oneshot_tx,
-                }) {
-                    panic!(
-                        "error sending VdfServiceMessage::GetVdfStateMessage: {:?}",
-                        e
-                    );
-                };
-                let vdf_steps_guard = oneshot_rx
-                    .await
-                    .expect("to receive VdfStepsReadGuard from GetVdfStateMessage message");
-                if vdf_steps_guard.read().global_step >= desired_step {
-                    break;
-                }
-                sleep(Duration::from_millis(200));
+            if let Err(e) = wait_for_vdf_step(vdf_service_sender.clone(), desired_step).await {
+                panic!("Error when waiting for desired step {:?}", e);
             }
 
             // allow block to be discovered by block discovery actor
@@ -393,4 +382,35 @@ pub async fn fetch_and_update_peers(
     });
     let results = futures::future::join_all(futures).await;
     Some(results.iter().sum())
+}
+
+async fn wait_for_vdf_step(
+    vdf_service_sender: UnboundedSender<VdfServiceMessage>,
+    desired_step: u64,
+) -> eyre::Result<()> {
+    let seconds_to_wait = 30;
+    let retries_per_second = 20;
+    let total_retries = seconds_to_wait * retries_per_second;
+    for _ in 0..total_retries {
+        tracing::trace!("looping waiting for step {}", desired_step);
+        let (oneshot_tx, oneshot_rx) = tokio::sync::oneshot::channel();
+        if let Err(e) = vdf_service_sender.send(VdfServiceMessage::GetVdfStateMessage {
+            response: oneshot_tx,
+        }) {
+            tracing::error!(
+                "error sending VdfServiceMessage::GetVdfStateMessage: {:?}",
+                e
+            );
+        };
+        let vdf_steps_guard = oneshot_rx
+            .await
+            .expect("to receive VdfStepsReadGuard from GetVdfStateMessage message");
+        if vdf_steps_guard.read().global_step >= desired_step {
+            return Ok(());
+        }
+        sleep(Duration::from_millis(1000 / retries_per_second)).await;
+    }
+    Err(eyre::eyre!(
+        "timed out after {seconds_to_wait}s waiting for VDF step {desired_step}"
+    ))
 }

--- a/crates/chain/src/peer_utilities.rs
+++ b/crates/chain/src/peer_utilities.rs
@@ -245,8 +245,8 @@ pub async fn sync_state_from_peers(
     let client = awc::Client::default();
     let peers = Arc::new(Mutex::new(trusted_peers.clone()));
 
-    // orignal comment "lets give the local api a few second to load..."
-    // I think this pause is actually to allow a few vdf steps to have occured...as it's removal causes the following types of errors:
+    // original comment "lets give the local api a few second to load..."
+    // I think this pause is actually to allow a few vdf steps to have occurred...as it's removal causes the following types of errors:
     //
     //     Block validation error Unavailable requested range (1..=2). Stored steps range is (1..=1)
     //     Block validation error No steps stored!

--- a/crates/chain/src/peer_utilities.rs
+++ b/crates/chain/src/peer_utilities.rs
@@ -245,13 +245,6 @@ pub async fn sync_state_from_peers(
     let client = awc::Client::default();
     let peers = Arc::new(Mutex::new(trusted_peers.clone()));
 
-    // original comment "lets give the local api a few second to load..."
-    // I think this pause is actually to allow a few vdf steps to have occurred...as it's removal causes the following types of errors:
-    //
-    //     Block validation error Unavailable requested range (1..=2). Stored steps range is (1..=1)
-    //     Block validation error No steps stored!
-    sleep(Duration::from_millis(2000));
-
     //initialize queue
     let block_queue: Arc<tokio::sync::Mutex<VecDeque<BlockIndexItem>>> =
         Arc::new(Mutex::new(VecDeque::new()));

--- a/crates/chain/src/peer_utilities.rs
+++ b/crates/chain/src/peer_utilities.rs
@@ -384,6 +384,7 @@ pub async fn fetch_and_update_peers(
     Some(results.iter().sum())
 }
 
+/// Polls VDF service for `VdfState` until `global_step` >= `desired_step`, with a 30s timeout.
 async fn wait_for_vdf_step(
     vdf_service_sender: UnboundedSender<VdfServiceMessage>,
     desired_step: u64,

--- a/crates/chain/tests/api/external_api.rs
+++ b/crates/chain/tests/api/external_api.rs
@@ -1,6 +1,4 @@
 //! endpoint tests
-use std::sync::Arc;
-
 use crate::{
     api::{
         block_index_endpoint_request, chunk_endpoint_request, info_endpoint_request,
@@ -9,10 +7,8 @@ use crate::{
     utils::{mine_block, IrysNodeTest},
 };
 use actix_web::{http::header::ContentType, HttpMessage};
-use irys_actors::BlockFinalizedMessage;
 use irys_api_server::routes::index::NodeInfo;
-use irys_types::{Address, BlockIndexItem, IrysTransactionHeader, Signature, H256};
-use tokio::time::{sleep, Duration};
+use irys_types::BlockIndexItem;
 use tracing::info;
 
 #[actix::test]

--- a/crates/chain/tests/api/external_api.rs
+++ b/crates/chain/tests/api/external_api.rs
@@ -58,37 +58,12 @@ async fn heavy_external_api() -> eyre::Result<()> {
     // advance one block
     let (_header, _payload) = mine_block(&ctx.node_ctx).await?.unwrap();
     // advance one block, finalizing the previous block
-    let (header, _payload) = mine_block(&ctx.node_ctx).await?.unwrap();
+    let (_header, _payload) = mine_block(&ctx.node_ctx).await?.unwrap();
 
-    let mock_header = IrysTransactionHeader {
-        id: H256::from([255u8; 32]),
-        anchor: H256::from([1u8; 32]),
-        signer: Address::default(),
-        data_root: H256::from([3u8; 32]),
-        data_size: 1024,
-        term_fee: 100,
-        perm_fee: Some(200),
-        ledger_id: 1,
-        bundle_format: None,
-        chain_id: ctx.node_ctx.config.consensus.chain_id,
-        version: 0,
-        ingress_proofs: None,
-        signature: Signature::test_signature().into(),
-    };
-
-    let block_finalized_message = BlockFinalizedMessage {
-        block_header: header,
-        all_txs: Arc::new(vec![mock_header]),
-    };
-
-    //FIXME: magic number could be a constant e.g. 3 blocks worth of time?
-    sleep(Duration::from_millis(10000)).await;
-
-    let _ = ctx
-        .node_ctx
-        .actor_addresses
-        .block_index
-        .send(block_finalized_message);
+    // wait for 1 block in the index
+    if let Err(e) = ctx.wait_until_height_on_chain(1, 10).await {
+        panic!("Error waiting for block height on chain. Error: {:?}", e);
+    }
 
     let mut response = info_endpoint_request(&address).await;
 

--- a/crates/p2p/src/gossip_service.rs
+++ b/crates/p2p/src/gossip_service.rs
@@ -651,6 +651,11 @@ pub async fn fast_forward_vdf_steps_from_block(
     let block_end_step = vdf_limiter_info.global_step_number;
     let len = vdf_limiter_info.steps.len();
     let block_start_step = block_end_step - len as u64;
+    tracing::trace!(
+        "VDF FF: block start-end step: {}-{}",
+        block_start_step,
+        block_end_step
+    );
     for (i, hash) in vdf_limiter_info.steps.iter().enumerate() {
         //fast forward VDF step and seed before adding the new block...or we wont be at a new enough vdf step to "discover" block
         let mining_seed = BroadcastMiningSeed {

--- a/crates/p2p/src/gossip_service.rs
+++ b/crates/p2p/src/gossip_service.rs
@@ -651,10 +651,10 @@ pub async fn fast_forward_vdf_steps_from_block(
     let block_end_step = vdf_limiter_info.global_step_number;
     let len = vdf_limiter_info.steps.len();
     let block_start_step = block_end_step - len as u64;
-    for (i, step) in vdf_limiter_info.steps.iter().enumerate() {
+    for (i, hash) in vdf_limiter_info.steps.iter().enumerate() {
         //fast forward VDF step and seed before adding the new block...or we wont be at a new enough vdf step to "discover" block
         let mining_seed = BroadcastMiningSeed {
-            seed: Seed { 0: *step },
+            seed: Seed { 0: *hash },
             global_step: block_start_step + i as u64,
             checkpoints: H256List::new(),
         };


### PR DESCRIPTION
**Describe the changes**
`sync_state_from_peers` now ~15s faster. Removed hard coded delay. Replace with fn that polls VDF service until `global_step >= desired_step`, with a 30s timeout.
`heavy_external_api()` now faster with less boiler plate.

**Related Issue(s)**
N/A

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
N/A
