### PR TITLE
feat: reorg support for ema service

### DIFF
--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -906,7 +906,7 @@ impl IrysNode {
 
         // Spawn EMA service
         let _handle =
-            EmaService::spawn_service(task_exec, block_tree_guard.clone(), receivers.ema, &config);
+            EmaService::spawn_service(task_exec, block_tree_guard.clone(), receivers.ema, &config, &service_senders);
 
         // Spawn the CommitmentCache service
         let _commitcache_handle = CommitmentCache::spawn_service(

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -905,8 +905,13 @@ impl IrysNode {
             .expect("to receive BlockTreeReadGuard response from GetBlockTreeReadGuard Message");
 
         // Spawn EMA service
-        let _handle =
-            EmaService::spawn_service(task_exec, block_tree_guard.clone(), receivers.ema, &config, &service_senders);
+        let _handle = EmaService::spawn_service(
+            task_exec,
+            block_tree_guard.clone(),
+            receivers.ema,
+            &config,
+            &service_senders,
+        );
 
         // Spawn the CommitmentCache service
         let _commitcache_handle = CommitmentCache::spawn_service(


### PR DESCRIPTION
**Describe the changes**
- ema service listents to a reorg event
- every time it receives a reorg event, it will recalculate its state from the canonical chain

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.
