### PR TITLE
feat: more granular gossip behavior control

### DIFF
--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -1425,16 +1425,14 @@ impl IrysNodeTest<IrysNodeCtx> {
 
     // enable node to gossip until disabled
     pub fn gossip_enable(&self) {
-        //FIXME: In future this "workaround" of using the syncing state to prevent gossip
-        //       broadcasts can be replaced with something more appropriate and correctly named
-        self.node_ctx.sync_state.set_is_syncing(false);
+        self.node_ctx.sync_state.set_gossip_reception_enabled(true);
+        self.node_ctx.sync_state.set_gossip_broadcast_enabled(true);
     }
 
     // disable node ability to gossip until enabled
     pub fn gossip_disable(&self) {
-        //FIXME: In future this "workaround" of using the syncing state to prevent gossip
-        //       broadcasts can be replaced with something more appropriate and correctly named
-        self.node_ctx.sync_state.set_is_syncing(true);
+        self.node_ctx.sync_state.set_gossip_reception_enabled(false);
+        self.node_ctx.sync_state.set_gossip_broadcast_enabled(false);
     }
 }
 

--- a/crates/p2p/src/gossip_service.rs
+++ b/crates/p2p/src/gossip_service.rs
@@ -230,8 +230,9 @@ impl P2PService {
     where
         P: PeerList,
     {
-        if self.is_syncing() {
-            // If we are syncing, we don't want to broadcast data
+        // Check if gossip broadcast is enabled
+        if !self.sync_state.is_gossip_broadcast_enabled() || self.is_syncing() {
+            debug!("Gossip broadcast is disabled, skipping broadcast");
             return Ok(());
         }
 

--- a/crates/p2p/src/server_data_handler.rs
+++ b/crates/p2p/src/server_data_handler.rs
@@ -79,6 +79,12 @@ where
         &self,
         chunk_request: GossipRequest<UnpackedChunk>,
     ) -> GossipResult<()> {
+        // Check if gossip reception is enabled
+        if !self.sync_state.is_gossip_reception_enabled() {
+            debug!("Gossip reception is disabled, skipping chunk handling");
+            return Ok(());
+        }
+
         let source_miner_address = chunk_request.miner_address;
         let chunk = chunk_request.data;
         let chunk_path_hash = chunk.chunk_path_hash();
@@ -129,6 +135,12 @@ where
         &self,
         transaction_request: GossipRequest<IrysTransactionHeader>,
     ) -> GossipResult<()> {
+        // Check if gossip reception is enabled
+        if !self.sync_state.is_gossip_reception_enabled() {
+            debug!("Gossip reception is disabled, skipping transaction handling");
+            return Ok(());
+        }
+
         debug!(
             "Node {}: Gossip transaction received from peer {}: {:?}",
             self.gossip_client.mining_address,
@@ -191,6 +203,12 @@ where
         &self,
         transaction_request: GossipRequest<CommitmentTransaction>,
     ) -> GossipResult<()> {
+        // Check if gossip reception is enabled
+        if !self.sync_state.is_gossip_reception_enabled() {
+            debug!("Gossip reception is disabled, skipping commitment transaction handling");
+            return Ok(());
+        }
+
         debug!(
             "Node {}: Gossip commitment transaction received from peer {}: {:?}",
             self.gossip_client.mining_address,
@@ -257,6 +275,12 @@ where
         block_header_request: GossipRequest<IrysBlockHeader>,
         source_api_address: SocketAddr,
     ) -> GossipResult<()> {
+        // Check if gossip reception is enabled
+        if !self.sync_state.is_gossip_reception_enabled() {
+            debug!("Gossip reception is disabled, skipping block header handling");
+            return Ok(());
+        }
+
         let span = self.span.clone();
         let _span = span.enter();
         let source_miner_address = block_header_request.miner_address;
@@ -417,6 +441,12 @@ where
         &self,
         execution_payload_request: GossipRequest<Block>,
     ) -> GossipResult<()> {
+        // Check if gossip reception is enabled
+        if !self.sync_state.is_gossip_reception_enabled() {
+            debug!("Gossip reception is disabled, skipping execution payload handling");
+            return Ok(());
+        }
+
         let source_miner_address = execution_payload_request.miner_address;
         let evm_block = execution_payload_request.data;
         let sealed_block = evm_block.seal_slow();
@@ -470,6 +500,12 @@ where
         peer_info: &PeerListItem,
         request: GossipRequest<GossipDataRequest>,
     ) -> GossipResult<bool> {
+        // Check if gossip reception is enabled
+        if !self.sync_state.is_gossip_reception_enabled() {
+            debug!("Gossip reception is disabled, skipping data request handling");
+            return Ok(false);
+        }
+
         match request.data {
             GossipDataRequest::Block(block_hash) => {
                 let block_result = self.block_pool.get_block_data(&block_hash).await;


### PR DESCRIPTION
**Describe the changes**
This PR adds two new flags to the `SyncState`: `is_gossip_broadcast_enabled` and `is_gossip_reception_enabled`. Setting `is_gossip_broadcast_enabled` to `false` will cause node to stop gossip broadcasts. Setting `is_gossip_reception_enabled` to `false` will cause gossip server request handlers to do nothing.

**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
