### PR TITLE
fix: stabilize p2p tests when run in parallel

### DIFF
--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -37,7 +37,7 @@ use irys_types::{
 };
 use irys_types::{
     Base64, DatabaseProvider, IrysBlockHeader, IrysTransaction, LedgerChunkOffset, PackedChunk,
-    UnpackedChunk,
+    PeerAddress, RethPeerInfo, UnpackedChunk,
 };
 use irys_types::{
     CommitmentTransaction, Config, IrysTransactionHeader, IrysTransactionId, NodeConfig, NodeMode,
@@ -444,6 +444,21 @@ impl IrysNodeTest<IrysNodeCtx> {
         } else {
             info!("transaction found in mempool after {} retries", &retries);
             Ok(())
+        }
+    }
+
+    pub fn peer_address(&self) -> PeerAddress {
+        let http = &self.node_ctx.config.node_config.http;
+        let gossip = &self.node_ctx.config.node_config.gossip;
+
+        PeerAddress {
+            api: format!("{}:{}", http.bind_ip, http.bind_port)
+                .parse()
+                .expect("valid SocketAddr expected"),
+            gossip: format!("{}:{}", gossip.bind_ip, gossip.bind_port)
+                .parse()
+                .expect("valid SocketAddr expected"),
+            execution: RethPeerInfo::default(),
         }
     }
 


### PR DESCRIPTION
**Describe the changes**
heavy_test_p2p_evm_gossip tests were clobbering each other with overlapping peers (apparently) when running in paralell during CI and were fixed by having more robust config initialization.

**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
