### PR TITLE
feat: sync fast track

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5005,6 +5005,7 @@ dependencies = [
  "irys-testing-utils",
  "irys-types",
  "irys-vdf",
+ "log",
  "lru 0.14.0",
  "rand 0.8.5",
  "reqwest 0.11.27",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5005,7 +5005,6 @@ dependencies = [
  "irys-testing-utils",
  "irys-types",
  "irys-vdf",
- "log",
  "lru 0.14.0",
  "rand 0.8.5",
  "reqwest 0.11.27",

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -80,7 +80,7 @@ pub enum BlockTreeServiceMessage {
     },
     FastTrackStorageFinalized {
         block_header: IrysBlockHeader,
-        response: oneshot::Sender<eyre::Result<bool>>,
+        response: oneshot::Sender<eyre::Result<Option<Addr<RethServiceActor>>>>,
     },
     ReloadCacheFromDb {
         response: oneshot::Sender<()>,
@@ -276,7 +276,7 @@ impl BlockTreeServiceInner {
     async fn fast_track_storage_finalized_message(
         &self,
         block_header: IrysBlockHeader,
-    ) -> eyre::Result<bool> {
+    ) -> eyre::Result<Option<Addr<RethServiceActor>>> {
         let submit_txs = self
             .get_data_ledger_tx_headers_from_mempool(&block_header, DataLedger::Submit)
             .await?;
@@ -306,7 +306,7 @@ impl BlockTreeServiceInner {
 
         block_index.do_send(block_finalized_message.clone());
         chunk_migration.do_send(block_finalized_message);
-        Ok(true)
+        Ok(Some(self.reth_service_actor.clone()))
     }
 
     async fn send_storage_finalized_message(&self, block_hash: BlockHash) -> eyre::Result<()> {

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -1710,7 +1710,7 @@ impl BlockTreeCache {
                 let max_height = earliest_height + (max_tree_depth / 2);
                 height <= max_height
             })
-            .unwrap_or(false)
+            .unwrap_or(true)
     }
 
     /// Gets block with matching solution hash, excluding specified block.

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -251,9 +251,7 @@ impl BlockTreeServiceInner {
                     .await;
                 let _ = response.send(result);
             }
-            BlockTreeServiceMessage::ReloadCacheFromDb {
-                response,
-            } => {
+            BlockTreeServiceMessage::ReloadCacheFromDb { response } => {
                 self.reload_cache_from_db();
                 let _ = response.send(());
             }
@@ -263,14 +261,14 @@ impl BlockTreeServiceInner {
 
     fn reload_cache_from_db(&self) {
         debug!("Reloading block tree cache from database");
-        let new_index = BlockTreeCache::restore_from_db(
+        let new_block_tree_cache = BlockTreeCache::restore_from_db(
             self.block_index_guard.clone(),
             self.commitment_state_guard.clone(),
             self.reth_service_actor.clone(),
             self.db.clone(),
             self.consensus_config.clone(),
         );
-        *self.cache.write().unwrap() = new_index;
+        *self.cache.write().unwrap() = new_block_tree_cache;
     }
 
     /// Fast tracks the storage finalization of a block by retrieving transaction headers. Do

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -80,7 +80,7 @@ pub enum BlockTreeServiceMessage {
     },
     FastTrackStorageFinalized {
         block_header: IrysBlockHeader,
-        response: oneshot::Sender<eyre::Result<()>>,
+        response: oneshot::Sender<eyre::Result<bool>>,
     },
     ReloadCacheFromDb {
         response: oneshot::Sender<()>,
@@ -276,7 +276,7 @@ impl BlockTreeServiceInner {
     async fn fast_track_storage_finalized_message(
         &self,
         block_header: IrysBlockHeader,
-    ) -> eyre::Result<()> {
+    ) -> eyre::Result<bool> {
         let submit_txs = self
             .get_data_ledger_tx_headers_from_mempool(&block_header, DataLedger::Submit)
             .await?;
@@ -306,7 +306,7 @@ impl BlockTreeServiceInner {
 
         block_index.do_send(block_finalized_message.clone());
         chunk_migration.do_send(block_finalized_message);
-        Ok(())
+        Ok(true)
     }
 
     async fn send_storage_finalized_message(&self, block_hash: BlockHash) -> eyre::Result<()> {

--- a/crates/actors/src/mempool_service/facade.rs
+++ b/crates/actors/src/mempool_service/facade.rs
@@ -31,7 +31,7 @@ pub trait MempoolFacade: Clone + Send + Sync + 'static {
     ) -> Result<Option<IrysBlockHeader>, TxReadError>;
     async fn migrate_block(
         &self,
-        irys_block_header: IrysBlockHeader,
+        irys_block_header: Arc<IrysBlockHeader>,
     ) -> Result<usize, TxIngressError>;
 
     async fn insert_poa_chunk(&self, block_hash: H256, chunk_data: Base64) -> eyre::Result<()>;
@@ -137,11 +137,11 @@ impl MempoolFacade for MempoolServiceFacadeImpl {
 
     async fn migrate_block(
         &self,
-        irys_block_header: IrysBlockHeader,
+        irys_block_header: Arc<IrysBlockHeader>,
     ) -> Result<usize, TxIngressError> {
         self.migration_sender
             .send(BlockMigratedEvent {
-                block: Arc::new(irys_block_header),
+                block: irys_block_header,
             })
             .map_err(|e| TxIngressError::Other(format!("Failed to send BlockMigratedEvent: {}", e)))
     }

--- a/crates/actors/src/mempool_service/facade.rs
+++ b/crates/actors/src/mempool_service/facade.rs
@@ -1,9 +1,15 @@
+use crate::block_tree_service::BlockMigratedEvent;
 use crate::mempool_service::{
     ChunkIngressError, MempoolServiceMessage, TxIngressError, TxReadError,
 };
+use crate::services::ServiceSenders;
+use eyre::eyre;
 use irys_types::{
-    chunk::UnpackedChunk, CommitmentTransaction, IrysBlockHeader, IrysTransactionHeader, H256,
+    chunk::UnpackedChunk, Base64, CommitmentTransaction, IrysBlockHeader, IrysTransactionHeader,
+    H256,
 };
+use std::sync::Arc;
+use tokio::sync::broadcast;
 use tokio::sync::mpsc::UnboundedSender;
 
 #[async_trait::async_trait]
@@ -23,16 +29,38 @@ pub trait MempoolFacade: Clone + Send + Sync + 'static {
         block_hash: H256,
         include_chunk: bool,
     ) -> Result<Option<IrysBlockHeader>, TxReadError>;
+    async fn migrate_block(
+        &self,
+        irys_block_header: IrysBlockHeader,
+    ) -> Result<usize, TxIngressError>;
+
+    async fn insert_poa_chunk(&self, block_hash: H256, chunk_data: Base64) -> eyre::Result<()>;
 }
 
 #[derive(Clone, Debug)]
 pub struct MempoolServiceFacadeImpl {
     service: UnboundedSender<MempoolServiceMessage>,
+    migration_sender: broadcast::Sender<BlockMigratedEvent>,
 }
 
-impl From<UnboundedSender<MempoolServiceMessage>> for MempoolServiceFacadeImpl {
-    fn from(value: UnboundedSender<MempoolServiceMessage>) -> Self {
-        Self { service: value }
+impl MempoolServiceFacadeImpl {
+    pub fn new(
+        service: UnboundedSender<MempoolServiceMessage>,
+        migration_sender: broadcast::Sender<BlockMigratedEvent>,
+    ) -> Self {
+        Self {
+            service,
+            migration_sender,
+        }
+    }
+}
+
+impl From<&ServiceSenders> for MempoolServiceFacadeImpl {
+    fn from(value: &ServiceSenders) -> Self {
+        Self {
+            service: value.mempool.clone(),
+            migration_sender: value.block_migrated_events.clone(),
+        }
     }
 }
 
@@ -105,5 +133,27 @@ impl MempoolFacade for MempoolServiceFacadeImpl {
 
         rx.await
             .map_err(|_| TxReadError::Other("GetBlockHeader response error".to_owned()))
+    }
+
+    async fn migrate_block(
+        &self,
+        irys_block_header: IrysBlockHeader,
+    ) -> Result<usize, TxIngressError> {
+        self.migration_sender
+            .send(BlockMigratedEvent {
+                block: Arc::new(irys_block_header),
+            })
+            .map_err(|e| TxIngressError::Other(format!("Failed to send BlockMigratedEvent: {}", e)))
+    }
+
+    async fn insert_poa_chunk(&self, block_hash: H256, chunk_data: Base64) -> eyre::Result<()> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.service
+            .send(MempoolServiceMessage::InsertPoAChunk(
+                block_hash, chunk_data, tx,
+            ))
+            .map_err(|send_error| eyre!("{send_error:?}"))?;
+
+        rx.await.map_err(|recv_error| eyre!("{recv_error:?}"))
     }
 }

--- a/crates/actors/src/mempool_service/inner.rs
+++ b/crates/actors/src/mempool_service/inner.rs
@@ -100,6 +100,7 @@ pub enum MempoolServiceMessage {
     ),
     /// Get block header from the mempool cache
     GetBlockHeader(H256, bool, oneshot::Sender<Option<IrysBlockHeader>>),
+    InsertPoAChunk(H256, Base64, oneshot::Sender<()>),
 }
 
 impl Inner {
@@ -182,6 +183,16 @@ impl Inner {
                 MempoolServiceMessage::IngestDataTx(tx, response) => {
                     let response_value = self.handle_data_tx_ingress_message(tx).await;
                     if let Err(e) = response.send(response_value) {
+                        tracing::error!("response.send() error: {:?}", e);
+                    };
+                }
+                MempoolServiceMessage::InsertPoAChunk(block_hash, chunk_data, response) => {
+                    self.mempool_state
+                        .write()
+                        .await
+                        .prevalidated_blocks_poa
+                        .insert(block_hash, chunk_data);
+                    if let Err(e) = response.send(()) {
                         tracing::error!("response.send() error: {:?}", e);
                     };
                 }

--- a/crates/api-server/src/routes/index.rs
+++ b/crates/api-server/src/routes/index.rs
@@ -24,7 +24,6 @@ pub async fn info_route(state: web::Data<ApiState>) -> HttpResponse {
         blocks: blocks as u64,
         is_syncing: state.sync_state.is_syncing(),
         current_sync_height: state.sync_state.sync_target_height(),
-        current_block_pool_height: state.sync_state.highest_processed_block() as u64
     };
 
     HttpResponse::Ok()

--- a/crates/api-server/src/routes/index.rs
+++ b/crates/api-server/src/routes/index.rs
@@ -6,22 +6,7 @@ use actix_web::{
 };
 use irys_actors::block_tree_service::get_canonical_chain;
 use irys_p2p::PeerList as _;
-use irys_types::H256;
-use serde::{Deserialize, Serialize};
-
-#[derive(Debug, Default, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct NodeInfo {
-    pub version: String,
-    pub peer_count: usize,
-    pub chain_id: u64,
-    pub height: u64,
-    pub block_hash: H256,
-    pub block_index_height: u64,
-    pub blocks: u64,
-    pub is_syncing: bool,
-    current_sync_height: usize,
-}
+use irys_types::NodeInfo;
 
 pub async fn info_route(state: web::Data<ApiState>) -> HttpResponse {
     let block_index_height = state.block_index.read().latest_height();

--- a/crates/api-server/src/routes/index.rs
+++ b/crates/api-server/src/routes/index.rs
@@ -24,6 +24,7 @@ pub async fn info_route(state: web::Data<ApiState>) -> HttpResponse {
         blocks: blocks as u64,
         is_syncing: state.sync_state.is_syncing(),
         current_sync_height: state.sync_state.sync_target_height(),
+        current_block_pool_height: state.sync_state.highest_processed_block() as u64
     };
 
     HttpResponse::Ok()

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -1012,6 +1012,8 @@ impl IrysNode {
             vdf_state_readonly.clone(),
             service_senders.vdf_fast_forward.clone(),
             service_senders.block_tree.clone(),
+            config.clone(),
+            service_senders.clone(),
         )?;
 
         // set up the price oracle

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -902,7 +902,6 @@ impl IrysNode {
         let p2p_service = P2PService::new(
             config.node_config.miner_address(),
             receivers.gossip_broadcast,
-            service_senders.gossip_broadcast.clone(),
         );
         let sync_state = p2p_service.sync_state.clone();
 
@@ -1014,8 +1013,6 @@ impl IrysNode {
             BlockStatusProvider::new(block_index_guard.clone(), block_tree_guard.clone()),
             execution_payload_provider,
             vdf_state_readonly.clone(),
-            service_senders.vdf_fast_forward.clone(),
-            service_senders.block_tree.clone(),
             config.clone(),
             service_senders.clone(),
         )?;

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -1011,6 +1011,7 @@ impl IrysNode {
             execution_payload_provider,
             vdf_state_readonly.clone(),
             service_senders.vdf_fast_forward.clone(),
+            service_senders.block_tree.clone(),
         )?;
 
         // set up the price oracle

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -347,7 +347,7 @@ impl IrysNode {
                 // Create a new genesis block for network initialization
                 self.create_new_genesis_block(genesis_block.clone())
             }
-            NodeMode::PeerSync => {
+            NodeMode::PeerSync | NodeMode::TrustedPeerSync => {
                 // Fetch genesis data from trusted peer when joining network
                 self.fetch_genesis_from_trusted_peer().await
             }
@@ -944,7 +944,7 @@ impl IrysNode {
             &config,
             &service_senders,
         );
-        let mempool_facade = MempoolServiceFacadeImpl::from(service_senders.mempool.clone());
+        let mempool_facade = MempoolServiceFacadeImpl::from(&service_senders);
 
         // spawn the chunk migration service
         Self::init_chunk_migration_service(
@@ -1009,6 +1009,8 @@ impl IrysNode {
             gossip_listener,
             BlockStatusProvider::new(block_index_guard.clone(), block_tree_guard.clone()),
             execution_payload_provider,
+            vdf_state_readonly.clone(),
+            service_senders.vdf_fast_forward.clone(),
         )?;
 
         // set up the price oracle

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -608,7 +608,7 @@ impl IrysNode {
             ctx.peer_list.clone(),
             node_mode,
             latest_known_block_height as usize,
-            ctx.config.node_config.genesis_peer_discovery_timeout_millis,
+            &ctx.config,
         )
         .await?;
 

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -109,7 +109,8 @@ pub struct IrysNodeCtx {
     pub sync_state: SyncState,
     pub shadow_tx_store: ShadowTxStore,
     pub validation_enabled: Arc<AtomicBool>,
-    pub block_pool: Arc<BlockPool<PeerListServiceFacade, BlockDiscoveryFacadeImpl, MempoolServiceFacadeImpl>>,
+    pub block_pool:
+        Arc<BlockPool<PeerListServiceFacade, BlockDiscoveryFacadeImpl, MempoolServiceFacadeImpl>>,
 }
 
 impl IrysNodeCtx {

--- a/crates/chain/src/utils.rs
+++ b/crates/chain/src/utils.rs
@@ -30,11 +30,6 @@ pub fn load_config() -> eyre::Result<NodeConfig> {
     if is_genesis {
         config.mode = NodeMode::Genesis;
     }
-    // This line made little sense to me - this would set the mode to whatever is in the config
-    // already before adding a new mode.
-    // else {
-    //     config.mode = NodeMode::PeerSync;
-    // };
 
     Ok(config)
 }

--- a/crates/chain/src/utils.rs
+++ b/crates/chain/src/utils.rs
@@ -29,9 +29,12 @@ pub fn load_config() -> eyre::Result<NodeConfig> {
         .unwrap_or(matches!(config.mode, NodeMode::Genesis));
     if is_genesis {
         config.mode = NodeMode::Genesis;
-    } else {
-        config.mode = NodeMode::PeerSync;
-    };
+    }
+    // This line made little sense to me - this would set the mode to whatever is in the config
+    // already before adding a new mode.
+    // else {
+    //     config.mode = NodeMode::PeerSync;
+    // };
 
     Ok(config)
 }

--- a/crates/chain/tests/api/client.rs
+++ b/crates/chain/tests/api/client.rs
@@ -139,6 +139,19 @@ async fn check_get_block_endpoint(
     debug!("block: {:?}", block);
 }
 
+async fn check_info_endpoint(
+    api_client: &IrysApiClient,
+    api_address: SocketAddr,
+    ctx: &IrysNodeTest<IrysNodeCtx>,
+) {
+    let info = api_client
+        .node_info(api_address)
+        .await
+        .expect("valid get info response");
+
+    assert_eq!(info.chain_id, ctx.node_ctx.config.consensus.chain_id);
+}
+
 #[test_log::test(actix_rt::test)]
 async fn heavy_api_client_all_endpoints_should_work() {
     let config = NodeConfig::testnet();
@@ -155,6 +168,7 @@ async fn heavy_api_client_all_endpoints_should_work() {
     check_transaction_endpoints(&api_client, api_address, &ctx).await;
     check_get_block_endpoint(&api_client, api_address, &ctx).await;
     check_get_block_index_endpoint(&api_client, api_address, &ctx).await;
+    check_info_endpoint(&api_client, api_address, &ctx).await;
 
     ctx.node_ctx.stop().await;
 }

--- a/crates/chain/tests/api/external_api.rs
+++ b/crates/chain/tests/api/external_api.rs
@@ -7,9 +7,8 @@ use crate::{
     utils::IrysNodeTest,
 };
 use actix_web::{http::header::ContentType, HttpMessage as _};
-use irys_api_server::routes::index::NodeInfo;
 use irys_testing_utils::initialize_tracing;
-use irys_types::BlockIndexItem;
+use irys_types::{BlockIndexItem, NodeInfo};
 use tracing::info;
 
 #[actix::test]

--- a/crates/chain/tests/multi_node/ema_forks.rs
+++ b/crates/chain/tests/multi_node/ema_forks.rs
@@ -1,6 +1,7 @@
 use crate::utils::IrysNodeTest;
 use irys_types::{storage_pricing::Amount, NodeConfig, OracleConfig};
 use rust_decimal_macros::dec;
+use std::sync::Arc;
 
 // Test verifies that EMA (Exponential Moving Average) price snapshots diverge correctly across chain forks.
 // Setup:
@@ -146,7 +147,7 @@ async fn heavy_ema_intervals_roll_over_in_forks() -> eyre::Result<()> {
         tip_block.height,
         common_height.height + BLOCKS_TO_MINE_NODE_2 as u64
     );
-    node_2.gossip_block(&tip_block)?;
+    node_2.gossip_block(&Arc::new(tip_block.clone()))?;
 
     node_1
         .wait_until_height_confirmed(tip_block.height, 200)

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -2,6 +2,7 @@ use crate::utils::IrysNodeTest;
 use base58::ToBase58 as _;
 use irys_testing_utils::*;
 use irys_types::{DataLedger, IrysTransaction, NodeConfig, H256};
+use std::sync::Arc;
 use tracing::debug;
 
 #[actix_web::test]
@@ -175,6 +176,9 @@ async fn heavy_fork_recovery_test() -> eyre::Result<()> {
     // that the peers prefer the first block they saw with this cumulative difficulty,
     // their own.
     assert_eq!(peer1_block.cumulative_diff, peer2_block.cumulative_diff);
+
+    let peer2_block = Arc::new(peer2_block);
+    let peer1_block = Arc::new(peer1_block);
 
     peer2_node.gossip_block(&peer2_block)?;
     peer1_node.gossip_block(&peer1_block)?;

--- a/crates/chain/tests/multi_node/fork_recovery_epoch.rs
+++ b/crates/chain/tests/multi_node/fork_recovery_epoch.rs
@@ -1,6 +1,7 @@
 use crate::utils::IrysNodeTest;
 use irys_testing_utils::*;
 use irys_types::{NodeConfig, H256};
+use std::sync::Arc;
 use tracing::debug;
 
 #[actix_web::test]
@@ -136,7 +137,7 @@ async fn heavy_fork_recovery_epoch_test() -> eyre::Result<()> {
 
     // Validate that the genesis node reorgs the epoch/commitment state correctly
     genesis_node.gossip_block(&peer2_epoch)?;
-    genesis_node.gossip_block(&peer2_head)?;
+    genesis_node.gossip_block(&Arc::new(peer2_head.clone()))?;
 
     let genesis_hash = genesis_node.wait_until_height(5, seconds_to_wait).await?;
     let _genesis_head = genesis_node.get_block_by_hash(&genesis_hash)?;

--- a/crates/chain/tests/multi_node/sync_chain_state.rs
+++ b/crates/chain/tests/multi_node/sync_chain_state.rs
@@ -1,6 +1,5 @@
 use crate::utils::{mine_blocks, AddTxError, IrysNodeTest};
 use irys_actors::mempool_service::TxIngressError;
-use irys_api_server::routes::index::NodeInfo;
 use irys_chain::{
     peer_utilities::{
         block_index_endpoint_request, info_endpoint_request, peer_list_endpoint_request,
@@ -9,8 +8,8 @@ use irys_chain::{
 };
 use irys_database::block_header_by_hash;
 use irys_types::{
-    irys::IrysSigner, BlockIndexItem, IrysTransaction, IrysTransactionId, NodeConfig, PeerAddress,
-    H256,
+    irys::IrysSigner, BlockIndexItem, IrysTransaction, IrysTransactionId, NodeConfig, NodeInfo,
+    PeerAddress, H256,
 };
 use reth::rpc::eth::EthApiServer as _;
 use reth_db::Database as _;

--- a/crates/chain/tests/multi_node/sync_chain_state.rs
+++ b/crates/chain/tests/multi_node/sync_chain_state.rs
@@ -7,7 +7,10 @@ use irys_chain::{
     IrysNodeCtx,
 };
 use irys_database::block_header_by_hash;
-use irys_types::{irys::IrysSigner, BlockIndexItem, IrysTransaction, IrysTransactionId, NodeConfig, NodeInfo, NodeMode, PeerAddress, H256};
+use irys_types::{
+    irys::IrysSigner, BlockIndexItem, IrysTransaction, IrysTransactionId, NodeConfig, NodeInfo,
+    NodeMode, PeerAddress, H256,
+};
 use reth::rpc::eth::EthApiServer as _;
 use reth_db::Database as _;
 use std::collections::HashMap;

--- a/crates/chain/tests/multi_node/sync_chain_state.rs
+++ b/crates/chain/tests/multi_node/sync_chain_state.rs
@@ -7,10 +7,7 @@ use irys_chain::{
     IrysNodeCtx,
 };
 use irys_database::block_header_by_hash;
-use irys_types::{
-    irys::IrysSigner, BlockIndexItem, IrysTransaction, IrysTransactionId, NodeConfig, NodeInfo,
-    PeerAddress, H256,
-};
+use irys_types::{irys::IrysSigner, BlockIndexItem, IrysTransaction, IrysTransactionId, NodeConfig, NodeInfo, NodeMode, PeerAddress, H256};
 use reth::rpc::eth::EthApiServer as _;
 use reth_db::Database as _;
 use std::collections::HashMap;
@@ -220,7 +217,8 @@ async fn slow_heavy_sync_chain_state_then_gossip_blocks() -> eyre::Result<()> {
         .await;
     ctx_peer1_node.start_public_api().await;
 
-    let ctx_peer2_node = ctx_genesis_node.testnet_peer();
+    let mut ctx_peer2_node = ctx_genesis_node.testnet_peer();
+    ctx_peer2_node.mode = NodeMode::TrustedPeerSync;
     let ctx_peer2_node = IrysNodeTest::new(ctx_peer2_node.clone())
         .start_with_name("PEER2")
         .await;

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -1068,11 +1068,11 @@ impl IrysNodeTest<IrysNodeCtx> {
             .ok_or_else(|| eyre::eyre!("Block at height {} not found", height))
     }
 
-    pub fn gossip_block(&self, block_header: &IrysBlockHeader) -> eyre::Result<()> {
+    pub fn gossip_block(&self, block_header: &Arc<IrysBlockHeader>) -> eyre::Result<()> {
         self.node_ctx
             .service_senders
             .gossip_broadcast
-            .send(GossipBroadcastMessage::from((*block_header).clone()))?;
+            .send(GossipBroadcastMessage::from(Arc::clone(block_header)))?;
 
         Ok(())
     }

--- a/crates/database/src/block_index_data.rs
+++ b/crates/database/src/block_index_data.rs
@@ -119,6 +119,17 @@ impl BlockIndex {
         } else {
             let prev_block = self.get_item(block.height.saturating_sub(1));
             if let Some(prev_block) = prev_block {
+                if prev_block.block_hash != block.previous_block_hash {
+                    // Use println! here because errors and tracing are not getting propagated
+                    println!(
+                        "Panic: prev_block at index {} does not match current block's prev_block_hash",
+                        block.height.saturating_sub(1)
+                    );
+                    return Err(eyre::eyre!(
+                        "prev_block at index {} does not match current block's prev_block_hash",
+                        block.height.saturating_sub(1)
+                    ));
+                }
                 (
                     prev_block.ledgers[DataLedger::Publish].max_chunk_offset + pub_chunks_added,
                     prev_block.ledgers[DataLedger::Submit].max_chunk_offset + sub_chunks_added,

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -30,6 +30,7 @@ async-trait = "0.1"
 reth.workspace = true
 alloy-rpc-types.workspace = true
 alloy-core.workspace = true
+log = "0.4.27"
 
 [dev-dependencies]
 irys-testing-utils.workspace = true

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -30,7 +30,6 @@ async-trait = "0.1"
 reth.workspace = true
 alloy-rpc-types.workspace = true
 alloy-core.workspace = true
-log = "0.4.27"
 
 [dev-dependencies]
 irys-testing-utils.workspace = true

--- a/crates/p2p/src/block_pool.rs
+++ b/crates/p2p/src/block_pool.rs
@@ -454,9 +454,14 @@ where
 
         // If the parent block is in the db, process it
         if previous_block_status.is_processed() {
-            info!("Found parent block for block {:?}, checking if tree has enough capacity", current_block_hash);
+            info!(
+                "Found parent block for block {:?}, checking if tree has enough capacity",
+                current_block_hash
+            );
 
-            self.block_status_provider.wait_for_block_tree_to_catch_up(block_header.height).await;
+            self.block_status_provider
+                .wait_for_block_tree_to_catch_up(block_header.height)
+                .await;
 
             if let Err(block_discovery_error) = self
                 .block_discovery

--- a/crates/p2p/src/block_pool.rs
+++ b/crates/p2p/src/block_pool.rs
@@ -377,18 +377,32 @@ where
             block_hash
         );
 
-        if let Some(switch_to_full_validation_at_height) = self.sync_state.full_validation_switch_height() {
+        if let Some(switch_to_full_validation_at_height) =
+            self.sync_state.full_validation_switch_height()
+        {
             // mark_processed called on the current block height will set trust sync to false
-            let switch_at_the_next_block = block_height as usize == switch_to_full_validation_at_height;
+            let switch_at_the_next_block =
+                block_height as usize == switch_to_full_validation_at_height;
             if switch_at_the_next_block {
                 let (tx, rx) = oneshot::channel();
-                self.block_tree_sender.send(BlockTreeServiceMessage::ReloadCacheFromDb { response: tx }).map_err(|err| {
-                    error!("Failed to send ReloadCacheFromDb message: {:?}", err);
-                    BlockPoolError::OtherInternal(format!("Failed to send ReloadCacheFromDb message: {:?}", err))
-                })?;
+                self.block_tree_sender
+                    .send(BlockTreeServiceMessage::ReloadCacheFromDb { response: tx })
+                    .map_err(|err| {
+                        error!("Failed to send ReloadCacheFromDb message: {:?}", err);
+                        BlockPoolError::OtherInternal(format!(
+                            "Failed to send ReloadCacheFromDb message: {:?}",
+                            err
+                        ))
+                    })?;
                 rx.await.map_err(|err| {
-                    error!("Failed to receive response for ReloadCacheFromDb: {:?}", err);
-                    BlockPoolError::OtherInternal(format!("Failed to receive response for ReloadCacheFromDb: {:?}", err))
+                    error!(
+                        "Failed to receive response for ReloadCacheFromDb: {:?}",
+                        err
+                    );
+                    BlockPoolError::OtherInternal(format!(
+                        "Failed to receive response for ReloadCacheFromDb: {:?}",
+                        err
+                    ))
                 })?;
             }
         }
@@ -465,6 +479,7 @@ where
             // Request the execution payload for the block if it is not already stored locally
             self.handle_execution_payload_for_prevalidated_block(block_header.evm_block_hash);
 
+            debug!("Block pool: Marking block {:?} as processed", current_block_hash);
             self.sync_state
                 .mark_processed(current_block_height as usize);
             self.blocks_cache

--- a/crates/p2p/src/block_pool.rs
+++ b/crates/p2p/src/block_pool.rs
@@ -512,6 +512,7 @@ where
     /// locally. After that, it waits for the payload to arrive and broadcasts it.
     /// This function spawns a new task to fire the request without waiting for the response.
     pub(crate) fn handle_execution_payload_for_prevalidated_block(&self, evm_block_hash: B256) {
+        debug!("Handling execution payload for EVM block hash: {:?}", evm_block_hash);
         let execution_payload_provider = self.execution_payload_provider.clone();
         let gossip_broadcast_sender = self.gossip_broadcast_sender.clone();
         tokio::spawn(async move {

--- a/crates/p2p/src/block_pool.rs
+++ b/crates/p2p/src/block_pool.rs
@@ -389,7 +389,7 @@ where
     ) -> Result<(), BlockPoolError> {
         if skip_validation_for_fast_track {
             debug!(
-                "Block pool: The block block {:?} (height {}) is marked for fast track, skipping validation",
+                "Block pool: The block {:?} (height {}) is marked for fast track, skipping validation",
                 block_header.block_hash, block_header.height,
             );
             return self.fast_track_block(block_header).await;

--- a/crates/p2p/src/block_pool.rs
+++ b/crates/p2p/src/block_pool.rs
@@ -454,7 +454,9 @@ where
 
         // If the parent block is in the db, process it
         if previous_block_status.is_processed() {
-            info!("Found parent block for block {:?}", current_block_hash);
+            info!("Found parent block for block {:?}, checking if tree has enough capacity", current_block_hash);
+
+            self.block_status_provider.wait_for_block_tree_to_catch_up(block_header.height).await;
 
             if let Err(block_discovery_error) = self
                 .block_discovery

--- a/crates/p2p/src/block_pool.rs
+++ b/crates/p2p/src/block_pool.rs
@@ -427,16 +427,23 @@ where
                     err
                 ))
             })?;
-        rx.await.map_err(|err| {
-            error!(
-                "Failed to receive response for ReloadCacheFromDb: {:?}",
-                err
-            );
-            BlockPoolError::OtherInternal(format!(
-                "Failed to receive response for ReloadCacheFromDb: {:?}",
-                err
-            ))
-        })?;
+        rx.await
+            .map_err(|err| {
+                error!(
+                    "Failed to receive response for ReloadCacheFromDb: {:?}",
+                    err
+                );
+                BlockPoolError::OtherInternal(format!(
+                    "Failed to receive response for ReloadCacheFromDb: {:?}",
+                    err
+                ))
+            })?
+            .map_err(|err| {
+                BlockPoolError::OtherInternal(format!(
+                    "Failed to reload block tree cache: {:?}",
+                    err
+                ))
+            })?;
         debug!("Block pool: Reloaded block tree cache");
         Ok(())
     }

--- a/crates/p2p/src/block_pool.rs
+++ b/crates/p2p/src/block_pool.rs
@@ -595,29 +595,26 @@ where
                             "Block pool: Failed to validate and submit execution payload for block {:?}: {:?}",
                             evm_block_hash, err
                         );
-                        return;
                     }
                 }
-            } else {
-                if let Some(sealed_block) = execution_payload_provider
-                    .wait_for_sealed_block(&evm_block_hash, validate_and_submit_payload)
-                    .await
-                {
-                    let evm_block = sealed_block.into_block();
-                    if let Err(err) = gossip_broadcast_sender.send(GossipBroadcastMessage::new(
-                        GossipCacheKey::ExecutionPayload(evm_block_hash),
-                        GossipData::ExecutionPayload(evm_block),
-                    )) {
-                        error!(
-                            "Failed to broadcast execution payload for block {:?}: {:?}",
-                            evm_block_hash, err
-                        );
-                    } else {
-                        debug!(
-                            "Execution payload for block {:?} has been broadcasted",
-                            evm_block_hash
-                        );
-                    }
+            } else if let Some(sealed_block) = execution_payload_provider
+                .wait_for_sealed_block(&evm_block_hash, validate_and_submit_payload)
+                .await
+            {
+                let evm_block = sealed_block.into_block();
+                if let Err(err) = gossip_broadcast_sender.send(GossipBroadcastMessage::new(
+                    GossipCacheKey::ExecutionPayload(evm_block_hash),
+                    GossipData::ExecutionPayload(evm_block),
+                )) {
+                    error!(
+                        "Failed to broadcast execution payload for block {:?}: {:?}",
+                        evm_block_hash, err
+                    );
+                } else {
+                    debug!(
+                        "Execution payload for block {:?} has been broadcasted",
+                        evm_block_hash
+                    );
                 }
             }
         });

--- a/crates/p2p/src/block_pool.rs
+++ b/crates/p2p/src/block_pool.rs
@@ -417,7 +417,9 @@ where
 
         // Remove the payload from the cache after it has been processed to prevent excessive memory usage
         // during the fast track process (The cache is LRU, but its upper limit is more for unexpected situations)
-        self.execution_payload_provider.remove_payload_from_cache(&block_header.evm_block_hash).await;
+        self.execution_payload_provider
+            .remove_payload_from_cache(&block_header.evm_block_hash)
+            .await;
 
         Ok(())
     }
@@ -602,12 +604,12 @@ where
                 block_header.block_hash, block_header.height,
             );
             return match self.fast_track_block(block_header).await {
-                Ok(()) => { Ok(()) }
+                Ok(()) => Ok(()),
                 Err(err) => {
                     self.blocks_cache.remove_block(&block_hash).await;
                     Err(err)
                 }
-            }
+            };
         }
 
         check_block_status(

--- a/crates/p2p/src/block_pool.rs
+++ b/crates/p2p/src/block_pool.rs
@@ -479,7 +479,10 @@ where
             // Request the execution payload for the block if it is not already stored locally
             self.handle_execution_payload_for_prevalidated_block(block_header.evm_block_hash);
 
-            debug!("Block pool: Marking block {:?} as processed", current_block_hash);
+            debug!(
+                "Block pool: Marking block {:?} as processed",
+                current_block_hash
+            );
             self.sync_state
                 .mark_processed(current_block_height as usize);
             self.blocks_cache
@@ -512,7 +515,10 @@ where
     /// locally. After that, it waits for the payload to arrive and broadcasts it.
     /// This function spawns a new task to fire the request without waiting for the response.
     pub(crate) fn handle_execution_payload_for_prevalidated_block(&self, evm_block_hash: B256) {
-        debug!("Handling execution payload for EVM block hash: {:?}", evm_block_hash);
+        debug!(
+            "Block pool: Handling execution payload for EVM block hash: {:?}",
+            evm_block_hash
+        );
         let execution_payload_provider = self.execution_payload_provider.clone();
         let gossip_broadcast_sender = self.gossip_broadcast_sender.clone();
         tokio::spawn(async move {

--- a/crates/p2p/src/block_status_provider.rs
+++ b/crates/p2p/src/block_status_provider.rs
@@ -8,7 +8,7 @@ use {
     irys_database::BlockIndex,
     irys_types::{BlockIndexItem, IrysBlockHeader, NodeConfig},
     std::sync::{Arc, RwLock},
-    tracing::{warn},
+    tracing::warn,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -129,9 +129,9 @@ impl BlockStatusProvider {
             if attempts % ATTEMPTS_PER_SECOND == 0 {
                 debug!(
                     "Block tree did not catch up to height {} after {} seconds, waiting...",
-                    block_height, attempts / ATTEMPTS_PER_SECOND
+                    block_height,
+                    attempts / ATTEMPTS_PER_SECOND
                 );
-                return;
             }
 
             let can_process_height = {

--- a/crates/p2p/src/block_status_provider.rs
+++ b/crates/p2p/src/block_status_provider.rs
@@ -1,12 +1,12 @@
 use irys_actors::block_index_service::BlockIndexReadGuard;
 use irys_actors::block_tree_service::BlockTreeReadGuard;
-use irys_types::{BlockHash, H256};
+use irys_types::{BlockHash, BlockIndexItem, H256};
 use tracing::debug;
 #[cfg(test)]
 use {
     irys_actors::block_tree_service::BlockTreeCache,
     irys_database::BlockIndex,
-    irys_types::{BlockIndexItem, IrysBlockHeader, NodeConfig},
+    irys_types::{IrysBlockHeader, NodeConfig},
     std::sync::{Arc, RwLock},
     tracing::warn,
 };
@@ -154,6 +154,11 @@ impl BlockStatusProvider {
         let binding = self.block_index_read_guard.read();
         let index_item = binding.get_item(block_height);
         index_item.is_some()
+    }
+
+    pub fn latest_block_in_index(&self) -> Option<BlockIndexItem> {
+        let binding = self.block_index_read_guard.read();
+        binding.get_latest_item().cloned()
     }
 }
 

--- a/crates/p2p/src/block_status_provider.rs
+++ b/crates/p2p/src/block_status_provider.rs
@@ -1,13 +1,14 @@
 use irys_actors::block_index_service::BlockIndexReadGuard;
 use irys_actors::block_tree_service::BlockTreeReadGuard;
 use irys_types::{BlockHash, H256};
+use tracing::debug;
 #[cfg(test)]
 use {
     irys_actors::block_tree_service::BlockTreeCache,
     irys_database::BlockIndex,
     irys_types::{BlockIndexItem, IrysBlockHeader, NodeConfig},
     std::sync::{Arc, RwLock},
-    tracing::{debug, warn},
+    tracing::{warn},
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -109,6 +110,37 @@ impl BlockStatusProvider {
                 if index_item.is_some() {
                     return;
                 }
+            }
+
+            tokio::time::sleep(tokio::time::Duration::from_millis(
+                1000 / ATTEMPTS_PER_SECOND,
+            ))
+            .await;
+        }
+    }
+
+    pub async fn wait_for_block_tree_to_catch_up(&self, block_height: u64) {
+        const ATTEMPTS_PER_SECOND: u64 = 5;
+        let mut attempts = 0;
+
+        loop {
+            attempts += 1;
+
+            if attempts % ATTEMPTS_PER_SECOND == 0 {
+                debug!(
+                    "Block tree did not catch up to height {} after {} seconds, waiting...",
+                    block_height, attempts / ATTEMPTS_PER_SECOND
+                );
+                return;
+            }
+
+            let can_process_height = {
+                let binding = self.block_tree_read_guard.read();
+                binding.can_process_height(block_height)
+            };
+
+            if can_process_height {
+                return;
             }
 
             tokio::time::sleep(tokio::time::Duration::from_millis(

--- a/crates/p2p/src/execution_payload_provider.rs
+++ b/crates/p2p/src/execution_payload_provider.rs
@@ -201,7 +201,10 @@ where
             .put(evm_block_hash, ());
         if let Err(peer_list_error) = self
             .peer_list
-            .request_data_from_the_network(GossipDataRequest::ExecutionPayload(evm_block_hash))
+            .request_data_from_the_network(
+                GossipDataRequest::ExecutionPayload(evm_block_hash),
+                false,
+            )
             .await
         {
             self.cache

--- a/crates/p2p/src/execution_payload_provider.rs
+++ b/crates/p2p/src/execution_payload_provider.rs
@@ -342,13 +342,15 @@ where
         irys_block_header: &IrysBlockHeader,
         db: &DatabaseProvider,
     ) -> Result<(), ExecutionPayloadProviderError> {
-        // let block_hash = irys_block_header.block_hash;
-        //     config: &Config,
-        //     service_senders: &ServiceSenders,
-        //     block: &IrysBlockHeader,
-        //     reth_adapter: &IrysRethNodeAdapter,
-        //     db: &DatabaseProvider,
-        //     payload_provider: impl PayloadProvider,
+        // For test that specifically want to mock the payload provider
+        // All tests that do not is going to use the real provider
+        #[cfg(test)]
+        {
+            if let RethBlockProvider::Mock(_) = &self.reth_payload_provider {
+                return Ok(());
+            }
+        }
+
         let adapter = self
             .reth_payload_provider
             .as_irys_reth_adapter()
@@ -365,12 +367,6 @@ where
         .await;
 
         result.map_err(ExecutionPayloadProviderError::PayloadValidationError)
-        // debug!("Block pool: Shadow transactions validation result for Irys block {:?}: {:?}", block_hash, result);
-        // let execution_data = <<irys_reth_node_bridge::irys_reth::IrysEthereumNode as reth::api::NodeTypes>::Payload as reth::api::PayloadTypes>::block_to_payload(sealed_block);
-        //
-        // self.reth_payload_provider
-        //     .submit_validated_payload(execution_data)
-        //     .await
     }
 }
 

--- a/crates/p2p/src/execution_payload_provider.rs
+++ b/crates/p2p/src/execution_payload_provider.rs
@@ -314,7 +314,7 @@ where
         irys_block_header: &IrysBlockHeader,
         db: &DatabaseProvider,
     ) -> Result<(), ExecutionPayloadProviderError> {
-        // For test that specifically want to mock the payload provider
+        // For tests that specifically want to mock the payload provider
         // All tests that do not is going to use the real provider
         #[cfg(test)]
         {

--- a/crates/p2p/src/execution_payload_provider.rs
+++ b/crates/p2p/src/execution_payload_provider.rs
@@ -158,10 +158,15 @@ where
     }
 
     pub async fn remove_payload_from_cache(&self, evm_block_hash: &B256) {
-        debug!("Removing execution payload from cache: {:?}", evm_block_hash);
+        debug!(
+            "Removing execution payload from cache: {:?}",
+            evm_block_hash
+        );
         let mut cache = self.cache.write().await;
         cache.payloads.pop(evm_block_hash);
-        cache.payloads_currently_requested_from_the_network.pop(evm_block_hash);
+        cache
+            .payloads_currently_requested_from_the_network
+            .pop(evm_block_hash);
         self.payload_senders.write().await.pop(evm_block_hash);
     }
 

--- a/crates/p2p/src/gossip_service.rs
+++ b/crates/p2p/src/gossip_service.rs
@@ -21,6 +21,7 @@ use crate::{
 };
 use actix_web::dev::{Server, ServerHandle};
 use core::time::Duration;
+use irys_actors::block_tree_service::BlockTreeServiceMessage;
 use irys_actors::{block_discovery::BlockDiscoveryFacade, mempool_service::MempoolFacade};
 use irys_api_client::ApiClient;
 use irys_types::{Address, DatabaseProvider, GossipBroadcastMessage, PeerListItem};
@@ -167,6 +168,7 @@ impl P2PService {
         execution_payload_provider: ExecutionPayloadProvider<P>,
         vdf_state: VdfStateReadonly,
         vdf_ff_sender: UnboundedSender<VdfStep>,
+        block_tree_sender: UnboundedSender<BlockTreeServiceMessage>,
     ) -> GossipResult<ServiceHandleWithShutdownSignal>
     where
         A: ApiClient,
@@ -185,6 +187,7 @@ impl P2PService {
             self.broadcast_data_sender.clone(),
             vdf_state,
             vdf_ff_sender,
+            block_tree_sender,
         );
 
         let server_data_handler = GossipServerDataHandler {

--- a/crates/p2p/src/gossip_service.rs
+++ b/crates/p2p/src/gossip_service.rs
@@ -22,9 +22,10 @@ use crate::{
 use actix_web::dev::{Server, ServerHandle};
 use core::time::Duration;
 use irys_actors::block_tree_service::BlockTreeServiceMessage;
+use irys_actors::services::ServiceSenders;
 use irys_actors::{block_discovery::BlockDiscoveryFacade, mempool_service::MempoolFacade};
 use irys_api_client::ApiClient;
-use irys_types::{Address, DatabaseProvider, GossipBroadcastMessage, PeerListItem};
+use irys_types::{Address, Config, DatabaseProvider, GossipBroadcastMessage, PeerListItem};
 use irys_vdf::state::VdfStateReadonly;
 use irys_vdf::VdfStep;
 use rand::prelude::SliceRandom as _;
@@ -169,6 +170,8 @@ impl P2PService {
         vdf_state: VdfStateReadonly,
         vdf_ff_sender: UnboundedSender<VdfStep>,
         block_tree_sender: UnboundedSender<BlockTreeServiceMessage>,
+        config: Config,
+        service_senders: ServiceSenders,
     ) -> GossipResult<ServiceHandleWithShutdownSignal>
     where
         A: ApiClient,
@@ -188,6 +191,8 @@ impl P2PService {
             vdf_state,
             vdf_ff_sender,
             block_tree_sender,
+            config,
+            service_senders,
         );
 
         let server_data_handler = GossipServerDataHandler {

--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -12,6 +12,7 @@ mod sync;
 mod tests;
 mod types;
 
+pub use block_pool::{BlockPool, BlockPoolError};
 pub use block_status_provider::{BlockStatus, BlockStatusProvider};
 pub use gossip_client::GossipClient;
 pub use gossip_service::P2PService;

--- a/crates/p2p/src/server.rs
+++ b/crates/p2p/src/server.rs
@@ -131,6 +131,10 @@ where
     ) -> HttpResponse {
         let gossip_request = irys_block_header_json.0;
         let source_miner_address = gossip_request.miner_address;
+        let Some(source_socket_addr) = req.peer_addr() else {
+            return HttpResponse::BadRequest().finish();
+        };
+
         let peer =
             match Self::check_peer(&server.peer_list, &req, gossip_request.miner_address).await {
                 Ok(peer_address) => peer_address,
@@ -143,7 +147,7 @@ where
             let block_hash_string = gossip_request.data.block_hash.0.to_base58();
             if let Err(error) = server
                 .data_handler
-                .handle_block_header_request(gossip_request, peer.address.api)
+                .handle_block_header_request(gossip_request, peer.address.api, source_socket_addr)
                 .await
             {
                 Self::handle_invalid_data(&source_miner_address, &error, &server.peer_list).await;

--- a/crates/p2p/src/server_data_handler.rs
+++ b/crates/p2p/src/server_data_handler.rs
@@ -420,7 +420,7 @@ where
                 .await?;
 
         self.block_pool
-            .process_block(block_header, skip_block_validation)
+            .process_block(Arc::new(block_header), skip_block_validation)
             .await
             .map_err(GossipError::BlockPool)?;
         Ok(())

--- a/crates/p2p/src/server_data_handler.rs
+++ b/crates/p2p/src/server_data_handler.rs
@@ -407,11 +407,13 @@ where
             }
         }
 
-        // TODO: Also check that we're within the block is within the range
-        //   Or better yet, set sync_state.is_trusted_sync to false
         let is_syncing_from_a_trusted_peer = self.sync_state.is_syncing_from_a_trusted_peer();
+        let is_in_the_trusted_sync_range = self
+            .sync_state
+            .is_in_trusted_sync_range(block_header.height as usize);
 
         let skip_block_validation = is_syncing_from_a_trusted_peer
+            && is_in_the_trusted_sync_range
             && self
                 .peer_list
                 .is_a_trusted_peer(source_miner_address, data_source_ip.ip())

--- a/crates/p2p/src/server_data_handler.rs
+++ b/crates/p2p/src/server_data_handler.rs
@@ -407,7 +407,7 @@ where
             }
         }
 
-        // TODO: Also check that we're within the block is withing the range
+        // TODO: Also check that we're within the block is within the range
         //   Or better yet, set sync_state.is_trusted_sync to false
         let is_syncing_from_a_trusted_peer = self.sync_state.is_syncing_from_a_trusted_peer();
 

--- a/crates/p2p/src/server_data_handler.rs
+++ b/crates/p2p/src/server_data_handler.rs
@@ -35,7 +35,7 @@ where
     TPeerList: PeerList,
 {
     pub mempool: TMempoolFacade,
-    pub block_pool: BlockPool<TPeerList, TBlockDiscovery, TMempoolFacade>,
+    pub block_pool: Arc<BlockPool<TPeerList, TBlockDiscovery, TMempoolFacade>>,
     pub cache: Arc<GossipCache>,
     pub api_client: TApiClient,
     pub gossip_client: GossipClient,

--- a/crates/p2p/src/sync.rs
+++ b/crates/p2p/src/sync.rs
@@ -105,9 +105,23 @@ impl SyncState {
         }
     }
 
+    /// Sets the height at which the node should switch to full validation.
     pub fn set_switch_to_full_validation_at_height(&self, height: Option<usize>) {
         let mut lock = self.switch_to_full_validation_at_height.write().unwrap();
         *lock = height;
+    }
+
+    /// Returns the height at which the node should switch to full validation.
+    pub fn full_validation_switch_height(&self) -> Option<usize> {
+        *self.switch_to_full_validation_at_height.read().unwrap()
+    }
+
+    pub fn is_in_trusted_sync_range(&self, height: usize) -> bool {
+        if let Some(switch_height) = self.full_validation_switch_height() {
+            self.is_trusted_sync() && switch_height >= height
+        } else {
+            false
+        }
     }
 
     /// Highest pre-validated block height. Set by the [`crate::block_pool::BlockPool`]

--- a/crates/p2p/src/sync.rs
+++ b/crates/p2p/src/sync.rs
@@ -317,12 +317,12 @@ pub async fn sync_chain(
                 block_hash,
                 sync_state_clone.sync_target_height()
             );
+            sync_state_clone.increment_sync_target_height();
             match peer_list_clone
                 .request_block_from_the_network(block_hash, sync_state_clone.is_trusted_sync())
                 .await
             {
                 Ok(()) => {
-                    sync_state_clone.increment_sync_target_height();
                     info!(
                         "Sync task: Successfully requested block {:?} (sync height is {}) from the network",
                         block_hash,
@@ -552,7 +552,6 @@ mod tests {
             // There should be three calls total: two that got items and one that didn't
             let data_requests = block_index_requests.lock().unwrap();
             assert_eq!(data_requests.len(), 3);
-            let starts_at = data_requests[0].height;
             debug!("Data requests: {:?}", data_requests);
             assert_eq!(data_requests[0].height, 10);
             assert_eq!(data_requests[1].height, 11);

--- a/crates/p2p/src/sync.rs
+++ b/crates/p2p/src/sync.rs
@@ -202,8 +202,8 @@ pub async fn sync_chain<P, B, M>(
     node_mode: &NodeMode,
     mut start_sync_from_height: usize,
     config: &irys_types::Config,
-    // BlockPool is option because test structured in a way that adding it to the sync
-    //  will require testing the payload repair functionality, and for the sake of the speed we
+    // BlockPool is optional because tests are structured in a way that would require testing the
+    // payload repair functionality if BlockPool is not optional. For the sake of the speed we
     //  don't want to do that
     block_pool: Option<Arc<BlockPool<P, B, M>>>,
     reth_service: Option<Addr<RethServiceActor>>,

--- a/crates/p2p/src/tests/block_pool/mod.rs
+++ b/crates/p2p/src/tests/block_pool/mod.rs
@@ -194,6 +194,18 @@ impl MockedServices {
         tokio::spawn(async move {
             while let Some(message) = block_tree_receiver.recv().await {
                 debug!("Received BlockTreeServiceMessage: {:?}", message);
+                if let BlockTreeServiceMessage::FastTrackStorageFinalized {
+                    block_header: _,
+                    response,
+                } = message
+                {
+                    // Simulate processing the block header
+                    response
+                        .send(Ok(()))
+                        .expect("to send response for FastTrackStorageFinalized");
+                } else {
+                    debug!("Received unsupported BlockTreeServiceMessage");
+                }
             }
             debug!("BlockTreeServiceMessage channel closed");
         });

--- a/crates/p2p/src/tests/block_pool/mod.rs
+++ b/crates/p2p/src/tests/block_pool/mod.rs
@@ -203,7 +203,7 @@ impl MockedServices {
                 {
                     // Simulate processing the block header
                     response
-                        .send(Ok(()))
+                        .send(Ok(false))
                         .expect("to send response for FastTrackStorageFinalized");
                 } else {
                     debug!("Received unsupported BlockTreeServiceMessage");

--- a/crates/p2p/src/tests/block_pool/mod.rs
+++ b/crates/p2p/src/tests/block_pool/mod.rs
@@ -203,7 +203,7 @@ impl MockedServices {
                 {
                     // Simulate processing the block header
                     response
-                        .send(Ok(false))
+                        .send(Ok(None))
                         .expect("to send response for FastTrackStorageFinalized");
                 } else {
                     debug!("Received unsupported BlockTreeServiceMessage");

--- a/crates/p2p/src/tests/integration/mod.rs
+++ b/crates/p2p/src/tests/integration/mod.rs
@@ -7,6 +7,7 @@ use irys_types::{
 };
 use reth::builder::Block as _;
 use reth::primitives::{Block, BlockBody, Header};
+use std::sync::Arc;
 use tracing::debug;
 
 #[actix_web::test]
@@ -314,7 +315,7 @@ async fn heavy_should_fetch_missing_transactions_for_block() -> eyre::Result<()>
 
     // Send block from service 1 to service 2
     gossip_service1_message_bus
-        .send(GossipBroadcastMessage::from(block))
+        .send(GossipBroadcastMessage::from(Arc::new(block)))
         .expect("Failed to send block to service 2");
 
     // Wait for service 2 to process the block and fetch transactions
@@ -368,7 +369,7 @@ async fn heavy_should_reject_block_with_missing_transactions() -> eyre::Result<(
 
     // Send block from service 1 to service 2
     gossip_service1_message_bus
-        .send(GossipBroadcastMessage::from(block))
+        .send(GossipBroadcastMessage::from(Arc::new(block)))
         .expect("Failed to send block to service 1");
 
     // Wait for service 2 to process the block and attempt to fetch transactions
@@ -439,7 +440,7 @@ async fn heavy_should_gossip_execution_payloads() -> eyre::Result<()> {
 
     // Send block from service 1 to service 2
     gossip_service1_message_bus
-        .send(GossipBroadcastMessage::from(block.clone()))
+        .send(GossipBroadcastMessage::from(Arc::new(block.clone())))
         .expect("Failed to send block to service 2");
 
     // Wait for service 2 to process the block and receive the execution payload with a timeout of 10 seconds

--- a/crates/p2p/src/tests/util.rs
+++ b/crates/p2p/src/tests/util.rs
@@ -419,7 +419,7 @@ impl GossipServiceTestFixture {
                 {
                     // Simulate processing the block header
                     response
-                        .send(Ok(()))
+                        .send(Ok(false))
                         .expect("to send response for FastTrackStorageFinalized");
                 } else {
                     debug!("Received unsupported BlockTreeServiceMessage");

--- a/crates/p2p/src/tests/util.rs
+++ b/crates/p2p/src/tests/util.rs
@@ -43,7 +43,7 @@ pub(crate) struct MempoolStub {
     pub txs: Arc<RwLock<Vec<IrysTransactionHeader>>>,
     pub chunks: Arc<RwLock<Vec<UnpackedChunk>>>,
     pub internal_message_bus: mpsc::UnboundedSender<GossipBroadcastMessage>,
-    pub migrated_blocks: Arc<RwLock<Vec<IrysBlockHeader>>>,
+    pub migrated_blocks: Arc<RwLock<Vec<Arc<IrysBlockHeader>>>>,
 }
 
 impl MempoolStub {
@@ -137,7 +137,7 @@ impl MempoolFacade for MempoolStub {
 
     async fn migrate_block(
         &self,
-        irys_block_header: IrysBlockHeader,
+        irys_block_header: Arc<IrysBlockHeader>,
     ) -> std::result::Result<usize, TxIngressError> {
         self.migrated_blocks
             .write()
@@ -153,7 +153,7 @@ impl MempoolFacade for MempoolStub {
 
 #[derive(Debug, Clone)]
 pub(crate) struct BlockDiscoveryStub {
-    pub blocks: Arc<RwLock<Vec<IrysBlockHeader>>>,
+    pub blocks: Arc<RwLock<Vec<Arc<IrysBlockHeader>>>>,
     pub internal_message_bus: mpsc::UnboundedSender<GossipBroadcastMessage>,
 }
 
@@ -161,7 +161,7 @@ pub(crate) struct BlockDiscoveryStub {
 impl BlockDiscoveryFacade for BlockDiscoveryStub {
     async fn handle_block(
         &self,
-        block: IrysBlockHeader,
+        block: Arc<IrysBlockHeader>,
     ) -> std::result::Result<(), BlockDiscoveryError> {
         self.blocks
             .write()
@@ -299,7 +299,7 @@ pub(crate) struct GossipServiceTestFixture {
     pub peer_list: PeerListMock,
     pub mempool_txs: Arc<RwLock<Vec<IrysTransactionHeader>>>,
     pub mempool_chunks: Arc<RwLock<Vec<UnpackedChunk>>>,
-    pub discovery_blocks: Arc<RwLock<Vec<IrysBlockHeader>>>,
+    pub discovery_blocks: Arc<RwLock<Vec<Arc<IrysBlockHeader>>>>,
     pub api_client_stub: ApiClientStub,
     // Tets need the task manager to be stored somewhere
     #[expect(dead_code)]

--- a/crates/p2p/src/tests/util.rs
+++ b/crates/p2p/src/tests/util.rs
@@ -419,7 +419,7 @@ impl GossipServiceTestFixture {
                 {
                     // Simulate processing the block header
                     response
-                        .send(Ok(false))
+                        .send(Ok(None))
                         .expect("to send response for FastTrackStorageFinalized");
                 } else {
                     debug!("Received unsupported BlockTreeServiceMessage");

--- a/crates/p2p/src/tests/util.rs
+++ b/crates/p2p/src/tests/util.rs
@@ -488,7 +488,7 @@ impl GossipServiceTestFixture {
         let (service_senders, _service_receivers) = ServiceSenders::new();
 
         gossip_service.sync_state.finish_sync();
-        let service_handle = gossip_service
+        let (service_handle, _block_pool) = gossip_service
             .run(
                 mempool_stub,
                 block_discovery_stub,

--- a/crates/p2p/src/tests/util.rs
+++ b/crates/p2p/src/tests/util.rs
@@ -11,6 +11,7 @@ use core::net::{IpAddr, Ipv4Addr, SocketAddr};
 use eyre::{eyre, Result};
 use irys_actors::block_discovery::BlockDiscoveryError;
 use irys_actors::block_tree_service::BlockTreeServiceMessage;
+use irys_actors::services::ServiceSenders;
 use irys_actors::{
     block_discovery::BlockDiscoveryFacade,
     mempool_service::{ChunkIngressError, MempoolFacade, TxIngressError, TxReadError},
@@ -484,6 +485,8 @@ impl GossipServiceTestFixture {
         let peer_list = self.peer_list.clone();
         let execution_payload_provider = self.execution_payload_provider.clone();
 
+        let (service_senders, _service_receivers) = ServiceSenders::new();
+
         gossip_service.sync_state.finish_sync();
         let service_handle = gossip_service
             .run(
@@ -499,6 +502,8 @@ impl GossipServiceTestFixture {
                 self.vdf_state_stub.clone(),
                 self.vdf_sender.clone(),
                 self.block_tree_sender.clone(),
+                self.config.clone(),
+                service_senders,
             )
             .expect("failed to run gossip service");
 

--- a/crates/p2p/src/types.rs
+++ b/crates/p2p/src/types.rs
@@ -38,6 +38,12 @@ impl From<PeerListFacadeError> for GossipError {
     }
 }
 
+impl From<InternalGossipError> for GossipError {
+    fn from(value: InternalGossipError) -> Self {
+        Self::Internal(value)
+    }
+}
+
 impl From<TxIngressError> for GossipError {
     fn from(value: TxIngressError) -> Self {
         match value {
@@ -115,6 +121,8 @@ pub enum InternalGossipError {
     BroadcastReceiverShutdown,
     #[error("Trying to shutdown a server that is already shutdown: {0}")]
     AlreadyShutdown(String),
+    #[error("Failed to perform repair task for reth payloads: {0}")]
+    PayloadRepair(BlockPoolError),
 }
 
 pub type GossipResult<T> = Result<T, GossipError>;

--- a/crates/types/src/config.rs
+++ b/crates/types/src/config.rs
@@ -239,6 +239,9 @@ pub enum NodeMode {
 
     /// Join an existing network by connecting to trusted peers
     PeerSync,
+
+    /// Trusted peer mode, where the node only connects to trusted peers
+    TrustedPeerSync,
 }
 
 /// # Consensus Configuration Source

--- a/crates/types/src/gossip.rs
+++ b/crates/types/src/gossip.rs
@@ -7,6 +7,7 @@ use base58::ToBase58 as _;
 use reth::core::primitives::SealedBlock;
 use reth_primitives::Block;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 #[derive(Clone, Debug)]
 pub struct GossipBroadcastMessage {
@@ -56,8 +57,8 @@ impl From<CommitmentTransaction> for GossipBroadcastMessage {
     }
 }
 
-impl From<IrysBlockHeader> for GossipBroadcastMessage {
-    fn from(block: IrysBlockHeader) -> Self {
+impl From<Arc<IrysBlockHeader>> for GossipBroadcastMessage {
+    fn from(block: Arc<IrysBlockHeader>) -> Self {
         let key = GossipCacheKey::irys_block(&block);
         let value = GossipData::Block(block);
         Self::new(key, value)
@@ -99,7 +100,7 @@ pub enum GossipData {
     Chunk(UnpackedChunk),
     Transaction(IrysTransactionHeader),
     CommitmentTransaction(CommitmentTransaction),
-    Block(IrysBlockHeader),
+    Block(Arc<IrysBlockHeader>),
     ExecutionPayload(Block),
 }
 

--- a/crates/types/src/version.rs
+++ b/crates/types/src/version.rs
@@ -259,4 +259,5 @@ pub struct NodeInfo {
     pub blocks: u64,
     pub is_syncing: bool,
     pub current_sync_height: usize,
+    pub current_block_pool_height: u64
 }

--- a/crates/types/src/version.rs
+++ b/crates/types/src/version.rs
@@ -259,5 +259,4 @@ pub struct NodeInfo {
     pub blocks: u64,
     pub is_syncing: bool,
     pub current_sync_height: usize,
-    pub current_block_pool_height: u64
 }

--- a/crates/types/src/version.rs
+++ b/crates/types/src/version.rs
@@ -1,6 +1,6 @@
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-use crate::{Arbitrary, RethPeerInfo};
+use crate::{Arbitrary, RethPeerInfo, H256};
 use alloy_primitives::Address;
 use semver::Version;
 use serde::{Deserialize, Serialize};
@@ -245,4 +245,18 @@ pub enum RejectionReason {
     BadHandshake,       // Malformed or invalid handshake request
     Untrusted,          // Peer doesn't meet trust requirements
     InternalError,      // Unable to complete request
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeInfo {
+    pub version: String,
+    pub peer_count: usize,
+    pub chain_id: u64,
+    pub height: u64,
+    pub block_hash: H256,
+    pub block_index_height: u64,
+    pub blocks: u64,
+    pub is_syncing: bool,
+    pub current_sync_height: usize,
 }


### PR DESCRIPTION
**Describe the changes**
This PR introduces a new sync type - `TrustedPeerSync`. It downloads all blocks from the peers specified in the trusted_peers in the config. Blocks synced this way are fast tracked - full validation is not performed for them.

- Entry point: `sync_chain` call in `src/chain/chain.rs`

**High level logic overview:**

`sync_chain` calls `/info` of the top trusted peer to see the height of its index. It does so in order to determine the target height for the trusted sync. Then `sync_chain` downloads the block index in chunks. When the first index chunk is downloaded, `sync_chain` requests blocks from the downloaded part of the index to be gossiped back to the node. It does so in parallel.

When the requested block arrives, `gossip_data_handler.rs` will check node's sync status. If the node is in the trusted sync mode, the block is within a trusted sync range, and is coming from a trusted peer, it will call `BlockPool::process_block` with a `fast_track` flag. If the flag is set, `BlockPool` will go to an alternative route for fast tracking blocks without applying full validation. 

`BlockPool::fast_track_block` performs sanity checks to ensure that we haven't process this block already. Then `BlockPool::fast_track_block` calls `vdf_state.wait_for_step(prev_output_step_number)`. This call ensures that the blocks are processed in sequence: the fast forward of previous steps is done once the previous block has been inserted into the index. 

Then `BlockPool` tries to follow a normal finalization and migration route for the block using `Mempool` and `BlockTree` finalization functions. It also uses `are_shadow_transactions_valid` function and `RethServiceActor` to sync and validate reth state. 

After the block has been added to the index and reth is in sync `BlockPool::fast_track_block` will fast forward VDF steps from the block in order to unblock next block processing. 

Once the trusted sync target height is reached `SyncState` will switch to a full validation sync mode. When this happens, `BlockPool::fast_track_block` sends a `BlockCacheReload` message to the `BlockTreeService`. `BlockTreeService` then reloads the block cache using the same function we use to load the cache on the node startup. All blocks received by gossip after that point are going to use normal gossip full validation route.

Notes:
If the node is stopped during the Irys' block finalization, reth might discard the payload for the block. In order to fix this, there's new `BlockPool::repair_missing_payloads_if_any` function that is called before the sync starts.

**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
