### PR TITLE
fix: move commitment_snapshot.rs out of actors and into database

### DIFF
--- a/crates/actors/src/block_discovery.rs
+++ b/crates/actors/src/block_discovery.rs
@@ -5,7 +5,7 @@ use crate::{
     epoch_service::{EpochServiceActor, NewEpochMessage, PartitionAssignmentsReadGuard},
     mempool_service::MempoolServiceMessage,
     services::ServiceSenders,
-    CommitmentSnapshot, CommitmentSnapshotStatus, GetCommitmentStateGuardMessage,
+    GetCommitmentStateGuardMessage,
 };
 use actix::prelude::*;
 use async_trait::async_trait;
@@ -13,7 +13,7 @@ use base58::ToBase58 as _;
 use eyre::eyre;
 use irys_database::{
     block_header_by_hash, commitment_tx_by_txid, db::IrysDatabaseExt as _, tx_header_by_txid,
-    SystemLedger,
+    CommitmentSnapshot, CommitmentSnapshotStatus, SystemLedger,
 };
 use irys_reward_curve::HalvingCurve;
 use irys_types::{

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -6,13 +6,16 @@ use crate::{
     reth_service::{BlockHashType, ForkChoiceUpdateMessage, RethServiceActor},
     services::ServiceSenders,
     validation_service::ValidationServiceMessage,
-    BlockFinalizedMessage, CommitmentSnapshot, CommitmentStateReadGuard,
+    BlockFinalizedMessage, CommitmentStateReadGuard,
 };
 use actix::prelude::*;
 use base58::ToBase58 as _;
 use eyre::{ensure, Context as _};
 use futures::future::Either;
-use irys_database::{block_header_by_hash, commitment_tx_by_txid, tx_header_by_txid, SystemLedger};
+use irys_database::{
+    block_header_by_hash, commitment_tx_by_txid, tx_header_by_txid, CommitmentSnapshot,
+    SystemLedger,
+};
 use irys_types::{
     Address, BlockHash, CommitmentTransaction, Config, ConsensusConfig, DataLedger,
     DatabaseProvider, H256List, IrysBlockHeader, IrysTransactionHeader, H256, U256,
@@ -932,7 +935,7 @@ impl BlockTreeCache {
         };
 
         // Initialize commitment snapshot and add start block
-        let mut commitment_snapshot = CommitmentSnapshot::current_epoch_commitments(
+        let mut commitment_snapshot = current_epoch_commitments(
             block_index_guard.clone(),
             commitment_state_guard.clone(),
             db.clone(),
@@ -1735,6 +1738,69 @@ pub async fn get_block(
     })
     .await?;
     Ok(res)
+}
+
+/// Reconstructs the commitment snapshot for the current epoch by loading all commitment
+/// transactions from blocks since the last epoch boundary.
+///
+/// Iterates through all blocks from the first block after the most recent epoch block
+/// up to the latest block, collecting and applying all commitment transactions to build
+/// the current epoch's commitment state. This is typically used during startup or when
+/// the commitment snapshot needs to be rebuilt from persistent storage.
+///
+/// # Returns
+/// Initialized commitment snapshot containing all commitments from the current epoch
+pub fn current_epoch_commitments(
+    block_index_guard: BlockIndexReadGuard,
+    commitment_state_guard: CommitmentStateReadGuard,
+    db: DatabaseProvider,
+    consensus_config: &ConsensusConfig,
+) -> CommitmentSnapshot {
+    let num_blocks_in_epoch = consensus_config.epoch.num_blocks_in_epoch;
+    let block_index = block_index_guard.read();
+    let latest_item = block_index.get_latest_item();
+
+    let mut snapshot = CommitmentSnapshot::default();
+
+    if let Some(latest_item) = latest_item {
+        let tx = db.tx().unwrap();
+
+        let latest = block_header_by_hash(&tx, &latest_item.block_hash, false)
+            .unwrap()
+            .expect("block_index block to be in database");
+        let last_epoch_block_height = latest.height - (latest.height % num_blocks_in_epoch);
+
+        let start = last_epoch_block_height + 1;
+
+        // Loop though all the blocks starting with the first block following the last epoch block
+        for height in start..=latest.height {
+            // Query each block to see if they have commitment txids
+            let block_item = block_index.get_item(height).unwrap();
+            let block = block_header_by_hash(&tx, &block_item.block_hash, false)
+                .unwrap()
+                .expect("block_index block to be in database");
+
+            let commitment_tx_ids = block.get_commitment_ledger_tx_ids();
+            if !commitment_tx_ids.is_empty() {
+                // If so, retrieve the full commitment transactions
+                for txid in commitment_tx_ids {
+                    let commitment_tx = commitment_tx_by_txid(&tx, &txid)
+                        .unwrap()
+                        .expect("commitment transactions to be in database");
+
+                    let is_staked_in_current_epoch =
+                        commitment_state_guard.is_staked(commitment_tx.signer);
+
+                    // Apply them to the commitment snapshot
+                    let _status =
+                        snapshot.add_commitment(&commitment_tx, is_staked_in_current_epoch);
+                }
+            }
+        }
+    }
+
+    // Return the initialized commitment snapshot
+    snapshot
 }
 
 /// Creates a new commitment snapshot for the given block based on commitment transactions

--- a/crates/actors/src/block_tree_service/test_utils.rs
+++ b/crates/actors/src/block_tree_service/test_utils.rs
@@ -3,6 +3,7 @@ use std::{
     time::SystemTime,
 };
 
+use irys_database::CommitmentSnapshot;
 use irys_types::{storage_pricing::TOKEN_SCALE, Config, IrysBlockHeader, IrysTokenPrice, H256};
 use reth::tasks::{TaskExecutor, TaskManager};
 use rust_decimal::Decimal;
@@ -10,7 +11,6 @@ use rust_decimal::Decimal;
 use crate::{
     ema_service::{EmaServiceMessage, NewBlockEmaResponse, PriceStatus},
     services::{ServiceReceivers, ServiceSenders},
-    CommitmentSnapshot,
 };
 
 use super::{BlockTreeCache, BlockTreeReadGuard, ChainState, ReorgEvent};

--- a/crates/actors/src/ema_service.rs
+++ b/crates/actors/src/ema_service.rs
@@ -843,7 +843,7 @@ mod tests {
         PriceInfo, TestCtx,
     };
     use crate::block_tree_service::{get_canonical_chain, ChainState};
-    use crate::CommitmentSnapshot;
+    use irys_database::CommitmentSnapshot;
     use irys_types::{
         block_height_to_use_for_price, ConsensusConfig, ConsensusOptions, EmaConfig, NodeConfig,
         H256,

--- a/crates/actors/src/lib.rs
+++ b/crates/actors/src/lib.rs
@@ -7,7 +7,6 @@ pub mod block_validation;
 pub mod broadcast_mining_service;
 pub mod cache_service;
 pub mod chunk_migration_service;
-pub mod commitment_snapshot;
 pub mod ema_service;
 pub mod epoch_service;
 pub mod mempool_service;
@@ -21,6 +20,5 @@ pub mod validation_service;
 
 pub use addresses::*;
 pub use block_producer::*;
-pub use commitment_snapshot::*;
 pub use epoch_service::*;
 pub use storage_module_service::*;

--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -1,6 +1,6 @@
 use crate::block_tree_service::{BlockMigratedEvent, BlockTreeReadGuard, ReorgEvent};
 use crate::services::ServiceSenders;
-use crate::{CommitmentSnapshotStatus, CommitmentStateReadGuard};
+use crate::CommitmentStateReadGuard;
 use base58::ToBase58 as _;
 use core::fmt::Display;
 use eyre::eyre;
@@ -12,7 +12,7 @@ use irys_database::{
     tables::{CachedChunks, CachedChunksIndex, DataRootLRU, IngressProofs},
     {insert_tx_header, tx_header_by_txid},
 };
-use irys_database::{insert_commitment_tx, SystemLedger};
+use irys_database::{insert_commitment_tx, CommitmentSnapshotStatus, SystemLedger};
 use irys_primitives::CommitmentType;
 use irys_reth_node_bridge::{ext::IrysRethRpcTestContextExt as _, IrysRethNodeAdapter};
 use irys_storage::{get_atomic_file, RecoveredMempoolState, StorageModulesReadGuard};

--- a/crates/actors/src/validation_service/active_validations.rs
+++ b/crates/actors/src/validation_service/active_validations.rs
@@ -193,8 +193,8 @@ mod tests {
     use super::*;
     use crate::block_tree_service::test_utils::genesis_tree;
     use crate::block_tree_service::{BlockState, ChainState};
-    use crate::CommitmentSnapshot;
     use futures::future::{pending, ready};
+    use irys_database::CommitmentSnapshot;
     use irys_types::{IrysBlockHeader, H256};
     use itertools::Itertools as _;
     use std::collections::HashMap;

--- a/crates/chain/tests/api/tx_commitments.rs
+++ b/crates/chain/tests/api/tx_commitments.rs
@@ -6,11 +6,11 @@ use assert_matches::assert_matches;
 use base58::ToBase58 as _;
 use eyre::eyre;
 use irys_actors::{
-    packing::wait_for_packing, CommitmentSnapshotStatus, CommitmentStateReadGuard,
-    GetCommitmentStateGuardMessage, GetPartitionAssignmentsGuardMessage,
-    PartitionAssignmentsReadGuard,
+    packing::wait_for_packing, CommitmentStateReadGuard, GetCommitmentStateGuardMessage,
+    GetPartitionAssignmentsGuardMessage, PartitionAssignmentsReadGuard,
 };
 use irys_api_server::routes;
+use irys_database::CommitmentSnapshotStatus;
 use irys_primitives::CommitmentType;
 use irys_testing_utils::initialize_tracing;
 use irys_types::{irys::IrysSigner, Address, CommitmentTransaction, NodeConfig, H256};

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -13,6 +13,7 @@ use base58::ToBase58 as _;
 use futures::future::select;
 use irys_actors::block_tree_service::ReorgEvent;
 use irys_actors::mempool_service::MempoolTxs;
+use irys_actors::GetMinerPartitionAssignmentsMessage;
 use irys_actors::{
     block_producer::SolutionFoundMessage,
     block_tree_service::get_canonical_chain,
@@ -21,9 +22,9 @@ use irys_actors::{
     packing::wait_for_packing,
     SetTestBlocksRemainingMessage,
 };
-use irys_actors::{CommitmentSnapshotStatus, GetMinerPartitionAssignmentsMessage};
 use irys_api_server::{create_listener, routes};
 use irys_chain::{IrysNode, IrysNodeCtx};
+use irys_database::CommitmentSnapshotStatus;
 use irys_database::{
     db::IrysDatabaseExt as _,
     tables::{IngressProofs, IrysBlockHeaders},

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -2,6 +2,7 @@
 //! database methods for reading and writing from the database as well as some
 //! database value types.
 pub mod block_index_data;
+pub mod commitment_snapshot;
 pub mod config;
 pub mod data_ledger;
 pub mod database;
@@ -26,6 +27,7 @@ pub mod submodule;
 pub mod tables;
 
 pub use block_index_data::*;
+pub use commitment_snapshot::*;
 pub use data_ledger::*;
 pub use database::*;
 pub use system_ledger::*;

--- a/crates/p2p/src/block_status_provider.rs
+++ b/crates/p2p/src/block_status_provider.rs
@@ -225,7 +225,7 @@ impl BlockStatusProvider {
 
     #[cfg(test)]
     pub fn add_block_mock_to_the_tree(&self, block: &IrysBlockHeader) {
-        use irys_actors::CommitmentSnapshot;
+        use irys_database::CommitmentSnapshot;
 
         self.block_tree_read_guard
             .write()


### PR DESCRIPTION
move the refactored `CommitmentSnapshot` out of the `actors` crate and into `database` because it's no longer an actor or service but a data model.