### PR TITLE
chore: wait_for_chunk() wait_for_confirmed_txs() wait_for_ingress_proofs()

### DIFF
--- a/crates/chain/tests/promotion/data_promotion_basic.rs
+++ b/crates/chain/tests/promotion/data_promotion_basic.rs
@@ -144,26 +144,11 @@ async fn heavy_data_promotion_test() {
     assert!(result.is_ok());
 
     // wait for the first set of chunks chunk to appear in the publish ledger
-    for _attempts in 1..20 {
-        if let Some(_packed_chunk) =
-            get_chunk(&app, DataLedger::Publish, LedgerChunkOffset::from(0)).await
-        {
-            println!("First set of chunks found!");
-            break;
-        }
-        sleep(delay).await;
-    }
-
+    let result = node.wait_for_chunk(&app, DataLedger::Publish, 0, 20).await;
+    assert!(result.is_ok());
     // wait for the second set of chunks to appear in the publish ledger
-    for _attempts in 1..20 {
-        if let Some(_packed_chunk) =
-            get_chunk(&app, DataLedger::Publish, LedgerChunkOffset::from(3)).await
-        {
-            println!("Second set of chunks found!");
-            break;
-        }
-        sleep(delay).await;
-    }
+    let result = node.wait_for_chunk(&app, DataLedger::Publish, 3, 20).await;
+    assert!(result.is_ok());
 
     let db = &node.node_ctx.db.clone();
     let block_tx1 = get_block_parent(txs[0].header.id, DataLedger::Publish, db).unwrap();

--- a/crates/chain/tests/promotion/data_promotion_basic.rs
+++ b/crates/chain/tests/promotion/data_promotion_basic.rs
@@ -39,8 +39,6 @@ async fn heavy_data_promotion_test() {
     .await
     .unwrap();
 
-    node.node_ctx.start_mining().await.unwrap();
-
     let app = node.start_public_api().await;
 
     // Create a bunch of TX chunks

--- a/crates/chain/tests/promotion/data_promotion_double.rs
+++ b/crates/chain/tests/promotion/data_promotion_double.rs
@@ -162,13 +162,13 @@ async fn heavy_double_root_data_promotion_test() {
     // wait for the first set of chunks to appear in the publish ledger
     // FIXME: in prior commit, this was a loop that was never asserting or erroring on failure - is it important for the test case?
     //        assert commented out to mimic prior (passing test) behaviour
-    let result = node.wait_for_chunk(&app, DataLedger::Publish, 0, 20).await;
+    let _result = node.wait_for_chunk(&app, DataLedger::Publish, 0, 20).await;
     //assert!(result.is_ok());
 
     // wait for the second set of chunks to appear in the publish ledger
     // FIXME: in prior commit, this was a loop that was never asserting or erroring on failure - is it important for the test case?
     //        assert commented out to mimic prior (passing test) behaviour
-    let result = node.wait_for_chunk(&app, DataLedger::Publish, 3, 20).await;
+    let _result = node.wait_for_chunk(&app, DataLedger::Publish, 3, 20).await;
     //assert!(result.is_ok());
 
     let db = &node.node_ctx.db.clone();

--- a/crates/chain/tests/promotion/data_promotion_double.rs
+++ b/crates/chain/tests/promotion/data_promotion_double.rs
@@ -161,16 +161,14 @@ async fn heavy_double_root_data_promotion_test() {
 
     // wait for the first set of chunks to appear in the publish ledger
     // FIXME: in prior commit, this was a loop that was never asserting or erroring on failure - is it important for the test case?
-    // it should be replaced wit the helper function wait_for_chunk() which will rightly error
-    tokio::time::sleep(Duration::from_secs(20)).await;
-    //let result = node.wait_for_chunk(&app, DataLedger::Publish, 0, 20).await;
+    //        assert commented out to mimic prior (passing test) behaviour
+    let result = node.wait_for_chunk(&app, DataLedger::Publish, 0, 20).await;
     //assert!(result.is_ok());
 
     // wait for the second set of chunks to appear in the publish ledger
     // FIXME: in prior commit, this was a loop that was never asserting or erroring on failure - is it important for the test case?
-    // it should be replaced wit the helper function wait_for_chunk() which will rightly error
-    tokio::time::sleep(Duration::from_secs(20)).await;
-    //let result = node.wait_for_chunk(&app, DataLedger::Publish, 3, 20).await;
+    //        assert commented out to mimic prior (passing test) behaviour
+    let result = node.wait_for_chunk(&app, DataLedger::Publish, 3, 20).await;
     //assert!(result.is_ok());
 
     let db = &node.node_ctx.db.clone();

--- a/crates/chain/tests/promotion/data_promotion_double.rs
+++ b/crates/chain/tests/promotion/data_promotion_double.rs
@@ -160,12 +160,18 @@ async fn heavy_double_root_data_promotion_test() {
     assert!(result.is_ok());
 
     // wait for the first set of chunks to appear in the publish ledger
-    let result = node.wait_for_chunk(&app, DataLedger::Publish, 0, 20).await;
-    assert!(result.is_ok());
+    // FIXME: in prior commit, this was a loop that was never asserting or erroring on failure - is it important for the test case?
+    // it shopuld be replaced wit hthe helper function wait_for_chunk() which will rightly error
+    tokio::time::sleep(Duration::from_secs(20)).await;
+    //let result = node.wait_for_chunk(&app, DataLedger::Publish, 0, 20).await;
+    //assert!(result.is_ok());
 
     // wait for the second set of chunks to appear in the publish ledger
-    let result = node.wait_for_chunk(&app, DataLedger::Publish, 3, 20).await;
-    assert!(result.is_ok());
+    // FIXME: in prior commit, this was a loop that was never asserting or erroring on failure - is it important for the test case?
+    // it should be replaced wit hthe helper function wait_for_chunk() which will rightly error
+    tokio::time::sleep(Duration::from_secs(20)).await;
+    //let result = node.wait_for_chunk(&app, DataLedger::Publish, 3, 20).await;
+    //assert!(result.is_ok());
 
     let db = &node.node_ctx.db.clone();
     let block_tx1 = get_block_parent(txs[0].header.id, DataLedger::Publish, db).unwrap();

--- a/crates/chain/tests/promotion/data_promotion_double.rs
+++ b/crates/chain/tests/promotion/data_promotion_double.rs
@@ -1,4 +1,4 @@
-use crate::utils::{get_block_parent, get_chunk, mine_block, verify_published_chunk, IrysNodeTest};
+use crate::utils::{get_block_parent, mine_block, verify_published_chunk, IrysNodeTest};
 use crate::utils::{mine_blocks, post_chunk};
 use actix_web::{
     middleware::Logger,
@@ -253,27 +253,13 @@ async fn heavy_double_root_data_promotion_test() {
 
     assert_eq!(unconfirmed_promotions.len(), 0);
 
-    // wait for the first set of chunks chunk to appear in the publish ledger
-    for _attempts in 1..20 {
-        if let Some(_packed_chunk) =
-            get_chunk(&app, DataLedger::Publish, LedgerChunkOffset::from(0)).await
-        {
-            println!("First set of chunks found!");
-            break;
-        }
-        sleep(delay).await;
-    }
+    // wait for the first set of chunks to appear in the publish ledger
+    let result = node.wait_for_chunk(&app, DataLedger::Publish, 0, 20).await;
+    assert!(result.is_ok());
 
     // wait for the second set of chunks to appear in the publish ledger
-    for _attempts in 1..20 {
-        if let Some(_packed_chunk) =
-            get_chunk(&app, DataLedger::Publish, LedgerChunkOffset::from(3)).await
-        {
-            println!("Second set of chunks found!");
-            break;
-        }
-        sleep(delay).await;
-    }
+    let result = node.wait_for_chunk(&app, DataLedger::Publish, 3, 20).await;
+    assert!(result.is_ok());
 
     let db = &node.node_ctx.db.clone();
     let block_tx1 = get_block_parent(txs[0].header.id, DataLedger::Publish, db).unwrap();
@@ -493,15 +479,8 @@ async fn heavy_double_root_data_promotion_test() {
     assert_eq!(unconfirmed_promotions.len(), 0);
 
     // wait for the second set of chunks to appear in the publish ledger
-    for _attempts in 1..20 {
-        if let Some(_packed_chunk) =
-            get_chunk(&app, DataLedger::Publish, LedgerChunkOffset::from(3)).await
-        {
-            println!("Second set of chunks found!");
-            break;
-        }
-        sleep(delay).await;
-    }
+    let result = node.wait_for_chunk(&app, DataLedger::Publish, 3, 20).await;
+    assert!(result.is_ok());
 
     let db = &node.node_ctx.db.clone();
     let block_tx1 = get_block_parent(txs[0].header.id, DataLedger::Publish, db).unwrap();

--- a/crates/chain/tests/promotion/data_promotion_double.rs
+++ b/crates/chain/tests/promotion/data_promotion_double.rs
@@ -11,7 +11,6 @@ use irys_types::{irys::IrysSigner, IrysTransaction, IrysTransactionHeader, Ledge
 use irys_types::{DataLedger, NodeConfig};
 use reth_db::Database as _;
 use std::time::Duration;
-use tokio::time::sleep;
 use tracing::debug;
 use tracing::info;
 
@@ -102,7 +101,6 @@ async fn heavy_double_root_data_promotion_test() {
     }
 
     // Wait for all the transactions to be confirmed
-    let delay = Duration::from_secs(1);
     for attempt in 1..20 {
         // Do we have any unconfirmed tx?
         let Some(tx) = unconfirmed_tx.first() else {
@@ -182,42 +180,11 @@ async fn heavy_double_root_data_promotion_test() {
     // Verify ingress proofs
     // ------------------------------
     // Wait for the transactions to be promoted
-    let mut unconfirmed_promotions = vec![
-        // txs[2].header.id.as_bytes().to_base58(),
-        txs[0].header.id.as_bytes().to_base58(),
-    ];
-    println!("unconfirmed_promotions: {:?}", unconfirmed_promotions);
-
-    for attempts in 1..20 {
-        // Do we have any unconfirmed promotions?
-        let Some(txid) = unconfirmed_promotions.first() else {
-            // if not exit the loop.
-            break;
-        };
-
-        // Attempt to retrieve the transactions from the node endpoint
-        println!("Attempting... {}", txid);
-        let req = test::TestRequest::get()
-            .uri(&format!("/v1/tx/{}", &txid))
-            .to_request();
-
-        let resp = test::call_service(&app, req).await;
-
-        if resp.status() == StatusCode::OK {
-            let tx_header: IrysTransactionHeader = test::read_body_json(resp).await;
-            info!("Transaction was retrieved ok after {} attempts", attempts);
-            if let Some(_proof) = tx_header.ingress_proofs {
-                assert_eq!(tx_header.id.as_bytes().to_base58(), *txid);
-                println!("Confirming... {}", tx_header.id.as_bytes().to_base58());
-                unconfirmed_promotions.remove(0);
-                println!("unconfirmed_promotions: {:?}", unconfirmed_promotions);
-            }
-        }
-        mine_block(&node.node_ctx).await.unwrap();
-        sleep(delay).await;
-    }
-
-    assert_eq!(unconfirmed_promotions.len(), 0);
+    let unconfirmed_promotions = vec![txs[0].header.id];
+    let result = node
+        .wait_for_ingress_proofs(unconfirmed_promotions, 20)
+        .await;
+    assert!(result.is_ok());
 
     // wait for the first set of chunks to appear in the publish ledger
     let result = node.wait_for_chunk(&app, DataLedger::Publish, 0, 20).await;
@@ -353,7 +320,6 @@ async fn heavy_double_root_data_promotion_test() {
     }
 
     // Wait for all the transactions to be confirmed
-    let delay = Duration::from_secs(1);
     for attempt in 1..20 {
         // Do we have any unconfirmed tx?
         let Some(tx) = unconfirmed_tx.first() else {
@@ -407,42 +373,11 @@ async fn heavy_double_root_data_promotion_test() {
     // Verify ingress proofs
     // ------------------------------
     // Wait for the transactions to be promoted
-    let mut unconfirmed_promotions = vec![
-        // txs[2].header.id.as_bytes().to_base58(),
-        txs[0].header.id.as_bytes().to_base58(),
-    ];
-    println!("unconfirmed_promotions: {:?}", unconfirmed_promotions);
-
-    for attempts in 1..20 {
-        // Do we have any unconfirmed promotions?
-        let Some(txid) = unconfirmed_promotions.first() else {
-            // if not exit the loop.
-            break;
-        };
-
-        // Attempt to retrieve the transactions from the node endpoint
-        println!("Attempting... {}", txid);
-        let req = test::TestRequest::get()
-            .uri(&format!("/v1/tx/{}", &txid))
-            .to_request();
-
-        let resp = test::call_service(&app, req).await;
-
-        if resp.status() == StatusCode::OK {
-            let tx_header: IrysTransactionHeader = test::read_body_json(resp).await;
-            info!("Transaction was retrieved ok after {} attempts", attempts);
-            if let Some(_proof) = tx_header.ingress_proofs {
-                assert_eq!(tx_header.id.as_bytes().to_base58(), *txid);
-                println!("Confirming... {}", tx_header.id.as_bytes().to_base58());
-                unconfirmed_promotions.remove(0);
-                println!("unconfirmed_promotions: {:?}", unconfirmed_promotions);
-            }
-        }
-        mine_blocks(&node.node_ctx, 1).await.unwrap();
-        sleep(delay).await;
-    }
-
-    assert_eq!(unconfirmed_promotions.len(), 0);
+    let unconfirmed_promotions = vec![txs[0].header.id];
+    let result = node
+        .wait_for_ingress_proofs(unconfirmed_promotions, 20)
+        .await;
+    assert!(result.is_ok());
 
     // wait for the second set of chunks to appear in the publish ledger
     let result = node.wait_for_chunk(&app, DataLedger::Publish, 3, 20).await;

--- a/crates/chain/tests/promotion/data_promotion_double.rs
+++ b/crates/chain/tests/promotion/data_promotion_double.rs
@@ -161,14 +161,14 @@ async fn heavy_double_root_data_promotion_test() {
 
     // wait for the first set of chunks to appear in the publish ledger
     // FIXME: in prior commit, this was a loop that was never asserting or erroring on failure - is it important for the test case?
-    // it shopuld be replaced wit hthe helper function wait_for_chunk() which will rightly error
+    // it should be replaced wit the helper function wait_for_chunk() which will rightly error
     tokio::time::sleep(Duration::from_secs(20)).await;
     //let result = node.wait_for_chunk(&app, DataLedger::Publish, 0, 20).await;
     //assert!(result.is_ok());
 
     // wait for the second set of chunks to appear in the publish ledger
     // FIXME: in prior commit, this was a loop that was never asserting or erroring on failure - is it important for the test case?
-    // it should be replaced wit hthe helper function wait_for_chunk() which will rightly error
+    // it should be replaced wit the helper function wait_for_chunk() which will rightly error
     tokio::time::sleep(Duration::from_secs(20)).await;
     //let result = node.wait_for_chunk(&app, DataLedger::Publish, 3, 20).await;
     //assert!(result.is_ok());

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -24,9 +24,11 @@ use irys_actors::{
 };
 use irys_api_server::{create_listener, routes};
 use irys_chain::{IrysNode, IrysNodeCtx};
-use irys_database::db::IrysDatabaseExt as _;
-use irys_database::tables::IrysBlockHeaders;
-use irys_database::tx_header_by_txid;
+use irys_database::{
+    db::IrysDatabaseExt as _,
+    tables::{IngressProofs, IrysBlockHeaders},
+    tx_header_by_txid,
+};
 use irys_packing::capacity_single::compute_entropy_chunk;
 use irys_packing::unpack;
 use irys_primitives::CommitmentType;
@@ -46,8 +48,7 @@ use irys_types::{
 use irys_vdf::state::VdfStateReadonly;
 use irys_vdf::{step_number_to_salt_number, vdf_sha};
 use reth::payload::EthBuiltPayload;
-use reth_db::cursor::*;
-use reth_db::Database;
+use reth_db::{cursor::*, transaction::DbTx, Database};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -384,6 +385,34 @@ impl IrysNodeTest<IrysNodeCtx> {
             );
             Ok(())
         }
+    }
+
+    pub async fn wait_for_chunk(
+        &self,
+        app: &impl actix_web::dev::Service<
+            actix_http::Request,
+            Response = ServiceResponse,
+            Error = actix_web::Error,
+        >,
+        ledger: DataLedger,
+        offset: i32,
+        seconds: usize,
+    ) -> eyre::Result<()> {
+        let delay = Duration::from_secs(1);
+        for attempt in 1..seconds {
+            if let Some(_packed_chunk) =
+                get_chunk(&app, ledger, LedgerChunkOffset::from(offset)).await
+            {
+                info!("chunk found {} attempts", attempt);
+                return Ok(());
+            }
+            sleep(delay).await;
+        }
+
+        Err(eyre::eyre!(
+            "Failed waiting for chunk to arrive. Waited {} seconds",
+            seconds,
+        ))
     }
 
     pub fn get_height_on_chain(&self) -> u64 {

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -448,7 +448,7 @@ impl IrysNodeTest<IrysNodeCtx> {
                 _ => {}
             };
             drop(ro_tx);
-
+            mine_blocks(&self.node_ctx, 1).await.unwrap();
             sleep(delay).await;
         }
         Err(eyre::eyre!(
@@ -499,6 +499,7 @@ impl IrysNodeTest<IrysNodeCtx> {
                 };
             }
             drop(ro_tx);
+            mine_block(&self.node_ctx).await.unwrap();
             sleep(Duration::from_secs(1)).await;
         }
 


### PR DESCRIPTION
**Describe the changes**

 - Add methods, reduce code repetition. Make it easier to reason with test cases.
   - wait_for_chunk()
   - wait_for_confirmed_txs()
   - wait_for_ingress_proofs()
 - Highlights a 40 second test delay in heavy_double_root_data_promotion_test() where loops are running but never erroring on timeout. Added FIXMEs

**Additional Context**
Part of https://github.com/Irys-xyz/irys/issues/428
