### PR TITLE
fix: decrease peer score on unsuccessful data request

### DIFF
--- a/crates/p2p/src/gossip_client.rs
+++ b/crates/p2p/src/gossip_client.rs
@@ -5,10 +5,14 @@
 use crate::peer_list::{PeerList, ScoreDecreaseReason, ScoreIncreaseReason};
 use crate::types::{GossipDataRequest, GossipError, GossipResult};
 use core::time::Duration;
-use irys_types::{Address, GossipData, GossipRequest, PeerListItem};
+use irys_types::{Address, GossipData, GossipRequest, PeerAddress, PeerListItem};
 use reqwest::Response;
 use serde::Serialize;
 use tracing::error;
+
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("Gossip client error: {0}")]
+pub struct GossipClientError(String);
 
 #[derive(Debug, Clone, Default)]
 pub struct GossipClient {
@@ -31,12 +35,83 @@ impl GossipClient {
         &self.client
     }
 
+    /// Send data to a peer and update their score based on the result
+    ///
+    /// # Errors
+    ///
+    /// If the peer is offline or the request fails, an error is returned.
+    pub async fn send_data_and_update_score<P>(
+        &self,
+        peer: (&Address, &PeerListItem),
+        data: &GossipData,
+        peer_list: &P,
+    ) -> GossipResult<()>
+    where
+        P: PeerList,
+    {
+        let peer_miner_address = peer.0;
+        let peer = peer.1;
+
+        let res = self.send_data(peer, data).await;
+        Self::handle_score(peer_list, &res, peer_miner_address).await;
+        res
+    }
+
+    /// Request a specific data to be gossiped. Returns true if the peer has the data,
+    /// and false if it doesn't.
+    pub async fn make_get_data_request_and_update_the_score(
+        &self,
+        peer: &(Address, PeerListItem),
+        requested_data: GossipDataRequest,
+        peer_list: &impl PeerList,
+    ) -> GossipResult<bool> {
+        let url = format!("http://{}/gossip/get_data", peer.1.address.gossip);
+        let get_data_request = self.create_request(requested_data);
+
+        let res = self
+            .client
+            .post(&url)
+            .timeout(self.timeout)
+            .json(&get_data_request)
+            .send()
+            .await
+            .map_err(|error| GossipError::Network(error.to_string()))?
+            .json()
+            .await
+            .map_err(|error| GossipError::Network(error.to_string()));
+        Self::handle_score(peer_list, &res, &peer.0).await;
+        res
+    }
+
+    pub async fn check_health(&self, peer: PeerAddress) -> Result<bool, GossipClientError> {
+        let url = format!("http://{}/gossip/health", peer.gossip);
+
+        let response = self
+            .internal_client()
+            .get(&url)
+            .send()
+            .await
+            .map_err(|error| GossipClientError(error.to_string()))?;
+
+        if !response.status().is_success() {
+            return Err(GossipClientError(format!(
+                "Health check failed with status: {}",
+                response.status()
+            )));
+        }
+
+        response
+            .json()
+            .await
+            .map_err(|error| GossipClientError(error.to_string()))
+    }
+
     /// Send data to a peer
     ///
     /// # Errors
     ///
     /// If the peer is offline or the request fails, an error is returned.
-    pub async fn send_data(&self, peer: &PeerListItem, data: &GossipData) -> GossipResult<()> {
+    async fn send_data(&self, peer: &PeerListItem, data: &GossipData) -> GossipResult<()> {
         Self::check_if_peer_is_online(peer)?;
         match data {
             GossipData::Chunk(unpacked_chunk) => {
@@ -101,26 +176,13 @@ impl GossipClient {
             .map_err(|error| GossipError::Network(error.to_string()))
     }
 
-    /// Send data to a peer and update their score based on the result
-    ///
-    /// # Errors
-    ///
-    /// If the peer is offline or the request fails, an error is returned.
-    pub async fn send_data_and_update_score<P>(
-        &self,
-        peer: (&Address, &PeerListItem),
-        data: &GossipData,
+    async fn handle_score<P: PeerList, T>(
         peer_list: &P,
-    ) -> GossipResult<()>
-    where
-        P: PeerList,
-    {
-        let peer_miner_address = peer.0;
-        let peer = peer.1;
-
-        let res = self.send_data(peer, data).await;
-        match res {
-            Ok(()) => {
+        result: &GossipResult<T>,
+        peer_miner_address: &Address,
+    ) {
+        match &result {
+            Ok(_) => {
                 // Successful send, increase score
                 if let Err(e) = peer_list
                     .increase_peer_score(peer_miner_address, ScoreIncreaseReason::Online)
@@ -128,9 +190,8 @@ impl GossipClient {
                 {
                     error!("Failed to increase peer score: {}", e);
                 }
-                Ok(())
             }
-            Err(error) => {
+            Err(_) => {
                 // Failed to send, decrease score
                 if let Err(e) = peer_list
                     .decrease_peer_score(peer_miner_address, ScoreDecreaseReason::Offline)
@@ -138,7 +199,6 @@ impl GossipClient {
                 {
                     error!("Failed to decrease peer score: {}", e);
                 };
-                Err(error)
             }
         }
     }
@@ -148,27 +208,5 @@ impl GossipClient {
             miner_address: self.mining_address,
             data,
         }
-    }
-
-    /// Request a specific data to be gossiped. Returns true if the peer has the data,
-    /// and false if it doesn't.
-    pub async fn get_data_request(
-        &self,
-        peer: &PeerListItem,
-        requested_data: GossipDataRequest,
-    ) -> GossipResult<bool> {
-        let url = format!("http://{}/gossip/get_data", peer.address.gossip);
-        let get_data_request = self.create_request(requested_data);
-
-        self.client
-            .post(&url)
-            .timeout(self.timeout)
-            .json(&get_data_request)
-            .send()
-            .await
-            .map_err(|error| GossipError::Network(error.to_string()))?
-            .json()
-            .await
-            .map_err(|error| GossipError::Network(error.to_string()))
     }
 }

--- a/crates/p2p/src/gossip_client.rs
+++ b/crates/p2p/src/gossip_client.rs
@@ -50,7 +50,7 @@ impl GossipClient {
     /// # Errors
     ///
     /// If the peer is offline or the request fails, an error is returned.
-    pub async fn send_data_and_update_score<P>(
+    async fn send_data_and_update_score_internal<P>(
         &self,
         peer: (&Address, &PeerListItem),
         data: &GossipData,
@@ -81,7 +81,6 @@ impl GossipClient {
         let res = self
             .client
             .post(&url)
-            .timeout(self.timeout)
             .json(&get_data_request)
             .send()
             .await

--- a/crates/p2p/src/peer_list.rs
+++ b/crates/p2p/src/peer_list.rs
@@ -19,7 +19,6 @@ use tracing::{debug, error, info, warn};
 
 const FLUSH_INTERVAL: Duration = Duration::from_secs(5);
 const INACTIVE_PEERS_HEALTH_CHECK_INTERVAL: Duration = Duration::from_secs(10);
-const HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(1);
 const PEER_HANDSHAKE_RETRY_INTERVAL: Duration = Duration::from_secs(5);
 pub(crate) const MILLISECONDS_IN_SECOND: u64 = 1000;
 pub(crate) const HANDSHAKE_COOLDOWN: u64 = MILLISECONDS_IN_SECOND * 5;
@@ -422,7 +421,7 @@ where
                 let peer_address = peer.address;
                 let client = act.gossip_client.clone();
                 // Create the future that does the health check
-                let fut = async move { check_health(peer_address, client).await }
+                let fut = async move { client.check_health(peer_address).await }
                     .into_actor(act)
                     .map(move |result, act, _ctx| match result {
                         Ok(true) => {
@@ -820,33 +819,6 @@ where
             }
         }
     }
-}
-
-async fn check_health(
-    peer: PeerAddress,
-    client: GossipClient,
-) -> Result<bool, PeerListServiceError> {
-    let url = format!("http://{}/gossip/health", peer.gossip);
-
-    let response = client
-        .internal_client()
-        .get(&url)
-        .timeout(HEALTH_CHECK_TIMEOUT)
-        .send()
-        .await
-        .map_err(|error| PeerListServiceError::HealthCheckFailed(error.to_string()))?;
-
-    if !response.status().is_success() {
-        return Err(PeerListServiceError::HealthCheckFailed(format!(
-            "Health check failed with status: {}",
-            response.status()
-        )));
-    }
-
-    response
-        .json()
-        .await
-        .map_err(|error| PeerListServiceError::HealthCheckFailed(error.to_string()))
 }
 
 impl From<eyre::Report> for PeerListServiceError {
@@ -1388,15 +1360,20 @@ where
                 // Try up to 5 peers to get the block
                 let mut last_error = None;
 
-                for (address, peer_item) in peers {
+                for peer in peers {
                     for attempt in 1..=5 {
+                        let address = &peer.0;
                         debug!(
                             "Attempting to fetch {:?} from peer {} (attempt {}/5)",
                             data_request, address, attempt
                         );
 
                         match gossip_client
-                            .get_data_request(&peer_item, data_request.clone())
+                            .make_get_data_request_and_update_the_score(
+                                &peer,
+                                data_request.clone(),
+                                &self_addr,
+                            )
                             .await
                         {
                             Ok(true) => {
@@ -1421,13 +1398,6 @@ where
                                     attempt,
                                     last_error.as_ref().unwrap()
                                 );
-                                self_addr
-                                    .send(DecreasePeerScore {
-                                        peer_miner_address: address,
-                                        reason: ScoreDecreaseReason::Offline,
-                                    })
-                                    .await
-                                    .ok();
 
                                 // Continue trying with the same peer if not the last attempt
                                 if attempt < 5 {

--- a/crates/p2p/src/peer_list.rs
+++ b/crates/p2p/src/peer_list.rs
@@ -1421,6 +1421,13 @@ where
                                     attempt,
                                     last_error.as_ref().unwrap()
                                 );
+                                self_addr
+                                    .send(DecreasePeerScore {
+                                        peer_miner_address: address,
+                                        reason: ScoreDecreaseReason::Offline,
+                                    })
+                                    .await
+                                    .ok();
 
                                 // Continue trying with the same peer if not the last attempt
                                 if attempt < 5 {


### PR DESCRIPTION
**Describe the changes**
This PR adds decreasing of a peer score if get_data request failed, as well as better score handling and client structure in general

**Related Issue(s)**


**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**

