### PR TITLE
Fix/testnet storage modules

### DIFF
--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -1269,8 +1269,12 @@ impl IrysNode {
             arbiters.push(part_arbiter);
         }
 
-        // request packing for uninitialized ranges
-        for sm in storage_modules_guard.read().iter() {
+        // request packing for uninitialized ranges of assigned storage modules
+        for sm in storage_modules_guard
+            .read()
+            .iter()
+            .filter(|sm| sm.partition_assignment().is_some())
+        {
             let uninitialized = sm.get_intervals(ChunkType::Uninitialized);
             for interval in uninitialized {
                 packing_actor_addr.do_send(PackingRequest {

--- a/crates/storage/src/storage_module.rs
+++ b/crates/storage/src/storage_module.rs
@@ -278,20 +278,25 @@ impl StorageModule {
             } else {
                 // Load the packing params and check to see if they match
                 let params = PackingParams::from_toml(params_path).expect("packing params to load");
-                let pa = storage_module_info.partition_assignment.unwrap();
+
                 ensure!(
                     params.packing_address == config.node_config.miner_address(),
                     "Active mining address: {} does not match partition packing address {}",
                     config.node_config.miner_address(),
                     params.packing_address
                 );
-                ensure!(params.partition_hash == Some(pa.partition_hash),
-                    "Partition hash mismatch:\nexpected: {}\nfound   : {}\n\nError: Submodule partition assignments are out of sync with genesis block. \
-                    This occurs when a new genesis block is created with a different last_epoch_hash, but submodules still have partition_hashes \
-                    assigned from the previous genesis. To fix: clear the contents of the submodule directories and let them be repacked with the current genesis",
-                    pa.partition_hash.0.to_base58(),
-                    params.partition_hash.unwrap().0.to_base58(),
-                );
+
+                // check the partition assignment if it's present
+                if let Some(pa) = storage_module_info.partition_assignment {
+                    ensure!(
+                        params.partition_hash == Some(pa.partition_hash),
+                        "Partition hash mismatch:\nexpected: {}\nfound   : {}\n\nError: Submodule partition assignments are out of sync with genesis block. \
+                        This occurs when a new genesis block is created with a different last_epoch_hash, but submodules still have partition_hashes \
+                        assigned from the previous genesis. To fix: clear the contents of the submodule directories and let them be repacked with the current genesis",
+                        pa.partition_hash.0.to_base58(),
+                        params.partition_hash.unwrap().0.to_base58(),
+                    );
+                }
             }
 
             let intervals_file_path = sub_base_path.join("intervals.json");


### PR DESCRIPTION
**Describe the changes**
A set of bugfixes from the testnet peer deployment to fix Storage module related behaviour that assumes that all storage modules always have a partition assignment.