### PR TITLE
fix: repair payloads before sending an FCU on startup

### DIFF
--- a/crates/actors/src/reth_service.rs
+++ b/crates/actors/src/reth_service.rs
@@ -247,9 +247,6 @@ impl Handler<ForkChoiceUpdateMessage> for RethServiceActor {
                     "Reth state before fork choice update"
                 );
 
-
-
-
                 handle
                     .update_forkchoice_full(head_hash, confirmed_hash, finalized_hash)
                     .await

--- a/crates/actors/src/reth_service.rs
+++ b/crates/actors/src/reth_service.rs
@@ -222,6 +222,34 @@ impl Handler<ForkChoiceUpdateMessage> for RethServiceActor {
                     "Updating Reth fork choice"
                 );
 
+                let latest = handle
+                    .inner
+                    .eth_api()
+                    .block_by_number(BlockNumberOrTag::Latest, false)
+                    .await;
+
+                let safe = handle
+                    .inner
+                    .eth_api()
+                    .block_by_number(BlockNumberOrTag::Safe, false)
+                    .await;
+
+                let finalized = handle
+                    .inner
+                    .eth_api()
+                    .block_by_number(BlockNumberOrTag::Finalized, false)
+                    .await;
+
+                debug!(
+                    latest_block = ?latest.as_ref().ok().and_then(|b| b.as_ref()).map(|b| (b.header.number, b.header.hash)),
+                    safe_block = ?safe.as_ref().ok().and_then(|b| b.as_ref()).map(|b| (b.header.number, b.header.hash)),
+                    finalized_block = ?finalized.as_ref().ok().and_then(|b| b.as_ref()).map(|b| (b.header.number, b.header.hash)),
+                    "Reth state before fork choice update"
+                );
+
+
+
+
                 handle
                     .update_forkchoice_full(head_hash, confirmed_hash, finalized_hash)
                     .await
@@ -251,9 +279,9 @@ impl Handler<ForkChoiceUpdateMessage> for RethServiceActor {
                     .await;
 
                 debug!(
-                    latest_block = ?latest.as_ref().ok().and_then(|b| b.as_ref()).map(|b| b.header.number),
-                    safe_block = ?safe.as_ref().ok().and_then(|b| b.as_ref()).map(|b| b.header.number),
-                    finalized_block = ?finalized.as_ref().ok().and_then(|b| b.as_ref()).map(|b| b.header.number),
+                    latest_block = ?latest.as_ref().ok().and_then(|b| b.as_ref()).map(|b| (b.header.number, b.header.hash)),
+                    safe_block = ?safe.as_ref().ok().and_then(|b| b.as_ref()).map(|b| (b.header.number, b.header.hash)),
+                    finalized_block = ?finalized.as_ref().ok().and_then(|b| b.as_ref()).map(|b| (b.header.number, b.header.hash)),
                     "Reth state after fork choice update"
                 );
                 Ok(fcu)

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -74,7 +74,7 @@ use std::{
 use tokio::runtime::Runtime;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot::{self};
-use tracing::{debug, error, info, warn, Instrument as _, Span};
+use tracing::{debug, error, info, instrument, warn, Instrument as _, Span};
 
 #[derive(Debug, Clone)]
 pub struct IrysNodeCtx {
@@ -846,16 +846,6 @@ impl IrysNode {
         node_config.reth_peer_info = reth_peering;
         let config = Config::new(node_config);
 
-        // update reth service about the latest block data it must use
-        reth_service_actor
-            .send(ForkChoiceUpdateMessage {
-                head_hash: BlockHashType::Evm(latest_block.evm_block_hash),
-                confirmed_hash: Some(BlockHashType::Evm(latest_block.evm_block_hash)),
-                finalized_hash: None,
-            })
-            .await??;
-        debug!("Reth Service Actor updated about fork choice");
-
         let _handle = ChunkCacheService::spawn_service(
             task_exec,
             irys_db.clone(),
@@ -1008,6 +998,21 @@ impl IrysNode {
             config.clone(),
             service_senders.clone(),
         )?;
+
+        // repair any missing payloads before triggering an FCU
+        block_pool
+            .repair_missing_payloads_if_any(Some(reth_service_actor.clone()))
+            .await?;
+
+        // update reth service about the latest block data it must use
+        reth_service_actor
+            .send(ForkChoiceUpdateMessage {
+                head_hash: BlockHashType::Evm(latest_block.evm_block_hash),
+                confirmed_hash: Some(BlockHashType::Evm(latest_block.evm_block_hash)),
+                finalized_hash: None,
+            })
+            .await??;
+        debug!("Reth Service Actor updated about fork choice");
 
         // set up the price oracle
         let price_oracle = Self::init_price_oracle(&config);
@@ -1546,6 +1551,7 @@ fn init_irys_db(config: &Config) -> Result<DatabaseProvider, eyre::Error> {
 /// 2) if we have no existing stake, submit a stake to the local mempool
 /// 3) check all local storage modules for partition assignments against all known partition pledges - historic or pending
 /// 4) post enough pledges so that there are enough pledges for all local storage modules
+#[instrument(skip_all)]
 async fn stake_and_pledge(
     config: &Config,
     block_tree_guard: BlockTreeReadGuard,

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -609,8 +609,6 @@ impl IrysNode {
             ctx.peer_list.clone(),
             latest_known_block_height as usize,
             &ctx.config,
-            Some(Arc::clone(&ctx.block_pool)),
-            Some(ctx.actor_addresses.reth.clone()),
         )
         .await?;
 


### PR DESCRIPTION
**Describe the changes**
This PR incorporates a hotfix from testnet for a case where the trusted fast sync was interrupted, and Reth was a block behind. This caused the testnet peer to crash loop, due to the FCU created during startup. The fix was to explicitly invoke `repair_missing_payloads_if_any` before sending the initial FCU, to allow the system to recover.
This PR also includes some logging tweaks.

**Checklist**

~~- [ ] Tests have been added/updated for the changes.~~ NB: testing for this case has been backlogged #533 
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

