### PR TITLE
test: reorg publish txs test across 3 nodes and multiple forks

### DIFF
--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -792,6 +792,11 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
         signer_c_genesis_balance
     );
 
+    // check block 1 mining reward is not 0
+    assert_ne!(a_block1.reward_amount, U256::from(0_u128));
+    assert_ne!(b_block1.reward_amount, U256::from(0_u128));
+    assert_ne!(c_block1.reward_amount, U256::from(0_u128));
+
     //
     // Stage 3: DISABLE ANY/ALL GOSSIP
     //

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -821,10 +821,16 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
     let peer_b_b2_submit_tx = node_b
         .post_data_tx(b_block1.block_hash, data.clone(), &b_signer)
         .await;
+    node_b
+        .post_chunk_32b(&peer_b_b2_submit_tx, 0, &data_chunks)
+        .await;
 
     // node_c generates txs in isolation for inclusion block 2
     let peer_c_b2_submit_tx = node_c
         .post_data_tx(c_block1.block_hash, data, &c_signer)
+        .await;
+    node_c
+        .post_chunk_32b(&peer_c_b2_submit_tx, 0, &data_chunks)
         .await;
 
     //

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -698,8 +698,8 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
         .await;
 
     // additional configs for peers
-    let config_b = node_a.testnet_peer_with_signer(&c_signer);
-    let config_c = node_a.testnet_peer_with_signer(&b_signer);
+    let config_b = node_a.testnet_peer_with_signer(&b_signer);
+    let config_c = node_a.testnet_peer_with_signer(&c_signer);
 
     // start peer nodes
     let node_b = IrysNodeTest::new(config_b)

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -934,12 +934,25 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
             sorted_data_txs_at(&node_a, 1, DataLedger::Submit).await?,
             vec![]
         );
+
+        assert_eq!(
+            sorted_data_txs_at(&node_a, 1, DataLedger::Publish).await?,
+            vec![]
+        );
         assert_eq!(
             sorted_data_txs_at(&node_a, 2, DataLedger::Submit).await?,
             peer_b_submit_txs
         ); // expect only the two txs included in Peer B B2
         assert_eq!(
+            sorted_data_txs_at(&node_a, 2, DataLedger::Publish).await?,
+            vec![]
+        );
+        assert_eq!(
             sorted_data_txs_at(&node_a, 3, DataLedger::Submit).await?,
+            vec![]
+        );
+        assert_eq!(
+            sorted_data_txs_at(&node_a, 3, DataLedger::Publish).await?,
             vec![]
         );
         // Expect txs that were mined in both c2 (non canonical) and c4 (now canonical)
@@ -948,6 +961,11 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
         assert_eq!(
             sorted_data_txs_at(&node_a, 4, DataLedger::Submit).await?,
             peer_c_submit_txs
+        );
+
+        assert_eq!(
+            sorted_data_txs_at(&node_a, 4, DataLedger::Publish).await?,
+            vec![]
         );
 
         assert_eq!(

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use crate::utils::IrysNodeTest;
 use base58::ToBase58 as _;
 use irys_chain::IrysNodeCtx;
@@ -913,13 +915,13 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
             height: u64,
             ledger: DataLedger,
         ) -> eyre::Result<Vec<H256>> {
-            let txs_map = node
+            let txs_map: HashSet<H256> = node
                 .get_block_by_height(height)
                 .await?
                 .get_data_ledger_tx_ids()
                 .get(&ledger)
                 .cloned()
-                .unwrap_or_default(); // HashSet<H256>
+                .unwrap_or_default();
 
             let mut txs: Vec<H256> = txs_map.into_iter().collect();
             txs.sort();

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -646,9 +646,9 @@ async fn heavy_reorg_tip_moves_across_nodes_commitment_txs() -> eyre::Result<()>
 ///   We need to verify that
 ///    - publish txs are eligible for inclusion in future blocks once they are no longer part of the canonical chain
 ///    - publish txs do not appear twice, or are missing from canonical chain
-///    - all canonical blocks move to all peers
-///    - TODO: all the balance changes that were applied in one fork are reverted during the Reorg
-///    - TODO: new balance changes are applied based on the new canonical branch
+///    - tests all canonical blocks move to all peers
+///    - tests all the balance changes that were applied in one fork are reverted during the Reorg
+///    - tests new balance changes are applied based on the new canonical branch
 #[test_log::test(actix_web::test)]
 async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
     initialize_tracing();

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -729,11 +729,11 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
 
     // check balances match genesis account balances
     assert_eq!(
-        node_a.get_balance(b_signer.address(), genesis_block.evm_block_hash.into()),
+        node_a.get_balance(b_signer.address(), genesis_block.evm_block_hash),
         signer_b_genesis_balance
     );
     assert_eq!(
-        node_a.get_balance(c_signer.address(), genesis_block.evm_block_hash.into()),
+        node_a.get_balance(c_signer.address(), genesis_block.evm_block_hash),
         signer_c_genesis_balance
     );
 
@@ -769,27 +769,27 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
 
     // check balances in block 1 are unchanged from genesis
     assert_eq!(
-        node_a.get_balance(b_signer.address(), a_block1.evm_block_hash.into()),
+        node_a.get_balance(b_signer.address(), a_block1.evm_block_hash),
         signer_b_genesis_balance
     );
     assert_eq!(
-        node_a.get_balance(c_signer.address(), a_block1.evm_block_hash.into()),
+        node_a.get_balance(c_signer.address(), a_block1.evm_block_hash),
         signer_c_genesis_balance
     );
     assert_eq!(
-        node_b.get_balance(b_signer.address(), b_block1.evm_block_hash.into()),
+        node_b.get_balance(b_signer.address(), b_block1.evm_block_hash),
         signer_b_genesis_balance
     );
     assert_eq!(
-        node_b.get_balance(c_signer.address(), b_block1.evm_block_hash.into()),
+        node_b.get_balance(c_signer.address(), b_block1.evm_block_hash),
         signer_c_genesis_balance
     );
     assert_eq!(
-        node_c.get_balance(b_signer.address(), c_block1.evm_block_hash.into()),
+        node_c.get_balance(b_signer.address(), c_block1.evm_block_hash),
         signer_b_genesis_balance
     );
     assert_eq!(
-        node_c.get_balance(c_signer.address(), c_block1.evm_block_hash.into()),
+        node_c.get_balance(c_signer.address(), c_block1.evm_block_hash),
         signer_c_genesis_balance
     );
 
@@ -856,13 +856,13 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
 
     // check balances in block a2
     assert_eq!(
-        node_a.get_balance(b_signer.address(), a_block2.evm_block_hash.into()),
+        node_a.get_balance(b_signer.address(), a_block2.evm_block_hash),
         signer_b_genesis_balance,
         "Address: {:?}",
         b_signer.address()
     );
     assert_eq!(
-        node_a.get_balance(c_signer.address(), a_block2.evm_block_hash.into()),
+        node_a.get_balance(c_signer.address(), a_block2.evm_block_hash),
         signer_c_genesis_balance,
         "Address: {:?}",
         c_signer.address()
@@ -873,13 +873,13 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
     // including the block reward is required for a valid assertion.
     // The block reward varies with time and therefore is not constant
     assert_eq!(
-        node_b.get_balance(b_signer.address(), b_block2.evm_block_hash.into()),
+        node_b.get_balance(b_signer.address(), b_block2.evm_block_hash),
         signer_b_genesis_balance + b_block2.reward_amount - tx_fee * 2,
         "Address: {:?}",
         b_signer.address()
     );
     assert_eq!(
-        node_b.get_balance(c_signer.address(), b_block2.evm_block_hash.into()),
+        node_b.get_balance(c_signer.address(), b_block2.evm_block_hash),
         signer_c_genesis_balance,
         "Address: {:?}",
         c_signer.address()
@@ -887,13 +887,13 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
 
     // check balances in block b3
     assert_eq!(
-        node_b.get_balance(b_signer.address(), b_block3.evm_block_hash.into()),
+        node_b.get_balance(b_signer.address(), b_block3.evm_block_hash),
         signer_b_genesis_balance + b_block2.reward_amount + b_block3.reward_amount - tx_fee * 2,
         "Address: {:?}",
         b_signer.address()
     );
     assert_eq!(
-        node_b.get_balance(c_signer.address(), b_block3.evm_block_hash.into()),
+        node_b.get_balance(c_signer.address(), b_block3.evm_block_hash),
         signer_c_genesis_balance,
         "Address: {:?}",
         c_signer.address()
@@ -1116,19 +1116,19 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
 
         // assert final balances
         assert_eq!(
-            node_a.get_balance(b_signer.address(), c_block1.evm_block_hash.into()),
+            node_a.get_balance(b_signer.address(), c_block1.evm_block_hash),
             signer_b_genesis_balance,
         );
         assert_eq!(
-            node_a.get_balance(c_signer.address(), c_block1.evm_block_hash.into()),
+            node_a.get_balance(c_signer.address(), c_block1.evm_block_hash),
             signer_c_genesis_balance,
         );
         assert_eq!(
-            node_a.get_balance(b_signer.address(), c_block4.evm_block_hash.into()),
+            node_a.get_balance(b_signer.address(), c_block4.evm_block_hash),
             signer_b_genesis_balance + b_block2.reward_amount + b_block3.reward_amount - tx_fee * 2,
         );
         assert_eq!(
-            node_a.get_balance(c_signer.address(), c_block4.evm_block_hash.into()),
+            node_a.get_balance(c_signer.address(), c_block4.evm_block_hash),
             signer_c_genesis_balance + c_block4.reward_amount - tx_fee * 2,
         );
     }

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -807,11 +807,9 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
     //
     // Stage 3: DISABLE ANY/ALL GOSSIP
     //
-    {
-        node_a.gossip_disable();
-        node_b.gossip_disable();
-        node_c.gossip_disable();
-    }
+    node_a.gossip_disable();
+    node_b.gossip_disable();
+    node_c.gossip_disable();
 
     //
     // Stage 4: GENERATE ISOLATED txs

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -925,6 +925,7 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
         node_c.wait_for_block(&b_block2.block_hash, 10).await?;
         node_c.wait_for_block(&b_block3.block_hash, 10).await?;
         // check node A has not received blocks from B
+        // i.e. that gossip has been disabled and the there is a fork between A and B
         assert!(
             node_a
                 .wait_for_block(&b_block2.block_hash, 1)

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -799,7 +799,7 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
     // Expected state at end of stage 2:
     //  Nodes A, B, C at block height 1
     //  Signer B, C balance remains at genesis balance
-    //  Node A signer has recieved a block reward but we don't use Node A signer in this test
+    //  Node A signer has received a block reward but we don't use Node A signer in this test
 
     //
     // Stage 3: DISABLE ANY/ALL GOSSIP

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -4,7 +4,7 @@ use crate::utils::IrysNodeTest;
 use base58::ToBase58 as _;
 use irys_chain::IrysNodeCtx;
 use irys_testing_utils::*;
-use irys_types::{DataLedger, IrysTransaction, NodeConfig, H256};
+use irys_types::{DataLedger, IrysTransaction, NodeConfig, H256, U256};
 use std::sync::Arc;
 use tracing::debug;
 

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -1064,39 +1064,39 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
         // check correct txs made it into specific canon blocks, that are now synced across every node
         for node in [&node_a, &node_b, &node_c] {
             assert_eq!(
-                sorted_data_txs_at(&node, 1, DataLedger::Submit).await?,
+                sorted_data_txs_at(node, 1, DataLedger::Submit).await?,
                 vec![]
             );
             assert_eq!(
-                sorted_data_txs_at(&node, 1, DataLedger::Publish).await?,
+                sorted_data_txs_at(node, 1, DataLedger::Publish).await?,
                 vec![]
             );
             assert_eq!(
-                sorted_data_txs_at(&node, 2, DataLedger::Submit).await?,
+                sorted_data_txs_at(node, 2, DataLedger::Submit).await?,
                 peer_b_submit_txs
             );
             assert_eq!(
-                sorted_data_txs_at(&node, 2, DataLedger::Publish).await?,
+                sorted_data_txs_at(node, 2, DataLedger::Publish).await?,
                 vec![]
             );
             assert_eq!(
-                sorted_data_txs_at(&node, 3, DataLedger::Submit).await?,
+                sorted_data_txs_at(node, 3, DataLedger::Submit).await?,
                 vec![]
             );
             assert_eq!(
-                sorted_data_txs_at(&node, 3, DataLedger::Publish).await?,
+                sorted_data_txs_at(node, 3, DataLedger::Publish).await?,
                 peer_b_submit_txs // promoted from previous block
             );
             // Expect txs that were mined in both c2 (non canonical) and c4 (now canonical)
             // The reason for them being in the 4th block, is that peer C sees them as non canon when it re-orgs after receiving B2 and B3. Therefore then returns as eligible txs
             // To reiterate. These were previously mined in non canon block C2. They were then mined again in canon block C4
             assert_eq!(
-                sorted_data_txs_at(&node, 4, DataLedger::Submit).await?,
+                sorted_data_txs_at(node, 4, DataLedger::Submit).await?,
                 peer_c_submit_txs
             );
 
             assert_eq!(
-                sorted_data_txs_at(&node, 4, DataLedger::Publish).await?,
+                sorted_data_txs_at(node, 4, DataLedger::Publish).await?,
                 vec![]
             );
         }

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -660,15 +660,17 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
     let num_blocks_in_epoch = 5; // test currently mines 4 blocks, and expects txs to remain in mempool
     let seconds_to_wait = 15;
     let tx_fee = U256::from(1_u128); // todo: this is hard coded in various places test utils and should be corrected in future
+    const DATA_CHUNK_SIZE: usize = 32;
 
     // setup config
     let block_migration_depth = num_blocks_in_epoch - 1;
     let mut genesis_config = NodeConfig::testnet_with_epochs(num_blocks_in_epoch);
-    genesis_config.consensus.get_mut().chunk_size = 32;
+    genesis_config.consensus.get_mut().chunk_size = DATA_CHUNK_SIZE as u64;
     genesis_config.consensus.get_mut().block_migration_depth = block_migration_depth.try_into()?;
 
     // create test data
-    let data = vec![0_u8; genesis_config.consensus.get_mut().chunk_size as usize];
+    let data = vec![0_u8; DATA_CHUNK_SIZE];
+    let data_chunks = vec![[0_u8; DATA_CHUNK_SIZE]];
 
     // signers
     let b_signer = genesis_config.new_random_signer();

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -810,6 +810,49 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
         a_block2.data_ledgers[DataLedger::Publish].tx_ids
     );
 
+    // check balances in block a2
+    assert_eq!(
+        node_a.get_balance(b_signer.address(), a_block2.evm_block_hash.into()),
+        U256::from(690000000000000000_u64),
+        "Address: {:?}",
+        b_signer.address()
+    );
+    assert_eq!(
+        node_a.get_balance(c_signer.address(), a_block2.evm_block_hash.into()),
+        U256::from(690000000000000000_u64),
+        "Address: {:?}",
+        c_signer.address()
+    );
+
+    // check balances in block b2
+    assert_eq!(
+        node_b.get_balance(b_signer.address(), b_block2.evm_block_hash.into()),
+        U256::from(689999999999999998_u64),
+        "Address: {:?}",
+        b_signer.address()
+    );
+    assert_eq!(
+        node_b.get_balance(c_signer.address(), b_block2.evm_block_hash.into()),
+        U256::from(690108687900000000_u64),
+        //         690108688400000000
+        "Address: {:?}",
+        c_signer.address()
+    );
+
+    // check balances in block b3
+    assert_eq!(
+        node_b.get_balance(b_signer.address(), b_block3.evm_block_hash.into()),
+        U256::from(690000000000000000_u64),
+        "Address: {:?}",
+        b_signer.address()
+    );
+    assert_eq!(
+        node_b.get_balance(c_signer.address(), b_block3.evm_block_hash.into()),
+        U256::from(690000000000000000_u64),
+        "Address: {:?}",
+        c_signer.address()
+    );
+
     // NODE B -> Node C
     // post commitment txs and then the blocks to node c
     // this will cause a reorg on node c (which is only height 2) to match the chain on node b (height 3)

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -334,13 +334,13 @@ async fn heavy_fork_recovery_test() -> eyre::Result<()> {
 
 /// Reorg where there are 3 forks and the tip moves across all of them as each is extended longer than the other.
 ///   We need to verify that
-///    - txs are eligible for inclusion in future blocks once they are no longer part of the canonical chain
-///    - txs do not appear twice, or are missing from canonical chain
+///    - commitment txs are eligible for inclusion in future blocks once they are no longer part of the canonical chain
+///    - commitment txs do not appear twice, or are missing from canonical chain
 ///    - all canonical blocks move to all peers
 ///    - TODO: all the balance changes that were applied in one fork are reverted during the Reorg
 ///    - TODO: new balance changes are applied based on the new canonical branch
 #[test_log::test(actix_web::test)]
-async fn heavy_reorg_tip_moves_across_nodes() -> eyre::Result<()> {
+async fn heavy_reorg_tip_moves_across_nodes_commitment_txs() -> eyre::Result<()> {
     initialize_tracing();
     // config variables
     let num_blocks_in_epoch = 5; // test currently mines 4 blocks, and expects txs to remain in mempool
@@ -450,10 +450,6 @@ async fn heavy_reorg_tip_moves_across_nodes() -> eyre::Result<()> {
     let (b_block3, _) = node_b.mine_block_without_gossip().await?; // block b3
 
     // check how many txs made it into each block, we expect no more than 2
-    tracing::error!("peer_b_b2_stake_tx: {:?}", peer_b_b2_stake_tx);
-    tracing::error!("peer_b_b2_pledge_tx: {:?}", peer_b_b2_pledge_tx);
-    tracing::error!("peer_c_b2_stake_tx: {:?}", peer_c_b2_stake_tx);
-    tracing::error!("peer_c_b2_pledge_tx: {:?}", peer_c_b2_pledge_tx);
     assert_eq!(
         b_block2.system_ledgers.len(),
         1,
@@ -586,7 +582,7 @@ async fn heavy_reorg_tip_moves_across_nodes() -> eyre::Result<()> {
         node_c
             .wait_for_mempool_commitment_txs(all_commitment_txs.clone(), seconds_to_wait)
             .await
-            .expect("node_c and node_c txs to still be on node_c");
+            .expect("node_b and node_c txs to still be on node_c");
 
         // sort tx order
         async fn sorted_commitments_at(

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -662,7 +662,7 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
     genesis_config.consensus.get_mut().chunk_size = 32;
     genesis_config.consensus.get_mut().block_migration_depth = block_migration_depth.try_into()?;
 
-    // test data
+    // create test data
     let data = vec![0_u8; genesis_config.consensus.get_mut().chunk_size as usize];
 
     // signers

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -670,6 +670,28 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
     let c_signer = genesis_config.new_random_signer();
     genesis_config.fund_genesis_accounts(vec![&b_signer, &c_signer]);
 
+    // starting balances from config
+    let signer_b_genesis_balance: U256 = genesis_config
+        .consensus
+        .get_mut()
+        .reth
+        .genesis
+        .alloc
+        .get(&b_signer.address())
+        .expect("Expected signer b to have genesis entry")
+        .balance
+        .into();
+    let signer_c_genesis_balance: U256 = genesis_config
+        .consensus
+        .get_mut()
+        .reth
+        .genesis
+        .alloc
+        .get(&c_signer.address())
+        .expect("Expected signer c to have genesis entry")
+        .balance
+        .into();
+
     // genesis node / node_a
     let node_a = IrysNodeTest::new_genesis(genesis_config.clone())
         .start_and_wait_for_packing("NODE_A", seconds_to_wait)
@@ -707,11 +729,11 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
     // check balances match genesis account balances
     assert_eq!(
         node_a.get_balance(b_signer.address(), genesis_block.evm_block_hash.into()),
-        U256::from(690000000000000000_u64)
+        signer_b_genesis_balance
     );
     assert_eq!(
         node_a.get_balance(c_signer.address(), genesis_block.evm_block_hash.into()),
-        U256::from(690000000000000000_u64)
+        signer_c_genesis_balance
     );
 
     //
@@ -747,11 +769,11 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
     // check balances in block 1
     assert_eq!(
         node_a.get_balance(b_signer.address(), a_block1.evm_block_hash.into()),
-        U256::from(690000000000000000_u64)
+        signer_b_genesis_balance
     );
     assert_eq!(
         node_a.get_balance(c_signer.address(), a_block1.evm_block_hash.into()),
-        U256::from(690000000000000000_u64)
+        signer_c_genesis_balance
     );
 
     //

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -1090,6 +1090,7 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
             // Expect txs that were mined in both c2 (non canonical) and c4 (now canonical)
             // The reason for them being in the 4th block, is that peer C sees them as non canon when it re-orgs after receiving B2 and B3. Therefore then returns as eligible txs
             // To reiterate. These were previously mined in non canon block C2. They were then mined again in canon block C4
+            // As they arrive with proofs in block 4, they appear in both the submit and publish ledgers.
             assert_eq!(
                 sorted_data_txs_at(node, 4, DataLedger::Submit).await?,
                 peer_c_submit_txs
@@ -1097,7 +1098,7 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
 
             assert_eq!(
                 sorted_data_txs_at(node, 4, DataLedger::Publish).await?,
-                vec![]
+                peer_c_submit_txs
             );
         }
 

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -4,7 +4,7 @@ use crate::utils::IrysNodeTest;
 use base58::ToBase58 as _;
 use irys_chain::IrysNodeCtx;
 use irys_testing_utils::*;
-use irys_types::{DataLedger, IrysTransaction, NodeConfig, H256};
+use irys_types::{DataLedger, IrysTransaction, NodeConfig, H256, U256};
 use tracing::debug;
 
 #[actix_web::test]
@@ -1000,6 +1000,24 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
         assert_eq!(
             sorted_data_txs_at(&node_c, 4, DataLedger::Submit).await?,
             peer_c_submit_txs
+        );
+
+        // assert balances
+        assert_eq!(
+            node_a.get_balance(b_signer.address(), c_block1.evm_block_hash.into()),
+            U256::from(690000000000000000_u64)
+        );
+        assert_eq!(
+            node_a.get_balance(c_signer.address(), c_block1.evm_block_hash.into()),
+            U256::from(690000000000000000_u64)
+        );
+        assert_eq!(
+            node_a.get_balance(b_signer.address(), c_block4.evm_block_hash.into()),
+            U256::from(690108725499999998_u64)
+        );
+        assert_eq!(
+            node_a.get_balance(c_signer.address(), c_block4.evm_block_hash.into()),
+            U256::from(690108725499999998_u64)
         );
     }
 

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -701,6 +701,19 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
         .wait_until_height(current_height, seconds_to_wait)
         .await?;
 
+    // get genesis block
+    let genesis_block = node_a.get_block_by_height(0).await?;
+
+    // check balances match genesis account balances
+    assert_eq!(
+        node_a.get_balance(b_signer.address(), genesis_block.evm_block_hash.into()),
+        U256::from(690000000000000000_u64)
+    );
+    assert_eq!(
+        node_a.get_balance(c_signer.address(), genesis_block.evm_block_hash.into()),
+        U256::from(690000000000000000_u64)
+    );
+
     //
     // Stage 2: MINE BLOCK
     //

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -881,7 +881,7 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
     );
 
     // check balances in block b2
-    // tx fee is 1, and there should be two txs that we got into block b2 ∴ subtract 2 in the assert
+    // tx fee is 1, and there should be two txs that we got into block b2 therefore subtract 2 in the assert
     // including the block reward is required for a valid assertion.
     // The block reward varies with time and therefore is not constant
     assert_eq!(

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -856,28 +856,30 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
     // check balances in block a2
     assert_eq!(
         node_a.get_balance(b_signer.address(), a_block2.evm_block_hash.into()),
-        U256::from(690000000000000000_u64),
+        signer_b_genesis_balance,
         "Address: {:?}",
         b_signer.address()
     );
     assert_eq!(
         node_a.get_balance(c_signer.address(), a_block2.evm_block_hash.into()),
-        U256::from(690000000000000000_u64),
+        signer_c_genesis_balance,
         "Address: {:?}",
         c_signer.address()
     );
 
     // check balances in block b2
+    // tx fee is 1, and there should be two txs that we got into block b2 ∴ subtract 2 in the assert
+    // including the block reward is required for a valid assertion.
+    // The block reward varies with time and therefore is not constant
     assert_eq!(
         node_b.get_balance(b_signer.address(), b_block2.evm_block_hash.into()),
-        U256::from(689999999999999998_u64),
+        signer_b_genesis_balance + b_block2.reward_amount - U256::from(2_u128),
         "Address: {:?}",
         b_signer.address()
     );
     assert_eq!(
         node_b.get_balance(c_signer.address(), b_block2.evm_block_hash.into()),
-        U256::from(690108687900000000_u64),
-        //         690108688400000000
+        signer_c_genesis_balance,
         "Address: {:?}",
         c_signer.address()
     );
@@ -885,13 +887,14 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
     // check balances in block b3
     assert_eq!(
         node_b.get_balance(b_signer.address(), b_block3.evm_block_hash.into()),
-        U256::from(690000000000000000_u64),
+        signer_b_genesis_balance + b_block2.reward_amount + b_block3.reward_amount
+            - U256::from(2_u128),
         "Address: {:?}",
         b_signer.address()
     );
     assert_eq!(
         node_b.get_balance(c_signer.address(), b_block3.evm_block_hash.into()),
-        U256::from(690000000000000000_u64),
+        signer_c_genesis_balance,
         "Address: {:?}",
         c_signer.address()
     );
@@ -1111,22 +1114,23 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
             peer_c_submit_txs
         );
 
-        // assert balances
+        // assert final balances
         assert_eq!(
             node_a.get_balance(b_signer.address(), c_block1.evm_block_hash.into()),
-            U256::from(690000000000000000_u64)
+            signer_b_genesis_balance,
         );
         assert_eq!(
             node_a.get_balance(c_signer.address(), c_block1.evm_block_hash.into()),
-            U256::from(690000000000000000_u64)
+            signer_c_genesis_balance,
         );
         assert_eq!(
             node_a.get_balance(b_signer.address(), c_block4.evm_block_hash.into()),
-            U256::from(690108725499999998_u64)
+            signer_b_genesis_balance + b_block2.reward_amount + b_block3.reward_amount
+                - U256::from(2_u128),
         );
         assert_eq!(
             node_a.get_balance(c_signer.address(), c_block4.evm_block_hash.into()),
-            U256::from(690108725499999998_u64)
+            signer_c_genesis_balance + c_block4.reward_amount - U256::from(2_u128),
         );
     }
 

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -1103,7 +1103,7 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
             );
         }
 
-        // assert final balances
+        // re-assert start balances
         assert_eq!(
             node_a.get_balance(b_signer.address(), c_block1.evm_block_hash),
             signer_b_genesis_balance,
@@ -1112,6 +1112,7 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
             node_a.get_balance(c_signer.address(), c_block1.evm_block_hash),
             signer_c_genesis_balance,
         );
+        // assert final balances
         assert_eq!(
             node_a.get_balance(b_signer.address(), c_block4.evm_block_hash),
             signer_b_genesis_balance + b_block2.reward_amount + b_block3.reward_amount - tx_fee * 2,

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -655,6 +655,7 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
     // config variables
     let num_blocks_in_epoch = 5; // test currently mines 4 blocks, and expects txs to remain in mempool
     let seconds_to_wait = 15;
+    let tx_fee = U256::from(1_u128); // todo: this is hard coded in various places test utils and should be corrected in future
 
     // setup config
     let block_migration_depth = num_blocks_in_epoch - 1;
@@ -873,7 +874,7 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
     // The block reward varies with time and therefore is not constant
     assert_eq!(
         node_b.get_balance(b_signer.address(), b_block2.evm_block_hash.into()),
-        signer_b_genesis_balance + b_block2.reward_amount - U256::from(2_u128),
+        signer_b_genesis_balance + b_block2.reward_amount - tx_fee * 2,
         "Address: {:?}",
         b_signer.address()
     );
@@ -887,8 +888,7 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
     // check balances in block b3
     assert_eq!(
         node_b.get_balance(b_signer.address(), b_block3.evm_block_hash.into()),
-        signer_b_genesis_balance + b_block2.reward_amount + b_block3.reward_amount
-            - U256::from(2_u128),
+        signer_b_genesis_balance + b_block2.reward_amount + b_block3.reward_amount - tx_fee * 2,
         "Address: {:?}",
         b_signer.address()
     );
@@ -1125,12 +1125,11 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
         );
         assert_eq!(
             node_a.get_balance(b_signer.address(), c_block4.evm_block_hash.into()),
-            signer_b_genesis_balance + b_block2.reward_amount + b_block3.reward_amount
-                - U256::from(2_u128),
+            signer_b_genesis_balance + b_block2.reward_amount + b_block3.reward_amount - tx_fee * 2,
         );
         assert_eq!(
             node_a.get_balance(c_signer.address(), c_block4.evm_block_hash.into()),
-            signer_c_genesis_balance + c_block4.reward_amount - U256::from(2_u128),
+            signer_c_genesis_balance + c_block4.reward_amount - tx_fee * 2,
         );
     }
 

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -690,7 +690,7 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
     //
 
     // check peer heights match genesis - i.e. that we are all in sync
-    let current_height = node_a.get_height().await;
+    let current_height = node_a.get_canonical_chain_height().await;
     assert_eq!(current_height, 0);
     node_b
         .wait_until_height(current_height, seconds_to_wait)
@@ -869,9 +869,9 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
             .await?;
 
         // confirm chain has identical and expected height on all three nodes
-        let a_latest_height = node_a.get_height().await;
-        let b_latest_height = node_b.get_height().await;
-        let c_latest_height = node_c.get_height().await;
+        let a_latest_height = node_a.get_canonical_chain_height().await;
+        let b_latest_height = node_b.get_canonical_chain_height().await;
+        let c_latest_height = node_c.get_canonical_chain_height().await;
         assert_eq!(a_latest_height, c_block4.height);
         assert_eq!(a_latest_height, b_latest_height);
         assert_eq!(a_latest_height, c_latest_height);

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -757,7 +757,9 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
     node_c
         .wait_for_block(&a_block1.block_hash, seconds_to_wait)
         .await?;
+    node_b.wait_until_height(1, seconds_to_wait).await?;
     let b_block1 = node_b.get_block_by_height(1).await?; // get block b1
+    node_c.wait_until_height(1, seconds_to_wait).await?;
     let c_block1 = node_c.get_block_by_height(1).await?; // get block c1
 
     assert_eq!(

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -744,6 +744,16 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
         a_block1.data_ledgers[DataLedger::Submit].tx_ids
     );
 
+    // check balances in block 1
+    assert_eq!(
+        node_a.get_balance(b_signer.address(), a_block1.evm_block_hash.into()),
+        U256::from(690000000000000000_u64)
+    );
+    assert_eq!(
+        node_a.get_balance(c_signer.address(), a_block1.evm_block_hash.into()),
+        U256::from(690000000000000000_u64)
+    );
+
     //
     // Stage 3: DISABLE ANY/ALL GOSSIP
     //

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -639,3 +639,351 @@ async fn heavy_reorg_tip_moves_across_nodes_commitment_txs() -> eyre::Result<()>
     tokio::join!(node_a.stop(), node_b.stop(), node_c.stop(),);
     Ok(())
 }
+
+/// Reorg where there are 3 forks and the tip moves across all of them as each is extended longer than the other.
+///   We need to verify that
+///    - publish txs are eligible for inclusion in future blocks once they are no longer part of the canonical chain
+///    - publish txs do not appear twice, or are missing from canonical chain
+///    - all canonical blocks move to all peers
+///    - TODO: all the balance changes that were applied in one fork are reverted during the Reorg
+///    - TODO: new balance changes are applied based on the new canonical branch
+#[test_log::test(actix_web::test)]
+async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
+    initialize_tracing();
+    // config variables
+    let num_blocks_in_epoch = 5; // test currently mines 4 blocks, and expects txs to remain in mempool
+    let seconds_to_wait = 15;
+
+    // setup config
+    let block_migration_depth = num_blocks_in_epoch - 1;
+    let mut genesis_config = NodeConfig::testnet_with_epochs(num_blocks_in_epoch);
+    genesis_config.consensus.get_mut().chunk_size = 32;
+    genesis_config.consensus.get_mut().block_migration_depth = block_migration_depth.try_into()?;
+
+    // test data
+    let data = vec![0_u8; genesis_config.consensus.get_mut().chunk_size as usize];
+
+    // signers
+    let b_signer = genesis_config.new_random_signer();
+    let c_signer = genesis_config.new_random_signer();
+    genesis_config.fund_genesis_accounts(vec![&b_signer, &c_signer]);
+
+    // genesis node / node_a
+    let node_a = IrysNodeTest::new_genesis(genesis_config.clone())
+        .start_and_wait_for_packing("NODE_A", seconds_to_wait)
+        .await;
+
+    // additional configs for peers
+    let config_b = node_a.testnet_peer_with_signer(&c_signer);
+    let config_c = node_a.testnet_peer_with_signer(&b_signer);
+
+    // start peer nodes
+    let node_b = IrysNodeTest::new(config_b)
+        .start_and_wait_for_packing("NODE_B", seconds_to_wait)
+        .await;
+    let node_c = IrysNodeTest::new(config_c)
+        .start_and_wait_for_packing("NODE_C", seconds_to_wait)
+        .await;
+
+    //
+    // Stage 1: STARTING STATE CHECKS
+    //
+
+    // check peer heights match genesis - i.e. that we are all in sync
+    let current_height = node_a.get_height().await;
+    assert_eq!(current_height, 0);
+    node_b
+        .wait_until_height(current_height, seconds_to_wait)
+        .await?;
+    node_c
+        .wait_until_height(current_height, seconds_to_wait)
+        .await?;
+
+    //
+    // Stage 2: MINE BLOCK
+    //
+
+    // mine a single block, and let everyone sync so future txs start at block height 1.
+    node_a.mine_block().await?; // mine block a1
+    node_a.wait_until_height(1, seconds_to_wait).await?;
+    let a_block1 = node_a.get_block_by_height(1).await?; // get block a1
+    node_b
+        .wait_for_block(&a_block1.block_hash, seconds_to_wait)
+        .await?;
+    node_c
+        .wait_for_block(&a_block1.block_hash, seconds_to_wait)
+        .await?;
+    let b_block1 = node_b.get_block_by_height(1).await?; // get block b1
+    let c_block1 = node_c.get_block_by_height(1).await?; // get block c1
+
+    assert_eq!(
+        a_block1.data_ledgers[DataLedger::Publish].tx_ids.len(),
+        0,
+        "No publish txs should exist to be included in this block. Ledgers: {:?}",
+        a_block1.data_ledgers[DataLedger::Publish].tx_ids
+    );
+    assert_eq!(
+        a_block1.data_ledgers[DataLedger::Submit].tx_ids.len(),
+        0,
+        "No submit txs should exist to be included in this block. Ledgers: {:?}",
+        a_block1.data_ledgers[DataLedger::Submit].tx_ids
+    );
+
+    //
+    // Stage 3: DISABLE ANY/ALL GOSSIP
+    //
+    {
+        node_a.gossip_disable();
+        node_b.gossip_disable();
+        node_c.gossip_disable();
+    }
+
+    //
+    // Stage 4: GENERATE ISOLATED txs
+    //
+
+    // node_b generates txs in isolation for inclusion in block 2
+    let peer_b_b2_submit_tx = node_b
+        .post_data_tx(b_block1.block_hash, data.clone(), &b_signer)
+        .await;
+
+    // node_c generates txs in isolation for inclusion block 2
+    let peer_c_b2_submit_tx = node_c
+        .post_data_tx(c_block1.block_hash, data, &c_signer)
+        .await;
+
+    //
+    // Stage 5: MINE FORK A and B TO HEIGHT 2 and 3
+    //
+
+    // Mine competing blocks on A and B without gossip
+    let (a_block2, _) = node_a.mine_block_without_gossip().await?; // block a2
+    let (b_block2, _) = node_b.mine_block_without_gossip().await?; // block b2
+    let (b_block3, _) = node_b.mine_block_without_gossip().await?; // block b3
+
+    // check how many txs made it into each block, we expect no more than 2
+    assert_eq!(
+        b_block2.data_ledgers[DataLedger::Publish].tx_ids.len(),
+        0,
+        "Expect 0 of the Publish txs on peer B to be in this block."
+    );
+    assert_eq!(
+        b_block2.data_ledgers[DataLedger::Submit].tx_ids.len(),
+        1,
+        "Expect 1 Submit txs on peer B to be in this block."
+    );
+    assert_eq!(
+        a_block2.data_ledgers[DataLedger::Submit].tx_ids.len(),
+        0,
+        "No txs should have been gossiped back to peer A! {:?}",
+        a_block2.data_ledgers[DataLedger::Submit].tx_ids
+    );
+    assert_eq!(
+        a_block2.data_ledgers[DataLedger::Publish].tx_ids.len(),
+        0,
+        "No txs should have been gossiped back to peer A! {:?}",
+        a_block2.data_ledgers[DataLedger::Publish].tx_ids
+    );
+
+    // NODE B -> Node C
+    // post commitment txs and then the blocks to node c
+    // this will cause a reorg on node c (which is only height 2) to match the chain on node b (height 3)
+    // this will cause the txs that were previously canonical from C2 to become non canon
+    {
+        node_c.post_data_tx_raw(&peer_b_b2_submit_tx.header).await;
+        node_b.send_block_to_peer(&node_c, &b_block2).await?;
+        tracing::error!("posted block 2: {:?}", b_block2.block_hash);
+        node_b.send_block_to_peer(&node_c, &b_block3).await?;
+        tracing::error!("posted block 3: {:?}", b_block3.block_hash);
+
+        node_c.wait_for_block(&b_block2.block_hash, 10).await?;
+        node_c.wait_for_block(&b_block3.block_hash, 10).await?;
+        // check node A has not received blocks from B
+        assert!(
+            node_a
+                .wait_for_block(&b_block2.block_hash, 1)
+                .await
+                .is_err(),
+            "Node A should not yet have received block 2 from Node B"
+        );
+        assert!(
+            node_a
+                .wait_for_block(&b_block3.block_hash, 1)
+                .await
+                .is_err(),
+            "Node A should not yet have received block 3 from Node B"
+        );
+    }
+
+    //
+    // Stage 6: MINE FORK C TO HEIGHT 4
+    //
+
+    // Node C mines on top of B's chain and does not gossip it back to B
+    // Node C has the non canon txs from it's now non canon block 2.
+    // Node C will choose to include these txs in block C4
+    if let Err(does_not_reach_height) = node_c.wait_until_height(3, seconds_to_wait).await {
+        tracing::error!(
+            "Node C Failed to reach block height 3: {:?}",
+            does_not_reach_height
+        );
+        Err(does_not_reach_height)?
+    }
+    let (c_block4, _) = node_c.mine_block_without_gossip().await?;
+    if let Err(does_not_reach_height) = node_c.wait_until_height(4, seconds_to_wait).await {
+        tracing::error!(
+            "Node C Failed to reach block height 4: {:?}",
+            does_not_reach_height
+        );
+    }
+    assert_eq!(c_block4.height, 4, "Node C Failed to reach block height 4"); // block c4
+
+    //
+    // Stage 7: FINAL SYNC / RE-ORGs
+    //
+    {
+        // Enable gossip
+        node_a.gossip_enable();
+        node_b.gossip_enable();
+        node_c.gossip_enable();
+        // Gossip all blocks so everyone syncs
+        node_b.gossip_block(&b_block2)?;
+        node_b.gossip_block(&b_block3)?;
+        node_c.gossip_block(&c_block4)?;
+        node_a.gossip_block(&a_block2)?;
+    }
+    //
+    // Stage 8: FINAL STATE CHECKS
+    //
+
+    // confirm all three nodes are at the same and expected height "4"
+    {
+        node_a
+            .wait_until_height(c_block4.height, seconds_to_wait)
+            .await?;
+        node_b
+            .wait_until_height(c_block4.height, seconds_to_wait)
+            .await?;
+        node_c
+            .wait_until_height(c_block4.height, seconds_to_wait)
+            .await?;
+
+        // confirm chain has identical and expected height on all three nodes
+        let a_latest_height = node_a.get_height().await;
+        let b_latest_height = node_b.get_height().await;
+        let c_latest_height = node_c.get_height().await;
+        assert_eq!(a_latest_height, c_block4.height);
+        assert_eq!(a_latest_height, b_latest_height);
+        assert_eq!(a_latest_height, c_latest_height);
+
+        // confirm blocks at this height match c4
+        let a3 = node_a.get_block_by_height(c_block4.height).await?;
+        let b3 = node_b.get_block_by_height(c_block4.height).await?;
+        let c3 = node_c.get_block_by_height(c_block4.height).await?;
+        assert_eq!(a3, b3);
+        assert_eq!(a3, c3);
+    }
+
+    // confirm mempool txs in nodes have remained in the mempool and,
+    // confirm that all txs have made it to all peers, regardless of canon status
+    // Canonical blocks by mining peer: A1, B2, B3, C4
+    {
+        let mut peer_b_submit_txs = vec![peer_b_b2_submit_tx.header.id];
+        peer_b_submit_txs.sort();
+        let mut peer_c_submit_txs = vec![peer_c_b2_submit_tx.header.id];
+        peer_c_submit_txs.sort();
+        let mut all_submit_txs = peer_b_submit_txs.clone();
+        all_submit_txs.extend(&peer_c_submit_txs);
+        all_submit_txs.sort();
+
+        // check txs are in mempools
+        node_b
+            .wait_for_mempool(peer_b_b2_submit_tx.header.id, seconds_to_wait)
+            .await
+            .expect("node_b txs to still be on node_b");
+
+        node_c
+            .wait_for_mempool(peer_c_b2_submit_tx.header.id, seconds_to_wait)
+            .await
+            .expect("node_c txs to still be on node_c");
+
+        // sort tx order
+        async fn sorted_data_txs_at(
+            node: &IrysNodeTest<IrysNodeCtx>,
+            height: u64,
+            ledger: DataLedger,
+        ) -> eyre::Result<Vec<H256>> {
+            let txs_map = node
+                .get_block_by_height(height)
+                .await?
+                .get_data_ledger_tx_ids()
+                .get(&ledger)
+                .cloned()
+                .unwrap_or_default(); // HashSet<H256>
+
+            let mut txs: Vec<H256> = txs_map.into_iter().collect();
+            txs.sort();
+
+            Ok(txs)
+        }
+
+        // check correct txs made it into specific canon blocks, that are now synced across every node
+        assert_eq!(
+            sorted_data_txs_at(&node_a, 1, DataLedger::Submit).await?,
+            vec![]
+        );
+        assert_eq!(
+            sorted_data_txs_at(&node_a, 2, DataLedger::Submit).await?,
+            peer_b_submit_txs
+        ); // expect only the two txs included in Peer B B2
+        assert_eq!(
+            sorted_data_txs_at(&node_a, 3, DataLedger::Submit).await?,
+            vec![]
+        );
+        // Expect txs that were mined in both c2 (non canonical) and c4 (now canonical)
+        // The reason for them being in the 4th block, is that peer C sees them as non canon when it re-orgs after receiving B2 and B3. Therefore then returns as eligible txs
+        // To reiterate. These were previously mined in non canon block C2. They were then mined again in canon block C4
+        assert_eq!(
+            sorted_data_txs_at(&node_a, 4, DataLedger::Submit).await?,
+            peer_c_submit_txs
+        );
+
+        assert_eq!(
+            sorted_data_txs_at(&node_b, 1, DataLedger::Submit).await?,
+            vec![]
+        );
+        assert_eq!(
+            sorted_data_txs_at(&node_b, 2, DataLedger::Submit).await?,
+            peer_b_submit_txs
+        );
+        assert_eq!(
+            sorted_data_txs_at(&node_b, 3, DataLedger::Submit).await?,
+            vec![]
+        );
+        assert_eq!(
+            sorted_data_txs_at(&node_b, 4, DataLedger::Submit).await?,
+            peer_c_submit_txs
+        );
+
+        assert_eq!(
+            sorted_data_txs_at(&node_c, 1, DataLedger::Submit).await?,
+            vec![]
+        );
+        assert_eq!(
+            sorted_data_txs_at(&node_c, 2, DataLedger::Submit).await?,
+            peer_b_submit_txs
+        );
+        assert_eq!(
+            sorted_data_txs_at(&node_c, 3, DataLedger::Submit).await?,
+            vec![]
+        );
+        assert_eq!(
+            sorted_data_txs_at(&node_c, 4, DataLedger::Submit).await?,
+            peer_c_submit_txs
+        );
+    }
+
+    // gracefully shutdown nodes
+    tokio::join!(node_a.stop(), node_b.stop(), node_c.stop(),);
+    Ok(())
+}

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -1064,101 +1064,44 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
         }
 
         // check correct txs made it into specific canon blocks, that are now synced across every node
-        assert_eq!(
-            sorted_data_txs_at(&node_a, 1, DataLedger::Submit).await?,
-            vec![]
-        );
+        for node in [&node_a, &node_b, &node_c] {
+            assert_eq!(
+                sorted_data_txs_at(&node, 1, DataLedger::Submit).await?,
+                vec![]
+            );
+            assert_eq!(
+                sorted_data_txs_at(&node, 1, DataLedger::Publish).await?,
+                vec![]
+            );
+            assert_eq!(
+                sorted_data_txs_at(&node, 2, DataLedger::Submit).await?,
+                peer_b_submit_txs
+            );
+            assert_eq!(
+                sorted_data_txs_at(&node, 2, DataLedger::Publish).await?,
+                vec![]
+            );
+            assert_eq!(
+                sorted_data_txs_at(&node, 3, DataLedger::Submit).await?,
+                vec![]
+            );
+            assert_eq!(
+                sorted_data_txs_at(&node, 3, DataLedger::Publish).await?,
+                peer_b_submit_txs // promoted from previous block
+            );
+            // Expect txs that were mined in both c2 (non canonical) and c4 (now canonical)
+            // The reason for them being in the 4th block, is that peer C sees them as non canon when it re-orgs after receiving B2 and B3. Therefore then returns as eligible txs
+            // To reiterate. These were previously mined in non canon block C2. They were then mined again in canon block C4
+            assert_eq!(
+                sorted_data_txs_at(&node, 4, DataLedger::Submit).await?,
+                peer_c_submit_txs
+            );
 
-        assert_eq!(
-            sorted_data_txs_at(&node_a, 1, DataLedger::Publish).await?,
-            vec![]
-        );
-        assert_eq!(
-            sorted_data_txs_at(&node_a, 2, DataLedger::Submit).await?,
-            peer_b_submit_txs
-        );
-        assert_eq!(
-            sorted_data_txs_at(&node_a, 2, DataLedger::Publish).await?,
-            vec![]
-        );
-        assert_eq!(
-            sorted_data_txs_at(&node_a, 3, DataLedger::Submit).await?,
-            vec![]
-        );
-        assert_eq!(
-            sorted_data_txs_at(&node_a, 3, DataLedger::Publish).await?,
-            peer_b_submit_txs // promoted from previous block
-        );
-        // Expect txs that were mined in both c2 (non canonical) and c4 (now canonical)
-        // The reason for them being in the 4th block, is that peer C sees them as non canon when it re-orgs after receiving B2 and B3. Therefore then returns as eligible txs
-        // To reiterate. These were previously mined in non canon block C2. They were then mined again in canon block C4
-        assert_eq!(
-            sorted_data_txs_at(&node_a, 4, DataLedger::Submit).await?,
-            peer_c_submit_txs
-        );
-
-        assert_eq!(
-            sorted_data_txs_at(&node_a, 4, DataLedger::Publish).await?,
-            vec![]
-        );
-
-        assert_eq!(
-            sorted_data_txs_at(&node_b, 1, DataLedger::Submit).await?,
-            vec![]
-        );
-        assert_eq!(
-            sorted_data_txs_at(&node_b, 2, DataLedger::Submit).await?,
-            peer_b_submit_txs
-        );
-        assert_eq!(
-            sorted_data_txs_at(&node_b, 2, DataLedger::Publish).await?,
-            vec![]
-        );
-        assert_eq!(
-            sorted_data_txs_at(&node_b, 3, DataLedger::Publish).await?,
-            peer_b_submit_txs
-        );
-        assert_eq!(
-            sorted_data_txs_at(&node_b, 3, DataLedger::Submit).await?,
-            vec![]
-        );
-        assert_eq!(
-            sorted_data_txs_at(&node_b, 4, DataLedger::Submit).await?,
-            peer_c_submit_txs
-        );
-        assert_eq!(
-            sorted_data_txs_at(&node_b, 4, DataLedger::Publish).await?,
-            vec![]
-        );
-
-        assert_eq!(
-            sorted_data_txs_at(&node_c, 1, DataLedger::Submit).await?,
-            vec![]
-        );
-        assert_eq!(
-            sorted_data_txs_at(&node_c, 2, DataLedger::Submit).await?,
-            peer_b_submit_txs
-        );
-        assert_eq!(
-            sorted_data_txs_at(&node_c, 2, DataLedger::Publish).await?,
-            vec![]
-        );
-        assert_eq!(
-            sorted_data_txs_at(&node_c, 3, DataLedger::Publish).await?,
-            peer_b_submit_txs
-        );
-        assert_eq!(
-            sorted_data_txs_at(&node_c, 3, DataLedger::Submit).await?,
-            vec![]
-        );
-        assert_eq!(
-            sorted_data_txs_at(&node_c, 4, DataLedger::Submit).await?,
-            peer_c_submit_txs
-        );
-        assert_eq!(
-            sorted_data_txs_at(&node_c, 4, DataLedger::Publish).await?,
-            vec![]
-        );
+            assert_eq!(
+                sorted_data_txs_at(&node, 4, DataLedger::Publish).await?,
+                vec![]
+            );
+        }
 
         // assert final balances
         assert_eq!(

--- a/crates/chain/tests/multi_node/fork_recovery.rs
+++ b/crates/chain/tests/multi_node/fork_recovery.rs
@@ -766,13 +766,29 @@ async fn heavy_reorg_tip_moves_across_nodes_publish_txs() -> eyre::Result<()> {
         a_block1.data_ledgers[DataLedger::Submit].tx_ids
     );
 
-    // check balances in block 1
+    // check balances in block 1 are unchanged from genesis
     assert_eq!(
         node_a.get_balance(b_signer.address(), a_block1.evm_block_hash.into()),
         signer_b_genesis_balance
     );
     assert_eq!(
         node_a.get_balance(c_signer.address(), a_block1.evm_block_hash.into()),
+        signer_c_genesis_balance
+    );
+    assert_eq!(
+        node_b.get_balance(b_signer.address(), b_block1.evm_block_hash.into()),
+        signer_b_genesis_balance
+    );
+    assert_eq!(
+        node_b.get_balance(c_signer.address(), b_block1.evm_block_hash.into()),
+        signer_c_genesis_balance
+    );
+    assert_eq!(
+        node_c.get_balance(b_signer.address(), c_block1.evm_block_hash.into()),
+        signer_b_genesis_balance
+    );
+    assert_eq!(
+        node_c.get_balance(c_signer.address(), c_block1.evm_block_hash.into()),
         signer_c_genesis_balance
     );
 

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -36,7 +36,7 @@ use irys_database::{
 use irys_packing::capacity_single::compute_entropy_chunk;
 use irys_packing::unpack;
 use irys_primitives::CommitmentType;
-use irys_reth_node_bridge::ext::IrysRethRpcTestContextExt;
+use irys_reth_node_bridge::ext::IrysRethRpcTestContextExt as _;
 use irys_storage::ii;
 use irys_testing_utils::utils::tempfile::TempDir;
 use irys_testing_utils::utils::temporary_directory;

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -7,6 +7,7 @@ use actix_web::{
     dev::{Service, ServiceResponse},
     Error,
 };
+use alloy_core::primitives::FixedBytes;
 use alloy_eips::BlockId;
 use awc::{body::MessageBody, http::StatusCode};
 use base58::ToBase58 as _;
@@ -35,12 +36,14 @@ use irys_database::{
 use irys_packing::capacity_single::compute_entropy_chunk;
 use irys_packing::unpack;
 use irys_primitives::CommitmentType;
+use irys_reth_node_bridge::ext::IrysRethRpcTestContextExt;
 use irys_storage::ii;
 use irys_testing_utils::utils::tempfile::TempDir;
 use irys_testing_utils::utils::temporary_directory;
 use irys_types::{
     block_production::Seed, block_production::SolutionContext, irys::IrysSigner,
     partition::PartitionAssignment, Address, DataLedger, GossipBroadcastMessage, H256List, H256,
+    U256,
 };
 use irys_types::{
     Base64, CommitmentTransaction, Config, DatabaseProvider, IrysBlockHeader, IrysTransaction,
@@ -49,8 +52,11 @@ use irys_types::{
 };
 use irys_vdf::state::VdfStateReadonly;
 use irys_vdf::{step_number_to_salt_number, vdf_sha};
-use reth::network::{PeerInfo, Peers as _};
-use reth::payload::EthBuiltPayload;
+use reth::{
+    network::{PeerInfo, Peers as _},
+    payload::EthBuiltPayload,
+    rpc::types::RpcBlockHash,
+};
 use reth_db::{cursor::*, transaction::DbTx as _, Database as _};
 use sha2::{Digest as _, Sha256};
 use std::collections::HashMap;
@@ -968,6 +974,18 @@ impl IrysNodeTest<IrysNodeCtx> {
                 .expect("valid SocketAddr expected"),
             execution: RethPeerInfo::default(),
         }
+    }
+
+    // get account reth balance at specific block
+    pub fn get_balance(&self, address: Address, evm_block_hash: FixedBytes<32>) -> U256 {
+        let block = Some(BlockId::Hash(RpcBlockHash {
+            block_hash: evm_block_hash,
+            require_canonical: Some(false),
+        }));
+        self.node_ctx
+            .reth_node_adapter
+            .rpc
+            .get_balance_irys(address, block)
     }
 
     pub async fn create_submit_data_tx(


### PR DESCRIPTION
**Describe the changes**
 - New test util method: `get_balance()` to retrieve reth balance on a node for a specific address at a specific block
 - New test scenario
   - Test scenario for three nodes, mining to three different heights in isolation from one another
   - submit/publish txs are created on canonical chain and seen to remain canonical
   - submit/publish txs are created on a non canonical chain and are seen to be reverted before inclusion in a later canonical block
   - Test for correct balances after each mined block, and after reorgs that bring all three nodes into sync
 
**Additional Context**
submit/publish txs are currently hard coded to have a fee of 1. This is outside the scope of this PR to correct this, but the PR is a good stepping stone to get there.
