### PR TITLE
chore: remove unused all_tx cache

### DIFF
--- a/crates/actors/src/block_discovery.rs
+++ b/crates/actors/src/block_discovery.rs
@@ -376,7 +376,6 @@ impl Handler<BlockDiscoveredMessage> for BlockDiscoveryActor {
                     let (oneshot_tx, oneshot_rx) = tokio::sync::oneshot::channel();
                     let _ = block_tree_sender.send(BlockTreeServiceMessage::BlockPreValidated {
                         block: new_block_header.clone(),
-                        all_txs: Arc::new(all_txs),
                         response: oneshot_tx,
                     });
                     let _ = oneshot_rx

--- a/crates/actors/src/ema_service.rs
+++ b/crates/actors/src/ema_service.rs
@@ -910,7 +910,7 @@ mod tests {
                 block_hash = block.block_hash;
             }
             block_tree_cache
-                .add_common(block.block_hash, block, Arc::new(Vec::new()), state.clone())
+                .add_common(block.block_hash, block, state.clone())
                 .unwrap();
         }
         let block_tree_cache = Arc::new(RwLock::new(block_tree_cache));
@@ -1143,7 +1143,6 @@ mod tests {
                 tree.add_common(
                     header.block_hash,
                     &header,
-                    Arc::new(Vec::new()),
                     ChainState::Validated(crate::block_tree_service::BlockState::ValidBlock),
                 )
                 .unwrap();
@@ -1569,13 +1568,8 @@ mod tests {
                 block.cumulative_diff = block.height.into();
                 latest_block_hash = H256::random();
                 block.block_hash = latest_block_hash;
-                tree.add_common(
-                    block.block_hash,
-                    &block,
-                    Arc::new(Vec::new()),
-                    ChainState::Onchain,
-                )
-                .unwrap();
+                tree.add_common(block.block_hash, &block, ChainState::Onchain)
+                    .unwrap();
             }
             drop(tree)
         };

--- a/crates/p2p/src/block_status_provider.rs
+++ b/crates/p2p/src/block_status_provider.rs
@@ -227,7 +227,7 @@ impl BlockStatusProvider {
     pub fn add_block_mock_to_the_tree(&self, block: &IrysBlockHeader) {
         self.block_tree_read_guard
             .write()
-            .add_block(block, Arc::new(Vec::new()))
+            .add_block(block)
             .expect("to add block to the tree");
     }
 


### PR DESCRIPTION
**Describe the changes**
I was debugging an issue on the large mempool PR and in talking with @DanMacDonald he suggested all_tx is not likely going to be used.
 - Deletes code, removes all_tx from `BlockTreeServiceMessage::BlockPreValidated` and adjusts tests and fn signatures as needed.

**Related Issue(s)**
N/A

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
N/A
