### PR TITLE
feat: disable VDF by default

### DIFF
--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -138,29 +138,38 @@ impl IrysNodeCtx {
         self.config.node_config.http.bind_port
     }
 
-    /// Stop VDF thread mining and send a message to all known partition actors to ignore any received VDF steps
+    /// Stop the VDF thread and send a message to all known partition actors to ignore any received VDF steps
     pub async fn stop_mining(&self) -> eyre::Result<()> {
-        // stop VDF thread mining
-        if let Err(e) = self.service_senders.vdf_mining.send(false).await {
-            tracing::error!("Error sending to vdf_mining_state_sender mspc {:?}", e);
-        }
+        // stop the VDF thread
+        self.stop_vdf().await?;
         self.set_partition_mining(false).await
     }
-    /// Start VDF thread mining and Send a message to all known partition actors to begin mining when they receive a VDF step
+    /// Start VDF thread and send a message to all known partition actors to begin mining when they receive a VDF step
     pub async fn start_mining(&self) -> eyre::Result<()> {
-        // start VDF thread mining
-        if let Err(e) = self.service_senders.vdf_mining.send(true).await {
-            tracing::error!("Error sending to vdf_mining_state_sender mspc {:?}", e);
-        }
+        // start the VDF thread
+        self.start_vdf().await?;
         self.set_partition_mining(true).await
     }
     // Send a custom control message to all known partition actors to enable/disable partition mining
+    // does NOT modify the state of the  VDF thread!
     pub async fn set_partition_mining(&self, should_mine: bool) -> eyre::Result<()> {
         // Send a custom control message to all known partition actors
         for part in &self.actor_addresses.partitions {
             part.try_send(MiningControl(should_mine))?;
         }
         Ok(())
+    }
+    // starts the VDF thread
+    pub async fn start_vdf(&self) -> eyre::Result<()> {
+        self.vdf_state(true).await
+    }
+    // stops the VDF thread
+    pub async fn stop_vdf(&self) -> eyre::Result<()> {
+        self.vdf_state(false).await
+    }
+    // sets the running state of the VDF thread
+    pub async fn vdf_state(&self, running: bool) -> eyre::Result<()> {
+        Ok(self.service_senders.vdf_mining.send(running).await?)
     }
 }
 

--- a/crates/chain/tests/block_production/testing_primitives.rs
+++ b/crates/chain/tests/block_production/testing_primitives.rs
@@ -12,7 +12,7 @@ async fn heavy_test_wait_until_height() {
     info!("height: {}", height);
     let steps = 2;
     let seconds = 60;
-    irys_node.node_ctx.set_partition_mining(true).await.unwrap();
+    irys_node.node_ctx.start_mining().await.unwrap();
     irys_node
         .wait_until_height(height + steps, seconds)
         .await

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -454,7 +454,6 @@ impl IrysNodeTest<IrysNodeCtx> {
             .block_producer
             .do_send(SetTestBlocksRemainingMessage(Some(num_blocks as u64)));
         let height = self.get_height().await;
-        // self.node_ctx.set_partition_mining(true).await?;
         self.node_ctx.start_mining().await?;
         self.wait_until_height(height + num_blocks as u64, 60 * num_blocks)
             .await?;

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -454,7 +454,8 @@ impl IrysNodeTest<IrysNodeCtx> {
             .block_producer
             .do_send(SetTestBlocksRemainingMessage(Some(num_blocks as u64)));
         let height = self.get_height().await;
-        self.node_ctx.set_partition_mining(true).await?;
+        // self.node_ctx.set_partition_mining(true).await?;
+        self.node_ctx.start_mining().await?;
         self.wait_until_height(height + num_blocks as u64, 60 * num_blocks)
             .await?;
         self.node_ctx
@@ -830,12 +831,15 @@ pub async fn mine_block(
     node_ctx: &IrysNodeCtx,
 ) -> eyre::Result<Option<(Arc<IrysBlockHeader>, EthBuiltPayload)>> {
     let vdf_steps_guard = node_ctx.vdf_steps_guard.clone();
+    node_ctx.start_vdf().await?;
     let poa_solution = capacity_chunk_solution(
         node_ctx.config.node_config.miner_address(),
         vdf_steps_guard.clone(),
         &node_ctx.config,
     )
     .await;
+    node_ctx.stop_vdf().await?;
+
     node_ctx
         .actor_addresses
         .block_producer
@@ -855,12 +859,6 @@ where
     F: Future<Output = T> + Unpin,
 {
     loop {
-        let poa_solution = capacity_chunk_solution(
-            node_ctx.config.node_config.miner_address(),
-            node_ctx.vdf_steps_guard.clone(),
-            &node_ctx.config,
-        )
-        .await;
         let race = select(&mut future, Box::pin(sleep(timeout_duration))).await;
         match race {
             // provided future finished
@@ -870,13 +868,7 @@ where
                 info!("deployment timed out, creating new block..")
             }
         };
-
-        let _ = node_ctx
-            .actor_addresses
-            .block_producer
-            .send(SolutionFoundMessage(poa_solution.clone()))
-            .await?
-            .unwrap();
+        mine_block(&node_ctx).await?;
     }
 }
 

--- a/crates/vdf/src/vdf.rs
+++ b/crates/vdf/src/vdf.rs
@@ -77,7 +77,8 @@ pub fn run_vdf(
     let nonce_limiter_reset_frequency = config.reset_frequency as u64;
 
     // maintain a state of whether or not this vdf loop should be mining
-    let mut vdf_mining: bool = true;
+    // don't start the VDF right away
+    let mut vdf_mining: bool = false;
 
     loop {
         if shutdown_listener.try_recv().is_ok() {
@@ -289,7 +290,9 @@ mod tests {
 
         let broadcast_mining_service = MockMining;
         let (_, ff_step_receiver) = mpsc::unbounded_channel::<VdfStep>();
-        let (_, mining_state_rx) = mpsc::channel::<bool>(1);
+
+        let (mining_state_tx, mining_state_rx) = mpsc::channel::<bool>(1);
+        mining_state_tx.send(true).await.unwrap();
 
         let vdf_state = mocked_vdf_service(&config).await;
         let vdf_steps_guard = VdfStateReadonly::new(vdf_state.clone());


### PR DESCRIPTION
**Describe the changes**
This PR:
- changes the VDF thread to be in a "paused" state by default
- adds new VDF control methods to IrysNodeCtx
- updates tests & util methods where appropriate
