### PR TITLE
feat: replace block_tree entry tuple with struct

### DIFF
--- a/crates/actors/src/ema_service.rs
+++ b/crates/actors/src/ema_service.rs
@@ -436,7 +436,7 @@ mod price_cache_context {
             let chain = get_canonical_chain(block_tree_read_guard).await?.0;
             let chain = chain
                 .into_iter()
-                .map(|(hash, height, ..)| (hash, height))
+                .map(|e| (e.block_hash, e.height))
                 .collect();
             Ok(chain)
         }
@@ -1320,8 +1320,9 @@ mod tests {
 
         // setup -- generate new blocks to be added
         let (chain, ..) = get_canonical_chain(ctx.guard.clone()).await.unwrap();
-        let (mut latest_block_hash, ..) = *chain.last().unwrap();
+        let latest = chain.last().unwrap();
         let (new_blocks, ..) = build_tree(initial_block_count, 100);
+        let mut latest_block_hash = latest.block_hash;
 
         // extract the final price that we expect.
         // in total there are 110 blocks once we add the new ones.

--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -1152,7 +1152,7 @@ impl Inner {
             // Remove any confirmed commitment tx
             if let Some(commitment_tx_ids) = commitment_tx_ids {
                 for tx_id in &commitment_tx_ids.0 {
-                    confirmed_commitments.insert(tx_id.clone());
+                    confirmed_commitments.insert(*tx_id);
                 }
             }
         }

--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -5,7 +5,6 @@ use base58::ToBase58 as _;
 use core::fmt::Display;
 use eyre::eyre;
 use futures::future::BoxFuture;
-use irys_database::insert_commitment_tx;
 use irys_database::{
     db::{IrysDatabaseExt as _, IrysDupCursorExt as _},
     db_cache::{data_size_to_chunk_count, DataRootLRUEntry},
@@ -13,6 +12,7 @@ use irys_database::{
     tables::{CachedChunks, CachedChunksIndex, DataRootLRU, IngressProofs},
     {insert_tx_header, tx_header_by_txid},
 };
+use irys_database::{insert_commitment_tx, SystemLedger};
 use irys_primitives::CommitmentType;
 use irys_reth_node_bridge::{ext::IrysRethRpcTestContextExt, IrysRethNodeAdapter};
 use irys_storage::{get_atomic_file, RecoveredMempoolState, StorageModulesReadGuard};
@@ -1052,7 +1052,7 @@ impl Inner {
 
             let canon_chain = self.block_tree_read_guard.read().get_canonical_chain();
 
-            let (_, latest_height, _, _) = canon_chain
+            let latest = canon_chain
                 .0
                 .last()
                 .ok_or(ChunkIngressError::ServiceUninitialized)
@@ -1060,7 +1060,7 @@ impl Inner {
 
             let db = self.irys_db.clone();
             let signer = self.config.irys_signer();
-            let latest_height = *latest_height;
+            let latest_height = latest.height;
             self.exec.clone().spawn_blocking(async move {
                 generate_ingress_proof(db.clone(), root_hash, data_size, chunk_size, signer)
                     // TODO: handle results instead of unwrapping
@@ -1145,18 +1145,15 @@ impl Inner {
 
         // Get a list of all recently confirmed commitment txids in the canonical chain
         let (canonical, _) = self.block_tree_read_guard.read().get_canonical_chain();
-        for (block_hash, _, _, _) in canonical {
+        for entry in canonical {
             // TODO: replace this with data from the canonical chain entry when block_tree refactors the tuple
-            let commitment_tx_ids = self
-                .block_tree_read_guard
-                .read()
-                .get_block(&block_hash)
-                .unwrap()
-                .get_commitment_ledger_tx_ids();
+            let commitment_tx_ids = entry.system_ledgers.get(&SystemLedger::Commitment);
 
             // Remove any confirmed commitment tx
-            for tx_id in commitment_tx_ids {
-                confirmed_commitments.insert(tx_id);
+            if let Some(commitment_tx_ids) = commitment_tx_ids {
+                for tx_id in &commitment_tx_ids.0 {
+                    confirmed_commitments.insert(tx_id.clone());
+                }
             }
         }
 
@@ -1744,9 +1741,9 @@ impl Inner {
         // Allow transactions to use the txid of a transaction in the mempool
         if mempool_state_read_guard.recent_valid_tx.contains(anchor) {
             let (canonical_blocks, _) = self.block_tree_read_guard.read().get_canonical_chain();
-            let (latest_block_hash, _, _, _) = canonical_blocks.last().unwrap();
+            let latest = canonical_blocks.last().unwrap();
             // Just provide the most recent block as an anchor
-            match irys_database::block_header_by_hash(&read_tx, latest_block_hash, false) {
+            match irys_database::block_header_by_hash(&read_tx, &latest.block_hash, false) {
                 Ok(Some(hdr)) if hdr.height + anchor_expiry_depth >= latest_height => {
                     debug!("valid txid anchor {} for tx {}", anchor, tx_id);
                     return Ok(hdr);
@@ -1774,11 +1771,11 @@ impl Inner {
     // Helper to get the canonical chain and latest height
     async fn get_latest_block_height(&self) -> Result<u64, TxIngressError> {
         let canon_chain = self.block_tree_read_guard.read().get_canonical_chain();
-        let (_, latest_height, _, _) = canon_chain.0.last().ok_or(TxIngressError::Other(
+        let latest = canon_chain.0.last().ok_or(TxIngressError::Other(
             "unable to get canonical chain from block tree".to_owned(),
         ))?;
 
-        Ok(*latest_height)
+        Ok(latest.height)
     }
 
     // Helper to verify signature

--- a/crates/api-server/src/routes/block.rs
+++ b/crates/api-server/src/routes/block.rs
@@ -30,8 +30,8 @@ pub async fn get_block(
                 .get_canonical_chain()
                 .0
                 .iter()
-                .find_map(|(hash, hght, _, _)| match *hght == height {
-                    true => Some(hash),
+                .find_map(|e| match e.height == height {
+                    true => Some(&e.block_hash),
                     false => None,
                 })
                 .cloned();

--- a/crates/api-server/src/routes/index.rs
+++ b/crates/api-server/src/routes/index.rs
@@ -26,14 +26,14 @@ pub async fn info_route(state: web::Data<ApiState>) -> HttpResponse {
     let block_index_height = state.block_index.read().latest_height();
 
     let (chain, blocks) = get_canonical_chain(state.block_tree.clone()).await.unwrap();
-    let (block_hash, height, _, _) = chain.last().unwrap();
+    let latest = chain.last().unwrap();
 
     let node_info = NodeInfo {
         version: "0.0.1".into(),
         peer_count: state.peer_list.peer_count().await.unwrap_or(0),
         chain_id: state.config.consensus.chain_id,
-        height: *height,
-        block_hash: *block_hash,
+        height: latest.height,
+        block_hash: latest.block_hash,
         block_index_height,
         blocks: blocks as u64,
         is_syncing: state.sync_state.is_syncing(),

--- a/crates/chain/tests/ema_pricing/ema_pricing.rs
+++ b/crates/chain/tests/ema_pricing/ema_pricing.rs
@@ -122,7 +122,7 @@ async fn heavy_test_oracle_price_too_high_gets_capped() -> eyre::Result<()> {
         .await
         .unwrap();
     assert_eq!(chain.len(), 4, "expected genesis + 3 new blocks");
-    let genesis_block = get_block(ctx.node_ctx.block_tree_guard.clone(), chain[0].0)
+    let genesis_block = get_block(ctx.node_ctx.block_tree_guard.clone(), chain[0].block_hash)
         .await
         .unwrap()
         .unwrap();

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -277,10 +277,13 @@ async fn heavy_fork_recovery_test() -> eyre::Result<()> {
     println!("old_fork:\n  {:?}", old_fork);
     println!("new_fork:\n  {:?}", new_fork);
 
-    assert_eq!(old_fork, vec![canon_before.0.last().unwrap().0]);
+    assert_eq!(old_fork, vec![canon_before.0.last().unwrap().block_hash]);
     assert_eq!(
         new_fork,
-        vec![canon.0[canon.0.len() - 2].0, canon.0.last().unwrap().0]
+        vec![
+            canon.0[canon.0.len() - 2].block_hash,
+            canon.0.last().unwrap().block_hash
+        ]
     );
 
     assert_eq!(reorg_event.new_tip, *new_fork.last().unwrap());

--- a/crates/chain/tests/startup/startup.rs
+++ b/crates/chain/tests/startup/startup.rs
@@ -27,7 +27,7 @@ async fn heavy_test_can_resume_from_genesis_startup_with_ctx() -> eyre::Result<(
         .unwrap();
     assert_eq!(
         header_1.height,
-        chain.last().unwrap().1,
+        chain.last().unwrap().height,
         "expect only the first manually mined block to be saved"
     );
     assert_eq!(
@@ -78,7 +78,7 @@ async fn heavy_test_can_resume_from_genesis_startup_no_ctx() -> eyre::Result<()>
         .unwrap();
     assert_eq!(
         header_1.height,
-        chain.last().unwrap().1,
+        chain.last().unwrap().height,
         "expect only the first manually mined block to be saved"
     );
     assert_eq!(

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -365,7 +365,7 @@ impl IrysNodeTest<IrysNodeCtx> {
             .0
             .last()
             .unwrap()
-            .1
+            .height
             < target_height
             && retries < max_retries
         {
@@ -514,7 +514,7 @@ impl IrysNodeTest<IrysNodeCtx> {
             .0
             .last()
             .unwrap()
-            .1
+            .height
     }
 
     /// Returns a future that resolves when a reorg is detected.
@@ -736,12 +736,12 @@ impl IrysNodeTest<IrysNodeCtx> {
             .unwrap()
             .0
             .iter()
-            .find(|(_, blk_height, _, _)| *blk_height == height)
-            .and_then(|(blk_hash, _, _, _)| {
+            .find(|e| e.height == height)
+            .and_then(|e| {
                 self.node_ctx
                     .block_tree_guard
                     .read()
-                    .get_block(blk_hash)
+                    .get_block(&e.block_hash)
                     .cloned()
             })
             .ok_or_else(|| eyre::eyre!("Block at height {} not found", height))


### PR DESCRIPTION
Replaces the terribly overloaded tuple in the block tree with a proper struct with field names.
