### PR TITLE
feat: handshake cooldown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5230,7 +5230,6 @@ dependencies = [
  "build-print",
  "bytemuck",
  "bytes",
- "chrono",
  "derive_more",
  "eyre",
  "fixed-hash",

--- a/crates/api-server/src/routes/post_version.rs
+++ b/crates/api-server/src/routes/post_version.rs
@@ -13,6 +13,7 @@ use irys_types::{
     RejectedResponse, RejectionReason, VersionRequest,
 };
 use semver::Version;
+use tracing::error;
 
 pub async fn post_version(
     state: web::Data<ApiState>,
@@ -50,17 +51,13 @@ pub async fn post_version(
         ..Default::default()
     };
 
-    // Check if peer already exists in the list
-    let is_new_peer = !peers.iter().any(|peer| peer == &peer_address);
-
     // Only update if it's a new peer
-    if is_new_peer
-        && state
-            .peer_list
-            .add_peer(mining_addr, peer_list_entry)
-            .await
-            .is_err()
+    if let Err(err) = state
+        .peer_list
+        .add_or_update_peer(mining_addr, peer_list_entry)
+        .await
     {
+        error!("Failed to update peer list: {}", err);
         let response = PeerResponse::Rejected(RejectedResponse {
             reason: RejectionReason::InternalError,
             message: Some("Could not update peer list".to_string()),

--- a/crates/p2p/src/sync.rs
+++ b/crates/p2p/src/sync.rs
@@ -607,7 +607,7 @@ mod tests {
             );
             let peer_list = peer_list_service.start();
             peer_list
-                .add_peer(
+                .add_or_update_peer(
                     Address::repeat_byte(2),
                     PeerListItem {
                         reputation_score: PeerScore::new(100),
@@ -715,7 +715,7 @@ mod tests {
 
             let peer_list = peer_list_service.start();
             peer_list
-                .add_peer(
+                .add_or_update_peer(
                     Address::repeat_byte(2),
                     PeerListItem {
                         reputation_score: PeerScore::new(100),

--- a/crates/p2p/src/tests/block_pool/mod.rs
+++ b/crates/p2p/src/tests/block_pool/mod.rs
@@ -333,7 +333,7 @@ async fn should_process_block_with_intermediate_block_in_api() {
     // Set the mock client to return block2 when requested
     // Adding a peer so we can send a request to the mock client
     peer_addr
-        .add_peer(
+        .add_or_update_peer(
             Address::new([0, 1, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0]),
             PeerListItem {
                 reputation_score: PeerScore::new(100),
@@ -507,7 +507,7 @@ async fn should_refuse_fresh_block_trying_to_build_old_chain() {
 
     // Adding a peer so we can send a request to the mock client
     peer_addr
-        .add_peer(
+        .add_or_update_peer(
             Address::new([0, 1, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0]),
             PeerListItem {
                 reputation_score: PeerScore::new(100),

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -25,7 +25,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.107"
 borsh = "1.3.0"
 borsh-derive = "1.3.0"
-chrono = "0.4.*"
 k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 tokio.workspace = true
 actix.workspace = true

--- a/crates/types/src/peer_list.rs
+++ b/crates/types/src/peer_list.rs
@@ -2,9 +2,9 @@ use crate::{Compact, PeerAddress};
 use actix::Message;
 use arbitrary::Arbitrary;
 use bytes::Buf as _;
-use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, Arbitrary, PartialEq, Hash)]
 pub struct PeerScore(u16);
@@ -59,7 +59,10 @@ impl Default for PeerListItem {
                 api: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 0)),
                 execution: RethPeerInfo::default(),
             },
-            last_seen: Utc::now().timestamp_millis() as u64,
+            last_seen: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as u64,
             is_online: true,
         }
     }


### PR DESCRIPTION
**Describe the changes**
This PR fixes an issue that causes the node to ignore multiple hansdhake requests from the same peer if the peer information hasn't changed. This PR introduces a p2p handshake cooldown. If additional handshake is made during cooldown period, it's going to be ignored. If it's made after the cooldown, it's going to be handled as if the peer information has been updated

**Related Issue(s)**


**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
