### PR TITLE
feat: peer list breakdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4793,6 +4793,7 @@ dependencies = [
  "reqwest 0.12.15",
  "serde",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4969,6 +4969,7 @@ name = "irys-domain"
 version = "0.1.0"
 dependencies = [
  "actix",
+ "alloy-core",
  "assert_matches",
  "base58",
  "eyre",
@@ -4984,6 +4985,7 @@ dependencies = [
  "rust_decimal",
  "rust_decimal_macros",
  "test-log",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]

--- a/crates/api-client/Cargo.toml
+++ b/crates/api-client/Cargo.toml
@@ -11,10 +11,11 @@ serde.workspace = true
 tokio.workspace = true
 async-trait = "0.1"
 base58.workspace = true
+tracing = { workspace = true, optional = true  }
 
 [features]
 default = []
-test-utils = []
+test-utils = ["tracing"]
 
 [lints]
 workspace = true

--- a/crates/api-client/src/lib.rs
+++ b/crates/api-client/src/lib.rs
@@ -246,6 +246,7 @@ pub mod test_utils {
     use irys_types::AcceptedResponse;
     use std::sync::Arc;
     use tokio::sync::Mutex;
+    use tracing::debug;
 
     #[derive(Default, Clone)]
     pub struct CountingMockClient {
@@ -273,6 +274,7 @@ pub mod test_utils {
             peer: std::net::SocketAddr,
             _version: VersionRequest,
         ) -> eyre::Result<PeerResponse> {
+            debug!("post_version called with peer: {}", peer);
             let mut calls = self.post_version_calls.lock().await;
             calls.push(peer);
             Ok(PeerResponse::Accepted(AcceptedResponse::default()))

--- a/crates/api-server/src/lib.rs
+++ b/crates/api-server/src/lib.rs
@@ -9,8 +9,8 @@ use actix_web::{
     App, HttpResponse, HttpServer,
 };
 use irys_actors::mempool_service::MempoolServiceMessage;
-use irys_domain::{BlockIndexReadGuard, BlockTreeReadGuard};
-use irys_p2p::{PeerListGuard, SyncState};
+use irys_domain::{BlockIndexReadGuard, BlockTreeReadGuard, PeerListGuard};
+use irys_p2p::SyncState;
 use irys_reth_node_bridge::node::RethNodeProvider;
 use irys_storage::ChunkProvider;
 use irys_types::{app_state::DatabaseProvider, Config, PeerAddress};

--- a/crates/api-server/src/lib.rs
+++ b/crates/api-server/src/lib.rs
@@ -10,7 +10,7 @@ use actix_web::{
 };
 use irys_actors::mempool_service::MempoolServiceMessage;
 use irys_domain::{BlockIndexReadGuard, BlockTreeReadGuard};
-use irys_p2p::{PeerList as _, PeerListGuard, PeerListServiceFacade, SyncState};
+use irys_p2p::{PeerListGuard, SyncState};
 use irys_reth_node_bridge::node::RethNodeProvider;
 use irys_storage::ChunkProvider;
 use irys_types::{app_state::DatabaseProvider, Config, PeerAddress};

--- a/crates/api-server/src/lib.rs
+++ b/crates/api-server/src/lib.rs
@@ -10,7 +10,7 @@ use actix_web::{
 };
 use irys_actors::mempool_service::MempoolServiceMessage;
 use irys_domain::{BlockIndexReadGuard, BlockTreeReadGuard};
-use irys_p2p::{PeerList as _, PeerListServiceFacade, SyncState};
+use irys_p2p::{PeerList as _, PeerListGuard, PeerListServiceFacade, SyncState};
 use irys_reth_node_bridge::node::RethNodeProvider;
 use irys_storage::ChunkProvider;
 use irys_types::{app_state::DatabaseProvider, Config, PeerAddress};
@@ -29,7 +29,7 @@ use tracing::{debug, info};
 pub struct ApiState {
     pub mempool_service: UnboundedSender<MempoolServiceMessage>,
     pub chunk_provider: Arc<ChunkProvider>,
-    pub peer_list: PeerListServiceFacade,
+    pub peer_list: PeerListGuard,
     pub db: DatabaseProvider,
     pub config: Config,
     // TODO: slim this down to what we actually use - beware the types!
@@ -41,11 +41,8 @@ pub struct ApiState {
 }
 
 impl ApiState {
-    pub async fn get_known_peers(&self) -> eyre::Result<Vec<PeerAddress>> {
-        self.peer_list
-            .all_known_peers()
-            .await
-            .map_err(|mailbox_err| eyre::eyre!("Failed to get known peers: {}", mailbox_err))
+    pub fn get_known_peers(&self) -> Vec<PeerAddress> {
+        self.peer_list.all_known_peers()
     }
 }
 

--- a/crates/api-server/src/routes/index.rs
+++ b/crates/api-server/src/routes/index.rs
@@ -16,7 +16,7 @@ pub async fn info_route(state: web::Data<ApiState>) -> HttpResponse {
 
     let node_info = NodeInfo {
         version: "0.0.1".into(),
-        peer_count: state.peer_list.peer_count().await.unwrap_or(0),
+        peer_count: state.peer_list.peer_count(),
         chain_id: state.config.consensus.chain_id,
         height: latest.height,
         block_hash: latest.block_hash,

--- a/crates/api-server/src/routes/index.rs
+++ b/crates/api-server/src/routes/index.rs
@@ -5,7 +5,6 @@ use actix_web::{
     HttpResponse,
 };
 use irys_domain::get_canonical_chain;
-use irys_p2p::PeerList as _;
 use irys_types::NodeInfo;
 
 pub async fn info_route(state: web::Data<ApiState>) -> HttpResponse {

--- a/crates/api-server/src/routes/peer_list.rs
+++ b/crates/api-server/src/routes/peer_list.rs
@@ -4,16 +4,7 @@ use serde_json::to_string;
 
 pub async fn peer_list_route(state: web::Data<ApiState>) -> HttpResponse {
     // Fetch the list of known peers
-    let ips_result = state.get_known_peers().await;
-
-    // Handle the Result from get_known_peers
-    let ips = match ips_result {
-        Ok(ips) => ips,
-        Err(e) => {
-            return HttpResponse::InternalServerError()
-                .body(format!("Failed to fetch peers: {}", e));
-        }
-    };
+    let ips = state.get_known_peers();
 
     // Serialize IPs to JSON and return as HTTP response
     match to_string(&ips) {

--- a/crates/api-server/src/routes/post_version.rs
+++ b/crates/api-server/src/routes/post_version.rs
@@ -41,17 +41,7 @@ pub async fn post_version(
     }
 
     // Fetch peers and handle potential errors
-    let peers = match state.get_known_peers().await {
-        Ok(peers) => peers,
-        Err(e) => {
-            let response = PeerResponse::Rejected(RejectedResponse {
-                reason: RejectionReason::InternalError,
-                message: Some(format!("Failed to fetch peers: {}", e)),
-                retry_after: Some(5000),
-            });
-            return Ok(HttpResponse::ServiceUnavailable().json(response));
-        }
-    };
+    let peers = state.get_known_peers();
 
     let peer_address = version_request.address;
     let mining_addr = version_request.mining_address;
@@ -60,20 +50,7 @@ pub async fn post_version(
         ..Default::default()
     };
 
-    // Only update if it's a new peer
-    if let Err(err) = state
-        .peer_list
-        .add_or_update_peer(mining_addr, peer_list_entry)
-        .await
-    {
-        error!("Failed to update peer list: {}", err);
-        let response = PeerResponse::Rejected(RejectedResponse {
-            reason: RejectionReason::InternalError,
-            message: Some("Could not update peer list".to_string()),
-            retry_after: Some(5000),
-        });
-        return Ok(HttpResponse::ServiceUnavailable().json(response));
-    }
+    state.peer_list.add_or_update_peer(mining_addr, peer_list_entry);
 
     let node_name = version_request
         .user_agent

--- a/crates/api-server/src/routes/post_version.rs
+++ b/crates/api-server/src/routes/post_version.rs
@@ -7,13 +7,11 @@ use actix_web::{
     HttpResponse,
 };
 
-use irys_p2p::PeerList as _;
 use irys_types::{
     parse_user_agent, AcceptedResponse, PeerListItem, PeerResponse, ProtocolVersion,
     RejectedResponse, RejectionReason, VersionRequest,
 };
 use semver::Version;
-use tracing::error;
 
 pub async fn post_version(
     state: web::Data<ApiState>,
@@ -50,7 +48,9 @@ pub async fn post_version(
         ..Default::default()
     };
 
-    state.peer_list.add_or_update_peer(mining_addr, peer_list_entry);
+    state
+        .peer_list
+        .add_or_update_peer(mining_addr, peer_list_entry);
 
     let node_name = version_request
         .user_agent

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -1521,9 +1521,6 @@ fn init_peer_list_service(
 ) -> (PeerListServiceFacade, Arbiter) {
     let peer_list_arbiter = Arbiter::new();
     let mut peer_list_service = PeerListService::new(irys_db.clone(), config, reth_service_addr);
-    peer_list_service
-        .initialize()
-        .expect("to initialize peer_list_service");
     let peer_list_service =
         PeerListService::start_in_arbiter(&peer_list_arbiter.handle(), |_| peer_list_service);
     SystemRegistry::set(peer_list_service.clone());

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -28,10 +28,12 @@ use irys_config::chain::chainspec::IrysChainSpecBuilder;
 use irys_config::submodules::StorageSubmodulesConfig;
 use irys_database::db::RethDbWrapper;
 use irys_database::{add_genesis_commitments, database, get_genesis_commitments, SystemLedger};
-use irys_domain::{BlockIndex, BlockIndexReadGuard, BlockTreeReadGuard, EpochReplayData};
+use irys_domain::{
+    BlockIndex, BlockIndexReadGuard, BlockTreeReadGuard, EpochReplayData, PeerListGuard,
+};
 use irys_p2p::execution_payload_provider::ExecutionPayloadProvider;
 use irys_p2p::{
-    BlockPool, BlockStatusProvider, GetPeerListGuard, P2PService, PeerListGuard, PeerListService,
+    BlockPool, BlockStatusProvider, GetPeerListGuard, P2PService, PeerListService,
     ServiceHandleWithShutdownSignal, SyncState,
 };
 use irys_price_oracle::{mock_oracle::MockOracle, IrysPriceOracle};

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -32,7 +32,7 @@ use irys_domain::{BlockIndex, BlockIndexReadGuard, BlockTreeReadGuard, EpochRepl
 use irys_p2p::execution_payload_provider::ExecutionPayloadProvider;
 use irys_p2p::{
     BlockPool, BlockStatusProvider, GetPeerListGuard, P2PService, PeerListGuard, PeerListService,
-    PeerListServiceFacade, ServiceHandleWithShutdownSignal, SyncState,
+    ServiceHandleWithShutdownSignal, SyncState,
 };
 use irys_price_oracle::{mock_oracle::MockOracle, IrysPriceOracle};
 use irys_reth_node_bridge::irys_reth::payload::ShadowTxStore;
@@ -101,8 +101,7 @@ pub struct IrysNodeCtx {
     pub sync_state: SyncState,
     pub shadow_tx_store: ShadowTxStore,
     pub validation_enabled: Arc<AtomicBool>,
-    pub block_pool:
-        Arc<BlockPool<PeerListServiceFacade, BlockDiscoveryFacadeImpl, MempoolServiceFacadeImpl>>,
+    pub block_pool: Arc<BlockPool<BlockDiscoveryFacadeImpl, MempoolServiceFacadeImpl>>,
     pub storage_modules_guard: StorageModulesReadGuard,
 }
 
@@ -919,7 +918,7 @@ impl IrysNode {
             .expect("to get peer list guard");
 
         let execution_payload_provider = ExecutionPayloadProvider::new(
-            peer_list_service.clone(),
+            peer_list_guard.clone(),
             reth_node_adapter.clone().into(),
         );
 
@@ -1522,7 +1521,7 @@ fn init_peer_list_service(
     irys_db: &DatabaseProvider,
     config: &Config,
     reth_service_addr: Addr<RethServiceActor>,
-) -> (PeerListServiceFacade, Arbiter) {
+) -> (Addr<PeerListService>, Arbiter) {
     let peer_list_arbiter = Arbiter::new();
     let peer_list_service = PeerListService::new(irys_db.clone(), config, reth_service_addr);
     let peer_list_service =

--- a/crates/domain/Cargo.toml
+++ b/crates/domain/Cargo.toml
@@ -21,6 +21,8 @@ base58.workspace = true
 reth-db.workspace = true
 rust_decimal.workspace = true
 tokio.workspace = true
+thiserror.workspace = true
+alloy-core.workspace = true
 
 [dev-dependencies]
 test-log.workspace = true

--- a/crates/domain/src/models/mod.rs
+++ b/crates/domain/src/models/mod.rs
@@ -1,5 +1,7 @@
 pub mod block_index;
 pub mod block_tree;
+pub mod peer_list;
 
 pub use block_index::*;
 pub use block_tree::*;
+pub use peer_list::*;

--- a/crates/domain/src/models/peer_list.rs
+++ b/crates/domain/src/models/peer_list.rs
@@ -1,0 +1,479 @@
+use actix::Message;
+use alloy_core::primitives::B256;
+use irys_database::reth_db::{Database as _, DatabaseError};
+use irys_database::tables::PeerListItems;
+use irys_database::walk_all;
+use irys_primitives::Address;
+use irys_types::{BlockHash, Config, DatabaseProvider, PeerAddress, PeerListItem};
+use std::collections::{HashMap, HashSet};
+use std::net::{IpAddr, SocketAddr};
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+use thiserror::Error;
+use tokio::sync::mpsc::error::SendError;
+use tokio::sync::mpsc::UnboundedSender;
+use tracing::{debug, error, warn};
+
+pub(crate) const MILLISECONDS_IN_SECOND: u64 = 1000;
+pub(crate) const HANDSHAKE_COOLDOWN: u64 = MILLISECONDS_IN_SECOND * 5;
+
+#[derive(Debug, Error)]
+pub enum PeerListDataError {
+    #[error("Internal database error: {0}")]
+    Database(DatabaseError),
+    #[error("Peer list internal error: {0:?}")]
+    InternalSendError(SendError<PeerListDataMessage>),
+    #[error("Peer list internal error: {0}")]
+    OtherInternalError(String),
+}
+
+impl From<SendError<PeerListDataMessage>> for PeerListDataError {
+    fn from(err: SendError<PeerListDataMessage>) -> Self {
+        Self::InternalSendError(err)
+    }
+}
+
+impl From<DatabaseError> for PeerListDataError {
+    fn from(err: DatabaseError) -> Self {
+        Self::Database(err)
+    }
+}
+
+impl From<eyre::Report> for PeerListDataError {
+    fn from(err: eyre::Report) -> Self {
+        Self::Database(DatabaseError::Other(err.to_string()))
+    }
+}
+
+#[derive(Clone, Debug, Copy)]
+pub enum ScoreDecreaseReason {
+    BogusData,
+    Offline,
+}
+
+#[derive(Clone, Debug, Copy)]
+pub enum ScoreIncreaseReason {
+    Online,
+    ValidData,
+}
+
+#[derive(Debug, Clone)]
+pub struct PeerListDataInner {
+    gossip_addr_to_mining_addr_map: HashMap<IpAddr, Address>,
+    api_addr_to_mining_addr_map: HashMap<SocketAddr, Address>,
+    peer_list_cache: HashMap<Address, PeerListItem>,
+    known_peers_cache: HashSet<PeerAddress>,
+    trusted_peers_api_addresses: HashSet<SocketAddr>,
+    peer_list_service_sender: UnboundedSender<PeerListDataMessage>,
+}
+
+// TODO: remove default, right now it's there just to make service into a ssytem service
+impl Default for PeerListDataInner {
+    fn default() -> Self {
+        panic!("PeerListData should be initialized with new() method, not default()");
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PeerListGuard(Arc<RwLock<PeerListDataInner>>);
+
+impl Default for PeerListGuard {
+    fn default() -> Self {
+        panic!("PeerListGuard should be initialized with new() method, not default()");
+    }
+}
+
+impl PeerListGuard {
+    pub fn new(
+        config: &Config,
+        db: &DatabaseProvider,
+        peer_service_sender: UnboundedSender<PeerListDataMessage>,
+    ) -> Result<Self, PeerListDataError> {
+        let inner = PeerListDataInner::new(config, db, peer_service_sender)?;
+        Ok(Self(Arc::new(RwLock::new(inner))))
+    }
+
+    pub fn add_or_update_peer(&self, mining_addr: Address, peer: PeerListItem) {
+        let mut inner = self.0.write().expect("PeerListDataInner lock poisoned");
+        inner.add_or_update_peer(mining_addr, peer);
+    }
+
+    pub fn increase_peer_score(&self, mining_addr: &Address, reason: ScoreIncreaseReason) {
+        let mut inner = self.0.write().expect("PeerListDataInner lock poisoned");
+        inner.increase_score(mining_addr, reason);
+    }
+
+    pub fn decrease_peer_score(&self, mining_addr: &Address, reason: ScoreDecreaseReason) {
+        let mut inner = self.0.write().expect("PeerListDataInner lock poisoned");
+        inner.decrease_peer_score(mining_addr, reason);
+    }
+
+    pub fn all_known_peers(&self) -> Vec<PeerAddress> {
+        self.read().known_peers_cache.iter().copied().collect()
+    }
+
+    pub fn all_know_peers_with_mining_address(&self) -> HashMap<Address, PeerListItem> {
+        let guard = self.read();
+        guard.peer_list_cache.clone()
+    }
+
+    pub fn contains_api_address(&self, api_address: &SocketAddr) -> bool {
+        self.read()
+            .api_addr_to_mining_addr_map
+            .contains_key(api_address)
+    }
+
+    pub async fn wait_for_active_peers(&self) {
+        loop {
+            let active_peers_count = {
+                let bindings = self.read();
+                bindings
+                    .peer_list_cache
+                    .values()
+                    .filter(|peer| peer.reputation_score.is_active() && peer.is_online)
+                    .count()
+            };
+
+            if active_peers_count > 0 {
+                return;
+            }
+
+            // Check for active peers every second
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    }
+
+    pub fn trusted_peers(&self) -> Vec<(Address, PeerListItem)> {
+        let guard = self.read();
+
+        let mut peers: Vec<(Address, PeerListItem)> = guard
+            .peer_list_cache
+            .iter()
+            .map(|(key, value)| (*key, value.clone()))
+            .collect();
+
+        peers.retain(|(_miner_address, peer)| {
+            guard
+                .trusted_peers_api_addresses
+                .contains(&peer.address.api)
+        });
+
+        peers.sort_by_key(|(_address, peer)| peer.reputation_score.get());
+        peers.reverse();
+
+        peers
+    }
+
+    pub fn trusted_peer_addresses(&self) -> HashSet<SocketAddr> {
+        self.read().trusted_peers_api_addresses.clone()
+    }
+
+    pub fn top_active_peers(
+        &self,
+        limit: Option<usize>,
+        exclude_peers: Option<HashSet<Address>>,
+    ) -> Vec<(Address, PeerListItem)> {
+        let guard = self.read();
+
+        let mut peers: Vec<(Address, PeerListItem)> = guard
+            .peer_list_cache
+            .iter()
+            .map(|(key, value)| (*key, value.clone()))
+            .collect();
+
+        peers.retain(|(miner_address, peer)| {
+            let exclude = if let Some(exclude_peers) = &exclude_peers {
+                exclude_peers.contains(miner_address)
+            } else {
+                false
+            };
+            !exclude && peer.reputation_score.is_active() && peer.is_online
+        });
+
+        peers.sort_by_key(|(_address, peer)| peer.reputation_score.get());
+        peers.reverse();
+
+        if let Some(truncate) = limit {
+            peers.truncate(truncate);
+        }
+
+        peers
+    }
+
+    pub fn inactive_peers(&self) -> Vec<(Address, PeerListItem, SocketAddr)> {
+        self.read()
+            .peer_list_cache
+            .iter()
+            .filter(|(_mining_addr, peer)| !peer.reputation_score.is_active())
+            .map(|(mining_addr, peer)| {
+                // Clone or copy the fields we need for the async operation
+                let peer_item = peer.clone();
+                let mining_addr = *mining_addr;
+                let peer_addr = peer_item.address;
+                (mining_addr, peer_item, peer_addr.gossip)
+            })
+            .collect()
+    }
+
+    pub fn peer_by_gossip_address(&self, address: SocketAddr) -> Option<PeerListItem> {
+        let binding = self.read();
+        let mining_address = binding
+            .gossip_addr_to_mining_addr_map
+            .get(&address.ip())
+            .copied()?;
+        binding.peer_list_cache.get(&mining_address).cloned()
+    }
+
+    pub fn peer_by_mining_address(&self, mining_address: &Address) -> Option<PeerListItem> {
+        let binding = self.read();
+        binding.peer_list_cache.get(mining_address).cloned()
+    }
+
+    pub fn is_a_trusted_peer(&self, miner_address: Address, source_ip: IpAddr) -> bool {
+        let binding = self.read();
+
+        let Some(peer) = binding.peer_list_cache.get(&miner_address) else {
+            return false;
+        };
+        let peer_api_ip = peer.address.api.ip();
+        let peer_gossip_ip = peer.address.gossip.ip();
+
+        let ip_matches_cached_ip = source_ip == peer_gossip_ip;
+        let ip_is_in_a_trusted_list = binding
+            .trusted_peers_api_addresses
+            .iter()
+            .any(|socket_addr| socket_addr.ip() == peer_api_ip);
+
+        ip_matches_cached_ip && ip_is_in_a_trusted_list
+    }
+
+    pub async fn request_block_from_the_network(
+        &self,
+        block_hash: BlockHash,
+        use_trusted_peers_only: bool,
+    ) -> Result<(), PeerListDataError> {
+        let (sender, receiver) = tokio::sync::oneshot::channel();
+        let message = PeerListDataMessage::RequestBlockFromNetwork {
+            block_hash,
+            use_trusted_peers_only,
+            response: sender,
+        };
+        self.0
+            .write()
+            .expect("PeerListDataInner lock poisoned")
+            .peer_list_service_sender
+            .send(message)?;
+
+        receiver.await.map_err(|recv_error| {
+            PeerListDataError::OtherInternalError(format!(
+                "Failed to receive response: {:?}",
+                recv_error
+            ))
+        })?
+    }
+
+    pub async fn request_payload_from_the_network(
+        &self,
+        evm_payload_hash: B256,
+        use_trusted_peers_only: bool,
+    ) -> Result<(), PeerListDataError> {
+        let (sender, receiver) = tokio::sync::oneshot::channel();
+        let message = PeerListDataMessage::RequestPayloadFromNetwork {
+            payload_hash: evm_payload_hash,
+            use_trusted_peers_only,
+            response: sender,
+        };
+        self.0
+            .write()
+            .expect("PeerListDataInner lock poisoned")
+            .peer_list_service_sender
+            .send(message)?;
+
+        receiver.await.map_err(|recv_error| {
+            PeerListDataError::OtherInternalError(format!(
+                "Failed to receive response: {:?}",
+                recv_error
+            ))
+        })?
+    }
+
+    pub fn read(&self) -> std::sync::RwLockReadGuard<'_, PeerListDataInner> {
+        self.0.read().expect("PeerListDataInner lock poisoned")
+    }
+
+    pub fn peer_count(&self) -> usize {
+        self.read().peer_list_cache.len()
+    }
+}
+
+#[derive(Message, Debug)]
+#[rtype(result = "()")]
+pub enum PeerListDataMessage {
+    PeerUpdated(PeerListItem),
+    RequestBlockFromNetwork {
+        block_hash: BlockHash,
+        use_trusted_peers_only: bool,
+        response: tokio::sync::oneshot::Sender<Result<(), PeerListDataError>>,
+    },
+    RequestPayloadFromNetwork {
+        payload_hash: B256,
+        use_trusted_peers_only: bool,
+        response: tokio::sync::oneshot::Sender<Result<(), PeerListDataError>>,
+    },
+}
+
+impl PeerListDataInner {
+    pub fn new(
+        config: &Config,
+        db: &DatabaseProvider,
+        peer_service_sender: UnboundedSender<PeerListDataMessage>,
+    ) -> Result<Self, PeerListDataError> {
+        let mut peer_list = Self {
+            gossip_addr_to_mining_addr_map: HashMap::new(),
+            api_addr_to_mining_addr_map: HashMap::new(),
+            peer_list_cache: HashMap::new(),
+            known_peers_cache: HashSet::new(),
+            trusted_peers_api_addresses: config
+                .node_config
+                .trusted_peers
+                .iter()
+                .map(|p| p.api)
+                .collect(),
+            peer_list_service_sender: peer_service_sender,
+        };
+
+        let read_tx = db.tx().map_err(PeerListDataError::from)?;
+
+        let peer_list_items =
+            walk_all::<PeerListItems, _>(&read_tx).map_err(PeerListDataError::from)?;
+
+        for (mining_addr, entry) in peer_list_items {
+            let address = entry.address;
+            peer_list
+                .gossip_addr_to_mining_addr_map
+                .insert(entry.address.gossip.ip(), mining_addr);
+            peer_list.peer_list_cache.insert(mining_addr, entry.0);
+            peer_list.known_peers_cache.insert(address);
+            peer_list
+                .api_addr_to_mining_addr_map
+                .insert(address.api, mining_addr);
+        }
+
+        Ok(peer_list)
+    }
+
+    pub fn add_or_update_peer(&mut self, mining_addr: Address, peer: PeerListItem) {
+        let is_updated = self.add_or_update_peer_internal(mining_addr, peer.clone());
+
+        if is_updated {
+            debug!(
+                "Sending PeerUpdated message to the service for peer {:?}",
+                mining_addr
+            );
+            // Notify the peer list service that a peer was updated
+            if let Err(e) = self
+                .peer_list_service_sender
+                .send(PeerListDataMessage::PeerUpdated(peer))
+            {
+                error!("Failed to send peer updated message: {:?}", e);
+            }
+        }
+    }
+
+    pub fn increase_score(&mut self, mining_addr: &Address, reason: ScoreIncreaseReason) {
+        if let Some(peer) = self.peer_list_cache.get_mut(mining_addr) {
+            match reason {
+                ScoreIncreaseReason::Online => {
+                    peer.reputation_score.increase();
+                }
+                ScoreIncreaseReason::ValidData => {
+                    peer.reputation_score.increase();
+                }
+            }
+        }
+    }
+
+    pub fn decrease_peer_score(&mut self, mining_addr: &Address, reason: ScoreDecreaseReason) {
+        if let Some(peer_item) = self.peer_list_cache.get_mut(mining_addr) {
+            match reason {
+                ScoreDecreaseReason::BogusData => {
+                    peer_item.reputation_score.decrease_bogus_data();
+                }
+                ScoreDecreaseReason::Offline => {
+                    peer_item.reputation_score.decrease_offline();
+                }
+            }
+
+            // Don't propagate inactive peers
+            if !peer_item.reputation_score.is_active() {
+                self.known_peers_cache.remove(&peer_item.address);
+            }
+        }
+    }
+
+    /// Add a peer to the peer list. Returns true if the peer was added, false if it already exists.
+    fn add_or_update_peer_internal(&mut self, mining_addr: Address, peer: PeerListItem) -> bool {
+        let gossip_addr = peer.address.gossip;
+        let peer_address = peer.address;
+
+        if let std::collections::hash_map::Entry::Vacant(peer_cache) =
+            self.peer_list_cache.entry(mining_addr)
+        {
+            debug!("Adding peer {:?} to the peer list", mining_addr);
+            peer_cache.insert(peer);
+            self.gossip_addr_to_mining_addr_map
+                .insert(gossip_addr.ip(), mining_addr);
+            self.api_addr_to_mining_addr_map
+                .insert(peer_address.api, mining_addr);
+            self.known_peers_cache.insert(peer_address);
+            debug!(
+                "Peer {:?} added to the peer list with address {:?}",
+                mining_addr, peer_address
+            );
+            true
+        } else {
+            debug!(
+                "Peer {:?} already exists in the peer list, checking if the address needs updating",
+                mining_addr
+            );
+            if let Some(existing_peer) = self.peer_list_cache.get_mut(&mining_addr) {
+                let handshake_cooldown_expired =
+                    existing_peer.last_seen + HANDSHAKE_COOLDOWN < peer.last_seen;
+                existing_peer.last_seen = peer.last_seen;
+                if existing_peer.address != peer_address {
+                    debug!("Peer address mismatch, updating to new address");
+                    self.update_peer_address(mining_addr, peer_address);
+                    true
+                } else if handshake_cooldown_expired {
+                    debug!("Peer address is the same, but the handshake cooldown has expired, so we need to re-handshake");
+                    true
+                } else {
+                    debug!("Peer address is the same, no update needed");
+                    false
+                }
+            } else {
+                warn!(
+                    "Peer {:?} is not found in the peer list cache, which shouldn't happen",
+                    mining_addr
+                );
+                false
+            }
+        }
+    }
+
+    fn update_peer_address(&mut self, mining_addr: Address, new_address: PeerAddress) {
+        if let Some(peer) = self.peer_list_cache.get_mut(&mining_addr) {
+            let old_address = peer.address;
+            peer.address = new_address;
+            self.gossip_addr_to_mining_addr_map
+                .remove(&old_address.gossip.ip());
+            self.gossip_addr_to_mining_addr_map
+                .insert(new_address.gossip.ip(), mining_addr);
+            self.known_peers_cache.remove(&old_address);
+            self.known_peers_cache.insert(old_address);
+            self.api_addr_to_mining_addr_map.remove(&old_address.api);
+            self.api_addr_to_mining_addr_map
+                .insert(new_address.api, mining_addr);
+        }
+    }
+}

--- a/crates/p2p/src/block_pool.rs
+++ b/crates/p2p/src/block_pool.rs
@@ -1,6 +1,6 @@
 use crate::block_status_provider::{BlockStatus, BlockStatusProvider};
 use crate::execution_payload_provider::ExecutionPayloadProvider;
-use crate::peer_list::{PeerList, PeerListDataError, PeerListFacadeError};
+use crate::peer_list::{PeerListDataError, PeerListFacadeError};
 use crate::{PeerListGuard, SyncState};
 use actix::Addr;
 use irys_actors::block_tree_service::BlockTreeServiceMessage;
@@ -65,9 +65,8 @@ impl From<PeerListDataError> for BlockPoolError {
 }
 
 #[derive(Debug, Clone)]
-pub struct BlockPool<P, B, M>
+pub struct BlockPool<B, M>
 where
-    P: PeerList,
     B: BlockDiscoveryFacade,
     M: MempoolFacade,
 {
@@ -83,7 +82,7 @@ where
     sync_state: SyncState,
 
     block_status_provider: BlockStatusProvider,
-    execution_payload_provider: ExecutionPayloadProvider<P>,
+    execution_payload_provider: ExecutionPayloadProvider,
 
     vdf_state: VdfStateReadonly,
 
@@ -224,9 +223,8 @@ impl BlockCacheInner {
     }
 }
 
-impl<P, B, M> BlockPool<P, B, M>
+impl<B, M> BlockPool<B, M>
 where
-    P: PeerList,
     B: BlockDiscoveryFacade,
     M: MempoolFacade,
 {
@@ -237,7 +235,7 @@ where
         mempool: M,
         sync_state: SyncState,
         block_status_provider: BlockStatusProvider,
-        execution_payload_provider: ExecutionPayloadProvider<P>,
+        execution_payload_provider: ExecutionPayloadProvider,
         vdf_state: VdfStateReadonly,
         config: Config,
         service_senders: ServiceSenders,

--- a/crates/p2p/src/block_pool.rs
+++ b/crates/p2p/src/block_pool.rs
@@ -1,7 +1,6 @@
 use crate::block_status_provider::{BlockStatus, BlockStatusProvider};
 use crate::execution_payload_provider::ExecutionPayloadProvider;
-use crate::peer_list::{PeerListDataError, PeerListFacadeError};
-use crate::{PeerListGuard, SyncState};
+use crate::SyncState;
 use actix::Addr;
 use irys_actors::block_tree_service::BlockTreeServiceMessage;
 use irys_actors::reth_service::{BlockHashType, ForkChoiceUpdateMessage, RethServiceActor};
@@ -9,6 +8,7 @@ use irys_actors::services::ServiceSenders;
 use irys_actors::{block_discovery::BlockDiscoveryFacade, mempool_service::MempoolFacade};
 use irys_database::block_header_by_hash;
 use irys_database::db::IrysDatabaseExt as _;
+use irys_domain::{PeerListDataError, PeerListGuard};
 use irys_types::{
     BlockHash, Config, DatabaseProvider, GossipBroadcastMessage, GossipCacheKey, GossipData,
     IrysBlockHeader,
@@ -50,12 +50,6 @@ pub enum BlockPoolError {
     ForkChoiceFailed(String),
     #[error("Previous block {0:?} not found")]
     PreviousBlockNotFound(BlockHash),
-}
-
-impl From<PeerListFacadeError> for BlockPoolError {
-    fn from(err: PeerListFacadeError) -> Self {
-        Self::OtherInternal(format!("Peer list error: {:?}", err))
-    }
 }
 
 impl From<PeerListDataError> for BlockPoolError {

--- a/crates/p2p/src/execution_payload_provider.rs
+++ b/crates/p2p/src/execution_payload_provider.rs
@@ -1,8 +1,8 @@
-use crate::PeerListGuard;
 use alloy_rpc_types::engine::ExecutionData;
 use async_trait::async_trait;
 use irys_actors::block_validation::{shadow_transactions_are_valid, PayloadProvider};
 use irys_actors::services::ServiceSenders;
+use irys_domain::PeerListGuard;
 use irys_reth_node_bridge::IrysRethNodeAdapter;
 use irys_types::{Config, DatabaseProvider, IrysBlockHeader};
 use lru::LruCache;

--- a/crates/p2p/src/execution_payload_provider.rs
+++ b/crates/p2p/src/execution_payload_provider.rs
@@ -1,5 +1,4 @@
-use crate::types::GossipDataRequest;
-use crate::PeerList;
+use crate::PeerListGuard;
 use alloy_rpc_types::engine::ExecutionData;
 use async_trait::async_trait;
 use irys_actors::block_validation::{shadow_transactions_are_valid, PayloadProvider};
@@ -109,19 +108,16 @@ impl From<IrysRethNodeAdapter> for RethBlockProvider {
 }
 
 #[derive(Clone, Debug)]
-pub struct ExecutionPayloadProvider<TPeerList: PeerList> {
+pub struct ExecutionPayloadProvider {
     cache: Arc<RwLock<ExecutionPayloadCache>>,
     reth_payload_provider: RethBlockProvider,
     payload_senders:
         Arc<RwLock<LruCache<B256, Vec<tokio::sync::oneshot::Sender<SealedBlock<Block>>>>>>,
-    peer_list: TPeerList,
+    peer_list: PeerListGuard,
 }
 
-impl<TPeerList> ExecutionPayloadProvider<TPeerList>
-where
-    TPeerList: PeerList,
-{
-    pub fn new(peer_list: TPeerList, reth_payload_provider: RethBlockProvider) -> Self {
+impl ExecutionPayloadProvider {
+    pub fn new(peer_list: PeerListGuard, reth_payload_provider: RethBlockProvider) -> Self {
         Self {
             cache: Arc::new(RwLock::new(ExecutionPayloadCache {
                 payloads: LruCache::new(NonZeroUsize::new(PAYLOAD_CACHE_CAPACITY).expect("payload capacity is not a non-zero usize")),
@@ -248,10 +244,7 @@ where
             .put(evm_block_hash, ());
         if let Err(peer_list_error) = self
             .peer_list
-            .request_data_from_the_network(
-                GossipDataRequest::ExecutionPayload(evm_block_hash),
-                use_trusted_peers_only,
-            )
+            .request_payload_from_the_network(evm_block_hash, use_trusted_peers_only)
             .await
         {
             self.cache
@@ -342,10 +335,7 @@ where
 }
 
 #[async_trait]
-impl<TPeerList> PayloadProvider for ExecutionPayloadProvider<TPeerList>
-where
-    TPeerList: PeerList,
-{
+impl PayloadProvider for ExecutionPayloadProvider {
     async fn wait_for_payload(&self, evm_block_hash: &B256) -> Option<ExecutionData> {
         self.wait_for_payload(evm_block_hash).await
     }

--- a/crates/p2p/src/gossip_client.rs
+++ b/crates/p2p/src/gossip_client.rs
@@ -2,10 +2,9 @@
     clippy::module_name_repetitions,
     reason = "I have no idea how to name this module to satisfy this lint"
 )]
-use crate::peer_list::{ScoreDecreaseReason, ScoreIncreaseReason};
 use crate::types::{GossipDataRequest, GossipError, GossipResult};
-use crate::PeerListGuard;
 use core::time::Duration;
+use irys_domain::{PeerListGuard, ScoreDecreaseReason, ScoreIncreaseReason};
 use irys_types::{Address, GossipData, GossipRequest, PeerAddress, PeerListItem};
 use reqwest::Client;
 use reqwest::Response;

--- a/crates/p2p/src/gossip_client.rs
+++ b/crates/p2p/src/gossip_client.rs
@@ -2,8 +2,9 @@
     clippy::module_name_repetitions,
     reason = "I have no idea how to name this module to satisfy this lint"
 )]
-use crate::peer_list::{PeerList, ScoreDecreaseReason, ScoreIncreaseReason};
+use crate::peer_list::{ScoreDecreaseReason, ScoreIncreaseReason};
 use crate::types::{GossipDataRequest, GossipError, GossipResult};
+use crate::PeerListGuard;
 use core::time::Duration;
 use irys_types::{Address, GossipData, GossipRequest, PeerAddress, PeerListItem};
 use reqwest::Client;
@@ -50,20 +51,17 @@ impl GossipClient {
     /// # Errors
     ///
     /// If the peer is offline or the request fails, an error is returned.
-    async fn send_data_and_update_score_internal<P>(
+    async fn send_data_and_update_score_internal(
         &self,
         peer: (&Address, &PeerListItem),
         data: &GossipData,
-        peer_list: &P,
-    ) -> GossipResult<()>
-    where
-        P: PeerList,
-    {
+        peer_list: &PeerListGuard,
+    ) -> GossipResult<()> {
         let peer_miner_address = peer.0;
         let peer = peer.1;
 
         let res = self.send_data(peer, data).await;
-        Self::handle_score(peer_list, &res, peer_miner_address).await;
+        Self::handle_score(peer_list, &res, peer_miner_address);
         res
     }
 
@@ -73,7 +71,7 @@ impl GossipClient {
         &self,
         peer: &(Address, PeerListItem),
         requested_data: GossipDataRequest,
-        peer_list: &impl PeerList,
+        peer_list: &PeerListGuard,
     ) -> GossipResult<bool> {
         let url = format!("http://{}/gossip/get_data", peer.1.address.gossip);
         let get_data_request = self.create_request(requested_data);
@@ -88,7 +86,7 @@ impl GossipClient {
             .json()
             .await
             .map_err(|error| GossipError::Network(error.to_string()));
-        Self::handle_score(peer_list, &res, &peer.0).await;
+        Self::handle_score(peer_list, &res, &peer.0);
         res
     }
 
@@ -184,39 +182,29 @@ impl GossipClient {
             .map_err(|error| GossipError::Network(error.to_string()))
     }
 
-    async fn handle_score<P: PeerList, T>(
-        peer_list: &P,
+    fn handle_score<T>(
+        peer_list: &PeerListGuard,
         result: &GossipResult<T>,
         peer_miner_address: &Address,
     ) {
         match &result {
             Ok(_) => {
                 // Successful send, increase score
-                if let Err(e) = peer_list
-                    .increase_peer_score(peer_miner_address, ScoreIncreaseReason::Online)
-                    .await
-                {
-                    error!("Failed to increase peer score: {}", e);
-                }
+                peer_list.increase_peer_score(peer_miner_address, ScoreIncreaseReason::Online);
             }
             Err(_) => {
                 // Failed to send, decrease score
-                if let Err(e) = peer_list
-                    .decrease_peer_score(peer_miner_address, ScoreDecreaseReason::Offline)
-                    .await
-                {
-                    error!("Failed to decrease peer score: {}", e);
-                };
+                peer_list.decrease_peer_score(peer_miner_address, ScoreDecreaseReason::Offline);
             }
         }
     }
 
     /// Sends data to a peer and update their score in a detached task
-    pub fn send_data_and_update_the_score_detached<P: PeerList>(
+    pub fn send_data_and_update_the_score_detached(
         &self,
         peer: (&Address, &PeerListItem),
         data: Arc<GossipData>,
-        peer_list: &P,
+        peer_list: &PeerListGuard,
     ) {
         let client = self.clone();
         let peer_list = peer_list.clone();

--- a/crates/p2p/src/gossip_service.rs
+++ b/crates/p2p/src/gossip_service.rs
@@ -17,14 +17,14 @@ use crate::{
     gossip_client::GossipClient,
     server::GossipServer,
     types::{GossipError, GossipResult},
-    SyncState,
+    PeerListGuard, SyncState,
 };
 use actix_web::dev::{Server, ServerHandle};
 use core::time::Duration;
 use irys_actors::services::ServiceSenders;
 use irys_actors::{block_discovery::BlockDiscoveryFacade, mempool_service::MempoolFacade};
 use irys_api_client::ApiClient;
-use irys_types::{Address, Config, DatabaseProvider, GossipBroadcastMessage, PeerListItem};
+use irys_types::{Address, Config, DatabaseProvider, GossipBroadcastMessage};
 use irys_vdf::state::VdfStateReadonly;
 use rand::prelude::SliceRandom as _;
 use reth_tasks::{TaskExecutor, TaskManager};
@@ -157,7 +157,7 @@ impl P2PService {
         block_discovery: B,
         api_client: A,
         task_executor: &TaskExecutor,
-        peer_list: P,
+        peer_list: PeerListGuard,
         db: DatabaseProvider,
         listener: TcpListener,
         block_status_provider: BlockStatusProvider,
@@ -230,14 +230,11 @@ impl P2PService {
         Ok((gossip_service_handle, arc_pool))
     }
 
-    async fn broadcast_data<P>(
+    async fn broadcast_data(
         &self,
         broadcast_message: GossipBroadcastMessage,
-        peer_list: &P,
-    ) -> GossipResult<()>
-    where
-        P: PeerList,
-    {
+        peer_list: &PeerListGuard,
+    ) -> GossipResult<()> {
         // Check if gossip broadcast is enabled
         if !self.sync_state.is_gossip_broadcast_enabled() {
             debug!("Gossip broadcast is disabled, skipping broadcast");
@@ -251,10 +248,7 @@ impl P2PService {
         debug!("Broadcasting data to peers: {}", message_type_and_id);
 
         // Get all active peers except the source
-        let mut peers: Vec<(Address, PeerListItem)> = peer_list
-            .top_active_peers(None, None)
-            .await
-            .map_err(|err| GossipError::Internal(InternalGossipError::Unknown(err.to_string())))?;
+        let mut peers = peer_list.top_active_peers(None, None);
 
         debug!(
             "Node {:?}: Peers selected for broadcast: {:?}",
@@ -348,15 +342,12 @@ fn spawn_cache_pruning_task(
     )
 }
 
-fn spawn_broadcast_task<P>(
+fn spawn_broadcast_task(
     mut mempool_data_receiver: UnboundedReceiver<GossipBroadcastMessage>,
     service: P2PService,
     task_executor: &TaskExecutor,
-    peer_list: P,
-) -> ServiceHandleWithShutdownSignal
-where
-    P: PeerList,
-{
+    peer_list: PeerListGuard,
+) -> ServiceHandleWithShutdownSignal {
     ServiceHandleWithShutdownSignal::spawn(
         "gossip broadcast",
         move |mut shutdown_rx| async move {

--- a/crates/p2p/src/gossip_service.rs
+++ b/crates/p2p/src/gossip_service.rs
@@ -9,7 +9,6 @@
 use crate::block_pool::BlockPool;
 use crate::block_status_provider::BlockStatusProvider;
 use crate::execution_payload_provider::ExecutionPayloadProvider;
-use crate::peer_list::PeerList;
 use crate::server_data_handler::GossipServerDataHandler;
 use crate::types::InternalGossipError;
 use crate::{
@@ -151,7 +150,7 @@ impl P2PService {
     ///
     /// If the service fails to start, an error is returned. This can happen if the server fails to
     /// bind to the address or if any of the tasks fails to spawn.
-    pub fn run<M, B, A, P>(
+    pub fn run<M, B, A>(
         mut self,
         mempool: M,
         block_discovery: B,
@@ -161,16 +160,15 @@ impl P2PService {
         db: DatabaseProvider,
         listener: TcpListener,
         block_status_provider: BlockStatusProvider,
-        execution_payload_provider: ExecutionPayloadProvider<P>,
+        execution_payload_provider: ExecutionPayloadProvider,
         vdf_state: VdfStateReadonly,
         config: Config,
         service_senders: ServiceSenders,
-    ) -> GossipResult<(ServiceHandleWithShutdownSignal, Arc<BlockPool<P, B, M>>)>
+    ) -> GossipResult<(ServiceHandleWithShutdownSignal, Arc<BlockPool<B, M>>)>
     where
         M: MempoolFacade,
         B: BlockDiscoveryFacade,
         A: ApiClient,
-        P: PeerList,
     {
         debug!("Staring gossip service");
 

--- a/crates/p2p/src/gossip_service.rs
+++ b/crates/p2p/src/gossip_service.rs
@@ -16,13 +16,14 @@ use crate::{
     gossip_client::GossipClient,
     server::GossipServer,
     types::{GossipError, GossipResult},
-    PeerListGuard, SyncState,
+    SyncState,
 };
 use actix_web::dev::{Server, ServerHandle};
 use core::time::Duration;
 use irys_actors::services::ServiceSenders;
 use irys_actors::{block_discovery::BlockDiscoveryFacade, mempool_service::MempoolFacade};
 use irys_api_client::ApiClient;
+use irys_domain::PeerListGuard;
 use irys_types::{Address, Config, DatabaseProvider, GossipBroadcastMessage};
 use irys_vdf::state::VdfStateReadonly;
 use rand::prelude::SliceRandom as _;

--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -18,7 +18,9 @@ pub use gossip_client::GossipClient;
 pub use gossip_service::P2PService;
 pub use gossip_service::ServiceHandleWithShutdownSignal;
 pub use irys_vdf::vdf_utils::fast_forward_vdf_steps_from_block;
-pub use peer_list::{PeerList, PeerListFacadeError, PeerListServiceFacade, PeerListGuard, GetPeerListGuard};
+pub use peer_list::{
+    GetPeerListGuard, PeerList, PeerListFacadeError, PeerListGuard, PeerListServiceFacade,
+};
 pub use peer_list::{PeerListService, PeerListServiceError};
 pub use sync::{sync_chain, SyncState};
 pub use types::{GossipError, GossipResult};

--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -18,7 +18,7 @@ pub use gossip_client::GossipClient;
 pub use gossip_service::P2PService;
 pub use gossip_service::ServiceHandleWithShutdownSignal;
 pub use irys_vdf::vdf_utils::fast_forward_vdf_steps_from_block;
-pub use peer_list::{PeerList, PeerListFacadeError, PeerListServiceFacade};
+pub use peer_list::{PeerList, PeerListFacadeError, PeerListServiceFacade, PeerListGuard, GetPeerListGuard};
 pub use peer_list::{PeerListService, PeerListServiceError};
 pub use sync::{sync_chain, SyncState};
 pub use types::{GossipError, GossipResult};

--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -18,9 +18,10 @@ pub use gossip_client::GossipClient;
 pub use gossip_service::P2PService;
 pub use gossip_service::ServiceHandleWithShutdownSignal;
 pub use irys_vdf::vdf_utils::fast_forward_vdf_steps_from_block;
+pub use peer_list::PeerListServiceError;
 pub use peer_list::{
-    GetPeerListGuard, PeerList, PeerListFacadeError, PeerListGuard, PeerListServiceFacade,
+    GetPeerListGuard, PeerListFacadeError, PeerListGuard, PeerListService,
+    PeerListServiceWithClient,
 };
-pub use peer_list::{PeerListService, PeerListServiceError};
 pub use sync::{sync_chain, SyncState};
 pub use types::{GossipError, GossipResult};

--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -19,9 +19,6 @@ pub use gossip_service::P2PService;
 pub use gossip_service::ServiceHandleWithShutdownSignal;
 pub use irys_vdf::vdf_utils::fast_forward_vdf_steps_from_block;
 pub use peer_list::PeerListServiceError;
-pub use peer_list::{
-    GetPeerListGuard, PeerListFacadeError, PeerListGuard, PeerListService,
-    PeerListServiceWithClient,
-};
+pub use peer_list::{GetPeerListGuard, PeerListService, PeerListServiceWithClient};
 pub use sync::{sync_chain, SyncState};
 pub use types::{GossipError, GossipResult};

--- a/crates/p2p/src/peer_list.rs
+++ b/crates/p2p/src/peer_list.rs
@@ -1,31 +1,27 @@
 use crate::types::GossipDataRequest;
 use crate::GossipClient;
 use actix::prelude::*;
-use alloy_core::primitives::B256;
 use irys_actors::reth_service::RethServiceActor;
 use irys_api_client::{ApiClient, IrysApiClient};
+use irys_database::insert_peer_list_item;
 use irys_database::reth_db::{Database as _, DatabaseError};
-use irys_database::tables::PeerListItems;
-use irys_database::{insert_peer_list_item, walk_all};
+use irys_domain::{
+    PeerListDataError, PeerListDataMessage, PeerListGuard, ScoreDecreaseReason, ScoreIncreaseReason,
+};
 use irys_types::{
-    build_user_agent, Address, BlockHash, Config, DatabaseProvider, PeerAddress, PeerListItem,
-    PeerResponse, RejectedResponse, RethPeerInfo, VersionRequest,
+    build_user_agent, Address, Config, DatabaseProvider, PeerAddress, PeerListItem, PeerResponse,
+    RejectedResponse, RethPeerInfo, VersionRequest,
 };
 use rand::prelude::SliceRandom as _;
 use std::collections::{HashMap, HashSet};
-use std::net::{IpAddr, SocketAddr};
-use std::sync::{Arc, RwLock};
+use std::net::SocketAddr;
 use std::time::Duration;
-use thiserror::Error;
-use tokio::sync::mpsc::error::SendError;
-use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use tokio::sync::mpsc::UnboundedReceiver;
 use tracing::{debug, error, info, warn};
 
 const FLUSH_INTERVAL: Duration = Duration::from_secs(5);
 const INACTIVE_PEERS_HEALTH_CHECK_INTERVAL: Duration = Duration::from_secs(10);
 const PEER_HANDSHAKE_RETRY_INTERVAL: Duration = Duration::from_secs(5);
-pub(crate) const MILLISECONDS_IN_SECOND: u64 = 1000;
-pub(crate) const HANDSHAKE_COOLDOWN: u64 = MILLISECONDS_IN_SECOND * 5;
 
 async fn send_message_and_print_error<T, A, R>(message: T, address: Addr<A>)
 where
@@ -40,416 +36,6 @@ where
                 "Failed to send message to peer service: {:?}",
                 mailbox_error
             );
-        }
-    }
-}
-
-#[derive(Debug, Error, Clone)]
-pub enum PeerListFacadeError {
-    #[error("Internal peer list service error: {0:?}")]
-    InternalError(String),
-    #[error("{0:?}")]
-    ServiceError(PeerListServiceError),
-}
-
-impl From<PeerListServiceError> for PeerListFacadeError {
-    fn from(err: PeerListServiceError) -> Self {
-        Self::ServiceError(err)
-    }
-}
-
-impl From<MailboxError> for PeerListFacadeError {
-    fn from(err: MailboxError) -> Self {
-        Self::InternalError(format!("{:?}", err))
-    }
-}
-#[derive(Debug, Clone)]
-pub struct PeerListDataInner {
-    gossip_addr_to_mining_addr_map: HashMap<IpAddr, Address>,
-    api_addr_to_mining_addr_map: HashMap<SocketAddr, Address>,
-    peer_list_cache: HashMap<Address, PeerListItem>,
-    known_peers_cache: HashSet<PeerAddress>,
-    trusted_peers_api_addresses: HashSet<SocketAddr>,
-    peer_list_service_sender: UnboundedSender<PeerListDataMessage>,
-}
-
-// TODO: remove default, right now it's there just to make service into a ssytem service
-impl Default for PeerListDataInner {
-    fn default() -> Self {
-        panic!("PeerListData should be initialized with new() method, not default()");
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct PeerListGuard(Arc<RwLock<PeerListDataInner>>);
-
-impl Default for PeerListGuard {
-    fn default() -> Self {
-        panic!("PeerListGuard should be initialized with new() method, not default()");
-    }
-}
-
-impl PeerListGuard {
-    pub fn new(
-        config: &Config,
-        db: &DatabaseProvider,
-        peer_service_sender: UnboundedSender<PeerListDataMessage>,
-    ) -> Result<Self, PeerListDataError> {
-        let inner = PeerListDataInner::new(config, db, peer_service_sender)?;
-        Ok(Self(Arc::new(RwLock::new(inner))))
-    }
-
-    pub fn add_or_update_peer(&self, mining_addr: Address, peer: PeerListItem) {
-        let mut inner = self.0.write().expect("PeerListDataInner lock poisoned");
-        inner.add_or_update_peer(mining_addr, peer);
-    }
-
-    pub fn increase_peer_score(&self, mining_addr: &Address, reason: ScoreIncreaseReason) {
-        let mut inner = self.0.write().expect("PeerListDataInner lock poisoned");
-        inner.increase_score(mining_addr, reason);
-    }
-
-    pub fn decrease_peer_score(&self, mining_addr: &Address, reason: ScoreDecreaseReason) {
-        let mut inner = self.0.write().expect("PeerListDataInner lock poisoned");
-        inner.decrease_peer_score(mining_addr, reason);
-    }
-
-    pub fn all_known_peers(&self) -> Vec<PeerAddress> {
-        self.read().known_peers_cache.iter().copied().collect()
-    }
-
-    pub async fn wait_for_active_peers(&self) {
-        loop {
-            let active_peers_count = {
-                let bindings = self.read();
-                bindings
-                    .peer_list_cache
-                    .values()
-                    .filter(|peer| peer.reputation_score.is_active() && peer.is_online)
-                    .count()
-            };
-
-            if active_peers_count > 0 {
-                return;
-            }
-
-            // Check for active peers every second
-            tokio::time::sleep(Duration::from_secs(1)).await;
-        }
-    }
-
-    pub fn trusted_peers(&self) -> Vec<(Address, PeerListItem)> {
-        let guard = self.read();
-
-        let mut peers: Vec<(Address, PeerListItem)> = guard
-            .peer_list_cache
-            .iter()
-            .map(|(key, value)| (*key, value.clone()))
-            .collect();
-
-        peers.retain(|(_miner_address, peer)| {
-            guard
-                .trusted_peers_api_addresses
-                .contains(&peer.address.api)
-        });
-
-        peers.sort_by_key(|(_address, peer)| peer.reputation_score.get());
-        peers.reverse();
-
-        peers
-    }
-
-    pub fn top_active_peers(
-        &self,
-        limit: Option<usize>,
-        exclude_peers: Option<HashSet<Address>>,
-    ) -> Vec<(Address, PeerListItem)> {
-        let guard = self.read();
-
-        let mut peers: Vec<(Address, PeerListItem)> = guard
-            .peer_list_cache
-            .iter()
-            .map(|(key, value)| (*key, value.clone()))
-            .collect();
-
-        peers.retain(|(miner_address, peer)| {
-            let exclude = if let Some(exclude_peers) = &exclude_peers {
-                exclude_peers.contains(miner_address)
-            } else {
-                false
-            };
-            !exclude && peer.reputation_score.is_active() && peer.is_online
-        });
-
-        peers.sort_by_key(|(_address, peer)| peer.reputation_score.get());
-        peers.reverse();
-
-        if let Some(truncate) = limit {
-            peers.truncate(truncate);
-        }
-
-        peers
-    }
-
-    pub fn peer_by_gossip_address(&self, address: SocketAddr) -> Option<PeerListItem> {
-        let binding = self.read();
-        let mining_address = binding
-            .gossip_addr_to_mining_addr_map
-            .get(&address.ip())
-            .copied()?;
-        binding.peer_list_cache.get(&mining_address).cloned()
-    }
-
-    pub fn peer_by_mining_address(&self, mining_address: &Address) -> Option<PeerListItem> {
-        let binding = self.read();
-        binding.peer_list_cache.get(mining_address).cloned()
-    }
-
-    pub fn is_a_trusted_peer(&self, miner_address: Address, source_ip: IpAddr) -> bool {
-        let binding = self.read();
-
-        let Some(peer) = binding.peer_list_cache.get(&miner_address) else {
-            return false;
-        };
-        let peer_api_ip = peer.address.api.ip();
-        let peer_gossip_ip = peer.address.gossip.ip();
-
-        let ip_matches_cached_ip = source_ip == peer_gossip_ip;
-        let ip_is_in_a_trusted_list = binding
-            .trusted_peers_api_addresses
-            .iter()
-            .any(|socket_addr| socket_addr.ip() == peer_api_ip);
-
-        ip_matches_cached_ip && ip_is_in_a_trusted_list
-    }
-
-    pub async fn request_block_from_the_network(
-        &self,
-        block_hash: BlockHash,
-        use_trusted_peers_only: bool,
-    ) -> Result<(), PeerListDataError> {
-        let (sender, receiver) = tokio::sync::oneshot::channel();
-        let message = PeerListDataMessage::RequestBlockFromNetwork {
-            block_hash,
-            use_trusted_peers_only,
-            response: sender,
-        };
-        self.0
-            .write()
-            .expect("PeerListDataInner lock poisoned")
-            .peer_list_service_sender
-            .send(message)?;
-
-        receiver.await.map_err(|recv_error| {
-            PeerListDataError::OtherInternalError(format!(
-                "Failed to receive response: {:?}",
-                recv_error
-            ))
-        })?
-    }
-
-    pub async fn request_payload_from_the_network(
-        &self,
-        evm_payload_hash: B256,
-        use_trusted_peers_only: bool,
-    ) -> Result<(), PeerListDataError> {
-        let (sender, receiver) = tokio::sync::oneshot::channel();
-        let message = PeerListDataMessage::RequestPayloadFromNetwork {
-            payload_hash: evm_payload_hash,
-            use_trusted_peers_only,
-            response: sender,
-        };
-        self.0
-            .write()
-            .expect("PeerListDataInner lock poisoned")
-            .peer_list_service_sender
-            .send(message)?;
-
-        receiver.await.map_err(|recv_error| {
-            PeerListDataError::OtherInternalError(format!(
-                "Failed to receive response: {:?}",
-                recv_error
-            ))
-        })?
-    }
-
-    pub fn read(&self) -> std::sync::RwLockReadGuard<'_, PeerListDataInner> {
-        self.0.read().expect("PeerListDataInner lock poisoned")
-    }
-
-    pub fn peer_count(&self) -> usize {
-        self.read().peer_list_cache.len()
-    }
-}
-
-#[derive(Message, Debug)]
-#[rtype(result = "()")]
-pub enum PeerListDataMessage {
-    PeerUpdated(PeerListItem),
-    RequestBlockFromNetwork {
-        block_hash: BlockHash,
-        use_trusted_peers_only: bool,
-        response: tokio::sync::oneshot::Sender<Result<(), PeerListDataError>>,
-    },
-    RequestPayloadFromNetwork {
-        payload_hash: B256,
-        use_trusted_peers_only: bool,
-        response: tokio::sync::oneshot::Sender<Result<(), PeerListDataError>>,
-    },
-}
-
-impl PeerListDataInner {
-    pub fn new(
-        config: &Config,
-        db: &DatabaseProvider,
-        peer_service_sender: UnboundedSender<PeerListDataMessage>,
-    ) -> Result<Self, PeerListDataError> {
-        let mut peer_list = Self {
-            gossip_addr_to_mining_addr_map: HashMap::new(),
-            api_addr_to_mining_addr_map: HashMap::new(),
-            peer_list_cache: HashMap::new(),
-            known_peers_cache: HashSet::new(),
-            trusted_peers_api_addresses: config
-                .node_config
-                .trusted_peers
-                .iter()
-                .map(|p| p.api)
-                .collect(),
-            peer_list_service_sender: peer_service_sender,
-        };
-
-        let read_tx = db.tx().map_err(PeerListDataError::from)?;
-
-        let peer_list_items =
-            walk_all::<PeerListItems, _>(&read_tx).map_err(PeerListDataError::from)?;
-
-        for (mining_addr, entry) in peer_list_items {
-            let address = entry.address;
-            peer_list
-                .gossip_addr_to_mining_addr_map
-                .insert(entry.address.gossip.ip(), mining_addr);
-            peer_list.peer_list_cache.insert(mining_addr, entry.0);
-            peer_list.known_peers_cache.insert(address);
-            peer_list
-                .api_addr_to_mining_addr_map
-                .insert(address.api, mining_addr);
-        }
-
-        Ok(peer_list)
-    }
-
-    pub fn add_or_update_peer(&mut self, mining_addr: Address, peer: PeerListItem) {
-        let is_updated = self.add_or_update_peer_internal(mining_addr, peer.clone());
-
-        if is_updated {
-            debug!(
-                "Sending PeerUpdated message to the service for peer {:?}",
-                mining_addr
-            );
-            // Notify the peer list service that a peer was updated
-            if let Err(e) = self
-                .peer_list_service_sender
-                .send(PeerListDataMessage::PeerUpdated(peer))
-            {
-                error!("Failed to send peer updated message: {:?}", e);
-            }
-        }
-    }
-
-    pub fn increase_score(&mut self, mining_addr: &Address, reason: ScoreIncreaseReason) {
-        if let Some(peer) = self.peer_list_cache.get_mut(mining_addr) {
-            match reason {
-                ScoreIncreaseReason::Online => {
-                    peer.reputation_score.increase();
-                }
-                ScoreIncreaseReason::ValidData => {
-                    peer.reputation_score.increase();
-                }
-            }
-        }
-    }
-
-    pub fn decrease_peer_score(&mut self, mining_addr: &Address, reason: ScoreDecreaseReason) {
-        if let Some(peer_item) = self.peer_list_cache.get_mut(mining_addr) {
-            match reason {
-                ScoreDecreaseReason::BogusData => {
-                    peer_item.reputation_score.decrease_bogus_data();
-                }
-                ScoreDecreaseReason::Offline => {
-                    peer_item.reputation_score.decrease_offline();
-                }
-            }
-
-            // Don't propagate inactive peers
-            if !peer_item.reputation_score.is_active() {
-                self.known_peers_cache.remove(&peer_item.address);
-            }
-        }
-    }
-
-    /// Add a peer to the peer list. Returns true if the peer was added, false if it already exists.
-    fn add_or_update_peer_internal(&mut self, mining_addr: Address, peer: PeerListItem) -> bool {
-        let gossip_addr = peer.address.gossip;
-        let peer_address = peer.address;
-
-        if let std::collections::hash_map::Entry::Vacant(peer_cache) =
-            self.peer_list_cache.entry(mining_addr)
-        {
-            debug!("Adding peer {:?} to the peer list", mining_addr);
-            peer_cache.insert(peer);
-            self.gossip_addr_to_mining_addr_map
-                .insert(gossip_addr.ip(), mining_addr);
-            self.api_addr_to_mining_addr_map
-                .insert(peer_address.api, mining_addr);
-            self.known_peers_cache.insert(peer_address);
-            debug!(
-                "Peer {:?} added to the peer list with address {:?}",
-                mining_addr, peer_address
-            );
-            true
-        } else {
-            debug!(
-                "Peer {:?} already exists in the peer list, checking if the address needs updating",
-                mining_addr
-            );
-            if let Some(existing_peer) = self.peer_list_cache.get_mut(&mining_addr) {
-                let handshake_cooldown_expired =
-                    existing_peer.last_seen + HANDSHAKE_COOLDOWN < peer.last_seen;
-                existing_peer.last_seen = peer.last_seen;
-                if existing_peer.address != peer_address {
-                    debug!("Peer address mismatch, updating to new address");
-                    self.update_peer_address(mining_addr, peer_address);
-                    true
-                } else if handshake_cooldown_expired {
-                    debug!("Peer address is the same, but the handshake cooldown has expired, so we need to re-handshake");
-                    true
-                } else {
-                    debug!("Peer address is the same, no update needed");
-                    false
-                }
-            } else {
-                warn!(
-                    "Peer {:?} is not found in the peer list cache, which shouldn't happen",
-                    mining_addr
-                );
-                false
-            }
-        }
-    }
-
-    fn update_peer_address(&mut self, mining_addr: Address, new_address: PeerAddress) {
-        if let Some(peer) = self.peer_list_cache.get_mut(&mining_addr) {
-            let old_address = peer.address;
-            peer.address = new_address;
-            self.gossip_addr_to_mining_addr_map
-                .remove(&old_address.gossip.ip());
-            self.gossip_addr_to_mining_addr_map
-                .insert(new_address.gossip.ip(), mining_addr);
-            self.known_peers_cache.remove(&old_address);
-            self.known_peers_cache.insert(old_address);
-            self.api_addr_to_mining_addr_map.remove(&old_address.api);
-            self.api_addr_to_mining_addr_map
-                .insert(new_address.api, mining_addr);
         }
     }
 }
@@ -702,20 +288,8 @@ where
 
         ctx.run_interval(INACTIVE_PEERS_HEALTH_CHECK_INTERVAL, |act, ctx| {
             // Collect inactive peers with the required fields
-            let inactive_peers: Vec<(Address, PeerListItem, SocketAddr)> = act
-                .peer_list_data_guard
-                .read()
-                .peer_list_cache
-                .iter()
-                .filter(|(_mining_addr, peer)| !peer.reputation_score.is_active())
-                .map(|(mining_addr, peer)| {
-                    // Clone or copy the fields we need for the async operation
-                    let peer_item = peer.clone();
-                    let mining_addr = *mining_addr;
-                    let peer_addr = peer_item.address;
-                    (mining_addr, peer_item, peer_addr.gossip)
-                })
-                .collect();
+            let inactive_peers: Vec<(Address, PeerListItem, SocketAddr)> =
+                act.peer_list_data_guard.inactive_peers();
 
             for (mining_addr, peer, ..) in inactive_peers {
                 // Clone the peer address to use in the async block
@@ -744,10 +318,7 @@ where
         // Initiate the trusted peers handshake
         let trusted_peers_handshake_task = Self::trusted_peers_handshake_task(
             peer_service_address.clone(),
-            self.peer_list_data_guard
-                .read()
-                .trusted_peers_api_addresses
-                .clone(),
+            self.peer_list_data_guard.trusted_peer_addresses(),
         )
         .into_actor(self);
         ctx.spawn(trusted_peers_handshake_task);
@@ -755,7 +326,7 @@ where
         // Announce yourself to the network
         let version_request = self.create_version_request();
         let api_client = self.irys_api_client.clone();
-        let peers_cache = self.peer_list_data_guard.read().known_peers_cache.clone();
+        let peers_cache = self.peer_list_data_guard.all_known_peers();
         let announce_fut = Self::announce_yourself_to_all_peers(
             api_client,
             version_request,
@@ -798,34 +369,6 @@ pub enum PeerListServiceError {
     FailedToRequestData(String),
 }
 
-#[derive(Debug, Error)]
-pub enum PeerListDataError {
-    #[error("Internal database error: {0}")]
-    Database(DatabaseError),
-    #[error("Peer list internal error: {0:?}")]
-    InternalSendError(SendError<PeerListDataMessage>),
-    #[error("Peer list internal error: {0}")]
-    OtherInternalError(String),
-}
-
-impl From<SendError<PeerListDataMessage>> for PeerListDataError {
-    fn from(err: SendError<PeerListDataMessage>) -> Self {
-        Self::InternalSendError(err)
-    }
-}
-
-impl From<DatabaseError> for PeerListDataError {
-    fn from(err: DatabaseError) -> Self {
-        Self::Database(err)
-    }
-}
-
-impl From<eyre::Report> for PeerListDataError {
-    fn from(err: eyre::Report) -> Self {
-        Self::Database(DatabaseError::Other(err.to_string()))
-    }
-}
-
 impl From<MailboxError> for PeerListServiceError {
     fn from(value: MailboxError) -> Self {
         Self::InternalSendError(value)
@@ -844,18 +387,6 @@ impl From<eyre::Report> for PeerListServiceError {
     }
 }
 
-#[derive(Clone, Debug, Copy)]
-pub enum ScoreDecreaseReason {
-    BogusData,
-    Offline,
-}
-
-#[derive(Clone, Debug, Copy)]
-pub enum ScoreIncreaseReason {
-    Online,
-    ValidData,
-}
-
 impl<A, R> PeerListServiceWithClient<A, R>
 where
     A: ApiClient,
@@ -864,7 +395,11 @@ where
     fn flush(&self) -> Result<(), PeerListServiceError> {
         if let Some(db) = &self.db {
             db.update(|tx| {
-                for (addr, peer) in self.peer_list_data_guard.read().peer_list_cache.iter() {
+                for (addr, peer) in self
+                    .peer_list_data_guard
+                    .all_know_peers_with_mining_address()
+                    .iter()
+                {
                     insert_peer_list_item(tx, addr, peer).map_err(PeerListServiceError::from)?;
                 }
                 Ok(())
@@ -1016,7 +551,7 @@ where
     async fn announce_yourself_to_all_peers(
         api_client: A,
         version_request: VersionRequest,
-        known_peers_cache: HashSet<PeerAddress>,
+        known_peers_cache: Vec<PeerAddress>,
         peer_service_address: Addr<Self>,
         reth_service_address: Option<Addr<R>>,
     ) {
@@ -1182,9 +717,7 @@ where
 
         let already_in_cache = self
             .peer_list_data_guard
-            .read()
-            .api_addr_to_mining_addr_map
-            .contains_key(&msg.api_address);
+            .contains_api_address(&msg.api_address);
         let already_announcing = self
             .currently_running_announcements
             .contains(&msg.api_address);
@@ -1383,6 +916,8 @@ where
 mod tests {
     use super::*;
     use irys_api_client::test_utils::CountingMockClient;
+    use irys_database::tables::PeerListItems;
+    use irys_database::walk_all;
     use irys_storage::irys_consensus_data_db::open_or_create_irys_consensus_data_db;
     use irys_testing_utils::utils::setup_tracing_and_temp_dir;
     use irys_types::peer_list::PeerScore;
@@ -1924,7 +1459,7 @@ mod tests {
             true,
             None,
         );
-        let known_peers: HashSet<_> = vec![peer1.address, peer2.address].into_iter().collect();
+        let known_peers = vec![peer1.address, peer2.address];
         let version_request = VersionRequest::default();
 
         PeerListServiceWithClient::announce_yourself_to_all_peers(

--- a/crates/p2p/src/server.rs
+++ b/crates/p2p/src/server.rs
@@ -2,7 +2,7 @@
     clippy::module_name_repetitions,
     reason = "I have no idea how to name this module to satisfy this lint"
 )]
-use crate::peer_list::{PeerList, ScoreDecreaseReason};
+use crate::peer_list::ScoreDecreaseReason;
 use crate::server_data_handler::GossipServerDataHandler;
 use crate::types::{GossipDataRequest, InternalGossipError};
 use crate::types::{GossipError, GossipResult};
@@ -25,23 +25,21 @@ use std::net::TcpListener;
 use tracing::{debug, error, info, warn};
 
 #[derive(Debug)]
-pub(crate) struct GossipServer<M, B, A, P>
+pub(crate) struct GossipServer<M, B, A>
 where
     M: MempoolFacade,
     B: BlockDiscoveryFacade,
     A: ApiClient,
-    P: PeerList,
 {
-    data_handler: GossipServerDataHandler<M, B, A, P>,
+    data_handler: GossipServerDataHandler<M, B, A>,
     peer_list: PeerListGuard,
 }
 
-impl<M, B, A, P> Clone for GossipServer<M, B, A, P>
+impl<M, B, A> Clone for GossipServer<M, B, A>
 where
     M: MempoolFacade,
     B: BlockDiscoveryFacade,
     A: ApiClient,
-    P: PeerList,
 {
     fn clone(&self) -> Self {
         Self {
@@ -51,15 +49,14 @@ where
     }
 }
 
-impl<M, B, A, P> GossipServer<M, B, A, P>
+impl<M, B, A> GossipServer<M, B, A>
 where
     M: MempoolFacade,
     B: BlockDiscoveryFacade,
     A: ApiClient,
-    P: PeerList,
 {
     pub(crate) const fn new(
-        gossip_server_data_handler: GossipServerDataHandler<M, B, A, P>,
+        gossip_server_data_handler: GossipServerDataHandler<M, B, A>,
         peer_list: PeerListGuard,
     ) -> Self {
         Self {

--- a/crates/p2p/src/server.rs
+++ b/crates/p2p/src/server.rs
@@ -2,11 +2,9 @@
     clippy::module_name_repetitions,
     reason = "I have no idea how to name this module to satisfy this lint"
 )]
-use crate::peer_list::ScoreDecreaseReason;
 use crate::server_data_handler::GossipServerDataHandler;
 use crate::types::{GossipDataRequest, InternalGossipError};
 use crate::types::{GossipError, GossipResult};
-use crate::PeerListGuard;
 use actix_web::dev::Server;
 use actix_web::{
     middleware,
@@ -15,6 +13,7 @@ use actix_web::{
 };
 use irys_actors::{block_discovery::BlockDiscoveryFacade, mempool_service::MempoolFacade};
 use irys_api_client::ApiClient;
+use irys_domain::{PeerListGuard, ScoreDecreaseReason};
 use irys_types::{
     Address, CommitmentTransaction, DataTransactionHeader, GossipRequest, IrysBlockHeader,
     PeerListItem, UnpackedChunk,

--- a/crates/p2p/src/server.rs
+++ b/crates/p2p/src/server.rs
@@ -6,6 +6,7 @@ use crate::peer_list::{PeerList, ScoreDecreaseReason};
 use crate::server_data_handler::GossipServerDataHandler;
 use crate::types::{GossipDataRequest, InternalGossipError};
 use crate::types::{GossipError, GossipResult};
+use crate::PeerListGuard;
 use actix_web::dev::Server;
 use actix_web::{
     middleware,
@@ -32,7 +33,7 @@ where
     P: PeerList,
 {
     data_handler: GossipServerDataHandler<M, B, A, P>,
-    peer_list: P,
+    peer_list: PeerListGuard,
 }
 
 impl<M, B, A, P> Clone for GossipServer<M, B, A, P>
@@ -59,7 +60,7 @@ where
 {
     pub(crate) const fn new(
         gossip_server_data_handler: GossipServerDataHandler<M, B, A, P>,
-        peer_list: P,
+        peer_list: PeerListGuard,
     ) -> Self {
         Self {
             data_handler: gossip_server_data_handler,
@@ -84,13 +85,13 @@ where
         let gossip_request = unpacked_chunk_json.0;
         let source_miner_address = gossip_request.miner_address;
 
-        match Self::check_peer(&server.peer_list, &req, source_miner_address).await {
+        match Self::check_peer(&server.peer_list, &req, source_miner_address) {
             Ok(peer_address) => peer_address,
             Err(error_response) => return error_response,
         };
 
         if let Err(error) = server.data_handler.handle_chunk(gossip_request).await {
-            Self::handle_invalid_data(&source_miner_address, &error, &server.peer_list).await;
+            Self::handle_invalid_data(&source_miner_address, &error, &server.peer_list);
             error!("Failed to send chunk: {}", error);
             return HttpResponse::InternalServerError().finish();
         }
@@ -98,8 +99,8 @@ where
         HttpResponse::Ok().finish()
     }
 
-    async fn check_peer(
-        peer_list: &P,
+    fn check_peer(
+        peer_list: &PeerListGuard,
         req: &actix_web::HttpRequest,
         miner_address: Address,
     ) -> Result<PeerListItem, HttpResponse> {
@@ -108,31 +109,27 @@ where
             return Err(HttpResponse::BadRequest().finish());
         };
 
-        match peer_list.peer_by_mining_address(miner_address).await {
-            Ok(maybe_peer) => {
-                if let Some(peer) = maybe_peer {
-                    if peer.address.gossip.ip() != peer_address.ip() {
-                        debug!(
-                            "Miner address {} request came from ip {}, but the expected ip was {}",
-                            miner_address,
-                            peer_address.ip(),
-                            peer.address.gossip.ip()
-                        );
-                        return Err(HttpResponse::Forbidden().finish());
-                    }
-                    Ok(peer)
-                } else {
-                    warn!("Miner address {} is not allowed", miner_address);
-                    Err(HttpResponse::Forbidden().finish())
-                }
+        if let Some(peer) = peer_list.peer_by_mining_address(&miner_address) {
+            if peer.address.gossip.ip() != peer_address.ip() {
+                debug!(
+                    "Miner address {} request came from ip {}, but the expected ip was {}",
+                    miner_address,
+                    peer_address.ip(),
+                    peer.address.gossip.ip()
+                );
+                return Err(HttpResponse::Forbidden().finish());
             }
-            Err(error) => {
-                error!("Failed to check if miner is allowed: {}", error);
-                Err(HttpResponse::InternalServerError().finish())
-            }
+            Ok(peer)
+        } else {
+            warn!("Miner address {} is not allowed", miner_address);
+            Err(HttpResponse::Forbidden().finish())
         }
     }
 
+    #[expect(
+        clippy::unused_async,
+        reason = "Actix-web handler signature requires handlers to be async"
+    )]
     async fn handle_block(
         server: Data<Self>,
         irys_block_header_json: web::Json<GossipRequest<IrysBlockHeader>>,
@@ -153,11 +150,10 @@ where
             return HttpResponse::BadRequest().finish();
         };
 
-        let peer =
-            match Self::check_peer(&server.peer_list, &req, gossip_request.miner_address).await {
-                Ok(peer_address) => peer_address,
-                Err(error_response) => return error_response,
-            };
+        let peer = match Self::check_peer(&server.peer_list, &req, gossip_request.miner_address) {
+            Ok(peer_address) => peer_address,
+            Err(error_response) => return error_response,
+        };
 
         let this_node_id = server.data_handler.gossip_client.mining_address;
 
@@ -168,7 +164,7 @@ where
                 .handle_block_header_request(gossip_request, peer.address.api, source_socket_addr)
                 .await
             {
-                Self::handle_invalid_data(&source_miner_address, &error, &server.peer_list).await;
+                Self::handle_invalid_data(&source_miner_address, &error, &server.peer_list);
                 error!(
                     "Node {:?}: Failed to process the block {:?}: {:?}",
                     this_node_id, block_hash_string, error
@@ -207,7 +203,7 @@ where
         let source_miner_address = evm_block_request.miner_address;
 
         if let Err(error_response) =
-            Self::check_peer(&server.peer_list, &req, evm_block_request.miner_address).await
+            Self::check_peer(&server.peer_list, &req, evm_block_request.miner_address)
         {
             return error_response;
         };
@@ -217,7 +213,7 @@ where
             .handle_execution_payload(evm_block_request)
             .await
         {
-            Self::handle_invalid_data(&source_miner_address, &error, &server.peer_list).await;
+            Self::handle_invalid_data(&source_miner_address, &error, &server.peer_list);
             error!("Failed to send transaction: {}", error);
             return HttpResponse::InternalServerError().finish();
         }
@@ -243,13 +239,13 @@ where
         let gossip_request = irys_transaction_header_json.0;
         let source_miner_address = gossip_request.miner_address;
 
-        match Self::check_peer(&server.peer_list, &req, gossip_request.miner_address).await {
+        match Self::check_peer(&server.peer_list, &req, gossip_request.miner_address) {
             Ok(peer_address) => peer_address,
             Err(error_response) => return error_response,
         };
 
         if let Err(error) = server.data_handler.handle_transaction(gossip_request).await {
-            Self::handle_invalid_data(&source_miner_address, &error, &server.peer_list).await;
+            Self::handle_invalid_data(&source_miner_address, &error, &server.peer_list);
             error!("Failed to send transaction: {}", error);
             return HttpResponse::InternalServerError().finish();
         }
@@ -275,7 +271,7 @@ where
         let gossip_request = commitment_tx_json.0;
         let source_miner_address = gossip_request.miner_address;
 
-        match Self::check_peer(&server.peer_list, &req, gossip_request.miner_address).await {
+        match Self::check_peer(&server.peer_list, &req, gossip_request.miner_address) {
             Ok(peer_address) => peer_address,
             Err(error_response) => return error_response,
         };
@@ -285,7 +281,7 @@ where
             .handle_commitment_tx(gossip_request)
             .await
         {
-            Self::handle_invalid_data(&source_miner_address, &error, &server.peer_list).await;
+            Self::handle_invalid_data(&source_miner_address, &error, &server.peer_list);
             error!("Failed to send transaction: {}", error);
             return HttpResponse::InternalServerError().finish();
         }
@@ -294,28 +290,28 @@ where
         HttpResponse::Ok().finish()
     }
 
+    #[expect(
+        clippy::unused_async,
+        reason = "Actix-web handler signature requires handlers to be async"
+    )]
     async fn handle_health_check(server: Data<Self>, req: actix_web::HttpRequest) -> HttpResponse {
         let Some(peer_addr) = req.peer_addr() else {
             return HttpResponse::BadRequest().finish();
         };
 
-        match server.peer_list.peer_by_gossip_address(peer_addr).await {
-            Ok(info) => match info {
-                Some(_info) => HttpResponse::Ok().json(true),
-                None => HttpResponse::NotFound().finish(),
-            },
-            Err(_) => HttpResponse::InternalServerError().finish(),
+        match server.peer_list.peer_by_gossip_address(peer_addr) {
+            Some(_info) => HttpResponse::Ok().json(true),
+            None => HttpResponse::NotFound().finish(),
         }
     }
 
-    async fn handle_invalid_data(peer_miner_address: &Address, error: &GossipError, peer_list: &P) {
+    fn handle_invalid_data(
+        peer_miner_address: &Address,
+        error: &GossipError,
+        peer_list: &PeerListGuard,
+    ) {
         if let GossipError::InvalidData(_) = error {
-            if let Err(error) = peer_list
-                .decrease_peer_score(peer_miner_address, ScoreDecreaseReason::BogusData)
-                .await
-            {
-                error!("Failed to decrease peer score: {}", error);
-            }
+            peer_list.decrease_peer_score(peer_miner_address, ScoreDecreaseReason::BogusData);
         }
     }
 
@@ -343,8 +339,7 @@ where
             );
             return HttpResponse::Forbidden().finish();
         }
-        let peer = match Self::check_peer(&server.peer_list, &req, data_request.miner_address).await
-        {
+        let peer = match Self::check_peer(&server.peer_list, &req, data_request.miner_address) {
             Ok(peer_address) => peer_address,
             Err(error_response) => return error_response,
         };

--- a/crates/p2p/src/server_data_handler.rs
+++ b/crates/p2p/src/server_data_handler.rs
@@ -1,11 +1,10 @@
 use crate::execution_payload_provider::ExecutionPayloadProvider;
-use crate::peer_list::ScoreDecreaseReason;
 use crate::{
     block_pool::BlockPool,
     cache::GossipCache,
     sync::SyncState,
     types::{GossipDataRequest, InternalGossipError, InvalidDataError},
-    GossipClient, GossipError, GossipResult, PeerListGuard,
+    GossipClient, GossipError, GossipResult,
 };
 use alloy_core::primitives::keccak256;
 use base58::ToBase58 as _;
@@ -15,6 +14,7 @@ use irys_actors::{
     mempool_service::{ChunkIngressError, MempoolFacade},
 };
 use irys_api_client::ApiClient;
+use irys_domain::{PeerListGuard, ScoreDecreaseReason};
 use irys_types::{
     CommitmentTransaction, DataTransactionHeader, GossipCacheKey, GossipData, GossipRequest,
     IrysBlockHeader, IrysTransactionResponse, PeerListItem, UnpackedChunk, H256,

--- a/crates/p2p/src/server_data_handler.rs
+++ b/crates/p2p/src/server_data_handler.rs
@@ -1,5 +1,5 @@
 use crate::execution_payload_provider::ExecutionPayloadProvider;
-use crate::peer_list::{PeerList, ScoreDecreaseReason};
+use crate::peer_list::ScoreDecreaseReason;
 use crate::{
     block_pool::BlockPool,
     cache::GossipCache,
@@ -27,15 +27,14 @@ use tracing::{debug, error, Span};
 
 /// Handles data received by the `GossipServer`
 #[derive(Debug)]
-pub(crate) struct GossipServerDataHandler<TMempoolFacade, TBlockDiscovery, TApiClient, TPeerList>
+pub(crate) struct GossipServerDataHandler<TMempoolFacade, TBlockDiscovery, TApiClient>
 where
     TMempoolFacade: MempoolFacade,
     TBlockDiscovery: BlockDiscoveryFacade,
     TApiClient: ApiClient,
-    TPeerList: PeerList,
 {
     pub mempool: TMempoolFacade,
-    pub block_pool: Arc<BlockPool<TPeerList, TBlockDiscovery, TMempoolFacade>>,
+    pub block_pool: Arc<BlockPool<TBlockDiscovery, TMempoolFacade>>,
     pub cache: Arc<GossipCache>,
     pub api_client: TApiClient,
     pub gossip_client: GossipClient,
@@ -43,15 +42,14 @@ where
     pub sync_state: SyncState,
     /// Tracing span
     pub span: Span,
-    pub execution_payload_provider: ExecutionPayloadProvider<TPeerList>,
+    pub execution_payload_provider: ExecutionPayloadProvider,
 }
 
-impl<M, B, A, P> Clone for GossipServerDataHandler<M, B, A, P>
+impl<M, B, A> Clone for GossipServerDataHandler<M, B, A>
 where
     M: MempoolFacade,
     B: BlockDiscoveryFacade,
     A: ApiClient,
-    P: PeerList,
 {
     fn clone(&self) -> Self {
         Self {
@@ -68,12 +66,11 @@ where
     }
 }
 
-impl<M, B, A, P> GossipServerDataHandler<M, B, A, P>
+impl<M, B, A> GossipServerDataHandler<M, B, A>
 where
     M: MempoolFacade,
     B: BlockDiscoveryFacade,
     A: ApiClient,
-    P: PeerList,
 {
     pub(crate) async fn handle_chunk(
         &self,

--- a/crates/p2p/src/sync.rs
+++ b/crates/p2p/src/sync.rs
@@ -1,6 +1,7 @@
-use crate::{GossipError, GossipResult, PeerListGuard};
+use crate::{GossipError, GossipResult};
 use base58::ToBase58 as _;
 use irys_api_client::ApiClient;
+use irys_domain::PeerListGuard;
 use irys_types::{BlockIndexItem, BlockIndexQuery, NodeMode};
 use rand::prelude::SliceRandom as _;
 use std::collections::VecDeque;

--- a/crates/p2p/src/tests/block_pool/mod.rs
+++ b/crates/p2p/src/tests/block_pool/mod.rs
@@ -2,7 +2,7 @@ use crate::block_pool::{BlockPool, BlockPoolError};
 use crate::execution_payload_provider::{ExecutionPayloadProvider, RethBlockProvider};
 use crate::peer_list::PeerListServiceWithClient;
 use crate::tests::util::{FakeGossipServer, MempoolStub, MockRethServiceActor};
-use crate::{BlockStatusProvider, PeerList as _, SyncState};
+use crate::{BlockStatusProvider, GetPeerListGuard, SyncState};
 use actix::{Actor as _, Addr};
 use async_trait::async_trait;
 use base58::ToBase58 as _;
@@ -234,6 +234,11 @@ async fn should_process_block() {
         vdf_state_stub,
         service_senders,
     } = MockedServices::new(&config).await;
+    let peer_addr = peer_addr
+        .send(GetPeerListGuard)
+        .await
+        .expect("to get peer list guard")
+        .expect("to get peer list guard");
 
     let sync_state = SyncState::new(false, false);
     let service = BlockPool::new(
@@ -330,26 +335,34 @@ async fn should_process_block_with_intermediate_block_in_api() {
         service_senders,
     } = MockedServices::new(&config).await;
 
+    let peer_list_guard = peer_addr
+        .send(GetPeerListGuard)
+        .await
+        .expect("to get peer list guard")
+        .expect("to get peer list guard");
     // Set the mock client to return block2 when requested
     // Adding a peer so we can send a request to the mock client
-    peer_addr
-        .add_or_update_peer(
-            Address::new([0, 1, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0]),
-            PeerListItem {
-                reputation_score: PeerScore::new(100),
-                response_time: 0,
-                address: PeerAddress {
-                    gossip: fake_peer_gossip_addr,
-                    ..PeerAddress::default()
-                },
-                last_seen: 0,
-                is_online: true,
+    peer_list_guard.add_or_update_peer(
+        Address::new([0, 1, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0]),
+        PeerListItem {
+            reputation_score: PeerScore::new(100),
+            response_time: 0,
+            address: PeerAddress {
+                gossip: fake_peer_gossip_addr,
+                ..PeerAddress::default()
             },
-        )
-        .await
-        .expect("can't send message to peer list");
+            last_seen: 0,
+            is_online: true,
+        },
+    );
 
     let sync_state = SyncState::new(false, false);
+
+    let peer_addr = peer_addr
+        .send(GetPeerListGuard)
+        .await
+        .expect("to get peer list guard")
+        .expect("to get peer list guard");
 
     let block_pool = BlockPool::new(
         db.clone(),
@@ -423,6 +436,12 @@ async fn should_warn_about_mismatches_for_very_old_block() {
     } = MockedServices::new(&config).await;
 
     let sync_state = SyncState::new(false, false);
+
+    let peer_addr = peer_addr
+        .send(GetPeerListGuard)
+        .await
+        .expect("to get peer list guard")
+        .expect("to get peer list guard");
 
     let block_pool = BlockPool::new(
         db.clone(),
@@ -505,25 +524,34 @@ async fn should_refuse_fresh_block_trying_to_build_old_chain() {
     // Wait for the server to start
     tokio::time::sleep(Duration::from_secs(5)).await;
 
-    // Adding a peer so we can send a request to the mock client
-    peer_addr
-        .add_or_update_peer(
-            Address::new([0, 1, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0]),
-            PeerListItem {
-                reputation_score: PeerScore::new(100),
-                response_time: 0,
-                address: PeerAddress {
-                    gossip: fake_peer_gossip_addr,
-                    ..PeerAddress::default()
-                },
-                last_seen: 0,
-                is_online: true,
-            },
-        )
+    let peer_list_guard = peer_addr
+        .send(GetPeerListGuard)
         .await
-        .expect("can't send message to peer list");
+        .expect("to get peer list guard")
+        .expect("to get peer list guard");
+
+    // Adding a peer so we can send a request to the mock client
+    peer_list_guard.add_or_update_peer(
+        Address::new([0, 1, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0]),
+        PeerListItem {
+            reputation_score: PeerScore::new(100),
+            response_time: 0,
+            address: PeerAddress {
+                gossip: fake_peer_gossip_addr,
+                ..PeerAddress::default()
+            },
+            last_seen: 0,
+            is_online: true,
+        },
+    );
 
     let sync_state = SyncState::new(false, false);
+
+    let peer_addr = peer_addr
+        .send(GetPeerListGuard)
+        .await
+        .expect("to get peer list guard")
+        .expect("to get peer list guard");
 
     let block_pool = BlockPool::new(
         db.clone(),
@@ -631,6 +659,12 @@ async fn should_fast_track_block() {
     } = MockedServices::new(&config).await;
 
     let sync_state = SyncState::new(false, true);
+
+    let peer_addr = peer_addr
+        .send(GetPeerListGuard)
+        .await
+        .expect("to get peer list guard")
+        .expect("to get peer list guard");
     let service = BlockPool::new(
         db.clone(),
         peer_addr,
@@ -690,6 +724,11 @@ async fn should_not_fast_track_block_already_in_index() {
         service_senders,
     } = MockedServices::new(&config).await;
 
+    let peer_addr = peer_addr
+        .send(GetPeerListGuard)
+        .await
+        .expect("to get peer list guard")
+        .expect("to get peer list guard");
     let sync_state = SyncState::new(false, true);
     let service = BlockPool::new(
         db.clone(),

--- a/crates/p2p/src/tests/block_pool/mod.rs
+++ b/crates/p2p/src/tests/block_pool/mod.rs
@@ -122,9 +122,7 @@ struct MockedServices {
     block_discovery_stub: BlockDiscoveryStub,
     peer_list_service_addr: Addr<PeerListServiceWithClient<MockApiClient, MockRethServiceActor>>,
     db: DatabaseProvider,
-    execution_payload_provider: ExecutionPayloadProvider<
-        Addr<PeerListServiceWithClient<MockApiClient, MockRethServiceActor>>,
-    >,
+    execution_payload_provider: ExecutionPayloadProvider,
     mempool_stub: MempoolStub,
     vdf_state_stub: VdfStateReadonly,
     service_senders: ServiceSenders,
@@ -155,9 +153,10 @@ impl MockedServices {
             mock_client.clone(),
             reth_addr,
         );
+        let peer_list_data_guard = peer_list_service.peer_list_data_guard.clone();
         let peer_addr = peer_list_service.start();
         let execution_payload_provider =
-            ExecutionPayloadProvider::new(peer_addr.clone(), RethBlockProvider::new_mock());
+            ExecutionPayloadProvider::new(peer_list_data_guard, RethBlockProvider::new_mock());
 
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         let mempool_stub = MempoolStub::new(tx);

--- a/crates/p2p/src/tests/integration/mod.rs
+++ b/crates/p2p/src/tests/integration/mod.rs
@@ -23,9 +23,9 @@ async fn heavy_should_broadcast_message_to_an_established_connection() -> eyre::
         .await;
 
     let (service1_handle, gossip_service1_message_bus) =
-        gossip_service_test_fixture_1.run_service();
+        gossip_service_test_fixture_1.run_service().await;
     let (service2_handle, _gossip_service2_message_bus) =
-        gossip_service_test_fixture_2.run_service();
+        gossip_service_test_fixture_2.run_service().await;
 
     // Waiting a little for the service to initialize
     tokio::time::sleep(Duration::from_millis(500)).await;
@@ -85,7 +85,7 @@ async fn heavy_should_broadcast_message_to_multiple_peers() -> eyre::Result<()> 
 
     // Start all services
     for fixture in &mut fixtures {
-        let (handle, bus) = fixture.run_service();
+        let (handle, bus) = fixture.run_service().await;
         handles.push(handle);
         message_buses.push(bus);
     }
@@ -133,8 +133,8 @@ async fn heavy_should_not_resend_recently_seen_data() -> eyre::Result<()> {
     fixture1.add_peer(&fixture2).await;
     fixture2.add_peer(&fixture1).await;
 
-    let (service1_handle, gossip_service1_message_bus) = fixture1.run_service();
-    let (service2_handle, _gossip_service2_message_bus) = fixture2.run_service();
+    let (service1_handle, gossip_service1_message_bus) = fixture1.run_service().await;
+    let (service2_handle, _gossip_service2_message_bus) = fixture2.run_service().await;
 
     tokio::time::sleep(Duration::from_millis(500)).await;
 
@@ -177,8 +177,8 @@ async fn heavy_should_broadcast_chunk_data() -> eyre::Result<()> {
     fixture1.add_peer(&fixture2).await;
     fixture2.add_peer(&fixture1).await;
 
-    let (service1_handle, gossip_service1_message_bus) = fixture1.run_service();
-    let (service2_handle, _) = fixture2.run_service();
+    let (service1_handle, gossip_service1_message_bus) = fixture1.run_service().await;
+    let (service2_handle, _) = fixture2.run_service().await;
 
     tokio::time::sleep(Duration::from_millis(500)).await;
 
@@ -222,8 +222,8 @@ async fn heavy_should_not_broadcast_to_low_reputation_peers() -> eyre::Result<()
         .await;
     fixture2.add_peer(&fixture1).await;
 
-    let (service1_handle, gossip_service1_message_bus) = fixture1.run_service();
-    let (service2_handle, _gossip_service2_message_bus) = fixture2.run_service();
+    let (service1_handle, gossip_service1_message_bus) = fixture1.run_service().await;
+    let (service2_handle, _gossip_service2_message_bus) = fixture2.run_service().await;
 
     tokio::time::sleep(Duration::from_millis(500)).await;
 
@@ -261,7 +261,7 @@ async fn heavy_should_handle_offline_peer_gracefully() -> eyre::Result<()> {
     // Add peer2 but don't start its service
     fixture1.add_peer(&fixture2).await;
 
-    let (service1_handle, gossip_service1_message_bus) = fixture1.run_service();
+    let (service1_handle, gossip_service1_message_bus) = fixture1.run_service().await;
 
     tokio::time::sleep(Duration::from_millis(500)).await;
 
@@ -307,8 +307,8 @@ async fn heavy_should_fetch_missing_transactions_for_block() -> eyre::Result<()>
     fixture2.api_client_stub.txs.insert(tx1.id, tx1.clone());
     fixture2.api_client_stub.txs.insert(tx2.id, tx2.clone());
 
-    let (service1_handle, gossip_service1_message_bus) = fixture1.run_service();
-    let (service2_handle, _gossip_service2_message_bus) = fixture2.run_service();
+    let (service1_handle, gossip_service1_message_bus) = fixture1.run_service().await;
+    let (service2_handle, _gossip_service2_message_bus) = fixture2.run_service().await;
 
     // Waiting a little for the service to initialize
     tokio::time::sleep(Duration::from_millis(500)).await;
@@ -345,8 +345,8 @@ async fn heavy_should_reject_block_with_missing_transactions() -> eyre::Result<(
     fixture1.add_peer(&fixture2).await;
     fixture2.add_peer(&fixture1).await;
 
-    let (service1_handle, gossip_service1_message_bus) = fixture1.run_service();
-    let (service2_handle, _gossip_service2_message_bus) = fixture2.run_service();
+    let (service1_handle, gossip_service1_message_bus) = fixture1.run_service().await;
+    let (service2_handle, _gossip_service2_message_bus) = fixture2.run_service().await;
 
     // Waiting a little for the service to initialize
     tokio::time::sleep(Duration::from_millis(1500)).await;
@@ -432,8 +432,8 @@ async fn heavy_should_gossip_execution_payloads() -> eyre::Result<()> {
         .add_payload_to_cache(sealed_block.clone())
         .await;
 
-    let (service1_handle, gossip_service1_message_bus) = fixture1.run_service();
-    let (service2_handle, _gossip_service2_message_bus) = fixture2.run_service();
+    let (service1_handle, gossip_service1_message_bus) = fixture1.run_service().await;
+    let (service2_handle, _gossip_service2_message_bus) = fixture2.run_service().await;
 
     // Waiting a little for the service to initialize
     tokio::time::sleep(Duration::from_millis(500)).await;

--- a/crates/p2p/src/tests/util.rs
+++ b/crates/p2p/src/tests/util.rs
@@ -305,7 +305,7 @@ pub(crate) struct GossipServiceTestFixture {
     pub task_manager: TaskManager,
     pub task_executor: TaskExecutor,
     pub block_status_provider: BlockStatusProvider,
-    pub execution_payload_provider: ExecutionPayloadProvider<PeerListMock>,
+    pub execution_payload_provider: ExecutionPayloadProvider,
     pub config: Config,
     pub vdf_state_stub: VdfStateReadonly,
     pub service_senders: ServiceSenders,
@@ -356,6 +356,7 @@ impl GossipServiceTestFixture {
             ApiClientStub::new(),
             reth_service_addr,
         );
+        let peer_list_data_guard = peer_service.peer_list_data_guard.clone();
         let peer_list = peer_service.start();
 
         let mempool_stub = MempoolStub::new(service_senders.gossip_broadcast.clone());
@@ -377,7 +378,7 @@ impl GossipServiceTestFixture {
 
         let mocked_execution_payloads = Arc::new(RwLock::new(HashMap::new()));
         let execution_payload_provider = ExecutionPayloadProvider::new(
-            peer_list.clone(),
+            peer_list_data_guard,
             RethBlockProvider::Mock(mocked_execution_payloads),
         );
 

--- a/crates/p2p/src/types.rs
+++ b/crates/p2p/src/types.rs
@@ -1,5 +1,4 @@
 use crate::block_pool::BlockPoolError;
-use crate::peer_list::PeerListFacadeError;
 use irys_actors::mempool_service::TxIngressError;
 use irys_types::{BlockHash, H256};
 use reth::revm::primitives::B256;
@@ -23,19 +22,6 @@ pub enum GossipError {
     BlockPool(BlockPoolError),
     #[error("Transaction has already been handled")]
     TransactionIsAlreadyHandled,
-}
-
-impl From<PeerListFacadeError> for GossipError {
-    fn from(error: PeerListFacadeError) -> Self {
-        match error {
-            PeerListFacadeError::InternalError(err) => {
-                Self::Internal(InternalGossipError::Unknown(err))
-            }
-            PeerListFacadeError::ServiceError(err) => {
-                Self::Internal(InternalGossipError::Unknown(format!("{:?}", err)))
-            }
-        }
-    }
 }
 
 impl From<InternalGossipError> for GossipError {


### PR DESCRIPTION
**Describe the changes**

This PR is intended to be the first one out of several PRs that are breaking down `PeerListService` into smaller pieces. This PR:
- Creates a `PeerListGuard` structure, and moves it to the domain crate
- Removes all data access functionality from the `PeerListService`
- Removes `PeerListFacade` traits and related error types
- Creates a tokio channel that serves as a plug between new `PeerListGuard` and old `PeerListService` without changing how `PeerListService` works internally - i.e, without removing actix

**Related Issue(s)**

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
