### PR TITLE
feat: block producer as a tokio service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5119,6 +5119,7 @@ dependencies = [
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-primitives-traits",
+ "reth-provider",
  "reth-storage-api",
  "reth-tracing",
  "reth-transaction-pool",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4878,6 +4878,7 @@ dependencies = [
  "irys-testing-utils",
  "irys-types",
  "irys-vdf",
+ "itertools 0.13.0",
  "k256",
  "modular-bitfield",
  "rand 0.8.5",

--- a/crates/actors/src/addresses.rs
+++ b/crates/actors/src/addresses.rs
@@ -1,8 +1,9 @@
 use actix::Addr;
+use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     block_discovery::BlockDiscoveryActor, block_index_service::BlockIndexService,
-    block_producer::BlockProducerActor, mining::PartitionMiningActor, packing::PackingActor,
+    block_producer::BlockProducerCommand, mining::PartitionMiningActor, packing::PackingActor,
     reth_service::RethServiceActor,
 };
 
@@ -12,7 +13,7 @@ use crate::{
 pub struct ActorAddresses {
     pub partitions: Vec<Addr<PartitionMiningActor>>,
     pub block_discovery_addr: Addr<BlockDiscoveryActor>,
-    pub block_producer: Addr<BlockProducerActor>,
+    pub block_producer: UnboundedSender<BlockProducerCommand>,
     pub packing: Addr<PackingActor>,
     pub block_index: Addr<BlockIndexService>,
     pub reth: Addr<RethServiceActor>,

--- a/crates/actors/src/addresses.rs
+++ b/crates/actors/src/addresses.rs
@@ -1,10 +1,8 @@
 use actix::Addr;
-use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     block_discovery::BlockDiscoveryActor, block_index_service::BlockIndexService,
-    block_producer::BlockProducerCommand, mining::PartitionMiningActor, packing::PackingActor,
-    reth_service::RethServiceActor,
+    mining::PartitionMiningActor, packing::PackingActor, reth_service::RethServiceActor,
 };
 
 /// Serves as a kind of app state that can be passed into actix web to allow
@@ -13,7 +11,6 @@ use crate::{
 pub struct ActorAddresses {
     pub partitions: Vec<Addr<PartitionMiningActor>>,
     pub block_discovery_addr: Addr<BlockDiscoveryActor>,
-    pub block_producer: UnboundedSender<BlockProducerCommand>,
     pub packing: Addr<PackingActor>,
     pub block_index: Addr<BlockIndexService>,
     pub reth: Addr<RethServiceActor>,

--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -7,67 +7,82 @@ use crate::{
     shadow_tx_generator::ShadowTxGenerator,
 };
 use actix::prelude::*;
-use actors::mocker::Mocker;
 use alloy_consensus::{
     transaction::SignerRecoverable as _, EthereumTxEnvelope, SignableTransaction as _, TxEip4844,
 };
 use alloy_eips::BlockHashOrNumber;
 use alloy_network::TxSignerSync as _;
-use alloy_rpc_types_engine::PayloadAttributes;
+use alloy_rpc_types_engine::{
+    ExecutionData, ExecutionPayload, ExecutionPayloadSidecar, PayloadAttributes, PayloadStatusEnum,
+};
 use alloy_signer_local::LocalSigner;
 use base58::ToBase58 as _;
 use eyre::eyre;
 use irys_database::{block_header_by_hash, db::IrysDatabaseExt as _, SystemLedger};
 use irys_domain::{BlockTreeReadGuard, EmaSnapshot, ExponentialMarketAvgCalculation};
 use irys_price_oracle::IrysPriceOracle;
-use irys_reth::compose_shadow_tx;
-use irys_reth_node_bridge::IrysRethNodeAdapter;
+use irys_reth::{
+    compose_shadow_tx,
+    payload::{DeterministicShadowTxKey, ShadowTxStore},
+    reth_node_ethereum::EthEngineTypes,
+    IrysEthereumNode,
+};
+use irys_reth_node_bridge::node::NodeProvider;
 use irys_reward_curve::HalvingCurve;
 use irys_types::{
     app_state::DatabaseProvider, block_production::SolutionContext, calculate_difficulty,
     next_cumulative_diff, storage_pricing::Amount, Base64, CommitmentTransaction, Config,
     DataLedger, DataTransactionLedger, GossipBroadcastMessage, H256List, IngressProofsList,
     IrysBlockHeader, IrysTransactionHeader, PoaData, Signature, SystemTransactionLedger,
-    TxIngressProof, VDFLimiterInfo, H256, U256,
+    TokioServiceHandle, TxIngressProof, VDFLimiterInfo, H256, U256,
 };
 use irys_vdf::state::VdfStateReadonly;
 use nodit::interval::ii;
 use openssl::sha;
 use reth::{
-    core::primitives::SealedBlock, payload::EthBuiltPayload, revm::primitives::B256,
+    api::{BeaconConsensusEngineHandle, NodeTypes, PayloadKind},
+    core::primitives::SealedBlock,
+    payload::{EthBuiltPayload, EthPayloadBuilderAttributes, PayloadBuilderHandle},
+    revm::primitives::B256,
     rpc::types::BlockId,
+    tasks::shutdown::Shutdown,
 };
 use reth_transaction_pool::EthPooledTransaction;
 use std::{
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
-use tokio::sync::oneshot;
-use tracing::{debug, error, info, warn, Instrument as _, Span};
+use tokio::sync::{mpsc, oneshot};
+use tracing::{debug, error, info, warn};
 
 mod block_validation_tracker;
 pub use block_validation_tracker::BlockValidationTracker;
 
-/// Used to mock up a `BlockProducerActor`
-pub type BlockProducerMockActor = Mocker<BlockProducerActor>;
-
-/// A mocked [`BlockProducerActor`] only needs to implement [`SolutionFoundMessage`]
+/// Commands that can be sent to the block producer service
 #[derive(Debug)]
-pub struct MockedBlockProducerAddr(pub Recipient<SolutionFoundMessage>);
+pub enum BlockProducerCommand {
+    /// Announce to the node a mining solution has been found
+    SolutionFound {
+        solution: SolutionContext,
+        response: oneshot::Sender<
+            eyre::Result<Option<(Arc<irys_types::IrysBlockHeader>, EthBuiltPayload)>>,
+        >,
+    },
+    /// Set the test blocks remaining (for testing)
+    SetTestBlocksRemaining(Option<u64>),
+}
 
-/// `BlockProducerActor` creates blocks from mining solutions
-#[derive(Debug, Clone)]
-pub struct BlockProducerActor {
-    pub inner: Arc<BlockProducerInner>,
+/// Block producer service that creates blocks from mining solutions
+#[derive(Debug)]
+pub struct BlockProducerService {
+    /// Graceful shutdown handle
+    shutdown: Shutdown,
+    /// Command receiver
+    cmd_rx: mpsc::UnboundedReceiver<BlockProducerCommand>,
+    /// Inner logic
+    inner: Arc<BlockProducerInner>,
     /// Enforces block production limits during testing
-    ///
-    /// Controls the exact number of blocks produced to ensure test determinism.
-    /// Since mining is probabilistic, solutions can be found nearly simultaneously
-    /// before mining can be stopped after the first solution. This guard prevents
-    /// producing extra blocks that would cause non-deterministic test behavior.
-    pub blocks_remaining_for_test: Option<u64>,
-    /// Tracing span
-    pub span: Span,
+    blocks_remaining_for_test: Option<u64>,
 }
 
 #[derive(Debug)]
@@ -90,100 +105,175 @@ pub struct BlockProducerInner {
     pub block_tree_guard: BlockTreeReadGuard,
     /// The Irys price oracle
     pub price_oracle: Arc<IrysPriceOracle>,
-    /// Reth node adapter
-    pub reth_node_adapter: IrysRethNodeAdapter,
+    /// Reth node payload builder
+    pub reth_payload_builder: PayloadBuilderHandle<EthEngineTypes>,
+    /// Reth blockchain provider
+    pub reth_provider: NodeProvider,
+    /// Shadow tx store
+    pub shadow_tx_store: ShadowTxStore,
     /// Reth service actor
     pub reth_service: Addr<RethServiceActor>,
+    /// Reth beacon engine handle
+    pub beacon_engine_handle: BeaconConsensusEngineHandle<<IrysEthereumNode as NodeTypes>::Payload>,
 }
 
-/// Actors can handle this message to learn about the `block_producer` actor at startup
-#[derive(Message, Debug, Clone)]
-#[rtype(result = "()")]
-pub struct RegisterBlockProducerMessage(pub Addr<BlockProducerActor>);
-
-impl Actor for BlockProducerActor {
-    type Context = Context<Self>;
-}
-
-#[derive(Message, Debug, Clone)]
-#[rtype(result = "()")]
-pub struct SetTestBlocksRemainingMessage(pub Option<u64>);
-
-impl Handler<SetTestBlocksRemainingMessage> for BlockProducerActor {
-    type Result = ();
-
-    fn handle(
-        &mut self,
-        msg: SetTestBlocksRemainingMessage,
-        _ctx: &mut Self::Context,
-    ) -> Self::Result {
-        self.blocks_remaining_for_test = msg.0;
-    }
-}
-
-#[derive(Message, Debug)]
-#[rtype(result = "eyre::Result<Option<(Arc<IrysBlockHeader>, EthBuiltPayload)>>")]
-/// Announce to the node a mining solution has been found.
-pub struct SolutionFoundMessage(pub SolutionContext);
-
-impl Handler<SolutionFoundMessage> for BlockProducerActor {
-    type Result =
-        AtomicResponse<Self, eyre::Result<Option<(Arc<IrysBlockHeader>, EthBuiltPayload)>>>;
-    #[tracing::instrument(skip_all, fields(
-        minting_address = ?msg.0.mining_address,
-        partition_hash = ?msg.0.partition_hash,
-        chunk_offset = ?msg.0.chunk_offset,
-        tx_path = ?msg.0.tx_path.is_none(),
-        chunk = ?msg.0.chunk.len(),
-    ))]
-    fn handle(&mut self, msg: SolutionFoundMessage, _ctx: &mut Self::Context) -> Self::Result {
-        let span = self.span.clone();
-        let span2 = span.clone();
-        let _span = span.enter();
-        let solution = msg.0;
+impl BlockProducerService {
+    /// Spawn a new block producer service
+    #[tracing::instrument(skip_all, fields(blocks_remaining_for_test = ?blocks_remaining_for_test))]
+    pub fn spawn_service(
+        inner: Arc<BlockProducerInner>,
+        blocks_remaining_for_test: Option<u64>,
+        rx: mpsc::UnboundedReceiver<BlockProducerCommand>,
+    ) -> TokioServiceHandle {
         info!(
-            "BlockProducerActor solution received: solution_hash={}",
-            solution.solution_hash.0.to_base58()
+            "Spawning block producer service with blocks_remaining_for_test: {:?}",
+            blocks_remaining_for_test
         );
 
-        if let Some(blocks_remaining) = self.blocks_remaining_for_test {
-            if blocks_remaining == 0 {
-                info!(
-                    "No more blocks needed for this test, skipping block production for solution_hash={}",
-                    solution.solution_hash.0.to_base58()
-                );
-                return AtomicResponse::new(Box::pin(fut::ready(Ok(None))));
+        let (shutdown_tx, shutdown_rx) = reth::tasks::shutdown::signal();
+        let handle = tokio::spawn(async move {
+            let service = Self {
+                shutdown: shutdown_rx,
+                cmd_rx: rx,
+                inner,
+                blocks_remaining_for_test,
+            };
+            service
+                .start()
+                .await
+                .expect("Block producer service encountered an irrecoverable error")
+        });
+        
+        TokioServiceHandle {
+            name: "block_producer_service".to_string(),
+            handle,
+            shutdown_signal: shutdown_tx,
+        }
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn start(mut self) -> eyre::Result<()> {
+        info!("Starting block producer service");
+        debug!(
+            "Service configuration - reward_address: {}, chain_id: {}",
+            self.inner.config.node_config.reward_address, self.inner.config.consensus.chain_id
+        );
+        loop {
+            tokio::select! {
+                // Handle commands
+                cmd = self.cmd_rx.recv() => {
+                    match cmd {
+                        Some(cmd) => {
+                            let res = self.handle_command(cmd).await;
+                            if let Err(err) = res {
+                                // because we don't have our shutdown system fully finished,
+                                // block producer may error out while other services are in the middle of shutting down.
+                                let is_shutdown = futures::future::poll_immediate(&mut self.shutdown).await.is_some();
+                                if is_shutdown {
+                                    // graceful shutdown
+                                    break;
+                                }
+                                // legit error - propagate
+                                return Err(err)
+                            }
+                        }
+                        None => {
+                            warn!("Command channel closed unexpectedly");
+                            break;
+                        }
+                    }
+                }
+                // Check for shutdown signal
+                _ = &mut self.shutdown => {
+                    info!("Shutdown signal received for block producer service");
+                    break;
+                }
             }
         }
 
-        let inner = self.inner.clone();
-        AtomicResponse::new(Box::pin(
-            async move {
-                ProductionStrategy { inner }
-                    .fully_produce_new_block(solution)
-                    .await
-            }
-            .instrument(span2)
-            .into_actor(self)
-            .map(move |result, actor, _ctx| {
-                // Only decrement blocks_remaining_for_test when a block is successfully produced
-                if let Ok(Some((_irys_block_header, _eth_built_payload))) = &result {
-                    // If blocks_remaining_for_test is Some, decrement it by 1
-                    if let Some(remaining) = actor.blocks_remaining_for_test {
-                        actor.blocks_remaining_for_test = Some(remaining.saturating_sub(1));
+        info!("Shutting down block producer service gracefully");
+        Ok(())
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn handle_command(&mut self, cmd: BlockProducerCommand) -> eyre::Result<()> {
+        match cmd {
+            BlockProducerCommand::SolutionFound { solution, response } => {
+                let solution_hash = solution.solution_hash.0.to_base58();
+                info!(
+                    solution_hash = %solution_hash,
+                    vdf_step = solution.vdf_step,
+                    mining_address = %solution.mining_address,
+                    "Block producer received mining solution"
+                );
+
+                if let Some(blocks_remaining) = self.blocks_remaining_for_test {
+                    if blocks_remaining == 0 {
+                        info!(
+                            solution_hash = %solution_hash,
+                            "No more blocks needed for test, skipping block production"
+                        );
+                        let _ = response.send(Ok(None));
+                        return Ok(());
                     }
+                    debug!("Test blocks remaining: {}", blocks_remaining);
                 }
-                result
-            })
-            .map_err(|e: eyre::Error, _, _| {
-                error!("Error producing a block: {}", &e);
-                std::process::abort();
-            }),
-        ))
+
+                let inner = self.inner.clone();
+                let result = Self::produce_block_inner(inner, solution).await?;
+
+                // Only decrement blocks_remaining_for_test when a block is successfully produced
+                if let Some((irys_block_header, _eth_built_payload)) = &result {
+                    info!(
+                        block_hash = %irys_block_header.block_hash.0.to_base58(),
+                        block_height = irys_block_header.height,
+                        "Block production completed successfully"
+                    );
+
+                    if let Some(remaining) = self.blocks_remaining_for_test.as_mut() {
+                        *remaining = remaining.saturating_sub(1);
+                        debug!("Test blocks remaining after production: {}", *remaining);
+                    }
+                } else {
+                    info!("Block production skipped (solution outdated or invalid)");
+                }
+
+                let _ = response.send(Ok(result));
+            }
+            BlockProducerCommand::SetTestBlocksRemaining(remaining) => {
+                debug!(
+                    old_value = ?self.blocks_remaining_for_test,
+                    new_value = ?remaining,
+                    "Updating test blocks remaining"
+                );
+                self.blocks_remaining_for_test = remaining;
+            }
+        }
+        Ok(())
+    }
+
+    /// Internal method to produce a block without the non-Send trait
+    #[tracing::instrument(skip_all, fields(
+        solution_hash = %solution.solution_hash.0.to_base58(),
+        vdf_step = solution.vdf_step,
+        mining_address = %solution.mining_address
+    ))]
+    async fn produce_block_inner(
+        inner: Arc<BlockProducerInner>,
+        solution: SolutionContext,
+    ) -> eyre::Result<Option<(Arc<IrysBlockHeader>, EthBuiltPayload)>> {
+        info!(
+            partition_hash = %solution.partition_hash.0.to_base58(),
+            chunk_offset = solution.chunk_offset,
+            "Starting block production for solution"
+        );
+
+        let production_strategy = ProductionStrategy { inner };
+        production_strategy.fully_produce_new_block(solution).await
     }
 }
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 pub trait BlockProdStrategy {
     fn inner(&self) -> &BlockProducerInner;
 
@@ -350,7 +440,11 @@ pub trait BlockProdStrategy {
         .await
     }
 
-    /// Builds and submits a Reth payload with forkchoice update
+    #[tracing::instrument(skip_all, fields(
+        parent_evm_hash = %prev_block_header.evm_block_hash,
+        timestamp_sec = timestamp_ms / 1000,
+        shadow_tx_count = shadow_txs.len()
+    ))]
     async fn build_and_submit_reth_payload(
         &self,
         prev_block_header: &IrysBlockHeader,
@@ -358,8 +452,10 @@ pub trait BlockProdStrategy {
         shadow_txs: Vec<EthPooledTransaction>,
         parent_mix_hash: B256,
     ) -> eyre::Result<EthBuiltPayload> {
+        debug!("Building Reth payload attributes");
+
         // generate payload attributes
-        let payload_attrs = PayloadAttributes {
+        let attributes = PayloadAttributes {
             timestamp: (timestamp_ms / 1000) as u64, // **THIS HAS TO BE SECONDS**
             prev_randao: parent_mix_hash,
             suggested_fee_recipient: self.inner().config.node_config.reward_address,
@@ -367,13 +463,71 @@ pub trait BlockProdStrategy {
             parent_beacon_block_root: Some(prev_block_header.block_hash.into()),
         };
 
-        let payload = self
-            .inner()
-            .reth_node_adapter
-            .build_submit_payload_irys(prev_block_header.evm_block_hash, payload_attrs, shadow_txs)
+        debug!(
+            timestamp_sec = attributes.timestamp,
+            fee_recipient = %attributes.suggested_fee_recipient,
+            parent_beacon_root = ?attributes.parent_beacon_block_root,
+            "Payload attributes created"
+        );
+
+        let attributes =
+            EthPayloadBuilderAttributes::new(prev_block_header.evm_block_hash, attributes);
+
+        let payload_builder = &self.inner().reth_payload_builder;
+        let beacon_engine_handle = &self.inner().beacon_engine_handle;
+
+        // store shadow txs
+        let key = DeterministicShadowTxKey::new(attributes.payload_id());
+        debug!(
+            payload_id = %attributes.payload_id(),
+            "Storing shadow transactions"
+        );
+        self.inner().shadow_tx_store.set_shadow_txs(key, shadow_txs);
+
+        // send & await the payload
+        info!("Sending new payload to Reth");
+
+        let payload_id = payload_builder
+            .send_new_payload(attributes.clone())
+            .await
+            .map_err(|e| eyre!("Failed to send payload to builder: {}", e))?
+            .map_err(|e| eyre!("Payload builder returned error: {}", e))?;
+
+        debug!(
+            payload_id = %payload_id,
+            "Payload accepted by builder"
+        );
+
+        let built_payload = payload_builder
+            .resolve_kind(payload_id, PayloadKind::WaitForPending)
+            .await
+            .ok_or_else(|| {
+                eyre!("Failed to resolve payload future - payload builder returned None")
+            })?
+            .map_err(|e| eyre!("Failed to build payload: {}", e))?;
+
+        let sidecar = ExecutionPayloadSidecar::from_block(&built_payload.block().clone().unseal());
+        let payload = built_payload.clone().try_into_v5().unwrap();
+        let new_payload_result = beacon_engine_handle
+            .new_payload(ExecutionData {
+                payload: ExecutionPayload::V3(payload.execution_payload),
+                sidecar,
+            })
             .await?;
 
-        Ok(payload)
+        eyre::ensure!(
+            new_payload_result.status == PayloadStatusEnum::Valid,
+            "Reth has gone out of sync {:?}",
+            new_payload_result.status
+        );
+
+        info!(
+            payload_block_hash = %built_payload.block().hash(),
+            payload_tx_count = built_payload.block().body().transactions.len(),
+            "Reth payload built successfully"
+        );
+
+        Ok(built_payload)
     }
 
     async fn produce_block(
@@ -765,9 +919,7 @@ pub trait BlockProdStrategy {
                 // whereas, if we use the reth rpc, it will fetch the block from reth peers (not what we want)!
                 let result = self
                     .inner()
-                    .reth_node_adapter
-                    .inner
-                    .provider
+                    .reth_provider
                     .block(BlockHashOrNumber::Hash(prev_block_header.evm_block_hash))?;
                 match result {
                     Some(block) => {

--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -143,7 +143,7 @@ impl BlockProducerService {
                 .await
                 .expect("Block producer service encountered an irrecoverable error")
         });
-        
+
         TokioServiceHandle {
             name: "block_producer_service".to_string(),
             handle,

--- a/crates/actors/src/mining.rs
+++ b/crates/actors/src/mining.rs
@@ -307,7 +307,6 @@ impl Handler<BroadcastMiningSeed> for PartitionMiningActor {
                 if let Err(err) = self.service_senders.block_producer.send(cmd) {
                     error!("Error submitting solution to block producer {:?}", err);
                 }
-                // debug!("Solution sent!");
             }
 
             Ok(None) => {

--- a/crates/actors/src/services.rs
+++ b/crates/actors/src/services.rs
@@ -1,4 +1,5 @@
 use crate::{
+    block_producer::BlockProducerCommand,
     block_tree_service::{
         BlockMigratedEvent, BlockStateUpdated, BlockTreeServiceMessage, ReorgEvent,
     },
@@ -60,6 +61,7 @@ pub struct ServiceReceivers {
     pub gossip_broadcast: UnboundedReceiver<GossipBroadcastMessage>,
     pub block_tree: UnboundedReceiver<BlockTreeServiceMessage>,
     pub validation_service: UnboundedReceiver<ValidationServiceMessage>,
+    pub block_producer: UnboundedReceiver<BlockProducerCommand>,
     pub reorg_events: broadcast::Receiver<ReorgEvent>,
     pub block_migrated_events: broadcast::Receiver<BlockMigratedEvent>,
     pub block_state_events: broadcast::Receiver<BlockStateUpdated>,
@@ -75,6 +77,7 @@ pub struct ServiceSendersInner {
     pub gossip_broadcast: UnboundedSender<GossipBroadcastMessage>,
     pub block_tree: UnboundedSender<BlockTreeServiceMessage>,
     pub validation_service: UnboundedSender<ValidationServiceMessage>,
+    pub block_producer: UnboundedSender<BlockProducerCommand>,
     pub reorg_events: broadcast::Sender<ReorgEvent>,
     pub block_migrated_events: broadcast::Sender<BlockMigratedEvent>,
     pub block_state_events: broadcast::Sender<BlockStateUpdated>,
@@ -97,6 +100,8 @@ impl ServiceSendersInner {
             unbounded_channel::<BlockTreeServiceMessage>();
         let (validation_sender, validation_receiver) =
             unbounded_channel::<ValidationServiceMessage>();
+        let (block_producer_sender, block_producer_receiver) =
+            unbounded_channel::<BlockProducerCommand>();
         // Create broadcast channel for reorg events
         let (reorg_sender, reorg_receiver) = broadcast::channel::<ReorgEvent>(100);
         let (block_migrated_sender, block_migrated_receiver) =
@@ -113,6 +118,7 @@ impl ServiceSendersInner {
             gossip_broadcast: gossip_broadcast_sender,
             block_tree: block_tree_sender,
             validation_service: validation_sender,
+            block_producer: block_producer_sender,
             reorg_events: reorg_sender,
             block_migrated_events: block_migrated_sender,
             block_state_events: block_state_sender,
@@ -126,6 +132,7 @@ impl ServiceSendersInner {
             gossip_broadcast: gossip_broadcast_receiver,
             block_tree: block_tree_receiver,
             validation_service: validation_receiver,
+            block_producer: block_producer_receiver,
             reorg_events: reorg_receiver,
             block_migrated_events: block_migrated_receiver,
             block_state_events: block_state_receiver,

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -77,6 +77,7 @@ rust_decimal.workspace = true
 rust_decimal_macros.workspace = true
 semver.workspace = true
 thiserror.workspace = true
+itertools.workspace = true
 
 
 [package.metadata.cargo-machete]

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -8,7 +8,7 @@ use irys_actors::{
     block_discovery::BlockDiscoveryActor,
     block_discovery::BlockDiscoveryFacadeImpl,
     block_index_service::{BlockIndexService, GetBlockIndexGuardMessage},
-    block_producer::BlockProducerActor,
+    block_producer::BlockProducerCommand,
     block_tree_service::BlockTreeService,
     broadcast_mining_service::BroadcastMiningService,
     cache_service::ChunkCacheService,
@@ -36,7 +36,7 @@ use irys_p2p::{
 };
 use irys_price_oracle::{mock_oracle::MockOracle, IrysPriceOracle};
 use irys_reth_node_bridge::irys_reth::payload::ShadowTxStore;
-use irys_reth_node_bridge::node::{RethNode, RethNodeHandle};
+use irys_reth_node_bridge::node::{NodeProvider, RethNode, RethNodeHandle};
 pub use irys_reth_node_bridge::node::{RethNodeAddOns, RethNodeProvider};
 use irys_reth_node_bridge::signal::run_until_ctrl_c_or_channel_message;
 use irys_reth_node_bridge::IrysRethNodeAdapter;
@@ -50,7 +50,7 @@ use irys_storage::{
 use irys_types::{
     app_state::DatabaseProvider, calculate_initial_difficulty, ArbiterEnum, ArbiterHandle,
     CloneableJoinHandle, CommitmentTransaction, Config, IrysBlockHeader, NodeConfig, NodeMode,
-    OracleConfig, PartitionChunkRange, ServiceSet, H256, U256,
+    OracleConfig, PartitionChunkRange, ServiceSet, TokioServiceHandle, H256, U256,
 };
 use irys_vdf::vdf::run_vdf_for_genesis_block;
 use irys_vdf::{
@@ -1013,20 +1013,23 @@ impl IrysNode {
         let price_oracle = Self::init_price_oracle(&config);
 
         // set up the block producer
-        let (block_producer_addr, block_producer_arbiter, block_producer_inner) =
-            Self::init_block_producer(
-                &config,
-                Arc::clone(&reward_curve),
-                &irys_db,
-                &service_senders,
-                &block_tree_guard,
-                &vdf_state_readonly,
-                block_discovery.clone(),
-                broadcast_mining_actor.clone(),
-                price_oracle,
-                reth_node_adapter.clone(),
-                reth_service_actor.clone(),
-            );
+        let (block_producer_inner, block_producer_handle) = Self::init_block_producer(
+            &config,
+            Arc::clone(&reward_curve),
+            &irys_db,
+            &service_senders,
+            &block_tree_guard,
+            &vdf_state_readonly,
+            block_discovery.clone(),
+            broadcast_mining_actor.clone(),
+            price_oracle,
+            reth_node_adapter.clone(),
+            reth_service_actor.clone(),
+            task_exec,
+            receivers.block_producer,
+            reth_node.provider.clone(),
+            shadow_tx_store.clone(),
+        );
 
         let (global_step_number, last_step_hash) =
             vdf_state_readonly.read().get_last_step_and_seed();
@@ -1045,7 +1048,7 @@ impl IrysNode {
             &config,
             &storage_modules_guard,
             &vdf_state_readonly,
-            &block_producer_addr,
+            &service_senders.block_producer,
             &atomic_global_step_number,
             &packing_actor_addr,
             latest_block.diff,
@@ -1074,7 +1077,7 @@ impl IrysNode {
             actor_addresses: ActorAddresses {
                 partitions: part_actors,
                 block_discovery_addr: block_discovery,
-                block_producer: block_producer_addr,
+                block_producer: service_senders.block_producer.clone(),
                 packing: packing_actor_addr,
                 block_index: block_index_service_actor,
                 reth: reth_service_actor,
@@ -1119,12 +1122,9 @@ impl IrysNode {
 
         let mut services = Vec::new();
         {
-            services.push(ArbiterEnum::ActixArbiter {
-                arbiter: ArbiterHandle::new(
-                    block_producer_arbiter,
-                    "block_producer_arbiter".to_string(),
-                ),
-            });
+            // Add the tokio service handle for block producer
+            services.push(ArbiterEnum::TokioService(block_producer_handle));
+
             services.push(ArbiterEnum::ActixArbiter {
                 arbiter: ArbiterHandle::new(broadcast_arbiter, "broadcast_arbiter".to_string()),
             });
@@ -1264,7 +1264,7 @@ impl IrysNode {
         config: &Config,
         storage_modules_guard: &StorageModulesReadGuard,
         vdf_steps_guard: &VdfStateReadonly,
-        block_producer_addr: &actix::Addr<BlockProducerActor>,
+        block_producer_tx: &mpsc::UnboundedSender<BlockProducerCommand>,
         atomic_global_step_number: &Arc<AtomicU64>,
         packing_actor_addr: &actix::Addr<PackingActor>,
         initial_difficulty: U256,
@@ -1274,7 +1274,7 @@ impl IrysNode {
         for sm in storage_modules_guard.read().iter() {
             let partition_mining_actor = PartitionMiningActor::new(
                 config,
-                block_producer_addr.clone().recipient(),
+                block_producer_tx.clone(),
                 packing_actor_addr.clone().recipient(),
                 sm.clone(),
                 false, // do not start mining automatically
@@ -1334,12 +1334,11 @@ impl IrysNode {
         price_oracle: Arc<IrysPriceOracle>,
         reth_node_adapter: IrysRethNodeAdapter,
         reth_service_actor: actix::Addr<RethServiceActor>,
-    ) -> (
-        actix::Addr<BlockProducerActor>,
-        Arbiter,
-        Arc<irys_actors::BlockProducerInner>,
-    ) {
-        let block_producer_arbiter = Arbiter::new();
+        _task_executor: &TaskExecutor,
+        block_producer_rx: mpsc::UnboundedReceiver<BlockProducerCommand>,
+        reth_provider: NodeProvider,
+        shadow_tx_store: ShadowTxStore,
+    ) -> (Arc<irys_actors::BlockProducerInner>, TokioServiceHandle) {
         let block_producer_inner = Arc::new(irys_actors::BlockProducerInner {
             db: irys_db.clone(),
             config: config.clone(),
@@ -1350,23 +1349,21 @@ impl IrysNode {
             block_tree_guard: block_tree_guard.clone(),
             price_oracle,
             service_senders: service_senders.clone(),
-            reth_node_adapter,
+            reth_payload_builder: reth_node_adapter.inner.payload_builder_handle.clone(),
+            reth_provider,
+            shadow_tx_store,
             reth_service: reth_service_actor,
+            beacon_engine_handle: reth_node_adapter.inner.beacon_engine_handle.clone(),
         });
-        let block_producer_actor = BlockProducerActor {
-            inner: block_producer_inner.clone(),
-            blocks_remaining_for_test: None,
-            span: Span::current(),
-        };
-        let block_producer_addr =
-            BlockProducerActor::start_in_arbiter(&block_producer_arbiter.handle(), move |_| {
-                block_producer_actor
-            });
-        (
-            block_producer_addr,
-            block_producer_arbiter,
-            block_producer_inner,
-        )
+
+        // Spawn the service and get the handle
+        let tokio_service_handle = irys_actors::BlockProducerService::spawn_service(
+            block_producer_inner.clone(),
+            None, // blocks_remaining_for_test
+            block_producer_rx,
+        );
+
+        (block_producer_inner, tokio_service_handle)
     }
 
     fn init_price_oracle(config: &Config) -> Arc<IrysPriceOracle> {

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -1025,7 +1025,6 @@ impl IrysNode {
             price_oracle,
             reth_node_adapter.clone(),
             reth_service_actor.clone(),
-            task_exec,
             receivers.block_producer,
             reth_node.provider.clone(),
             shadow_tx_store.clone(),
@@ -1321,6 +1320,7 @@ impl IrysNode {
             PackingActor::new(task_executor.clone(), sm_ids, packing_config).start();
         (atomic_global_step_number, packing_actor_addr)
     }
+
     fn init_block_producer(
         config: &Config,
         reward_curve: Arc<HalvingCurve>,
@@ -1333,7 +1333,6 @@ impl IrysNode {
         price_oracle: Arc<IrysPriceOracle>,
         reth_node_adapter: IrysRethNodeAdapter,
         reth_service_actor: actix::Addr<RethServiceActor>,
-        _task_executor: &TaskExecutor,
         block_producer_rx: mpsc::UnboundedReceiver<BlockProducerCommand>,
         reth_provider: NodeProvider,
         shadow_tx_store: ShadowTxStore,

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -1048,7 +1048,7 @@ impl IrysNode {
             &config,
             &storage_modules_guard,
             &vdf_state_readonly,
-            &service_senders.block_producer,
+            &service_senders,
             &atomic_global_step_number,
             &packing_actor_addr,
             latest_block.diff,
@@ -1077,7 +1077,6 @@ impl IrysNode {
             actor_addresses: ActorAddresses {
                 partitions: part_actors,
                 block_discovery_addr: block_discovery,
-                block_producer: service_senders.block_producer.clone(),
                 packing: packing_actor_addr,
                 block_index: block_index_service_actor,
                 reth: reth_service_actor,
@@ -1264,7 +1263,7 @@ impl IrysNode {
         config: &Config,
         storage_modules_guard: &StorageModulesReadGuard,
         vdf_steps_guard: &VdfStateReadonly,
-        block_producer_tx: &mpsc::UnboundedSender<BlockProducerCommand>,
+        service_senders: &ServiceSenders,
         atomic_global_step_number: &Arc<AtomicU64>,
         packing_actor_addr: &actix::Addr<PackingActor>,
         initial_difficulty: U256,
@@ -1274,7 +1273,7 @@ impl IrysNode {
         for sm in storage_modules_guard.read().iter() {
             let partition_mining_actor = PartitionMiningActor::new(
                 config,
-                block_producer_tx.clone(),
+                service_senders.clone(),
                 packing_actor_addr.clone().recipient(),
                 sm.clone(),
                 false, // do not start mining automatically

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -1044,7 +1044,7 @@ async fn heavy_test_always_build_on_max_difficulty_block() -> eyre::Result<()> {
         pub prod: ProductionStrategy,
     }
 
-    #[async_trait::async_trait(?Send)]
+    #[async_trait::async_trait]
     impl BlockProdStrategy for OptimisticBlockMiningStrategy {
         fn inner(&self) -> &BlockProducerInner {
             &self.prod.inner

--- a/crates/chain/tests/block_production/reset_seed.rs
+++ b/crates/chain/tests/block_production/reset_seed.rs
@@ -14,7 +14,7 @@ use tracing::{debug, error, warn};
 /// What we're testing:
 /// - Genesis node mines a bunch of blocks (about 42) with reset happening every 8 VDF steps
 /// - Since test mining produces ~1-2 steps per block, resets happen roughly every 4-8 blocks
-/// - We verify the reset seed logic: when a reset happens, the new seed comes from the 
+/// - We verify the reset seed logic: when a reset happens, the new seed comes from the
 ///   previous block's hash, and the current seed rotates from the previous next_seed
 /// - Then we spin up a peer node to sync all these blocks and make sure it validates
 ///   the reset seeds correctly too

--- a/crates/chain/tests/block_production/reset_seed.rs
+++ b/crates/chain/tests/block_production/reset_seed.rs
@@ -2,8 +2,8 @@ use crate::utils::{AddTxError, IrysNodeTest};
 use irys_actors::mempool_service::TxIngressError;
 use irys_chain::IrysNodeCtx;
 use irys_types::{
-    irys::IrysSigner, BlockHash, ConsensusConfig, ConsensusOptions, IrysTransaction,
-    IrysTransactionId, NodeConfig, NodeMode,
+    irys::IrysSigner, BlockHash, ConsensusConfig, ConsensusOptions, IrysBlockHeader,
+    IrysTransaction, IrysTransactionId, NodeConfig, NodeMode,
 };
 use std::collections::HashMap;
 use tracing::{debug, warn};
@@ -18,20 +18,18 @@ use tracing::{debug, warn};
 ///    - seed = previous block's next_seed
 /// 3. Verifies non-reset blocks maintain seed continuity
 /// 4. Spins up a peer node to verify reset seeds propagate correctly during sync
-///
-/// This approach is machine-independent since we detect resets dynamically rather
-/// than trying to predict when they'll occur.
 #[test_log::test(actix_web::test)]
 async fn slow_heavy_reset_seeds_should_be_correctly_applied_by_the_miner_and_verified_by_the_peer(
 ) -> eyre::Result<()> {
     let max_seconds = 20;
     let reset_frequency = 8; // Reset every 8 VDF steps
     let min_resets_required = 2; // Need at least 2 resets to verify behavior
+    let block_migration_depth = 1;
 
     // Setting up parameters explicitly to check that the reset seed is applied correctly
     let mut consensus_config = ConsensusConfig::testnet();
     consensus_config.vdf.reset_frequency = reset_frequency;
-    consensus_config.block_migration_depth = 1;
+    consensus_config.block_migration_depth = block_migration_depth;
     consensus_config.block_tree_depth = 200;
 
     // setup trusted peers connection data and configs for genesis and nodes
@@ -45,178 +43,44 @@ async fn slow_heavy_reset_seeds_should_be_correctly_applied_by_the_miner_and_ver
         .start_and_wait_for_packing("GENESIS", max_seconds)
         .await;
 
-    // generate a txn and add it to the block...
+    // Generate a test transaction to include in blocks
     generate_test_transaction_and_add_to_block(&ctx_genesis_node, &account1).await;
 
-    // Mine blocks until we observe enough resets
-    let mut resets_found = 0;
-    let mut total_blocks_mined = 0;
-    let blocks_per_batch = 10;
-    let max_blocks = 100; // Safety limit
-    
-    let mut all_blocks = Vec::new();
-    
-    while resets_found < min_resets_required && total_blocks_mined < max_blocks {
-        // Mine a batch of blocks
-        ctx_genesis_node
-            .mine_blocks(blocks_per_batch)
-            .await
-            .expect("expected to mine blocks");
-        
-        total_blocks_mined += blocks_per_batch;
-        
-        // Wait for blocks to be indexed
-        ctx_genesis_node
-            .wait_until_height(total_blocks_mined as u64, max_seconds)
-            .await?;
-        
-        // Get all blocks mined so far
-        let blocks = ctx_genesis_node
-            .get_blocks(0, total_blocks_mined as u64)
-            .await
-            .expect("expected to get mined blocks");
-        
-        // Count resets in all blocks
-        resets_found = blocks
-            .iter()
-            .filter(|block| block.vdf_limiter_info.reset_step(reset_frequency as u64).is_some())
-            .count();
-        
-        all_blocks = blocks;
-        
-        debug!(
-            "Mined {} blocks, found {} resets so far",
-            total_blocks_mined, resets_found
-        );
-    }
-    
-    if resets_found < min_resets_required {
-        return Err(eyre::eyre!(
-            "Only found {} resets after mining {} blocks, needed at least {}",
-            resets_found,
-            total_blocks_mined,
-            min_resets_required
-        ));
-    }
-    
-    warn!(
-        "Genesis node mined {} blocks, found {} reset events",
-        total_blocks_mined, resets_found
-    );
-    
-    let genesis_node_blocks = all_blocks;
+    // Mine blocks until we observe enough VDF resets
+    let reset_frequency_u64 = reset_frequency as u64;
+    let total_blocks_mined = ctx_genesis_node
+        .mine_until_condition(
+            |blocks| {
+                blocks
+                    .iter()
+                    .filter(|block| {
+                        block
+                            .vdf_limiter_info
+                            .reset_step(reset_frequency_u64)
+                            .is_some()
+                    })
+                    .count()
+                    >= min_resets_required
+            },
+            10,  // blocks_per_batch
+            100, // max_blocks
+            max_seconds,
+        )
+        .await?;
 
-    // Debug: Log all blocks to understand VDF step progression
-    for (index, block) in genesis_node_blocks.iter().enumerate() {
-        let first_step = block.vdf_limiter_info.first_step_number();
-        let last_step = block.vdf_limiter_info.global_step_number;
-        debug!(
-            "Block {} ({}): steps {} to {} (span: {})",
-            index,
-            block.block_hash,
-            first_step,
-            last_step,
-            last_step - first_step + 1
-        );
-    }
+    let genesis_node_blocks = ctx_genesis_node
+        .get_blocks(0, total_blocks_mined as u64)
+        .await?;
 
-    // Find all blocks that contain a reset
-    let blocks_with_resets = genesis_node_blocks
-        .iter()
-        .enumerate()
-        .filter_map(|(index, block)| {
-            if block.vdf_limiter_info.reset_step(reset_frequency as u64).is_some() {
-                let previous_block = if index == 0 {
-                    None
-                } else {
-                    Some(&genesis_node_blocks[index - 1])
-                };
-                Some((block.clone(), previous_block.cloned()))
-            } else {
-                None
-            }
-        })
-        .collect::<Vec<_>>();
+    // Find and verify blocks that contain VDF resets
+    let blocks_with_resets = ctx_genesis_node
+        .get_blocks_with_vdf_resets(0, total_blocks_mined as u64)
+        .await?;
 
-    for (block, previous_block) in blocks_with_resets.iter() {
-        // When performing a reset, the next reset seed is set to the block hash of the previous block,
-        // and the current reset seed is set to the next reset seed of the previous block.
-        let (expected_next_reset_seed, expected_current_reset_seed) = previous_block
-            .as_ref()
-            .map(|block| (block.block_hash, block.vdf_limiter_info.next_seed))
-            .unwrap_or_else(|| (BlockHash::zero(), BlockHash::zero()));
+    verify_reset_seeds(&blocks_with_resets, &genesis_node_blocks);
 
-        let first_step = block.vdf_limiter_info.first_step_number();
-        let last_step = block.vdf_limiter_info.global_step_number;
-
-        assert_eq!(
-            block.vdf_limiter_info.next_seed, expected_next_reset_seed,
-            "Reset seed mismatch for block {:?}: expected {:?}, got {:?}",
-            block.block_hash, expected_next_reset_seed, block.vdf_limiter_info.next_seed
-        );
-        assert_eq!(
-            block.vdf_limiter_info.seed, expected_current_reset_seed,
-            "Current reset seed mismatch for block {:?}: expected {:?}, got {:?}",
-            block.block_hash, expected_current_reset_seed, block.vdf_limiter_info.seed
-        );
-        debug!(
-            "Block with reset seed found: {}: first_step: {}, last_step: {}, next_seed: {:?}",
-            block.block_hash, first_step, last_step, block.vdf_limiter_info.next_seed
-        );
-    }
-
-    let mut resets_so_far = 0;
-    // The test above verifies that the reset seed is applied correctly at a correct block,
-    // this test ensures that the reset seed is carried over correctly on the blocks that don't
-    // have a reset step
-    for (index, block) in genesis_node_blocks.iter().enumerate() {
-        let previous_block = if index == 0 {
-            // The first block should not have a previous block
-            None
-        } else {
-            Some(&genesis_node_blocks[index - 1])
-        };
-
-        // Check that reset seeds are rotating correctly
-        if let Some(prev_block) = previous_block {
-            if block
-                .vdf_limiter_info
-                .reset_step(reset_frequency as u64)
-                .is_some()
-            {
-                if resets_so_far == 0 {
-                    // During the first reset, both seeds should be zero
-                    assert_eq!(block.vdf_limiter_info.seed, BlockHash::zero());
-                    assert_eq!(block.vdf_limiter_info.next_seed, prev_block.block_hash);
-                } else {
-                    // After that point seeds should rotate each reset block
-                    assert_eq!(
-                        block.vdf_limiter_info.seed,
-                        prev_block.vdf_limiter_info.next_seed
-                    );
-                    assert_ne!(
-                        block.vdf_limiter_info.seed,
-                        prev_block.vdf_limiter_info.seed
-                    );
-                    assert_ne!(
-                        block.vdf_limiter_info.next_seed,
-                        prev_block.vdf_limiter_info.next_seed
-                    );
-                }
-                resets_so_far += 1;
-            } else {
-                assert_eq!(
-                    block.vdf_limiter_info.seed, prev_block.vdf_limiter_info.seed,
-                    "Seed should not change for non-reset blocks at index {}",
-                    index
-                );
-            }
-        } else {
-            // The genesis block should not have a reset seed
-            assert_eq!(block.vdf_limiter_info.seed, BlockHash::zero());
-            assert_eq!(block.vdf_limiter_info.next_seed, BlockHash::zero());
-        }
-    }
+    // Verify seed continuity across all blocks
+    verify_seed_continuity(&genesis_node_blocks, reset_frequency as u64);
 
     warn!("Reset seed verification completed, starting peer node to verify that syncing works");
 
@@ -229,47 +93,22 @@ async fn slow_heavy_reset_seeds_should_be_correctly_applied_by_the_miner_and_ver
         .await;
     ctx_peer1_node.start_public_api().await;
 
-    // Wait for peer to sync all the blocks we mined
-    // We need to wait for a bit less than total_blocks_mined due to block_migration_depth
-    let peer_sync_height = (total_blocks_mined as u64).saturating_sub(2);
+    // Wait for peer to sync
+    let peer_sync_height = (total_blocks_mined as u64).saturating_sub(block_migration_depth as u64);
     ctx_peer1_node
         .wait_until_height(peer_sync_height, max_seconds * 3)
         .await?;
 
-    let peer_node_blocks = ctx_peer1_node
-        .get_blocks(0, peer_sync_height)
-        .await
-        .expect("expected peer 1 to be fully synced");
+    warn!("Peer node synced, verifying blocks match");
 
-    warn!("Peer node synced, shutting down the nodes as we've got all blocks");
+    ctx_genesis_node
+        .verify_blocks_match(&ctx_peer1_node, 0, peer_sync_height)
+        .await?;
+
+    warn!("Block verification completed, shutting down nodes");
 
     ctx_genesis_node.stop().await;
     ctx_peer1_node.stop().await;
-
-    // Compare only the blocks that the peer has synced
-    let blocks_to_compare = peer_node_blocks.len();
-    for index in 0..blocks_to_compare {
-        let peer_node_block = &peer_node_blocks[index];
-        let genesis_node_block = &genesis_node_blocks[index];
-        assert_eq!(
-            peer_node_block.block_hash, genesis_node_block.block_hash,
-            "Block hash mismatch at index {}: expected {:?}, got {:?}",
-            index, genesis_node_block.block_hash, peer_node_block.block_hash
-        );
-        assert_eq!(
-            peer_node_block.vdf_limiter_info.next_seed,
-            genesis_node_block.vdf_limiter_info.next_seed,
-            "Next reset seed mismatch at index {}: expected {:?}, got {:?}",
-            index,
-            genesis_node_block.vdf_limiter_info.next_seed,
-            peer_node_block.vdf_limiter_info.next_seed
-        );
-        assert_eq!(
-            peer_node_block.vdf_limiter_info.seed, genesis_node_block.vdf_limiter_info.seed,
-            "Current reset seed mismatch at index {}: expected {:?}, got {:?}",
-            index, genesis_node_block.vdf_limiter_info.seed, peer_node_block.vdf_limiter_info.seed
-        );
-    }
 
     warn!("Reset seed peer verification completed");
 
@@ -294,4 +133,82 @@ async fn generate_test_transaction_and_add_to_block(
         Err(e) => panic!("unexpected error {:?}", e),
     }
     irys_txs
+}
+
+/// Verify reset seeds are applied correctly
+fn verify_reset_seeds(blocks_with_resets: &[IrysBlockHeader], all_blocks: &[IrysBlockHeader]) {
+    for block in blocks_with_resets.iter() {
+        // Find the previous block
+        let previous_block = if block.height == 0 {
+            None
+        } else {
+            all_blocks.iter().find(|b| b.height == block.height - 1)
+        };
+
+        // When performing a reset, the next reset seed is set to the block hash of the previous block,
+        // and the current reset seed is set to the next reset seed of the previous block.
+        let (expected_next_reset_seed, expected_current_reset_seed) = previous_block
+            .map(|block| (block.block_hash, block.vdf_limiter_info.next_seed))
+            .unwrap_or_else(|| (BlockHash::zero(), BlockHash::zero()));
+
+        let first_step = block.vdf_limiter_info.first_step_number();
+        let last_step = block.vdf_limiter_info.global_step_number;
+
+        assert_eq!(
+            block.vdf_limiter_info.next_seed, expected_next_reset_seed,
+            "Reset seed mismatch for block {:?}: expected {:?}, got {:?}",
+            block.block_hash, expected_next_reset_seed, block.vdf_limiter_info.next_seed
+        );
+        assert_eq!(
+            block.vdf_limiter_info.seed, expected_current_reset_seed,
+            "Current reset seed mismatch for block {:?}: expected {:?}, got {:?}",
+            block.block_hash, expected_current_reset_seed, block.vdf_limiter_info.seed
+        );
+        debug!(
+            "Block with reset seed found: {}: first_step: {}, last_step: {}, next_seed: {:?}",
+            block.block_hash, first_step, last_step, block.vdf_limiter_info.next_seed
+        );
+    }
+}
+
+/// Verify seed continuity across all blocks
+fn verify_seed_continuity(blocks: &[IrysBlockHeader], reset_frequency: u64) {
+    let mut resets_so_far = 0;
+
+    for (index, block) in blocks.iter().enumerate() {
+        let previous_block = if index == 0 {
+            None
+        } else {
+            Some(&blocks[index - 1])
+        };
+
+        // Check that reset seeds are rotating correctly
+        if let Some(prev_block) = previous_block {
+            if block.vdf_limiter_info.reset_step(reset_frequency).is_some() {
+                // For reset blocks:
+                // - next_seed should always be the previous block's hash
+                // - seed should be the previous block's next_seed (except for genesis)
+                assert_eq!(block.vdf_limiter_info.next_seed, prev_block.block_hash);
+
+                if resets_so_far > 0 {
+                    // After the first reset, seed should come from previous block's next_seed
+                    assert_eq!(
+                        block.vdf_limiter_info.seed,
+                        prev_block.vdf_limiter_info.next_seed
+                    );
+                }
+                resets_so_far += 1;
+            } else {
+                assert_eq!(
+                    block.vdf_limiter_info.seed, prev_block.vdf_limiter_info.seed,
+                    "Seed should not change for non-reset blocks at index {}",
+                    index
+                );
+            }
+        } else {
+            // The genesis block should not have a reset seed
+            assert_eq!(block.vdf_limiter_info.seed, BlockHash::zero());
+            assert_eq!(block.vdf_limiter_info.next_seed, BlockHash::zero());
+        }
+    }
 }

--- a/crates/chain/tests/block_production/reset_seed.rs
+++ b/crates/chain/tests/block_production/reset_seed.rs
@@ -187,13 +187,25 @@ fn verify_seed_continuity(blocks: &[IrysBlockHeader], reset_frequency: u64) {
             if block.vdf_limiter_info.reset_step(reset_frequency).is_some() {
                 // For reset blocks:
                 // - next_seed should always be the previous block's hash
-                // - seed should be the previous block's next_seed (except for genesis)
+                // - seed should be the previous block's next_seed (except for first reset)
                 assert_eq!(block.vdf_limiter_info.next_seed, prev_block.block_hash);
 
-                if resets_so_far > 0 {
+                if resets_so_far == 0 {
+                    // During the first reset, the seed should still be zero
+                    assert_eq!(block.vdf_limiter_info.seed, BlockHash::zero());
+                } else {
                     // After the first reset, seed should come from previous block's next_seed
                     assert_eq!(
                         block.vdf_limiter_info.seed,
+                        prev_block.vdf_limiter_info.next_seed
+                    );
+                    // Verify that seeds are actually rotating (changing)
+                    assert_ne!(
+                        block.vdf_limiter_info.seed,
+                        prev_block.vdf_limiter_info.seed
+                    );
+                    assert_ne!(
+                        block.vdf_limiter_info.next_seed,
                         prev_block.vdf_limiter_info.next_seed
                     );
                 }

--- a/crates/chain/tests/block_production/reset_seed.rs
+++ b/crates/chain/tests/block_production/reset_seed.rs
@@ -62,7 +62,7 @@ async fn slow_heavy_reset_seeds_should_be_correctly_applied_by_the_miner_and_ver
                     .count()
                     >= min_resets_required
             },
-            10,  // blocks_per_batch
+            1,   // blocks_per_batch
             100, // max_blocks
             max_seconds,
         )

--- a/crates/chain/tests/multi_node/validation.rs
+++ b/crates/chain/tests/multi_node/validation.rs
@@ -20,7 +20,7 @@ async fn heavy_block_invalid_evm_block_reward_gets_rejected() -> eyre::Result<()
         pub prod: ProductionStrategy,
     }
 
-    #[async_trait::async_trait(?Send)]
+    #[async_trait::async_trait]
     impl BlockProdStrategy for EvilBlockProdStrategy {
         fn inner(&self) -> &BlockProducerInner {
             &self.prod.inner
@@ -171,7 +171,7 @@ async fn heavy_block_shadow_txs_misalignment_block_rejected() -> eyre::Result<()
         pub extra_tx: IrysTransactionHeader,
     }
 
-    #[async_trait::async_trait(?Send)]
+    #[async_trait::async_trait]
     impl BlockProdStrategy for EvilBlockProdStrategy {
         fn inner(&self) -> &BlockProducerInner {
             &self.prod.inner
@@ -259,7 +259,7 @@ async fn heavy_block_shadow_txs_different_order_of_txs() -> eyre::Result<()> {
         pub prod: ProductionStrategy,
     }
 
-    #[async_trait::async_trait(?Send)]
+    #[async_trait::async_trait]
     impl BlockProdStrategy for EvilBlockProdStrategy {
         fn inner(&self) -> &BlockProducerInner {
             &self.prod.inner

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -47,9 +47,9 @@ use irys_types::{
     U256,
 };
 use irys_types::{
-    Base64, CommitmentTransaction, Config, DatabaseProvider,
-    IrysBlockHeader, IrysTransaction, IrysTransactionHeader, IrysTransactionId, LedgerChunkOffset,
-    NodeConfig, NodeMode, PackedChunk, PeerAddress, RethPeerInfo, TxChunkOffset, UnpackedChunk,
+    Base64, CommitmentTransaction, Config, DatabaseProvider, IrysBlockHeader, IrysTransaction,
+    IrysTransactionHeader, IrysTransactionId, LedgerChunkOffset, NodeConfig, NodeMode, PackedChunk,
+    PeerAddress, RethPeerInfo, TxChunkOffset, UnpackedChunk,
 };
 use irys_vdf::state::VdfStateReadonly;
 use irys_vdf::{step_number_to_salt_number, vdf_sha};

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -53,6 +53,7 @@ use irys_types::{
 };
 use irys_vdf::state::VdfStateReadonly;
 use irys_vdf::{step_number_to_salt_number, vdf_sha};
+use itertools::Itertools;
 use reth::{
     api::Block as _,
     network::{PeerInfo, Peers as _},
@@ -1800,16 +1801,8 @@ impl IrysNodeTest<IrysNodeCtx> {
         let self_blocks = self.get_blocks(start_height, end_height).await?;
         let other_blocks = other.get_blocks(start_height, end_height).await?;
 
-        if self_blocks.len() != other_blocks.len() {
-            return Err(eyre::eyre!(
-                "Block count mismatch: {} vs {}",
-                self_blocks.len(),
-                other_blocks.len()
-            ));
-        }
-
         for (index, (self_block, other_block)) in
-            self_blocks.iter().zip(other_blocks.iter()).enumerate()
+            self_blocks.iter().zip_eq(other_blocks.iter()).enumerate()
         {
             // Compare full headers for completeness and clarity
             eyre::ensure!(

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -53,7 +53,7 @@ use irys_types::{
 };
 use irys_vdf::state::VdfStateReadonly;
 use irys_vdf::{step_number_to_salt_number, vdf_sha};
-use itertools::Itertools;
+use itertools::Itertools as _;
 use reth::{
     api::Block as _,
     network::{PeerInfo, Peers as _},

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -1790,21 +1790,6 @@ impl IrysNodeTest<IrysNodeCtx> {
             .collect())
     }
 
-    /// Sync a peer node to a specific height with proper error handling
-    pub async fn sync_peer_to_height(
-        &self,
-        peer: &Self,
-        target_height: u64,
-        max_seconds: usize,
-    ) -> eyre::Result<()> {
-        // Account for block migration depth
-        let block_migration_depth = self.node_ctx.config.consensus.block_migration_depth;
-        let sync_height = target_height.saturating_sub(block_migration_depth as u64);
-
-        peer.wait_until_height(sync_height, max_seconds).await?;
-        Ok(())
-    }
-
     /// Verify that blocks match between two nodes
     pub async fn verify_blocks_match(
         &self,

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -464,6 +464,7 @@ impl IrysNodeTest<IrysNodeCtx> {
         .await
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn wait_until_height(
         &self,
         target_height: u64,
@@ -486,13 +487,12 @@ impl IrysNodeTest<IrysNodeCtx> {
                 return Ok(latest_block.block_hash);
             }
 
-            if retries >= max_retries {
-                return Err(eyre::eyre!(
-                    "Failed to reach target height {} after {} retries",
-                    target_height,
-                    retries
-                ));
-            }
+            eyre::ensure!(
+                retries < max_retries,
+                "Failed to reach target height {} after {} retries",
+                target_height,
+                retries
+            );
 
             sleep(Duration::from_secs(1)).await;
             retries += 1;
@@ -1735,6 +1735,7 @@ impl IrysNodeTest<IrysNodeCtx> {
     }
 
     /// Mine blocks until a condition is met
+    #[tracing::instrument(skip_all)]
     pub async fn mine_until_condition<F>(
         &self,
         mut condition: F,

--- a/crates/irys-reth/Cargo.toml
+++ b/crates/irys-reth/Cargo.toml
@@ -43,6 +43,8 @@ reth-chain-state.workspace = true
 reth-payload-builder-primitives.workspace = true
 reth-ethereum-payload-builder.workspace = true
 reth-node-builder.workspace = true
+reth-provider.workspace = true
+
 
 tokio.workspace = true
 eyre.workspace = true

--- a/crates/irys-reth/src/lib.rs
+++ b/crates/irys-reth/src/lib.rs
@@ -37,14 +37,17 @@ use reth::{
     transaction_pool::TransactionValidationTaskExecutor,
 };
 use reth_chainspec::{ChainSpec, ChainSpecProvider, EthChainSpec, EthereumHardforks};
+pub use reth_ethereum_engine_primitives;
 use reth_ethereum_engine_primitives::EthPayloadAttributes;
 use reth_ethereum_primitives::TransactionSigned;
 use reth_evm_ethereum::RethReceiptBuilder;
+pub use reth_node_ethereum;
 use reth_node_ethereum::{
     node::{EthereumAddOns, EthereumConsensusBuilder, EthereumNetworkBuilder},
     EthEngineTypes, EthEvmConfig,
 };
 use reth_primitives_traits::constants::MINIMUM_GAS_LIMIT;
+pub use reth_provider::{providers::BlockchainProvider, BlockReaderIdExt};
 use reth_tracing::tracing;
 use reth_transaction_pool::{
     blobstore::{DiskFileBlobStore, DiskFileBlobStoreConfig},

--- a/crates/reth-node-bridge/src/adapter.rs
+++ b/crates/reth-node-bridge/src/adapter.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use crate::node::{eth_payload_attributes, NodeHelperType, RethNode};
-use crate::node::{RethNodeAdapter, RethNodeAddOns};
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{BlockNumber, B256};
 use alloy_rpc_types_engine::{ForkchoiceState, PayloadAttributes, PayloadStatusEnum};

--- a/crates/reth-node-bridge/src/adapter.rs
+++ b/crates/reth-node-bridge/src/adapter.rs
@@ -4,7 +4,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use crate::node::{eth_payload_attributes, RethNode};
+use crate::node::{eth_payload_attributes, NodeHelperType, RethNode};
 use crate::node::{RethNodeAdapter, RethNodeAddOns};
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{BlockNumber, B256};
@@ -23,7 +23,7 @@ use reth_provider::BlockReaderIdExt as _;
 
 #[derive(Clone)]
 pub struct IrysRethNodeAdapter {
-    pub reth_node: Arc<NodeTestContext<RethNodeAdapter, RethNodeAddOns>>,
+    pub reth_node: Arc<NodeHelperType>,
     pub shadow_tx_store: ShadowTxStore,
 }
 
@@ -44,7 +44,7 @@ impl IrysRethNodeAdapter {
 }
 
 impl Deref for IrysRethNodeAdapter {
-    type Target = NodeTestContext<RethNodeAdapter, RethNodeAddOns>;
+    type Target = NodeHelperType;
     fn deref(&self) -> &Self::Target {
         &self.reth_node
     }

--- a/crates/reth-node-bridge/src/node.rs
+++ b/crates/reth-node-bridge/src/node.rs
@@ -1,9 +1,7 @@
 use alloy_eips::BlockNumberOrTag;
 use alloy_rpc_types_engine::PayloadAttributes;
 use irys_database::db::RethDbWrapper;
-use irys_reth::{
-    payload::ShadowTxStore, IrysEthereumNode,
-};
+use irys_reth::{payload::ShadowTxStore, IrysEthereumNode};
 use irys_storage::reth_provider::IrysRethProvider;
 use irys_types::Address;
 use reth::{

--- a/crates/reth-node-bridge/src/node.rs
+++ b/crates/reth-node-bridge/src/node.rs
@@ -2,24 +2,17 @@ use alloy_eips::BlockNumberOrTag;
 use alloy_rpc_types_engine::PayloadAttributes;
 use irys_database::db::RethDbWrapper;
 use irys_reth::{
-    evm::IrysEvmConfig, payload::ShadowTxStore, IrysEthereumNode, IrysShadowTxValidator,
+    payload::ShadowTxStore, IrysEthereumNode,
 };
 use irys_storage::reth_provider::IrysRethProvider;
-use irys_types::{Address, Node as MerkleNode};
+use irys_types::Address;
 use reth::{
     args::DatabaseArgs,
-    consensus::{ConsensusError, FullConsensus},
-    network::NetworkHandle,
     payload::EthPayloadBuilderAttributes,
-    primitives::EthPrimitives,
     prometheus_exporter::install_prometheus_recorder,
     revm::primitives::B256,
     rpc::builder::{RethRpcModule, RpcModuleSelection},
     tasks::TaskExecutor,
-    transaction_pool::{
-        blobstore::DiskFileBlobStore, CoinbaseTipOrdering, EthPooledTransaction,
-        TransactionValidationTaskExecutor,
-    },
 };
 use reth_chainspec::ChainSpec;
 use reth_db::init_db;

--- a/crates/reth-node-bridge/src/node.rs
+++ b/crates/reth-node-bridge/src/node.rs
@@ -27,21 +27,20 @@ use tracing::error;
 use crate::{unwind::unwind_to, IrysRethNodeAdapter};
 pub use reth_e2e_test_utils::node::NodeTestContext;
 
-type TmpNodeAdapter = FullNodeTypesAdapter<IrysEthereumNode, RethDbWrapper, NodeProvider>;
+type NodeTypesAdapter = FullNodeTypesAdapter<IrysEthereumNode, RethDbWrapper, NodeProvider>;
 
 /// Type alias for a `NodeAdapter`
 pub type RethNodeAdapter = NodeAdapter<
-    TmpNodeAdapter,
-    <<IrysEthereumNode as Node<TmpNodeAdapter>>::ComponentsBuilder as NodeComponentsBuilder<
-        TmpNodeAdapter,
+    NodeTypesAdapter,
+    <<IrysEthereumNode as Node<NodeTypesAdapter>>::ComponentsBuilder as NodeComponentsBuilder<
+        NodeTypesAdapter,
     >>::Components,
 >;
 
 pub type NodeProvider = BlockchainProvider<NodeTypesWithDBAdapter<IrysEthereumNode, RethDbWrapper>>;
 
-/// Type alias for a type of `NodeHelper`
 pub type NodeHelperType =
-    NodeTestContext<RethNodeAdapter, <IrysEthereumNode as Node<TmpNodeAdapter>>::AddOns>;
+    NodeTestContext<RethNodeAdapter, <IrysEthereumNode as Node<NodeTypesAdapter>>::AddOns>;
 
 pub type RethNodeHandle = NodeHandle<RethNodeAdapter, RethNodeAddOns>;
 

--- a/crates/types/src/arbiter_handle.rs
+++ b/crates/types/src/arbiter_handle.rs
@@ -81,7 +81,7 @@ impl fmt::Debug for ServiceSet {
                 for service in services {
                     match service {
                         ArbiterEnum::ActixArbiter { .. } => actix_count += 1,
-                        ArbiterEnum::TokioService { .. } => tokio_count += 1,
+                        ArbiterEnum::TokioService(_) => tokio_count += 1,
                     }
                 }
 
@@ -163,15 +163,18 @@ impl Future for ServiceSet {
 }
 
 #[derive(Debug)]
+pub struct TokioServiceHandle {
+    pub name: String,
+    pub handle: TokioJoinHandle<()>,
+    pub shutdown_signal: reth::tasks::shutdown::Signal,
+}
+
+#[derive(Debug)]
 pub enum ArbiterEnum {
     ActixArbiter {
         arbiter: ArbiterHandle,
     },
-    TokioService {
-        name: String,
-        handle: TokioJoinHandle<()>,
-        shutdown_signal: reth::tasks::shutdown::Signal,
-    },
+    TokioService(TokioServiceHandle),
 }
 
 impl ArbiterEnum {
@@ -180,17 +183,17 @@ impl ArbiterEnum {
         handle: TokioJoinHandle<()>,
         shutdown_signal: reth::tasks::shutdown::Signal,
     ) -> Self {
-        Self::TokioService {
+        Self::TokioService(TokioServiceHandle {
             name,
             handle,
             shutdown_signal,
-        }
+        })
     }
 
     pub fn name(&self) -> &str {
         match self {
             Self::ActixArbiter { arbiter } => &arbiter.name,
-            Self::TokioService { name, .. } => name,
+            Self::TokioService(service) => &service.name,
         }
     }
 
@@ -199,21 +202,17 @@ impl ArbiterEnum {
             Self::ActixArbiter { arbiter } => {
                 arbiter.stop_and_join();
             }
-            Self::TokioService {
-                name,
-                handle,
-                shutdown_signal,
-            } => {
+            Self::TokioService(service) => {
                 // Fire the shutdown signal
-                shutdown_signal.fire();
+                service.shutdown_signal.fire();
 
                 // Wait for the task to complete
-                match handle.await {
+                match service.handle.await {
                     Ok(()) => {
-                        tracing::debug!("Tokio service '{}' shut down successfully", name)
+                        tracing::debug!("Tokio service '{}' shut down successfully", service.name)
                     }
                     Err(e) => {
-                        tracing::error!("Tokio service '{}' panicked: {:?}", name, e)
+                        tracing::error!("Tokio service '{}' panicked: {:?}", service.name, e)
                     }
                 }
             }
@@ -221,7 +220,7 @@ impl ArbiterEnum {
     }
 
     pub fn is_tokio_service(&self) -> bool {
-        matches!(self, Self::TokioService { .. })
+        matches!(self, Self::TokioService(_))
     }
 }
 
@@ -238,9 +237,9 @@ impl Future for ArbiterEnum {
                 // They need to be explicitly stopped
                 std::task::Poll::Pending
             }
-            Self::TokioService { handle, .. } => {
+            Self::TokioService(service) => {
                 // Poll the tokio join handle
-                match handle.poll_unpin(cx) {
+                match service.handle.poll_unpin(cx) {
                     std::task::Poll::Ready(res) => {
                         std::task::Poll::Ready(res.map_err(|err| eyre::Report::new(err)))
                     }

--- a/crates/types/src/arbiter_handle.rs
+++ b/crates/types/src/arbiter_handle.rs
@@ -171,9 +171,7 @@ pub struct TokioServiceHandle {
 
 #[derive(Debug)]
 pub enum ArbiterEnum {
-    ActixArbiter {
-        arbiter: ArbiterHandle,
-    },
+    ActixArbiter { arbiter: ArbiterHandle },
     TokioService(TokioServiceHandle),
 }
 


### PR DESCRIPTION
**Describe the changes**
- block producer is now a tokio service
- block producer does not use the reth-test-helper adapter because some methods are not Send when using it
  - main culprit was when interacting with the payload helper - instead the logic has been hoisted out & embedded into block producer (logic for building a payload, submitting to reth)
- all interactions with block producer are done via channels
- refactor of `slow_heavy_reset_seeds_should_be_correctly_applied_by_the_miner_and_verified_by_the_peer` test - previous implementation made a lot of false assumptions about vdf speed, and how many checkpoints are included in a block. it made the test non-deterministic.

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.
