### PR TITLE
test: ema fork test where interval rolls over forks

### DIFF
--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -1,7 +1,7 @@
 use crate::{
     block_discovery::{BlockDiscoveredMessage, BlockDiscoveryActor},
     block_tree_service::{
-        ema_snapshot::{EmaBlock, EmaSnapshot},
+        ema_snapshot::{EmaSnapshot, ExponentialMarketAvgCalculation},
         BlockState, BlockTreeReadGuard, ChainState,
     },
     broadcast_mining_service::{BroadcastDifficultyUpdate, BroadcastMiningService},
@@ -28,11 +28,16 @@ use irys_reth::compose_shadow_tx;
 use irys_reth_node_bridge::IrysRethNodeAdapter;
 use irys_reward_curve::HalvingCurve;
 use irys_types::{
-    app_state::DatabaseProvider, block_production::SolutionContext, calculate_difficulty,
-    next_cumulative_diff, storage_pricing::Amount, Base64, CommitmentTransaction, Config,
-    DataLedger, DataTransactionLedger, GossipBroadcastMessage, H256List, IngressProofsList,
-    IrysBlockHeader, IrysTransactionHeader, PoaData, Signature, SystemTransactionLedger,
-    TxIngressProof, VDFLimiterInfo, H256, U256,
+    app_state::DatabaseProvider,
+    block_production::SolutionContext,
+    calculate_difficulty, next_cumulative_diff,
+    storage_pricing::{
+        phantoms::{IrysPrice, Usd},
+        Amount,
+    },
+    Base64, CommitmentTransaction, Config, DataLedger, DataTransactionLedger,
+    GossipBroadcastMessage, H256List, IngressProofsList, IrysBlockHeader, IrysTransactionHeader,
+    PoaData, Signature, SystemTransactionLedger, TxIngressProof, VDFLimiterInfo, H256, U256,
 };
 use irys_vdf::state::VdfStateReadonly;
 use nodit::interval::ii;
@@ -457,7 +462,7 @@ pub trait BlockProdStrategy {
         };
         steps.push(solution.seed.0);
 
-        let ema_irys_price = self
+        let ema_calculation = self
             .get_ema_price(prev_block_header, perv_block_ema_snapshot)
             .await?;
 
@@ -534,8 +539,8 @@ pub trait BlockProdStrategy {
                 steps,
                 ..Default::default()
             },
-            oracle_irys_price: ema_irys_price.range_adjusted_oracle_price,
-            ema_irys_price: ema_irys_price.ema,
+            oracle_irys_price: ema_calculation.oracle_price_for_block_inclusion,
+            ema_irys_price: ema_calculation.ema,
         };
 
         // Now that all fields are initialized, Sign the block and initialize its block_hash
@@ -634,16 +639,17 @@ pub trait BlockProdStrategy {
         &self,
         parent_block: &IrysBlockHeader,
         parent_block_ema_snapshot: &EmaSnapshot,
-    ) -> eyre::Result<EmaBlock> {
+    ) -> eyre::Result<ExponentialMarketAvgCalculation> {
         let oracle_irys_price = self.inner().price_oracle.current_price().await?;
-        let ema_irys_price = parent_block_ema_snapshot.calculate_ema_for_new_block(
+        dbg!(&oracle_irys_price);
+        let ema_calculation = parent_block_ema_snapshot.calculate_ema_for_new_block(
             parent_block,
             oracle_irys_price,
             self.inner().config.consensus.token_price_safe_range,
             self.inner().config.consensus.ema.price_adjustment_interval,
         );
 
-        Ok(ema_irys_price)
+        Ok(ema_calculation)
     }
 
     async fn get_mempool_txs(

--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -2,7 +2,7 @@ use crate::{
     block_discovery::{BlockDiscoveredMessage, BlockDiscoveryActor},
     block_tree_service::{
         ema_snapshot::{EmaSnapshot, ExponentialMarketAvgCalculation},
-        BlockState, BlockTreeReadGuard, ChainState,
+        BlockTreeReadGuard,
     },
     broadcast_mining_service::{BroadcastDifficultyUpdate, BroadcastMiningService},
     mempool_service::MempoolServiceMessage,

--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -31,10 +31,7 @@ use irys_types::{
     app_state::DatabaseProvider,
     block_production::SolutionContext,
     calculate_difficulty, next_cumulative_diff,
-    storage_pricing::{
-        phantoms::{IrysPrice, Usd},
-        Amount,
-    },
+    storage_pricing::Amount,
     Base64, CommitmentTransaction, Config, DataLedger, DataTransactionLedger,
     GossipBroadcastMessage, H256List, IngressProofsList, IrysBlockHeader, IrysTransactionHeader,
     PoaData, Signature, SystemTransactionLedger, TxIngressProof, VDFLimiterInfo, H256, U256,

--- a/crates/actors/src/block_tree_service/ema_snapshot.rs
+++ b/crates/actors/src/block_tree_service/ema_snapshot.rs
@@ -219,8 +219,6 @@ impl EmaSnapshot {
             safe_range,
             parent_block.oracle_irys_price,
         );
-        dbg!(&parent_block.height + 1);
-        dbg!(&oracle_price_for_calculation);
 
         let ema = oracle_price_for_calculation
             .calculate_ema(

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -1344,11 +1344,11 @@ impl IrysNode {
         let price_oracle = match config.node_config.oracle {
             OracleConfig::Mock {
                 initial_price,
-                percent_change,
+                incremental_change,
                 smoothing_interval,
             } => IrysPriceOracle::MockOracle(MockOracle::new(
                 initial_price,
-                percent_change,
+                incremental_change,
                 smoothing_interval,
             )),
             // note: depending on the oracle, it may require spawning an async background service.

--- a/crates/chain/tests/api/tx_duplicates.rs
+++ b/crates/chain/tests/api/tx_duplicates.rs
@@ -38,7 +38,7 @@ async fn heavy_test_rejection_of_duplicate_tx() -> eyre::Result<()> {
 
     // Mine a block and verify that it is included in a block
     node.mine_block().await?;
-    assert_eq!(node.get_height().await, 1);
+    assert_eq!(node.get_canonical_chain_height().await, 1);
     let block1 = node.get_block_by_height(1).await?;
     let txid_map = block1.get_data_ledger_tx_ids();
     assert!(txid_map.get(&DataLedger::Submit).unwrap().contains(&txid));
@@ -57,7 +57,7 @@ async fn heavy_test_rejection_of_duplicate_tx() -> eyre::Result<()> {
     // Mine a block and verify the duplicate tx is not included again
     node.mine_block().await?;
     let block2 = node.get_block_by_height(2).await?;
-    assert_eq!(node.get_height().await, 2);
+    assert_eq!(node.get_canonical_chain_height().await, 2);
     let txid_map = block2.get_data_ledger_tx_ids();
     assert!(!txid_map.get(&DataLedger::Submit).unwrap().contains(&txid));
 
@@ -81,7 +81,7 @@ async fn heavy_test_rejection_of_duplicate_tx() -> eyre::Result<()> {
 
     // Mine a block and verify the stake commitment is included
     node.mine_block().await?;
-    assert_eq!(node.get_height().await, 3);
+    assert_eq!(node.get_canonical_chain_height().await, 3);
     let block3 = node.get_block_by_height(3).await?;
     let tx_ids = block3.get_commitment_ledger_tx_ids();
     let txid_map = block3.get_data_ledger_tx_ids();
@@ -96,7 +96,7 @@ async fn heavy_test_rejection_of_duplicate_tx() -> eyre::Result<()> {
 
     // Mine a block and make sure the commitment isn't included again
     node.mine_block().await?;
-    assert_eq!(node.get_height().await, 4);
+    assert_eq!(node.get_canonical_chain_height().await, 4);
     let block4 = node.get_block_by_height(4).await?;
     let tx_ids = block4.get_commitment_ledger_tx_ids();
     let txid_map = block4.get_data_ledger_tx_ids();
@@ -120,7 +120,7 @@ async fn heavy_test_rejection_of_duplicate_tx() -> eyre::Result<()> {
 
     // Mine a block and verify the pledge commitment is included
     node.mine_block().await?;
-    assert_eq!(node.get_height().await, 5);
+    assert_eq!(node.get_canonical_chain_height().await, 5);
     let block5 = node.get_block_by_height(5).await?;
     let tx_ids = block5.get_commitment_ledger_tx_ids();
     let txid_map = block5.get_data_ledger_tx_ids();
@@ -135,7 +135,7 @@ async fn heavy_test_rejection_of_duplicate_tx() -> eyre::Result<()> {
 
     // Mine a block and verify the pledge is not included again
     node.mine_block().await?;
-    assert_eq!(node.get_height().await, 6);
+    assert_eq!(node.get_canonical_chain_height().await, 6);
     let block6 = node.get_block_by_height(6).await?;
     let tx_ids = block6.get_commitment_ledger_tx_ids();
     let txid_map = block6.get_data_ledger_tx_ids();
@@ -145,7 +145,7 @@ async fn heavy_test_rejection_of_duplicate_tx() -> eyre::Result<()> {
 
     // ===== TEST CASE 4: mine an epoch block and test duplicates again =====
     node.mine_blocks(2).await?;
-    assert_eq!(node.get_height().await, 8);
+    assert_eq!(node.get_canonical_chain_height().await, 8);
     let block8 = node.get_block_by_height(8).await?;
     let tx_ids = block8.get_commitment_ledger_tx_ids();
     let txid_map = block8.get_data_ledger_tx_ids();
@@ -170,7 +170,7 @@ async fn heavy_test_rejection_of_duplicate_tx() -> eyre::Result<()> {
 
     // Mine a block and validate that none of them are included
     node.mine_block().await?;
-    assert_eq!(node.get_height().await, 9);
+    assert_eq!(node.get_canonical_chain_height().await, 9);
     let block9 = node.get_block_by_height(9).await?;
     let txid_map = block9.get_data_ledger_tx_ids();
     assert_eq!(txid_map.get(&DataLedger::Submit).unwrap().len(), 0);

--- a/crates/chain/tests/block_production/testing_primitives.rs
+++ b/crates/chain/tests/block_production/testing_primitives.rs
@@ -8,7 +8,7 @@ use crate::utils::IrysNodeTest;
 #[test_log::test(actix::test)]
 async fn heavy_test_wait_until_height() {
     let irys_node = IrysNodeTest::default_async().start().await;
-    let height = irys_node.get_height().await;
+    let height = irys_node.get_canonical_chain_height().await;
     info!("height: {}", height);
     let steps = 2;
     let seconds = 60;
@@ -17,7 +17,7 @@ async fn heavy_test_wait_until_height() {
         .wait_until_height(height + steps, seconds)
         .await
         .unwrap();
-    let height5 = irys_node.get_height().await;
+    let height5 = irys_node.get_canonical_chain_height().await;
     assert!(height5 >= height + steps);
     irys_node.stop().await;
 }
@@ -25,11 +25,11 @@ async fn heavy_test_wait_until_height() {
 #[test_log::test(actix::test)]
 async fn heavy_test_mine() {
     let irys_node = IrysNodeTest::default_async().start().await;
-    let height = irys_node.get_height().await;
+    let height = irys_node.get_canonical_chain_height().await;
     info!("height: {}", height);
     let blocks = 4;
     irys_node.mine_blocks(blocks).await.unwrap();
-    let next_height = irys_node.get_height().await;
+    let next_height = irys_node.get_canonical_chain_height().await;
     assert_eq!(next_height, height + blocks as u64);
     let block = irys_node.get_block_by_height(next_height).await.unwrap();
     assert_eq!(block.height, next_height);
@@ -50,7 +50,7 @@ async fn heavy_test_mine_tx() {
     )]);
     let irys_node = IrysNodeTest::new_genesis(config.clone()).start().await;
 
-    let height = irys_node.get_height().await;
+    let height = irys_node.get_canonical_chain_height().await;
     let data = "Hello, world!".as_bytes().to_vec();
     info!("height: {}", height);
     let tx = irys_node
@@ -58,7 +58,7 @@ async fn heavy_test_mine_tx() {
         .await
         .unwrap();
     irys_node.mine_block().await.unwrap();
-    let next_height = irys_node.get_height().await;
+    let next_height = irys_node.get_canonical_chain_height().await;
     assert_eq!(next_height, height + 1_u64);
     let tx_header = irys_node
         .get_storage_tx_header_from_mempool(&tx.header.id)

--- a/crates/chain/tests/ema_pricing/ema_pricing.rs
+++ b/crates/chain/tests/ema_pricing/ema_pricing.rs
@@ -132,7 +132,7 @@ async fn heavy_test_oracle_price_too_high_gets_capped() -> eyre::Result<()> {
 
     config.oracle = OracleConfig::Mock {
         initial_price: Amount::token(dec!(1.0)).unwrap(),
-        percent_change: Amount::percentage(dec!(0.2)).unwrap(), // every block will increase price by 20%
+        incremental_change: Amount::token(dec!(1.0)).unwrap(),
         // only change direction after 10 blocks
         smoothing_interval: 10,
     };

--- a/crates/chain/tests/integration/cache_service.rs
+++ b/crates/chain/tests/integration/cache_service.rs
@@ -69,9 +69,11 @@ async fn heavy_test_cache_pruning() -> eyre::Result<()> {
 
     // mine block 1 and confirm height is exactly what we need
     node.mine_block().await?;
-    assert_eq!(node.get_height().await, 1_u64);
+    assert_eq!(node.get_canonical_chain_height().await, 1_u64);
 
-    let block = node.get_block_by_height(node.get_height().await).await?;
+    let block = node
+        .get_block_by_height(node.get_canonical_chain_height().await)
+        .await?;
     let anchor = Some(block.block_hash);
 
     // create and sign a data tx
@@ -91,7 +93,7 @@ async fn heavy_test_cache_pruning() -> eyre::Result<()> {
     assert_eq!(resp.status(), StatusCode::OK);
 
     node.mine_block().await?;
-    assert_eq!(node.get_height().await, 2_u64);
+    assert_eq!(node.get_canonical_chain_height().await, 2_u64);
 
     // upload chunk(s)
     for (tx_chunk_offset, chunk_node) in tx.chunks.iter().enumerate() {

--- a/crates/chain/tests/multi_node/ema_forks.rs
+++ b/crates/chain/tests/multi_node/ema_forks.rs
@@ -15,7 +15,8 @@ use rust_decimal_macros::dec;
 #[test_log::test(actix_web::test)]
 async fn heavy_ema_states_valid_across_forks() -> eyre::Result<()> {
     // setup
-    let num_blocks_in_epoch = 10;
+    const PRICE_ADJUSTMENT_INTERVAL: u64 = 2;
+    let num_blocks_in_epoch = 13;
     let seconds_to_wait = 20;
     let block_migration_depth = num_blocks_in_epoch - 1;
     let mut genesis_config = NodeConfig::testnet_with_epochs(num_blocks_in_epoch);
@@ -25,7 +26,7 @@ async fn heavy_ema_states_valid_across_forks() -> eyre::Result<()> {
         .consensus
         .get_mut()
         .ema
-        .price_adjustment_interval = 3;
+        .price_adjustment_interval = PRICE_ADJUSTMENT_INTERVAL;
 
     let peer_signer = genesis_config.new_random_signer();
     genesis_config.fund_genesis_accounts(vec![&peer_signer]);
@@ -36,7 +37,7 @@ async fn heavy_ema_states_valid_across_forks() -> eyre::Result<()> {
     let mut peer_config = node_1.testnet_peer_with_signer(&peer_signer);
     peer_config.oracle = OracleConfig::Mock {
         initial_price: Amount::token(dec!(1.01)).unwrap(),
-        percent_change: Amount::percentage(dec!(0.005)).unwrap(),
+        incremental_change: Amount::token(dec!(0.005)).unwrap(),
         smoothing_interval: 3,
     };
 
@@ -44,10 +45,17 @@ async fn heavy_ema_states_valid_across_forks() -> eyre::Result<()> {
         .testnet_peer_with_assignments_and_name(peer_config, "PEER")
         .await;
 
-    node_1.mine_blocks_without_gossip(7).await?;
-    node_2.mine_blocks_without_gossip(9).await?;
+    let common_height = node_1.get_max_difficulty_block().await;
+    assert_eq!(common_height, node_2.get_max_difficulty_block().await);
+    const BLOCKS_TO_MINE_NODE_1: usize = (PRICE_ADJUSTMENT_INTERVAL as usize * 2) + 3;
+    const BLOCKS_TO_MINE_NODE_2: usize = (PRICE_ADJUSTMENT_INTERVAL as usize * 2) + 5;
+    node_1
+        .mine_blocks_without_gossip(BLOCKS_TO_MINE_NODE_1)
+        .await?;
+    node_2
+        .mine_blocks_without_gossip(BLOCKS_TO_MINE_NODE_2)
+        .await?;
 
-    // todo assert that all the blocks are unique
     let chain_node_1 = node_1
         .node_ctx
         .block_tree_guard
@@ -61,20 +69,58 @@ async fn heavy_ema_states_valid_across_forks() -> eyre::Result<()> {
         .get_canonical_chain()
         .0;
 
-    // compare all unique blocks
-    let blocks_to_compare = chain_node_1.iter().zip(chain_node_2.iter());
+    // Find the height where chains diverged (last common block)
+    let fork_height = common_height.height;
 
-    let mut blocks_validated = 0;
-    for (block_1, block_2) in blocks_to_compare {
-        if block_1.block_hash == block_2.block_hash {
-            continue;
-        }
-        blocks_validated += 1;
+    // Ensure fork happens after the special EMA handling period
+    assert!(
+        fork_height >= (PRICE_ADJUSTMENT_INTERVAL * 2),
+        "Fork height {} must be >= {} (2 price adjustment intervals) for this test",
+        fork_height,
+        PRICE_ADJUSTMENT_INTERVAL * 2
+    );
+
+    // Calculate minimum height where EMA differences should appear
+    // Standard case: need at least 2 intervals for oracle differences to affect EMA
+    let min_height_for_ema_diff = fork_height + (PRICE_ADJUSTMENT_INTERVAL * 2);
+
+    // Compare blocks that have diverged
+    let diverged_blocks: Vec<_> = chain_node_1
+        .iter()
+        .zip(chain_node_2.iter())
+        .filter(|(b1, b2)| b1.block_hash != b2.block_hash)
+        .collect();
+
+    let blocks_compared = diverged_blocks.len();
+    assert_eq!(
+        blocks_compared, BLOCKS_TO_MINE_NODE_1,
+        "expect to have compared the len of the shortest fork amount of blocks"
+    );
+
+    // Process blocks where EMA should differ
+    let blocks_with_ema_diff: Vec<_> = diverged_blocks
+        .iter()
+        .filter(|(b1, _)| b1.height >= min_height_for_ema_diff)
+        .collect();
+
+    tracing::info!(
+        "Fork at height {}, checking EMA differences starting from height {} ({} blocks)",
+        fork_height,
+        min_height_for_ema_diff,
+        blocks_with_ema_diff.len()
+    );
+
+    // Verify all diverged blocks have different hashes
+    for (block_1, block_2) in &diverged_blocks {
         assert_eq!(block_1.height, block_2.height, "heights must be the same");
         assert_ne!(
             block_1.block_hash, block_2.block_hash,
             "block hashes must differ"
         );
+    }
+
+    // Verify EMA differences for blocks after the delay period
+    for (block_1, block_2) in &blocks_with_ema_diff {
         let ema_1 = node_1
             .node_ctx
             .block_tree_guard
@@ -87,28 +133,108 @@ async fn heavy_ema_states_valid_across_forks() -> eyre::Result<()> {
             .read()
             .get_ema_snapshot(&block_2.block_hash)
             .unwrap();
-        let block_raw_1 = node_1.get_block_by_hash(&block_1.block_hash).unwrap();
-        let block_raw_2 = node_2.get_block_by_hash(&block_2.block_hash).unwrap();
+
         assert_ne!(
-            block_raw_1.block_hash, block_raw_2.block_hash,
-            "block hashes must differ"
+            ema_1, ema_2,
+            "ema snapshot values must differ at height {} (>= {} required for EMA differences)",
+            block_1.height, min_height_for_ema_diff
         );
-        dbg!();
-        dbg!();
-        dbg!(
-            block_1.height,
-            // block_raw_1.oracle_irys_price,
-            // block_raw_2.oracle_irys_price,
-            ema_1.ema_price_current_interval,
-            ema_2.ema_price_current_interval
-        );
-        // assert_ne!(ema_1, ema_2, "ema snapshot values must differ");
     }
+
+    // Calculate expected number of blocks with different EMA values
+    // We mined BLOCKS_TO_MINE_NODE_1 blocks after fork_height
+    // EMA differences start at min_height_for_ema_diff
+    // So we expect: (fork_height + BLOCKS_TO_MINE_NODE_1) - min_height_for_ema_diff + 1
+    let last_mined_height = fork_height + BLOCKS_TO_MINE_NODE_1 as u64;
+    let expected_blocks_with_ema_diff = (last_mined_height - min_height_for_ema_diff + 1) as usize;
+
+    assert!(blocks_with_ema_diff.len() > 0);
     assert_eq!(
-        blocks_validated, 7,
-        "expect to have compared the len of the shortest fork"
+        blocks_with_ema_diff.len(),
+        expected_blocks_with_ema_diff,
+        "Expected exactly {} blocks with different EMA values. \
+         Fork at height {}, mined {} blocks (up to height {}), \
+         EMA differences start at height {}",
+        expected_blocks_with_ema_diff,
+        fork_height,
+        BLOCKS_TO_MINE_NODE_1,
+        last_mined_height,
+        min_height_for_ema_diff
     );
-    panic!();
+
+    node_2.gossip_enable();
+    node_1.gossip_enable();
+
+    // converge to the longest chain
+    let tip_block = node_2.get_max_difficulty_block().await;
+    assert_eq!(
+        tip_block.height,
+        common_height.height + BLOCKS_TO_MINE_NODE_2 as u64
+    );
+    node_2.gossip_block(&tip_block)?;
+
+    node_1
+        .wait_until_height_confirmed(tip_block.height, 200)
+        .await?;
+
+    // Verify both nodes have converged to the same canonical chain
+    let final_chain_node_1 = node_1
+        .node_ctx
+        .block_tree_guard
+        .read()
+        .get_canonical_chain()
+        .0;
+    let final_chain_node_2 = node_2
+        .node_ctx
+        .block_tree_guard
+        .read()
+        .get_canonical_chain()
+        .0;
+
+    // Both chains should have the same length
+    assert_eq!(
+        final_chain_node_1.len(),
+        final_chain_node_2.len(),
+        "Both nodes should have chains of equal length after convergence"
+    );
+
+    // Verify all blocks in the canonical chain are identical and have identical EMA snapshots
+    for (block_1, block_2) in final_chain_node_1.iter().zip(final_chain_node_2.iter()) {
+        assert_eq!(
+            block_1.block_hash, block_2.block_hash,
+            "Block hashes must be identical at height {} after convergence",
+            block_1.height
+        );
+        assert_eq!(
+            block_1.height, block_2.height,
+            "Block heights must match"
+        );
+
+        // Get EMA snapshots for both blocks
+        let ema_1 = node_1
+            .node_ctx
+            .block_tree_guard
+            .read()
+            .get_ema_snapshot(&block_1.block_hash)
+            .unwrap();
+        let ema_2 = node_2
+            .node_ctx
+            .block_tree_guard
+            .read()
+            .get_ema_snapshot(&block_2.block_hash)
+            .unwrap();
+
+        assert_eq!(
+            ema_1, ema_2,
+            "EMA snapshots must be identical for block at height {} after convergence",
+            block_1.height
+        );
+    }
+
+    tracing::info!(
+        "Successfully verified convergence: {} blocks with identical EMA snapshots",
+        final_chain_node_1.len()
+    );
 
     node_2.stop().await;
     node_1.stop().await;

--- a/crates/chain/tests/multi_node/ema_forks.rs
+++ b/crates/chain/tests/multi_node/ema_forks.rs
@@ -12,7 +12,7 @@ use rust_decimal_macros::dec;
 // Assert: EMA snapshots differ after the price adjustment interval during the fork.
 // Assert: After convergence, both nodes have identical chains with matching EMA snapshots.
 #[test_log::test(actix_web::test)]
-async fn heavy_ema_states_valid_across_forks() -> eyre::Result<()> {
+async fn heavy_ema_intervals_roll_over_in_forks() -> eyre::Result<()> {
     // setup
     const PRICE_ADJUSTMENT_INTERVAL: u64 = 2;
     let num_blocks_in_epoch = 13;
@@ -46,8 +46,8 @@ async fn heavy_ema_states_valid_across_forks() -> eyre::Result<()> {
 
     let common_height = node_1.get_max_difficulty_block();
     assert_eq!(common_height, node_2.get_max_difficulty_block());
-    const BLOCKS_TO_MINE_NODE_1: usize = (PRICE_ADJUSTMENT_INTERVAL as usize * 2) + 3;
-    const BLOCKS_TO_MINE_NODE_2: usize = (PRICE_ADJUSTMENT_INTERVAL as usize * 2) + 5;
+    const BLOCKS_TO_MINE_NODE_1: usize = (PRICE_ADJUSTMENT_INTERVAL as usize * 2) + 6;
+    const BLOCKS_TO_MINE_NODE_2: usize = (PRICE_ADJUSTMENT_INTERVAL as usize * 2) + 8;
     // Mine blocks in parallel on both nodes to create fork
     tokio::try_join!(
         node_1.mine_blocks_without_gossip(BLOCKS_TO_MINE_NODE_1),

--- a/crates/chain/tests/multi_node/ema_forks.rs
+++ b/crates/chain/tests/multi_node/ema_forks.rs
@@ -1,0 +1,117 @@
+use std::sync::Arc;
+
+use crate::utils::{read_block_from_state, solution_context, BlockValidationOutcome, IrysNodeTest};
+use irys_actors::{
+    async_trait, reth_ethereum_primitives, BlockProdStrategy, BlockProducerInner,
+    ProductionStrategy,
+};
+use irys_types::{
+    storage_pricing::Amount, CommitmentTransaction, IrysBlockHeader, IrysTransactionHeader,
+    NodeConfig, OracleConfig,
+};
+use reth::payload::EthBuiltPayload;
+use rust_decimal_macros::dec;
+
+#[test_log::test(actix_web::test)]
+async fn heavy_ema_states_valid_across_forks() -> eyre::Result<()> {
+    // setup
+    let num_blocks_in_epoch = 10;
+    let seconds_to_wait = 20;
+    let block_migration_depth = num_blocks_in_epoch - 1;
+    let mut genesis_config = NodeConfig::testnet_with_epochs(num_blocks_in_epoch);
+    genesis_config.consensus.get_mut().chunk_size = 32;
+    genesis_config.consensus.get_mut().block_migration_depth = block_migration_depth.try_into()?;
+    genesis_config
+        .consensus
+        .get_mut()
+        .ema
+        .price_adjustment_interval = 3;
+
+    let peer_signer = genesis_config.new_random_signer();
+    genesis_config.fund_genesis_accounts(vec![&peer_signer]);
+    let node_1 = IrysNodeTest::new_genesis(genesis_config.clone())
+        .start_and_wait_for_packing("GENESIS", seconds_to_wait)
+        .await;
+    node_1.start_public_api().await;
+    let mut peer_config = node_1.testnet_peer_with_signer(&peer_signer);
+    peer_config.oracle = OracleConfig::Mock {
+        initial_price: Amount::token(dec!(1.01)).unwrap(),
+        percent_change: Amount::percentage(dec!(0.005)).unwrap(),
+        smoothing_interval: 3,
+    };
+
+    let node_2 = node_1
+        .testnet_peer_with_assignments_and_name(peer_config, "PEER")
+        .await;
+
+    node_1.mine_blocks_without_gossip(7).await?;
+    node_2.mine_blocks_without_gossip(9).await?;
+
+    // todo assert that all the blocks are unique
+    let chain_node_1 = node_1
+        .node_ctx
+        .block_tree_guard
+        .read()
+        .get_canonical_chain()
+        .0;
+    let chain_node_2 = node_2
+        .node_ctx
+        .block_tree_guard
+        .read()
+        .get_canonical_chain()
+        .0;
+
+    // compare all unique blocks
+    let blocks_to_compare = chain_node_1.iter().zip(chain_node_2.iter());
+
+    let mut blocks_validated = 0;
+    for (block_1, block_2) in blocks_to_compare {
+        if block_1.block_hash == block_2.block_hash {
+            continue;
+        }
+        blocks_validated += 1;
+        assert_eq!(block_1.height, block_2.height, "heights must be the same");
+        assert_ne!(
+            block_1.block_hash, block_2.block_hash,
+            "block hashes must differ"
+        );
+        let ema_1 = node_1
+            .node_ctx
+            .block_tree_guard
+            .read()
+            .get_ema_snapshot(&block_1.block_hash)
+            .unwrap();
+        let ema_2 = node_2
+            .node_ctx
+            .block_tree_guard
+            .read()
+            .get_ema_snapshot(&block_2.block_hash)
+            .unwrap();
+        let block_raw_1 = node_1.get_block_by_hash(&block_1.block_hash).unwrap();
+        let block_raw_2 = node_2.get_block_by_hash(&block_2.block_hash).unwrap();
+        assert_ne!(
+            block_raw_1.block_hash, block_raw_2.block_hash,
+            "block hashes must differ"
+        );
+        dbg!();
+        dbg!();
+        dbg!(
+            block_1.height,
+            // block_raw_1.oracle_irys_price,
+            // block_raw_2.oracle_irys_price,
+            ema_1.ema_price_current_interval,
+            ema_2.ema_price_current_interval
+        );
+        // assert_ne!(ema_1, ema_2, "ema snapshot values must differ");
+    }
+    assert_eq!(
+        blocks_validated, 7,
+        "expect to have compared the len of the shortest fork"
+    );
+    panic!();
+
+    node_2.stop().await;
+    node_1.stop().await;
+
+    Ok(())
+}

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -381,7 +381,7 @@ async fn heavy_reorg_tip_moves_across_nodes() -> eyre::Result<()> {
     //
 
     // check peer heights match genesis - i.e. that we are all in sync
-    let current_height = node_a.get_height().await;
+    let current_height = node_a.get_canonical_chain_height().await;
     assert_eq!(current_height, 0);
     node_b
         .wait_until_height(current_height, seconds_to_wait)
@@ -551,9 +551,9 @@ async fn heavy_reorg_tip_moves_across_nodes() -> eyre::Result<()> {
             .await?;
 
         // confirm chain has identical and expected height on all three nodes
-        let a_latest_height = node_a.get_height().await;
-        let b_latest_height = node_b.get_height().await;
-        let c_latest_height = node_c.get_height().await;
+        let a_latest_height = node_a.get_canonical_chain_height().await;
+        let b_latest_height = node_b.get_canonical_chain_height().await;
+        let c_latest_height = node_c.get_canonical_chain_height().await;
         assert_eq!(a_latest_height, c_block4.height);
         assert_eq!(a_latest_height, b_latest_height);
         assert_eq!(a_latest_height, c_latest_height);

--- a/crates/chain/tests/multi_node/mempool_tests.rs
+++ b/crates/chain/tests/multi_node/mempool_tests.rs
@@ -529,7 +529,9 @@ async fn heavy_mempool_fork_recovery_test() -> eyre::Result<()> {
         .service_senders
         .mempool
         .send(MempoolServiceMessage::GetBestMempoolTxs(
-            Some(BlockId::number(peer2.get_height().await - 1)),
+            Some(BlockId::number(
+                peer2.get_canonical_chain_height().await - 1,
+            )),
             tx,
         ))?;
 
@@ -557,7 +559,7 @@ async fn heavy_mempool_fork_recovery_test() -> eyre::Result<()> {
     );
 
     // mine another block on peer1, so it's the longest chain (with gossip)
-    let height = peer1.get_height().await;
+    let height = peer1.get_canonical_chain_height().await;
     peer1.mine_block().await?;
     // peers should be able to sync
     let (gen, p2) = tokio::join!(

--- a/crates/chain/tests/multi_node/mod.rs
+++ b/crates/chain/tests/multi_node/mod.rs
@@ -1,3 +1,4 @@
+pub mod ema_forks;
 pub mod fork_recovery;
 pub mod mempool_tests;
 pub mod peer_discovery;

--- a/crates/chain/tests/multi_node/sync_chain_state.rs
+++ b/crates/chain/tests/multi_node/sync_chain_state.rs
@@ -371,7 +371,7 @@ async fn slow_heavy_sync_chain_state_then_gossip_blocks() -> eyre::Result<()> {
                 .await?;
         }
 
-        let genesis_index_height = ctx_genesis_node.get_height_on_chain();
+        let genesis_index_height = ctx_genesis_node.get_block_index_height();
         // mine block on genesis
         ctx_genesis_node
             .mine_blocks(1)
@@ -419,7 +419,7 @@ async fn slow_heavy_sync_chain_state_then_gossip_blocks() -> eyre::Result<()> {
     //
     {
         let additional_blocks_for_gossip_test: usize = 2;
-        let genesis_starting_index_height = ctx_genesis_node.get_height_on_chain();
+        let genesis_starting_index_height = ctx_genesis_node.get_block_index_height();
         mine_blocks(
             &ctx_genesis_node.node_ctx,
             additional_blocks_for_gossip_test,

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -15,7 +15,7 @@ use futures::future::select;
 use irys_actors::{
     block_discovery::BlockDiscoveredMessage,
     block_producer::SolutionFoundMessage,
-    block_tree_service::{get_canonical_chain, BlockState, ChainState, ReorgEvent},
+    block_tree_service::{ema_snapshot::EmaSnapshot, get_canonical_chain, BlockState, BlockTreeEntry, ChainState, ReorgEvent},
     block_validation,
     mempool_service::{MempoolServiceMessage, MempoolTxs, TxIngressError},
     packing::wait_for_packing,
@@ -1495,6 +1495,23 @@ impl IrysNodeTest<IrysNodeCtx> {
         //FIXME: In future this "workaround" of using the syncing state to prevent gossip
         //       broadcasts can be replaced with something more appropriate and correctly named
         self.node_ctx.sync_state.set_is_syncing(true);
+    }
+
+    /// Get the full canonical chain as BlockTreeEntry items
+    pub fn get_canonical_chain(&self) -> Vec<BlockTreeEntry> {
+        self.node_ctx
+            .block_tree_guard
+            .read()
+            .get_canonical_chain()
+            .0
+    }
+
+    /// Get the EMA snapshot for a given block hash
+    pub fn get_ema_snapshot(&self, block_hash: &H256) -> Option<Arc<EmaSnapshot>> {
+        self.node_ctx
+            .block_tree_guard
+            .read()
+            .get_ema_snapshot(block_hash)
     }
 }
 

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -15,7 +15,10 @@ use futures::future::select;
 use irys_actors::{
     block_discovery::BlockDiscoveredMessage,
     block_producer::SolutionFoundMessage,
-    block_tree_service::{ema_snapshot::EmaSnapshot, get_canonical_chain, BlockState, BlockTreeEntry, ChainState, ReorgEvent},
+    block_tree_service::{
+        ema_snapshot::EmaSnapshot, get_canonical_chain, BlockState, BlockTreeEntry, ChainState,
+        ReorgEvent,
+    },
     block_validation,
     mempool_service::{MempoolServiceMessage, MempoolTxs, TxIngressError},
     packing::wait_for_packing,
@@ -55,10 +58,7 @@ use std::net::SocketAddr;
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 use std::{future::Future, time::Duration};
-use tokio::{
-    sync::oneshot::error::RecvError,
-    time::{sleep, Instant},
-};
+use tokio::{sync::oneshot::error::RecvError, time::sleep};
 use tracing::{debug, debug_span, error, info};
 
 pub async fn capacity_chunk_solution(
@@ -701,21 +701,19 @@ impl IrysNodeTest<IrysNodeCtx> {
             .height
     }
 
-    pub async fn get_max_difficulty_block(&self) -> IrysBlockHeader {
+    pub fn get_max_difficulty_block(&self) -> IrysBlockHeader {
         let block = self
             .node_ctx
             .block_tree_guard
             .read()
             .get_max_cumulative_difficulty_block()
             .1;
-        let block = self
-            .node_ctx
+        self.node_ctx
             .block_tree_guard
             .read()
             .get_block(&block)
             .unwrap()
-            .clone();
-        block
+            .clone()
     }
 
     /// Returns a future that resolves when a reorg is detected.

--- a/crates/price-oracle/src/lib.rs
+++ b/crates/price-oracle/src/lib.rs
@@ -35,8 +35,7 @@ impl IrysPriceOracle {
 
 /// Self-contained module for the `MockOracle` implementation
 pub mod mock_oracle {
-    use irys_types::storage_pricing::phantoms::Percentage;
-    use rust_decimal_macros::dec;
+
     use std::sync::Mutex;
 
     use super::*;

--- a/crates/price-oracle/src/lib.rs
+++ b/crates/price-oracle/src/lib.rs
@@ -56,8 +56,8 @@ pub mod mock_oracle {
     pub struct MockOracle {
         /// Mutable price state
         context: Mutex<PriceContext>,
-        /// Percent change in decimal form; e.g. dec!(0.05) means 5%
-        percent_change: Amount<Percentage>,
+        /// Const value change on each call
+        incremental_change: Amount<(IrysPrice, Usd)>,
         /// After this many calls, we toggle the direction of change (up/down)
         smoothing_interval: u64,
     }
@@ -67,7 +67,7 @@ pub mod mock_oracle {
         #[must_use]
         pub const fn new(
             initial_price: Amount<(IrysPrice, Usd)>,
-            percent_change: Amount<Percentage>,
+            incremental_change: Amount<(IrysPrice, Usd)>,
             smoothing_interval: u64,
         ) -> Self {
             let price_context = PriceContext {
@@ -77,7 +77,7 @@ pub mod mock_oracle {
             };
             Self {
                 context: Mutex::new(price_context),
-                percent_change,
+                incremental_change,
                 smoothing_interval,
             }
         }
@@ -112,17 +112,21 @@ pub mod mock_oracle {
 
             // Update the price in the current direction
             if guard.going_up {
-                // Price goes up by percent_change
-                guard.price = guard
-                    .price
-                    .add_multiplier(self.percent_change)
-                    .unwrap_or_else(|_| Amount::token(dec!(1.0)).expect("valid token price"));
+                // Price goes up
+                guard.price = Amount::new(
+                    guard
+                        .price
+                        .amount
+                        .saturating_add(self.incremental_change.amount),
+                );
             } else {
-                // Price goes down by percent_change
-                guard.price = guard
-                    .price
-                    .sub_multiplier(self.percent_change)
-                    .unwrap_or_else(|_| Amount::token(dec!(1.0)).expect("valid token price"));
+                // Price goes down
+                guard.price = Amount::new(
+                    guard
+                        .price
+                        .amount
+                        .saturating_sub(self.incremental_change.amount),
+                );
             }
 
             Ok(Amount::new(guard.price.amount))
@@ -142,7 +146,7 @@ pub mod mock_oracle {
             let smoothing_interval = 2;
             let oracle = MockOracle::new(
                 Amount::token(dec!(1.0)).unwrap(),
-                Amount::percentage(dec!(0.05)).unwrap(),
+                Amount::token(dec!(0.05)).unwrap(),
                 smoothing_interval,
             );
 
@@ -161,7 +165,7 @@ pub mod mock_oracle {
             let smoothing_interval = 3;
             let oracle = MockOracle::new(
                 Amount::token(dec!(1.0)).unwrap(),
-                Amount::percentage(dec!(0.10)).unwrap(),
+                Amount::token(dec!(0.10)).unwrap(),
                 smoothing_interval,
             );
 
@@ -178,7 +182,7 @@ pub mod mock_oracle {
             let smoothing_interval = 2;
             let oracle = MockOracle::new(
                 Amount::token(dec!(1.0)).unwrap(),
-                Amount::percentage(dec!(0.10)).unwrap(),
+                Amount::token(dec!(0.10)).unwrap(),
                 smoothing_interval,
             );
 

--- a/crates/types/src/config.rs
+++ b/crates/types/src/config.rs
@@ -305,10 +305,10 @@ pub enum OracleConfig {
 
         /// How much the price can change between updates
         #[serde(
-            deserialize_with = "serde_utils::percentage_amount",
-            serialize_with = "serde_utils::serializes_percentage_amount"
+            deserialize_with = "serde_utils::token_amount",
+            serialize_with = "serde_utils::serializes_token_amount"
         )]
-        percent_change: Amount<Percentage>,
+        incremental_change: Amount<(IrysPrice, Usd)>,
 
         /// Number of blocks between price updates
         smoothing_interval: u64,
@@ -671,7 +671,7 @@ impl NodeConfig {
 
             oracle: OracleConfig::Mock {
                 initial_price: Amount::token(dec!(1)).expect("valid token amount"),
-                percent_change: Amount::percentage(dec!(0.01)).expect("valid percentage"),
+                incremental_change: Amount::percentage(dec!(0.01)).expect("valid percentage"),
                 smoothing_interval: 15,
             },
             mining_key,


### PR DESCRIPTION
**Describe the changes**
- new test that creates 2 forks, each with their own unique EMA snapshot values 
- sync the 2 chains and check if the EMA values on both chains are equal

bugfix:
- The oracle price stored in IrysBlockHeader was incorrect after the second EMA price adjustment interval. This resulted in the oracle price **not** changing **ever** after the 19th block.

misc:
- minor function renaming in test utils to make things clearer


**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.
