### PR TITLE
feat: block producer will wait for vdf steps to catch up before building upon an optimistic block

### DIFF
--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -1287,6 +1287,14 @@ impl BlockTreeCache {
         self.longest_chain_cache.clone()
     }
 
+    #[must_use]
+    pub fn get_latest_canonical_entry(&self) -> &BlockTreeEntry {
+        self.longest_chain_cache
+            .0
+            .last()
+            .expect("canonical chain must always have an entry in it")
+    }
+
     fn update_longest_chain_cache(&mut self) {
         let pairs = {
             self.longest_chain_cache.0.clear();


### PR DESCRIPTION
**Describe the changes**
- This PR refactors the `parent_irys_block()` function in block producer.
  - Whenveer we read a block form the canonical chain, we also check its state. Depending on the canonical chains tip block, block producer:
    - `sleep` if validation is not even yet scheduled (then re-fetches the latest canonical block)
    - waits for vdf steps to become available if validation is scheduled (then refetches the latest cononical block)
    - if vdf is valid then we build on it
    - if vdf is invalid, then we sleep a bit with the assumption it's going to be removed form the canonical chain

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.
