### PR TITLE
feat: peer_mining test unblocked + logging spans

### DIFF
--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -32,7 +32,7 @@ use std::{
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, warn, Span};
 
 use crate::{
     block_discovery::{BlockDiscoveredMessage, BlockDiscoveryActor},
@@ -86,6 +86,8 @@ pub struct BlockProducerActor {
     /// before mining can be stopped after the first solution. This guard prevents
     /// producing extra blocks that would cause non-deterministic test behavior.
     pub blocks_remaining_for_test: Option<u64>,
+    /// Tracing span
+    pub span: Span,
 }
 
 /// Actors can handle this message to learn about the `block_producer` actor at startup
@@ -123,7 +125,6 @@ impl Handler<SolutionFoundMessage> for BlockProducerActor {
         Self,
         eyre::Result<Option<(Arc<IrysBlockHeader>, ExecutionPayloadEnvelopeV1Irys)>>,
     >;
-
     #[tracing::instrument(skip_all, fields(
         minting_address = ?msg.0.mining_address,
         partition_hash = ?msg.0.partition_hash,
@@ -132,6 +133,8 @@ impl Handler<SolutionFoundMessage> for BlockProducerActor {
         chunk = ?msg.0.chunk.len(),
     ))]
     fn handle(&mut self, msg: SolutionFoundMessage, _ctx: &mut Self::Context) -> Self::Result {
+        let span = self.span.clone();
+        let _span = span.enter();
         let solution = msg.0;
         info!(
             "BlockProducerActor solution received: solution_hash={}",

--- a/crates/actors/src/broadcast_mining_service.rs
+++ b/crates/actors/src/broadcast_mining_service.rs
@@ -2,7 +2,7 @@ use crate::mining::PartitionMiningActor;
 use actix::prelude::*;
 use irys_types::{block_production::Seed, H256List, IrysBlockHeader};
 use std::sync::Arc;
-use tracing::{debug, info};
+use tracing::{debug, info, Span};
 
 // Message types
 
@@ -38,15 +38,17 @@ pub struct BroadcastPartitionsExpiration(pub H256List);
 /// Broadcaster actor
 #[derive(Debug, Default)]
 pub struct BroadcastMiningService {
-    subscribers: Vec<Addr<PartitionMiningActor>>,
+    pub subscribers: Vec<Addr<PartitionMiningActor>>,
+    pub span: Option<Span>,
 }
 // Actor Definition
 
 impl BroadcastMiningService {
     /// Initialize a new `MiningBroadcaster`
-    pub const fn new() -> Self {
+    pub fn new(span: Option<Span>) -> Self {
         Self {
             subscribers: Vec::new(),
+            span: Some(span.unwrap_or(Span::current())),
         }
     }
 }
@@ -69,6 +71,11 @@ impl Handler<Subscribe> for BroadcastMiningService {
     type Result = ();
 
     fn handle(&mut self, msg: Subscribe, _: &mut Context<Self>) {
+        let span = self.span.clone().unwrap();
+        let _span = span.enter();
+
+        debug!("PartitionMiningActor subscribed");
+
         self.subscribers.push(msg.0);
     }
 }
@@ -87,6 +94,8 @@ impl Handler<BroadcastMiningSeed> for BroadcastMiningService {
     type Result = ();
 
     fn handle(&mut self, msg: BroadcastMiningSeed, _: &mut Context<Self>) {
+        let span = self.span.clone().unwrap();
+        let _span = span.enter();
         info!(
             "Broadcast Mining: {:?} subs: {}",
             msg.seed,

--- a/crates/actors/src/broadcast_mining_service.rs
+++ b/crates/actors/src/broadcast_mining_service.rs
@@ -71,8 +71,10 @@ impl Handler<Subscribe> for BroadcastMiningService {
     type Result = ();
 
     fn handle(&mut self, msg: Subscribe, _: &mut Context<Self>) {
-        let span = self.span.clone().unwrap();
-        let _span = span.enter();
+        if self.span.is_some() {
+            let span = self.span.clone().unwrap();
+            let _span = span.enter();
+        }
 
         debug!("PartitionMiningActor subscribed");
 

--- a/crates/actors/src/chunk_migration_service.rs
+++ b/crates/actors/src/chunk_migration_service.rs
@@ -327,7 +327,7 @@ fn find_storage_module(
     guard.iter().find_map(|module| {
         // First check ledger
         module
-            .partition_assignment
+            .partition_assignment()
             .as_ref()
             .and_then(|pa| pa.ledger_id)
             .filter(|&id| id == ledger as u32)

--- a/crates/actors/src/epoch_service/epoch_service.rs
+++ b/crates/actors/src/epoch_service/epoch_service.rs
@@ -21,7 +21,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use tracing::{debug, error, trace, warn};
+use tracing::{debug, error, trace, warn, Span};
 
 use crate::broadcast_mining_service::{BroadcastMiningService, BroadcastPartitionsExpiration};
 use crate::services::ServiceSenders;
@@ -50,6 +50,8 @@ pub struct EpochServiceActor {
     pub config: Config,
     /// Computed commitment state
     pub(super) commitment_state: Arc<RwLock<CommitmentState>>,
+    /// Tracing span
+    pub span: Span,
 }
 
 impl Actor for EpochServiceActor {
@@ -86,6 +88,7 @@ impl EpochServiceActor {
             storage_submodules_config: storage_submodules_config.clone(),
             config: config.clone(),
             commitment_state: Default::default(),
+            span: Span::current(),
         }
     }
 
@@ -94,6 +97,8 @@ impl EpochServiceActor {
         genesis_block: IrysBlockHeader,
         commitments: Vec<CommitmentTransaction>,
     ) -> eyre::Result<Vec<StorageModuleInfo>> {
+        let span = self.span.clone();
+        let _span = span.enter();
         Self::validate_commitments(&genesis_block, &commitments)?;
 
         match self.perform_epoch_tasks(&None, &genesis_block, commitments) {
@@ -113,6 +118,8 @@ impl EpochServiceActor {
         &mut self,
         epoch_replay_data: Vec<EpochReplayData>,
     ) -> eyre::Result<Vec<StorageModuleInfo>> {
+        let span = self.span.clone();
+        let _span = span.enter();
         // Initialize as None for the first iteration
         let mut previous_epoch_block: Option<IrysBlockHeader> = None;
 
@@ -182,6 +189,8 @@ impl EpochServiceActor {
         new_epoch_block: &IrysBlockHeader,
         new_epoch_commitments: Vec<CommitmentTransaction>,
     ) -> Result<(), EpochServiceError> {
+        let span = self.span.clone();
+        let _span = span.enter();
         // Validate the epoch blocks
         self.is_epoch_block(new_epoch_block)?;
 
@@ -769,7 +778,7 @@ impl EpochServiceActor {
 
         // Send the message
         if let Err(e) = self.service_senders.storage_modules.send(message) {
-            warn!("Failed to send partition assignments update: {}", e);
+            error!("Failed to send partition assignments update: {}", e);
         }
     }
 
@@ -844,6 +853,8 @@ impl EpochServiceActor {
         let num_chunks = self.config.consensus.num_chunks_in_partition as u32;
         let paths = &cfg.submodule_paths;
 
+        debug!("{:#?}", assignments);
+
         let mut module_infos = Vec::new();
 
         // STEP 1: Publish ledger
@@ -905,6 +916,16 @@ impl EpochServiceActor {
                 id,
                 partition_assignment: Some(*pa),
                 submodules: vec![(partition_chunk_offset_ie!(0, num_chunks), path)],
+            });
+        }
+
+        // STEP 4: Unassigned
+        for (idx, path) in paths.iter().enumerate().skip(module_infos.len()) {
+            // Create StorageModuleInfo entries without partition assignments
+            module_infos.push(StorageModuleInfo {
+                id: idx,
+                partition_assignment: None, // No partition assignment
+                submodules: vec![(partition_chunk_offset_ie!(0, num_chunks), path.clone())],
             });
         }
 

--- a/crates/actors/src/packing.rs
+++ b/crates/actors/src/packing.rs
@@ -112,7 +112,7 @@ impl PackingActor {
                 chunk_range,
             } = next_range;
 
-            let assignment = match storage_module.partition_assignment {
+            let assignment = match storage_module.partition_assignment() {
                 Some(v) => v,
                 None => {
                     warn!(target:"irys::packing", "Partition assignment for storage module {} is `None`, cannot pack requested range {:?}", &storage_module.id, &chunk_range);

--- a/crates/chain/tests/api/tx_commitments.rs
+++ b/crates/chain/tests/api/tx_commitments.rs
@@ -199,7 +199,7 @@ async fn heavy_test_commitments_3epochs_test() -> eyre::Result<()> {
     let node = {
         // Start a test node with custom configuration
         let node = IrysNodeTest::new_genesis(config.clone())
-            .start_and_wait_for_packing(10)
+            .start_and_wait_for_packing("GENESIS", 10)
             .await;
 
         // Initialize blockchain components

--- a/crates/chain/tests/multi_node/peer_mining.rs
+++ b/crates/chain/tests/multi_node/peer_mining.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use irys_testing_utils::*;
 use irys_types::{NodeConfig, H256};
 use tracing::debug;
@@ -12,7 +14,9 @@ async fn heavy_peer_mining_test() -> eyre::Result<()> {
 
     // Configure a test network with accelerated epochs (2 blocks per epoch)
     let num_blocks_in_epoch = 2;
+    let seconds_to_wait = 10;
     let mut genesis_config = NodeConfig::testnet_with_epochs(num_blocks_in_epoch);
+    genesis_config.consensus.get_mut().chunk_size = 32;
 
     // Create a signer (keypair) for the peer and fund it
     let peer_signer = genesis_config.new_random_signer();
@@ -20,7 +24,7 @@ async fn heavy_peer_mining_test() -> eyre::Result<()> {
 
     // Start the genesis node and wait for packing
     let genesis_node = IrysNodeTest::new_genesis(genesis_config.clone())
-        .start_and_wait_for_packing(10)
+        .start_and_wait_for_packing("GENESIS", seconds_to_wait)
         .await;
     genesis_node.start_public_api().await;
 
@@ -28,19 +32,45 @@ async fn heavy_peer_mining_test() -> eyre::Result<()> {
     let peer_config = genesis_node.testnet_peer_with_signer(&peer_signer);
 
     // Start the peer: No packing on the peer, it doesn't have partition assignments yet
-    let peer_node = IrysNodeTest::new(peer_config.clone()).start().await;
+    let peer_node = IrysNodeTest::new(peer_config.clone())
+        .start_with_name("PEER")
+        .await;
     peer_node.start_public_api().await;
-    debug!("{:#?}", peer_node.node_ctx.config.node_config);
 
+    // Post stake + pledge commitments to the peer
     let stake_tx = peer_node.post_stake_commitment(H256::zero()).await; // zero() is the genesis block hash
     let pledge_tx = peer_node.post_pledge_commitment(H256::zero()).await;
 
-    genesis_node.wait_for_mempool(stake_tx.id, 10).await?;
-    genesis_node.wait_for_mempool(pledge_tx.id, 10).await?;
+    // Wait for them to show up in the genesis_node's mempool
+    genesis_node
+        .wait_for_mempool(stake_tx.id, seconds_to_wait)
+        .await?;
+    genesis_node
+        .wait_for_mempool(pledge_tx.id, seconds_to_wait)
+        .await?;
 
+    // Mine a block to get the commitments included
     genesis_node.mine_block().await.unwrap();
     let block = genesis_node.get_block_by_height(1).await.unwrap();
     debug!("SystemLedgers: {:#?}", block.system_ledgers);
+
+    // Mine another block to perform epoch tasks
+    genesis_node.mine_block().await.unwrap();
+
+    // Assuming the peer is assigned a partition
+    peer_node.wait_for_packing(seconds_to_wait).await;
+
+    let _ = peer_node.wait_until_height(2, seconds_to_wait).await;
+    let peer_block = peer_node.get_block_by_height(2).await.unwrap();
+    debug!("{}", peer_block);
+
+    peer_node.mine_block().await?;
+
+    let peer_block = peer_node.get_block_by_height(3).await.unwrap();
+    debug!("{}", peer_block);
+
+    // Wait to see if anything happens on the peer node
+    tokio::time::sleep(Duration::from_secs(10)).await;
 
     genesis_node.stop().await;
     peer_node.stop().await;

--- a/crates/storage/src/chunk_provider.rs
+++ b/crates/storage/src/chunk_provider.rs
@@ -56,6 +56,8 @@ impl ChunkProvider {
             .iter()
             .filter(|sm| {
                 sm.partition_assignment
+                    .read()
+                    .unwrap()
                     .and_then(|sm| sm.ledger_id)
                     .map_or(false, |ledger_id| ledger_id == ledger as u32)
             })
@@ -97,6 +99,8 @@ impl ChunkProvider {
             .iter()
             .filter(|sm| {
                 sm.partition_assignment
+                    .read()
+                    .unwrap()
                     .and_then(|sm| sm.ledger_id)
                     .map_or(false, |ledger_id| ledger_id == ledger as u32)
             })

--- a/crates/storage/src/storage_module.rs
+++ b/crates/storage/src/storage_module.rs
@@ -88,7 +88,7 @@ pub struct StorageModule {
     /// an integer uniquely identifying the module
     pub id: usize,
     /// The (Optional) info about a partition assigned to this storage module
-    pub partition_assignment: Option<PartitionAssignment>,
+    pub partition_assignment: RwLock<Option<PartitionAssignment>>,
     /// In-memory chunk buffer awaiting disk write
     pending_writes: Arc<RwLock<ChunkMap>>,
     /// Tracks the storage state of each chunk across all submodules
@@ -248,6 +248,7 @@ impl StorageModule {
             ));
 
             let submodule_db_path = sub_base_path.join("db");
+            debug!("submodule_db_path: {:?}", submodule_db_path);
             let submodule_db = create_or_open_submodule_db(&submodule_db_path).map_err(|e| {
                 eyre!(
                     "Failed to create or open submodule database: {} - {}",
@@ -345,7 +346,7 @@ impl StorageModule {
 
         Ok(StorageModule {
             id: storage_module_info.id,
-            partition_assignment: storage_module_info.partition_assignment,
+            partition_assignment: RwLock::new(storage_module_info.partition_assignment),
             pending_writes: Arc::new(RwLock::new(ChunkMap::new())),
             intervals: Arc::new(RwLock::new(loaded_intervals)),
             submodules: submodule_map,
@@ -353,13 +354,24 @@ impl StorageModule {
         })
     }
 
+    pub fn assign_partition(&self, partition_assignment: PartitionAssignment) {
+        let mut pa = self.partition_assignment.write().unwrap();
+        *pa = Some(partition_assignment);
+    }
+
     /// Returns the StorageModules partition_hash if assigned
     pub fn partition_hash(&self) -> Option<PartitionHash> {
-        if let Some(part_assign) = self.partition_assignment {
+        let pa = self.partition_assignment.read().unwrap();
+        if let Some(part_assign) = *pa {
             Some(part_assign.partition_hash)
         } else {
             None
         }
+    }
+
+    pub fn partition_assignment(&self) -> Option<PartitionAssignment> {
+        let pa = self.partition_assignment.read().unwrap();
+        *pa
     }
 
     /// Reinit intervals setting them as Uninitialized, and erase db
@@ -390,6 +402,8 @@ impl StorageModule {
     /// Returns whether the given chunk offset falls within this StorageModules assigned range
     pub fn contains_offset(&self, chunk_offset: LedgerChunkOffset) -> bool {
         self.partition_assignment
+            .read()
+            .unwrap()
             .and_then(|part| part.slot_index)
             .map(|slot_index| {
                 let start_offset =
@@ -1074,7 +1088,8 @@ impl StorageModule {
     /// Utility method asking the StorageModule to return its chunk range in
     /// ledger relative coordinates
     pub fn get_storage_module_ledger_range(&self) -> eyre::Result<LedgerChunkRange> {
-        if let Some(part_assign) = self.partition_assignment {
+        let pa = self.partition_assignment.read().unwrap();
+        if let Some(part_assign) = *pa {
             if let Some(slot_index) = part_assign.slot_index {
                 let start = slot_index as u64 * self.config.consensus.num_chunks_in_partition;
                 let end = start + self.config.consensus.num_chunks_in_partition;
@@ -1249,6 +1264,8 @@ pub fn get_overlapped_storage_modules(
         .filter(|module| {
             module
                 .partition_assignment
+                .read()
+                .unwrap()
                 .and_then(|pa| pa.ledger_id)
                 .map_or(false, |id| id == ledger as u32)
                 && module
@@ -1272,6 +1289,8 @@ pub fn get_storage_module_at_offset(
         .find(|module| {
             module
                 .partition_assignment
+                .read()
+                .unwrap()
                 .and_then(|pa| pa.ledger_id)
                 .map_or(false, |id| id == ledger as u32)
                 && module


### PR DESCRIPTION
### Logging Improvements
* Added span logging to enhance traceability across the following actors & services:
  * EpochService 
  * BlockDiscovery + block_validation module
  * BlockProducer
  * BroadcastMiningService
  * PartitionMiningActor

### Storage Module Runtime Updates
* Made `StorageModule::partition_assignment` thread-safe by wrapping `Option<PartitionAssignment>` in an `RwLock`
* This enables safe runtime updates to partition assignments through `Arc<StorageModule>` references in the global storage modules vector
* Allows dynamic assignment of partitions without requiring full module recreation

### Node Initialization Optimization
* Pre-initialize packing and mining actors for all storage modules at startup, including unassigned ones
* Unassigned actors remain idle until activated by partition assignment
* Simplifies the activation process when partition hashes are assigned during an epoch block

### Temporary Database Integration Fix
* Modified MempoolService to directly insert commitment transactions into the database upon receipt
* This temporary change ensures proper `block_discovery` validation
* **Note**: This workaround will be removed once MempoolService is migrated to a tokio-based service architecture
**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
