### PR TITLE
fix: Reth RPC API HTTP proxy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -445,7 +445,6 @@ bind_instead_of_map = "deny"
 bool_assert_comparison = "deny"
 cloned_instead_of_copied = "deny"
 explicit_into_iter_loop = "deny"
-ignored_unit_patterns = "deny"
 implicit_clone = "deny"
 inefficient_to_string = "deny"
 manual_instant_elapsed = "deny"
@@ -486,6 +485,7 @@ use_self = "deny"
 # deref_by_slicing = "deny" # reduces clarity
 # assertions_on_result_states = "deny" # keeping the asserts helps to improve test clarity
 # needless_collect = "deny" # reduces clarity
+# ignored_unit_patterns = "deny" # unnecessary & no findings
 
 
 [workspace.metadata.cargo-machete]

--- a/crates/api-server/src/routes/proxy.rs
+++ b/crates/api-server/src/routes/proxy.rs
@@ -51,7 +51,8 @@ pub async fn proxy(
         actix_web::http::Method::OPTIONS => client.options(target_uri),
         actix_web::http::Method::PATCH => client.patch(target_uri),
         _ => return Err(ProxyError::MethodNotAllowed),
-    };
+    }
+    .no_decompress(); // <- very important!
 
     // Forward relevant headers
     for (header_name, header_value) in req.headers() {
@@ -86,17 +87,17 @@ pub async fn proxy(
     Ok(client_response.streaming(response))
 }
 
-fn is_hop_by_hop_header(header: &str) -> bool {
-    let hop_by_hop_headers = [
-        "connection",
-        "keep-alive",
-        "proxy-authenticate",
-        "proxy-authorization",
-        "te",
-        "trailers",
-        "transfer-encoding",
-        "upgrade",
-    ];
+const HOP_BY_HOP_HEADERS: [&str; 8] = [
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+];
 
-    hop_by_hop_headers.contains(&header.to_lowercase().as_str())
+fn is_hop_by_hop_header(header: &str) -> bool {
+    HOP_BY_HOP_HEADERS.contains(&header.to_lowercase().as_str())
 }


### PR DESCRIPTION

**Describe the changes**
The Reth Proxy was causing GZIP errors, as it was decompressing the response body without removing the headers - this fixes that by instructing the AWC to not decompress content/
This also disables the `ignored_unit_patterns` lint.
