### PR TITLE
feat: detect and broadcast reorgs

### DIFF
--- a/crates/actors/src/commitment_cache.rs
+++ b/crates/actors/src/commitment_cache.rs
@@ -40,7 +40,7 @@ pub enum CommitmentCacheMessage {
 pub enum CommitmentCacheStatus {
     Accepted,    // The commitment is valid and was added to the cache
     Unknown,     // The commitment is unknown to the cache & has no status
-    Unsupported, // The commitment is an unsupported type (pledge/unpledge)
+    Unsupported, // The commitment is an unsupported type (unstake/unpledge)
     Unstaked,    // The pledge commitment doesn't have a corresponding stake
 }
 

--- a/crates/actors/src/ema_service.rs
+++ b/crates/actors/src/ema_service.rs
@@ -102,7 +102,7 @@ impl EmaService {
     /// Spawn a new EMA service
     pub fn spawn_service(
         exec: &TaskExecutor,
-        block_tree_read_guard: BlockTreeReadGuard,
+        block_tree_guard: BlockTreeReadGuard,
         rx: UnboundedReceiver<EmaServiceMessage>,
         config: &Config,
     ) -> JoinHandle<()> {
@@ -110,13 +110,13 @@ impl EmaService {
         let token_price_safe_range = config.consensus.token_price_safe_range;
         exec.spawn_critical_with_graceful_shutdown_signal("EMA Service", |shutdown| async move {
             let confirmed_price_ctx = PriceCacheContext::<Confirmed>::from_chain(
-                block_tree_read_guard.clone(),
+                block_tree_guard.clone(),
                 blocks_in_interval,
             )
             .await
             .expect("initial PriceCacheContext restoration failed");
             let optimistic_price_ctx = PriceCacheContext::<Optimistic>::from_chain(
-                block_tree_read_guard.clone(),
+                block_tree_guard.clone(),
                 blocks_in_interval,
             )
             .await
@@ -130,7 +130,7 @@ impl EmaService {
                     confirmed_price_ctx,
                     token_price_safe_range,
                     blocks_in_interval,
-                    block_tree_read_guard,
+                    block_tree_read_guard: block_tree_guard,
                 },
             };
             ema_service

--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -235,6 +235,7 @@ impl MempoolService {
         let storage_modules_guard = storage_modules_guard.clone();
         let irys_db = irys_db.clone();
         let service_senders = service_senders.clone();
+        let reorg_rx = service_senders.subscribe_reorgs();
         exec.clone().spawn_critical_with_graceful_shutdown_signal(
             "Mempool Service",
             |shutdown| async move {

--- a/crates/actors/src/services.rs
+++ b/crates/actors/src/services.rs
@@ -1,7 +1,7 @@
 use crate::{
-    broadcast_mining_service::BroadcastMiningSeed, cache_service::CacheServiceAction,
-    ema_service::EmaServiceMessage, vdf_service::VdfServiceMessage, CommitmentCacheMessage,
-    StorageModuleServiceMessage,
+    block_tree_service::BlockTreeServiceMessage, broadcast_mining_service::BroadcastMiningSeed,
+    cache_service::CacheServiceAction, ema_service::EmaServiceMessage,
+    vdf_service::VdfServiceMessage, CommitmentCacheMessage, StorageModuleServiceMessage,
 };
 use actix::Message;
 use core::ops::Deref;
@@ -42,6 +42,7 @@ pub struct ServiceReceivers {
     pub vdf_seed: Receiver<BroadcastMiningSeed>,
     pub storage_modules: UnboundedReceiver<StorageModuleServiceMessage>,
     pub gossip_broadcast: UnboundedReceiver<GossipData>,
+    pub block_tree: UnboundedReceiver<BlockTreeServiceMessage>,
 }
 
 #[derive(Debug)]
@@ -54,6 +55,7 @@ pub struct ServiceSendersInner {
     pub vdf_seed: Sender<BroadcastMiningSeed>,
     pub storage_modules: UnboundedSender<StorageModuleServiceMessage>,
     pub gossip_broadcast: UnboundedSender<GossipData>,
+    pub block_tree: UnboundedSender<BlockTreeServiceMessage>,
 }
 
 impl ServiceSendersInner {
@@ -71,6 +73,8 @@ impl ServiceSendersInner {
         let (sm_sender, sm_receiver) = unbounded_channel::<StorageModuleServiceMessage>();
         let (gossip_broadcast_sender, gossip_broadcast_receiver) =
             unbounded_channel::<GossipData>();
+        let (block_tree_sender, block_tree_receiver) =
+            unbounded_channel::<BlockTreeServiceMessage>();
 
         let senders = Self {
             chunk_cache: chunk_cache_sender,
@@ -81,6 +85,7 @@ impl ServiceSendersInner {
             vdf_seed: vdf_seed_sender,
             storage_modules: sm_sender,
             gossip_broadcast: gossip_broadcast_sender,
+            block_tree: block_tree_sender,
         };
         let receivers = ServiceReceivers {
             chunk_cache: chunk_cache_receiver,
@@ -91,6 +96,7 @@ impl ServiceSendersInner {
             vdf_seed: vdf_seed_receiver,
             storage_modules: sm_receiver,
             gossip_broadcast: gossip_broadcast_receiver,
+            block_tree: block_tree_receiver,
         };
         (senders, receivers)
     }

--- a/crates/actors/src/services.rs
+++ b/crates/actors/src/services.rs
@@ -1,6 +1,9 @@
 use crate::{
-    cache_service::CacheServiceAction, ema_service::EmaServiceMessage,
-    mempool_service::MempoolServiceMessage, CommitmentCacheMessage, StorageModuleServiceMessage,
+    block_tree_service::{BlockTreeServiceMessage, ReorgEvent},
+    cache_service::CacheServiceAction,
+    ema_service::EmaServiceMessage,
+    mempool_service::MempoolServiceMessage,
+    CommitmentCacheMessage, StorageModuleServiceMessage,
 };
 use actix::Message;
 use core::ops::Deref;

--- a/crates/actors/src/validation_service.rs
+++ b/crates/actors/src/validation_service.rs
@@ -124,7 +124,7 @@ impl Handler<RequestValidationMessage> for ValidationService {
 
                 block_tree_sender
                     .send(
-                        crate::block_tree_service::BlockTreeServiceMessage::ValidationResult {
+                        crate::block_tree_service::BlockTreeServiceMessage::ValidationComplete {
                             block_hash,
                             validation_result,
                         },

--- a/crates/actors/src/validation_service.rs
+++ b/crates/actors/src/validation_service.rs
@@ -1,4 +1,5 @@
 use crate::{
+    block_tree_service::BlockTreeServiceMessage,
     services::ServiceSenders,
     vdf_service::{vdf_steps_are_valid, VdfStepsReadGuard},
 };
@@ -123,12 +124,10 @@ impl Handler<RequestValidationMessage> for ValidationService {
                 };
 
                 block_tree_sender
-                    .send(
-                        crate::block_tree_service::BlockTreeServiceMessage::ValidationComplete {
-                            block_hash,
-                            validation_result,
-                        },
-                    )
+                    .send(BlockTreeServiceMessage::BlockValidationFinished {
+                        block_hash,
+                        validation_result,
+                    })
                     .unwrap();
             }
             .into_actor(self),

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -847,8 +847,7 @@ impl IrysNode {
             &config,
             reth_service_actor.clone(),
             &service_senders,
-        )
-        .await?;
+        );
 
         let (oneshot_tx, oneshot_rx) = tokio::sync::oneshot::channel();
         let block_tree_sender = service_senders.block_tree.clone();

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -724,7 +724,7 @@ impl IrysNode {
                         ),
                     )
                     .await
-                    .inspect_err(|e| error!("Reth thread error: {:?}", &e));
+                    .inspect_err(|e| error!("Reth thread error: {}", &e));
 
                     debug!("Sending shutdown signal to the main actor thread");
                     let _ = main_actor_thread_shutdown_tx.try_send(());
@@ -845,8 +845,8 @@ impl IrysNode {
             irys_db.clone(),
             block_index_guard.clone(),
             &config,
-            reth_service_actor.clone(),
             &service_senders,
+            reth_service_actor.clone(),
         );
 
         let (oneshot_tx, oneshot_rx) = tokio::sync::oneshot::channel();

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -27,8 +27,8 @@ use irys_actors::{
     vdf_service::{VdfService, VdfServiceMessage, VdfStepsReadGuard},
 };
 use irys_actors::{
-    ActorAddresses, CommitmentCache, CommitmentStateReadGuard, EpochReplayData,
-    GetCommitmentStateGuardMessage, StorageModuleService,
+    ActorAddresses, CommitmentCache, EpochReplayData, GetCommitmentStateGuardMessage,
+    StorageModuleService,
 };
 use irys_api_server::{create_listener, run_server, ApiState};
 use irys_config::chain::chainspec::IrysChainSpecBuilder;

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -844,7 +844,7 @@ impl IrysNode {
 
         // start the block tree service
         let _handle = BlockTreeService::spawn_service(
-            &task_exec,
+            task_exec,
             receivers.block_tree,
             irys_db.clone(),
             block_index_guard.clone(),

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -194,7 +194,7 @@ async fn heavy_fork_recovery_test() -> eyre::Result<()> {
     };
 
     // GENESIS occasionally doesn't arrive at block 4 - 10s for gossip is too slow!
-    genesis_node.wait_until_height(4, seconds_to_wait).await?;
+    let _reorg_event = genesis_node.wait_for_reorg(seconds_to_wait * 2).await?;
     let genesis_block = genesis_node.get_block_by_height(4).await?;
 
     // Make sure the reorg_tx is back in the mempool ready to be included in the next block

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -189,13 +189,13 @@ async fn heavy_fork_recovery_test() -> eyre::Result<()> {
     // to trigger a reorganization. The losing peer's transaction will be evicted
     // and returned to the mempool.
     let reorg_tx: IrysTransaction;
-    let reorg_block_hash: H256;
-    let reorg_block = if genesis_block.block_hash == peer1_block.block_hash {
+    let _reorg_block_hash: H256;
+    let _reorg_block = if genesis_block.block_hash == peer1_block.block_hash {
         debug!(
             "GENESIS: should ignore {} and should already be on {} height: {}",
             peer2_block.block_hash, peer1_block.block_hash, genesis_block.height
         );
-        reorg_block_hash = peer1_block.block_hash;
+        _reorg_block_hash = peer1_block.block_hash;
         reorg_tx = peer1_tx; // Peer1 won initially, so peer2's chain will overtake it
         peer2_node.mine_block().await?;
         peer2_node.get_block_by_height(4).await?
@@ -204,7 +204,7 @@ async fn heavy_fork_recovery_test() -> eyre::Result<()> {
             "GENESIS: should ignore {} and should already be on {} height: {}",
             peer1_block.block_hash, peer2_block.block_hash, genesis_block.height
         );
-        reorg_block_hash = peer2_block.block_hash;
+        _reorg_block_hash = peer2_block.block_hash;
         reorg_tx = peer2_tx; // Peer2 won initially, so peer1's chain will overtake it
         peer1_node.mine_block().await?;
         peer1_node.get_block_by_height(4).await?

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -407,8 +407,8 @@ impl IrysNodeTest<IrysNodeCtx> {
             Ok(Ok(reorg_event)) => {
                 info!(
                     "Reorg detected: {} blocks orphaned at height {}, new tip: {}",
-                    reorg_event.orphaned_blocks.len(),
-                    reorg_event.fork_height,
+                    reorg_event.old_fork.len(),
+                    reorg_event.fork_parent.height,
                     reorg_event.new_tip.0.to_base58()
                 );
                 Ok(reorg_event)

--- a/crates/database/src/block_index_data.rs
+++ b/crates/database/src/block_index_data.rs
@@ -117,11 +117,23 @@ impl BlockIndex {
         {
             (0, sub_chunks_added)
         } else {
-            let prev_block = self.get_item(block.height.saturating_sub(1)).unwrap();
-            (
-                prev_block.ledgers[DataLedger::Publish].max_chunk_offset + pub_chunks_added,
-                prev_block.ledgers[DataLedger::Submit].max_chunk_offset + sub_chunks_added,
-            )
+            let prev_block = self.get_item(block.height.saturating_sub(1));
+            if let Some(prev_block) = prev_block {
+                (
+                    prev_block.ledgers[DataLedger::Publish].max_chunk_offset + pub_chunks_added,
+                    prev_block.ledgers[DataLedger::Submit].max_chunk_offset + sub_chunks_added,
+                )
+            } else {
+                // Use println! here because errors and tracing are not getting propagated
+                println!(
+                    "Panic: prev_block at index {} not found in block_index",
+                    block.height.saturating_sub(1)
+                );
+                return Err(eyre::eyre!(
+                    "prev_block at index {} not found in block_index",
+                    block.height.saturating_sub(1)
+                ));
+            }
         };
 
         let block_index_item = BlockIndexItem {

--- a/crates/p2p/src/gossip_service.rs
+++ b/crates/p2p/src/gossip_service.rs
@@ -36,7 +36,7 @@ use tokio::{
     sync::mpsc::{channel, error::SendError, Receiver, Sender},
     time,
 };
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, warn, Span};
 
 const ONE_HOUR: Duration = Duration::from_secs(3600);
 const TWO_HOURS: Duration = Duration::from_secs(7200);
@@ -190,6 +190,7 @@ impl P2PService {
             gossip_client: self.client.clone(),
             peer_list_service: peer_list.clone(),
             sync_state: self.sync_state.clone(),
+            span: Span::current().clone(),
         };
         let server = GossipServer::new(server_data_handler, peer_list.clone());
 

--- a/crates/types/src/gossip.rs
+++ b/crates/types/src/gossip.rs
@@ -24,7 +24,7 @@ impl GossipData {
                 format!("commitment transaction {}", commitment_tx.id.0.to_base58())
             }
             GossipData::Block(block) => {
-                format!("block {}", block.block_hash.0.to_base58())
+                format!("block {} height: {}", block.block_hash, block.height)
             }
         }
     }


### PR DESCRIPTION
* converts the `block_tree_service` to a tokio actor
* adds the plumbing for a tokio::broadcast channel for reorg messsages
* adds plumbing for the mempool to subscribe to said messages
* adds a `ReorgEvent` that contains state about the reorg broadcast
* adds some tests to `block_tree` just to validate the inner implementation