### PR TITLE
feat: add an method to truncate block index

### DIFF
--- a/crates/actors/src/block_index_service.rs
+++ b/crates/actors/src/block_index_service.rs
@@ -242,3 +242,22 @@ impl Handler<GetLatestBlockIndexMessage> for BlockIndexService {
         Some(bi.get_item(block_height)?.clone())
     }
 }
+
+/// Returns the current block height in the index
+#[derive(Message, Clone, Debug)]
+#[rtype(result = "()")]
+pub struct Truncate {
+    pub to: usize,
+}
+
+impl Handler<Truncate> for BlockIndexService {
+    type Result = ();
+    fn handle(&mut self, msg: Truncate, _ctx: &mut Self::Context) -> Self::Result {
+        if let Some(block_index) = self.block_index.clone() {
+            block_index
+                .write()
+                .unwrap()
+                .truncate(msg.to);
+        }
+    }
+}

--- a/crates/database/src/block_index_data.rs
+++ b/crates/database/src/block_index_data.rs
@@ -85,6 +85,12 @@ impl BlockIndex {
         Ok(())
     }
 
+    pub fn truncate(&mut self, to: usize) {
+        let mut items_vec = self.items.to_vec();
+        items_vec.truncate(to);
+        self.items = items_vec.into();
+    }
+
     pub fn push_block(
         &mut self,
         block: &IrysBlockHeader,


### PR DESCRIPTION
**Describe the changes**
This PR adds a method to truncate block index. It is needed in order to fix an issue when sometimes on restart we have more blocks in the index that in the block tree, which causes EMA validation to fail.

**Related Issue(s)**

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**

