### PR TITLE
fix: strip problematic env vars from xtask subcommands

### DIFF
--- a/crates/chain/tests/api/tx_commitments.rs
+++ b/crates/chain/tests/api/tx_commitments.rs
@@ -76,9 +76,12 @@ async fn heavy_test_commitments_3epochs_test() -> eyre::Result<()> {
         // Check that the genesis block producer has the expected initial pledges
 
         {
+            let genesis_block = node.get_block_by_height(0).await?;
+
             let commitment_state = commitment_state_guard.read();
             let pledges = commitment_state.pledge_commitments.get(&genesis_signer);
             let stakes = commitment_state.stake_commitments.get(&genesis_signer);
+
             if let Some(pledges) = pledges {
                 assert_eq!(
                     pledges.len(),
@@ -89,14 +92,12 @@ async fn heavy_test_commitments_3epochs_test() -> eyre::Result<()> {
                 panic!("Expected genesis miner to have pledges!");
             }
 
-            let genesis_block = node.get_block_by_height(0).await?;
             debug!(
                 "\nGenesis Block Commitments:\n{:#?}\nStake: {:#?}\nPledges:\n{:#?}",
                 genesis_block.get_commitment_ledger_tx_ids(),
                 stakes.unwrap().id,
                 pledges.unwrap().iter().map(|x| x.id).collect::<Vec<_>>(),
             );
-
             drop(commitment_state); // Release lock to allow node operations
         }
 

--- a/crates/chain/tests/api/tx_duplicates.rs
+++ b/crates/chain/tests/api/tx_duplicates.rs
@@ -60,10 +60,7 @@ async fn heavy_test_rejection_of_duplicate_tx() -> eyre::Result<()> {
     node.mine_block().await?;
     let block2 = node.get_block_by_height(2).await?;
     let txid_map = block2.get_data_ledger_tx_ids();
-    assert_eq!(
-        txid_map.get(&DataLedger::Submit).unwrap().contains(&txid),
-        false
-    );
+    assert!(!txid_map.get(&DataLedger::Submit).unwrap().contains(&txid));
 
     // Verify the tx is published
     assert!(txid_map.get(&DataLedger::Publish).unwrap().contains(&txid));

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -881,10 +881,8 @@ impl IrysNodeTest<IrysNodeCtx> {
             "to receive IrysTransactionResponse from MempoolServiceMessage::GetDataTxs message",
         );
         let maybe_mempool_tx = mempool_response.first();
-        if let Some(result) = maybe_mempool_tx {
-            if let Some(tx) = result {
-                return Ok(tx.clone());
-            }
+        if let Some(Some(tx)) = maybe_mempool_tx {
+            return Ok(tx.clone());
         }
         Err(eyre::eyre!("No tx header found for txid {:?}", tx_id))
     }

--- a/crates/packing/src/lib.rs
+++ b/crates/packing/src/lib.rs
@@ -279,7 +279,7 @@ mod tests {
         let node_config = NodeConfig::testnet();
         let mining_address = node_config.miner_address();
         let chunk_offset = rng.gen_range(1..=1000);
-        let mut partition_hash = [0u8; SHA_HASH_SIZE];
+        let mut partition_hash = [0_u8; SHA_HASH_SIZE];
         rng.fill(&mut partition_hash[..]);
         let iterations = 2 * testnet_config.chunk_size as u32;
 
@@ -474,7 +474,7 @@ mod tests {
         let mut chunks_rust: Vec<ChunkBytes> = Vec::with_capacity(num_chunks);
 
         for _i in 0..num_chunks {
-            let mut chunk = [0u8; ConsensusConfig::CHUNK_SIZE as usize];
+            let mut chunk = [0_u8; ConsensusConfig::CHUNK_SIZE as usize];
             rng.fill_bytes(&mut chunk);
             chunks_rust.push(chunk.to_vec());
             for j in 0..ConsensusConfig::CHUNK_SIZE as usize {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use xshell::{cmd, Shell};
+use xshell::{cmd, Cmd, Shell};
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -57,10 +57,10 @@ fn run_command(command: Commands, sh: &Shell) -> eyre::Result<()> {
     match command {
         Commands::Test { args, coverage } => {
             println!("cargo test");
-            let _ = cmd!(sh, "cargo install --locked cargo-nextest").run();
+            let _ = cmd!(sh, "cargo install --locked cargo-nextest").remove_and_run();
 
             if coverage {
-                cmd!(sh, "cargo install  --locked grcov").run()?;
+                cmd!(sh, "cargo install  --locked grcov").remove_and_run()?;
                 for (key, val) in [
                     ("CARGO_INCREMENTAL", "0"),
                     ("RUSTFLAGS", "-Cinstrument-coverage"),
@@ -77,82 +77,82 @@ fn run_command(command: Commands, sh: &Shell) -> eyre::Result<()> {
                 sh,
                 "cargo nextest run --workspace --tests --all-targets {args...}"
             )
-            .run()?;
+            .remove_and_run()?;
 
             if coverage {
-                cmd!(sh, "mkdir -p target/coverage").run()?;
-                cmd!(sh, "grcov . --binary-path ./target/debug/deps/ -s . -t html,cobertura --branch --ignore-not-existing --ignore '../*' --ignore \"/*\" -o target/coverage/").run()?;
+                cmd!(sh, "mkdir -p target/coverage").remove_and_run()?;
+                cmd!(sh, "grcov . --binary-path ./target/debug/deps/ -s . -t html,cobertura --branch --ignore-not-existing --ignore '../*' --ignore \"/*\" -o target/coverage/").remove_and_run()?;
 
                 // Open the generated file
                 if std::option_env!("CI").is_none() {
                     #[cfg(target_os = "macos")]
-                    cmd!(sh, "open target/coverage/html/index.html").run()?;
+                    cmd!(sh, "open target/coverage/html/index.html").remove_and_run()?;
 
                     #[cfg(target_os = "linux")]
-                    cmd!(sh, "xdg-open target/coverage/html/index.html").run()?;
+                    cmd!(sh, "xdg-open target/coverage/html/index.html").remove_and_run()?;
                 }
             }
         }
         Commands::Check { args } => {
             println!("cargo check");
-            cmd!(sh, "cargo check {args...}").run()?;
+            cmd!(sh, "cargo check {args...}").remove_and_run()?;
         }
         Commands::FullCheck { args } => {
             println!("cargo check --all-features --all-targets");
-            cmd!(sh, "cargo check --all-features --all-targets {args...}").run()?;
+            cmd!(sh, "cargo check --all-features --all-targets {args...}").remove_and_run()?;
         }
         Commands::FullBacon { args } => {
-            let _ = cmd!(sh, "cargo install --locked bacon").run();
+            let _ = cmd!(sh, "cargo install --locked bacon").remove_and_run();
             println!("bacon check-all ");
-            cmd!(sh, "bacon check-all {args...}").run()?;
+            cmd!(sh, "bacon check-all {args...}").remove_and_run()?;
         }
         Commands::Clippy { args } => {
             println!("cargo clippy");
-            cmd!(sh, "cargo clippy --workspace --locked {args...}").run()?;
+            cmd!(sh, "cargo clippy --workspace --locked {args...}").remove_and_run()?;
         }
         Commands::Fmt {
             check_only: only_check,
             args,
         } => {
             if only_check {
-                cmd!(sh, "cargo fmt --check {args...}").run()?;
+                cmd!(sh, "cargo fmt --check {args...}").remove_and_run()?;
             } else {
                 println!("cargo fmt & fix & clippy fix");
-                cmd!(sh, "cargo fmt --all").run()?;
+                cmd!(sh, "cargo fmt --all").remove_and_run()?;
                 let args_clone = args.clone();
                 cmd!(
                     sh,
                     "cargo fix --allow-dirty --allow-staged --workspace --tests {args_clone...}"
                 )
-                .run()?;
+                .remove_and_run()?;
                 cmd!(
                     sh,
                     "cargo clippy --fix --allow-dirty --allow-staged --workspace --tests {args...}"
                 )
-                .run()?;
+                .remove_and_run()?;
             }
         }
         Commands::Doc { args } => {
             println!("cargo doc");
-            cmd!(sh, "cargo doc --workspace --no-deps {args...}").run()?;
+            cmd!(sh, "cargo doc --workspace --no-deps {args...}").remove_and_run()?;
 
             if std::option_env!("CI").is_none() {
                 #[cfg(target_os = "macos")]
-                cmd!(sh, "open target/doc/irys/index.html").run()?;
+                cmd!(sh, "open target/doc/irys/index.html").remove_and_run()?;
 
                 #[cfg(target_os = "linux")]
-                cmd!(sh, "xdg-open target/doc/irys/index.html").run()?;
+                cmd!(sh, "xdg-open target/doc/irys/index.html").remove_and_run()?;
             }
         }
         Commands::Typos => {
             println!("typos check");
-            cmd!(sh, "cargo install --locked typos-cli").run()?;
-            cmd!(sh, "typos").run()?;
+            cmd!(sh, "cargo install --locked typos-cli").remove_and_run()?;
+            cmd!(sh, "typos").remove_and_run()?;
         }
         Commands::UnusedDeps => {
             println!("unused deps");
-            cmd!(sh, "cargo install --locked cargo-machete").run()?;
-            cmd!(sh, "cargo-machete").run()?;
+            cmd!(sh, "cargo install --locked cargo-machete").remove_and_run()?;
+            cmd!(sh, "cargo-machete").remove_and_run()?;
         }
         Commands::EmissionSimulation => {
             println!("block reward emission simulation");
@@ -160,7 +160,7 @@ fn run_command(command: Commands, sh: &Shell) -> eyre::Result<()> {
                 sh,
                 "cargo run --bin irys-reward-curve-simulation --features=emission-sim"
             )
-            .run()?;
+            .remove_and_run()?;
         }
         Commands::LocalChecks { with_tests, fix } => {
             run_command(
@@ -202,4 +202,32 @@ fn main() -> eyre::Result<()> {
     let sh = Shell::new()?;
     let args = Args::parse();
     run_command(args.command, &sh)
+}
+
+pub trait CmdExt {
+    fn remove_and_run(self) -> Result<(), xshell::Error>;
+}
+
+impl CmdExt for Cmd<'_> {
+    /// removes a set of problematic env vars set by xtask being a cargo subcommand
+    /// this is for ring, as their build.rs emits rerun conditions for the following env vars
+    /// many of which are not present if you use a regular `cargo check`,
+    /// which causes a re-run if you alternate between `cargo check` and an xtask command
+    fn remove_and_run(self) -> Result<(), xshell::Error> {
+        let mut c = self;
+        // TODO: once ring releases  0.17.15+, we should no longer need this
+        // these were taken from Ring's build.rs
+        for k in [
+            "CARGO_MANIFEST_DIR",
+            "CARGO_PKG_NAME",
+            "CARGO_PKG_VERSION_MAJOR",
+            "CARGO_PKG_VERSION_MINOR",
+            "CARGO_PKG_VERSION_PATCH",
+            "CARGO_PKG_VERSION_PRE",
+            "CARGO_MANIFEST_LINKS",
+        ] {
+            c = c.env_remove(k);
+        }
+        c.run()
+    }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -152,7 +152,7 @@ fn run_command(command: Commands, sh: &Shell) -> eyre::Result<()> {
         Commands::UnusedDeps => {
             println!("unused deps");
             cmd!(sh, "cargo install --locked cargo-machete").remove_and_run()?;
-            cmd!(sh, "cargo-machete").remove_and_run()?;
+            cmd!(sh, "cargo-machete").run()?;
         }
         Commands::EmissionSimulation => {
             println!("block reward emission simulation");
@@ -225,6 +225,13 @@ impl CmdExt for Cmd<'_> {
             "CARGO_PKG_VERSION_PATCH",
             "CARGO_PKG_VERSION_PRE",
             "CARGO_MANIFEST_LINKS",
+            "RING_PREGENERATE_ASM",
+            "OUT_DIR",
+            "CARGO_CFG_TARGET_ARCH",
+            "CARGO_CFG_TARGET_OS",
+            "CARGO_CFG_TARGET_ENV",
+            "CARGO_CFG_TARGET_ENDIAN",
+            "DEBUG",
         ] {
             c = c.env_remove(k);
         }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -108,7 +108,7 @@ fn run_command(command: Commands, sh: &Shell) -> eyre::Result<()> {
         }
         Commands::Clippy { args } => {
             println!("cargo clippy");
-            cmd!(sh, "cargo clippy --workspace --locked {args...}").remove_and_run()?;
+            cmd!(sh, "cargo clippy --workspace --tests --locked {args...}").remove_and_run()?;
         }
         Commands::Fmt {
             check_only: only_check,
@@ -226,12 +226,12 @@ impl CmdExt for Cmd<'_> {
             "CARGO_PKG_VERSION_PRE",
             "CARGO_MANIFEST_LINKS",
             "RING_PREGENERATE_ASM",
-            "OUT_DIR",
+            // "OUT_DIR",
             "CARGO_CFG_TARGET_ARCH",
             "CARGO_CFG_TARGET_OS",
             "CARGO_CFG_TARGET_ENV",
             "CARGO_CFG_TARGET_ENDIAN",
-            "DEBUG",
+            // "DEBUG",
         ] {
             c = c.env_remove(k);
         }


### PR DESCRIPTION
**Describe the changes**
This PR modifies xtask/xshell to strip problematic cargo env vars that are set when xtask is run as a cargo subcommand.
These env vars trigger unnecessary rebuilds of the `ring` crate, which is a pretty deep dependency, when switching from xtask to cargo check, for example.

This PR also changes CI to run clippy check on tests, and resolves some lingering lint violations left by the absence of this check.

**Additional Context**
see https://github.com/oxidecomputer/omicron/pull/7740 for more information, as this is exactly the problem we're having

