### PR TITLE
feat: replace the epoch_service with epoch_snapshots on the block_tree

### DIFF
--- a/crates/actors/src/block_discovery.rs
+++ b/crates/actors/src/block_discovery.rs
@@ -446,75 +446,85 @@ impl Handler<BlockDiscoveredMessage> for BlockDiscoveryActor {
                         .get_epoch_snapshot(&parent_block_hash)
                         .expect("parent blocks epoch_snapshot should be retrievable");
 
-                    let commitment_state_guard = epoch_snapshot.commitment_state.read().unwrap();
+                    {
+                        let commitment_state_guard =
+                            epoch_snapshot.commitment_state.read().unwrap();
 
-                    // Get the current epoch snapshot from the parent block
-                    let mut parent_commitment_snapshot = block_tree_guard
-                        .read()
-                        .get_commitment_snapshot(&parent_block_hash)
-                        .expect("parent block to be in block_tree")
-                        .as_ref()
-                        .clone();
+                        // Get the current epoch snapshot from the parent block
+                        let mut parent_commitment_snapshot = block_tree_guard
+                            .read()
+                            .get_commitment_snapshot(&parent_block_hash)
+                            .expect("parent block to be in block_tree")
+                            .as_ref()
+                            .clone();
 
-                    if is_epoch_block {
-                        let expected_commitment_tx =
-                            parent_commitment_snapshot.get_epoch_commitments();
+                        if is_epoch_block {
+                            let expected_commitment_tx =
+                                parent_commitment_snapshot.get_epoch_commitments();
 
-                        // Validate epoch block has expected commitments in correct order
-                        let commitments_match =
-                            expected_commitment_tx.iter().eq(arc_commitment_txs.iter());
-                        if !commitments_match {
-                            debug!(
+                            // Validate epoch block has expected commitments in correct order
+                            let commitments_match =
+                                expected_commitment_tx.iter().eq(arc_commitment_txs.iter());
+                            if !commitments_match {
+                                debug!(
                                 "Epoch block commitment tx for block height: {block_height}\nexpected: {:#?}\nactual: {:#?}",
                                 expected_commitment_tx.iter().map(|x| x.id).collect::<Vec<_>>(),
                                 arc_commitment_txs.iter().map(|x| x.id).collect::<Vec<_>>()
                             );
-                            return Err(BlockDiscoveryError::InvalidEpochBlock(
-                                "Epoch block commitments don't match expected".to_string(),
-                            ));
-                        }
-                    } else {
-                        // Validate and add each commitment transaction for non-epoch blocks
-                        for commitment_tx in arc_commitment_txs.iter() {
-                            let is_staked = commitment_state_guard.is_staked(commitment_tx.signer);
-                            let status = parent_commitment_snapshot
-                                .get_commitment_status(commitment_tx, is_staked);
-
-                            // Ensure commitment is unknown (new) and from staked address
-                            match status {
-                                CommitmentSnapshotStatus::Accepted => {
-                                    return Err(BlockDiscoveryError::InvalidCommitmentTransaction(
-                                        "Commitment tx included in prior block".to_string(),
-                                    ));
-                                }
-                                CommitmentSnapshotStatus::Unsupported => {
-                                    return Err(BlockDiscoveryError::InvalidCommitmentTransaction(
-                                        "Commitment tx of unsupported type".to_string(),
-                                    ));
-                                }
-                                CommitmentSnapshotStatus::Unstaked => {
-                                    return Err(BlockDiscoveryError::InvalidCommitmentTransaction(
-                                        format!(
-                                            "Commitment tx {} from unstaked address {:?}",
-                                            commitment_tx.id, commitment_tx.signer
-                                        ),
-                                    ));
-                                }
-                                CommitmentSnapshotStatus::Unknown => {} // Success case
-                            }
-
-                            // Add commitment and validate it's accepted
-                            let is_staked_in_current_epoch =
-                                commitment_state_guard.is_staked(commitment_tx.signer);
-                            let add_status = parent_commitment_snapshot
-                                .add_commitment(commitment_tx, is_staked_in_current_epoch);
-                            if add_status != CommitmentSnapshotStatus::Accepted {
-                                return Err(BlockDiscoveryError::InvalidCommitmentTransaction(
-                                    "Commitment tx is invalid".to_string(),
+                                return Err(BlockDiscoveryError::InvalidEpochBlock(
+                                    "Epoch block commitments don't match expected".to_string(),
                                 ));
                             }
+                        } else {
+                            // Validate and add each commitment transaction for non-epoch blocks
+                            for commitment_tx in arc_commitment_txs.iter() {
+                                let is_staked =
+                                    commitment_state_guard.is_staked(commitment_tx.signer);
+                                let status = parent_commitment_snapshot
+                                    .get_commitment_status(commitment_tx, is_staked);
+
+                                // Ensure commitment is unknown (new) and from staked address
+                                match status {
+                                    CommitmentSnapshotStatus::Accepted => {
+                                        return Err(
+                                            BlockDiscoveryError::InvalidCommitmentTransaction(
+                                                "Commitment tx included in prior block".to_string(),
+                                            ),
+                                        );
+                                    }
+                                    CommitmentSnapshotStatus::Unsupported => {
+                                        return Err(
+                                            BlockDiscoveryError::InvalidCommitmentTransaction(
+                                                "Commitment tx of unsupported type".to_string(),
+                                            ),
+                                        );
+                                    }
+                                    CommitmentSnapshotStatus::Unstaked => {
+                                        return Err(
+                                            BlockDiscoveryError::InvalidCommitmentTransaction(
+                                                format!(
+                                                    "Commitment tx {} from unstaked address {:?}",
+                                                    commitment_tx.id, commitment_tx.signer
+                                                ),
+                                            ),
+                                        );
+                                    }
+                                    CommitmentSnapshotStatus::Unknown => {} // Success case
+                                }
+
+                                // Add commitment and validate it's accepted
+                                let is_staked_in_current_epoch =
+                                    commitment_state_guard.is_staked(commitment_tx.signer);
+                                let add_status = parent_commitment_snapshot
+                                    .add_commitment(commitment_tx, is_staked_in_current_epoch);
+                                if add_status != CommitmentSnapshotStatus::Accepted {
+                                    return Err(BlockDiscoveryError::InvalidCommitmentTransaction(
+                                        "Commitment tx is invalid".to_string(),
+                                    ));
+                                }
+                            }
                         }
-                    }
+                    } // Force drop commitment_state_guard.read() for clippy to understand :/
 
                     // WARNING: All block pre-validation needs to be completed before
                     // sending this message.

--- a/crates/actors/src/block_discovery.rs
+++ b/crates/actors/src/block_discovery.rs
@@ -501,6 +501,7 @@ impl Handler<BlockDiscoveredMessage> for BlockDiscoveryActor {
                                 ))
                             })?;
 
+                        // FIXME: this should be done only if this extends the canonical chain
                         let (oneshot_tx, rx) = tokio::sync::oneshot::channel();
                         epoch_sender
                             .send(crate::EpochServiceMessage::NewEpoch {

--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -9,7 +9,6 @@ use crate::{
     reth_service::{BlockHashType, ForkChoiceUpdateMessage, RethServiceActor},
     services::ServiceSenders,
     shadow_tx_generator::ShadowTxGenerator,
-    EpochServiceMessage,
 };
 use actix::prelude::*;
 use actors::mocker::Mocker;
@@ -379,7 +378,6 @@ pub trait BlockProdStrategy {
         let prev_block_hash = prev_block_header.block_hash;
         let block_height = prev_block_header.height + 1;
         let evm_block_hash = eth_built_payload.hash();
-        let epoch_service = self.inner().service_senders.epoch_service.clone();
 
         if solution.vdf_step <= prev_block_header.vdf_limiter_info.global_step_number {
             warn!("Skipping solution for old step number {}, previous block step number {} for block {}", solution.vdf_step, prev_block_header.vdf_limiter_info.global_step_number, prev_block_hash.0.to_base58());
@@ -428,14 +426,16 @@ pub trait BlockProdStrategy {
         let cumulative_difficulty = next_cumulative_diff(prev_block_header.cumulative_diff, diff);
 
         // Use the partition hash to figure out what ledger it belongs to
-        let (sender, rx) = tokio::sync::oneshot::channel();
-        epoch_service
-            .send(EpochServiceMessage::GetPartitionAssignment(
-                solution.partition_hash,
-                sender,
-            ))
-            .unwrap();
-        let ledger_id = rx.await?.and_then(|pa| pa.ledger_id);
+        let epoch_snapshot = self
+            .inner()
+            .block_tree_guard
+            .read()
+            .get_epoch_snapshot(&prev_block_hash)
+            .expect("parent epoch snapshot to be retrievable");
+
+        let ledger_id = epoch_snapshot
+            .get_data_partition_assignment(solution.partition_hash)
+            .and_then(|pa| pa.ledger_id);
 
         let poa_chunk = Base64(solution.chunk);
         let poa_chunk_hash = H256(sha::sha256(&poa_chunk.0));

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -640,6 +640,16 @@ impl BlockTreeServiceInner {
                     // Get the new canonical chain that's replacing the orphaned blocks
                     let new_canonical = cache.get_canonical_chain();
 
+                    for o in old_canonical.iter() {
+                        debug!("old_canonical({}) - {}", o.height, o.block_hash);
+                    }
+
+                    for o in new_canonical.0.iter() {
+                        debug!("new_canonical({}) - {}", o.height, o.block_hash);
+                    }
+
+                    debug!("fork_height: {} fork_hash: {}", fork_height, fork_hash);
+
                     // Trim both chains back to their common ancestor to isolate the divergent portions
                     let (old_fork, new_fork) = prune_chains_at_ancestor(
                         old_canonical,
@@ -1782,6 +1792,7 @@ impl BlockTreeCache {
             }
         }
 
+        fork_blocks.reverse();
         fork_blocks
     }
 

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -1056,7 +1056,7 @@ impl BlockTreeCache {
     /// Restores the block tree cache from the database and `block_index` during startup.
     ///
     /// Rebuilds the block tree by loading the most recent blocks from the database (up to
-    /// `block_cache_depth` blocks). The restoration process involves:
+    /// `block_tree_depth` blocks). The restoration process involves:
     ///
     /// 1. **Determines block range**: Calculates start/end positions based on cache depth
     /// 2. **Replays epoch history**: Initializes genesis epoch snapshot and replays historical
@@ -1099,7 +1099,7 @@ impl BlockTreeCache {
 
             let start = block_index
                 .num_blocks()
-                .saturating_sub(consensus_config.block_cache_depth - 1);
+                .saturating_sub(consensus_config.block_tree_depth - 1);
             let end = block_index.num_blocks();
             let start_block_hash = block_index.get_item(start).unwrap().block_hash;
             (start, end, start_block_hash)
@@ -1493,7 +1493,7 @@ impl BlockTreeCache {
         let mut not_onchain_count = 0;
 
         let mut current = self.max_cumulative_difficulty.1;
-        let mut blocks_to_collect = self.consensus_config.block_cache_depth;
+        let mut blocks_to_collect = self.consensus_config.block_tree_depth;
         debug!(
             "updating canonical chain cache latest_cache_tip: {}",
             current
@@ -1507,7 +1507,7 @@ impl BlockTreeCache {
                     pairs.clear();
                     not_onchain_count = 0;
                     current = entry.block.previous_block_hash;
-                    blocks_to_collect = self.consensus_config.block_cache_depth;
+                    blocks_to_collect = self.consensus_config.block_tree_depth;
                     continue;
                 }
 
@@ -1831,7 +1831,7 @@ impl BlockTreeCache {
         let mut prev_block = &current_entry.block;
         let mut depth_count = 0;
 
-        while prev_block.height > 0 && depth_count < self.consensus_config.block_cache_depth {
+        while prev_block.height > 0 && depth_count < self.consensus_config.block_tree_depth {
             let prev_hash = prev_block.previous_block_hash;
             let prev_entry = self.blocks.get(&prev_hash)?;
             debug!(
@@ -2040,7 +2040,7 @@ pub async fn get_optimistic_chain(tree: BlockTreeReadGuard) -> eyre::Result<Vec<
     let canonical_chain = tokio::task::spawn_blocking(move || {
         let cache = tree.read();
 
-        let mut blocks_to_collect = cache.consensus_config.block_cache_depth;
+        let mut blocks_to_collect = cache.consensus_config.block_tree_depth;
         let mut chain_cache = Vec::with_capacity(
             blocks_to_collect
                 .try_into()

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -1462,7 +1462,7 @@ impl BlockTreeCache {
     /// - **Non-onchain count**: Number of blocks not yet fully validated
     ///
     /// ## Canonical Chain Structure
-    /// * **First element**: Genesis block or the oldest block within `block_cache_depth`
+    /// * **First element**: Genesis block or the oldest block within `block_tree_depth`
     /// * **Last element**: Current chain tip (highest cumulative difficulty)
     /// * **Ordering**: Chronological from oldest to newest block
     ///

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -116,6 +116,7 @@ pub struct ReorgEvent {
     pub fork_parent: Arc<IrysBlockHeader>,
     pub new_tip: BlockHash,
     pub timestamp: SystemTime,
+    pub db: Option<DatabaseProvider>,
 }
 
 #[derive(Debug, Clone)]
@@ -577,7 +578,8 @@ impl BlockTreeServiceInner {
                             let fork_height = fork_block.height;
 
                             // Populate `old_canonical` by converting each orphaned block into a `ChainCacheEntry`.
-                            let mut old_canonical = Vec::with_capacity(orphaned_blocks.len());
+                            let mut old_canonical: Vec<BlockTreeEntry> =
+                                Vec::with_capacity(orphaned_blocks.len());
                             for block in &orphaned_blocks {
                                 let entry = make_block_tree_entry(block);
                                 old_canonical.push(entry);
@@ -620,6 +622,7 @@ impl BlockTreeServiceInner {
                                 fork_parent: Arc::new(fork_block.clone()),
                                 new_tip: block_hash,
                                 timestamp: SystemTime::now(),
+                                db: Some(self.db.clone()),
                             };
 
                             // Broadcast reorg event using the shared sender

--- a/crates/actors/src/block_tree_service/test_utils.rs
+++ b/crates/actors/src/block_tree_service/test_utils.rs
@@ -284,6 +284,7 @@ pub fn create_and_apply_fork(
         fork_parent,
         new_tip,
         timestamp: SystemTime::now(),
+        db: None,
     };
 
     (reorg_event, fork_prices)

--- a/crates/actors/src/block_tree_service/test_utils.rs
+++ b/crates/actors/src/block_tree_service/test_utils.rs
@@ -8,7 +8,10 @@ use irys_types::{storage_pricing::TOKEN_SCALE, Config, IrysBlockHeader, IrysToke
 use reth::tasks::{TaskExecutor, TaskManager};
 use rust_decimal::Decimal;
 
-use crate::services::{ServiceReceivers, ServiceSenders};
+use crate::{
+    services::{ServiceReceivers, ServiceSenders},
+    EpochSnapshot,
+};
 
 use super::{
     ema_snapshot::EmaSnapshot, BlockTreeCache, BlockTreeReadGuard, ChainState, ReorgEvent,
@@ -63,6 +66,10 @@ pub fn dummy_ema_snapshot() -> Arc<EmaSnapshot> {
     EmaSnapshot::genesis(&genesis_header)
 }
 
+pub fn dummy_epoch_snapshot() -> Arc<EpochSnapshot> {
+    Arc::new(EpochSnapshot::default())
+}
+
 pub fn genesis_tree(blocks: &mut [(IrysBlockHeader, ChainState)]) -> BlockTreeReadGuard {
     let mut block_hash = if blocks[0].0.block_hash == H256::default() {
         H256::random()
@@ -91,6 +98,7 @@ pub fn genesis_tree(blocks: &mut [(IrysBlockHeader, ChainState)]) -> BlockTreeRe
                 block.block_hash,
                 block,
                 Arc::new(CommitmentSnapshot::default()),
+                Arc::new(EpochSnapshot::default()),
                 dummy_ema_snapshot(),
                 *state,
             )
@@ -252,6 +260,7 @@ pub fn create_and_apply_fork(
                 header.block_hash,
                 &header,
                 Arc::new(CommitmentSnapshot::default()),
+                Arc::new(EpochSnapshot::default()),
                 dummy_ema_snapshot(),
                 chain_state,
             )

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -764,8 +764,12 @@ mod tests {
         let storage_submodules_config =
             StorageSubmodulesConfig::load(config.node_config.base_directory.clone()).unwrap();
         let service_senders = ServiceSenders::new().0;
-        let mut epoch_service =
-            EpochServiceInner::new(&service_senders, &storage_submodules_config, &config);
+        let mut epoch_service = EpochServiceInner::new(
+            &service_senders,
+            &storage_submodules_config,
+            &config,
+            System::current(),
+        );
 
         // Tell the epoch service to initialize the ledgers
         let (sender, _rx) = tokio::sync::oneshot::channel();

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -4,11 +4,11 @@ use crate::{
     block_discovery::{get_commitment_tx_in_parallel, get_data_tx_in_parallel},
     block_index_service::BlockIndexReadGuard,
     block_tree_service::ema_snapshot::EmaSnapshot,
-    epoch_service::PartitionAssignmentsReadGuard,
     mempool_service::MempoolServiceMessage,
     mining::hash_to_number,
     services::ServiceSenders,
     shadow_tx_generator::ShadowTxGenerator,
+    EpochSnapshot,
 };
 use alloy_consensus::Transaction as _;
 use alloy_eips::eip7685::{Requests, RequestsOrHash};
@@ -50,7 +50,7 @@ pub trait PayloadProvider: Clone + Send + Sync + 'static {
 pub async fn prevalidate_block(
     block: IrysBlockHeader,
     previous_block: IrysBlockHeader,
-    partitions_guard: PartitionAssignmentsReadGuard,
+    parent_epoch_snapshot: Arc<EpochSnapshot>,
     config: Config,
     reward_curve: Arc<HalvingCurve>,
     parent_ema_snapshot: &EmaSnapshot,
@@ -101,7 +101,7 @@ pub async fn prevalidate_block(
         "cumulative_difficulty_is_valid",
     );
 
-    check_poa_data_expiration(&block.poa, &partitions_guard)?;
+    check_poa_data_expiration(&block.poa, parent_epoch_snapshot.clone())?;
     debug!("poa data not expired");
 
     // Check the solution_hash
@@ -209,16 +209,20 @@ pub fn difficulty_is_valid(
 /// Checks PoA data chunk data solution partitions has not expired
 pub fn check_poa_data_expiration(
     poa: &PoaData,
-    partitions_guard: &PartitionAssignmentsReadGuard,
+    epoch_snapshot: Arc<EpochSnapshot>,
 ) -> eyre::Result<()> {
+    let is_data_partition_assigned = epoch_snapshot
+        .partition_assignments
+        .read()
+        .unwrap()
+        .data_partitions
+        .contains_key(&poa.partition_hash);
+
     // if is a data chunk
     if poa.data_path.is_some()
         && poa.tx_path.is_some()
         && poa.ledger_id.is_some()
-        && !partitions_guard
-            .read()
-            .data_partitions
-            .contains_key(&poa.partition_hash)
+        && !is_data_partition_assigned
     {
         return Err(eyre::eyre!(
             "Invalid data PoA, partition hash is not a data partition, it may have expired"
@@ -328,10 +332,11 @@ pub fn get_recall_range(
     entropy_packing_iterations = ?config.entropy_packing_iterations,
     chunk_size = ?config.chunk_size
 ), err)]
+
 pub fn poa_is_valid(
     poa: &PoaData,
     block_index_guard: &BlockIndexReadGuard,
-    partitions_guard: &PartitionAssignmentsReadGuard,
+    epoch_snapshot: &EpochSnapshot,
     config: &ConsensusConfig,
     miner_address: &Address,
 ) -> eyre::Result<()> {
@@ -345,9 +350,8 @@ pub fn poa_is_valid(
         (poa.data_path.clone(), poa.tx_path.clone(), poa.ledger_id)
     {
         // partition data -> ledger data
-        let partition_assignment = partitions_guard
-            .read()
-            .get_assignment(poa.partition_hash)
+        let partition_assignment = epoch_snapshot
+            .get_data_partition_assignment(poa.partition_hash)
             .unwrap();
 
         let ledger_chunk_offset = partition_assignment.slot_index.unwrap() as u64
@@ -688,9 +692,8 @@ fn validate_shadow_transactions_match(
 mod tests {
     use crate::{
         block_index_service::{BlockIndexService, GetBlockIndexGuardMessage},
-        epoch_service::EpochServiceInner,
-        services::ServiceSenders,
-        BlockFinalizedMessage, EpochServiceMessage,
+        epoch_service::EpochSnapshot,
+        BlockFinalizedMessage,
     };
     use actix::{prelude::*, SystemRegistry};
 
@@ -710,8 +713,8 @@ mod tests {
     pub(super) struct TestContext {
         pub block_index: Arc<RwLock<BlockIndex>>,
         pub block_index_actor: Addr<BlockIndexService>,
-        pub partitions_guard: PartitionAssignmentsReadGuard,
         pub miner_address: Address,
+        pub epoch_snapshot: EpochSnapshot,
         pub partition_hash: H256,
         pub partition_assignment: PartitionAssignment,
         pub consensus_config: ConsensusConfig,
@@ -750,7 +753,7 @@ mod tests {
 
         let commitments = add_genesis_commitments(&mut genesis_block, &config);
 
-        let arc_genesis = Arc::new(genesis_block);
+        let arc_genesis = Arc::new(genesis_block.clone());
         let signer = config.irys_signer();
         let miner_address = signer.address();
 
@@ -763,44 +766,17 @@ mod tests {
 
         let storage_submodules_config =
             StorageSubmodulesConfig::load(config.node_config.base_directory.clone()).unwrap();
-        let service_senders = ServiceSenders::new().0;
-        let mut epoch_service = EpochServiceInner::new(
-            &service_senders,
+
+        // Create an epoch snapshot for the genesis block
+        let epoch_snapshot = EpochSnapshot::new(
             &storage_submodules_config,
+            genesis_block,
+            commitments.clone(),
             &config,
-            System::current(),
         );
+        info!("Genesis Epoch tasks complete.");
 
-        // Tell the epoch service to initialize the ledgers
-        let (sender, _rx) = tokio::sync::oneshot::channel();
-        match epoch_service.handle_message(EpochServiceMessage::NewEpoch {
-            new_epoch_block: arc_genesis.clone(),
-            previous_epoch_block: None,
-            commitments: Arc::new(commitments),
-            sender,
-        }) {
-            Ok(_) => info!("Genesis Epoch tasks complete."),
-            Err(_) => panic!("Failed to perform genesis epoch tasks"),
-        }
-
-        let (sender, rx) = tokio::sync::oneshot::channel();
-        epoch_service
-            .handle_message(EpochServiceMessage::GetLedgersGuard(sender))
-            .unwrap();
-        let ledgers_guard = rx.await.unwrap();
-
-        let (sender, rx) = tokio::sync::oneshot::channel();
-        epoch_service
-            .handle_message(EpochServiceMessage::GetPartitionAssignmentsGuard(sender))
-            .unwrap();
-        let partitions_guard = rx.await.unwrap();
-
-        let partition_hash = {
-            let ledgers = ledgers_guard.read();
-            debug!("ledgers: {:?}", ledgers);
-            let sub_slots = ledgers.get_slots(DataLedger::Submit);
-            sub_slots[0].partitions[0]
-        };
+        let partition_hash = epoch_snapshot.ledgers.get_slots(DataLedger::Submit)[0].partitions[0];
 
         let msg = BlockFinalizedMessage {
             block_header: arc_genesis.clone(),
@@ -813,9 +789,8 @@ mod tests {
             Err(_) => panic!("Failed to index genesis block"),
         }
 
-        let partition_assignment = partitions_guard
-            .read()
-            .get_assignment(partition_hash)
+        let partition_assignment = epoch_snapshot
+            .get_data_partition_assignment(partition_hash)
             .unwrap();
 
         debug!("Partition assignment {:?}", partition_assignment);
@@ -825,8 +800,8 @@ mod tests {
             TestContext {
                 block_index,
                 block_index_actor,
-                partitions_guard,
                 miner_address,
+                epoch_snapshot,
                 partition_hash,
                 partition_assignment,
                 consensus_config,
@@ -1044,7 +1019,7 @@ mod tests {
         let poa_valid = poa_is_valid(
             &poa,
             &block_index_guard,
-            &context.partitions_guard,
+            &context.epoch_snapshot,
             &context.consensus_config,
             &context.miner_address,
         );

--- a/crates/actors/src/epoch_service/commitment_state.rs
+++ b/crates/actors/src/epoch_service/commitment_state.rs
@@ -18,3 +18,12 @@ pub struct CommitmentState {
     pub stake_commitments: BTreeMap<Address, CommitmentStateEntry>,
     pub pledge_commitments: BTreeMap<Address, Vec<CommitmentStateEntry>>,
 }
+
+impl CommitmentState {
+    pub fn is_staked(&self, address: Address) -> bool {
+        if let Some(commitment) = self.stake_commitments.get(&address) {
+            return commitment.commitment_status == CommitmentStatus::Active;
+        }
+        false
+    }
+}

--- a/crates/actors/src/epoch_service/epoch_service.rs
+++ b/crates/actors/src/epoch_service/epoch_service.rs
@@ -1,71 +1,94 @@
-use actix::{System, SystemService as _};
+use super::{CommitmentState, CommitmentStateEntry, PartitionAssignments};
+use crate::EpochBlockData;
+use actix::System;
 use base58::ToBase58 as _;
 use eyre::{Error, Result};
 use irys_config::submodules::StorageSubmodulesConfig;
-use irys_database::{block_header_by_hash, data_ledger::*, SystemLedger};
+use irys_database::{data_ledger::*, SystemLedger};
 use irys_primitives::CommitmentStatus;
 use irys_storage::{ie, StorageModuleInfo};
+use irys_types::Config;
 use irys_types::{
     partition::{PartitionAssignment, PartitionHash},
-    IrysBlockHeader, SimpleRNG, H256,
+    IrysBlockHeader, NodeConfig, SimpleRNG, H256,
 };
 use irys_types::{
     partition_chunk_offset_ie, Address, CommitmentTransaction, ConsensusConfig, DataLedger,
     PartitionChunkOffset,
 };
-use irys_types::{Config, H256List};
 use openssl::sha;
 use reth::tasks::{shutdown::GracefulShutdown, TaskExecutor};
-use reth_db::Database;
 use std::{
     collections::VecDeque,
     pin::pin,
     sync::{Arc, RwLock},
 };
-use tokio::{
-    sync::{broadcast, mpsc::UnboundedReceiver},
-    task::JoinHandle,
-};
-
+use tokio::task::JoinHandle;
 use tracing::{debug, error, trace, warn, Span};
 
-use super::{CommitmentState, CommitmentStateEntry, EpochReplayData, PartitionAssignments};
-use crate::{block_tree_service::ReorgEvent, services::ServiceSenders};
-use crate::{
-    broadcast_mining_service::{BroadcastMiningService, BroadcastPartitionsExpiration},
-    EpochServiceMessage,
-};
-use crate::{mempool_service::MempoolServiceMessage, StorageModuleServiceMessage};
-
 /// Temporarily track all of the ledger definitions inside the epoch service actor
-#[derive(Debug, Clone)]
-pub struct EpochServiceInner {
-    /// Source of randomness derived from previous epoch
-    pub last_epoch_hash: H256,
+#[derive(Debug)]
+pub struct EpochSnapshot {
     /// Protocol-managed data ledgers (one permanent, N term)
-    pub ledgers: Arc<RwLock<Ledgers>>,
+    pub ledgers: Ledgers,
     /// Tracks active mining assignments for partitions (by hash)
     pub partition_assignments: Arc<RwLock<PartitionAssignments>>,
     /// Sequential list of activated partition hashes
     pub all_active_partitions: Vec<PartitionHash>,
     /// List of partition hashes not yet assigned to a mining address
     pub unassigned_partitions: Vec<PartitionHash>,
-    /// Reference to mpsc service channels
-    pub service_senders: ServiceSenders,
     /// Submodules config
-    pub storage_submodules_config: StorageSubmodulesConfig,
+    pub storage_submodules_config: Option<StorageSubmodulesConfig>,
     /// Current partition & ledger parameters
     pub config: Config,
-    /// Computed commitment state
-    pub(super) commitment_state: Arc<RwLock<CommitmentState>>,
-    /// Tracing span
-    pub span: Span,
-    /// Current actix system (temp hack until broadcast mining actor is a broadcast)
-    pub system: System,
-    /// Keeps a snapshot of the previous epoch state to simplify the logic of reorgs
-    pub previous_epoch_snapshot: Option<Box<(H256, EpochServiceInner)>>,
-    /// Hold onto a copy of the genesis block from initialization
-    genesis_block: Option<IrysBlockHeader>,
+    /// Commitment state (all stakes and pledges) as computed at this epoch's start
+    pub commitment_state: Arc<RwLock<CommitmentState>>,
+    /// The epoch block that was used to compute this snapshot
+    pub epoch_block: IrysBlockHeader,
+    /// The prior epoch block
+    pub previous_epoch_block: Option<IrysBlockHeader>,
+    /// Partition hashes that expired with this snapshot
+    pub expired_partition_hashes: Vec<PartitionHash>,
+}
+
+impl Clone for EpochSnapshot {
+    fn clone(&self) -> Self {
+        Self {
+            ledgers: self.ledgers.clone(),
+            // Deep copy the partition assignments by cloning the inner data
+            partition_assignments: Arc::new(RwLock::new(
+                self.partition_assignments.read().unwrap().clone(),
+            )),
+            all_active_partitions: self.all_active_partitions.clone(),
+            unassigned_partitions: self.unassigned_partitions.clone(),
+            storage_submodules_config: self.storage_submodules_config.clone(),
+            config: self.config.clone(),
+            // Deep copy the commitment state by cloning the inner data
+            commitment_state: Arc::new(RwLock::new(self.commitment_state.read().unwrap().clone())),
+            epoch_block: self.epoch_block.clone(),
+            previous_epoch_block: self.previous_epoch_block.clone(),
+            expired_partition_hashes: self.expired_partition_hashes.clone(),
+        }
+    }
+}
+
+impl Default for EpochSnapshot {
+    fn default() -> Self {
+        let node_config = NodeConfig::testnet();
+        let config = Config::new(node_config);
+        Self {
+            ledgers: Ledgers::new(&config.consensus),
+            partition_assignments: Arc::new(RwLock::new(PartitionAssignments::new())),
+            all_active_partitions: Vec::new(),
+            unassigned_partitions: Vec::new(),
+            storage_submodules_config: None, // This is only ever valid for test scenarios where epochs don't matter
+            config: config.clone(),
+            commitment_state: Arc::new(RwLock::new(CommitmentState::default())),
+            epoch_block: IrysBlockHeader::default(),
+            previous_epoch_block: None,
+            expired_partition_hashes: Vec::new(),
+        }
+    }
 }
 
 /// Reasons why the epoch service actors epoch tasks might fail
@@ -84,74 +107,68 @@ pub enum EpochServiceError {
 #[derive(Debug)]
 pub struct EpochService {
     shutdown: GracefulShutdown,
-    msg_rx: UnboundedReceiver<EpochServiceMessage>,
-    reorg_rx: broadcast::Receiver<ReorgEvent>, // reorg broadcast receiver
-    inner: EpochServiceInner,
+    // msg_rx: UnboundedReceiver<EpochServiceMessage>,
+    // reorg_rx: broadcast::Receiver<ReorgEvent>, // reorg broadcast receiver
+    // service_senders: ServiceSenders,
+    /// Tracing span
+    pub span: Span,
+    /// Current actix system (temp hack until broadcast mining actor is a broadcast)
+    pub system: System,
+    // Reference to mpsc service channels
+    // inner: EpochSnapshot,
 }
 
-impl EpochServiceInner {
+impl EpochSnapshot {
     /// Create a new instance of the epoch service actor
     pub fn new(
-        service_senders: &ServiceSenders,
         storage_submodules_config: &StorageSubmodulesConfig,
+        genesis_block: IrysBlockHeader,
+        commitments: Vec<CommitmentTransaction>,
         config: &Config,
-        system: System,
     ) -> Self {
-        Self {
-            last_epoch_hash: H256::zero(),
-            ledgers: Arc::new(RwLock::new(Ledgers::new(&config.consensus))),
+        let mut new_self = Self {
+            ledgers: Ledgers::new(&config.consensus),
             partition_assignments: Arc::new(RwLock::new(PartitionAssignments::new())),
             all_active_partitions: Vec::new(),
             unassigned_partitions: Vec::new(),
-            service_senders: service_senders.clone(),
-            storage_submodules_config: storage_submodules_config.clone(),
+            storage_submodules_config: Some(storage_submodules_config.clone()),
             config: config.clone(),
             commitment_state: Default::default(),
-            span: Span::current(),
-            system,
-            previous_epoch_snapshot: None,
-            genesis_block: None,
-        }
-    }
-    pub fn initialize(
-        &mut self,
-        genesis_block: IrysBlockHeader,
-        commitments: Vec<CommitmentTransaction>,
-    ) -> eyre::Result<Vec<StorageModuleInfo>> {
-        let span = self.span.clone();
-        let _span = span.enter();
-        Self::validate_commitments(&genesis_block, &commitments)?;
+            epoch_block: genesis_block.clone(),
+            previous_epoch_block: None,
+            expired_partition_hashes: Vec::new(),
+        };
 
-        match self.perform_epoch_tasks(&None, &genesis_block, commitments) {
-            Ok(()) => debug!("Initialized Epoch Service"),
+        if Self::validate_commitments(&genesis_block, &commitments).is_err() {
+            panic!("Cannot validate genesis block commitments");
+        }
+
+        match new_self.perform_epoch_tasks(&None, &genesis_block, commitments) {
+            Ok(_) => debug!("Initialized Epoch Snapshot"),
             Err(e) => {
-                return Err(eyre::eyre!("Error performing genesis init tasks {:?}", e));
+                panic!("Error performing init tasks {:?}", e);
             }
         }
 
-        self.genesis_block = Some(genesis_block);
+        // While we don't return these module infos, we call this method for validating of the storage modules
+        let _storage_module_info = new_self.map_storage_modules_to_partition_assignments();
 
-        let storage_module_info =
-            self.map_storage_modules_to_partition_assignments(&self.storage_submodules_config);
-
-        Ok(storage_module_info)
+        new_self
     }
 
     pub fn replay_epoch_data(
         &mut self,
-        epoch_replay_data: Vec<EpochReplayData>,
+        epoch_replay_data: Vec<EpochBlockData>,
     ) -> eyre::Result<Vec<StorageModuleInfo>> {
-        let span = self.span.clone();
-        let _span = span.enter();
         // Initialize as None for the first iteration
-        let mut previous_epoch_block: Option<IrysBlockHeader> = self.genesis_block.clone();
+        let mut previous_epoch_block: Option<IrysBlockHeader> = self.previous_epoch_block.clone();
 
         for replay_data in epoch_replay_data {
             let block_header = replay_data.epoch_block;
             let commitments = replay_data.commitments;
 
             match self.perform_epoch_tasks(&previous_epoch_block, &block_header, commitments) {
-                Ok(()) => debug!("Processed replay epoch block"),
+                Ok(_expired_partition_hashes) => debug!("Processed replay epoch block"),
                 Err(e) => {
                     return Err(eyre::eyre!("Error performing epoch tasks {:?}", e));
                 }
@@ -161,8 +178,7 @@ impl EpochServiceInner {
             previous_epoch_block = Some(block_header);
         }
 
-        let storage_module_info =
-            self.map_storage_modules_to_partition_assignments(&self.storage_submodules_config);
+        let storage_module_info = self.map_storage_modules_to_partition_assignments();
 
         Ok(storage_module_info)
     }
@@ -212,7 +228,6 @@ impl EpochServiceInner {
         new_epoch_block: &IrysBlockHeader,
         new_epoch_commitments: Vec<CommitmentTransaction>,
     ) -> Result<(), EpochServiceError> {
-        let _enter = self.span.clone().entered();
         // Validate the epoch blocks
         self.is_epoch_block(new_epoch_block)?;
 
@@ -243,7 +258,8 @@ impl EpochServiceInner {
             "\u{001b}[32mProcessing epoch block\u{001b}[0m"
         );
 
-        self.store_previous_epoch_snapshot(previous_epoch_block, new_epoch_block);
+        self.epoch_block = new_epoch_block.clone();
+        self.previous_epoch_block = previous_epoch_block.clone();
 
         self.compute_commitment_state(new_epoch_commitments);
 
@@ -258,8 +274,6 @@ impl EpochServiceInner {
         self.allocate_additional_capacity();
 
         self.assign_partition_hashes_to_pledges();
-
-        self.notify_storage_module_service();
 
         Ok(())
     }
@@ -281,18 +295,14 @@ impl EpochServiceInner {
     fn try_genesis_init(&mut self, new_epoch_block: &IrysBlockHeader) {
         if self.all_active_partitions.is_empty() && new_epoch_block.is_genesis() {
             debug!("Performing genesis init");
-            // Store the genesis epoch hash
-            self.last_epoch_hash = new_epoch_block.last_epoch_hash;
-
             // Allocate 1 slot to each ledger and calculate the number of partitions
             let mut num_data_partitions = 0;
             {
                 // Create a scope for the write lock to expire with
-                let mut ledgers = self.ledgers.write().unwrap();
                 for ledger in DataLedger::iter() {
                     debug!("Allocating 1 slot for {:?}", &ledger);
                     num_data_partitions +=
-                        ledgers[ledger].allocate_slots(1, new_epoch_block.height);
+                        self.ledgers[ledger].allocate_slots(1, new_epoch_block.height);
                 }
             }
 
@@ -330,48 +340,42 @@ impl EpochServiceInner {
 
     /// Loops though all of the term ledgers and looks for slots that are older
     /// than the `epoch_length` (term length) of the ledger.
-    fn expire_term_ledger_slots(&self, new_epoch_block: &IrysBlockHeader) {
+    /// Stores a vec of expired partition hashes in the epoch snapshot
+    fn expire_term_ledger_slots(&mut self, new_epoch_block: &IrysBlockHeader) {
         let epoch_height = new_epoch_block.height;
-
-        let mut ledgers = self.ledgers.write().unwrap();
-        let expired_hashes: Vec<H256> = ledgers.get_expired_partition_hashes(epoch_height);
-        drop(ledgers);
+        let expired_hashes: Vec<H256> = self.ledgers.get_expired_partition_hashes(epoch_height);
 
         // Return early if there's no more work to do
         if expired_hashes.is_empty() {
             return;
         }
 
-        debug!("Expiring Hashes: {:?}", expired_hashes);
-
-        // HACK to get from_registry to work outside of actix
-        System::set_current(self.system.clone());
-
-        let mining_broadcaster_addr = BroadcastMiningService::from_registry();
-        mining_broadcaster_addr.do_send(BroadcastPartitionsExpiration(H256List(
-            expired_hashes.clone(),
-        )));
+        // NOTE: We used to do a broadcast here
+        // let mining_broadcaster_addr = BroadcastMiningService::from_registry();
+        // mining_broadcaster_addr.do_send(BroadcastPartitionsExpiration(H256List(
+        //     expired_hashes.clone(),
+        // )));
 
         // Update expired data partitions assignments marking them as capacity partitions
-        for partition_hash in expired_hashes {
-            self.return_expired_partition_to_capacity(partition_hash);
+        for partition_hash in expired_hashes.iter() {
+            self.return_expired_partition_to_capacity(*partition_hash);
         }
+
+        self.expired_partition_hashes = expired_hashes;
     }
 
     /// Loops though all the ledgers both perm and term, checking to see if any
     /// require additional ledger slots added to accommodate data ingress.
     fn allocate_additional_ledger_slots(
-        &self,
+        &mut self,
         previous_epoch_block: &Option<IrysBlockHeader>,
         new_epoch_block: &IrysBlockHeader,
     ) {
         for ledger in DataLedger::iter() {
             let part_slots =
                 self.calculate_additional_slots(previous_epoch_block, new_epoch_block, ledger);
-            let mut ledgers = self.ledgers.write().unwrap();
             debug!("Allocating {} slots for ledger {:?}", &part_slots, &ledger);
-            ledgers[ledger].allocate_slots(part_slots, new_epoch_block.height);
-            drop(ledgers);
+            self.ledgers[ledger].allocate_slots(part_slots, new_epoch_block.height);
         }
     }
 
@@ -413,7 +417,7 @@ impl EpochServiceInner {
         capacity_partitions.sort_unstable();
 
         // Use the previous epoch hash as a seed/entropy to the prng
-        let seed = self.last_epoch_hash.to_u32();
+        let seed = self.epoch_block.last_epoch_hash.to_u32();
         let mut rng = SimpleRNG::new(seed);
 
         // Loop though all of the ledgers processing their slot needs
@@ -432,11 +436,8 @@ impl EpochServiceInner {
     ) {
         debug!("Processing slot needs for ledger {:?}", &ledger);
         // Get slot needs for the specified ledger
-        let slot_needs: Vec<(usize, usize)>;
-        {
-            let ledgers = self.ledgers.read().unwrap();
-            slot_needs = ledgers.get_slot_needs(ledger);
-        }
+        let slot_needs = self.ledgers.get_slot_needs(ledger);
+
         let mut capacity_count: u32 = capacity_partitions
             .len()
             .try_into()
@@ -463,15 +464,13 @@ impl EpochServiceInner {
 
                 // Push the newly assigned partition hash to the appropriate slot
                 // in the ledger
-                {
-                    let mut ledgers = self.ledgers.write().unwrap();
-                    debug!(
-                        "Assigning partition hash {} to slot {} for  {:?}",
-                        &partition_hash, &slot_index, &ledger
-                    );
+                debug!(
+                    "Assigning partition hash {} to slot {} for  {:?}",
+                    &partition_hash, &slot_index, &ledger
+                );
 
-                    ledgers.push_partition_to_slot(ledger, slot_index, partition_hash);
-                }
+                self.ledgers
+                    .push_partition_to_slot(ledger, slot_index, partition_hash);
             }
         }
     }
@@ -493,9 +492,9 @@ impl EpochServiceInner {
     /// follows the process of sequentially hashing the previous partitions
     /// hash to compute the next partitions hash.
     fn add_capacity_partitions(&mut self, parts_to_add: u64) {
-        let mut prev_partition_hash = *match self.all_active_partitions.last() {
-            Some(last_hash) => last_hash,
-            None => &self.last_epoch_hash,
+        let mut prev_partition_hash = match self.all_active_partitions.last() {
+            Some(last_hash) => last_hash.clone(),
+            None => self.epoch_block.last_epoch_hash,
         };
 
         debug!("Adding {} capacity partitions", &parts_to_add);
@@ -516,7 +515,7 @@ impl EpochServiceInner {
 
     // Updates PartitionAssignment information about a partition hash, marking
     // it as expired (or unassigned to a slot in a data ledger)
-    fn return_expired_partition_to_capacity(&self, partition_hash: H256) {
+    fn return_expired_partition_to_capacity(&mut self, partition_hash: H256) {
         let mut pa = self.partition_assignments.write().unwrap();
         // Convert data partition to capacity partition if it exists
         if let Some(mut assignment) = pa.data_partitions.remove(&partition_hash) {
@@ -524,9 +523,8 @@ impl EpochServiceInner {
             let ledger: DataLedger = DataLedger::try_from(assignment.ledger_id.unwrap()).unwrap();
             let partition_hash = assignment.partition_hash;
             let slot_index = assignment.slot_index.unwrap();
-            let mut write = self.ledgers.write().unwrap();
-            write.remove_partition_from_slot(ledger, slot_index, &partition_hash);
-            drop(write);
+            self.ledgers
+                .remove_partition_from_slot(ledger, slot_index, &partition_hash);
 
             // Clear ledger assignment
             assignment.ledger_id = None;
@@ -576,10 +574,8 @@ impl EpochServiceInner {
         ledger: DataLedger,
     ) -> u64 {
         // Get current ledger state
-        let ledgers = self.ledgers.read().unwrap();
-        let data_ledger = &ledgers[ledger];
+        let data_ledger = &self.ledgers[ledger];
         let num_slots = data_ledger.slot_count() as u64;
-        drop(ledgers);
 
         let num_chunks_in_partition = self.config.consensus.num_chunks_in_partition;
         let max_ledger_capacity = num_slots * num_chunks_in_partition;
@@ -611,48 +607,6 @@ impl EpochServiceInner {
         }
 
         slots_to_add
-    }
-
-    /// Stores a deep copy of the current epoch state as a snapshot before transitioning to a new epoch.
-    /// Skips storage for genesis blocks. Creates independent copies of shared data structures
-    /// (ledgers, partition assignments, commitment state) to preserve historical state.
-    pub fn store_previous_epoch_snapshot(
-        &mut self,
-        previous_epoch_block: &Option<IrysBlockHeader>,
-        new_epoch_block: &IrysBlockHeader,
-    ) {
-        if new_epoch_block.is_genesis() {
-            return;
-        }
-
-        let mut snapshot = self.clone();
-
-        // Deep copy the ledgers
-        let ledgers = self.ledgers.read().unwrap().clone();
-        // Replace the entire Arc with a new one containing the cloned data
-        snapshot.ledgers = Arc::new(RwLock::new(ledgers));
-
-        // Deep copy the partition assignments
-        let pa = self.partition_assignments.read().unwrap().clone();
-        snapshot.partition_assignments = Arc::new(RwLock::new(pa));
-
-        // Deep copy the commitment state
-        let commitment_state = self.commitment_state.read().unwrap().clone();
-        snapshot.commitment_state = Arc::new(RwLock::new(commitment_state));
-
-        // Store the deep copied snapshot state as the previous epoch snapshot
-        debug!(
-            "{:?}\n{:?}",
-            previous_epoch_block.as_ref().map(|block| &block.block_hash),
-            new_epoch_block.block_hash
-        );
-
-        if previous_epoch_block.is_none() {
-            debug!("It's none");
-        }
-
-        let block_hash = previous_epoch_block.as_ref().unwrap().block_hash;
-        self.previous_epoch_snapshot = Some(Box::new((block_hash, snapshot)));
     }
 
     /// Computes the commitment state based on an epoch block and commitment transactions
@@ -827,30 +781,6 @@ impl EpochServiceInner {
         }
     }
 
-    /// Notifies the StorageModuleService about partition assignment changes.
-    ///
-    /// Maps current storage modules to their partition assignments and sends
-    /// this information to the StorageModuleService for processing.
-    ///
-    /// NOTE: Currently sends updates on every epoch block. Future optimization:
-    /// only send when assignments actually change.
-    ///
-    /// # Returns
-    /// Result indicating success or failure of the message send operation.
-    pub fn notify_storage_module_service(&self) {
-        let storage_module_infos =
-            self.map_storage_modules_to_partition_assignments(&self.storage_submodules_config);
-        // Create the message
-        let message = StorageModuleServiceMessage::PartitionAssignmentsUpdated {
-            storage_module_infos: storage_module_infos.into(),
-        };
-
-        // Send the message
-        if let Err(e) = self.service_senders.storage_modules.send(message) {
-            error!("Failed to send partition assignments update: {}", e);
-        }
-    }
-
     /// Returns a vector of all partition assignments associated with the provided miner address.
     ///
     /// This function extracts assignments from both data and capacity partitions where
@@ -913,14 +843,15 @@ impl EpochServiceInner {
     ///
     /// # Returns
     /// * `Vec<StorageModuleInfo>` - Vector of storage module information with assigned partitions
-    pub fn map_storage_modules_to_partition_assignments(
-        &self,
-        cfg: &StorageSubmodulesConfig,
-    ) -> Vec<StorageModuleInfo> {
+    pub fn map_storage_modules_to_partition_assignments(&self) -> Vec<StorageModuleInfo> {
         let miner = self.config.node_config.miner_address();
         let assignments = self.get_partition_assignments(miner);
         let num_chunks = self.config.consensus.num_chunks_in_partition as u32;
-        let paths = &cfg.submodule_paths;
+        let paths = &self
+            .storage_submodules_config
+            .as_ref()
+            .unwrap()
+            .submodule_paths;
 
         let mut module_infos = Vec::new();
 
@@ -998,6 +929,15 @@ impl EpochServiceInner {
 
         module_infos
     }
+
+    /// Gets a partitions assignment to a data partition by partition hash
+    pub fn get_data_partition_assignment(
+        &self,
+        partition_hash: PartitionHash,
+    ) -> Option<PartitionAssignment> {
+        let pa = self.partition_assignments.read().unwrap();
+        pa.get_assignment(partition_hash)
+    }
 }
 
 /// SHA256 hash the message parameter
@@ -1015,60 +955,16 @@ fn truncate_to_3_decimals(value: f64) -> f64 {
 /// mpsc style service wrapper for the Epoch Service
 impl EpochService {
     /// Spawn a new Epoch sService
-    pub fn spawn_service(
-        exec: &TaskExecutor,
-        genesis_block: IrysBlockHeader,
-        commitments: Vec<CommitmentTransaction>,
-        rx: UnboundedReceiver<EpochServiceMessage>,
-        service_senders: &ServiceSenders,
-        storage_submodules_config: &StorageSubmodulesConfig,
-        config: &Config,
-    ) -> JoinHandle<()> {
-        let config = config.clone();
-        let reorg_rx = service_senders.subscribe_reorgs();
-        let ledgers = Arc::new(RwLock::new(Ledgers::new(&config.consensus)));
-        let service_senders = service_senders.clone();
-        let storage_submodules_config = storage_submodules_config.clone();
+    pub fn spawn_service(exec: &TaskExecutor) -> JoinHandle<()> {
         let system = System::current();
-        let block_hash = genesis_block.block_hash;
+        let span = Span::current();
 
         exec.spawn_critical_with_graceful_shutdown_signal("Epoch Service", |shutdown| async move {
-            let mut pending_epoch_service = Self {
+            let pending_epoch_service = Self {
                 shutdown,
-                msg_rx: rx,
-                reorg_rx,
-                inner: EpochServiceInner {
-                    last_epoch_hash: H256::zero(),
-                    ledgers,
-                    partition_assignments: Arc::new(RwLock::new(PartitionAssignments::new())),
-                    all_active_partitions: Vec::new(),
-                    unassigned_partitions: Vec::new(),
-                    service_senders: service_senders.clone(),
-                    storage_submodules_config: storage_submodules_config.clone(),
-                    config: config.clone(),
-                    commitment_state: Default::default(),
-                    span: Span::current(),
-                    system: system.clone(),
-                    previous_epoch_snapshot: Some(Box::new((
-                        block_hash,
-                        EpochServiceInner::new(
-                            &service_senders,
-                            &storage_submodules_config,
-                            &config,
-                            system,
-                        ),
-                    ))),
-                    genesis_block: None,
-                },
+                system,
+                span,
             };
-
-            match pending_epoch_service
-                .inner
-                .initialize(genesis_block, commitments)
-            {
-                Ok(_) => {}
-                Err(e) => panic!("{}", e),
-            }
 
             match pending_epoch_service.start().await {
                 Ok(_) => {}
@@ -1079,30 +975,30 @@ impl EpochService {
         })
     }
 
-    async fn start(mut self) -> eyre::Result<()> {
+    async fn start(self) -> eyre::Result<()> {
         tracing::info!("starting Epoch service");
 
         let mut shutdown_future = pin!(self.shutdown);
         let shutdown_guard = loop {
             tokio::select! {
                 // Handle regular epoch service messages
-                msg = self.msg_rx.recv() => {
-                    match msg {
-                        Some(msg) => self.inner.handle_message(msg)?,
-                        None => {
-                            tracing::warn!("receiver channel closed");
-                            break None;
-                        }
-                    }
-                }
+                // msg = self.msg_rx.recv() => {
+                //     match msg {
+                //         Some(msg) => Self::handle_message(&mut self.inner, &self.service_senders, &self.system, msg)?,
+                //         None => {
+                //             tracing::warn!("receiver channel closed");
+                //             break None;
+                //         }
+                //     }
+                // }
 
                 // Handle reorg events
-                reorg_result = self.reorg_rx.recv() => {
-                    if let Some(event) = handle_broadcast_recv(reorg_result, "Reorg") {
-                        let mempool = self.inner.service_senders.mempool.clone();
-                        handle_reorg(&mut self.inner, &mempool, event).await?;
-                    }
-                }
+                // reorg_result = self.reorg_rx.recv() => {
+                //     if let Some(event) = handle_broadcast_recv(reorg_result, "Reorg") {
+                //         let mempool = self.service_senders.mempool.clone();
+                //         // handle_reorg(&mut self.inner, &mempool, event).await?;
+                //     }
+                // }
 
                 // Handle shutdown signal
                 shutdown = &mut shutdown_future => {
@@ -1112,10 +1008,10 @@ impl EpochService {
             }
         };
 
-        tracing::debug!(amount_of_messages = ?self.msg_rx.len(), "processing last in-bound messages before shutdown");
-        while let Ok(msg) = self.msg_rx.try_recv() {
-            self.inner.handle_message(msg)?;
-        }
+        // tracing::debug!(amount_of_messages = ?self.msg_rx.len(), "processing last in-bound messages before shutdown");
+        // while let Ok(msg) = self.msg_rx.try_recv() {
+        //     self.inner.handle_message(msg)?;
+        // }
 
         // explicitly inform the TaskManager that we're shutting down
         drop(shutdown_guard);
@@ -1123,95 +1019,86 @@ impl EpochService {
         tracing::info!("shutting down epoch service");
         Ok(())
     }
+
+    // fn handle_message(
+    //     inner: &mut EpochSnapshot,
+    //     service_senders: &ServiceSenders,
+    //     system: &System,
+    //     msg: EpochServiceMessage,
+    // ) -> eyre::Result<()> {
+    //     match msg {
+    //         EpochServiceMessage::NewEpoch {
+    //             new_epoch_block,
+    //             previous_epoch_block,
+    //             commitments,
+    //             sender,
+    //         } => {
+    //             handle_new_epoch(
+    //                 inner,
+    //                 new_epoch_block,
+    //                 previous_epoch_block,
+    //                 commitments,
+    //                 service_senders,
+    //                 system,
+    //                 sender,
+    //             )?;
+    //         }
+    //         _ => {
+    //             inner.handle_message(msg)?;
+    //         }
+    //     }
+    //     Ok(())
+    // }
 }
 
-/// Handles blockchain reorganization events by detecting epoch blocks in the new canonical chain.
-/// If an epoch block is found, restores the previous epoch snapshot and re-executes epoch tasks
-/// to maintain consistent epoch state after the reorg.
-async fn handle_reorg(
-    inner: &mut EpochServiceInner,
-    mempool: &tokio::sync::mpsc::UnboundedSender<MempoolServiceMessage>,
-    event: ReorgEvent,
-) -> eyre::Result<()> {
-    tracing::debug!(
-        "Processing reorg: {} orphaned blocks from height {}",
-        event.old_fork.len(),
-        event.fork_parent.height
-    );
+// // FIXME: this broadcast work still hs to be done somewhere
+// fn handle_new_epoch(
+//     inner: &mut EpochSnapshot,
+//     new_epoch_block: Arc<IrysBlockHeader>,
+//     previous_epoch_block: Option<IrysBlockHeader>,
+//     commitments: Arc<Vec<CommitmentTransaction>>,
+//     service_senders: &ServiceSenders,
+//     system: &System,
+//     response: oneshot::Sender<Result<(), EpochServiceError>>,
+// ) -> eyre::Result<()> {
+//     let mut new_snapshot = inner.clone();
 
-    // Check to see if the new canonical chain contains an epoch block
-    let new_epoch_block = event
-        .new_fork
-        .iter()
-        .find(|bh| inner.is_epoch_block(bh).is_ok());
+//     let result = new_snapshot.perform_epoch_tasks(
+//         &previous_epoch_block,
+//         &new_epoch_block,
+//         (*commitments).clone(),
+//     );
 
-    if let Some(new_epoch_block) = new_epoch_block {
-        // If it does, collect the commitment tx headers and previous epoch block
-        let commitment_tx_ids = new_epoch_block.get_commitment_ledger_tx_ids();
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        mempool.send(MempoolServiceMessage::GetCommitmentTxs {
-            commitment_tx_ids,
-            response: tx,
-        })?;
+//     let epoch_task_result = match result {
+//         Ok(_) => {
+//             let storage_module_infos = inner.map_storage_modules_to_partition_assignments();
+//             if let Err(e) = service_senders.storage_modules.send(
+//                 StorageModuleServiceMessage::PartitionAssignmentsUpdated {
+//                     storage_module_infos: storage_module_infos.into(),
+//                 },
+//             ) {
+//                 error!("Failed to send partition assignments update: {}", e);
+//             }
 
-        let commitment_txs = rx.await?.values().cloned().collect::<Vec<_>>();
+//             // HACK to get from_registry to work outside of actix
+//             System::set_current(system.clone());
 
-        // Get the last epoch block header by hash
-        let block_hash = inner.previous_epoch_snapshot.as_ref().unwrap().0;
+//             let expired_partition_hashes = &new_snapshot.expired_partition_hashes;
+//             let mining_broadcaster_addr = BroadcastMiningService::from_registry();
+//             mining_broadcaster_addr.do_send(BroadcastPartitionsExpiration(H256List(
+//                 expired_partition_hashes.clone(),
+//             )));
 
-        // Check the mempool first
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        mempool.send(MempoolServiceMessage::GetBlockHeader(block_hash, false, tx))?;
-        let mut previous_epoch_block = rx.await?;
+//             Ok(())
+//         }
+//         Err(err) => Err(err),
+//     };
 
-        // Then check the DB if necessary
-        if previous_epoch_block.is_none() {
-            previous_epoch_block = match event
-                .db
-                .expect("db should be initialized in the ReorgEvent")
-                .view(|tx| block_header_by_hash(tx, &block_hash, false))
-                .unwrap()
-            {
-                Ok(bh) => bh,
-                Err(err) => {
-                    return Err(eyre::eyre!(
-                        "Failed to find previous epoch block: {:?}",
-                        err
-                    ))
-                }
-            };
-        }
+//     response
+//         .send(epoch_task_result)
+//         .expect("send on response channel should succeed");
 
-        // Restore the previous epoch snapshot
-        *inner = inner.previous_epoch_snapshot.as_ref().unwrap().1.clone();
+//     *inner = new_snapshot;
 
-        // re-perform the epoch tasks to compute a new canonical state
-        inner
-            .perform_epoch_tasks(&previous_epoch_block, &new_epoch_block, commitment_txs)
-            .map_err(|err| eyre::eyre!("Failed to perform epoch tasks: {:?}", err))?;
-    }
-
-    tracing::info!("Reorg handled, new tip: {}", event.new_tip.0.to_base58());
-
-    Ok(())
-}
-
-fn handle_broadcast_recv<T>(
-    result: Result<T, broadcast::error::RecvError>,
-    channel_name: &str,
-) -> Option<T> {
-    match result {
-        Ok(event) => Some(event),
-        Err(broadcast::error::RecvError::Closed) => {
-            tracing::debug!("{} channel closed", channel_name);
-            None
-        }
-        Err(broadcast::error::RecvError::Lagged(n)) => {
-            tracing::warn!("{} lagged by {} events", channel_name, n);
-            if n > 5 {
-                tracing::error!("{} significantly lagged", channel_name);
-            }
-            None
-        }
-    }
-}
+//     Ok(())
+// }

--- a/crates/actors/src/epoch_service/epoch_service.rs
+++ b/crates/actors/src/epoch_service/epoch_service.rs
@@ -418,6 +418,7 @@ impl EpochSnapshot {
 
         // Use the previous epoch hash as a seed/entropy to the prng
         let seed = self.epoch_block.last_epoch_hash.to_u32();
+        debug!("RNG seed: {}", self.epoch_block.last_epoch_hash);
         let mut rng = SimpleRNG::new(seed);
 
         // Loop though all of the ledgers processing their slot needs

--- a/crates/actors/src/epoch_service/epoch_service_messages.rs
+++ b/crates/actors/src/epoch_service/epoch_service_messages.rs
@@ -1,157 +1,124 @@
-use super::{CommitmentState, EpochServiceError, EpochServiceInner, PartitionAssignments};
-use crate::EpochReplayData;
+use super::{CommitmentState, EpochSnapshot, PartitionAssignments};
 use irys_database::Ledgers;
 use irys_primitives::CommitmentStatus;
-use irys_storage::StorageModuleInfo;
-use irys_types::{
-    partition::{PartitionAssignment, PartitionHash},
-    Address, CommitmentTransaction, IrysBlockHeader,
-};
+use irys_types::Address;
 use std::sync::{Arc, RwLock, RwLockReadGuard};
-use tokio::sync::oneshot;
 
-// Messages that the StorageModuleService service supports
-#[derive(Debug)]
-pub enum EpochServiceMessage {
-    // Tells the epoch service a new epoch block has been discovered
-    NewEpoch {
-        new_epoch_block: Arc<IrysBlockHeader>,
-        previous_epoch_block: Option<IrysBlockHeader>,
-        commitments: Arc<Vec<CommitmentTransaction>>,
-        sender: oneshot::Sender<Result<(), EpochServiceError>>,
-    },
-    // Read only access to ledgers state (maps ledger slots to partition hashes)
-    GetLedgersGuard(oneshot::Sender<LedgersReadGuard>),
-    // Read only access to the PartitionAssignments state (mapping partition hashes to miner addresses)
-    GetPartitionAssignmentsGuard(oneshot::Sender<PartitionAssignmentsReadGuard>),
-    // Read only access to commitment state (status of stakes and pledges at the end of the last epoch)
-    GetCommitmentStateGuard(oneshot::Sender<CommitmentStateReadGuard>),
-    // Gets partition metadata for a particular partition hash
-    GetPartitionAssignment(PartitionHash, oneshot::Sender<Option<PartitionAssignment>>),
-    // Gets all the partition assignments for a given miner address
-    GetMinerPartitionAssignments(Address, oneshot::Sender<Vec<PartitionAssignment>>),
-    ReplayEpochData(
-        Vec<EpochReplayData>,
-        oneshot::Sender<Vec<StorageModuleInfo>>,
-    ),
-}
+// // Messages that the StorageModuleService service supports
+// #[derive(Debug)]
+// pub enum EpochServiceMessage {
+//     // Tells the epoch service a new epoch block has been discovered
+//     NewEpoch {
+//         new_epoch_block: Arc<IrysBlockHeader>,
+//         previous_epoch_block: Option<IrysBlockHeader>,
+//         commitments: Arc<Vec<CommitmentTransaction>>,
+//         sender: oneshot::Sender<Result<(), EpochServiceError>>,
+//     },
+//     // Read only access to ledgers state (maps ledger slots to partition hashes)
+//     GetLedgersGuard(oneshot::Sender<LedgersReadGuard>),
+//     // Read only access to the PartitionAssignments state (mapping partition hashes to miner addresses)
+//     GetPartitionAssignmentsGuard(oneshot::Sender<PartitionAssignmentsReadGuard>),
+//     // Read only access to commitment state (status of stakes and pledges at the end of the last epoch)
+//     GetCommitmentStateGuard(oneshot::Sender<CommitmentStateReadGuard>),
+//     // Gets partition metadata for a particular partition hash
+//     GetPartitionAssignment(PartitionHash, oneshot::Sender<Option<PartitionAssignment>>),
+//     // Gets all the partition assignments for a given miner address
+//     GetMinerPartitionAssignments(Address, oneshot::Sender<Vec<PartitionAssignment>>),
+//     ReplayEpochData(Vec<EpochBlockData>, oneshot::Sender<Vec<StorageModuleInfo>>),
+// }
 
-impl EpochServiceInner {
-    pub fn handle_message(&mut self, msg: EpochServiceMessage) -> eyre::Result<()> {
-        match msg {
-            EpochServiceMessage::NewEpoch {
-                new_epoch_block,
-                previous_epoch_block,
-                commitments,
-                sender,
-            } => {
-                self.handle_new_epoch(new_epoch_block, previous_epoch_block, commitments, sender)?;
-            }
-            EpochServiceMessage::GetLedgersGuard(sender) => {
-                self.handle_get_ledgers_guard(sender)?;
-            }
-            EpochServiceMessage::GetPartitionAssignmentsGuard(sender) => {
-                self.handle_get_partition_assignments_guard(sender)?;
-            }
-            EpochServiceMessage::GetCommitmentStateGuard(sender) => {
-                self.handle_get_commitment_state_guard(sender)?;
-            }
-            EpochServiceMessage::GetPartitionAssignment(partition_hash, sender) => {
-                self.handle_get_partition_assignment(partition_hash, sender)?;
-            }
-            EpochServiceMessage::GetMinerPartitionAssignments(miner_address, sender) => {
-                self.handle_get_miner_partition_assignments(miner_address, sender)?;
-            }
-            EpochServiceMessage::ReplayEpochData(epoch_replay_data, sender) => {
-                self.handle_replay_epoch_data(epoch_replay_data, sender)?;
-            }
-        }
-        Ok(())
-    }
+impl EpochSnapshot {
+    // pub fn handle_message(&mut self, msg: EpochServiceMessage) -> eyre::Result<()> {
+    //     match msg {
+    //         EpochServiceMessage::NewEpoch { .. } => {}
+    //         EpochServiceMessage::GetLedgersGuard(sender) => {
+    //             self.handle_get_ledgers_guard(sender)?;
+    //         }
+    //         EpochServiceMessage::GetPartitionAssignmentsGuard(sender) => {
+    //             self.handle_get_partition_assignments_guard(sender)?;
+    //         }
+    //         EpochServiceMessage::GetCommitmentStateGuard(sender) => {
+    //             self.handle_get_commitment_state_guard(sender)?;
+    //         }
+    //         EpochServiceMessage::GetPartitionAssignment(partition_hash, sender) => {
+    //             self.handle_get_partition_assignment(partition_hash, sender)?;
+    //         }
+    //         EpochServiceMessage::GetMinerPartitionAssignments(miner_address, sender) => {
+    //             self.handle_get_miner_partition_assignments(miner_address, sender)?;
+    //         }
+    //         EpochServiceMessage::ReplayEpochData(epoch_replay_data, sender) => {
+    //             self.handle_replay_epoch_data(epoch_replay_data, sender)?;
+    //         }
+    //     }
+    //     Ok(())
+    // }
 
-    fn handle_new_epoch(
-        &mut self,
-        new_epoch_block: Arc<IrysBlockHeader>,
-        previous_epoch_block: Option<IrysBlockHeader>,
-        commitments: Arc<Vec<CommitmentTransaction>>,
-        response: oneshot::Sender<Result<(), EpochServiceError>>,
-    ) -> eyre::Result<()> {
-        match response.send(self.perform_epoch_tasks(
-            &previous_epoch_block,
-            &new_epoch_block,
-            (*commitments).clone(),
-        )) {
-            Ok(()) => Ok(()),
-            Err(e) => Err(eyre::eyre!("response.send() error: {:?}", e)),
-        }
-    }
+    // fn handle_get_ledgers_guard(
+    //     &self,
+    //     sender: oneshot::Sender<LedgersReadGuard>,
+    // ) -> eyre::Result<()> {
+    //     match sender.send(LedgersReadGuard::new(Arc::clone(&self.ledgers))) {
+    //         Ok(()) => Ok(()),
+    //         Err(e) => Err(eyre::eyre!("response.send() error: {:?}", e)),
+    //     }
+    // }
 
-    fn handle_get_ledgers_guard(
-        &self,
-        sender: oneshot::Sender<LedgersReadGuard>,
-    ) -> eyre::Result<()> {
-        match sender.send(LedgersReadGuard::new(Arc::clone(&self.ledgers))) {
-            Ok(()) => Ok(()),
-            Err(e) => Err(eyre::eyre!("response.send() error: {:?}", e)),
-        }
-    }
+    // fn handle_get_partition_assignments_guard(
+    //     &self,
+    //     sender: oneshot::Sender<PartitionAssignmentsReadGuard>,
+    // ) -> eyre::Result<()> {
+    //     match sender.send(PartitionAssignmentsReadGuard::new(
+    //         self.partition_assignments.clone(),
+    //     )) {
+    //         Ok(()) => Ok(()),
+    //         Err(e) => Err(eyre::eyre!("response.send() error: {:?}", e)),
+    //     }
+    // }
 
-    fn handle_get_partition_assignments_guard(
-        &self,
-        sender: oneshot::Sender<PartitionAssignmentsReadGuard>,
-    ) -> eyre::Result<()> {
-        match sender.send(PartitionAssignmentsReadGuard::new(
-            self.partition_assignments.clone(),
-        )) {
-            Ok(()) => Ok(()),
-            Err(e) => Err(eyre::eyre!("response.send() error: {:?}", e)),
-        }
-    }
+    // fn handle_get_commitment_state_guard(
+    //     &self,
+    //     sender: oneshot::Sender<CommitmentStateReadGuard>,
+    // ) -> eyre::Result<()> {
+    //     match sender.send(CommitmentStateReadGuard::new(self.commitment_state.clone())) {
+    //         Ok(()) => Ok(()),
+    //         Err(e) => Err(eyre::eyre!("response.send() error: {:?}", e)),
+    //     }
+    // }
 
-    fn handle_get_commitment_state_guard(
-        &self,
-        sender: oneshot::Sender<CommitmentStateReadGuard>,
-    ) -> eyre::Result<()> {
-        match sender.send(CommitmentStateReadGuard::new(self.commitment_state.clone())) {
-            Ok(()) => Ok(()),
-            Err(e) => Err(eyre::eyre!("response.send() error: {:?}", e)),
-        }
-    }
+    // fn handle_get_partition_assignment(
+    //     &self,
+    //     partition_hash: PartitionHash,
+    //     sender: oneshot::Sender<Option<PartitionAssignment>>,
+    // ) -> eyre::Result<()> {
+    //     let pa = self.partition_assignments.read().unwrap();
+    //     match sender.send(pa.get_assignment(partition_hash)) {
+    //         Ok(()) => Ok(()),
+    //         Err(e) => Err(eyre::eyre!("response.send() error: {:?}", e)),
+    //     }
+    // }
 
-    fn handle_get_partition_assignment(
-        &self,
-        partition_hash: PartitionHash,
-        sender: oneshot::Sender<Option<PartitionAssignment>>,
-    ) -> eyre::Result<()> {
-        let pa = self.partition_assignments.read().unwrap();
-        match sender.send(pa.get_assignment(partition_hash)) {
-            Ok(()) => Ok(()),
-            Err(e) => Err(eyre::eyre!("response.send() error: {:?}", e)),
-        }
-    }
+    // fn handle_get_miner_partition_assignments(
+    //     &self,
+    //     miner_address: Address,
+    //     sender: oneshot::Sender<Vec<PartitionAssignment>>,
+    // ) -> eyre::Result<()> {
+    //     match sender.send(self.get_partition_assignments(miner_address)) {
+    //         Ok(()) => Ok(()),
+    //         Err(e) => Err(eyre::eyre!("response.send() error: {:?}", e)),
+    //     }
+    // }
 
-    fn handle_get_miner_partition_assignments(
-        &self,
-        miner_address: Address,
-        sender: oneshot::Sender<Vec<PartitionAssignment>>,
-    ) -> eyre::Result<()> {
-        match sender.send(self.get_partition_assignments(miner_address)) {
-            Ok(()) => Ok(()),
-            Err(e) => Err(eyre::eyre!("response.send() error: {:?}", e)),
-        }
-    }
-
-    fn handle_replay_epoch_data(
-        &mut self,
-        epoch_replay_data: Vec<EpochReplayData>,
-        sender: oneshot::Sender<Vec<StorageModuleInfo>>,
-    ) -> eyre::Result<()> {
-        let infos = self.replay_epoch_data(epoch_replay_data)?;
-        match sender.send(infos) {
-            Ok(()) => Ok(()),
-            Err(e) => Err(eyre::eyre!("response.send() error: {:?}", e)),
-        }
-    }
+    // fn handle_replay_epoch_data(
+    //     &mut self,
+    //     epoch_replay_data: Vec<EpochBlockData>,
+    //     sender: oneshot::Sender<Vec<StorageModuleInfo>>,
+    // ) -> eyre::Result<()> {
+    //     let infos = self.replay_epoch_data(epoch_replay_data)?;
+    //     match sender.send(infos) {
+    //         Ok(()) => Ok(()),
+    //         Err(e) => Err(eyre::eyre!("response.send() error: {:?}", e)),
+    //     }
+    // }
 }
 
 //==============================================================================

--- a/crates/actors/src/epoch_service/partition_assignments.rs
+++ b/crates/actors/src/epoch_service/partition_assignments.rs
@@ -32,7 +32,7 @@ impl PartitionAssignments {
         }
     }
 
-    /// Retrieves a `PartitionAssignment` by partition hash if it exists
+    /// Retrieves a `PartitionAssignment` to a data partition by partition hash if it exists
     pub fn get_assignment(&self, partition_hash: H256) -> Option<PartitionAssignment> {
         self.data_partitions
             .get(&partition_hash)

--- a/crates/actors/src/epoch_service/partition_assignments.rs
+++ b/crates/actors/src/epoch_service/partition_assignments.rs
@@ -8,7 +8,7 @@ use irys_types::{
 use tracing::debug;
 
 /// A state struct that can be wrapped with Arc<`RwLock`<>> to provide parallel read access
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PartitionAssignments {
     /// Active data partition state mapped by partition hash
     pub data_partitions: BTreeMap<PartitionHash, PartitionAssignment>,

--- a/crates/actors/src/mempool_service/commitment_txs.rs
+++ b/crates/actors/src/mempool_service/commitment_txs.rs
@@ -288,7 +288,14 @@ impl Inner {
             .read()
             .canonical_commitment_snapshot();
 
-        let is_staked = self.commitment_state_guard.is_staked(commitment_tx.signer);
+        let epoch_snapshot = self.block_tree_read_guard.read().canonical_epoch_snapshot();
+
+        let is_staked = epoch_snapshot
+            .commitment_state
+            .read()
+            .unwrap()
+            .is_staked(commitment_tx.signer);
+
         let cache_status = commitment_snapshot.get_commitment_status(commitment_tx, is_staked);
 
         // Reject unsupported commitment types

--- a/crates/actors/src/mempool_service/inner.rs
+++ b/crates/actors/src/mempool_service/inner.rs
@@ -1,7 +1,6 @@
 use crate::block_tree_service::BlockTreeReadGuard;
 use crate::mempool_service::ChunkIngressError;
 use crate::services::ServiceSenders;
-use crate::CommitmentStateReadGuard;
 use base58::ToBase58 as _;
 use futures::future::BoxFuture;
 use irys_database::SystemLedger;
@@ -35,7 +34,6 @@ use tracing::{debug, error, info, warn};
 #[derive(Debug)]
 pub struct Inner {
     pub block_tree_read_guard: BlockTreeReadGuard,
-    pub commitment_state_guard: CommitmentStateReadGuard,
     pub config: Config,
     /// `task_exec` is used to spawn background jobs on reth's MT tokio runtime
     /// instead of the actor executor runtime, while also providing some `QoL`

--- a/crates/actors/src/mempool_service/mod.rs
+++ b/crates/actors/src/mempool_service/mod.rs
@@ -11,7 +11,6 @@ pub use inner::*;
 
 use crate::block_tree_service::{BlockMigratedEvent, BlockTreeReadGuard, ReorgEvent};
 use crate::services::ServiceSenders;
-use crate::CommitmentStateReadGuard;
 use irys_reth_node_bridge::IrysRethNodeAdapter;
 use irys_storage::StorageModulesReadGuard;
 use irys_types::{app_state::DatabaseProvider, Config};
@@ -48,7 +47,6 @@ impl MempoolService {
         reth_node_adapter: IrysRethNodeAdapter,
         storage_modules_guard: StorageModulesReadGuard,
         block_tree_read_guard: &BlockTreeReadGuard,
-        commitment_state_guard: &CommitmentStateReadGuard,
         rx: UnboundedReceiver<MempoolServiceMessage>,
         config: &Config,
         service_senders: &ServiceSenders,
@@ -59,7 +57,6 @@ impl MempoolService {
         let mempool_config = &config.consensus.mempool;
         let mempool_state = create_state(mempool_config);
         let exec = exec.clone();
-        let commitment_state_guard = commitment_state_guard.clone();
         let storage_modules_guard = storage_modules_guard;
         let service_senders = service_senders.clone();
         let reorg_rx = service_senders.subscribe_reorgs();
@@ -75,7 +72,6 @@ impl MempoolService {
                     block_migrated_rx,
                     inner: Inner {
                         block_tree_read_guard,
-                        commitment_state_guard,
                         config,
                         exec,
                         irys_db,

--- a/crates/actors/src/services.rs
+++ b/crates/actors/src/services.rs
@@ -3,7 +3,7 @@ use crate::{
     cache_service::CacheServiceAction,
     mempool_service::MempoolServiceMessage,
     validation_service::ValidationServiceMessage,
-    EpochServiceMessage, StorageModuleServiceMessage,
+    StorageModuleServiceMessage,
 };
 use actix::Message;
 use core::ops::Deref;
@@ -54,7 +54,6 @@ pub struct ServiceReceivers {
     pub gossip_broadcast: UnboundedReceiver<GossipBroadcastMessage>,
     pub block_tree: UnboundedReceiver<BlockTreeServiceMessage>,
     pub validation_service: UnboundedReceiver<ValidationServiceMessage>,
-    pub epoch_service: UnboundedReceiver<EpochServiceMessage>,
     pub reorg_events: broadcast::Receiver<ReorgEvent>,
     pub block_migrated_events: broadcast::Receiver<BlockMigratedEvent>,
 }
@@ -69,7 +68,6 @@ pub struct ServiceSendersInner {
     pub gossip_broadcast: UnboundedSender<GossipBroadcastMessage>,
     pub block_tree: UnboundedSender<BlockTreeServiceMessage>,
     pub validation_service: UnboundedSender<ValidationServiceMessage>,
-    pub epoch_service: UnboundedSender<EpochServiceMessage>,
     pub reorg_events: broadcast::Sender<ReorgEvent>,
     pub block_migrated_events: broadcast::Sender<BlockMigratedEvent>,
 }
@@ -91,7 +89,6 @@ impl ServiceSendersInner {
             unbounded_channel::<BlockTreeServiceMessage>();
         let (validation_sender, validation_receiver) =
             unbounded_channel::<ValidationServiceMessage>();
-        let (epoch_sender, epoch_receiver) = unbounded_channel::<EpochServiceMessage>();
         // Create broadcast channel for reorg events
         let (reorg_sender, reorg_receiver) = broadcast::channel::<ReorgEvent>(100);
         let (block_migrated_sender, block_migrated_receiver) =
@@ -106,7 +103,6 @@ impl ServiceSendersInner {
             gossip_broadcast: gossip_broadcast_sender,
             block_tree: block_tree_sender,
             validation_service: validation_sender,
-            epoch_service: epoch_sender,
             reorg_events: reorg_sender,
             block_migrated_events: block_migrated_sender,
         };
@@ -119,7 +115,6 @@ impl ServiceSendersInner {
             gossip_broadcast: gossip_broadcast_receiver,
             block_tree: block_tree_receiver,
             validation_service: validation_receiver,
-            epoch_service: epoch_receiver,
             reorg_events: reorg_receiver,
             block_migrated_events: block_migrated_receiver,
         };

--- a/crates/actors/src/validation_service.rs
+++ b/crates/actors/src/validation_service.rs
@@ -16,7 +16,6 @@ use crate::{
     block_index_service::BlockIndexReadGuard,
     block_tree_service::{BlockTreeServiceMessage, ReorgEvent, ValidationResult},
     block_validation::PayloadProvider,
-    epoch_service::PartitionAssignmentsReadGuard,
     services::ServiceSenders,
 };
 use active_validations::ActiveValidations;
@@ -63,8 +62,6 @@ pub struct ValidationService<T: PayloadProvider> {
 pub(crate) struct ValidationServiceInner<T: PayloadProvider> {
     /// Read only view of the block index
     pub(crate) block_index_guard: BlockIndexReadGuard,
-    /// `PartitionAssignmentsReadGuard` for looking up ledger info
-    pub(crate) partition_assignments_guard: PartitionAssignmentsReadGuard,
     /// VDF steps read guard
     pub(crate) vdf_state: VdfStateReadonly,
     /// Reference to global config for node
@@ -89,7 +86,6 @@ impl<T: PayloadProvider> ValidationService<T> {
         exec: &TaskExecutor,
         block_index_guard: BlockIndexReadGuard,
         block_tree_guard: BlockTreeReadGuard,
-        partition_assignments_guard: PartitionAssignmentsReadGuard,
         vdf_state_readonly: VdfStateReadonly,
         config: &Config,
         service_senders: &ServiceSenders,
@@ -115,7 +111,6 @@ impl<T: PayloadProvider> ValidationService<T> {
                             .build()
                             .expect("to be able to build vdf validation pool"),
                         block_index_guard,
-                        partition_assignments_guard,
                         vdf_state: vdf_state_readonly,
                         config,
                         service_senders,

--- a/crates/actors/src/validation_service/active_validations.rs
+++ b/crates/actors/src/validation_service/active_validations.rs
@@ -194,7 +194,7 @@ impl ActiveValidations {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::block_tree_service::test_utils::genesis_tree;
+    use crate::block_tree_service::test_utils::{dummy_epoch_snapshot, genesis_tree};
     use crate::block_tree_service::{BlockState, ChainState};
     use futures::future::{pending, ready};
     use irys_database::CommitmentSnapshot;
@@ -422,6 +422,7 @@ mod tests {
                 fork_block_11.block_hash,
                 &fork_block_11,
                 Arc::new(CommitmentSnapshot::default()),
+                dummy_epoch_snapshot(),
                 dummy_ema_snapshot(),
                 ChainState::NotOnchain(BlockState::ValidationScheduled),
             )
@@ -430,6 +431,7 @@ mod tests {
                 fork_block_12.block_hash,
                 &fork_block_12,
                 Arc::new(CommitmentSnapshot::default()),
+                dummy_epoch_snapshot(),
                 dummy_ema_snapshot(),
                 ChainState::NotOnchain(BlockState::ValidationScheduled),
             )
@@ -438,6 +440,7 @@ mod tests {
                 extension_block_21.block_hash,
                 &extension_block_21,
                 Arc::new(CommitmentSnapshot::default()),
+                dummy_epoch_snapshot(),
                 dummy_ema_snapshot(),
                 ChainState::NotOnchain(BlockState::ValidationScheduled),
             )
@@ -446,6 +449,7 @@ mod tests {
                 extension_block_22.block_hash,
                 &extension_block_22,
                 Arc::new(CommitmentSnapshot::default()),
+                dummy_epoch_snapshot(),
                 dummy_ema_snapshot(),
                 ChainState::NotOnchain(BlockState::ValidationScheduled),
             )
@@ -717,6 +721,7 @@ mod tests {
                     header.block_hash,
                     &header,
                     Arc::new(CommitmentSnapshot::default()),
+                    dummy_epoch_snapshot(),
                     dummy_ema_snapshot(),
                     ChainState::NotOnchain(BlockState::ValidationScheduled),
                 )
@@ -762,6 +767,7 @@ mod tests {
                     header.block_hash,
                     &header,
                     Arc::new(CommitmentSnapshot::default()),
+                    dummy_epoch_snapshot(),
                     dummy_ema_snapshot(),
                     ChainState::NotOnchain(BlockState::ValidationScheduled),
                 )

--- a/crates/actors/src/validation_service/block_validation_task.rs
+++ b/crates/actors/src/validation_service/block_validation_task.rs
@@ -118,7 +118,7 @@ impl<T: PayloadProvider> BlockValidationTask<T> {
 
         if let Some(tip_block) = block_tree.get_block(&tip_hash) {
             let height_diff = tip_block.height.saturating_sub(self.block.height);
-            height_diff > self.service_inner.config.consensus.block_cache_depth
+            height_diff > self.service_inner.config.consensus.block_tree_depth
         } else {
             false
         }

--- a/crates/actors/src/validation_service/block_validation_task.rs
+++ b/crates/actors/src/validation_service/block_validation_task.rs
@@ -174,18 +174,23 @@ impl<T: PayloadProvider> BlockValidationTask<T> {
         }
         .instrument(tracing::info_span!("recall_range_validation", block_hash = %self.block_hash, block_height = %self.block.height));
 
+        let epoch_snapshot = self
+            .block_tree_guard
+            .read()
+            .get_epoch_snapshot(&block.block_hash)
+            .expect("block should have an epoch snapshot in the block_tree");
+
         // POA validation
         let poa_task = {
             let consensus_config = self.service_inner.config.consensus.clone();
             let block_index_guard = self.service_inner.block_index_guard.clone();
-            let partitions_guard = self.service_inner.partition_assignments_guard.clone();
             let block_hash = self.block_hash;
             let block_height = self.block.height;
             tokio::task::spawn_blocking(move || {
                 poa_is_valid(
                     &poa,
                     &block_index_guard,
-                    &partitions_guard,
+                    &epoch_snapshot,
                     &consensus_config,
                     &miner_address,
                 )

--- a/crates/actors/tests/epoch_service_tests.rs
+++ b/crates/actors/tests/epoch_service_tests.rs
@@ -1,5 +1,5 @@
 use actix::{actors::mocker::Mocker, Addr, Arbiter, Recipient, SystemRegistry};
-use actix::{Actor as _, SystemService};
+use actix::{Actor as _, SystemService as _};
 use base58::ToBase58 as _;
 use irys_actors::broadcast_mining_service::{
     BroadcastMiningService, BroadcastPartitionsExpiration,
@@ -893,7 +893,7 @@ async fn partitions_assignment_determinism_test() {
         .unwrap()
         .capacity_partitions
         .keys()
-        .cloned()
+        .copied()
         .collect();
 
     // Now create a new epoch block & give the Submit ledger enough size to add a slot

--- a/crates/actors/tests/epoch_service_tests.rs
+++ b/crates/actors/tests/epoch_service_tests.rs
@@ -1,4 +1,4 @@
-use actix::Actor as _;
+use actix::{Actor as _, System};
 use base58::ToBase58 as _;
 use irys_actors::epoch_service::EpochReplayData;
 
@@ -59,8 +59,12 @@ async fn genesis_test() {
     let storage_submodules_config =
         StorageSubmodulesConfig::load(config.node_config.base_directory.clone()).unwrap();
     let service_senders = ServiceSenders::new().0;
-    let mut epoch_service =
-        EpochServiceInner::new(&service_senders, &storage_submodules_config, &config);
+    let mut epoch_service = EpochServiceInner::new(
+        &service_senders,
+        &storage_submodules_config,
+        &config,
+        System::current(),
+    );
     let miner_address = config.node_config.miner_address();
 
     // Process genesis message directly instead of through actor system
@@ -227,8 +231,12 @@ async fn add_slots_test() {
     let storage_submodules_config =
         StorageSubmodulesConfig::load(config.node_config.base_directory.clone()).unwrap();
     let service_senders = ServiceSenders::new().0;
-    let mut epoch_service =
-        EpochServiceInner::new(&service_senders, &storage_submodules_config, &config);
+    let mut epoch_service = EpochServiceInner::new(
+        &service_senders,
+        &storage_submodules_config,
+        &config,
+        System::current(),
+    );
 
     let _ = epoch_service.initialize(genesis_block.clone(), commitments);
 
@@ -353,8 +361,12 @@ async fn partition_expiration_and_repacking_test() {
     // Create epoch service
     let storage_submodules_config = StorageSubmodulesConfig::load(base_path.clone()).unwrap();
     let service_senders = ServiceSenders::new().0;
-    let mut epoch_service =
-        EpochServiceInner::new(&service_senders, &storage_submodules_config, &config);
+    let mut epoch_service = EpochServiceInner::new(
+        &service_senders,
+        &storage_submodules_config,
+        &config,
+        System::current(),
+    );
     let storage_module_infos = epoch_service
         .initialize(genesis_block.clone(), commitments)
         .unwrap();
@@ -725,8 +737,12 @@ async fn epoch_blocks_reinitialization_test() {
     let storage_submodules_config =
         StorageSubmodulesConfig::load(config.node_config.base_directory.clone()).unwrap();
     let service_senders = ServiceSenders::new().0;
-    let mut epoch_service =
-        EpochServiceInner::new(&service_senders, &storage_submodules_config, &config);
+    let mut epoch_service = EpochServiceInner::new(
+        &service_senders,
+        &storage_submodules_config,
+        &config,
+        System::current(),
+    );
 
     // Initialize genesis block at height 0
     let mut genesis_block = IrysBlockHeader::new_mock_header();
@@ -866,8 +882,12 @@ async fn epoch_blocks_reinitialization_test() {
 
     let service_senders = ServiceSenders::new().0;
     // Get the genesis storage modules and their assigned partitions
-    let mut epoch_service =
-        EpochServiceInner::new(&service_senders, &storage_submodules_config, &config);
+    let mut epoch_service = EpochServiceInner::new(
+        &service_senders,
+        &storage_submodules_config,
+        &config,
+        System::current(),
+    );
     let storage_module_infos = epoch_service
         .initialize(genesis_block, commitments)
         .unwrap();
@@ -933,8 +953,12 @@ async fn partitions_assignment_determinism_test() {
 
     let storage_submodules_config = StorageSubmodulesConfig::load_for_test(base_path, 40).unwrap();
     let service_senders = ServiceSenders::new().0;
-    let mut epoch_service =
-        EpochServiceInner::new(&service_senders, &storage_submodules_config, &config);
+    let mut epoch_service = EpochServiceInner::new(
+        &service_senders,
+        &storage_submodules_config,
+        &config,
+        System::current(),
+    );
 
     let _ = epoch_service.initialize(genesis_block.clone(), commitments);
 

--- a/crates/actors/tests/epoch_service_tests.rs
+++ b/crates/actors/tests/epoch_service_tests.rs
@@ -1,20 +1,13 @@
-use actix::{Actor as _, System};
-use base58::ToBase58 as _;
-use irys_actors::epoch_service::EpochReplayData;
-
 use actix::{actors::mocker::Mocker, Addr, Arbiter, Recipient, SystemRegistry};
-use irys_actors::EpochServiceMessage;
-use reth::payload::EthBuiltPayload;
-use std::collections::VecDeque;
-use std::sync::{Arc, RwLock};
-use std::{any::Any, sync::atomic::AtomicU64, time::Duration};
-use tokio::time::sleep;
-use tracing::{debug, error, info};
-
-use irys_actors::services::ServiceSenders;
+use actix::{Actor as _, SystemService};
+use base58::ToBase58 as _;
+use irys_actors::broadcast_mining_service::{
+    BroadcastMiningService, BroadcastPartitionsExpiration,
+};
+use irys_actors::EpochBlockData;
 use irys_actors::{
     block_index_service::{BlockIndexService, GetBlockIndexGuardMessage},
-    epoch_service::EpochServiceInner,
+    epoch_service::EpochSnapshot,
 };
 use irys_actors::{
     mining::PartitionMiningActor,
@@ -25,14 +18,20 @@ use irys_config::StorageSubmodulesConfig;
 use irys_database::{add_genesis_commitments, add_test_commitments, BlockIndex};
 use irys_storage::{ie, StorageModule, StorageModuleVec};
 use irys_testing_utils::utils::setup_tracing_and_temp_dir;
-use irys_types::NodeConfig;
 use irys_types::PartitionChunkRange;
 use irys_types::{partition::PartitionAssignment, DataLedger, IrysBlockHeader, H256};
 use irys_types::{
     partition_chunk_offset_ie, ConsensusConfig, ConsensusOptions, EpochConfig, PartitionChunkOffset,
 };
 use irys_types::{Config, U256};
+use irys_types::{H256List, NodeConfig};
 use irys_vdf::state::{VdfState, VdfStateReadonly};
+use reth::payload::EthBuiltPayload;
+use std::collections::VecDeque;
+use std::sync::{Arc, RwLock};
+use std::{any::Any, sync::atomic::AtomicU64, time::Duration};
+use tokio::time::sleep;
+use tracing::{debug, error, info};
 
 #[actix::test]
 async fn genesis_test() {
@@ -58,36 +57,25 @@ async fn genesis_test() {
 
     let storage_submodules_config =
         StorageSubmodulesConfig::load(config.node_config.base_directory.clone()).unwrap();
-    let service_senders = ServiceSenders::new().0;
-    let mut epoch_service = EpochServiceInner::new(
-        &service_senders,
+
+    let epoch_snapshot = EpochSnapshot::new(
         &storage_submodules_config,
+        genesis_block.clone(),
+        commitments.clone(),
         &config,
-        System::current(),
     );
     let miner_address = config.node_config.miner_address();
 
     // Process genesis message directly instead of through actor system
     // This allows us to inspect the actor's state after processing
-    let (sender, _rx) = tokio::sync::oneshot::channel();
-    epoch_service
-        .handle_message(EpochServiceMessage::NewEpoch {
-            new_epoch_block: genesis_block.into(),
-            previous_epoch_block: None,
-            commitments: Arc::new(commitments),
-            sender,
-        })
-        .unwrap();
-
     {
         // Verify the correct number of ledgers have been added
-        let ledgers = epoch_service.ledgers.read().unwrap();
         let expected_ledger_count = DataLedger::ALL.len();
-        assert_eq!(ledgers.len(), expected_ledger_count);
+        assert_eq!(epoch_snapshot.ledgers.len(), expected_ledger_count);
 
         // Verify each ledger has one slot and the correct number of partitions
-        let pub_slots = ledgers.get_slots(DataLedger::Publish);
-        let sub_slots = ledgers.get_slots(DataLedger::Submit);
+        let pub_slots = epoch_snapshot.ledgers.get_slots(DataLedger::Publish);
+        let sub_slots = epoch_snapshot.ledgers.get_slots(DataLedger::Submit);
 
         assert_eq!(pub_slots.len(), 1);
         assert_eq!(sub_slots.len(), 1);
@@ -103,7 +91,7 @@ async fn genesis_test() {
 
         // Verify data partition assignments match _PUBLISH_ ledger slots
         for (slot_idx, slot) in pub_slots.iter().enumerate() {
-            let pa = epoch_service.partition_assignments.read().unwrap();
+            let pa = epoch_snapshot.partition_assignments.read().unwrap();
             for &partition_hash in &slot.partitions {
                 let assignment = pa
                     .data_partitions
@@ -128,7 +116,7 @@ async fn genesis_test() {
 
         // Verify data partition assignments match _SUBMIT_ledger slots
         for (slot_idx, slot) in sub_slots.iter().enumerate() {
-            let pa = epoch_service.partition_assignments.read().unwrap();
+            let pa = epoch_snapshot.partition_assignments.read().unwrap();
             for &partition_hash in &slot.partitions {
                 let assignment = pa
                     .data_partitions
@@ -154,15 +142,12 @@ async fn genesis_test() {
 
     // Verify the correct number of genesis partitions have been activated
     {
-        let pa = epoch_service.partition_assignments.read().unwrap();
+        let pa = epoch_snapshot.partition_assignments.read().unwrap();
         let data_partition_count = pa.data_partitions.len() as u64;
         let expected_partitions = data_partition_count
-            + EpochServiceInner::get_num_capacity_partitions(
-                data_partition_count,
-                &config.consensus,
-            );
+            + EpochSnapshot::get_num_capacity_partitions(data_partition_count, &config.consensus);
         assert_eq!(
-            epoch_service.all_active_partitions.len(),
+            epoch_snapshot.all_active_partitions.len(),
             expected_partitions as usize
         );
 
@@ -185,15 +170,7 @@ async fn genesis_test() {
 
     // Debug output for verification
     // println!("Data Partitions: {:#?}", epoch_service.capacity_partitions);
-    println!("Ledger State: {:#?}", epoch_service.ledgers);
-
-    let (sender, rx) = tokio::sync::oneshot::channel();
-    epoch_service
-        .handle_message(EpochServiceMessage::GetLedgersGuard(sender))
-        .unwrap();
-    let ledgers = rx.await.unwrap();
-
-    println!("{:?}", ledgers.read());
+    println!("Ledger State: {:#?}", epoch_snapshot.ledgers);
 
     // let infos = epoch_service.get_genesis_storage_module_infos();
     // println!("{:#?}", infos);
@@ -230,15 +207,13 @@ async fn add_slots_test() {
 
     let storage_submodules_config =
         StorageSubmodulesConfig::load(config.node_config.base_directory.clone()).unwrap();
-    let service_senders = ServiceSenders::new().0;
-    let mut epoch_service = EpochServiceInner::new(
-        &service_senders,
-        &storage_submodules_config,
-        &config,
-        System::current(),
-    );
 
-    let _ = epoch_service.initialize(genesis_block.clone(), commitments);
+    let mut epoch_snapshot = EpochSnapshot::new(
+        &storage_submodules_config,
+        genesis_block.clone(),
+        commitments,
+        &config,
+    );
 
     let mut mock_header = IrysBlockHeader::new_mock_header();
     mock_header.data_ledgers[DataLedger::Submit].max_chunk_offset = 0;
@@ -249,25 +224,18 @@ async fn add_slots_test() {
     new_epoch_block.data_ledgers[DataLedger::Submit].max_chunk_offset = num_chunks_in_partition / 2;
 
     // Post the new epoch block to the service and let it perform_epoch_tasks()
-    let (sender, _rx) = tokio::sync::oneshot::channel();
-    epoch_service
-        .handle_message(EpochServiceMessage::NewEpoch {
-            new_epoch_block: new_epoch_block.clone().into(),
-            previous_epoch_block: Some(genesis_block.clone()),
-            commitments: Arc::new(Vec::new()),
-            sender,
-        })
-        .unwrap();
+    let _ = epoch_snapshot.perform_epoch_tasks(
+        &Some(genesis_block.clone()),
+        &new_epoch_block,
+        Vec::new(),
+    );
 
-    let ledgers = epoch_service.ledgers.read().unwrap();
-    debug!("{:#?}", ledgers);
-    drop(ledgers);
+    debug!("{:#?}", epoch_snapshot.ledgers);
 
     // Verify each ledger has one slot and the correct number of partitions
     {
-        let ledgers = epoch_service.ledgers.read().unwrap();
-        let pub_slots = ledgers.get_slots(DataLedger::Publish);
-        let sub_slots = ledgers.get_slots(DataLedger::Submit);
+        let pub_slots = epoch_snapshot.ledgers.get_slots(DataLedger::Publish);
+        let sub_slots = epoch_snapshot.ledgers.get_slots(DataLedger::Submit);
         assert_eq!(pub_slots.len(), 1);
         assert_eq!(sub_slots.len(), 3); // TODO: check 1 expired, 2 new slots added
     }
@@ -284,29 +252,16 @@ async fn add_slots_test() {
     new_epoch_block.data_ledgers[DataLedger::Publish as usize].max_chunk_offset =
         (num_chunks_in_partition as f64 * 0.75) as u64;
 
-    let (sender, _rx) = tokio::sync::oneshot::channel();
-    epoch_service
-        .handle_message(EpochServiceMessage::NewEpoch {
-            new_epoch_block: new_epoch_block.clone().into(),
-            previous_epoch_block,
-            commitments: Arc::new(Vec::new()),
-            sender,
-        })
-        .unwrap();
+    let _ = epoch_snapshot.perform_epoch_tasks(&previous_epoch_block, &new_epoch_block, Vec::new());
 
-    let ledgers = epoch_service.ledgers.read().unwrap();
-    debug!("{:#?}", ledgers);
-    drop(ledgers);
+    debug!("{:#?}", epoch_snapshot.ledgers);
 
     // Validate the correct number of ledgers slots were added to each ledger
-    {
-        let ledgers = epoch_service.ledgers.read().unwrap();
-        let pub_slots = ledgers.get_slots(DataLedger::Publish);
-        let sub_slots = ledgers.get_slots(DataLedger::Submit);
-        assert_eq!(pub_slots.len(), 3);
-        assert_eq!(sub_slots.len(), 7);
-        println!("Ledger State: {:#?}", ledgers);
-    }
+    let pub_slots = epoch_snapshot.ledgers.get_slots(DataLedger::Publish);
+    let sub_slots = epoch_snapshot.ledgers.get_slots(DataLedger::Submit);
+    assert_eq!(pub_slots.len(), 3);
+    assert_eq!(sub_slots.len(), 7);
+    println!("Ledger State: {:#?}", epoch_snapshot.ledgers);
 }
 
 #[actix::test]
@@ -316,7 +271,7 @@ async fn capacity_projection_tests() {
     for i in (0..max_data_parts).step_by(10) {
         let data_partition_count = i;
         let capacity_count =
-            EpochServiceInner::get_num_capacity_partitions(data_partition_count, &config);
+            EpochSnapshot::get_num_capacity_partitions(data_partition_count, &config);
         let total = data_partition_count + capacity_count;
         println!(
             "data:{}, capacity:{}, total:{}",
@@ -360,17 +315,14 @@ async fn partition_expiration_and_repacking_test() {
 
     // Create epoch service
     let storage_submodules_config = StorageSubmodulesConfig::load(base_path.clone()).unwrap();
-    let service_senders = ServiceSenders::new().0;
-    let mut epoch_service = EpochServiceInner::new(
-        &service_senders,
-        &storage_submodules_config,
-        &config,
-        System::current(),
-    );
-    let storage_module_infos = epoch_service
-        .initialize(genesis_block.clone(), commitments)
-        .unwrap();
 
+    let mut epoch_snapshot = EpochSnapshot::new(
+        &storage_submodules_config,
+        genesis_block.clone(),
+        commitments,
+        &config,
+    );
+    let storage_module_infos = epoch_snapshot.map_storage_modules_to_partition_assignments();
     let mut storage_modules: StorageModuleVec = Vec::new();
     // Create a list of storage modules wrapping the storage files
     for info in storage_module_infos {
@@ -443,14 +395,10 @@ async fn partition_expiration_and_repacking_test() {
     }
 
     let assign_submit_partition_hash = {
-        let (sender, rx) = tokio::sync::oneshot::channel();
-        epoch_service
-            .handle_message(EpochServiceMessage::GetPartitionAssignmentsGuard(sender))
-            .unwrap();
-        let partitions_guard = rx.await.unwrap();
-
-        let partition_hash = partitions_guard
+        let partition_hash = epoch_snapshot
+            .partition_assignments
             .read()
+            .unwrap()
             .data_partitions
             .iter()
             .find(|(_hash, assignment)| assignment.ledger_id == Some(DataLedger::Submit.get_id()))
@@ -461,14 +409,11 @@ async fn partition_expiration_and_repacking_test() {
     };
 
     let (publish_partition_hash, submit_partition_hash) = {
-        let (sender, rx) = tokio::sync::oneshot::channel();
-        epoch_service
-            .handle_message(EpochServiceMessage::GetLedgersGuard(sender))
-            .unwrap();
-        let ledgers = rx.await.unwrap();
-
-        let pub_slots = ledgers.read().get_slots(DataLedger::Publish).clone();
-        let sub_slots = ledgers.read().get_slots(DataLedger::Submit).clone();
+        let pub_slots = epoch_snapshot
+            .ledgers
+            .get_slots(DataLedger::Publish)
+            .clone();
+        let sub_slots = epoch_snapshot.ledgers.get_slots(DataLedger::Submit).clone();
         assert_eq!(pub_slots.len(), 1);
         assert_eq!(sub_slots.len(), 1);
 
@@ -478,14 +423,10 @@ async fn partition_expiration_and_repacking_test() {
     assert_eq!(assign_submit_partition_hash, submit_partition_hash);
 
     let capacity_partitions = {
-        let (sender, rx) = tokio::sync::oneshot::channel();
-        epoch_service
-            .handle_message(EpochServiceMessage::GetPartitionAssignmentsGuard(sender))
-            .unwrap();
-        let partitions_guard = rx.await.unwrap();
-
-        let capacity_partitions: Vec<H256> = partitions_guard
+        let capacity_partitions: Vec<H256> = epoch_snapshot
+            .partition_assignments
             .read()
+            .unwrap()
             .capacity_partitions
             .keys()
             .copied()
@@ -503,12 +444,6 @@ async fn partition_expiration_and_repacking_test() {
 
         capacity_partitions
     };
-
-    let (sender, rx) = tokio::sync::oneshot::channel();
-    epoch_service
-        .handle_message(EpochServiceMessage::GetLedgersGuard(sender))
-        .unwrap();
-    let ledgers_guard = rx.await.unwrap();
 
     // Simulate enough epoch blocks to compete a Submit ledger storage term, expiring a slot
     let mut new_epoch_block = IrysBlockHeader::new_mock_header();
@@ -531,26 +466,24 @@ async fn partition_expiration_and_repacking_test() {
             new_epoch_block.data_ledgers[DataLedger::Submit].max_chunk_offset
         );
 
-        let (sender, rx) = tokio::sync::oneshot::channel();
-        epoch_service
-            .handle_message(EpochServiceMessage::NewEpoch {
-                new_epoch_block: new_epoch_block.clone().into(),
-                previous_epoch_block,
-                commitments: Arc::new(Vec::new()),
-                sender,
-            })
-            .unwrap();
-        let result = rx.await.unwrap();
+        let result =
+            epoch_snapshot.perform_epoch_tasks(&previous_epoch_block, &new_epoch_block, Vec::new());
 
         if let Err(err) = result {
             error!("Error processing NewEpochMessage: {:?}", err);
             panic!("Test failed: {:?}", err);
         }
 
+        // Simulate the partition expiry broadcast the service would normally do
+        let expired_partition_hashes = &epoch_snapshot.expired_partition_hashes;
+        let mining_broadcaster_addr = BroadcastMiningService::from_registry();
+        mining_broadcaster_addr.do_send(BroadcastPartitionsExpiration(H256List(
+            expired_partition_hashes.clone(),
+        )));
+
         previous_epoch_block = Some(new_epoch_block.clone());
-        let ledgers = ledgers_guard.read();
-        debug!("{:#?}", ledgers);
-        drop(ledgers);
+
+        debug!("{:#?}", epoch_snapshot.ledgers);
     }
 
     // busypoll the solution context rwlock
@@ -579,14 +512,17 @@ async fn partition_expiration_and_repacking_test() {
 
     // check a new slots is inserted with a partition assigned to it, and slot 0 expired and its partition was removed
     let (publish_partition, submit_partition, submit_partition2) = {
-        let pub_slots = ledgers_guard.read().get_slots(DataLedger::Publish).clone();
-        let sub_slots = ledgers_guard.read().get_slots(DataLedger::Submit).clone();
+        let pub_slots = epoch_snapshot
+            .ledgers
+            .get_slots(DataLedger::Publish)
+            .clone();
+        let sub_slots = epoch_snapshot.ledgers.get_slots(DataLedger::Submit).clone();
         assert_eq!(
             pub_slots.len(),
             1,
             "Publish should still have only one slot"
         );
-        debug!("Ledger State: {:#?}", ledgers_guard);
+        debug!("Ledger State: {:#?}", epoch_snapshot.ledgers);
 
         assert_eq!(sub_slots.len(), 3, "Submit slots should have two new not expired slots with a new fresh partition from available previous capacity ones!");
         assert!(
@@ -629,20 +565,21 @@ async fn partition_expiration_and_repacking_test() {
 
     // check repacking request expired partition for its whole interval range, and partitions assignments are consistent
     {
-        let (sender, rx) = tokio::sync::oneshot::channel();
-        epoch_service
-            .handle_message(EpochServiceMessage::GetPartitionAssignmentsGuard(sender))
-            .unwrap();
-        let partitions_guard = rx.await.unwrap();
-
         assert_eq!(
-            partitions_guard.read().data_partitions.len(),
+            epoch_snapshot
+                .partition_assignments
+                .read()
+                .unwrap()
+                .data_partitions
+                .len(),
             3,
             "Should have four partitions assignments"
         );
 
-        if let Some(publish_assignment) = partitions_guard
+        if let Some(publish_assignment) = epoch_snapshot
+            .partition_assignments
             .read()
+            .unwrap()
             .data_partitions
             .get(&publish_partition)
         {
@@ -660,8 +597,10 @@ async fn partition_expiration_and_repacking_test() {
             panic!("Should have an assignment");
         };
 
-        if let Some(submit_assignment) = partitions_guard
+        if let Some(submit_assignment) = epoch_snapshot
+            .partition_assignments
             .read()
+            .unwrap()
             .data_partitions
             .get(&submit_partition)
         {
@@ -679,8 +618,10 @@ async fn partition_expiration_and_repacking_test() {
             panic!("Should have an assignment");
         };
 
-        if let Some(submit_assignment) = partitions_guard
+        if let Some(submit_assignment) = epoch_snapshot
+            .partition_assignments
             .read()
+            .unwrap()
             .data_partitions
             .get(&submit_partition2)
         {
@@ -734,27 +675,24 @@ async fn epoch_blocks_reinitialization_test() {
     let block_index_actor = BlockIndexService::new(block_index.clone(), &config.consensus).start();
     SystemRegistry::set(block_index_actor.clone());
 
-    let storage_submodules_config =
-        StorageSubmodulesConfig::load(config.node_config.base_directory.clone()).unwrap();
-    let service_senders = ServiceSenders::new().0;
-    let mut epoch_service = EpochServiceInner::new(
-        &service_senders,
-        &storage_submodules_config,
-        &config,
-        System::current(),
-    );
-
     // Initialize genesis block at height 0
     let mut genesis_block = IrysBlockHeader::new_mock_header();
     genesis_block.height = 0;
     let pledge_count = config.consensus.epoch.num_capacity_partitions.unwrap_or(31) as u8;
     let commitments = add_test_commitments(&mut genesis_block, pledge_count, &config);
 
-    // Get the genesis storage modules and their assigned partitions
+    let storage_submodules_config =
+        StorageSubmodulesConfig::load(config.node_config.base_directory.clone()).unwrap();
 
-    let storage_module_infos = epoch_service
-        .initialize(genesis_block.clone(), commitments.clone())
-        .unwrap();
+    let mut epoch_snapshot = EpochSnapshot::new(
+        &storage_submodules_config,
+        genesis_block.clone(),
+        commitments.clone(),
+        &config,
+    );
+
+    // Get the genesis storage modules and their assigned partitions
+    let storage_module_infos = epoch_snapshot.map_storage_modules_to_partition_assignments();
     debug!("{:#?}", storage_module_infos);
 
     genesis_block.block_hash = H256::from_slice(&[0; 32]);
@@ -798,7 +736,7 @@ async fn epoch_blocks_reinitialization_test() {
     let mut new_epoch_block = IrysBlockHeader::new_mock_header();
     new_epoch_block.data_ledgers[DataLedger::Submit].max_chunk_offset = 0;
 
-    let mut epoch_replay_data: Vec<EpochReplayData> = Vec::new();
+    let mut epoch_block_data: Vec<EpochBlockData> = Vec::new();
     let epochs_in_term = config.consensus.epoch.submit_ledger_epoch_length;
     let mut previous_epoch_block = Some(genesis_block.clone());
 
@@ -815,23 +753,15 @@ async fn epoch_blocks_reinitialization_test() {
         // Send the epoch message
         new_epoch_block.height = next_epoch_height;
 
-        let (sender, rx) = tokio::sync::oneshot::channel();
-        epoch_service
-            .handle_message(EpochServiceMessage::NewEpoch {
-                new_epoch_block: new_epoch_block.clone().into(),
-                previous_epoch_block,
-                commitments: Arc::new(Vec::new()),
-                sender,
-            })
-            .unwrap();
-        let result = rx.await.unwrap();
+        let result =
+            epoch_snapshot.perform_epoch_tasks(&previous_epoch_block, &new_epoch_block, Vec::new());
 
         if let Err(err) = result {
             error!("Error processing NewEpochMessage: {:?}", err);
             panic!("Test failed: {:?}", err);
         }
 
-        epoch_replay_data.push(EpochReplayData {
+        epoch_block_data.push(EpochBlockData {
             epoch_block: new_epoch_block.clone(),
             commitments: Vec::new(),
         });
@@ -840,10 +770,9 @@ async fn epoch_blocks_reinitialization_test() {
 
     // Verify each ledger has one slot and the correct number of partitions
     {
-        let ledgers = epoch_service.ledgers.read().unwrap();
-        debug!("{:#?}", ledgers);
-        let pub_slots = ledgers.get_slots(DataLedger::Publish);
-        let sub_slots = ledgers.get_slots(DataLedger::Submit);
+        debug!("{:#?}", epoch_snapshot.ledgers);
+        let pub_slots = epoch_snapshot.ledgers.get_slots(DataLedger::Publish);
+        let sub_slots = epoch_snapshot.ledgers.get_slots(DataLedger::Submit);
         assert_eq!(pub_slots.len(), 1);
         assert_eq!(sub_slots.len(), 3); // TODO: check slot 1 expired, 2 new slots added
     }
@@ -862,13 +791,7 @@ async fn epoch_blocks_reinitialization_test() {
     //             0    1     2
     // Capacity
 
-    let (sender, rx) = tokio::sync::oneshot::channel();
-    epoch_service
-        .handle_message(EpochServiceMessage::GetPartitionAssignmentsGuard(sender))
-        .unwrap();
-    let partitions_guard = rx.await.unwrap();
-
-    partitions_guard.read().print_assignments();
+    // partitions_guard.read().print_assignments();
 
     let block_index_guard = block_index_actor
         .send(GetBlockIndexGuardMessage)
@@ -880,26 +803,21 @@ async fn epoch_blocks_reinitialization_test() {
         block_index_guard.read().num_blocks()
     );
 
-    let service_senders = ServiceSenders::new().0;
     // Get the genesis storage modules and their assigned partitions
-    let mut epoch_service = EpochServiceInner::new(
-        &service_senders,
+    let mut epoch_service = EpochSnapshot::new(
         &storage_submodules_config,
+        genesis_block,
+        commitments,
         &config,
-        System::current(),
     );
-    let storage_module_infos = epoch_service
-        .initialize(genesis_block, commitments)
-        .unwrap();
-
+    let storage_module_infos = epoch_service.map_storage_modules_to_partition_assignments();
     epoch_service
-        .replay_epoch_data(epoch_replay_data)
+        .replay_epoch_data(epoch_block_data)
         .expect("to replay the epoch data");
 
     debug!("{:#?}", storage_module_infos);
 
-    let new_sm_infos =
-        epoch_service.map_storage_modules_to_partition_assignments(&storage_submodules_config);
+    let new_sm_infos = epoch_service.map_storage_modules_to_partition_assignments();
 
     debug!("{:#?}", new_sm_infos);
 
@@ -917,7 +835,7 @@ async fn epoch_blocks_reinitialization_test() {
 
 #[actix::test]
 async fn partitions_assignment_determinism_test() {
-    //std::env::set_var("RUST_LOG", "debug");
+    std::env::set_var("RUST_LOG", "debug");
     let tmp_dir = setup_tracing_and_temp_dir(Some("partitions_assignment_determinism_test"), false);
     let base_path = tmp_dir.path().to_path_buf();
     let chunk_size = 32;
@@ -952,22 +870,19 @@ async fn partitions_assignment_determinism_test() {
     let commitments = add_test_commitments(&mut genesis_block, pledge_count, &config);
 
     let storage_submodules_config = StorageSubmodulesConfig::load_for_test(base_path, 40).unwrap();
-    let service_senders = ServiceSenders::new().0;
-    let mut epoch_service = EpochServiceInner::new(
-        &service_senders,
+
+    let mut epoch_snapshot = EpochSnapshot::new(
         &storage_submodules_config,
+        genesis_block.clone(),
+        commitments,
         &config,
-        System::current(),
     );
 
-    let _ = epoch_service.initialize(genesis_block.clone(), commitments);
-
-    let (sender, rx) = tokio::sync::oneshot::channel();
-    epoch_service
-        .handle_message(EpochServiceMessage::GetPartitionAssignmentsGuard(sender))
-        .unwrap();
-    let partitions_guard = rx.await.unwrap();
-    partitions_guard.read().print_assignments();
+    epoch_snapshot
+        .partition_assignments
+        .read()
+        .unwrap()
+        .print_assignments();
 
     // Now create a new epoch block & give the Submit ledger enough size to add a slot
     let total_epoch_messages = 6;
@@ -982,30 +897,29 @@ async fn partitions_assignment_determinism_test() {
         //(testnet_config.submit_ledger_epoch_length * epoch_num) * num_blocks_in_epoch; // next epoch block, next multiple of num_blocks_in epoch,
         epoch_num += 1;
         debug!("epoch block {}", new_epoch_block.height);
-        let (sender, _rx) = tokio::sync::oneshot::channel();
-        epoch_service
-            .handle_message(EpochServiceMessage::NewEpoch {
-                new_epoch_block: new_epoch_block.clone().into(),
-                previous_epoch_block,
-                commitments: Arc::new(Vec::new()),
-                sender,
-            })
-            .unwrap();
+
+        let _ =
+            epoch_snapshot.perform_epoch_tasks(&previous_epoch_block, &new_epoch_block, Vec::new());
         previous_epoch_block = Some(new_epoch_block.clone());
     }
 
-    partitions_guard.read().print_assignments();
+    epoch_snapshot
+        .partition_assignments
+        .read()
+        .unwrap()
+        .print_assignments();
+
     debug!(
         "\nAll Partitions({})\n{}",
-        &epoch_service.all_active_partitions.len(),
-        serde_json::to_string_pretty(&epoch_service.all_active_partitions).unwrap()
+        &epoch_snapshot.all_active_partitions.len(),
+        serde_json::to_string_pretty(&epoch_snapshot.all_active_partitions).unwrap()
     );
 
     // Check determinism in assigned partitions
     let publish_slot_0 = H256::from_base58("2F5eg8FE2VmXGcgpyUKTzBrLzSmVXMKqawUJeDgKC1vW");
     debug!("expected publish[0] -> {}", publish_slot_0.0.to_base58());
 
-    if let Some(publish_assignment) = epoch_service
+    if let Some(publish_assignment) = epoch_snapshot
         .partition_assignments
         .read()
         .unwrap()
@@ -1027,9 +941,16 @@ async fn partitions_assignment_determinism_test() {
     };
 
     let publish_slot_1 = H256::from_base58("2HVmW86qVyKTw1DYJMX6NoNvVxATLNZHSAyMceEWPtLC");
+
+    epoch_snapshot
+        .partition_assignments
+        .read()
+        .unwrap()
+        .print_assignments();
+
     debug!("expected publish[1] -> {}", publish_slot_1.0.to_base58());
 
-    if let Some(publish_assignment) = epoch_service
+    if let Some(publish_assignment) = epoch_snapshot
         .partition_assignments
         .read()
         .unwrap()
@@ -1052,7 +973,7 @@ async fn partitions_assignment_determinism_test() {
 
     let capacity_partition = H256::from_base58("5Wvv6erYhpk9aAzdrS9i6noQf57dBXHgLaMz46mNZeds");
 
-    if let Some(capacity_assignment) = epoch_service
+    if let Some(capacity_assignment) = epoch_snapshot
         .partition_assignments
         .read()
         .unwrap()
@@ -1073,7 +994,7 @@ async fn partitions_assignment_determinism_test() {
 
     let submit_slot_2 = H256::from_base58("8sRHV12yycwpUSzean97JemQrzAXSSQWMmC4Jx3xUXzQ");
 
-    if let Some(submit_assignment) = epoch_service
+    if let Some(submit_assignment) = epoch_snapshot
         .partition_assignments
         .read()
         .unwrap()

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -23,10 +23,7 @@ use irys_actors::{
     services::ServiceSenders,
     validation_service::ValidationService,
 };
-use irys_actors::{
-    ActorAddresses, CommitmentStateReadGuard, EpochReplayData, EpochService, EpochServiceMessage,
-    StorageModuleService,
-};
+use irys_actors::{ActorAddresses, EpochReplayData, StorageModuleService};
 use irys_api_server::{create_listener, run_server, ApiState};
 use irys_config::chain::chainspec::IrysChainSpecBuilder;
 use irys_config::submodules::StorageSubmodulesConfig;
@@ -97,7 +94,6 @@ pub struct IrysNodeCtx {
     pub chunk_provider: Arc<ChunkProvider>,
     pub block_index_guard: BlockIndexReadGuard,
     pub block_tree_guard: BlockTreeReadGuard,
-    pub commitment_state_guard: CommitmentStateReadGuard,
     pub vdf_steps_guard: VdfStateReadonly,
     pub service_senders: ServiceSenders,
     // Shutdown channels
@@ -857,43 +853,16 @@ impl IrysNode {
         let (broadcast_mining_actor, broadcast_arbiter) = init_broadcaster_service(span.clone());
 
         // start the epoch service
-        let (genesis_block, commitments, epoch_replay_data) =
+        let replay_data =
             EpochReplayData::query_replay_data(&irys_db, &block_index_guard, &config).await?;
+        // let (genesis_block, commitments, epoch_block_data) = (
+        //     &replay_data.genesis_block_header,
+        //     &replay_data.genesis_commitments,
+        //     &replay_data.epoch_blocks,
+        // );
 
         let storage_submodules_config =
             StorageSubmodulesConfig::load(config.node_config.base_directory.clone())?;
-        let _handle = EpochService::spawn_service(
-            task_exec,
-            genesis_block,
-            commitments,
-            receivers.epoch_service,
-            &service_senders,
-            &storage_submodules_config,
-            &config,
-        );
-
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        service_senders
-            .epoch_service
-            .send(EpochServiceMessage::ReplayEpochData(epoch_replay_data, tx))?;
-        let storage_module_infos = rx.await?;
-
-        // Retrieve Partition assignment
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        service_senders
-            .epoch_service
-            .send(EpochServiceMessage::GetPartitionAssignmentsGuard(tx))?;
-        let partition_assignments_guard = rx.await?;
-
-        let storage_modules = Self::init_storage_modules(&config, storage_module_infos)?;
-        let storage_modules_guard = StorageModulesReadGuard::new(storage_modules.clone());
-
-        // Retrieve Commitment State
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        service_senders
-            .epoch_service
-            .send(EpochServiceMessage::GetCommitmentStateGuard(tx))?;
-        let commitment_state_guard = rx.await?;
 
         let p2p_service = P2PService::new(
             config.node_config.miner_address(),
@@ -908,7 +877,8 @@ impl IrysNode {
             receivers.block_tree,
             irys_db.clone(),
             block_index_guard.clone(),
-            commitment_state_guard.clone(),
+            &replay_data,
+            &storage_submodules_config,
             &config,
             &service_senders,
             reth_service_actor.clone(),
@@ -922,6 +892,12 @@ impl IrysNode {
         let block_tree_guard = oneshot_rx
             .await
             .expect("to receive BlockTreeReadGuard response from GetBlockTreeReadGuard Message");
+
+        let epoch_snapshot = block_tree_guard.read().canonical_epoch_snapshot();
+        let storage_module_infos = epoch_snapshot.map_storage_modules_to_partition_assignments();
+
+        let storage_modules = Self::init_storage_modules(&config, storage_module_infos)?;
+        let storage_modules_guard = StorageModulesReadGuard::new(storage_modules.clone());
 
         // Spawn peer list service
         let (peer_list_service, peer_list_arbiter) =
@@ -939,7 +915,6 @@ impl IrysNode {
             reth_node_adapter.clone(),
             storage_modules_guard.clone(),
             &block_tree_guard,
-            &commitment_state_guard,
             receivers.mempool,
             &config,
             &service_senders,
@@ -969,7 +944,6 @@ impl IrysNode {
             task_exec,
             block_index_guard.clone(),
             block_tree_guard.clone(),
-            partition_assignments_guard.clone(),
             vdf_state_readonly.clone(),
             &config,
             &service_senders,
@@ -993,7 +967,6 @@ impl IrysNode {
             &service_senders,
             &block_index_guard,
             &block_tree_guard,
-            partition_assignments_guard,
             &vdf_state_readonly,
             Arc::clone(&reward_curve),
         );
@@ -1097,7 +1070,6 @@ impl IrysNode {
             sync_state: sync_state.clone(),
             shadow_tx_store,
             reth_node_adapter,
-            commitment_state_guard,
             block_producer_inner,
         };
 
@@ -1385,14 +1357,12 @@ impl IrysNode {
         service_senders: &ServiceSenders,
         block_index_guard: &BlockIndexReadGuard,
         block_tree_guard: &BlockTreeReadGuard,
-        partition_assignments_guard: irys_actors::epoch_service::PartitionAssignmentsReadGuard,
         vdf_steps_guard: &VdfStateReadonly,
         reward_curve: Arc<HalvingCurve>,
     ) -> (actix::Addr<BlockDiscoveryActor>, Arbiter) {
         let block_discovery_actor = BlockDiscoveryActor {
             block_index_guard: block_index_guard.clone(),
             block_tree_guard: block_tree_guard.clone(),
-            partition_assignments_guard,
             db: irys_db.clone(),
             config: config.clone(),
             vdf_steps_guard: vdf_steps_guard.clone(),

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -845,9 +845,7 @@ async fn heavy_staking_pledging_txs_included() -> eyre::Result<()> {
     );
 
     // Get the genesis nodes view of the peers assignments
-    let peer_assignments = genesis_node
-        .get_partition_assignments(peer_signer.address())
-        .await;
+    let peer_assignments = genesis_node.get_partition_assignments(peer_signer.address());
 
     // Verify that one partition has been assigned to the peer to match its pledge
     assert_eq!(peer_assignments.len(), 1);

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -5,7 +5,7 @@ use irys_types::{DataLedger, IrysTransaction, NodeConfig, H256};
 use tracing::debug;
 
 #[actix_web::test]
-async fn heavy_fork_recovery_test() -> eyre::Result<()> {
+async fn heavy_fork_recovery_submit_tx_test() -> eyre::Result<()> {
     // Turn on tracing even before the nodes start
     std::env::set_var(
         "RUST_LOG",

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -90,12 +90,8 @@ async fn heavy_fork_recovery_submit_tx_test() -> eyre::Result<()> {
         .await?;
 
     // Get the genesis nodes view of the peers assignments
-    let peer1_assignments = genesis_node
-        .get_partition_assignments(peer1_signer.address())
-        .await;
-    let peer2_assignments = genesis_node
-        .get_partition_assignments(peer2_signer.address())
-        .await;
+    let peer1_assignments = genesis_node.get_partition_assignments(peer1_signer.address());
+    let peer2_assignments = genesis_node.get_partition_assignments(peer2_signer.address());
 
     // Verify that one partition has been assigned to each peer to match its pledge
     assert_eq!(peer1_assignments.len(), 1);

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -7,10 +7,11 @@ use tracing::debug;
 #[actix_web::test]
 async fn heavy_fork_recovery_submit_tx_test() -> eyre::Result<()> {
     // Turn on tracing even before the nodes start
-    std::env::set_var(
-        "RUST_LOG",
-        "debug,irys_actors::block_validation=none;irys_p2p::server=none;irys_actors::mining=error",
-    );
+    // std::env::set_var(
+    //     "RUST_LOG",
+    //     "debug,irys_actors::block_validation=none;irys_p2p::server=none;irys_actors::mining=error",
+    // );
+    std::env::set_var("RUST_LOG", "debug,irys_database=off,irys_p2p::gossip_service=off,irys_actors::storage_module_service=off,trie=off,irys_reth::evm=off,engine::root=off,irys_p2p::peer_list=off,storage::db::mdbx=off,reth_basic_payload_builder=off,irys_gossip_service=off,providers::db=off,reth_payload_builder::service=off,irys_actors::broadcast_mining_service=off,reth_ethereum_payload_builder=off,provider::static_file=off,engine::persistence=off,provider::storage_writer=off,reth_engine_tree::persistence=off,irys_actors::cache_service=off,irys_vdf=off,irys_actors::block_tree_service=debug,irys_actors::vdf_service=off,rys_gossip_service::service=off,eth_ethereum_payload_builder=off,reth_node_events::node=off,reth::cli=off,reth_engine_tree::tree=off,irys_actors::ema_service=off,irys_efficient_sampling=off,hyper_util::client::legacy::connect::http=off,hyper_util::client::legacy::pool=off,irys_database::migration::v0_to_v1=off,irys_storage::storage_module=off,actix_server::worker=off,irys::packing::update=off,engine::tree=off,irys_actors::mining=error,payload_builder=off,irys_actors::reth_service=off,irys_actors::packing=off,irys_actors::reth_service=off,irys::packing::progress=off,irys_chain::vdf=off,irys_vdf::vdf_state=off");
     initialize_tracing();
 
     // Configure a test network with accelerated epochs (2 blocks per epoch)
@@ -71,13 +72,18 @@ async fn heavy_fork_recovery_submit_tx_test() -> eyre::Result<()> {
         .await?;
 
     // Mine a block to get the commitments included
-    genesis_node.mine_block().await.unwrap();
+    let block1 = genesis_node.mine_block().await.unwrap();
+
+    debug!("block1: {}", block1.height);
 
     // Mine another block to perform epoch tasks, and assign partition_hash's to the peers
-    genesis_node.mine_block().await.unwrap();
+    let block2 = genesis_node.mine_block().await.unwrap();
+
+    debug!("block1: {} block2: {}", block1.height, block2.height);
 
     // wait for block mining to reach tree height
     genesis_node.wait_until_height(2, seconds_to_wait).await?;
+
     // wait for migration to reach index height
     genesis_node
         .wait_until_height_on_chain(1, seconds_to_wait)

--- a/crates/chain/tests/multi_node/fork_recovery_epoch.rs
+++ b/crates/chain/tests/multi_node/fork_recovery_epoch.rs
@@ -1,0 +1,144 @@
+use crate::utils::IrysNodeTest;
+use irys_testing_utils::*;
+use irys_types::{NodeConfig, H256};
+use tracing::debug;
+
+#[actix_web::test]
+async fn heavy_fork_recovery_epoch_test() -> eyre::Result<()> {
+    // Turn on tracing even before the nodes start
+    std::env::set_var(
+        "RUST_LOG",
+        "debug,irys_actors::block_validation=none;irys_p2p::server=none;irys_actors::mining=error",
+    );
+    initialize_tracing();
+
+    // Configure a test network with accelerated epochs (2 blocks per epoch)
+    let num_blocks_in_epoch = 2;
+    let seconds_to_wait = 10;
+    let mut genesis_config = NodeConfig::testnet_with_epochs(num_blocks_in_epoch);
+    genesis_config.consensus.get_mut().chunk_size = 32;
+
+    // Create a signer (keypair) for the peer and fund it
+    let peer1_signer = genesis_config.new_random_signer();
+    let peer2_signer = genesis_config.new_random_signer();
+    genesis_config.fund_genesis_accounts(vec![&peer1_signer, &peer2_signer]);
+
+    // Start the genesis node and wait for packing
+    let genesis_node = IrysNodeTest::new_genesis(genesis_config.clone())
+        .start_and_wait_for_packing("GENESIS", seconds_to_wait)
+        .await;
+    genesis_node.start_public_api().await;
+
+    // Initialize peer configs with their keypair/signer
+    let peer1_config = genesis_node.testnet_peer_with_signer(&peer1_signer);
+    let peer2_config = genesis_node.testnet_peer_with_signer(&peer2_signer);
+
+    // Start the peers: No packing on the peers, they don't have partition assignments yet
+    let peer1_node = IrysNodeTest::new(peer1_config.clone())
+        .start_with_name("PEER1")
+        .await;
+    peer1_node.start_public_api().await;
+
+    let peer2_node = IrysNodeTest::new(peer2_config.clone())
+        .start_with_name("PEER2")
+        .await;
+    peer2_node.start_public_api().await;
+
+    // Post stake + pledge commitments to peer1
+    let peer1_stake_tx = peer1_node.post_stake_commitment(H256::zero()).await; // zero() is the genesis block hash
+    let peer1_pledge_tx = peer1_node.post_pledge_commitment(H256::zero()).await;
+
+    // Post stake + pledge commitments to peer2
+    let peer2_stake_tx = peer2_node.post_stake_commitment(H256::zero()).await;
+    let peer2_pledge_tx = peer2_node.post_pledge_commitment(H256::zero()).await;
+
+    // Wait for all commitment tx to show up in the genesis_node's mempool
+    genesis_node
+        .wait_for_mempool(peer1_stake_tx.id, seconds_to_wait)
+        .await?;
+    genesis_node
+        .wait_for_mempool(peer1_pledge_tx.id, seconds_to_wait)
+        .await?;
+    genesis_node
+        .wait_for_mempool(peer2_stake_tx.id, seconds_to_wait)
+        .await?;
+    genesis_node
+        .wait_for_mempool(peer2_pledge_tx.id, seconds_to_wait)
+        .await?;
+
+    // Mine a block to get the commitments included
+    genesis_node.mine_block().await.unwrap();
+
+    // Mine another block to perform epoch tasks, and assign partition_hash's to the peers
+    let epoch_block = genesis_node.mine_block().await.unwrap();
+
+    // Get the genesis nodes view of the peers assignments
+    let peer1_assignments = genesis_node
+        .get_partition_assignments(peer1_signer.address())
+        .await;
+    let peer2_assignments = genesis_node
+        .get_partition_assignments(peer2_signer.address())
+        .await;
+
+    // Verify that one partition has been assigned to each peer to match its pledge
+    assert_eq!(peer1_assignments.len(), 1);
+    assert_eq!(peer2_assignments.len(), 1);
+
+    // Wait for the peers to receive & process the epoch block
+    let _block_hash = peer1_node.wait_until_height(2, seconds_to_wait).await?;
+    let _block_hash = peer2_node.wait_until_height(2, seconds_to_wait).await?;
+
+    // Wait for them to pack their storage modules with the partition_hashes
+    peer1_node.wait_for_packing(seconds_to_wait).await;
+    peer2_node.wait_for_packing(seconds_to_wait).await;
+
+    // Now it's time to create different epoch timelines for each peers fork
+    let _pledge1 = peer1_node
+        .post_pledge_commitment_without_gossip(epoch_block.block_hash)
+        .await;
+    let fork1_3 = peer1_node.mine_block_without_gossip().await?;
+
+    let _pledge2 = peer2_node
+        .post_pledge_commitment_without_gossip(epoch_block.block_hash)
+        .await;
+    let fork2_3 = peer2_node.mine_block_without_gossip().await?;
+
+    // Make sure the blocks on each for have different hashes
+    assert_ne!(fork1_3.0.block_hash, fork2_3.0.block_hash);
+    debug!(
+        fork1_3_height = fork1_3.0.height,
+        fork2_3_height = fork2_3.0.height,
+        "Comparing fork heights"
+    );
+
+    // Mine a block with gossip on one of the peers to extend the chain on genesis to have the peers epoch block
+    peer1_node.gossip_block(&fork1_3.0)?;
+    let genesis_hash = genesis_node
+        .wait_until_height(fork1_3.0.height, seconds_to_wait)
+        .await?;
+    assert_eq!(genesis_hash, fork1_3.0.block_hash);
+
+    // Have peer1 and peer2 both mine their 4th block, but don't gossip peer2s
+    let peer2_epoch = peer2_node.mine_block_without_gossip().await?.0;
+    let peer1_epoch = peer1_node.mine_block().await.unwrap();
+
+    // Wait for peer1_epoch block to arrive at genesis node
+    let genesis_epoch_hash = genesis_node.wait_until_height(4, seconds_to_wait).await?;
+    assert_eq!(peer1_epoch.block_hash, genesis_epoch_hash);
+
+    // Then extend peer2's chain to be the longest
+    peer2_node.mine_blocks(1).await?;
+    let peer2_hash = peer2_node.wait_until_height(5, seconds_to_wait).await?;
+    let peer2_head = peer2_node.get_block_by_hash(&peer2_hash)?;
+
+    // Verify the height 4 block on peer2's chain is not the height 4 on genesis
+    assert_ne!(peer2_head.previous_block_hash, genesis_epoch_hash);
+
+    // Validate that the genesis node reorgs the epoch/commitment state correctly
+
+    // Wind down test
+    genesis_node.stop().await;
+    peer1_node.stop().await;
+    peer2_node.stop().await;
+    Ok(())
+}

--- a/crates/chain/tests/multi_node/fork_recovery_epoch.rs
+++ b/crates/chain/tests/multi_node/fork_recovery_epoch.rs
@@ -119,7 +119,7 @@ async fn heavy_fork_recovery_epoch_test() -> eyre::Result<()> {
     assert_eq!(genesis_hash, fork1_3.0.block_hash);
 
     // Have peer1 and peer2 both mine their 4th block, but don't gossip peer2s
-    let peer2_epoch = peer2_node.mine_block_without_gossip().await?.0;
+    let _peer2_epoch = peer2_node.mine_block_without_gossip().await?.0;
     let peer1_epoch = peer1_node.mine_block().await.unwrap();
 
     // Wait for peer1_epoch block to arrive at genesis node

--- a/crates/chain/tests/multi_node/fork_recovery_epoch.rs
+++ b/crates/chain/tests/multi_node/fork_recovery_epoch.rs
@@ -150,31 +150,32 @@ async fn heavy_fork_recovery_epoch_test() -> eyre::Result<()> {
         .read()
         .canonical_epoch_snapshot();
 
-    let cs = epoch_snapshot.commitment_state.read().unwrap();
+    {
+        let cs = epoch_snapshot.commitment_state.read().unwrap();
 
-    // Verify Peer2's pledge is in the commitment state now
-    assert!(cs
-        .pledge_commitments
-        .get(&peer2_signer.address())
-        .unwrap()
-        .iter()
-        .find(|cse| cse.id == pledge2.id)
-        .is_some());
+        // Verify Peer2's pledge is in the commitment state now
+        assert!(cs
+            .pledge_commitments
+            .get(&peer2_signer.address())
+            .unwrap()
+            .iter()
+            .any(|cse| cse.id == pledge2.id));
 
-    // Verify peer1's pledge has been removed
-    assert!(cs
-        .pledge_commitments
-        .get(&peer1_signer.address())
-        .unwrap()
-        .iter()
-        .find(|cse| cse.id == pledge1.id)
-        .is_none());
+        // Verify peer1's pledge has been removed (note the !cs)
+        assert!(!cs
+            .pledge_commitments
+            .get(&peer1_signer.address())
+            .unwrap()
+            .iter()
+            .any(|cse| cse.id == pledge1.id));
 
-    // TODO:
-    // Verify that packing is started on peer2 for whatever partition_hash was assigned to pledge2
-    // Verify that a Miner is started on peer2 for whatever partition_hash was assigned to pledge2
-    // Verify that packing is stopped on peer1 for whatever partition_hash was assigned to pledge1
-    // Verify that a Miner is stopped on peer1 for whatever partition_hash was assigned to pledge1
+        // TODO:
+        // Verify that packing is started on peer2 for whatever partition_hash was assigned to pledge2
+        // Verify that a Miner is started on peer2 for whatever partition_hash was assigned to pledge2
+        // Verify that packing is stopped on peer1 for whatever partition_hash was assigned to pledge1
+        // Verify that a Miner is stopped on peer1 for whatever partition_hash was assigned to pledge1
+        //
+    } // Make clippy happy about dropping cs
 
     // Wind down test
     genesis_node.stop().await;

--- a/crates/chain/tests/multi_node/fork_recovery_epoch.rs
+++ b/crates/chain/tests/multi_node/fork_recovery_epoch.rs
@@ -73,12 +73,8 @@ async fn heavy_fork_recovery_epoch_test() -> eyre::Result<()> {
     let epoch_block = genesis_node.mine_block().await.unwrap();
 
     // Get the genesis nodes view of the peers assignments
-    let peer1_assignments = genesis_node
-        .get_partition_assignments(peer1_signer.address())
-        .await;
-    let peer2_assignments = genesis_node
-        .get_partition_assignments(peer2_signer.address())
-        .await;
+    let peer1_assignments = genesis_node.get_partition_assignments(peer1_signer.address());
+    let peer2_assignments = genesis_node.get_partition_assignments(peer2_signer.address());
 
     // Verify that one partition has been assigned to each peer to match its pledge
     assert_eq!(peer1_assignments.len(), 1);

--- a/crates/chain/tests/multi_node/fork_recovery_epoch.rs
+++ b/crates/chain/tests/multi_node/fork_recovery_epoch.rs
@@ -122,6 +122,10 @@ async fn heavy_fork_recovery_epoch_test() -> eyre::Result<()> {
     let genesis_epoch_hash = genesis_node.wait_until_height(4, seconds_to_wait).await?;
     assert_eq!(peer1_epoch.block_hash, genesis_epoch_hash);
 
+    // TODO: Verify pledge1 is in the genesis epoch state
+    // Verify that packing is started on peer1 for whatever partition_hash was assigned to pledge1
+    // Verify that a Miner is started on peer1 for whatever partition_hash was assigned to pledge1
+
     // Then extend peer2's chain to be the longest
     peer2_node.mine_blocks(1).await?;
     let peer2_hash = peer2_node.wait_until_height(5, seconds_to_wait).await?;
@@ -165,6 +169,12 @@ async fn heavy_fork_recovery_epoch_test() -> eyre::Result<()> {
         .iter()
         .find(|cse| cse.id == pledge1.id)
         .is_none());
+
+    // TODO:
+    // Verify that packing is started on peer2 for whatever partition_hash was assigned to pledge2
+    // Verify that a Miner is started on peer2 for whatever partition_hash was assigned to pledge2
+    // Verify that packing is stopped on peer1 for whatever partition_hash was assigned to pledge1
+    // Verify that a Miner is stopped on peer1 for whatever partition_hash was assigned to pledge1
 
     // Wind down test
     genesis_node.stop().await;

--- a/crates/chain/tests/multi_node/mod.rs
+++ b/crates/chain/tests/multi_node/mod.rs
@@ -1,4 +1,5 @@
 pub mod fork_recovery;
+pub mod fork_recovery_epoch;
 pub mod mempool_tests;
 pub mod peer_discovery;
 pub mod peer_mining;

--- a/crates/chain/tests/multi_node/peer_mining.rs
+++ b/crates/chain/tests/multi_node/peer_mining.rs
@@ -53,9 +53,7 @@ async fn heavy_peer_mining_test() -> eyre::Result<()> {
         .await?;
 
     // Get the genesis nodes view of the peers assignments
-    let peer_assignments = genesis_node
-        .get_partition_assignments(peer_signer.address())
-        .await;
+    let peer_assignments = genesis_node.get_partition_assignments(peer_signer.address());
 
     // Verify that one partition has been assigned to the peer to match its pledge
     assert_eq!(peer_assignments.len(), 1);
@@ -67,9 +65,7 @@ async fn heavy_peer_mining_test() -> eyre::Result<()> {
     peer_node.wait_for_packing(seconds_to_wait).await;
 
     // Verify that the peer has the same view of its own assignments
-    let peer_assignments_on_peer = peer_node
-        .get_partition_assignments(peer_signer.address())
-        .await;
+    let peer_assignments_on_peer = peer_node.get_partition_assignments(peer_signer.address());
 
     // Verify the peer has the same view of assignments as the genesis node
     assert_eq!(peer_assignments_on_peer.len(), 1);

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -358,9 +358,7 @@ impl IrysNodeTest<IrysNodeCtx> {
         peer_node.wait_for_packing(seconds_to_wait).await;
 
         // Verify that partition assignments were created
-        let peer_assignments = peer_node
-            .get_partition_assignments(peer_signer.address())
-            .await;
+        let peer_assignments = peer_node.get_partition_assignments(peer_signer.address());
 
         // Ensure at least one partition has been assigned
         assert!(
@@ -1287,10 +1285,7 @@ impl IrysNodeTest<IrysNodeCtx> {
         stake_tx
     }
 
-    pub async fn get_partition_assignments(
-        &self,
-        miner_address: Address,
-    ) -> Vec<PartitionAssignment> {
+    pub fn get_partition_assignments(&self, miner_address: Address) -> Vec<PartitionAssignment> {
         let epoch_snapshot = self
             .node_ctx
             .block_tree_guard

--- a/crates/database/src/data_ledger.rs
+++ b/crates/database/src/data_ledger.rs
@@ -281,6 +281,7 @@ impl Ledgers {
         }
     }
 
+    /// Get the slot needs for the ledger, returning a vector of (slot index, number of partitions needed)
     pub fn get_slot_needs(&self, ledger: DataLedger) -> Vec<(usize, usize)> {
         match ledger {
             DataLedger::Publish => self.perm.get_slot_needs(),

--- a/crates/p2p/src/block_status_provider.rs
+++ b/crates/p2p/src/block_status_provider.rs
@@ -225,7 +225,7 @@ impl BlockStatusProvider {
 
     #[cfg(test)]
     pub fn add_block_mock_to_the_tree(&self, block: &IrysBlockHeader) {
-        use irys_actors::block_tree_service::ema_snapshot::EmaSnapshot;
+        use irys_actors::{block_tree_service::ema_snapshot::EmaSnapshot, EpochSnapshot};
         use irys_database::CommitmentSnapshot;
 
         self.block_tree_read_guard
@@ -233,6 +233,7 @@ impl BlockStatusProvider {
             .add_peer_block(
                 block,
                 Arc::new(CommitmentSnapshot::default()),
+                Arc::new(EpochSnapshot::default()),
                 Arc::new(EmaSnapshot::default()),
             )
             .expect("to add block to the tree");

--- a/crates/types/src/config.rs
+++ b/crates/types/src/config.rs
@@ -905,7 +905,7 @@ mod tests {
         decay_rate = 0.01
         chunk_size = 262144
         block_migration_depth = 6
-        block_cache_depth = 50
+        block_tree_depth = 50
         num_chunks_in_partition = 10
         num_chunks_in_recall_range = 2
         num_partitions_per_slot = 1

--- a/crates/types/src/config.rs
+++ b/crates/types/src/config.rs
@@ -114,8 +114,8 @@ pub struct ConsensusConfig {
     /// Defines how many blocks must pass before a block is marked as finalized
     pub block_migration_depth: u32,
 
-    /// Number of blocks to retain in cache from chain head
-    pub block_cache_depth: u64,
+    /// Number of blocks to retain in the block tree from chain head
+    pub block_tree_depth: u64,
 
     /// Number of chunks that make up a single partition
     pub num_chunks_in_partition: u64,
@@ -542,7 +542,7 @@ impl ConsensusConfig {
             num_chunks_in_recall_range: 2,
             num_partitions_per_slot: 1,
             block_migration_depth: 6,
-            block_cache_depth: 50,
+            block_tree_depth: 50,
             epoch: EpochConfig {
                 capacity_scalar: 100,
                 num_blocks_in_epoch: 100,


### PR DESCRIPTION
## Summary

The `epoch_service` was not fork-aware, which caused issues because each fork can have its own `epoch_state` with distinct pledges, commitments, and partition assignments. Simply storing the canonical `epoch_state` in an `epoch_service` was insufficient for validating blocks on forks or handling reorgs gracefully.

## Changes

**Architecture Change**: This PR refactors the `epoch_service` state into `epoch_snapshot` objects owned by the `block_tree`. When adding blocks to the `block_tree`, callers must now provide an `epoch_snapshot`:
- **Standard blocks**: Copy the parent's `Arc<EpochSnapshot>` (90% of cases)
- **Epoch blocks**: Apply commitments from the epoch block to create a new snapshot
- **Tests**: Use the new `dummy_epoch_snapshot()` utility for non-epoch-aware tests

**Lock Removal**: Previously, `epoch_state` was a singleton requiring `RwLocks` on member fields and many epoch service messages for read guards. With snapshots being write-once/read-only, these locks can be removed. Started with the `Ledgers` field, but removing all `RwLocks` from `EpochSnapshot` would impact most core files, so this cleanup is deferred to a future PR.

**Block Validation**: Updated to use the parent block's `EpochSnapshot` for POA validation instead of the canonical chain snapshot, ensuring correct validation on forks.

**Bug Fix**: Fixed a bug where reorgs with forks longer than 1-2 blocks could crash the node.

**New Test**: Adds a `heavy_fork_recovery_epoch` test

**Renamed Config**: `block_cache_depth` -> `block_tree_depth` this avoids confusion between the large Cache / Index separation of the node, and the depth of the block_tree which crosses over the depth of the cache.  The `block_tree` has an internal struct named `BlockTreeCache` that will be renamed to something less confusing in a future PR as it has nothing to do with the node Cache.

## Impact

- **`block_tree_service`**: Most heavily impacted, now handles initialization from DB, startup scenarios, and reorg/forking state for epoch snapshots
- **Tests**: Many updated to incorporate the new snapshot system
- **File organization**: `EpochSnapshot` remains in `epoch_service.rs` temporarily (will be moved in future PR)

## Technical Debt

- Remove remaining `RwLocks` from `EpochSnapshot` (follow-up PR)
- Relocate `EpochSnapshot` to the correct crate (follow-up PR
- Remove spawned `epoch_service` entirely (follow-up PR)
- Add more validation to `heavy_fork_recovery_epoch` test (follow-up PR)
- Rename `BlockTreeCache` something that doesn't overlap with the naming of the node's cache.
