### PR TITLE
chore: test utils cleanup mine_block() usage

### DIFF
--- a/crates/chain/tests/api/client.rs
+++ b/crates/chain/tests/api/client.rs
@@ -1,6 +1,6 @@
 //! api client tests
 
-use crate::utils::{mine_block, IrysNodeTest};
+use crate::utils::IrysNodeTest;
 use irys_api_client::{ApiClient as _, IrysApiClient};
 use irys_chain::IrysNodeCtx;
 use irys_types::{
@@ -73,9 +73,15 @@ async fn check_transaction_endpoints(
     ctx: &IrysNodeTest<IrysNodeCtx>,
 ) {
     // advance one block
-    let (_previous_header, _payload) = mine_block(&ctx.node_ctx).await.unwrap().unwrap();
+    let _previous_header = ctx
+        .mine_block()
+        .await
+        .expect("expected mined block");
     // advance one block, finalizing the previous block
-    let (_header, _payload) = mine_block(&ctx.node_ctx).await.unwrap().unwrap();
+    let _header = ctx
+        .mine_block()
+        .await
+        .expect("expected mined block");
 
     let tx = ctx
         .create_signed_data_tx(&ctx.node_ctx.config.irys_signer(), vec![1, 2, 3])
@@ -97,7 +103,10 @@ async fn check_transaction_endpoints(
         .expect("valid post transaction response");
 
     // advance one block to add the transaction to the block
-    let (_header, _payload) = mine_block(&ctx.node_ctx).await.unwrap().unwrap();
+    let _header = ctx
+        .mine_block()
+        .await
+        .expect("expected mined block");
 
     let retrieved_tx = api_client
         .get_transaction(api_address, tx_id)
@@ -125,9 +134,15 @@ async fn check_get_block_endpoint(
     ctx: &IrysNodeTest<IrysNodeCtx>,
 ) {
     // advance one block
-    let (previous_header, _payload) = mine_block(&ctx.node_ctx).await.unwrap().unwrap();
+    let previous_header = ctx
+        .mine_block()
+        .await
+        .expect("expected mined block");
     // advance one block, finalizing the previous block
-    let (_header, _payload) = mine_block(&ctx.node_ctx).await.unwrap().unwrap();
+    let _header = ctx
+        .mine_block()
+        .await
+        .expect("expected mined block");
 
     let previous_block_hash = previous_header.block_hash;
     let block = api_client

--- a/crates/chain/tests/api/client.rs
+++ b/crates/chain/tests/api/client.rs
@@ -73,15 +73,9 @@ async fn check_transaction_endpoints(
     ctx: &IrysNodeTest<IrysNodeCtx>,
 ) {
     // advance one block
-    let _previous_header = ctx
-        .mine_block()
-        .await
-        .expect("expected mined block");
+    let _previous_header = ctx.mine_block().await.expect("expected mined block");
     // advance one block, finalizing the previous block
-    let _header = ctx
-        .mine_block()
-        .await
-        .expect("expected mined block");
+    let _header = ctx.mine_block().await.expect("expected mined block");
 
     let tx = ctx
         .create_signed_data_tx(&ctx.node_ctx.config.irys_signer(), vec![1, 2, 3])
@@ -103,10 +97,7 @@ async fn check_transaction_endpoints(
         .expect("valid post transaction response");
 
     // advance one block to add the transaction to the block
-    let _header = ctx
-        .mine_block()
-        .await
-        .expect("expected mined block");
+    let _header = ctx.mine_block().await.expect("expected mined block");
 
     let retrieved_tx = api_client
         .get_transaction(api_address, tx_id)
@@ -134,15 +125,9 @@ async fn check_get_block_endpoint(
     ctx: &IrysNodeTest<IrysNodeCtx>,
 ) {
     // advance one block
-    let previous_header = ctx
-        .mine_block()
-        .await
-        .expect("expected mined block");
+    let previous_header = ctx.mine_block().await.expect("expected mined block");
     // advance one block, finalizing the previous block
-    let _header = ctx
-        .mine_block()
-        .await
-        .expect("expected mined block");
+    let _header = ctx.mine_block().await.expect("expected mined block");
 
     let previous_block_hash = previous_header.block_hash;
     let block = api_client

--- a/crates/chain/tests/block_production/analytics.rs
+++ b/crates/chain/tests/block_production/analytics.rs
@@ -21,7 +21,6 @@ use irys_types::TxChunkOffset;
 use irys_types::UnpackedChunk;
 use irys_types::{irys::IrysSigner, serialization::*, IrysTransaction, SimpleRNG};
 
-use crate::utils::mine_block;
 use crate::utils::IrysNodeTest;
 
 // network simulation test for analytics
@@ -241,7 +240,7 @@ async fn test_blockprod_with_evm_txs() -> eyre::Result<()> {
             }
         }
 
-        mine_block(&node.node_ctx).await?;
+        node.mine_block().await?;
         info!("Finished step {}", &i);
     }
 

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -1123,6 +1123,9 @@ async fn heavy_test_always_build_on_max_difficulty_block() -> eyre::Result<()> {
     // re-enable validation
     node.node_ctx.set_validation_enabled(true);
 
+    // the following wait stabilises the mining to block 6 that occurs directly after this wait.
+    node.wait_until_height(5, 9).await?;
+
     // Now mine a new block using the normal mining method
     // This should wait for validation and build on the last optimistic block
     info!("Mining normal block after optimistic chain");

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -1123,13 +1123,10 @@ async fn heavy_test_always_build_on_max_difficulty_block() -> eyre::Result<()> {
     // re-enable validation
     node.node_ctx.set_validation_enabled(true);
 
-    // the following wait stabilises the mining to block 6 that occurs directly after this wait.
-    node.wait_until_height(5, 9).await?;
-
     // Now mine a new block using the normal mining method
     // This should wait for validation and build on the last optimistic block
     info!("Mining normal block after optimistic chain");
-    let normal_block = node.mine_block().await?;
+    let (normal_block, _) = mine_block(&node.node_ctx).await?.unwrap();
 
     // Wait for the normal block to be fully processed
     node.wait_until_height(normal_block.height, 10).await?;

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -2,7 +2,6 @@ use alloy_core::primitives::{ruint::aliases::U256, TxKind};
 use alloy_eips::eip2718::Encodable2718 as _;
 use alloy_eips::HashOrNumber;
 use alloy_genesis::GenesisAccount;
-use eyre::OptionExt as _;
 use irys_actors::block_tree_service::{ema_snapshot::EmaSnapshot, BlockState, ChainState};
 use irys_actors::mempool_service::TxIngressError;
 use irys_actors::{async_trait, sha, BlockProdStrategy, BlockProducerInner, ProductionStrategy};
@@ -14,10 +13,13 @@ use irys_reth_node_bridge::irys_reth::shadow_tx::{
 use irys_reth_node_bridge::reth_e2e_test_utils::transaction::TransactionTestContext;
 use irys_types::{irys::IrysSigner, IrysBlockHeader, NodeConfig};
 use irys_types::{IrysTransactionCommon as _, H256};
-use reth::providers::{AccountReader as _, ReceiptProvider as _, TransactionsProvider as _};
-use reth::{providers::BlockReader as _, rpc::types::TransactionRequest};
-use std::sync::Arc;
-use std::time::Duration;
+use reth::{
+    providers::{
+        AccountReader as _, BlockReader as _, ReceiptProvider as _, TransactionsProvider as _,
+    },
+    rpc::types::TransactionRequest,
+};
+use std::{sync::Arc, time::Duration};
 use tokio::time::sleep;
 use tracing::info;
 
@@ -64,7 +66,7 @@ async fn heavy_test_blockprod() -> eyre::Result<()> {
     let reth_receipts = context
         .inner
         .provider
-        .receipts_by_block(HashOrNumber::Hash(reth_exec_env.block().hash()))?
+        .receipts_by_block(HashOrNumber::Hash(irys_block.evm_block_hash))?
         .unwrap();
 
     // block reward
@@ -134,7 +136,7 @@ async fn heavy_test_blockprod() -> eyre::Result<()> {
     let db_irys_block = node.get_block_by_hash(&irys_block.block_hash).unwrap();
     assert_eq!(
         db_irys_block.evm_block_hash,
-        reth_block.into_header().hash_slow()
+        reth_block.clone().into_header().hash_slow()
     );
 
     node.stop().await;
@@ -393,9 +395,7 @@ async fn heavy_rewards_get_calculated_correctly() -> eyre::Result<()> {
 
     for _ in 0..3 {
         // mine a single block
-        let (block, _reth_exec_env) = mine_block(&node.node_ctx)
-            .await?
-            .ok_or_eyre("block was not mined")?;
+        let block = node.mine_block().await?;
 
         // obtain the EVM timestamp for this block from Reth
         let reth_block = reth_context
@@ -460,16 +460,15 @@ async fn heavy_test_unfunded_user_tx_rejected() -> eyre::Result<()> {
     }
 
     // Mine a block - should only contain block reward transaction
-    let (_irys_block, reth_exec_env) = mine_block(&node.node_ctx).await?.unwrap();
+    let irys_block = node.mine_block().await?;
     let context = node.node_ctx.reth_node_adapter.clone();
 
     // Verify block transactions - should only contain block reward shadow transaction
-    let block_txs = reth_exec_env
-        .block()
-        .body()
-        .transactions
-        .iter()
-        .collect::<Vec<_>>();
+    let block_txs = context
+        .inner
+        .provider
+        .transactions_by_block(HashOrNumber::Hash(irys_block.evm_block_hash))?
+        .unwrap();
 
     assert_eq!(
         block_txs.len(),
@@ -544,16 +543,15 @@ async fn heavy_test_nonexistent_user_tx_rejected() -> eyre::Result<()> {
     }
 
     // Mine a block - should only contain block reward transaction
-    let (_irys_block, reth_exec_env) = mine_block(&node.node_ctx).await?.unwrap();
+    let irys_block = node.mine_block().await?;
     let context = node.node_ctx.reth_node_adapter.clone();
 
     // Verify block transactions - should only contain block reward shadow transaction
-    let block_txs = reth_exec_env
-        .block()
-        .body()
-        .transactions
-        .iter()
-        .collect::<Vec<_>>();
+    let block_txs = context
+        .inner
+        .provider
+        .transactions_by_block(HashOrNumber::Hash(irys_block.evm_block_hash))?
+        .unwrap();
 
     assert_eq!(
         block_txs.len(),
@@ -629,13 +627,13 @@ async fn heavy_test_just_enough_funds_tx_included() -> eyre::Result<()> {
     assert_eq!(tx.header.total_fee(), 2, "Total fee should be 2");
 
     // Mine a block - should contain block reward and storage fee transactions
-    let (irys_block, reth_exec_env) = mine_block(&node.node_ctx).await?.unwrap();
+    let irys_block = node.mine_block().await?;
     node.wait_until_height(irys_block.height, 10).await?;
     let context = node.node_ctx.reth_node_adapter.clone();
     let reth_receipts = context
         .inner
         .provider
-        .receipts_by_block(HashOrNumber::Hash(reth_exec_env.block().hash()))?
+        .receipts_by_block(HashOrNumber::Hash(irys_block.evm_block_hash))?
         .unwrap();
 
     // Should have 2 receipts: block reward and storage fees
@@ -746,7 +744,7 @@ async fn heavy_staking_pledging_txs_included() -> eyre::Result<()> {
         .await?;
 
     // Mine a block to get the stake commitment included
-    let (irys_block1, reth_exec_env1) = mine_block(&genesis_node.node_ctx).await?.unwrap();
+    let irys_block1 = genesis_node.mine_block().await?;
     genesis_node
         .wait_until_height(irys_block1.height, 10)
         .await?;
@@ -755,7 +753,7 @@ async fn heavy_staking_pledging_txs_included() -> eyre::Result<()> {
     let receipts1 = reth_context
         .inner
         .provider
-        .receipts_by_block(HashOrNumber::Hash(reth_exec_env1.block().hash()))?
+        .receipts_by_block(HashOrNumber::Hash(irys_block1.evm_block_hash))?
         .unwrap();
 
     // Verify block contains all expected shadow transactions
@@ -830,7 +828,7 @@ async fn heavy_staking_pledging_txs_included() -> eyre::Result<()> {
     );
 
     // Mine another block to verify the system continues to work
-    let (irys_block2, reth_exec_env2) = mine_block(&genesis_node.node_ctx).await?.unwrap();
+    let irys_block2 = genesis_node.mine_block().await?;
     genesis_node
         .wait_until_height(irys_block2.height, 10)
         .await?;
@@ -839,7 +837,7 @@ async fn heavy_staking_pledging_txs_included() -> eyre::Result<()> {
     let receipts2 = reth_context
         .inner
         .provider
-        .receipts_by_block(HashOrNumber::Hash(reth_exec_env2.block().hash()))?
+        .receipts_by_block(HashOrNumber::Hash(irys_block2.evm_block_hash))?
         .unwrap();
 
     // Second block should only have block reward
@@ -861,12 +859,11 @@ async fn heavy_staking_pledging_txs_included() -> eyre::Result<()> {
     assert_eq!(peer_assignments.len(), 1);
 
     // Verify block transactions contain the expected shadow transactions in the correct order
-    let block_txs1 = reth_exec_env1
-        .block()
-        .body()
-        .transactions
-        .iter()
-        .collect::<Vec<_>>();
+    let block_txs1 = reth_context
+        .inner
+        .provider
+        .transactions_by_block(HashOrNumber::Hash(irys_block1.evm_block_hash))?
+        .unwrap();
 
     // Block should contain exactly 3 transactions: block reward, stake, pledge (in that order)
     assert_eq!(
@@ -1129,7 +1126,7 @@ async fn heavy_test_always_build_on_max_difficulty_block() -> eyre::Result<()> {
     // Now mine a new block using the normal mining method
     // This should wait for validation and build on the last optimistic block
     info!("Mining normal block after optimistic chain");
-    let (normal_block, _) = mine_block(&node.node_ctx).await?.unwrap();
+    let normal_block = node.mine_block().await?;
 
     // Wait for the normal block to be fully processed
     node.wait_until_height(normal_block.height, 10).await?;

--- a/crates/chain/tests/ema_pricing/ema_pricing.rs
+++ b/crates/chain/tests/ema_pricing/ema_pricing.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::utils::{mine_block, IrysNodeTest};
+use crate::utils::IrysNodeTest;
 use irys_actors::block_tree_service::{get_canonical_chain, BlockTreeReadGuard};
 use irys_types::{storage_pricing::Amount, IrysBlockHeader, NodeConfig, OracleConfig, H256};
 use rust_decimal_macros::dec;
@@ -140,11 +140,11 @@ async fn heavy_test_oracle_price_too_high_gets_capped() -> eyre::Result<()> {
     let ctx = IrysNodeTest::new_genesis(config).start().await;
 
     // mine 3 blocks
-    let (header_1, _payload) = mine_block(&ctx.node_ctx).await?.unwrap();
+    let header_1 = ctx.mine_block().await?;
     ctx.wait_until_height(header_1.height, 10).await?;
-    let (header_2, _payload) = mine_block(&ctx.node_ctx).await?.unwrap();
+    let header_2 = ctx.mine_block().await?;
     ctx.wait_until_height(header_2.height, 10).await?;
-    let (header_3, _payload) = mine_block(&ctx.node_ctx).await?.unwrap();
+    let header_3 = ctx.mine_block().await?;
     ctx.wait_until_height(header_3.height, 10).await?;
 
     // assert that all of the prices are the max allowed ones (guaranteed by the mock oracle reporting inflated values)

--- a/crates/chain/tests/multi_node/mempool_tests.rs
+++ b/crates/chain/tests/multi_node/mempool_tests.rs
@@ -13,7 +13,6 @@ use irys_testing_utils::initialize_tracing;
 use irys_types::{irys::IrysSigner, CommitmentTransaction, DataLedger, NodeConfig, H256};
 use k256::ecdsa::SigningKey;
 use reth::{
-    network::{PeerInfo, Peers as _},
     primitives::{Receipt, Transaction},
     rpc::{
         api::EthApiClient,
@@ -496,18 +495,9 @@ async fn heavy_mempool_fork_recovery_test() -> eyre::Result<()> {
     assert_ne!(peer2_recipient1_balance, expected_recipient1_balance);
 
     // reconnect the peers
-
-    let reconnect_all = async |ctx: &IrysRethNodeAdapter, peers: &Vec<PeerInfo>| {
-        for peer in peers {
-            ctx.inner
-                .network
-                .connect_peer(peer.remote_id, peer.remote_addr);
-        }
-    };
-
-    reconnect_all(&genesis_reth_context, &genesis_peers).await;
-    reconnect_all(&peer1_reth_context, &peer1_peers).await;
-    reconnect_all(&peer2_reth_context, &peer2_peers).await;
+    genesis.reconnect_all_reth_peers(&genesis_peers);
+    peer1.reconnect_all_reth_peers(&peer1_peers);
+    peer2.reconnect_all_reth_peers(&peer2_peers);
 
     // try to insert a storage tx that is only valid on peer2's fork
     // then try to fetch best txs from peer2 once it reorgs to peer1's fork

--- a/crates/chain/tests/promotion/data_promotion_double.rs
+++ b/crates/chain/tests/promotion/data_promotion_double.rs
@@ -1,4 +1,4 @@
-use crate::utils::{get_block_parent, mine_block, verify_published_chunk, IrysNodeTest};
+use crate::utils::{get_block_parent, verify_published_chunk, IrysNodeTest};
 use crate::utils::{mine_blocks, post_chunk};
 use actix_web::test::{self, call_service, TestRequest};
 use alloy_core::primitives::U256;
@@ -52,7 +52,7 @@ async fn heavy_double_root_data_promotion_test() {
     .await
     .unwrap();
 
-    let block1 = mine_block(&node.node_ctx).await.unwrap().unwrap();
+    let block1 = node.mine_block().await.expect("expected mined block");
 
     let app = node.start_public_api().await;
 
@@ -205,8 +205,8 @@ async fn heavy_double_root_data_promotion_test() {
     debug!("PHASE 2");
 
     // mine 1 block
-    let blk = mine_block(&node.node_ctx).await.unwrap().unwrap();
-    debug!("P2 block {}", &blk.0.height);
+    let blk = node.mine_block().await.expect("expected mined block");
+    debug!("P2 block {}", &blk.height);
 
     // ensure the ingress proof still exists
     let ingress_proofs = db.view(walk_all::<IngressProofs, _>).unwrap().unwrap();
@@ -227,9 +227,7 @@ async fn heavy_double_root_data_promotion_test() {
         }
         // we have to use a different signer so we get a unique txid for each transaction, despite the identical data_root
         let s = &signer2;
-        let tx = s
-            .create_transaction(data, Some(block1.0.block_hash))
-            .unwrap();
+        let tx = s.create_transaction(data, Some(block1.block_hash)).unwrap();
         let tx = s.sign_transaction(tx).unwrap();
         println!("tx[2] {}", tx.header.id.as_bytes().to_base58());
         txs.push(tx);

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -653,7 +653,7 @@ impl IrysNodeTest<IrysNodeCtx> {
                 };
             }
             drop(ro_tx);
-            mine_block(&self.node_ctx).await.unwrap();
+            self.mine_block().await?;
             sleep(Duration::from_secs(1)).await;
         }
 

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -699,7 +699,7 @@ impl IrysNodeTest<IrysNodeCtx> {
             }
             drop(ro_tx);
             if mine_blocks {
-              self.mine_block().await?;
+                self.mine_block().await?;
             }
             sleep(Duration::from_secs(1)).await;
         }


### PR DESCRIPTION
**Describe the changes**
 - Remove many uses of deprecated `mine_block()` fn in favour of `mine_block()` method.
 - ~Improve stability of `heavy_test_always_build_on_max_difficulty_block()`~ see https://github.com/Irys-xyz/irys/issues/519

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.
