### PR TITLE
chore: use submit_ledger_epoch_length from the config

### DIFF
--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -498,7 +498,7 @@ pub trait BlockProdStrategy {
                     tx_root: DataTransactionLedger::merklize_tx_root(&submit_txs).0,
                     tx_ids: H256List(submit_txs.iter().map(|t| t.id).collect::<Vec<_>>()),
                     max_chunk_offset: submit_max_chunk_offset,
-                    expires: Some(1622543200), // todo this should be updated `submit_ledger_epoch_length` from the config
+                    expires: Some(self.inner().config.consensus.epoch.submit_ledger_epoch_length), 
                     proofs: None,
                 },
             ],


### PR DESCRIPTION
**Describe the changes**
Small fix to remove hardcoded expiry and use submit_ledger_epoch_length from the config

**Related Issue(s)**
Closes #490 

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
