### PR TITLE
feat: make sure blocks have time to migrate

### DIFF
--- a/crates/chain/tests/api/tx_commitments.rs
+++ b/crates/chain/tests/api/tx_commitments.rs
@@ -217,6 +217,8 @@ async fn heavy_test_commitments_3epochs_test() -> eyre::Result<()> {
             &signer2_address,
         ));
 
+        node.wait_until_height_confirmed(6, 10).await?;
+
         node
     };
 

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -470,6 +470,44 @@ impl IrysNodeTest<IrysNodeCtx> {
         }
     }
 
+    pub async fn wait_until_height_confirmed(
+        &self,
+        target_height: u64,
+        max_seconds: usize,
+    ) -> eyre::Result<H256> {
+        let mut retries = 0;
+        let max_retries = max_seconds; // 1 second per retry
+
+        loop {
+            let canonical_chain = get_canonical_chain(self.node_ctx.block_tree_guard.clone())
+                .await
+                .unwrap();
+            let latest_block = canonical_chain.0.last().unwrap();
+
+            let latest_height = latest_block.height;
+            let not_onchain_count = canonical_chain.1 as u64;
+            if (latest_height - not_onchain_count) >= target_height {
+                info!(
+                    "reached height {} after {} retries",
+                    target_height, &retries
+                );
+
+                return Ok(latest_block.block_hash);
+            }
+
+            if retries >= max_retries {
+                return Err(eyre::eyre!(
+                    "Failed to reach target height {} after {} retries",
+                    target_height,
+                    retries
+                ));
+            }
+
+            sleep(Duration::from_secs(1)).await;
+            retries += 1;
+        }
+    }
+
     pub async fn wait_for_chunk(
         &self,
         app: &impl actix_web::dev::Service<


### PR DESCRIPTION
**Fix flaky tx_commitments test by ensuring epoch blocks are confirmed before shutdown**

The `tx_commitments::heavy_test_commitments_3epochs_test` was experiencing intermittent failures due to a race condition introduced by recent changes to block migration and validation. 

**Problem:** The test was shutting down before all blocks were consistently written to the block_index, causing non-deterministic test results.

**Solution:** The test now waits for epoch blocks to be confirmed before initiating shutdown. With `block_migration_depth = 1`, this ensures blocks are properly written to the block_index and persisted during graceful shutdown, eliminating the race condition.