### PR TITLE
chore: http api remove unused routes

### DIFF
--- a/crates/api-server/src/lib.rs
+++ b/crates/api-server/src/lib.rs
@@ -82,10 +82,6 @@ pub fn routes() -> impl HttpServiceFactory {
         .route("/tx", web::post().to(tx::post_tx))
         .route("/tx/{tx_id}", web::get().to(tx::get_transaction_api))
         .route(
-            "/tx/{tx_id}/is_promoted",
-            web::get().to(tx::get_tx_is_promoted),
-        )
-        .route(
             "/tx/{tx_id}/local/data_start_offset",
             web::get().to(tx::get_tx_local_start_offset),
         )

--- a/crates/api-server/src/lib.rs
+++ b/crates/api-server/src/lib.rs
@@ -64,10 +64,6 @@ pub fn routes() -> impl HttpServiceFactory {
         )
         .route("/chunk", web::post().to(post_chunk::post_chunk))
         .route(
-            "/chunk/data_root/{ledger_id}/{data_root}/{offset}",
-            web::get().to(get_chunk::get_chunk_by_data_root_offset),
-        )
-        .route(
             "/chunk/ledger/{ledger_id}/{ledger_offset}",
             web::get().to(get_chunk::get_chunk_by_ledger_offset),
         )

--- a/crates/api-server/src/routes/get_chunk.rs
+++ b/crates/api-server/src/routes/get_chunk.rs
@@ -5,7 +5,7 @@ use actix_web::{
     HttpResponse,
 };
 
-use irys_types::{ChunkFormat, DataLedger, H256};
+use irys_types::{ChunkFormat, DataLedger};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -30,36 +30,6 @@ pub async fn get_chunk_by_ledger_offset(
         Ok(Some(chunk)) => Ok(HttpResponse::Ok()
             .content_type(ContentType::json())
             .json(ChunkFormat::Packed(chunk))),
-        Ok(None) => Ok(HttpResponse::NotFound().body("Chunk not found")),
-        Err(e) => {
-            Ok(HttpResponse::InternalServerError().body(format!("Error retrieving chunk: {}", e)))
-        }
-    }
-}
-
-#[derive(Deserialize)]
-pub struct DataRootChunkApiPath {
-    ledger_id: u32,
-    data_root: H256,
-    offset: u32,
-}
-
-pub async fn get_chunk_by_data_root_offset(
-    state: web::Data<ApiState>,
-    path: web::Path<DataRootChunkApiPath>,
-) -> actix_web::Result<HttpResponse> {
-    let ledger = match DataLedger::try_from(path.ledger_id) {
-        Ok(l) => l,
-        Err(e) => return Ok(HttpResponse::BadRequest().body(format!("Invalid ledger id: {}", e))),
-    };
-
-    match state
-        .chunk_provider
-        .get_chunk_by_data_root(ledger, path.data_root, path.offset.into())
-    {
-        Ok(Some(chunk)) => Ok(HttpResponse::Ok()
-            .content_type(ContentType::json())
-            .json(chunk)),
         Ok(None) => Ok(HttpResponse::NotFound().body("Chunk not found")),
         Err(e) => {
             Ok(HttpResponse::InternalServerError().body(format!("Error retrieving chunk: {}", e)))

--- a/crates/api-server/src/routes/tx.rs
+++ b/crates/api-server/src/routes/tx.rs
@@ -193,18 +193,3 @@ pub async fn get_tx_local_start_offset(
         }
     }
 }
-
-// TODO: REMOVE ME ONCE WE HAVE A GATEWAY
-/// Returns whether or not a transaction has been promoted
-/// by checking if the ingress_proofs field of the tx's header is `Some`,
-///  which only occurs when it's been promoted.
-pub async fn get_tx_is_promoted(
-    state: web::Data<ApiState>,
-    path: web::Path<H256>,
-) -> Result<Json<bool>, ApiError> {
-    let tx_id: H256 = path.into_inner();
-    info!("Get tx_is_promoted by tx_id: {}", tx_id);
-    let tx_header = get_storage_transaction(&state, tx_id)?;
-
-    Ok(web::Json(tx_header.ingress_proofs.is_some()))
-}


### PR DESCRIPTION
**Describe the changes**
 - Remove two endpoints and supporting code:
   - `/chunk/data_root/{ledger_id}/{data_root}/{offset}`
   - `/tx/{tx_id}/is_promoted`

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

