### PR TITLE
feat: add valdiator for system txs inside validation_service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4737,6 +4737,7 @@ dependencies = [
  "actix",
  "actix-rt",
  "alloy-consensus",
+ "alloy-eips",
  "alloy-network",
  "alloy-rpc-types-engine",
  "alloy-signer-local",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4743,7 +4743,6 @@ dependencies = [
  "alloy-signer-local",
  "assert_matches",
  "async-trait",
- "atomic-write-file",
  "base58",
  "eyre",
  "futures",

--- a/crates/actors/Cargo.toml
+++ b/crates/actors/Cargo.toml
@@ -6,7 +6,6 @@ rust-version.workspace = true
 
 [dependencies]
 assert_matches = "1.5.0"
-atomic-write-file = "0.2"
 irys-types.workspace = true
 irys-database.workspace = true
 irys-packing.workspace = true

--- a/crates/actors/Cargo.toml
+++ b/crates/actors/Cargo.toml
@@ -42,6 +42,7 @@ alloy-rpc-types-engine.workspace = true
 alloy-signer-local.workspace = true
 alloy-network.workspace = true
 alloy-consensus.workspace = true
+alloy-eips.workspace = true
 reth-transaction-pool.workspace = true
 
 [dev-dependencies]

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -5,7 +5,7 @@ use crate::{
     mempool_service::MempoolServiceMessage,
     reth_service::{BlockHashType, ForkChoiceUpdateMessage, RethServiceActor},
     services::ServiceSenders,
-    validation_service::{ValidationService, ValidationServiceMessage},
+    validation_service::ValidationServiceMessage,
     BlockFinalizedMessage,
 };
 use actix::prelude::*;

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -1568,7 +1568,9 @@ pub async fn get_optimistic_chain(tree: BlockTreeReadGuard) -> eyre::Result<Vec<
 }
 
 /// Returns the canonical chain where the first item in the Vec is the oldest block
-/// Implementation detail: utilises `tokio::task::spawn_blocking`
+/// Uses spawn_blocking to prevent the read operation from blocking the async executor
+/// and locking other async tasks while traversing the block tree.
+/// Notably useful in single-threaded tokio based unittests.
 pub async fn get_canonical_chain(
     tree: BlockTreeReadGuard,
 ) -> eyre::Result<(Vec<(H256, u64, Vec<H256>, Vec<H256>)>, usize)> {
@@ -1578,7 +1580,9 @@ pub async fn get_canonical_chain(
 }
 
 /// Returns the block from the block tree at a given block hash
-/// Implementation detail: utilises `tokio::task::spawn_blocking`
+/// Uses spawn_blocking to prevent the read operation from blocking the async executor
+/// and locking other async tasks while accessing the block tree.
+/// Notably useful in single-threaded tokio based unittests.
 pub async fn get_block(
     block_tree_read_guard: BlockTreeReadGuard,
     block_hash: H256,

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -439,7 +439,6 @@ impl BlockTreeServiceInner {
 
             if add_result.is_ok() {
                 // Schedule block for full validation regardless of origin
-                // HACK
                 self.service_senders
                     .validation_service
                     .send(ValidationServiceMessage::ValidateBlock {

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -550,6 +550,7 @@ pub fn generate_expected_system_transactions(
 }
 
 /// Generates expected system transactions by looking up required data from the database
+#[tracing::instrument(skip_all, err)]
 async fn generate_expected_system_transactions_from_db(
     block: &IrysBlockHeader,
     db: &DatabaseProvider,
@@ -586,7 +587,7 @@ async fn generate_expected_system_transactions_from_db(
 }
 
 /// Validates that the actual system transactions match the expected ones
-#[tracing::instrument(err)]
+#[tracing::instrument(skip_all, err)]
 fn validate_system_transactions_match(
     actual: &[SystemTransaction],
     expected: &[SystemTransaction],

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -6,18 +6,28 @@ use crate::{
     epoch_service::PartitionAssignmentsReadGuard,
     mining::hash_to_number,
 };
+use alloy_consensus::Transaction;
+use alloy_eips::HashOrNumber;
 use base58::ToBase58;
-use eyre::ensure;
+use eyre::{ensure, eyre, OptionExt};
+use irys_database::{block_header_by_hash, db::IrysDatabaseExt, tx_header_by_txid};
 use irys_packing::{capacity_single::compute_entropy_chunk, xor_vec_u8_arrays_in_place};
+use irys_reth::alloy_rlp::Decodable;
+use irys_reth::system_tx::{
+    BalanceDecrement, BalanceIncrement, SystemTransaction, TransactionPacket,
+};
+use irys_reth_node_bridge::IrysRethNodeAdapter;
 use irys_reward_curve::HalvingCurve;
 use irys_storage::ii;
 use irys_types::{
-    calculate_difficulty, next_cumulative_diff, validate_path, Address, Config, ConsensusConfig,
-    DataLedger, DifficultyAdjustmentConfig, IrysBlockHeader, PoaData, H256,
+    app_state::DatabaseProvider, calculate_difficulty, next_cumulative_diff, validate_path,
+    Address, Config, ConsensusConfig, DataLedger, DifficultyAdjustmentConfig, IrysBlockHeader,
+    IrysTransactionCommon, IrysTransactionHeader, PoaData, H256,
 };
 use irys_vdf::last_step_checkpoints_is_valid;
 use irys_vdf::state::VdfStateReadonly;
 use openssl::sha;
+use reth::{providers::TransactionsProvider, revm::primitives::ruint::Uint};
 use tracing::{debug, info};
 
 /// Full pre-validation steps for a block
@@ -459,6 +469,148 @@ pub fn poa_is_valid(
             ));
         }
     }
+    Ok(())
+}
+
+/// Validates that the system transactions in the EVM block match the expected system transactions
+/// generated from the Irys block data.
+pub async fn system_transactions_are_valid(
+    block: &IrysBlockHeader,
+    reth_adapter: &IrysRethNodeAdapter,
+    db: &DatabaseProvider,
+) -> eyre::Result<()> {
+    // 1. Fetch EVM block transactions
+    let block_txs = reth_adapter
+        .inner
+        .provider
+        .transactions_by_block(HashOrNumber::Hash(block.evm_block_hash))?
+        .ok_or_eyre("Block not found in reth")?;
+
+    // 2. Extract system transactions from the beginning of the block
+    let mut system_txs = Vec::new();
+    for tx in block_txs {
+        // Try to decode as system transaction
+        if let Ok(system_tx) = SystemTransaction::decode(&mut tx.input().as_ref()) {
+            let tx_signer = tx.into_signed().recover_signer()?;
+            ensure!(
+                block.miner_address == tx_signer,
+                "System tx signer is not the miner"
+            );
+            system_txs.push(system_tx);
+        } else {
+            // If we can't decode as system tx, we've reached the regular transactions
+            break;
+        }
+    }
+
+    // 3. Generate expected system transactions
+    let expected_txs = generate_expected_system_transactions_from_db(block, db).await?;
+
+    // 4. Validate they match
+    validate_system_transactions_match(&system_txs, &expected_txs)
+}
+
+/// Generates the expected system transactions for a given block
+///
+/// Safety: block rewrards are already validate in block prevadliatino thus we trust them at face-value
+pub fn generate_expected_system_transactions(
+    block_height: u64,
+    reward_address: Address,
+    reward_amount: reth::revm::primitives::U256,
+    parent_evm_block_hash: H256,
+    submit_txs: &[IrysTransactionHeader],
+) -> eyre::Result<Vec<SystemTransaction>> {
+    let mut expected_txs = Vec::new();
+
+    // 1. Block reward transaction (always first)
+    let block_reward_tx = SystemTransaction::new_v1(
+        block_height,
+        parent_evm_block_hash.into(),
+        TransactionPacket::BlockReward(BalanceIncrement {
+            amount: reward_amount.into(),
+            target: reward_address,
+        }),
+    );
+    expected_txs.push(block_reward_tx);
+
+    // For each transaction in the submit ledger, create a storage fee system transaction
+    for submit_tx in submit_txs {
+        let storage_fee_tx = SystemTransaction::new_v1(
+            block_height,
+            parent_evm_block_hash.into(),
+            TransactionPacket::StorageFees(BalanceDecrement {
+                amount: Uint::from(submit_tx.total_fee()),
+                target: submit_tx.signer,
+            }),
+        );
+        expected_txs.push(storage_fee_tx);
+    }
+
+    Ok(expected_txs)
+}
+
+/// Generates expected system transactions by looking up required data from the database
+async fn generate_expected_system_transactions_from_db(
+    block: &IrysBlockHeader,
+    db: &DatabaseProvider,
+) -> eyre::Result<Vec<SystemTransaction>> {
+    // Look up previous block to get EVM hash
+    let prev_block = db
+        .view_eyre(|tx| block_header_by_hash(tx, &block.previous_block_hash, false))?
+        .ok_or_eyre("Previous block not found")?;
+
+    // Look up submit transaction headers
+    let submit_ledger = block
+        .data_ledgers
+        .iter()
+        .find(|ledger| ledger.ledger_id == DataLedger::Submit as u32)
+        .ok_or_eyre("Submit ledger not found")?;
+
+    let submit_txs = Vec::new();
+    for _tx_id in &submit_ledger.tx_ids.0 {
+        // todo: we need to query the db and mempool at the same time because
+        // there's no guarantee where the tx will be located
+        //
+        // if let Some(tx_header) = db.view_eyre(|tx| tx_header_by_txid(tx, tx_id))? {
+        //     submit_txs.push(tx_header);
+        // }
+    }
+
+    generate_expected_system_transactions(
+        block.height,
+        block.reward_address,
+        block.reward_amount.into(),
+        H256(prev_block.evm_block_hash.0),
+        &submit_txs,
+    )
+}
+
+/// Validates that the actual system transactions match the expected ones
+#[tracing::instrument(err)]
+fn validate_system_transactions_match(
+    actual: &[SystemTransaction],
+    expected: &[SystemTransaction],
+) -> eyre::Result<()> {
+    // Check that we have at least the expected number of system transactions
+    ensure!(
+        actual.len() >= expected.len(),
+        "Insufficient system transactions: expected at least {}, got {}",
+        expected.len(),
+        actual.len()
+    );
+
+    // Validate each expected system transaction
+    for (i, (actual_tx, expected_tx)) in actual.iter().zip(expected.iter()).enumerate() {
+        // Check block height using getter method
+        ensure!(
+            actual_tx == expected_tx,
+            "System transaction mismatch at idx {}. expected {:?}, got {:?}",
+            i,
+            expected_tx,
+            actual_tx
+        );
+    }
+
     Ok(())
 }
 

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -512,7 +512,7 @@ pub async fn system_transactions_are_valid(
 
 /// Generates the expected system transactions for a given block
 ///
-/// Safety: block rewrards are already validate in block prevadliatino thus we trust them at face-value
+/// Safety: block rewards are already validated in block prevalidation thus we trust them at face-value
 pub fn generate_expected_system_transactions(
     block_height: u64,
     reward_address: Address,

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -533,7 +533,7 @@ pub fn generate_expected_system_transactions(
     );
     expected_txs.push(block_reward_tx);
 
-    // For each transaction in the submit ledger, create a storage fee system transaction
+    // create a storage fee system txs
     for submit_tx in submit_txs {
         let storage_fee_tx = SystemTransaction::new_v1(
             block_height,
@@ -545,6 +545,8 @@ pub fn generate_expected_system_transactions(
         );
         expected_txs.push(storage_fee_tx);
     }
+
+    // TODO: create staking system txs
 
     Ok(expected_txs)
 }

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -9,8 +9,8 @@ use crate::{
 use alloy_consensus::Transaction;
 use alloy_eips::HashOrNumber;
 use base58::ToBase58;
-use eyre::{ensure, eyre, OptionExt};
-use irys_database::{block_header_by_hash, db::IrysDatabaseExt, tx_header_by_txid};
+use eyre::{ensure, OptionExt};
+use irys_database::{block_header_by_hash, db::IrysDatabaseExt};
 use irys_packing::{capacity_single::compute_entropy_chunk, xor_vec_u8_arrays_in_place};
 use irys_reth::alloy_rlp::Decodable;
 use irys_reth::system_tx::{
@@ -527,7 +527,7 @@ pub fn generate_expected_system_transactions(
         block_height,
         parent_evm_block_hash.into(),
         TransactionPacket::BlockReward(BalanceIncrement {
-            amount: reward_amount.into(),
+            amount: reward_amount,
             target: reward_address,
         }),
     );

--- a/crates/actors/src/services.rs
+++ b/crates/actors/src/services.rs
@@ -3,6 +3,7 @@ use crate::{
     cache_service::CacheServiceAction,
     ema_service::EmaServiceMessage,
     mempool_service::MempoolServiceMessage,
+    validation_service::ValidationServiceMessage,
     CommitmentCacheMessage, StorageModuleServiceMessage,
 };
 use actix::Message;
@@ -55,6 +56,7 @@ pub struct ServiceReceivers {
     pub storage_modules: UnboundedReceiver<StorageModuleServiceMessage>,
     pub gossip_broadcast: UnboundedReceiver<GossipData>,
     pub block_tree: UnboundedReceiver<BlockTreeServiceMessage>,
+    pub validation_service: UnboundedReceiver<ValidationServiceMessage>,
     pub reorg_events: broadcast::Receiver<ReorgEvent>,
     pub block_migrated_events: broadcast::Receiver<BlockMigratedEvent>,
 }
@@ -70,6 +72,7 @@ pub struct ServiceSendersInner {
     pub storage_modules: UnboundedSender<StorageModuleServiceMessage>,
     pub gossip_broadcast: UnboundedSender<GossipData>,
     pub block_tree: UnboundedSender<BlockTreeServiceMessage>,
+    pub validation_service: UnboundedSender<ValidationServiceMessage>,
     pub reorg_events: broadcast::Sender<ReorgEvent>,
     pub block_migrated_events: broadcast::Sender<BlockMigratedEvent>,
 }
@@ -92,6 +95,8 @@ impl ServiceSendersInner {
             unbounded_channel::<GossipData>();
         let (block_tree_sender, block_tree_receiver) =
             unbounded_channel::<BlockTreeServiceMessage>();
+        let (validation_sender, validation_receiver) =
+            unbounded_channel::<ValidationServiceMessage>();
         // Create broadcast channel for reorg events
         let (reorg_sender, reorg_receiver) = broadcast::channel::<ReorgEvent>(100);
         let (block_migrated_sender, block_migrated_receiver) =
@@ -107,6 +112,7 @@ impl ServiceSendersInner {
             storage_modules: sm_sender,
             gossip_broadcast: gossip_broadcast_sender,
             block_tree: block_tree_sender,
+            validation_service: validation_sender,
             reorg_events: reorg_sender,
             block_migrated_events: block_migrated_sender,
         };
@@ -120,6 +126,7 @@ impl ServiceSendersInner {
             storage_modules: sm_receiver,
             gossip_broadcast: gossip_broadcast_receiver,
             block_tree: block_tree_receiver,
+            validation_service: validation_receiver,
             reorg_events: reorg_receiver,
             block_migrated_events: block_migrated_receiver,
         };

--- a/crates/actors/src/validation_service.rs
+++ b/crates/actors/src/validation_service.rs
@@ -1,3 +1,12 @@
+//! Validation service module.
+//!
+//! The validation service is responsible for validating blocks by:
+//! - Validating VDF (Verifiable Delay Function) steps
+//! - Validating recall range
+//! - Validating PoA (Proof of Access)
+//!
+//! The service supports concurrent validation tasks for improved performance.
+
 use crate::block_validation::recall_recall_range_is_valid;
 use crate::{
     block_index_service::BlockIndexReadGuard,
@@ -6,167 +15,295 @@ use crate::{
     epoch_service::PartitionAssignmentsReadGuard,
     services::ServiceSenders,
 };
-use actix::{
-    Actor, AsyncContext, Context, Handler, Message, Supervised, SystemService, WrapFuture,
-};
-use irys_types::{Config, IrysBlockHeader};
+use eyre::ensure;
+use futures::future::Either;
+use irys_types::{Config, IrysBlockHeader, H256};
 use irys_vdf::state::{vdf_steps_are_valid, VdfStateReadonly};
 use irys_vdf::vdf_utils::fast_forward_vdf_steps_from_block;
-use std::sync::Arc;
-use tracing::error;
+use reth::tasks::{shutdown::GracefulShutdown, TaskExecutor};
+use std::{pin::pin, sync::Arc};
+use tokio::{
+    sync::{
+        mpsc::{UnboundedReceiver, UnboundedSender},
+        oneshot,
+    },
+    task::{JoinHandle, JoinSet},
+};
+use tracing::{debug, error, info, instrument, trace, warn, Instrument};
 
+/// Messages that the validation service supports
 #[derive(Debug)]
-pub struct ValidationService {
-    /// Read only view of the block index
-    pub block_index_guard: BlockIndexReadGuard,
-    /// `PartitionAssignmentsReadGuard` for looking up ledger info
-    pub partition_assignments_guard: PartitionAssignmentsReadGuard,
-    /// VDF steps read guard
-    pub vdf_state_readonly: VdfStateReadonly,
-    /// Reference to global config for node
-    pub config: Config,
-    /// Service channels
-    pub service_senders: ServiceSenders,
+pub enum ValidationServiceMessage {
+    /// Validate a block
+    ValidateBlock { block: Arc<IrysBlockHeader> },
 }
 
-impl Default for ValidationService {
-    fn default() -> Self {
-        unimplemented!("don't rely on the default implementation for ValidationService");
-    }
+/// Main validation service structure
+#[derive(Debug)]
+pub struct ValidationService {
+    /// Graceful shutdown handle
+    shutdown: GracefulShutdown,
+    /// Message receiver
+    msg_rx: UnboundedReceiver<ValidationServiceMessage>,
+    /// Inner service logic
+    inner: ValidationServiceInner,
+}
+
+/// Inner service structure containing business logic
+#[derive(Debug)]
+struct ValidationServiceInner {
+    /// Read only view of the block index
+    block_index_guard: BlockIndexReadGuard,
+    /// `PartitionAssignmentsReadGuard` for looking up ledger info
+    partition_assignments_guard: PartitionAssignmentsReadGuard,
+    /// VDF steps read guard
+    vdf_state_readonly: VdfStateReadonly,
+    /// Reference to global config for node
+    config: Config,
+    /// Service channels
+    service_senders: ServiceSenders,
+    /// Active validation tasks
+    validation_tasks: JoinSet<()>,
 }
 
 impl ValidationService {
-    /// Creates a new `VdfService` setting up how many steps are stored in memory
-    pub fn new(
+    /// Spawn a new validation service
+    pub fn spawn_service(
+        exec: &TaskExecutor,
         block_index_guard: BlockIndexReadGuard,
         partition_assignments_guard: PartitionAssignmentsReadGuard,
         vdf_state_readonly: VdfStateReadonly,
         config: &Config,
         service_senders: &ServiceSenders,
-    ) -> Self {
-        Self {
-            block_index_guard,
-            partition_assignments_guard,
-            vdf_state_readonly,
-            config: config.clone(),
-            service_senders: service_senders.clone(),
-        }
-    }
-}
+        rx: UnboundedReceiver<ValidationServiceMessage>,
+    ) -> JoinHandle<()> {
+        let config = config.clone();
+        let service_senders = service_senders.clone();
 
-/// `ValidationService` is an Actor
-impl Actor for ValidationService {
-    type Context = Context<Self>;
-}
-
-/// Allows this actor to live in the the local service registry
-impl Supervised for ValidationService {}
-
-impl SystemService for ValidationService {
-    fn service_started(&mut self, _ctx: &mut Context<Self>) {
-        println!("service started: block_index");
-    }
-}
-
-#[derive(Message, Debug)]
-#[rtype(result = "()")]
-pub struct RequestValidationMessage(pub Arc<IrysBlockHeader>);
-
-impl Handler<RequestValidationMessage> for ValidationService {
-    type Result = ();
-
-    fn handle(&mut self, msg: RequestValidationMessage, ctx: &mut Self::Context) -> Self::Result {
-        let block = msg.0;
-        let block_index_guard = self.block_index_guard.clone();
-        let partitions_guard = self.partition_assignments_guard.clone();
-        let miner_address = block.miner_address;
-        let block_hash = block.block_hash;
-        let block_height = block.height;
-        let vdf_info = block.vdf_limiter_info.clone();
-        let vdf_to_fast_forward = vdf_info.clone();
-        let poa = block.poa.clone();
-        let vdf_state_for_validation = self.vdf_state_readonly.clone();
-        let vdf_state = self.vdf_state_readonly.clone();
-
-        // Spawn VDF validation first
-        let vdf_config = self.config.consensus.vdf.clone();
-        let vdf_future = tokio::task::spawn_blocking(move || {
-            vdf_steps_are_valid(&vdf_info, &vdf_config, vdf_state_for_validation)
-        });
-
-        // Wait for results before processing the next message
-        let config = self.config.clone();
-        let block_tree_sender = self.service_senders.block_tree.clone();
-        let vdf_fast_forward_sender = self.service_senders.vdf_fast_forward.clone();
-        ctx.wait(
-            async move {
-                let first_step_number = vdf_to_fast_forward.first_step_number();
-                let prev_output_step_number = first_step_number.saturating_sub(1);
-
-                vdf_state.wait_for_step(prev_output_step_number).await;
-                let stored_previous_step = vdf_state.get_step(prev_output_step_number).expect("to get the step, since we've just waited for it");
-
-                if stored_previous_step != vdf_to_fast_forward.prev_output {
-                    error!("Previous output from the block {}/{} is not equal to the saved step with the same index. Expected {}, got {}", block_hash, block_height, stored_previous_step, vdf_to_fast_forward.prev_output);
-                    block_tree_sender
-                        .send(BlockTreeServiceMessage::BlockValidationFinished {
-                            block_hash,
-                            validation_result: ValidationResult::Invalid,
-                        })
-                        .unwrap();
-                    return;
-                }
-
-                let validation_result = match vdf_future.await.unwrap() {
-                    Ok(_) => {
-                        fast_forward_vdf_steps_from_block(&vdf_to_fast_forward, vdf_fast_forward_sender).await;
-                        vdf_state.wait_for_step(vdf_to_fast_forward.global_step_number).await;
-
-                        // Recall range check
-                        if let Err(report) = recall_recall_range_is_valid(&block, &config.consensus, &vdf_state).await {
-                            error!("Recall range check for block {}/{} failed: {}", block_hash, block_height, report);
-                            block_tree_sender
-                                .send(BlockTreeServiceMessage::BlockValidationFinished {
-                                    block_hash,
-                                    validation_result: ValidationResult::Invalid,
-                                })
-                                .unwrap();
-                            return;
-                        }
-
-                        // VDF passed, now spawn and run PoA validation
-                        let poa_future = tokio::task::spawn_blocking(move || {
-                            poa_is_valid(
-                                &poa,
-                                &block_index_guard,
-                                &partitions_guard,
-                                &config.consensus,
-                                &miner_address,
-                            )
-                        });
-
-                        match poa_future.await.unwrap() {
-                            Ok(_) => ValidationResult::Valid,
-                            Err(e) => {
-                                error!("PoA validation failed: {}", e);
-                                ValidationResult::Invalid
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        error!("VDF validation failed: {}", e);
-                        ValidationResult::Invalid
-                    }
+        exec.spawn_critical_with_graceful_shutdown_signal(
+            "Validation Service",
+            |shutdown| async move {
+                let validation_service = Self {
+                    shutdown,
+                    msg_rx: rx,
+                    inner: ValidationServiceInner {
+                        block_index_guard,
+                        partition_assignments_guard,
+                        vdf_state_readonly,
+                        config,
+                        service_senders,
+                        validation_tasks: JoinSet::new(),
+                    },
                 };
 
-                block_tree_sender
+                validation_service
+                    .start()
+                    .await
+                    .expect("validation service encountered an irrecoverable error")
+            },
+        )
+    }
+
+    /// Main service loop
+    async fn start(mut self) -> eyre::Result<()> {
+        info!("starting validation service");
+
+        let mut shutdown_future = pin!(self.shutdown);
+        let shutdown_guard = loop {
+            tokio::select! {
+                // Handle incoming messages
+                msg = self.msg_rx.recv() => {
+                    match msg {
+                        Some(msg) => self.inner.handle_message(msg),
+                        None => {
+                            warn!("receiver channel closed");
+                            break None;
+                        }
+                    }
+                }
+                // Clean up completed tasks
+                Some(result) = self.inner.validation_tasks.join_next() => {
+                    match result {
+                        Ok(()) => {
+                            debug!("validation task completed successfully");
+                        }
+                        Err(e) if e.is_cancelled() => {
+                            debug!("validation task was cancelled");
+                        }
+                        Err(e) => {
+                            error!(?e, "validation task panicked");
+                        }
+                    }
+                }
+                // Handle shutdown signal
+                shutdown = &mut shutdown_future => {
+                    warn!("shutdown signal received");
+                    break Some(shutdown);
+                }
+            }
+        };
+
+        // Process remaining messages before shutdown
+        debug!(
+            amount_of_messages = ?self.msg_rx.len(),
+            "processing last in-bound messages before shutdown"
+        );
+        while let Ok(msg) = self.msg_rx.try_recv() {
+            self.inner.handle_message(msg);
+        }
+
+        // Abort all active validation tasks and wait for them to finish
+        info!(
+            "aborting {} active validation tasks",
+            self.inner.validation_tasks.len()
+        );
+        self.inner.validation_tasks.shutdown().await;
+
+        // Explicitly inform the TaskManager that we're shutting down
+        drop(shutdown_guard);
+
+        info!("shutting down validation service");
+        Ok(())
+    }
+}
+
+impl ValidationServiceInner {
+    /// Handle incoming messages
+    #[instrument(skip_all)]
+    fn handle_message(&mut self, msg: ValidationServiceMessage) {
+        match msg {
+            ValidationServiceMessage::ValidateBlock { block } => {
+                self.spawn_validation_task(block);
+            }
+        }
+    }
+
+    /// Spawn a validation task for a block
+    fn spawn_validation_task(&mut self, block: Arc<IrysBlockHeader>) {
+        let block_hash = block.block_hash;
+        let block_height = block.height;
+
+        debug!(?block_hash, ?block_height, "spawning validation task");
+
+        // Clone necessary data for the spawned task
+        let block_index_guard = self.block_index_guard.clone();
+        let partitions_guard = self.partition_assignments_guard.clone();
+        let vdf_state = self.vdf_state_readonly.clone();
+        let config = self.config.clone();
+        let service_senders = self.service_senders.clone();
+
+        // Spawn the validation task
+        self.validation_tasks.spawn(async move {
+            let validation_result = validate_block_concurrent(
+                block,
+                block_index_guard,
+                partitions_guard,
+                vdf_state,
+                config,
+                service_senders.clone(),
+            )
+            .await
+            .unwrap_or(ValidationResult::Invalid);
+
+            // Also notify the block tree service
+            if let Err(e) =
+                service_senders
+                    .block_tree
                     .send(BlockTreeServiceMessage::BlockValidationFinished {
                         block_hash,
                         validation_result,
                     })
-                    .unwrap();
-            }
-            .into_actor(self),
-        );
+            {
+                error!(?e, "Failed to send validation result to block tree service");
+            };
+        });
+    }
+}
+
+/// Perform concurrent block validation
+#[tracing::instrument(err, skip_all, fields(block_hash = ?block.block_hash, block_height = ?block.height))]
+async fn validate_block_concurrent(
+    block: Arc<IrysBlockHeader>,
+    block_index_guard: BlockIndexReadGuard,
+    partitions_guard: PartitionAssignmentsReadGuard,
+    vdf_state: VdfStateReadonly,
+    config: Config,
+    service_senders: ServiceSenders,
+) -> eyre::Result<ValidationResult> {
+    let vdf_info = block.vdf_limiter_info.clone();
+
+    // First, wait for the previous VDF step to be available
+    let first_step_number = vdf_info.first_step_number();
+    let prev_output_step_number = first_step_number.saturating_sub(1);
+
+    vdf_state.wait_for_step(prev_output_step_number).await;
+    let stored_previous_step = vdf_state
+        .get_step(prev_output_step_number)
+        .expect("to get the step, since we've just waited for it");
+
+    trace!(
+        expected = ?stored_previous_step,
+        got = ?vdf_info.prev_output,
+        "Previous output from the block is not equal to the saved step with the same index"
+    );
+    ensure!(
+        stored_previous_step == vdf_info.prev_output,
+        "Previous output from the block is not equal to the saved step with the same index"
+    );
+
+    // Spawn VDF validation task
+    let vdf_config = config.consensus.vdf.clone();
+    let vdf_state_for_validation = vdf_state.clone();
+    let vdf_info_clone = vdf_info.clone();
+    tokio::task::spawn_blocking(move || {
+        vdf_steps_are_valid(&vdf_info_clone, &vdf_config, vdf_state_for_validation)
+    })
+    .await??;
+
+    // Fast forward VDF steps
+    fast_forward_vdf_steps_from_block(&vdf_info, service_senders.vdf_fast_forward.clone()).await;
+    vdf_state.wait_for_step(vdf_info.global_step_number).await;
+
+    // Recall range validation
+    let recall_task = {
+        let block = block.clone();
+        let consensus_config = config.consensus.clone();
+        let vdf_state = vdf_state.clone();
+        tokio::spawn(async move {
+            recall_recall_range_is_valid(&block, &consensus_config, &vdf_state)
+                .await
+                .inspect_err(|err| tracing::error!(?err, "poa is invalid"))
+                .map(|_| ValidationResult::Valid)
+                .unwrap_or(ValidationResult::Invalid)
+        })
+        .instrument(tracing::info_span!("recall range validation"))
+    };
+
+    // POA validation
+    let poa_task = {
+        let poa = block.poa.clone();
+        let miner_address = block.miner_address;
+        let consensus_config = config.consensus.clone();
+        tokio::task::spawn_blocking(move || {
+            poa_is_valid(
+                &poa,
+                &block_index_guard,
+                &partitions_guard,
+                &consensus_config,
+                &miner_address,
+            )
+            .inspect_err(|err| tracing::error!(?err, "poa is invalid"))
+            .map(|_| ValidationResult::Valid)
+            .unwrap_or(ValidationResult::Invalid)
+        })
+        .instrument(tracing::info_span!("poa task validation"))
+    };
+
+    // Wait for both tasks to complete
+    let (recall_result, poa_result) = tokio::try_join!(recall_task, poa_task)?;
+
+    match (recall_result, poa_result) {
+        (ValidationResult::Valid, ValidationResult::Valid) => Ok(ValidationResult::Valid),
+        _ => Ok(ValidationResult::Invalid),
     }
 }

--- a/crates/actors/src/validation_service.rs
+++ b/crates/actors/src/validation_service.rs
@@ -94,7 +94,7 @@ impl ValidationService {
                         pool: rayon::ThreadPoolBuilder::new()
                             .num_threads(config.consensus.vdf.parallel_verification_thread_limit)
                             .build()
-                            .expect("to be able to build vdf validatoin pool"),
+                            .expect("to be able to build vdf validation pool"),
                         block_index_guard,
                         partition_assignments_guard,
                         vdf_state: vdf_state_readonly,

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -960,6 +960,8 @@ impl IrysNode {
             vdf_state_readonly.clone(),
             &config,
             &service_senders,
+            reth_node_adapter.clone(),
+            irys_db.clone(),
             receivers.validation_service,
         );
 

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -952,7 +952,7 @@ impl IrysNode {
         )));
         let vdf_state_readonly = VdfStateReadonly::new(Arc::clone(&vdf_state));
 
-        // Spawn Valdiation service
+        // Spawn the valdiation service
         let _handle = ValidationService::spawn_service(
             task_exec,
             block_index_guard.clone(),

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -952,13 +952,15 @@ impl IrysNode {
         )));
         let vdf_state_readonly = VdfStateReadonly::new(Arc::clone(&vdf_state));
 
-        // spawn the validation service
-        let validation_arbiter = Self::init_validation_service(
+        // Spawn Valdiation service
+        let _handle = ValidationService::spawn_service(
+            task_exec,
+            block_index_guard.clone(),
+            partition_assignments_guard.clone(),
+            vdf_state_readonly.clone(),
             &config,
-            &block_index_guard,
-            &partition_assignments_guard,
-            &vdf_state_readonly,
             &service_senders,
+            receivers.validation_service,
         );
 
         // create the block reward curve
@@ -1107,10 +1109,6 @@ impl IrysNode {
             arbiters_guard.push(ArbiterHandle::new(
                 block_discovery_arbiter,
                 "block_discovery_arbiter".to_string(),
-            ));
-            arbiters_guard.push(ArbiterHandle::new(
-                validation_arbiter,
-                "validation_arbiter".to_string(),
             ));
             arbiters_guard.push(ArbiterHandle::new(
                 peer_list_arbiter,
@@ -1375,29 +1373,6 @@ impl IrysNode {
                 block_discovery_actor
             });
         (block_discovery, block_discovery_arbiter)
-    }
-
-    fn init_validation_service(
-        config: &Config,
-        block_index_guard: &BlockIndexReadGuard,
-        partition_assignments_guard: &irys_actors::epoch_service::PartitionAssignmentsReadGuard,
-        vdf_state_readonly: &VdfStateReadonly,
-        service_senders: &ServiceSenders,
-    ) -> Arbiter {
-        let validation_service = ValidationService::new(
-            block_index_guard.clone(),
-            partition_assignments_guard.clone(),
-            vdf_state_readonly.clone(),
-            config,
-            service_senders,
-        );
-        let validation_arbiter = Arbiter::new();
-        let validation_service =
-            ValidationService::start_in_arbiter(&validation_arbiter.handle(), |_| {
-                validation_service
-            });
-        SystemRegistry::set(validation_service);
-        validation_arbiter
     }
 
     fn init_chunk_migration_service(

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -439,13 +439,10 @@ impl IrysNodeTest<IrysNodeCtx> {
                 .unwrap();
 
             // Retrieve the transaction header from database
-            match tx_header_by_txid(&ro_tx, &tx.id) {
-                Ok(Some(header)) => {
-                    assert_eq!(*tx, header);
-                    info!("Transaction was retrieved ok after {} attempts", attempt);
-                    unconfirmed_txs.pop();
-                }
-                _ => {}
+            if let Ok(Some(header)) = tx_header_by_txid(&ro_tx, &tx.id) {
+                assert_eq!(*tx, header);
+                info!("Transaction was retrieved ok after {} attempts", attempt);
+                unconfirmed_txs.pop();
             };
             drop(ro_tx);
             mine_blocks(&self.node_ctx, 1).await.unwrap();
@@ -489,13 +486,10 @@ impl IrysNodeTest<IrysNodeCtx> {
             let tx_header = tx_header_by_txid(&ro_tx, txid).unwrap();
             if let Some(tx_header) = tx_header {
                 //read its ingressproof(s)
-                match ro_tx.get::<IngressProofs>(tx_header.data_root).unwrap() {
-                    Some(proof) => {
-                        assert_eq!(proof.data_root, tx_header.data_root);
-                        tracing::info!("Proofs available after {} attempts", attempts);
-                        unconfirmed_promotions.pop();
-                    }
-                    _ => {}
+                if let Some(proof) = ro_tx.get::<IngressProofs>(tx_header.data_root).unwrap() {
+                    assert_eq!(proof.data_root, tx_header.data_root);
+                    tracing::info!("Proofs available after {} attempts", attempts);
+                    unconfirmed_promotions.pop();
                 };
             }
             drop(ro_tx);

--- a/crates/efficient-sampling/src/lib.rs
+++ b/crates/efficient-sampling/src/lib.rs
@@ -87,11 +87,7 @@ impl Ranges {
         }
         self.last_range_pos = self.num_recall_ranges_in_partition - 1;
 
-        let last_step_to_keep = if self.last_step_num >= NUMBER_OF_KEPT_LAST_STEPS {
-            self.last_step_num - NUMBER_OF_KEPT_LAST_STEPS
-        } else {
-            0
-        };
+        let last_step_to_keep = self.last_step_num.saturating_sub(NUMBER_OF_KEPT_LAST_STEPS);
         self.last_recall_ranges
             .retain(|k, _| *k > last_step_to_keep);
     }

--- a/crates/irys-reth/src/evm.rs
+++ b/crates/irys-reth/src/evm.rs
@@ -151,7 +151,6 @@ where
             &ExecutionResult<<Self::Evm as Evm>::HaltReason>,
         ) -> reth_evm::block::CommitChanges,
     ) -> Result<Option<u64>, BlockExecutionError> {
-        tracing::trace!(tx_hash = %tx.tx().hash(), "executing transaction");
         let tx_envelope = tx.tx();
         let tx_envelope_input_buf = tx_envelope.input();
         let rlp_decoded_system_tx = SystemTransaction::decode(&mut &tx_envelope_input_buf[..]);
@@ -162,6 +161,7 @@ where
                 .inner
                 .execute_transaction_with_commit_condition(tx, on_result_f);
         };
+        tracing::trace!(tx_hash = %tx.tx().hash(), "executing system transaction");
 
         // Validate system tx metadata
         self.validate_system_transaction_metadata(&system_tx, tx_envelope.hash())?;
@@ -577,7 +577,6 @@ where
     type Transaction = TransactionSigned;
     type Receipt = Receipt;
 
-    #[must_use]
     fn evm_factory(&self) -> &Self::EvmFactory {
         self.inner.evm_factory()
     }

--- a/crates/irys-reth/src/evm.rs
+++ b/crates/irys-reth/src/evm.rs
@@ -151,7 +151,7 @@ where
             &ExecutionResult<<Self::Evm as Evm>::HaltReason>,
         ) -> reth_evm::block::CommitChanges,
     ) -> Result<Option<u64>, BlockExecutionError> {
-        tracing::error!(tx_hash = %tx.tx().hash(), "executing transaction");
+        tracing::trace!(tx_hash = %tx.tx().hash(), "executing transaction");
         let tx_envelope = tx.tx();
         let tx_envelope_input_buf = tx_envelope.input();
         let rlp_decoded_system_tx = SystemTransaction::decode(&mut &tx_envelope_input_buf[..]);
@@ -162,8 +162,6 @@ where
                 .inner
                 .execute_transaction_with_commit_condition(tx, on_result_f);
         };
-
-        tracing::error!(tx_hash = %tx.tx().hash(), "executing system tx");
 
         // Validate system tx metadata
         self.validate_system_transaction_metadata(&system_tx, tx_envelope.hash())?;

--- a/crates/vdf/src/lib.rs
+++ b/crates/vdf/src/lib.rs
@@ -5,6 +5,7 @@ use eyre::Context;
 use irys_types::block_production::Seed;
 use irys_types::{H256List, VDFLimiterInfo, VdfConfig, H256, U256};
 use openssl::sha;
+pub use rayon;
 use rayon::prelude::*;
 use sha2::{Digest, Sha256};
 use std::time::Duration;

--- a/crates/vdf/src/state.rs
+++ b/crates/vdf/src/state.rs
@@ -250,18 +250,11 @@ fn calc_capacity(config: &Config) -> usize {
 
 /// Validate the steps from the `nonce_info` to see if they are valid.
 /// Verifies each step in parallel across as many cores as are available.
-///
-/// # Arguments
-///
-/// * `vdf_info` - The Vdf limiter info from the block header to validate.
-///
-/// # Returns
-///
-/// - `bool` - `true` if the steps are valid, false otherwise.
 pub fn vdf_steps_are_valid(
+    pool: &rayon::ThreadPool,
     vdf_info: &VDFLimiterInfo,
     config: &VdfConfig,
-    vdf_steps_guard: VdfStateReadonly,
+    vdf_steps_guard: &VdfStateReadonly,
 ) -> eyre::Result<()> {
     info!(
         "Checking seed {:?} reset_seed {:?}",
@@ -304,10 +297,6 @@ pub fn vdf_steps_are_valid(
     // because we only have the first and last checkpoint of each step, but we
     // can calculate each of the steps in parallel
     // Limit threads number to avoid overloading the system using configuration limit
-    let pool = rayon::ThreadPoolBuilder::new()
-        .num_threads(config.parallel_verification_thread_limit)
-        .build()
-        .unwrap();
     let test: Vec<(H256, Option<H256List>)> = pool.install(|| {
         (0..steps.len() - 1)
             .into_par_iter()

--- a/crates/vdf/src/vdf.rs
+++ b/crates/vdf/src/vdf.rs
@@ -368,8 +368,13 @@ mod tests {
             ..VDFLimiterInfo::default()
         };
 
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(config.consensus.vdf.parallel_verification_thread_limit)
+            .build()
+            .expect("to be able to build vdf validatoin pool");
+
         assert!(
-            vdf_steps_are_valid(&vdf_info, &config.consensus.vdf, vdf_steps_guard).is_ok(),
+            vdf_steps_are_valid(&pool, &vdf_info, &config.consensus.vdf, &vdf_steps_guard).is_ok(),
             "Invalid VDF"
         );
 

--- a/crates/vdf/src/vdf.rs
+++ b/crates/vdf/src/vdf.rs
@@ -371,7 +371,7 @@ mod tests {
         let pool = rayon::ThreadPoolBuilder::new()
             .num_threads(config.consensus.vdf.parallel_verification_thread_limit)
             .build()
-            .expect("to be able to build vdf validatoin pool");
+            .expect("to be able to build vdf validation pool");
 
         assert!(
             vdf_steps_are_valid(&pool, &vdf_info, &config.consensus.vdf, &vdf_steps_guard).is_ok(),

--- a/crates/vdf/src/vdf_utils.rs
+++ b/crates/vdf/src/vdf_utils.rs
@@ -6,7 +6,7 @@ use tracing::error;
 /// Replay vdf steps on local node, provided by an existing block's VDFLimiterInfo
 pub async fn fast_forward_vdf_steps_from_block(
     vdf_limiter_info: &VDFLimiterInfo,
-    vdf_fast_forward_sender: UnboundedSender<VdfStep>,
+    vdf_fast_forward_sender: &UnboundedSender<VdfStep>,
 ) {
     let block_end_step = vdf_limiter_info.global_step_number;
     let block_start_step = vdf_limiter_info.first_step_number();


### PR DESCRIPTION
**Describe the changes**

- Rewrote validation_service.rs to use tokio instead of actors
- Added system tx validation logic in block_validation.rs
- Updated block_producer.rs to use common systx builders

⚠️ The validation for system txs is incomplete because I don't yet fetch the sytem txs for the incoming block. Awaiting on other work. Will be done in future pr.
⚠️ No unittests for catching invalid system txs becuase the core functionality is mocked for the time being (ignoring failing errors), all system txs are deemed valid from the validation serviec perspective.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.
