### PR TITLE
fix: Remove the obsoleted RwLock from PartitionAssignments

### DIFF
--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -213,8 +213,6 @@ pub fn check_poa_data_expiration(
 ) -> eyre::Result<()> {
     let is_data_partition_assigned = epoch_snapshot
         .partition_assignments
-        .read()
-        .unwrap()
         .data_partitions
         .contains_key(&poa.partition_hash);
 

--- a/crates/actors/tests/epoch_service_tests.rs
+++ b/crates/actors/tests/epoch_service_tests.rs
@@ -91,7 +91,7 @@ async fn genesis_test() {
 
         // Verify data partition assignments match _PUBLISH_ ledger slots
         for (slot_idx, slot) in pub_slots.iter().enumerate() {
-            let pa = epoch_snapshot.partition_assignments.read().unwrap();
+            let pa = &epoch_snapshot.partition_assignments;
             for &partition_hash in &slot.partitions {
                 let assignment = pa
                     .data_partitions
@@ -116,7 +116,7 @@ async fn genesis_test() {
 
         // Verify data partition assignments match _SUBMIT_ledger slots
         for (slot_idx, slot) in sub_slots.iter().enumerate() {
-            let pa = epoch_snapshot.partition_assignments.read().unwrap();
+            let pa = &epoch_snapshot.partition_assignments;
             for &partition_hash in &slot.partitions {
                 let assignment = pa
                     .data_partitions
@@ -142,7 +142,7 @@ async fn genesis_test() {
 
     // Verify the correct number of genesis partitions have been activated
     {
-        let pa = epoch_snapshot.partition_assignments.read().unwrap();
+        let pa = &epoch_snapshot.partition_assignments;
         let data_partition_count = pa.data_partitions.len() as u64;
         let expected_partitions = data_partition_count
             + EpochSnapshot::get_num_capacity_partitions(data_partition_count, &config.consensus);
@@ -397,8 +397,6 @@ async fn partition_expiration_and_repacking_test() {
     let assign_submit_partition_hash = {
         let partition_hash = epoch_snapshot
             .partition_assignments
-            .read()
-            .unwrap()
             .data_partitions
             .iter()
             .find(|(_hash, assignment)| assignment.ledger_id == Some(DataLedger::Submit.get_id()))
@@ -425,8 +423,6 @@ async fn partition_expiration_and_repacking_test() {
     let capacity_partitions = {
         let capacity_partitions: Vec<H256> = epoch_snapshot
             .partition_assignments
-            .read()
-            .unwrap()
             .capacity_partitions
             .keys()
             .copied()
@@ -566,20 +562,13 @@ async fn partition_expiration_and_repacking_test() {
     // check repacking request expired partition for its whole interval range, and partitions assignments are consistent
     {
         assert_eq!(
-            epoch_snapshot
-                .partition_assignments
-                .read()
-                .unwrap()
-                .data_partitions
-                .len(),
+            epoch_snapshot.partition_assignments.data_partitions.len(),
             3,
             "Should have four partitions assignments"
         );
 
         if let Some(publish_assignment) = epoch_snapshot
             .partition_assignments
-            .read()
-            .unwrap()
             .data_partitions
             .get(&publish_partition)
         {
@@ -599,8 +588,6 @@ async fn partition_expiration_and_repacking_test() {
 
         if let Some(submit_assignment) = epoch_snapshot
             .partition_assignments
-            .read()
-            .unwrap()
             .data_partitions
             .get(&submit_partition)
         {
@@ -620,8 +607,6 @@ async fn partition_expiration_and_repacking_test() {
 
         if let Some(submit_assignment) = epoch_snapshot
             .partition_assignments
-            .read()
-            .unwrap()
             .data_partitions
             .get(&submit_partition2)
         {
@@ -878,19 +863,13 @@ async fn partitions_assignment_determinism_test() {
         &config,
     );
 
-    epoch_snapshot
-        .partition_assignments
-        .read()
-        .unwrap()
-        .print_assignments();
+    epoch_snapshot.partition_assignments.print_assignments();
 
     // Because we aren't actually building blocks with block_producer we need to
     // stub out some block hashes, for this tests we use the capacity partition hashes
     // as the source because it doubles down on determinism.
     let test_hashes: Vec<_> = epoch_snapshot
         .partition_assignments
-        .read()
-        .unwrap()
         .capacity_partitions
         .keys()
         .copied()
@@ -921,11 +900,7 @@ async fn partitions_assignment_determinism_test() {
         previous_epoch_block = new_epoch_block.clone();
     }
 
-    epoch_snapshot
-        .partition_assignments
-        .read()
-        .unwrap()
-        .print_assignments();
+    epoch_snapshot.partition_assignments.print_assignments();
 
     debug!(
         "\nAll Partitions({})\n{}",
@@ -939,8 +914,6 @@ async fn partitions_assignment_determinism_test() {
 
     if let Some(publish_assignment) = epoch_snapshot
         .partition_assignments
-        .read()
-        .unwrap()
         .data_partitions
         .get(&publish_slot_0)
     {
@@ -960,18 +933,12 @@ async fn partitions_assignment_determinism_test() {
 
     let publish_slot_1 = H256::from_base58("2HVmW86qVyKTw1DYJMX6NoNvVxATLNZHSAyMceEWPtLC");
 
-    epoch_snapshot
-        .partition_assignments
-        .read()
-        .unwrap()
-        .print_assignments();
+    epoch_snapshot.partition_assignments.print_assignments();
 
     debug!("expected publish[1] -> {}", publish_slot_1.0.to_base58());
 
     if let Some(publish_assignment) = epoch_snapshot
         .partition_assignments
-        .read()
-        .unwrap()
         .data_partitions
         .get(&publish_slot_1)
     {
@@ -993,8 +960,6 @@ async fn partitions_assignment_determinism_test() {
 
     if let Some(capacity_assignment) = epoch_snapshot
         .partition_assignments
-        .read()
-        .unwrap()
         .capacity_partitions
         .get(&capacity_partition)
     {
@@ -1014,8 +979,6 @@ async fn partitions_assignment_determinism_test() {
 
     if let Some(submit_assignment) = epoch_snapshot
         .partition_assignments
-        .read()
-        .unwrap()
         .data_partitions
         .get(&submit_slot_2)
     {


### PR DESCRIPTION
Removes the `Arc<RwLock<..>>` from `EpochSnapshot::PartitionAssignments` as epoch snapshots are only mutated during initialization. 
