### PR TITLE
fix: util method fixes and test improvements

### DIFF
--- a/crates/chain/tests/api/api.rs
+++ b/crates/chain/tests/api/api.rs
@@ -16,19 +16,21 @@ use tokio::time::sleep;
 use tracing::{debug, info};
 
 #[actix_web::test]
-async fn heavy_api_end_to_end_test_32b() {
+async fn heavy_api_end_to_end_test_32b() -> eyre::Result<()> {
     setup_tracing_and_temp_dir(Some("heavy_api_end_to_end_test_32kb"), false);
     if PACKING_TYPE == PackingType::CPU {
-        api_end_to_end_test(32).await;
+        api_end_to_end_test(32).await?;
     } else {
         info!("C packing implementation does not support chunk size different from CHUNK_SIZE");
     }
+    Ok(())
 }
 
 #[actix_web::test]
-async fn heavy_api_end_to_end_test_256kb() {
+async fn heavy_api_end_to_end_test_256kb() -> eyre::Result<()> {
     setup_tracing_and_temp_dir(Some("heavy_api_end_to_end_test_256kb"), false);
-    api_end_to_end_test(256 * 1024).await;
+    api_end_to_end_test(256 * 1024).await?;
+    Ok(())
 }
 
 async fn api_end_to_end_test(chunk_size: usize) {

--- a/crates/chain/tests/api/api.rs
+++ b/crates/chain/tests/api/api.rs
@@ -50,7 +50,7 @@ async fn api_end_to_end_test(chunk_size: usize) -> eyre::Result<()> {
     let chain_id = config.consensus_config().chain_id;
     let node = IrysNodeTest::new_genesis(config.clone()).start().await;
 
-    node.node_ctx.start_mining().await.unwrap();
+    node.node_ctx.start_mining().await?;
 
     let app = node.start_public_api().await;
 
@@ -58,8 +58,7 @@ async fn api_end_to_end_test(chunk_size: usize) -> eyre::Result<()> {
         node.node_ctx.actor_addresses.packing.clone(),
         Some(Duration::from_secs(10)),
     )
-    .await
-    .unwrap();
+    .await?;
 
     // Create 2.5 chunks worth of data *  fill the data with random bytes
     let data_size = chunk_size * 2_usize;
@@ -79,7 +78,7 @@ async fn api_end_to_end_test(chunk_size: usize) -> eyre::Result<()> {
         .set_json(&tx.header)
         .to_request();
 
-    info!("{}", serde_json::to_string_pretty(&tx.header).unwrap());
+    info!("{}", serde_json::to_string_pretty(&tx.header)?);
 
     // Call the service
     let resp = test::call_service(&app, req).await;

--- a/crates/chain/tests/api/api.rs
+++ b/crates/chain/tests/api/api.rs
@@ -49,7 +49,6 @@ async fn api_end_to_end_test(chunk_size: usize) {
     let chain_id = config.consensus_config().chain_id;
     let node = IrysNodeTest::new_genesis(config.clone()).start().await;
 
-    // Is there any reason for spawning another one here?
     node.node_ctx.start_mining().await.unwrap();
 
     let app = node.start_public_api().await;

--- a/crates/chain/tests/api/api.rs
+++ b/crates/chain/tests/api/api.rs
@@ -6,9 +6,10 @@ use alloy_genesis::GenesisAccount;
 use base58::ToBase58;
 use irys_actors::packing::wait_for_packing;
 use irys_packing::{unpack, PackingType, PACKING_TYPE};
-use irys_types::TxChunkOffset;
+use irys_testing_utils::setup_tracing_and_temp_dir;
 use irys_types::{
-    irys::IrysSigner, Base64, IrysTransactionHeader, NodeConfig, PackedChunk, UnpackedChunk,
+    irys::IrysSigner, Base64, IrysTransactionHeader, NodeConfig, PackedChunk, TxChunkOffset,
+    UnpackedChunk,
 };
 use rand::Rng;
 use std::time::Duration;

--- a/crates/chain/tests/api/api.rs
+++ b/crates/chain/tests/api/api.rs
@@ -33,7 +33,7 @@ async fn heavy_api_end_to_end_test_256kb() -> eyre::Result<()> {
     Ok(())
 }
 
-async fn api_end_to_end_test(chunk_size: usize) {
+async fn api_end_to_end_test(chunk_size: usize) -> eyre::Result<()> {
     let entropy_packing_iterations = 1_000;
     let mut config = NodeConfig::testnet();
     config.consensus.get_mut().chunk_size = chunk_size.try_into().unwrap();
@@ -207,4 +207,6 @@ async fn api_end_to_end_test(chunk_size: usize) {
     );
 
     node.node_ctx.stop().await;
+
+    Ok(())
 }

--- a/crates/chain/tests/api/api.rs
+++ b/crates/chain/tests/api/api.rs
@@ -17,6 +17,7 @@ use tracing::{debug, info};
 
 #[actix_web::test]
 async fn heavy_api_end_to_end_test_32b() {
+    setup_tracing_and_temp_dir(Some("heavy_api_end_to_end_test_32kb"), false);
     if PACKING_TYPE == PackingType::CPU {
         api_end_to_end_test(32).await;
     } else {
@@ -26,6 +27,7 @@ async fn heavy_api_end_to_end_test_32b() {
 
 #[actix_web::test]
 async fn heavy_api_end_to_end_test_256kb() {
+    setup_tracing_and_temp_dir(Some("heavy_api_end_to_end_test_256kb"), false);
     api_end_to_end_test(256 * 1024).await;
 }
 

--- a/crates/chain/tests/api/api.rs
+++ b/crates/chain/tests/api/api.rs
@@ -6,7 +6,7 @@ use alloy_genesis::GenesisAccount;
 use base58::ToBase58;
 use irys_actors::packing::wait_for_packing;
 use irys_packing::{unpack, PackingType, PACKING_TYPE};
-use irys_testing_utils::setup_tracing_and_temp_dir;
+use irys_testing_utils::initialize_tracing;
 use irys_types::{
     irys::IrysSigner, Base64, IrysTransactionHeader, NodeConfig, PackedChunk, TxChunkOffset,
     UnpackedChunk,
@@ -18,7 +18,7 @@ use tracing::{debug, info};
 
 #[actix_web::test]
 async fn heavy_api_end_to_end_test_32b() -> eyre::Result<()> {
-    setup_tracing_and_temp_dir(Some("heavy_api_end_to_end_test_32kb"), false);
+    initialize_tracing();
     if PACKING_TYPE == PackingType::CPU {
         api_end_to_end_test(32).await?;
     } else {
@@ -29,7 +29,7 @@ async fn heavy_api_end_to_end_test_32b() -> eyre::Result<()> {
 
 #[actix_web::test]
 async fn heavy_api_end_to_end_test_256kb() -> eyre::Result<()> {
-    setup_tracing_and_temp_dir(Some("heavy_api_end_to_end_test_256kb"), false);
+    initialize_tracing();
     api_end_to_end_test(256 * 1024).await?;
     Ok(())
 }

--- a/crates/chain/tests/api/client.rs
+++ b/crates/chain/tests/api/client.rs
@@ -140,6 +140,7 @@ async fn check_get_block_endpoint(
 #[actix_rt::test]
 #[test_log::test]
 async fn heavy_api_client_all_endpoints_should_work() {
+    setup_tracing_and_temp_dir(Some("heavy_api_client_all_endpoints_should_work"), false);
     let config = NodeConfig::testnet();
     let ctx = IrysNodeTest::new_genesis(config).start().await;
 

--- a/crates/chain/tests/api/client.rs
+++ b/crates/chain/tests/api/client.rs
@@ -3,13 +3,16 @@
 use crate::utils::{mine_block, IrysNodeTest};
 use irys_api_client::{ApiClient, IrysApiClient};
 use irys_chain::IrysNodeCtx;
+use irys_testing_utils::setup_tracing_and_temp_dir;
 use irys_types::{
     AcceptedResponse, BlockIndexQuery, IrysTransactionResponse, NodeConfig, PeerResponse,
     ProtocolVersion, VersionRequest,
 };
 use semver::Version;
-use std::net::{IpAddr, SocketAddr};
-use std::str::FromStr;
+use std::{
+    net::{IpAddr, SocketAddr},
+    str::FromStr,
+};
 use tracing::debug;
 
 async fn check_post_version_endpoint(api_client: &IrysApiClient, api_address: SocketAddr) {

--- a/crates/chain/tests/api/client.rs
+++ b/crates/chain/tests/api/client.rs
@@ -3,7 +3,7 @@
 use crate::utils::{mine_block, IrysNodeTest};
 use irys_api_client::{ApiClient, IrysApiClient};
 use irys_chain::IrysNodeCtx;
-use irys_testing_utils::setup_tracing_and_temp_dir;
+use irys_testing_utils::initialize_tracing;
 use irys_types::{
     AcceptedResponse, BlockIndexQuery, IrysTransactionResponse, NodeConfig, PeerResponse,
     ProtocolVersion, VersionRequest,
@@ -143,7 +143,7 @@ async fn check_get_block_endpoint(
 #[actix_rt::test]
 #[test_log::test]
 async fn heavy_api_client_all_endpoints_should_work() {
-    setup_tracing_and_temp_dir(Some("heavy_api_client_all_endpoints_should_work"), false);
+    initialize_tracing();
     let config = NodeConfig::testnet();
     let ctx = IrysNodeTest::new_genesis(config).start().await;
 

--- a/crates/chain/tests/api/tx.rs
+++ b/crates/chain/tests/api/tx.rs
@@ -64,33 +64,7 @@ async fn test_get_tx() -> eyre::Result<()> {
         Some(_tx_header) => info!("commitment_tx found!"),
     };
 
-    let app_state = ApiState {
-        ema_service: node.node_ctx.service_senders.ema.clone(),
-        reth_provider: node.node_ctx.reth_handle.clone(),
-        reth_http_url: node
-            .node_ctx
-            .reth_handle
-            .rpc_server_handle()
-            .http_url()
-            .unwrap(),
-        block_index: node.node_ctx.block_index_guard.clone(),
-        block_tree: node.node_ctx.block_tree_guard.clone(),
-        db: node.node_ctx.db.clone(),
-        mempool_service: node.node_ctx.service_senders.mempool.clone(),
-        peer_list: node.node_ctx.peer_list.clone(),
-        chunk_provider: node.node_ctx.chunk_provider.clone(),
-        config: config.into(),
-        sync_state: node.node_ctx.sync_state.clone(),
-    };
-
-    // Start the actix webserver
-    let app = actix_web::test::init_service(
-        App::new()
-            .wrap(Logger::default())
-            .app_data(actix_web::web::Data::new(app_state))
-            .service(routes()),
-    )
-    .await;
+    let app = node.start_public_api().await;
 
     // Test storage transaction
     let id: String = storage_tx.id.as_bytes().to_base58();

--- a/crates/chain/tests/api/tx.rs
+++ b/crates/chain/tests/api/tx.rs
@@ -1,12 +1,10 @@
 //! endpoint tests
 use crate::utils::IrysNodeTest;
 use actix_http::StatusCode;
-use actix_web::{middleware::Logger, App};
 use alloy_core::primitives::U256;
 use alloy_genesis::GenesisAccount;
 use base58::ToBase58;
 use irys_actors::packing::wait_for_packing;
-use irys_api_server::{routes, ApiState};
 use irys_database::{database, db::IrysDatabaseExt as _};
 use irys_types::{
     irys::IrysSigner, CommitmentTransaction, IrysTransactionHeader, IrysTransactionResponse,

--- a/crates/chain/tests/api/tx_commitments.rs
+++ b/crates/chain/tests/api/tx_commitments.rs
@@ -349,6 +349,8 @@ async fn heavy_no_commitments_basic_test() -> eyre::Result<()> {
 
 #[actix_web::test]
 async fn heavy_test_commitments_basic_test() -> eyre::Result<()> {
+    // tracing
+    initialize_tracing();
     // ===== TEST SETUP =====
     // Create test environment with a funded signer for transaction creation
     let mut config = NodeConfig::testnet();

--- a/crates/chain/tests/promotion/data_promotion_double.rs
+++ b/crates/chain/tests/promotion/data_promotion_double.rs
@@ -107,20 +107,7 @@ async fn heavy_double_root_data_promotion_test() {
     // ==============================
     // Post Tx chunks out of order
     // ------------------------------
-    let _tx_index = 2;
-
-    // // Last Tx, last chunk
-    // let chunk_index = 2;
-    // post_chunk(&app, &txs[tx_index], chunk_index, &data_chunks[tx_index]).await;
-
-    // // Last Tx, middle chunk
-    // let chunk_index = 1;
-    // post_chunk(&app, &txs[tx_index], chunk_index, &data_chunks[tx_index]).await;
-
-    // // Last Tx, first chunk
-    // let chunk_index = 0;
-    // post_chunk(&app, &txs[tx_index], chunk_index, &data_chunks[tx_index]).await;
-
+    
     let tx_index = 1;
 
     // Middle Tx, middle chunk
@@ -173,39 +160,10 @@ async fn heavy_double_root_data_promotion_test() {
 
     let db = &node.node_ctx.db.clone();
     let block_tx1 = get_block_parent(txs[0].header.id, DataLedger::Publish, db).unwrap();
-    // let block_tx2 = get_block_parent(txs[2].header.id, Ledger::Publish, db).unwrap();
-
-    let _next_tx_index: usize;
-
-    // if block_tx1.block_hash == block_tx2.block_hash {
-    //     // Extract the transaction order
-    //     let txid_1 = block_tx1.ledgers[Ledger::Publish].tx_ids.0[0];
-    //     // let txid_2 = block_tx1.ledgers[Ledger::Publish].tx_ids.0[1];
-    //     first_tx_index = txs.iter().position(|tx| tx.header.id == txid_1).unwrap();
-    //     // next_tx_index = txs.iter().position(|tx| tx.header.id == txid_2).unwrap();
-    //     println!("1:{}", block_tx1);
-    // } else if block_tx1.height > block_tx2.height {
-    //     let txid_1 = block_tx2.ledgers[Ledger::Publish].tx_ids.0[0];
-    //     let txid_2 = block_tx1.ledgers[Ledger::Publish].tx_ids.0[0];
-    //     first_tx_index = txs.iter().position(|tx| tx.header.id == txid_1).unwrap();
-    //     next_tx_index = txs.iter().position(|tx| tx.header.id == txid_2).unwrap();
-    //     println!("1:{}", block_tx2);
-    //     println!("2:{}", block_tx1);
-    // } else {
-    //     let txid_1 = block_tx1.ledgers[Ledger::Publish].tx_ids.0[0];
-    //     let txid_2 = block_tx2.ledgers[Ledger::Publish].tx_ids.0[0];
-    //     first_tx_index = txs.iter().position(|tx| tx.header.id == txid_1).unwrap();
-    //     next_tx_index = txs.iter().position(|tx| tx.header.id == txid_2).unwrap();
-    //     println!("1:{}", block_tx1);
-    //     println!("2:{}", block_tx2);
-    // }
 
     let txid_1 = block_tx1.data_ledgers[DataLedger::Publish].tx_ids.0[0];
-    //     let txid_2 = block_tx2.ledgers[Ledger::Publish].tx_ids.0[0];
     let first_tx_index: usize = txs.iter().position(|tx| tx.header.id == txid_1).unwrap();
-    //     next_tx_index = txs.iter().position(|tx| tx.header.id == txid_2).unwrap();
     println!("1:{}", block_tx1);
-    //     println!("2:{}", block_tx2);
 
     // ==============================
     // Verify chunk ordering in publish ledger storage module

--- a/crates/chain/tests/promotion/data_promotion_double.rs
+++ b/crates/chain/tests/promotion/data_promotion_double.rs
@@ -107,7 +107,7 @@ async fn heavy_double_root_data_promotion_test() {
     // ==============================
     // Post Tx chunks out of order
     // ------------------------------
-    
+
     let tx_index = 1;
 
     // Middle Tx, middle chunk

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -578,7 +578,7 @@ impl IrysNodeTest<IrysNodeCtx> {
             .actor_addresses
             .block_producer
             .do_send(SetTestBlocksRemainingMessage(None));
-        self.node_ctx.set_partition_mining(false)
+        self.node_ctx.stop_mining().await
     }
 
     pub async fn mine_blocks_without_gossip(&self, num_blocks: usize) -> eyre::Result<()> {


### PR DESCRIPTION
**Describe the changes**
 - Replace incorrect call to `self.node_ctx.set_partition_mining(false)` with `self.node_ctx.stop_mining().await`
 - removed dead code
 - added tracing
 - enforced named test folder isolation

**Related Issue(s)**
N/A

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
N/A
