### PR TITLE
feat: cash / index separation for commitment transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4742,6 +4742,7 @@ dependencies = [
  "alloy-signer-local",
  "assert_matches",
  "async-trait",
+ "atomic-write-file",
  "base58",
  "eyre",
  "futures",
@@ -5155,6 +5156,7 @@ dependencies = [
  "serde",
  "serde_json",
  "test-log",
+ "tokio",
  "toml",
  "tracing",
 ]

--- a/crates/actors/Cargo.toml
+++ b/crates/actors/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 
 [dependencies]
 assert_matches = "1.5.0"
+atomic-write-file = "0.2"
 irys-types.workspace = true
 irys-database.workspace = true
 irys-packing.workspace = true

--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -10,11 +10,11 @@ use irys_database::{
     db_cache::{data_size_to_chunk_count, DataRootLRUEntry},
     submodule::get_data_size_by_data_root,
     tables::{CachedChunks, CachedChunksIndex, DataRootLRU, IngressProofs},
-    {insert_tx_header, tx_header_by_txid, SystemLedger},
+    {insert_tx_header, tx_header_by_txid},
 };
 use irys_primitives::CommitmentType;
 use irys_reth_node_bridge::{ext::IrysRethRpcTestContextExt, IrysRethNodeAdapter};
-use irys_storage::StorageModulesReadGuard;
+use irys_storage::{get_atomic_file, RecoveredMempoolState, StorageModulesReadGuard};
 use irys_types::{
     app_state::DatabaseProvider, chunk::UnpackedChunk, hash_sha256, irys::IrysSigner,
     validate_path, Address, CommitmentTransaction, Config, DataLedger, DataRoot, GossipData,
@@ -28,13 +28,15 @@ use reth_db::{
     cursor::DbDupCursorRO as _, transaction::DbTx as _, transaction::DbTxMut as _, Database as _,
     DatabaseError,
 };
+use std::fs;
+use std::io::Write;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     num::NonZeroUsize,
     pin::pin,
     sync::Arc,
 };
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, oneshot};
 use tokio::{
     sync::{mpsc::UnboundedReceiver, mpsc::UnboundedSender, RwLock},
     task::JoinHandle,
@@ -146,14 +148,11 @@ pub enum MempoolServiceMessage {
     /// Block Confirmed, remove confirmed txns from mempool
     BlockConfirmedMessage(Arc<IrysBlockHeader>, Arc<Vec<IrysTransactionHeader>>),
     /// Get IrysTransactionHeader
-    GetTransaction(
-        H256,
-        tokio::sync::oneshot::Sender<Option<IrysTransactionHeader>>,
-    ),
+    GetTransaction(H256, oneshot::Sender<Option<IrysTransactionHeader>>),
     /// Ingress Chunk, Add to CachedChunks, generate_ingress_proof, gossip chunk
     ChunkIngressMessage(
         UnpackedChunk,
-        tokio::sync::oneshot::Sender<Result<(), ChunkIngressError>>,
+        oneshot::Sender<Result<(), ChunkIngressError>>,
     ),
     /// Ingress CommitmentTransaction into the mempool
     ///
@@ -166,21 +165,23 @@ pub enum MempoolServiceMessage {
     /// - Caches the transaction for unstaked signers to be reprocessed later
     CommitmentTxIngressMessage(
         CommitmentTransaction,
-        tokio::sync::oneshot::Sender<Result<(), TxIngressError>>,
+        oneshot::Sender<Result<(), TxIngressError>>,
     ),
     /// Return filtered list of candidate txns
     /// Filtering based on funding status etc based on the provided EVM block ID
     /// If `None` is provided, the latest canonical block is used
-    GetBestMempoolTxs(Option<BlockId>, tokio::sync::oneshot::Sender<MempoolTxs>),
+    GetBestMempoolTxs(Option<BlockId>, oneshot::Sender<MempoolTxs>),
+    /// Retrieves a list of CommitmentTransactions based on the provided tx ids
+    GetCommitmentTxs {
+        commitment_tx_ids: Vec<IrysTransactionId>,
+        response: oneshot::Sender<HashMap<IrysTransactionId, CommitmentTransaction>>,
+    },
     /// Confirm if tx exists in database
-    TxExistenceQuery(
-        H256,
-        tokio::sync::oneshot::Sender<Result<bool, TxIngressError>>,
-    ),
+    TxExistenceQuery(H256, oneshot::Sender<Result<bool, TxIngressError>>),
     /// validate and process an incoming IrysTransactionHeader
     TxIngressMessage(
         IrysTransactionHeader,
-        tokio::sync::oneshot::Sender<Result<(), TxIngressError>>,
+        oneshot::Sender<Result<(), TxIngressError>>,
     ),
 }
 
@@ -269,6 +270,8 @@ impl MempoolService {
     async fn start(mut self) -> eyre::Result<()> {
         tracing::info!("starting Mempool service");
 
+        self.inner.restore_mempool_from_disk().await;
+
         let mut shutdown_future = pin!(self.shutdown);
         let shutdown_guard = loop {
             tokio::select! {
@@ -320,6 +323,8 @@ impl MempoolService {
 
         // explicitly inform the TaskManager that we're shutting down
         drop(shutdown_guard);
+
+        self.inner.persist_mempool_to_disk().await?;
 
         tracing::info!("shutting down Mempool service");
         Ok(())
@@ -590,29 +595,29 @@ impl Inner {
                 }
             }
 
-            // HACK HACK: in order for block discovery to validate incoming blocks
-            // it needs to read commitment tx from the database. Ideally it should
-            // be reading them from the mempool_service in memory cache, but we are
-            // putting off that work until the actix mempool_service is rewritten as a
-            // tokio service.
-            match self.irys_db.update_eyre(|db_tx| {
-                irys_database::insert_commitment_tx(db_tx, &commitment_tx)?;
-                Ok(())
-            }) {
-                Ok(()) => {
-                    info!(
-                        "Successfully stored commitment_tx in db {:?}",
-                        commitment_tx.id.0.to_base58()
-                    );
-                }
-                Err(db_error) => {
-                    error!(
-                        "Failed to store commitment_tx in db {:?}: {:?}",
-                        commitment_tx.id.0.to_base58(),
-                        db_error
-                    );
-                }
-            }
+            // // HACK HACK: in order for block discovery to validate incoming blocks
+            // // it needs to read commitment tx from the database. Ideally it should
+            // // be reading them from the mempool_service in memory cache, but we are
+            // // putting off that work until the actix mempool_service is rewritten as a
+            // // tokio service.
+            // match self.irys_db.update_eyre(|db_tx| {
+            //     irys_database::insert_commitment_tx(db_tx, &commitment_tx)?;
+            //     Ok(())
+            // }) {
+            //     Ok(()) => {
+            //         info!(
+            //             "Successfully stored commitment_tx in db {:?}",
+            //             commitment_tx.id.0.to_base58()
+            //         );
+            //     }
+            //     Err(db_error) => {
+            //         error!(
+            //             "Failed to store commitment_tx in db {:?}: {:?}",
+            //             commitment_tx.id.0.to_base58(),
+            //             db_error
+            //         );
+            //     }
+            // }
 
             // Gossip transaction
             self.service_senders
@@ -666,19 +671,6 @@ impl Inner {
             mempool_state_write_guard.recent_valid_tx.remove(txid);
         }
         drop(mempool_state_write_guard);
-
-        // Is there a commitment ledger in this block?
-        let commitment_ledger = block
-            .system_ledgers
-            .iter()
-            .find(|b| b.ledger_id == SystemLedger::Commitment);
-
-        if let Some(commitment_ledger) = commitment_ledger {
-            for txid in commitment_ledger.tx_ids.iter() {
-                // Remove the commitment tx from the pending valid_tx pool
-                self.remove_commitment_tx(txid).await;
-            }
-        }
 
         let published_txids = &block.data_ledgers[DataLedger::Publish].tx_ids.0;
 
@@ -1052,6 +1044,7 @@ impl Inner {
     ) -> MempoolTxs {
         let mempool_state = &self.mempool_state;
         let mut fees_spent_per_address = HashMap::new();
+        let mut confirmed_commitments = HashSet::new();
         let mut commitment_tx = Vec::new();
         let mut unfunded_address = HashSet::new();
 
@@ -1098,6 +1091,23 @@ impl Inner {
             has_funds
         };
 
+        // Get a list of all recently confirmed commitment txids in the canonical chain
+        let (canonical, _) = self.block_tree_read_guard.read().get_canonical_chain();
+        for (block_hash, _, _, _) in canonical {
+            // TODO: replace this with data from the canonical chain entry when block_tree refactors the tuple
+            let commitment_tx_ids = self
+                .block_tree_read_guard
+                .read()
+                .get_block(&block_hash)
+                .unwrap()
+                .get_commitment_ledger_tx_ids();
+
+            // Remove any confirmed commitment tx
+            for tx_id in commitment_tx_ids {
+                confirmed_commitments.insert(tx_id);
+            }
+        }
+
         // Process commitments in priority order (stakes then pledges)
         // This order ensures stake transactions are processed before pledges
 
@@ -1120,6 +1130,9 @@ impl Inner {
 
             // Select fundable commitments in fee-priority order
             for tx in sorted_commitments {
+                if confirmed_commitments.contains(&tx.id) {
+                    continue; // Skip already confirmed
+                }
                 if check_funding(&tx) {
                     commitment_tx.push(tx);
                 }
@@ -1349,6 +1362,51 @@ impl Inner {
         }
     }
 
+    async fn handle_get_commitment_txs(
+        &self,
+        commitment_tx_ids: Vec<H256>,
+    ) -> HashMap<IrysTransactionId, CommitmentTransaction> {
+        let mut hash_map = HashMap::new();
+
+        // first flat_map all the commitment transactions
+        let mempool_state = &self.mempool_state;
+        let mempool_state_guard = mempool_state.read().await;
+
+        // Get any CommitmentTransactions from the valid commitments Map
+        mempool_state_guard
+            .valid_commitment_tx
+            .values()
+            .flat_map(|txs| txs.iter())
+            .for_each(|tx| {
+                hash_map.insert(tx.id, tx.clone());
+            });
+
+        // Get any CommitmentTransactions from the pending commitments LRU cache
+        mempool_state_guard
+            .pending_pledges
+            .iter()
+            .flat_map(|(_, inner)| inner.iter())
+            .for_each(|(tx_id, tx)| {
+                hash_map.insert(*tx_id, tx.clone());
+            });
+
+        debug!(
+            "handle_get_commitment_tsx: {:?}",
+            hash_map.iter().map(|x| x.0).collect::<Vec<_>>()
+        );
+
+        // Attempt to locate and retain only the requested tx_ids
+        let mut filtered_map = HashMap::with_capacity(commitment_tx_ids.len());
+        for txid in commitment_tx_ids {
+            if let Some(tx) = hash_map.get(&txid) {
+                filtered_map.insert(txid, tx.clone());
+            }
+        }
+
+        // Return only the transactions matching the requested IDs
+        filtered_map
+    }
+
     #[tracing::instrument(skip_all, err)]
     /// handle inbound MempoolServiceMessage and send oneshot responses where required to do so
     fn handle_message<'a>(
@@ -1388,6 +1446,15 @@ impl Inner {
                         tracing::error!("response.send() error: {:?}", e);
                     };
                 }
+                MempoolServiceMessage::GetCommitmentTxs {
+                    commitment_tx_ids,
+                    response,
+                } => {
+                    let response_value = self.handle_get_commitment_txs(commitment_tx_ids).await;
+                    if let Err(e) = response.send(response_value) {
+                        tracing::error!("response.send() error: {:?}", e);
+                    };
+                }
                 MempoolServiceMessage::TxExistenceQuery(txid, response) => {
                     let response_value = self.handle_tx_existence_query(txid).await;
                     if let Err(e) = response.send(response_value) {
@@ -1417,8 +1484,84 @@ impl Inner {
             .inspect_err(|e| error!("database error reading tx: {:?}", e))
     }
 
+    async fn persist_mempool_to_disk(&self) -> eyre::Result<()> {
+        let base_path = self.config.node_config.mempool_dir();
+
+        let commitment_tx_path = base_path.join("commitment_tx");
+        fs::create_dir_all(commitment_tx_path.clone())
+            .expect("to create the mempool/commitment_tx dir");
+        let commitment_hash_map = self.get_all_commitment_tx().await;
+        for tx in commitment_hash_map.values() {
+            // Create a filepath for this transaction
+            let tx_path = commitment_tx_path.join(format!("{}.json", tx.id.0.to_base58()));
+
+            // Check to see if the file exists
+            if tx_path.exists() {
+                continue;
+            }
+
+            // If not, write it to  {mempool_dir}/commitment_tx/{txid}.json
+            let json = serde_json::to_string(tx).unwrap();
+            debug!("{}", json);
+            debug!("{}", tx_path.to_str().unwrap());
+
+            let mut file = get_atomic_file(tx_path).unwrap();
+            file.write_all(json.as_bytes())?;
+            file.commit()?;
+        }
+
+        // TODO: Do the same for all the pending storage tx
+        let _storage_tx_path = base_path.join("storage_tx");
+
+        Ok(())
+    }
+
+    /// should really only be called by persist_mempool_to_disk, all other scenarios need a more
+    /// subtle filtering of commitment state, recently confirmed? pending? valid? etc.
+    async fn get_all_commitment_tx(&self) -> HashMap<IrysTransactionId, CommitmentTransaction> {
+        let mut hash_map = HashMap::new();
+
+        // first flat_map all the commitment transactions
+        let mempool_state = &self.mempool_state;
+        let mempool_state_guard = mempool_state.read().await;
+
+        // Get any CommitmentTransactions from the valid commitments
+        mempool_state_guard
+            .valid_commitment_tx
+            .values()
+            .flat_map(|txs| txs.iter())
+            .for_each(|tx| {
+                hash_map.insert(tx.id, tx.clone());
+            });
+
+        // Get any CommitmentTransactions from the pending commitments
+        mempool_state_guard
+            .pending_pledges
+            .iter()
+            .flat_map(|(_, inner)| inner.iter())
+            .for_each(|(tx_id, tx)| {
+                hash_map.insert(*tx_id, tx.clone());
+            });
+
+        hash_map
+    }
+
+    async fn restore_mempool_from_disk(&mut self) {
+        let recovered =
+            RecoveredMempoolState::load_from_disk(&self.config.node_config.mempool_dir()).await;
+
+        for (_txid, commitment_tx) in recovered.commitment_txs {
+            self.handle_commitment_tx_ingress_message(commitment_tx)
+                .await
+                .unwrap(); // We don't care about the outcome, just giving the mempool a crack at validating it
+        }
+
+        // TODO: Similar logic for storage_tx
+    }
+
     /// Removes a commitment transaction with the specified transaction ID from the valid_commitment_tx map
     /// Returns true if the transaction was found and removed, false otherwise
+    #[allow(dead_code)]
     async fn remove_commitment_tx(&mut self, txid: &H256) -> bool {
         let mut found = false;
 

--- a/crates/chain/tests/api/tx_commitments.rs
+++ b/crates/chain/tests/api/tx_commitments.rs
@@ -4,6 +4,7 @@ use alloy_core::primitives::U256;
 use alloy_genesis::GenesisAccount;
 use assert_matches::assert_matches;
 use base58::ToBase58;
+use eyre::eyre;
 use irys_actors::{
     packing::wait_for_packing, CommitmentCacheMessage, CommitmentCacheStatus,
     CommitmentStateReadGuard, GetCommitmentStateGuardMessage, GetPartitionAssignmentsGuardMessage,
@@ -16,6 +17,282 @@ use irys_testing_utils::initialize_tracing;
 use irys_types::{irys::IrysSigner, Address, CommitmentTransaction, NodeConfig, H256};
 use tokio::time::Duration;
 use tracing::{debug, debug_span, info};
+macro_rules! assert_ok {
+    ($result:expr) => {
+        match $result {
+            Ok(val) => val,
+            Err(e) => panic!("Assertion failed: {:?}", e),
+        }
+    };
+}
+
+#[actix_web::test]
+async fn heavy_test_commitments_3epochs_test() -> eyre::Result<()> {
+    // ===== TEST ENVIRONMENT SETUP =====
+    // Configure logging to reduce noise while keeping relevant commitment outputs
+    std::env::set_var("RUST_LOG", "debug,irys_database=off,irys_actors::block_producer=off,irys_p2p::gossip_service=off,irys_actors::storage_module_service=off,trie=off,irys_reth::evm=off,engine::root=off,irys_p2p::peer_list=off,storage::db::mdbx=off,reth_basic_payload_builder=off,irys_gossip_service=off,providers::db=off,reth_payload_builder::service=off,irys_actors::broadcast_mining_service=off,reth_ethereum_payload_builder=off,provider::static_file=off,engine::persistence=off,provider::storage_writer=off,reth_engine_tree::persistence=off,irys_actors::cache_service=off,irys_actors::block_validation=off,irys_vdf=off,irys_actors::block_tree_service=off,irys_actors::vdf_service=off,rys_gossip_service::service=off,eth_ethereum_payload_builder=off,reth_node_events::node=off,reth::cli=off,reth_engine_tree::tree=off,irys_actors::ema_service=off,irys_efficient_sampling=off,hyper_util::client::legacy::connect::http=off,hyper_util::client::legacy::pool=off,irys_database::migration::v0_to_v1=off,irys_storage::storage_module=off,actix_server::worker=off,irys::packing::update=off,engine::tree=off,irys_actors::mining=error,payload_builder=off,irys_actors::reth_service=off,irys_actors::packing=off,irys_actors::reth_service=off,irys::packing::progress=off,irys_chain::vdf=off,irys_vdf::vdf_state=off");
+    initialize_tracing();
+
+    // ===== TEST PURPOSE: Multiple Epochs with Commitments =====
+    // This test verifies that:
+    // 1. Stake and pledge commitments are correctly processed across multiple epoch transitions
+    // 2. Partition assignments are properly created and maintained for all pledges
+    // 3. The commitment state correctly tracks stake and pledge relationships
+
+    // Configure a test network with accelerated epochs (2 blocks per epoch)
+    let num_blocks_in_epoch = 2;
+    let mut config = NodeConfig::testnet_with_epochs(num_blocks_in_epoch);
+
+    // Create multiple signers to test different commitment scenarios
+    let signer1 = IrysSigner::random_signer(&config.consensus_config());
+    let signer2 = IrysSigner::random_signer(&config.consensus_config());
+    let signer1_address = signer1.address();
+    let signer2_address = signer2.address();
+
+    config.fund_genesis_accounts(vec![&signer1, &signer2]);
+
+    let genesis_signer = config.miner_address();
+    let genesis_parts_before;
+    let signer1_parts_before;
+    let signer2_parts_before;
+
+    let node = {
+        // Start a test node with custom configuration
+        let node = IrysNodeTest::new_genesis(config.clone())
+            .start_and_wait_for_packing("GENESIS", 10)
+            .await;
+
+        // Initialize blockchain components
+        node.start_mining().await;
+
+        let uri = format!(
+            "http://127.0.0.1:{}",
+            node.node_ctx.config.node_config.http.bind_port
+        );
+
+        // Initialize blockchain components
+        wait_for_packing(
+            node.node_ctx.actor_addresses.packing.clone(),
+            Some(Duration::from_secs(10)),
+        )
+        .await?;
+
+        // Initialize API for submitting commitment transactions
+        let api_state = node.node_ctx.get_api_state();
+
+        let _app = actix_web::test::init_service(
+            App::new()
+                .wrap(Logger::default())
+                .app_data(actix_web::web::Data::new(api_state))
+                .service(routes()),
+        )
+        .await;
+
+        // Get access to commitment and partition services for verification
+        let epoch_service = node.node_ctx.actor_addresses.epoch_service.clone();
+        let commitment_state_guard = epoch_service
+            .send(GetCommitmentStateGuardMessage)
+            .await
+            .unwrap();
+        let pa_guard = epoch_service
+            .send(GetPartitionAssignmentsGuardMessage)
+            .await
+            .unwrap();
+
+        // ===== PHASE 1: Verify Genesis Block Initialization =====
+        // Check that the genesis block producer has the expected initial pledges
+
+        {
+            let commitment_state = commitment_state_guard.read();
+            let pledges = commitment_state.pledge_commitments.get(&genesis_signer);
+            if let Some(pledges) = pledges {
+                assert_eq!(
+                    pledges.len(),
+                    3,
+                    "Genesis miner should have exactly 3 pledges"
+                );
+            } else {
+                panic!("Expected genesis miner to have pledges!");
+            }
+            drop(commitment_state); // Release lock to allow node operations
+        }
+
+        // ===== PHASE 2: First Epoch - Create Commitments =====
+        // Create stake commitment for first test signer
+        post_stake_commitment(&uri, &signer1).await;
+
+        // Create two pledge commitments for first test signer
+        let anchor = post_pledge_commitment(&uri, &signer1, H256::default())
+            .await
+            .id;
+        post_pledge_commitment(&uri, &signer1, anchor).await;
+
+        // Create stake commitment for second test signer
+        post_stake_commitment(&uri, &signer2).await;
+
+        // Mine enough blocks to reach the first epoch boundary
+        info!("MINE FIRST EPOCH BLOCK:");
+        node.mine_blocks(num_blocks_in_epoch).await?;
+
+        // ===== PHASE 3: Verify First Epoch Assignments =====
+        // Verify that all pledges have been assigned partitions
+        assert_ok!(validate_pledge_assignments(
+            &commitment_state_guard,
+            &pa_guard,
+            "genesis",
+            &genesis_signer,
+        ));
+        assert_ok!(validate_pledge_assignments(
+            &commitment_state_guard,
+            &pa_guard,
+            "signer1",
+            &signer1.address(),
+        ));
+
+        // Verify commitment state contains expected pledges and stakes
+        {
+            let commitment_state = commitment_state_guard.read();
+
+            // Check genesis miner pledges
+            let pledges = commitment_state
+                .pledge_commitments
+                .get(&genesis_signer)
+                .expect("Expected genesis miner pledges!");
+            assert_eq!(
+                pledges.len(),
+                3,
+                "Genesis miner should still have 3 pledges after first epoch"
+            );
+
+            // Check signer1 pledges and stake
+            let pledges = commitment_state
+                .pledge_commitments
+                .get(&signer1.address())
+                .expect("Expected signer1 miner pledges!");
+            assert_eq!(
+                pledges.len(),
+                2,
+                "Signer1 should have 2 pledges after first epoch"
+            );
+
+            let stake = commitment_state.stake_commitments.get(&signer1.address());
+            assert_matches!(stake, Some(_), "Signer1 should have a stake commitment");
+            drop(commitment_state);
+        }
+
+        // ===== PHASE 4: Second Epoch - Add More Commitments =====
+        // Create pledge for second test signer
+        let c_tx = post_pledge_commitment(&uri, &signer2, H256::default()).await;
+        info!("signer2: {} post pledge: {}", signer2_address, c_tx.id);
+
+        // Mine enough blocks to reach the second epoch boundary
+        info!("MINE SECOND EPOCH BLOCK:");
+        node.mine_blocks(num_blocks_in_epoch + 2).await?;
+
+        // ===== PHASE 5: Verify Second Epoch Assignments =====
+        // Verify all signers have proper partition assignments for all pledges
+        genesis_parts_before = assert_ok!(validate_pledge_assignments(
+            &commitment_state_guard,
+            &pa_guard,
+            "genesis",
+            &genesis_signer,
+        ));
+        signer1_parts_before = assert_ok!(validate_pledge_assignments(
+            &commitment_state_guard,
+            &pa_guard,
+            "signer1",
+            &signer1_address,
+        ));
+        signer2_parts_before = assert_ok!(validate_pledge_assignments(
+            &commitment_state_guard,
+            &pa_guard,
+            "signer2",
+            &signer2_address,
+        ));
+
+        node
+    };
+
+    // Restart the node
+    info!("Restarting node");
+    let restarted_node = node.stop().await.start().await;
+
+    // Get access to commitment and partition services for verification
+    let epoch_service = restarted_node
+        .node_ctx
+        .actor_addresses
+        .epoch_service
+        .clone();
+    let commitment_state_guard = epoch_service
+        .send(GetCommitmentStateGuardMessage)
+        .await
+        .unwrap();
+    let pa_guard = epoch_service
+        .send(GetPartitionAssignmentsGuardMessage)
+        .await
+        .unwrap();
+
+    // Make sure genesis has 3 commitments (1 stake, 2 pledge)
+    assert_eq!(
+        commitment_state_guard
+            .read()
+            .pledge_commitments
+            .get(&genesis_signer)
+            .expect("commitments for genesis miner")
+            .len(),
+        3
+    );
+
+    // Make sure signer1 has 2 commitments (1 stake, 1 pledge)
+    assert_eq!(
+        commitment_state_guard
+            .read()
+            .pledge_commitments
+            .get(&signer1.address())
+            .expect("commitments for genesis miner")
+            .len(),
+        2
+    );
+
+    // Make sure signer2 has 1 commitments (1 stake, 0 pledge)
+    assert_eq!(
+        commitment_state_guard
+            .read()
+            .pledge_commitments
+            .get(&signer2.address())
+            .expect("commitments for genesis miner")
+            .len(),
+        1
+    );
+
+    // Verify the partition assignments persist (and the map to the same pledges)
+    let genesis_parts_after = assert_ok!(validate_pledge_assignments(
+        &commitment_state_guard,
+        &pa_guard,
+        "genesis",
+        &genesis_signer,
+    ));
+    let signer1_parts_after = assert_ok!(validate_pledge_assignments(
+        &commitment_state_guard,
+        &pa_guard,
+        "signer1",
+        &signer1.address(),
+    ));
+    let signer2_parts_after = assert_ok!(validate_pledge_assignments(
+        &commitment_state_guard,
+        &pa_guard,
+        "signer2",
+        &signer2.address(),
+    ));
+
+    assert_eq!(genesis_parts_after, genesis_parts_before);
+    assert_eq!(signer1_parts_after, signer1_parts_before);
+    assert_eq!(signer2_parts_after, signer2_parts_before);
+
+    // ===== TEST CLEANUP =====
+    restarted_node.node_ctx.stop().await;
+    Ok(())
+}
 
 #[actix_web::test]
 async fn heavy_no_commitments_basic_test() -> eyre::Result<()> {
@@ -222,236 +499,6 @@ async fn get_commitment_status(
         .expect("to receive CommitmentStatus from GetCommitmentStatus message")
 }
 
-#[actix_web::test]
-async fn heavy_test_commitments_3epochs_test() -> eyre::Result<()> {
-    // ===== TEST ENVIRONMENT SETUP =====
-    // Configure logging to reduce noise while keeping relevant commitment outputs
-    std::env::set_var("RUST_LOG", "debug,reth_basic_payload_builder=off,irys_gossip_service=off,providers::db=off,reth_payload_builder::service=off,irys_actors::broadcast_mining_service=off,reth_ethereum_payload_builder=off,provider::static_file=off,engine::persistence=off,provider::storage_writer=off,reth_engine_tree::persistence=off,irys_actors::cache_service=off,irys_actors::block_validation=off,irys_vdf=off,irys_actors::block_tree_service=off,irys_actors::vdf_service=off,rys_gossip_service::service=off,eth_ethereum_payload_builder=off,reth_node_events::node=off,reth::cli=off,reth_engine_tree::tree=off,irys_actors::ema_service=off,irys_efficient_sampling=off,hyper_util::client::legacy::connect::http=off,hyper_util::client::legacy::pool=off,irys_database::migration::v0_to_v1=off,irys_storage::storage_module=off,actix_server::worker=off,irys::packing::update=off,engine::tree=off,irys_actors::mining=error,payload_builder=off,irys_actors::block_producer=info,irys_actors::reth_service=off,irys_actors::packing=off,irys_actors::reth_service=off,irys::packing::progress=off,irys_chain::vdf=off,irys_vdf::vdf_state=off");
-
-    // ===== TEST PURPOSE: Multiple Epochs with Commitments =====
-    // This test verifies that:
-    // 1. Stake and pledge commitments are correctly processed across multiple epoch transitions
-    // 2. Partition assignments are properly created and maintained for all pledges
-    // 3. The commitment state correctly tracks stake and pledge relationships
-
-    // Configure a test network with accelerated epochs (2 blocks per epoch)
-    let num_blocks_in_epoch = 2;
-    let mut config = NodeConfig::testnet_with_epochs(num_blocks_in_epoch);
-
-    // Create multiple signers to test different commitment scenarios
-    let signer1 = IrysSigner::random_signer(&config.consensus_config());
-    let signer2 = IrysSigner::random_signer(&config.consensus_config());
-
-    config.fund_genesis_accounts(vec![&signer1, &signer2]);
-
-    let genesis_signer = config.miner_address();
-    let genesis_parts_before;
-    let signer1_parts_before;
-    let signer2_parts_before;
-
-    let node = {
-        // Start a test node with custom configuration
-        let node = IrysNodeTest::new_genesis(config.clone())
-            .start_and_wait_for_packing("GENESIS", 10)
-            .await;
-
-        // Initialize blockchain components
-        node.start_mining().await;
-
-        let uri = format!(
-            "http://127.0.0.1:{}",
-            node.node_ctx.config.node_config.http.bind_port
-        );
-
-        // Initialize blockchain components
-        wait_for_packing(
-            node.node_ctx.actor_addresses.packing.clone(),
-            Some(Duration::from_secs(10)),
-        )
-        .await?;
-
-        // Initialize API for submitting commitment transactions
-        let api_state = node.node_ctx.get_api_state();
-
-        let _app = actix_web::test::init_service(
-            App::new()
-                .wrap(Logger::default())
-                .app_data(actix_web::web::Data::new(api_state))
-                .service(routes()),
-        )
-        .await;
-
-        // Get access to commitment and partition services for verification
-        let epoch_service = node.node_ctx.actor_addresses.epoch_service.clone();
-        let commitment_state_guard = epoch_service
-            .send(GetCommitmentStateGuardMessage)
-            .await
-            .unwrap();
-        let pa_guard = epoch_service
-            .send(GetPartitionAssignmentsGuardMessage)
-            .await
-            .unwrap();
-
-        // ===== PHASE 1: Verify Genesis Block Initialization =====
-        // Check that the genesis block producer has the expected initial pledges
-
-        {
-            let commitment_state = commitment_state_guard.read();
-            let pledges = commitment_state.pledge_commitments.get(&genesis_signer);
-            if let Some(pledges) = pledges {
-                assert_eq!(
-                    pledges.len(),
-                    3,
-                    "Genesis miner should have exactly 3 pledges"
-                );
-            } else {
-                panic!("Expected genesis miner to have pledges!");
-            }
-            drop(commitment_state); // Release lock to allow node operations
-        }
-
-        // ===== PHASE 2: First Epoch - Create Commitments =====
-        // Create stake commitment for first test signer
-        post_stake_commitment(&uri, &signer1).await;
-
-        // Create two pledge commitments for first test signer
-        let anchor = post_pledge_commitment(&uri, &signer1, H256::default())
-            .await
-            .id;
-        post_pledge_commitment(&uri, &signer1, anchor).await;
-
-        // Create stake commitment for second test signer
-        post_stake_commitment(&uri, &signer2).await;
-
-        // Mine enough blocks to reach the first epoch boundary
-        info!("MINE FIRST EPOCH BLOCK:");
-        node.mine_blocks(num_blocks_in_epoch).await?;
-
-        // ===== PHASE 3: Verify First Epoch Assignments =====
-        // Verify that all pledges have been assigned partitions
-        validate_pledge_assignments(&commitment_state_guard, &pa_guard, &genesis_signer);
-        validate_pledge_assignments(&commitment_state_guard, &pa_guard, &signer1.address());
-
-        // Verify commitment state contains expected pledges and stakes
-        {
-            let commitment_state = commitment_state_guard.read();
-
-            // Check genesis miner pledges
-            let pledges = commitment_state
-                .pledge_commitments
-                .get(&genesis_signer)
-                .expect("Expected genesis miner pledges!");
-            assert_eq!(
-                pledges.len(),
-                3,
-                "Genesis miner should still have 3 pledges after first epoch"
-            );
-
-            // Check signer1 pledges and stake
-            let pledges = commitment_state
-                .pledge_commitments
-                .get(&signer1.address())
-                .expect("Expected signer1 miner pledges!");
-            assert_eq!(
-                pledges.len(),
-                2,
-                "Signer1 should have 2 pledges after first epoch"
-            );
-
-            let stake = commitment_state.stake_commitments.get(&signer1.address());
-            assert_matches!(stake, Some(_), "Signer1 should have a stake commitment");
-            drop(commitment_state);
-        }
-
-        // ===== PHASE 4: Second Epoch - Add More Commitments =====
-        // Create pledge for second test signer
-        post_pledge_commitment(&uri, &signer2, H256::default()).await;
-
-        // Mine enough blocks to reach the second epoch boundary
-        info!("MINE SECOND EPOCH BLOCK:");
-        node.mine_blocks(num_blocks_in_epoch + 2).await?;
-
-        // ===== PHASE 5: Verify Second Epoch Assignments =====
-        // Verify all signers have proper partition assignments for all pledges
-        genesis_parts_before =
-            validate_pledge_assignments(&commitment_state_guard, &pa_guard, &genesis_signer);
-        signer1_parts_before =
-            validate_pledge_assignments(&commitment_state_guard, &pa_guard, &signer1.address());
-        signer2_parts_before =
-            validate_pledge_assignments(&commitment_state_guard, &pa_guard, &signer2.address());
-
-        node
-    };
-
-    // Restart the node
-    info!("Restarting node");
-    let restarted_node = node.stop().await.start().await;
-
-    // Get access to commitment and partition services for verification
-    let epoch_service = restarted_node
-        .node_ctx
-        .actor_addresses
-        .epoch_service
-        .clone();
-    let commitment_state_guard = epoch_service
-        .send(GetCommitmentStateGuardMessage)
-        .await
-        .unwrap();
-    let pa_guard = epoch_service
-        .send(GetPartitionAssignmentsGuardMessage)
-        .await
-        .unwrap();
-
-    // Make sure genesis has 3 commitments (1 stake, 2 pledge)
-    assert_eq!(
-        commitment_state_guard
-            .read()
-            .pledge_commitments
-            .get(&genesis_signer)
-            .expect("commitments for genesis miner")
-            .len(),
-        3
-    );
-
-    // Make sure signer1 has 2 commitments (1 stake, 1 pledge)
-    assert_eq!(
-        commitment_state_guard
-            .read()
-            .pledge_commitments
-            .get(&signer1.address())
-            .expect("commitments for genesis miner")
-            .len(),
-        2
-    );
-
-    // Make sure signer2 has 1 commitments (1 stake, 0 pledge)
-    assert_eq!(
-        commitment_state_guard
-            .read()
-            .pledge_commitments
-            .get(&signer2.address())
-            .expect("commitments for genesis miner")
-            .len(),
-        1
-    );
-
-    // Verify the partition assignments persist (and the map to the same pledges)
-    let genesis_parts_after =
-        validate_pledge_assignments(&commitment_state_guard, &pa_guard, &genesis_signer);
-    let signer1_parts_after =
-        validate_pledge_assignments(&commitment_state_guard, &pa_guard, &signer1.address());
-    let signer2_parts_after =
-        validate_pledge_assignments(&commitment_state_guard, &pa_guard, &signer2.address());
-
-    assert_eq!(genesis_parts_after, genesis_parts_before);
-    assert_eq!(signer1_parts_after, signer1_parts_before);
-    assert_eq!(signer2_parts_after, signer2_parts_before);
-
-    // ===== TEST CLEANUP =====
-    restarted_node.node_ctx.stop().await;
-    Ok(())
-}
-
 async fn post_stake_commitment(uri: &str, signer: &IrysSigner) {
     let stake_tx = CommitmentTransaction {
         commitment_type: CommitmentType::Stake,
@@ -488,9 +535,11 @@ async fn post_pledge_commitment(
 fn validate_pledge_assignments(
     commitment_state_guard: &CommitmentStateReadGuard,
     pa_guard: &PartitionAssignmentsReadGuard,
+    address_name: &str,
     address: &Address,
-) -> Vec<H256> {
-    // Extract partition hashes from pledges
+) -> eyre::Result<Vec<H256>> {
+    // Get all partition hashes from this address's pledges
+    // Each pledge contains a partition_hash that identifies which partition the pledge is for
     let partition_hashes: Vec<Option<H256>> = commitment_state_guard
         .read()
         .pledge_commitments
@@ -498,37 +547,51 @@ fn validate_pledge_assignments(
         .map(|pledges| pledges.iter().map(|pledge| pledge.partition_hash).collect())
         .unwrap_or_default();
 
-    let direct = commitment_state_guard
-        .read()
-        .pledge_commitments
-        .get(address)
-        .unwrap()
-        .clone();
+    // Retrieve the full commitment state entries for this address
+    // These entries contain the complete pledge information needed for validation
+    // Note: mostly used for debug logging here
+    let binding = commitment_state_guard.read();
+    let result = binding.pledge_commitments.get(address);
+    let direct = match result {
+        Some(entries) => entries,
+        None => {
+            return Err(eyre!(
+                "Expected to find commitment entries for {}",
+                address_name
+            ))
+        }
+    };
 
     debug!(
-        "Got partition_hashes from pledges {:#?} {:#?}",
-        partition_hashes, direct
+        "\nGot partition_hashes from pledges for {} : address {}\nPartition Assignments in epoch_service:\n{:#?}\nPledge Status in CommitmentState:\n{:#?}",
+        address_name, address, partition_hashes, direct
     );
 
-    // Look up their partition assignments
+    // For each partition hash entry in the commitment state for this address
     for partition_hash in partition_hashes.iter() {
+        // Expect it to exist
         if let Some(partition_hash) = partition_hash {
+            // Check that the partition assignments state is in sync with the commitment state
+            // with regards to the partition_hash
             let pa = pa_guard.read().get_assignment(*partition_hash);
             match pa {
                 Some(pa) => {
                     // Verify the partition assignments in the partition assignment state
                     assert_eq!(&pa.miner_address, address);
                 }
-                None => panic!("expected partition assignment for hash"),
+                None => return Err(eyre::eyre!("expected partition assignment for hash")),
             }
         } else {
-            panic!("expected partition hash for pledge")
+            return Err(eyre::eyre!(
+                "expected partition hash for {}'s pledge, was None should be Some(partition_hash)",
+                address_name
+            ));
         }
     }
 
     // Return a vec of partition hashes
-    direct
+    Ok(direct
         .iter()
         .filter_map(|entry| entry.partition_hash)
-        .collect()
+        .collect())
 }

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -12,6 +12,7 @@ serde.workspace = true
 irys-types = { workspace = true, features = ["test-utils"] }
 rand.workspace = true
 tracing.workspace = true
+tokio.workspace = true
 serde_json.workspace = true
 toml.workspace = true
 irys-database.workspace = true

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -1,8 +1,9 @@
 pub use chunk_provider::*;
 pub use nodit::interval::*;
 pub use nodit::Interval;
-
 pub mod chunk_provider;
+pub mod recovered_mempool_state;
+pub use recovered_mempool_state::*;
 pub mod storage_module;
 pub use storage_module::*;
 pub mod irys_consensus_data_db;

--- a/crates/storage/src/recovered_mempool_state.rs
+++ b/crates/storage/src/recovered_mempool_state.rs
@@ -1,0 +1,47 @@
+use std::{collections::HashMap, path::Path};
+
+use irys_types::{CommitmentTransaction, H256};
+use tracing::debug;
+
+pub struct RecoveredMempoolState {
+    pub commitment_txs: HashMap<H256, CommitmentTransaction>,
+    // TODO:
+    // storage_txs
+}
+
+impl RecoveredMempoolState {
+    pub async fn load_from_disk(mempool_dir: &Path) -> Self {
+        let commitment_tx_path = mempool_dir.join("commitment_tx");
+        let mut commitment_txs = HashMap::new();
+
+        if !commitment_tx_path.exists() {
+            return Self { commitment_txs };
+        }
+
+        let Ok(mut entries) = tokio::fs::read_dir(&commitment_tx_path).await else {
+            return Self { commitment_txs };
+        };
+
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+
+            let Ok(json) = tokio::fs::read_to_string(&path).await else {
+                debug!("Failed to read {:?}", path);
+                continue;
+            };
+
+            let Ok(tx) = serde_json::from_str::<CommitmentTransaction>(&json) else {
+                debug!("Failed to parse {:?}", path);
+                continue;
+            };
+
+            commitment_txs.insert(tx.id, tx);
+            let _ = tokio::fs::remove_file(&path).await;
+        }
+
+        Self { commitment_txs }
+    }
+}

--- a/crates/types/src/block.rs
+++ b/crates/types/src/block.rs
@@ -227,6 +227,19 @@ impl IrysBlockHeader {
     ) -> u64 {
         previous_ema_recalculation_block_height(self.height, blocks_in_price_adjustment_interval)
     }
+
+    pub fn get_commitment_ledger_tx_ids(&self) -> Vec<H256> {
+        let mut commitment_txids = Vec::new();
+        // Because of a circular dependency the types crate can't import the SystemLedger enum
+        // SystemLedger::Commitments = 0, so finding `ledger_id: 0` here, locates the commitment ledger
+        let commitment_ledger = self.system_ledgers.iter().find(|l| l.ledger_id == 0);
+
+        if let Some(commitment_ledger) = commitment_ledger {
+            commitment_txids = commitment_ledger.tx_ids.0.clone();
+        }
+
+        commitment_txids
+    }
 }
 
 // treat any block whose height is a multiple of blocks_in_price_adjustment_interval

--- a/crates/types/src/config.rs
+++ b/crates/types/src/config.rs
@@ -741,6 +741,11 @@ impl NodeConfig {
     pub fn irys_consensus_data_dir(&self) -> PathBuf {
         self.base_directory.join("irys_consensus_data")
     }
+
+    /// get the irys mempool persistance path
+    pub fn mempool_dir(&self) -> PathBuf {
+        self.base_directory.join("mempool")
+    }
     /// get the reth data directory path
     pub fn reth_data_dir(&self) -> PathBuf {
         self.base_directory.join("reth")


### PR DESCRIPTION
### Problem

The node architecture is designed to maintain a clean separation between **cache** and **index** layers:

* **Cache**: in-memory (e.g. `block_tree`, `mempool`, `in-memory`)
* **Index**: persisted (e.g. `block_index`, `StorageModules`, `mdbx`)

To ship testnet quickly, this separation was blurred: storage and commitment transactions entering the **mempool (cache)** were being written **immediately** to the **DB (index)**.

This introduced several issues:

* Violates intended cache/index boundaries
* Creates potential denial-of-service attack vectors
* Obsoletes LRU caches in the mempool designed to carefully manage/cap data ingress resources

### Fixes

**Removed premature DB writes**:

* In `block_producer`: local blocks no longer write commitment tx directly to DB
* In `mempool_service`: ingress via gossip or HTTP no longer stores commitment tx in DB

**Reworked transaction access**:

1. `block_discovery` and other systems now query **both DB and mempool** for transaction headers.
2. `epoch_service` at startup now requires access to cached transactions to replay epoch blocks.
3. Introduced a new message for fetching commitment tx from the mempool with a list of txids
4. Added support for **persisting cached mempool tx to disk on shutdown** and **restoring cached tx from disk** at startup:

   * While not strictly neccessary, having this persist/restore path Enables clean single-node test runs with restarts when there is no other peers to sync with.
   * Still allows gossip to restore tx if needed

### Structural Change

A new struct, `RecoveredMempoolState`, handles loading persisted tx from disk. This breaks the circular startup dependency between `epoch_service` and `mempool_service`, allowing both to access restored tx early in initialization.

Another biprouct of this change is that when the `block_producer`  requests tx from the mempool to include in a block the mempool needs to filter out any tx that are in the current canonical chain. 


### Correct Insertion Point

The only correct moment to persist transactions to the DB is when they **reach a certain confirmation depth** in the `block_tree` where they migrate to the `block_index`. This PR enforces that rule. For testnet, confirmation depth is 1, but this will move to 5–6 soon to support recovering from fork lengths we expect to see in production.

### Updated Test
`heavy_test_commitments_3epochs_test` has been updated to improve its ability to detect errors in stake and pledge commitments and restarting a peer and restoring commitment state. This is done somewhat awkardly in `handle_get_best_mempool_txs()` and should be updated in a future pr.

### Validation Issues
In debugging these issues I found that when we accept a new block, we validate the the transactions are valid, but we don't validate if they are already in the parent blocks of the new block.  Including a txid that's already been included in the chain would make the block invalid and we need to check that.


**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).

**Additional Context**
* This PR focuses purely on getting  Cache/Index separation for commitment transactions in the mempool. 
* The work to support publish and submit transactions should be able to piggy back on this system and I've left some TODOs where it makes sense to add storage tx support.
* The improved validation that checks to see if a txid already exists in the chain will need to be added.
* Refactoring the ugly tuple in `block_tree` is coming in a future PR.



