### PR TITLE
feat: handle duplicate transactions in mempool and block discovery

### DIFF
--- a/crates/actors/src/block_discovery.rs
+++ b/crates/actors/src/block_discovery.rs
@@ -363,13 +363,8 @@ impl Handler<BlockDiscoveredMessage> for BlockDiscoveryActor {
                         let expected_commitment_tx = parent_snapshot.get_epoch_commitments();
 
                         // Validate epoch block has expected commitments in correct order
-                        let commitments_match = expected_commitment_tx.len()
-                            == arc_commitment_txs.len()
-                            && expected_commitment_tx
-                                .iter()
-                                .zip(arc_commitment_txs.iter())
-                                .all(|(tx1, tx2)| tx1.id == tx2.id);
-
+                        let commitments_match =
+                            expected_commitment_tx.iter().eq(arc_commitment_txs.iter());
                         if !commitments_match {
                             debug!(
                                 "Epoch block commitment tx for block height: {block_height}\nexpected: {:#?}\nactual: {:#?}",

--- a/crates/actors/src/block_discovery.rs
+++ b/crates/actors/src/block_discovery.rs
@@ -1,6 +1,6 @@
 use crate::{
     block_index_service::BlockIndexReadGuard,
-    block_tree_service::BlockTreeServiceMessage,
+    block_tree_service::{BlockTreeReadGuard, BlockTreeServiceMessage},
     block_validation::prevalidate_block,
     epoch_service::{EpochServiceActor, NewEpochMessage, PartitionAssignmentsReadGuard},
     mempool_service::MempoolServiceMessage,
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use eyre::eyre;
 use irys_database::{
     block_header_by_hash, commitment_tx_by_txid, db::IrysDatabaseExt as _, tx_header_by_txid,
-    CommitmentSnapshot, CommitmentSnapshotStatus, SystemLedger,
+    CommitmentSnapshotStatus, SystemLedger,
 };
 use irys_reward_curve::HalvingCurve;
 use irys_types::{
@@ -35,6 +35,8 @@ pub struct BlockDiscoveryActor {
     pub epoch_service: Addr<EpochServiceActor>,
     /// Read only view of the block index
     pub block_index_guard: BlockIndexReadGuard,
+    /// Read only view of the block_tree
+    pub block_tree_guard: BlockTreeReadGuard,
     /// `PartitionAssignmentsReadGuard` for looking up ledger info
     pub partition_assignments_guard: PartitionAssignmentsReadGuard,
     /// Reference to the global config
@@ -124,7 +126,8 @@ impl Handler<BlockDiscoveredMessage> for BlockDiscoveryActor {
         //====================================
         // Block header pre-validation
         //------------------------------------
-        let block_index_guard2 = self.block_index_guard.clone();
+        let block_index_guard = self.block_index_guard.clone();
+        let block_tree_guard = self.block_tree_guard.clone();
         let partitions_guard = self.partition_assignments_guard.clone();
         let config = self.config.clone();
         let db = self.db.clone();
@@ -146,6 +149,7 @@ impl Handler<BlockDiscoveredMessage> for BlockDiscoveryActor {
         let gossip_sender = self.service_senders.gossip_broadcast.clone();
         let reward_curve = Arc::clone(&self.reward_curve);
         let mempool = self.service_senders.mempool.clone();
+        let mempool_config = self.config.consensus.mempool.clone();
         Box::pin(async move {
             let span3 = span2.clone();
             let _span = span3.enter();
@@ -239,7 +243,7 @@ impl Handler<BlockDiscoveredMessage> for BlockDiscoveryActor {
                 .iter()
                 .find(|b| b.ledger_id == SystemLedger::Commitment);
 
-            // Validate commitments (if there are some)
+            // Validate commitments transactions exist (if there are commitment txids in the block)
             let mut commitments: Vec<CommitmentTransaction> = Vec::new();
             if let Some(commitment_ledger) = commitment_ledger {
                 debug!(
@@ -260,69 +264,57 @@ impl Handler<BlockDiscoveredMessage> for BlockDiscoveryActor {
                 }
             }
 
-            info!("Pre-validating block: {}", new_block_header.height);
-
-            // TODO: This first pass a validating transactions are not duplicates causes a bunch
-            // of tests to fail that seem to rely on or not expect this validation check.
-            // Disabling the code for now as this is already a difficult to marge PR.
+            info!(
+                "Pre-validating block {:?} {}\ncommitments:\n{:#?}\ntransactions:\n{:?}",
+                new_block_header.block_hash,
+                new_block_header.height,
+                new_block_header.get_commitment_ledger_tx_ids(),
+                commitments.iter().map(|x| x.id).collect::<Vec<_>>()
+            );
 
             // Walk the this blocks ancestors up to the anchor depth checking to see if any of the transactions
             // have already been included in a recent parent.
             let block_height = new_block_header.height;
 
-            /*(
             let anchor_expiry_depth = mempool_config.anchor_expiry_depth as u64;
             let min_anchor_height = block_height.saturating_sub(anchor_expiry_depth);
             let mut parent_block = previous_block_header.clone();
 
-            // Get the transaction IDs from the current block to check against
-            let _current_commitment_tx_ids: HashSet<_> = new_block_header
-                .get_commitment_ledger_tx_ids()
-                .into_iter()
-                .collect();
-            let current_data_tx_ids = new_block_header.get_data_ledger_tx_ids();
+            let binding = new_block_header.get_data_ledger_tx_ids();
+            let incoming_data_tx_ids = binding.get(&DataLedger::Submit);
 
-            while parent_block.height >= min_anchor_height {
-                // Check to see if any commitment txids appeared in prior blocks
-                // let parent_commitment_tx_ids = parent_block.get_commitment_ledger_tx_ids();
-                // for txid in &parent_commitment_tx_ids {
-                //     if current_commitment_tx_ids.contains(txid) {
-                //         return Err(eyre!("Duplicate commitment transaction id {}", txid));
-                //     }
-                // }
+            if let Some(incoming_data_tx_ids) = incoming_data_tx_ids {
+                while parent_block.height >= min_anchor_height {
+                    // Check to see if any data txids appeared in prior blocks
+                    let parent_data_tx_ids = parent_block.get_data_ledger_tx_ids();
 
-                // Check to see if any data txids appeared in prior blocks
-                let parent_data_tx_ids = parent_block.get_data_ledger_tx_ids();
-
-                // Compare each ledger type between current and parent blocks
-                for (ledger_type, current_txids) in &current_data_tx_ids {
-                    if let Some(parent_txids) = parent_data_tx_ids.get(ledger_type) {
+                    // Compare each ledger type between current and parent blocks
+                    if let Some(parent_txids) = parent_data_tx_ids.get(&DataLedger::Submit) {
                         // Check for intersection between current and parent txids for this ledger
-                        for txid in current_txids {
+                        for txid in incoming_data_tx_ids {
                             if parent_txids.contains(txid) {
                                 return Err(eyre!("Duplicate data transaction id {}", txid));
                             }
                         }
                     }
+
+                    if parent_block.height == 0 {
+                        break;
+                    }
+
+                    // Continue the loop - get the next parent block
+                    // Get the next parent block and own it
+                    let previous_block_header = match db.view_eyre(|tx| {
+                        block_header_by_hash(tx, &parent_block.previous_block_hash, false)
+                    }) {
+                        Ok(Some(header)) => header,
+                        Ok(None) => break,
+                        Err(e) => return Err(e),
+                    };
+
+                    parent_block = previous_block_header; // Move instead of borrow
                 }
-
-                if parent_block.height == 0 {
-                    break;
-                }
-
-                // Continue the loop - get the next parent block
-                // Get the next parent block and own it
-                let previous_block_header = match db.view_eyre(|tx| {
-                    block_header_by_hash(tx, &parent_block.previous_block_hash, false)
-                }) {
-                    Ok(Some(header)) => header,
-                    Ok(None) => break,
-                    Err(e) => return Err(e),
-                };
-
-                parent_block = previous_block_header; // Move instead of borrow
             }
-            */
 
             let validation_result = tokio::task::spawn_blocking(move || {
                 prevalidate_block(
@@ -349,58 +341,98 @@ impl Handler<BlockDiscoveredMessage> for BlockDiscoveryActor {
                     all_txs.extend_from_slice(&publish_txs);
 
                     // Check if we've reached the end of an epoch and should finalize commitments
-
                     let blocks_in_epoch = epoch_config.num_blocks_in_epoch;
                     let is_epoch_block = block_height > 0 && block_height % blocks_in_epoch == 0;
 
                     let arc_commitment_txs = Arc::new(commitments);
 
+                    let commitment_state_guard = epoch_service
+                        .send(GetCommitmentStateGuardMessage)
+                        .await
+                        .unwrap();
+
+                    // Get the current epoch snapshot from the parent block
+                    let mut parent_snapshot = block_tree_guard
+                        .read()
+                        .get_commitment_snapshot(&prev_block_hash)
+                        .expect("parent block to be in block_tree")
+                        .as_ref()
+                        .clone();
+
                     if is_epoch_block {
-                        // For epoch blocks, validate that all included commitments are legitimate
-                        // Get current commitment state from epoch service for validation
-                        let commitment_state_guard = epoch_service
-                            .send(GetCommitmentStateGuardMessage)
-                            .await
-                            .unwrap();
+                        let expected_commitment_tx = parent_snapshot.get_epoch_commitments();
 
-                        // Create a temporary local commitment validation environment
-                        // This avoids async overhead while checking commitment validity and creates
-                        // an independent cache we can populate and discard
-                        let mut local_snapshot = CommitmentSnapshot::default();
+                        // Validate epoch block has expected commitments in correct order
+                        let commitments_match = expected_commitment_tx.len()
+                            == arc_commitment_txs.len()
+                            && expected_commitment_tx
+                                .iter()
+                                .zip(arc_commitment_txs.iter())
+                                .all(|(tx1, tx2)| tx1.id == tx2.id);
 
-                        // Validate each commitment transaction before accepting the epoch block
-                        for commitment_tx in arc_commitment_txs.iter() {
-                            let is_staked_in_current_epoch =
-                                commitment_state_guard.is_staked(commitment_tx.signer);
-
-                            let status = local_snapshot
-                                .add_commitment(commitment_tx, is_staked_in_current_epoch);
-
-                            // Reject the entire epoch block if any commitment is invalid
-                            // This ensures only verified commitments are finalized at epoch boundaries
-                            if status != CommitmentSnapshotStatus::Accepted {
-                                return Err(eyre::eyre!("Invalid commitments in epoch block"));
-                            }
+                        if !commitments_match {
+                            debug!(
+                                "Epoch block commitment tx for block height: {block_height}\nexpected: {:#?}\nactual: {:#?}",
+                                expected_commitment_tx.iter().map(|x| x.id).collect::<Vec<_>>(),
+                                arc_commitment_txs.iter().map(|x| x.id).collect::<Vec<_>>()
+                            );
+                            return Err(eyre::eyre!(
+                                "Epoch block commitments don't match expected"
+                            ));
                         }
 
-                        // Look up the previous epoch block
-                        let block_item = block_index_guard2
+                        // Send NewEpochMessage with previous and current epoch blocks
+                        let block_item = block_index_guard
                             .read()
                             .get_item(block_height - blocks_in_epoch)
                             .expect("previous epoch block to be in block index")
                             .clone();
-
                         let previous_epoch_block = db
                             .view(|tx| block_header_by_hash(tx, &block_item.block_hash, false))
                             .unwrap()
                             .expect("previous epoch block to be in database");
 
-                        // Send the NewEpochMessage referencing the current and previous epoch blocks
                         epoch_service.do_send(NewEpochMessage {
                             previous_epoch_block,
                             epoch_block: new_block_header.clone(),
                             commitments: arc_commitment_txs.clone(),
                         });
+                    } else {
+                        // Validate and add each commitment transaction for non-epoch blocks
+                        for commitment_tx in arc_commitment_txs.iter() {
+                            let is_staked = commitment_state_guard.is_staked(commitment_tx.signer);
+                            let status =
+                                parent_snapshot.get_commitment_status(commitment_tx, is_staked);
+
+                            // Ensure commitment is unknown (new) and from staked address
+                            match status {
+                                CommitmentSnapshotStatus::Accepted => {
+                                    return Err(eyre::eyre!(
+                                        "Commitment tx included in prior block"
+                                    ))
+                                }
+                                CommitmentSnapshotStatus::Unsupported => {
+                                    return Err(eyre::eyre!("Commitment tx of unsupported type"))
+                                }
+                                CommitmentSnapshotStatus::Unstaked => {
+                                    return Err(eyre::eyre!(
+                                        "Commitment tx {} from unstaked address {:?}",
+                                        commitment_tx.id,
+                                        commitment_tx.signer
+                                    ))
+                                }
+                                CommitmentSnapshotStatus::Unknown => {} // Success case
+                            }
+
+                            // Add commitment and validate it's accepted
+                            let is_staked_in_current_epoch =
+                                commitment_state_guard.is_staked(commitment_tx.signer);
+                            let add_status = parent_snapshot
+                                .add_commitment(commitment_tx, is_staked_in_current_epoch);
+                            if add_status != CommitmentSnapshotStatus::Accepted {
+                                return Err(eyre::eyre!("Commitment tx is invalid"));
+                            }
+                        }
                     }
 
                     // WARNING: All block pre-validation needs to be completed before

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -951,7 +951,7 @@ impl BlockTreeCache {
         };
 
         // Initialize commitment snapshot and add start block
-        let mut commitment_snapshot = current_epoch_commitments(
+        let mut commitment_snapshot = build_current_snapshot_from_index(
             block_index_guard.clone(),
             commitment_state_guard.clone(),
             db.clone(),
@@ -1766,7 +1766,7 @@ pub async fn get_block(
 ///
 /// # Returns
 /// Initialized commitment snapshot containing all commitments from the current epoch
-pub fn current_epoch_commitments(
+pub fn build_current_snapshot_from_index(
     block_index_guard: BlockIndexReadGuard,
     commitment_state_guard: CommitmentStateReadGuard,
     db: DatabaseProvider,

--- a/crates/chain/tests/api/mod.rs
+++ b/crates/chain/tests/api/mod.rs
@@ -1,14 +1,11 @@
-use actix_http::StatusCode;
-use base58::ToBase58 as _;
-use irys_types::{CommitmentTransaction, DataLedger};
-use tracing::info;
-
+use irys_types::DataLedger;
 mod api;
 mod client;
 mod external_api;
 mod pricing_endpoint;
 mod tx;
 mod tx_commitments;
+mod tx_duplicates;
 
 pub async fn client_request(
     url: &str,
@@ -67,34 +64,4 @@ pub async fn version_endpoint_request(
     address: &str,
 ) -> awc::ClientResponse<actix_web::dev::Decompress<actix_http::Payload>> {
     client_request(&format!("{}{}", &address, "/v1/version")).await
-}
-
-pub async fn post_commitment_tx_request(address: &str, commitment_tx: &CommitmentTransaction) {
-    info!("Posting Commitment TX: {}", commitment_tx.id.0.to_base58());
-
-    let client = awc::Client::default();
-    let mut response = client
-        .post(format!("{}/v1/commitment_tx", address))
-        .send_json(commitment_tx) // Send the commitment_tx as JSON in the request body
-        .await
-        .expect("client post failed");
-
-    if response.status() != StatusCode::OK {
-        // Read the response body
-        let body_bytes = response.body().await.expect("Failed to read response body");
-        let body_str = String::from_utf8_lossy(&body_bytes);
-
-        panic!(
-            "Response status: {} - {}\nRequest Body: {}",
-            response.status(),
-            body_str,
-            serde_json::to_string_pretty(&commitment_tx).unwrap(),
-        );
-    } else {
-        info!(
-            "Response status: {}\n{}",
-            response.status(),
-            serde_json::to_string_pretty(&commitment_tx).unwrap()
-        );
-    }
 }

--- a/crates/chain/tests/api/tx_commitments.rs
+++ b/crates/chain/tests/api/tx_commitments.rs
@@ -93,7 +93,7 @@ async fn heavy_test_commitments_3epochs_test() -> eyre::Result<()> {
             debug!(
                 "\nGenesis Block Commitments:\n{:#?}\nStake: {:#?}\nPledges:\n{:#?}",
                 genesis_block.get_commitment_ledger_tx_ids(),
-                steaks.unwrap().id,
+                stakes.unwrap().id,
                 pledges.unwrap().iter().map(|x| x.id).collect::<Vec<_>>(),
             );
 

--- a/crates/chain/tests/api/tx_commitments.rs
+++ b/crates/chain/tests/api/tx_commitments.rs
@@ -1,7 +1,4 @@
-use crate::{api::post_commitment_tx_request, utils::*};
-use actix_web::{middleware::Logger, App};
-use alloy_core::primitives::U256;
-use alloy_genesis::GenesisAccount;
+use crate::utils::*;
 use assert_matches::assert_matches;
 use base58::ToBase58 as _;
 use eyre::eyre;
@@ -9,7 +6,7 @@ use irys_actors::{
     packing::wait_for_packing, CommitmentStateReadGuard, GetCommitmentStateGuardMessage,
     GetPartitionAssignmentsGuardMessage, PartitionAssignmentsReadGuard,
 };
-use irys_api_server::routes;
+use irys_chain::IrysNodeCtx;
 use irys_database::CommitmentSnapshotStatus;
 use irys_primitives::CommitmentType;
 use irys_testing_utils::initialize_tracing;
@@ -64,29 +61,6 @@ async fn heavy_test_commitments_3epochs_test() -> eyre::Result<()> {
         // Initialize blockchain components
         node.start_mining().await;
 
-        let uri = format!(
-            "http://127.0.0.1:{}",
-            node.node_ctx.config.node_config.http.bind_port
-        );
-
-        // Initialize blockchain components
-        wait_for_packing(
-            node.node_ctx.actor_addresses.packing.clone(),
-            Some(Duration::from_secs(10)),
-        )
-        .await?;
-
-        // Initialize API for submitting commitment transactions
-        let api_state = node.node_ctx.get_api_state();
-
-        let _app = actix_web::test::init_service(
-            App::new()
-                .wrap(Logger::default())
-                .app_data(actix_web::web::Data::new(api_state))
-                .service(routes()),
-        )
-        .await;
-
         // Get access to commitment and partition services for verification
         let epoch_service = node.node_ctx.actor_addresses.epoch_service.clone();
         let commitment_state_guard = epoch_service
@@ -104,6 +78,7 @@ async fn heavy_test_commitments_3epochs_test() -> eyre::Result<()> {
         {
             let commitment_state = commitment_state_guard.read();
             let pledges = commitment_state.pledge_commitments.get(&genesis_signer);
+            let steaks = commitment_state.stake_commitments.get(&genesis_signer);
             if let Some(pledges) = pledges {
                 assert_eq!(
                     pledges.len(),
@@ -113,25 +88,52 @@ async fn heavy_test_commitments_3epochs_test() -> eyre::Result<()> {
             } else {
                 panic!("Expected genesis miner to have pledges!");
             }
+
+            let genesis_block = node.get_block_by_height(0).await?;
+            debug!(
+                "\nGenesis Block Commitments:\n{:#?}\nStake: {:#?}\nPledges:\n{:#?}",
+                genesis_block.get_commitment_ledger_tx_ids(),
+                steaks.unwrap().id,
+                pledges.unwrap().iter().map(|x| x.id).collect::<Vec<_>>(),
+            );
+
             drop(commitment_state); // Release lock to allow node operations
         }
 
         // ===== PHASE 2: First Epoch - Create Commitments =====
         // Create stake commitment for first test signer
-        post_stake_commitment(&uri, &signer1).await;
+        let stake_tx1 = post_stake_commitment(&node, &signer1).await;
 
         // Create two pledge commitments for first test signer
-        let anchor = post_pledge_commitment(&uri, &signer1, H256::default())
-            .await
-            .id;
-        post_pledge_commitment(&uri, &signer1, anchor).await;
+        let pledge1 = post_pledge_commitment(&node, &signer1, H256::default()).await;
+        let pledge2 = post_pledge_commitment(&node, &signer1, pledge1.id).await;
 
         // Create stake commitment for second test signer
-        post_stake_commitment(&uri, &signer2).await;
+        let stake_tx2 = post_stake_commitment(&node, &signer2).await;
 
         // Mine enough blocks to reach the first epoch boundary
         info!("MINE FIRST EPOCH BLOCK:");
         node.mine_blocks(num_blocks_in_epoch).await?;
+
+        debug!(
+            "Post Commitments:\nstake1: {:?}\nstake2: {:?}\npledge1: {:?}\npledge2: {:?}\n",
+            stake_tx1.id, stake_tx2.id, pledge1.id, pledge2.id
+        );
+
+        // Block height: 1 should have two stake and two pledge commitments
+        let expected_ids = [stake_tx1.id, stake_tx2.id, pledge1.id, pledge2.id];
+        let block_1 = node.get_block_by_height(1).await.unwrap();
+        let commitments_1 = block_1.get_commitment_ledger_tx_ids();
+        debug!("Block - height: {:?}\n{:#?}", block_1.height, commitments_1,);
+        assert_eq!(commitments_1.len(), 4);
+        assert!(expected_ids.iter().all(|id| commitments_1.contains(id)));
+
+        // Block height: 2 is an epoch block and should have the same commitments and no more
+        let block_2 = node.get_block_by_height(2).await.unwrap();
+        let commitments_2 = block_2.get_commitment_ledger_tx_ids();
+        debug!("Block - height: {:?}\n{:#?}", block_2.height, commitments_2);
+        assert_eq!(commitments_2.len(), 4);
+        assert!(expected_ids.iter().all(|id| commitments_2.contains(id)));
 
         // ===== PHASE 3: Verify First Epoch Assignments =====
         // Verify that all pledges have been assigned partitions
@@ -181,12 +183,20 @@ async fn heavy_test_commitments_3epochs_test() -> eyre::Result<()> {
 
         // ===== PHASE 4: Second Epoch - Add More Commitments =====
         // Create pledge for second test signer
-        let c_tx = post_pledge_commitment(&uri, &signer2, H256::default()).await;
-        info!("signer2: {} post pledge: {}", signer2_address, c_tx.id);
+        let pledge3 = post_pledge_commitment(&node, &signer2, H256::default()).await;
+        info!("signer2: {} post pledge: {}", signer2_address, pledge3.id);
 
         // Mine enough blocks to reach the second epoch boundary
         info!("MINE SECOND EPOCH BLOCK:");
         node.mine_blocks(num_blocks_in_epoch + 2).await?;
+
+        let block_3 = node.get_block_by_height(3).await.unwrap();
+        let commitments_3 = block_3.get_commitment_ledger_tx_ids();
+        debug!("Block - height: {:?}\n{:#?}", block_3.height, commitments_3);
+
+        // Block height: 3 should have 1 pledge commitment
+        assert_eq!(commitments_3.len(), 1);
+        assert_eq!(commitments_3, vec![pledge3.id]);
 
         // ===== PHASE 5: Verify Second Epoch Assignments =====
         // Verify all signers have proper partition assignments for all pledges
@@ -355,19 +365,9 @@ async fn heavy_test_commitments_basic_test() -> eyre::Result<()> {
     // Create test environment with a funded signer for transaction creation
     let mut config = NodeConfig::testnet();
     let signer = IrysSigner::random_signer(&config.consensus_config());
-    config.consensus.extend_genesis_accounts(vec![(
-        signer.address(),
-        GenesisAccount {
-            balance: U256::from(690000000000000000_u128),
-            ..Default::default()
-        },
-    )]);
-    let node = IrysNodeTest::new_genesis(config.clone()).start().await;
+    config.fund_genesis_accounts(vec![&signer]);
 
-    let uri = format!(
-        "http://127.0.0.1:{}",
-        node.node_ctx.config.node_config.http.bind_port
-    );
+    let node = IrysNodeTest::new_genesis(config.clone()).start().await;
 
     // Initialize packing and mining
     wait_for_packing(
@@ -391,7 +391,7 @@ async fn heavy_test_commitments_basic_test() -> eyre::Result<()> {
     assert_eq!(status, CommitmentSnapshotStatus::Unknown);
 
     // Submit stake commitment via API
-    post_commitment_tx_request(&uri, &stake_tx).await;
+    node.post_commitment_tx(&stake_tx).await;
 
     // Mine a block to include the commitment
     node.mine_blocks(1).await?;
@@ -415,7 +415,7 @@ async fn heavy_test_commitments_basic_test() -> eyre::Result<()> {
     assert_eq!(status, CommitmentSnapshotStatus::Unknown);
 
     // Submit pledge via API
-    post_commitment_tx_request(&uri, &pledge_tx).await;
+    node.post_commitment_tx(&pledge_tx).await;
 
     // Verify pledge is still 'Unknown' before mining
     let status = node.get_commitment_snapshot_status(&pledge_tx);
@@ -435,7 +435,7 @@ async fn heavy_test_commitments_basic_test() -> eyre::Result<()> {
     assert_eq!(status, CommitmentSnapshotStatus::Accepted);
 
     // Re-submit the same stake commitment
-    post_commitment_tx_request(&uri, &stake_tx).await;
+    node.post_commitment_tx(&stake_tx).await;
     node.mine_blocks(1).await?;
 
     // Verify stake is still 'Accepted' (idempotent operation)
@@ -460,7 +460,7 @@ async fn heavy_test_commitments_basic_test() -> eyre::Result<()> {
     assert_eq!(status, CommitmentSnapshotStatus::Unstaked);
 
     // Submit pledge via API
-    post_commitment_tx_request(&uri, &pledge_tx).await;
+    node.post_commitment_tx(&pledge_tx).await;
     node.mine_blocks(1).await?;
 
     // Verify pledge remains 'Unstaked' (invalid without stake)
@@ -472,7 +472,10 @@ async fn heavy_test_commitments_basic_test() -> eyre::Result<()> {
     Ok(())
 }
 
-async fn post_stake_commitment(uri: &str, signer: &IrysSigner) {
+async fn post_stake_commitment(
+    node: &IrysNodeTest<IrysNodeCtx>,
+    signer: &IrysSigner,
+) -> CommitmentTransaction {
     let stake_tx = CommitmentTransaction {
         commitment_type: CommitmentType::Stake,
         fee: 1,
@@ -482,11 +485,12 @@ async fn post_stake_commitment(uri: &str, signer: &IrysSigner) {
     info!("Generated stake_tx.id: {}", stake_tx.id.0.to_base58());
 
     // Submit stake commitment via API
-    post_commitment_tx_request(uri, &stake_tx).await;
+    node.post_commitment_tx(&stake_tx).await;
+    stake_tx
 }
 
 async fn post_pledge_commitment(
-    uri: &str,
+    node: &IrysNodeTest<IrysNodeCtx>,
     signer: &IrysSigner,
     anchor: H256,
 ) -> CommitmentTransaction {
@@ -500,7 +504,7 @@ async fn post_pledge_commitment(
     info!("Generated pledge_tx.id: {}", pledge_tx.id.0.to_base58());
 
     // Submit pledge commitment via API
-    post_commitment_tx_request(uri, &pledge_tx).await;
+    node.post_commitment_tx(&pledge_tx).await;
 
     pledge_tx
 }

--- a/crates/chain/tests/api/tx_commitments.rs
+++ b/crates/chain/tests/api/tx_commitments.rs
@@ -78,7 +78,7 @@ async fn heavy_test_commitments_3epochs_test() -> eyre::Result<()> {
         {
             let commitment_state = commitment_state_guard.read();
             let pledges = commitment_state.pledge_commitments.get(&genesis_signer);
-            let steaks = commitment_state.stake_commitments.get(&genesis_signer);
+            let stakes = commitment_state.stake_commitments.get(&genesis_signer);
             if let Some(pledges) = pledges {
                 assert_eq!(
                     pledges.len(),

--- a/crates/chain/tests/api/tx_duplicates.rs
+++ b/crates/chain/tests/api/tx_duplicates.rs
@@ -1,0 +1,165 @@
+use crate::utils::IrysNodeTest;
+use irys_primitives::CommitmentType;
+use irys_testing_utils::initialize_tracing;
+use irys_types::{irys::IrysSigner, CommitmentTransaction, DataLedger, NodeConfig, H256};
+
+#[actix_web::test]
+async fn test_rejection_of_duplicate_tx() -> eyre::Result<()> {
+    // ===== TEST ENVIRONMENT SETUP =====
+    std::env::set_var("RUST_LOG", "debug");
+    initialize_tracing();
+
+    // Default test node config
+    let seconds_to_wait = 10;
+    let num_blocks_in_epoch = 8;
+    let mut config = NodeConfig::testnet_with_epochs(num_blocks_in_epoch);
+    config.consensus.get_mut().chunk_size = 32;
+    let signer = IrysSigner::random_signer(&config.consensus_config());
+    config.fund_genesis_accounts(vec![&signer]);
+
+    // Start a test node with default configuration
+    let node = IrysNodeTest::new_genesis(config.clone())
+        .start_and_wait_for_packing("GENESIS", seconds_to_wait)
+        .await;
+
+    // Initialize blockchain components
+    node.start_mining().await;
+
+    // ===== TEST CASE 1: post duplicate data tx =====
+    let chunks = vec![[10; 32], [20; 32], [30; 32]];
+    let mut data: Vec<u8> = Vec::new();
+    for chunk in chunks.iter() {
+        data.extend_from_slice(chunk);
+    }
+
+    // Then post the tx and wait for it to arrive
+    let anchor = H256::zero(); // Genesis block
+    let data_tx = node.post_data_tx(anchor, data, &signer).await;
+    let tx = data_tx.header.clone();
+    let txid = tx.id;
+    node.wait_for_mempool(txid, seconds_to_wait).await?;
+
+    // Mine a block and verify that it is included in a block
+    node.mine_block().await?;
+    let block1 = node.get_block_by_height(1).await?;
+    let txid_map = block1.get_data_ledger_tx_ids();
+    assert!(txid_map.get(&DataLedger::Submit).unwrap().contains(&txid));
+
+    // Post the chunks for the data tx
+    for i in 0..chunks.len() {
+        node.post_chunk_32b(&data_tx, i, &chunks).await;
+    }
+
+    // Re-post the transaction as duplicate of an already included txid
+    node.post_data_tx_raw(&tx).await;
+
+    // Wait for mempool should return immediately because the transaction is already known
+    node.wait_for_mempool(txid, seconds_to_wait).await?;
+
+    // Mine a block and verify the duplicate tx is not included again
+    node.mine_block().await?;
+    let block2 = node.get_block_by_height(2).await?;
+    let txid_map = block2.get_data_ledger_tx_ids();
+    assert_eq!(
+        txid_map.get(&DataLedger::Submit).unwrap().contains(&txid),
+        false
+    );
+
+    // Verify the tx is published
+    assert!(txid_map.get(&DataLedger::Publish).unwrap().contains(&txid));
+    assert_eq!(txid_map.get(&DataLedger::Publish).unwrap().len(), 1);
+
+    // ===== TEST CASE 2: post duplicate commitment tx =====
+    let stake_tx = CommitmentTransaction {
+        commitment_type: CommitmentType::Stake,
+        fee: 1,
+        ..Default::default()
+    };
+
+    // Post the stake commitment and await it in the mempool
+    let stake_tx = signer.sign_commitment(stake_tx).unwrap();
+    node.post_commitment_tx(&stake_tx).await;
+    node.wait_for_mempool_commitment_txs(vec![stake_tx.id], seconds_to_wait)
+        .await?;
+
+    // Mine a block and verify the stake commitment is included
+    node.mine_block().await?;
+    let block3 = node.get_block_by_height(3).await?;
+    let tx_ids = block3.get_commitment_ledger_tx_ids();
+    assert_eq!(tx_ids, vec![stake_tx.id]);
+
+    // Post the stake commitment again
+    node.post_commitment_tx(&stake_tx).await;
+    node.wait_for_mempool_commitment_txs(vec![stake_tx.id], seconds_to_wait)
+        .await?;
+
+    // Mine a block and make sure the commitment isn't included again
+    node.mine_block().await?;
+    let block4 = node.get_block_by_height(4).await?;
+    let tx_ids = block4.get_commitment_ledger_tx_ids();
+    assert_eq!(tx_ids, vec![]);
+
+    // ===== TEST CASE 3: post duplicate pledge tx =====
+    let pledge_tx = CommitmentTransaction {
+        commitment_type: CommitmentType::Pledge,
+        anchor,
+        fee: 1,
+        ..Default::default()
+    };
+    let pledge_tx = signer.sign_commitment(pledge_tx).unwrap();
+
+    // Post pledge commitment
+    node.post_commitment_tx(&pledge_tx).await;
+    node.wait_for_mempool_commitment_txs(vec![pledge_tx.id], seconds_to_wait)
+        .await?;
+
+    // Mine a block and verify the pledge commitment is included
+    node.mine_block().await?;
+    let block5 = node.get_block_by_height(5).await?;
+    let tx_ids = block5.get_commitment_ledger_tx_ids();
+    assert_eq!(tx_ids, vec![pledge_tx.id]);
+
+    // Post the pledge commitment again
+    node.post_commitment_tx(&pledge_tx).await;
+    node.wait_for_mempool_commitment_txs(vec![pledge_tx.id], seconds_to_wait)
+        .await?;
+
+    // Mine a block and verify the pledges is not included again
+    node.mine_block().await?;
+    let block6 = node.get_block_by_height(6).await?;
+    let tx_ids = block6.get_commitment_ledger_tx_ids();
+    assert_eq!(tx_ids, vec![]);
+
+    // ===== TEST CASE 4: mine an epoch block and test duplicates again =====
+    node.mine_blocks(2).await?;
+    let block8 = node.get_block_by_height(8).await?;
+    let tx_ids = block8.get_commitment_ledger_tx_ids();
+
+    // Validate the stake and pledge tx are in the commitments roll up
+    assert_eq!(tx_ids, vec![stake_tx.id, pledge_tx.id]);
+
+    // Post all the transactions again
+    node.post_data_tx_raw(&tx).await;
+    node.post_commitment_tx(&stake_tx).await;
+    node.post_commitment_tx(&pledge_tx).await;
+    node.wait_for_mempool_commitment_txs(vec![stake_tx.id, pledge_tx.id], seconds_to_wait)
+        .await?;
+
+    // Post the chunks for the data again
+    for i in 0..chunks.len() {
+        node.post_chunk_32b(&data_tx, i, &chunks).await;
+    }
+
+    // Mine a block and validate that none of them are included
+    node.mine_block().await?;
+    let block9 = node.get_block_by_height(9).await?;
+    let txid_map = block9.get_data_ledger_tx_ids();
+    assert_eq!(txid_map.get(&DataLedger::Submit).unwrap().len(), 0);
+    let tx_ids = block9.get_commitment_ledger_tx_ids();
+    assert_eq!(tx_ids, vec![]);
+
+    // Validate the data tx is not published again
+    assert_eq!(txid_map.get(&DataLedger::Publish).unwrap().len(), 0);
+
+    Ok(())
+}

--- a/crates/chain/tests/api/tx_duplicates.rs
+++ b/crates/chain/tests/api/tx_duplicates.rs
@@ -4,7 +4,7 @@ use irys_testing_utils::initialize_tracing;
 use irys_types::{irys::IrysSigner, CommitmentTransaction, DataLedger, NodeConfig, H256};
 
 #[actix_web::test]
-async fn test_rejection_of_duplicate_tx() -> eyre::Result<()> {
+async fn heavy_test_rejection_of_duplicate_tx() -> eyre::Result<()> {
     // ===== TEST ENVIRONMENT SETUP =====
     std::env::set_var("RUST_LOG", "debug");
     initialize_tracing();

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -104,7 +104,7 @@ async fn heavy_fork_recovery_test() -> eyre::Result<()> {
 
     // Post a transaction that should be gossiped to all peers
     let shared_tx = genesis_node
-        .post_storage_tx(
+        .post_data_tx(
             H256::zero(),
             data3,
             &genesis_node.node_ctx.config.irys_signer(),
@@ -118,10 +118,10 @@ async fn heavy_fork_recovery_test() -> eyre::Result<()> {
 
     // Post a unique storage transaction to each peer
     let peer1_tx = peer1_node
-        .post_storage_tx_without_gossip(H256::zero(), data1, &peer1_signer)
+        .post_data_tx_without_gossip(H256::zero(), data1, &peer1_signer)
         .await;
     let peer2_tx = peer2_node
-        .post_storage_tx_without_gossip(H256::zero(), data2, &peer2_signer)
+        .post_data_tx_without_gossip(H256::zero(), data2, &peer2_signer)
         .await;
 
     // Mine mine blocks on both peers in parallel

--- a/crates/chain/tests/multi_node/mempool_tests.rs
+++ b/crates/chain/tests/multi_node/mempool_tests.rs
@@ -61,7 +61,7 @@ async fn heavy_pending_chunks_test() -> eyre::Result<()> {
     post_chunk(&app, &tx, 2, &chunks).await;
 
     // Then post the tx
-    post_storage_tx(&app, &tx).await;
+    post_data_tx(&app, &tx).await;
 
     // Mine some blocks to trigger chunk migration
     genesis_node.mine_blocks(2).await?;
@@ -170,7 +170,7 @@ async fn mempool_persistence_test() -> eyre::Result<()> {
 
     // post storage tx
     let storage_tx = genesis_node
-        .post_storage_tx_without_gossip(H256::zero(), data, &signer)
+        .post_data_tx_without_gossip(H256::zero(), data, &signer)
         .await;
 
     // Restart the node
@@ -524,7 +524,7 @@ async fn heavy_mempool_fork_recovery_test() -> eyre::Result<()> {
     let data: Vec<u8> = chunks.concat();
 
     let _peer2_tx = peer2
-        .post_storage_tx_without_gossip(H256::zero(), data, &recipient2)
+        .post_data_tx_without_gossip(H256::zero(), data, &recipient2)
         .await;
 
     // call get best txs from the mempool

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -689,7 +689,11 @@ impl IrysNodeTest<IrysNodeCtx> {
             .read()
             .canonical_commitment_snapshot();
 
-        commitment_snapshot.get_commitment_status(commitment_tx)
+        let is_staked = self
+            .node_ctx
+            .commitment_state_guard
+            .is_staked(commitment_tx.signer);
+        commitment_snapshot.get_commitment_status(commitment_tx, is_staked)
     }
 
     /// wait for tx to appear in the mempool or be found in the database
@@ -992,7 +996,7 @@ impl IrysNodeTest<IrysNodeCtx> {
         }
     }
 
-    pub async fn post_storage_tx_without_gossip(
+    pub async fn post_data_tx_without_gossip(
         &self,
         anchor: H256,
         data: Vec<u8>,
@@ -1000,12 +1004,12 @@ impl IrysNodeTest<IrysNodeCtx> {
     ) -> IrysTransaction {
         let prev_is_syncing = self.node_ctx.sync_state.is_syncing();
         self.node_ctx.sync_state.set_is_syncing(true);
-        let tx = self.post_storage_tx(anchor, data, signer).await;
+        let tx = self.post_data_tx(anchor, data, signer).await;
         self.node_ctx.sync_state.set_is_syncing(prev_is_syncing);
         tx
     }
 
-    pub async fn post_storage_tx(
+    pub async fn post_data_tx(
         &self,
         anchor: H256,
         data: Vec<u8>,
@@ -1046,6 +1050,63 @@ impl IrysNodeTest<IrysNodeCtx> {
             );
         }
         tx
+    }
+
+    pub async fn post_data_tx_raw(&self, tx: &IrysTransactionHeader) {
+        let client = awc::Client::default();
+        let api_uri = self.node_ctx.config.node_config.api_uri();
+        let url = format!("{}/v1/tx", api_uri);
+        let mut response = client
+            .post(url)
+            .send_json(&tx) // Send the tx as JSON in the request body
+            .await
+            .expect("client post failed");
+
+        if response.status() != StatusCode::OK {
+            // Read the response body
+            let body_bytes = response.body().await.expect("Failed to read response body");
+            let body_str = String::from_utf8_lossy(&body_bytes);
+
+            panic!(
+                "Response status: {} - {}\nRequest Body: {}",
+                response.status(),
+                body_str,
+                serde_json::to_string_pretty(&tx).unwrap(),
+            );
+        } else {
+            info!(
+                "Response status: {}\n{}",
+                response.status(),
+                serde_json::to_string_pretty(&tx).unwrap()
+            );
+        }
+    }
+
+    pub async fn post_chunk_32b(
+        &self,
+        tx: &IrysTransaction,
+        chunk_index: usize,
+        chunks: &[[u8; 32]],
+    ) {
+        let chunk = UnpackedChunk {
+            data_root: tx.header.data_root,
+            data_size: tx.header.data_size,
+            data_path: Base64(tx.proofs[chunk_index].proof.clone()),
+            bytes: Base64(chunks[chunk_index].to_vec()),
+            tx_offset: TxChunkOffset::from(chunk_index as u32),
+        };
+
+        let client = awc::Client::default();
+        let api_uri = self.node_ctx.config.node_config.api_uri();
+        let url = format!("{}/v1/chunk", api_uri);
+        let response = client
+            .post(url)
+            .send_json(&chunk) // Send the tx as JSON in the request body
+            .await
+            .expect("client post failed");
+
+        debug!("chunk_index: {:?}", chunk_index);
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     pub async fn post_commitment_tx(&self, commitment_tx: &CommitmentTransaction) {
@@ -1238,7 +1299,7 @@ pub async fn post_chunk<T, B>(
 ///
 /// # Panics
 /// Panics if the response status is not HTTP 200 OK.
-pub async fn post_storage_tx<T, B>(app: &T, tx: &IrysTransaction)
+pub async fn post_data_tx<T, B>(app: &T, tx: &IrysTransaction)
 where
     T: Service<actix_http::Request, Response = ServiceResponse<B>, Error = actix_web::Error>,
     B: MessageBody + Unpin,


### PR DESCRIPTION
**Changes**

* Streamline and add checks to `tx_commitments.rs` test
* Add duplicate detection for commitment transactions (stake/pledge) and submit ledger transactions in block discovery
* Filter `getBestMempoolTx` to only include pending transactions not present in canonical chain
* Rename `post_storage_tx` test to `post_data_tx` for clarity
* Fix bug in `CommitmentSnapshot::get_commitment_status()` that incorrectly returned `Unstaked` for pledge commitments when address was staked in prior epoch
* Refactor test methods to use HTTP client instead of actix app reference
* Add test context methods for posting chunks
* Remove dead code for rolling back commitments from `CommitmentSnapshot`
* adds new `tx_duplicates.rs` test

**Additional Context:**
Publish transaction validation is not included in this PR. Currently it's difficult but possible for an adversary to create blocks with duplicate promoted transaction IDs. Future work will:
1. Check if publish transaction ID exists in database with ingress proofs
2. Walk back discovered block parents (to migration depth) to ensure publish transaction ID doesn't appear

This validation will be implemented in a future PR.