### PR TITLE
fix: introduce commitment tx limit per block

### DIFF
--- a/crates/actors/src/mempool_service/inner.rs
+++ b/crates/actors/src/mempool_service/inner.rs
@@ -215,6 +215,15 @@ impl Inner {
         let mut commitment_tx = Vec::new();
         let mut unfunded_address = HashSet::new();
 
+        let max_commitments: usize = self
+            .config
+            .node_config
+            .consensus_config()
+            .mempool
+            .max_commitment_txs_per_block
+            .try_into()
+            .expect("max_commitment_txs_per_block to fit into usize");
+
         // Helper function that verifies transaction funding and tracks cumulative fees
         // Returns true if the transaction can be funded based on current account balance
         // and previously included transactions in this block
@@ -287,7 +296,7 @@ impl Inner {
         // This order ensures stake transactions are processed before pledges
         let mempool_state_guard = mempool_state.read().await;
 
-        for commitment_type in &[CommitmentType::Stake, CommitmentType::Pledge] {
+        'outer: for commitment_type in &[CommitmentType::Stake, CommitmentType::Pledge] {
             // Gather all commitments of current type from all addresses
             let mut sorted_commitments: Vec<_> = mempool_state_guard
                 .valid_commitment_tx
@@ -360,6 +369,12 @@ impl Inner {
 
                 debug!("best_mempool_txs: adding commitment tx {}", tx.id);
                 commitment_tx.push(tx);
+
+                // if we have reached the maximum allowed number of commitment txs per block
+                // do not push anymore
+                if commitment_tx.len() >= max_commitments {
+                    break 'outer;
+                }
             }
         }
         drop(mempool_state_guard);

--- a/crates/actors/src/mempool_service/inner.rs
+++ b/crates/actors/src/mempool_service/inner.rs
@@ -403,7 +403,7 @@ impl Inner {
 
         // Apply block size constraint and funding checks to data transactions
         let mut submit_tx = Vec::new();
-        let max_txs = self
+        let max_data_txs = self
             .config
             .node_config
             .consensus_config()
@@ -419,7 +419,7 @@ impl Inner {
             if check_funding(&tx) {
                 debug!("Submit tx {} passed the funding check", &tx.id);
                 submit_tx.push(tx);
-                if submit_tx.len() >= max_txs {
+                if submit_tx.len() >= max_data_txs {
                     break;
                 }
             } else {

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -1348,6 +1348,7 @@ async fn commitment_txs_are_capped_per_block() -> eyre::Result<()> {
     assert_eq!(epoch_tx_ids, tx_ids[..max_commitments_per_epoch as usize]);
 
     // some blocks after epoch should contain commitment txs
+    // this will be a few blocks, as we posted enough txs above to populate two more blocks
     for h in 6..=7 {
         let block_n = genesis_node.get_block_by_height(h).await?;
         assert_eq!(

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -1297,7 +1297,7 @@ async fn commitment_txs_are_capped_per_block() -> eyre::Result<()> {
     for i in 1..=8 {
         genesis_node.mine_block().await?;
         let block = genesis_node.get_block_by_height(i).await?;
-        let is_epoch_block = block.height > 0 && block.height % num_blocks_in_epoch as u64 == 0;
+        let is_epoch_block = block.height > 0 && block.height % num_blocks_in_epoch == 0;
         counts.push(
             block
                 .system_ledgers
@@ -1338,7 +1338,7 @@ async fn commitment_txs_are_capped_per_block() -> eyre::Result<()> {
     let epoch_block = genesis_node
         .get_block_by_height(num_blocks_in_epoch)
         .await?;
-    assert_eq!(epoch_block.height % num_blocks_in_epoch as u64, 0);
+    assert_eq!(epoch_block.height % num_blocks_in_epoch, 0);
     let epoch_tx_ids = epoch_block
         .system_ledgers
         .get(SystemLedger::Commitment as usize)

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -4,6 +4,7 @@ use alloy_eips::HashOrNumber;
 use alloy_genesis::GenesisAccount;
 use irys_actors::mempool_service::TxIngressError;
 use irys_actors::{async_trait, sha, BlockProdStrategy, BlockProducerInner, ProductionStrategy};
+use irys_database::SystemLedger;
 use irys_domain::{BlockState, ChainState, EmaSnapshot};
 use irys_reth_node_bridge::ext::IrysRethRpcTestContextExt as _;
 use irys_reth_node_bridge::irys_reth::alloy_rlp::Decodable as _;
@@ -1291,7 +1292,12 @@ async fn commitment_txs_are_capped_per_block() -> eyre::Result<()> {
     for i in 1..=3 {
         genesis_node.mine_block().await?;
         let block = genesis_node.get_block_by_height(i).await?;
-        counts.push(block.system_ledgers.get(0).map_or(0, |l| l.tx_ids.len()));
+        counts.push(
+            block
+                .system_ledgers
+                .get(SystemLedger::Commitment as usize)
+                .map_or(0, |l| l.tx_ids.len()),
+        );
     }
 
     // check the total txs is correct
@@ -1309,19 +1315,28 @@ async fn commitment_txs_are_capped_per_block() -> eyre::Result<()> {
     let block1 = genesis_node.get_block_by_height(1).await?;
     assert_eq!(
         2,
-        block1.system_ledgers.get(0).map_or(0, |l| l.tx_ids.len()),
+        block1
+            .system_ledgers
+            .get(SystemLedger::Commitment as usize)
+            .map_or(0, |l| l.tx_ids.len()),
         "block 1 commitment tx count is incorrect"
     );
     let block2 = genesis_node.get_block_by_height(2).await?;
     assert_eq!(
         2,
-        block2.system_ledgers.get(0).map_or(0, |l| l.tx_ids.len()),
+        block2
+            .system_ledgers
+            .get(SystemLedger::Commitment as usize)
+            .map_or(0, |l| l.tx_ids.len()),
         "block 2 commitment tx count is incorrect"
     );
     let block3 = genesis_node.get_block_by_height(3).await?;
     assert_eq!(
         1,
-        block3.system_ledgers.get(0).map_or(0, |l| l.tx_ids.len()),
+        block3
+            .system_ledgers
+            .get(SystemLedger::Commitment as usize)
+            .map_or(0, |l| l.tx_ids.len()),
         "block 3 commitment tx count is incorrect"
     );
 

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -1246,9 +1246,11 @@ async fn heavy_test_block_tree_pruning() -> eyre::Result<()> {
 }
 
 #[actix::test]
-/// test that max_commitment_txs_per_block is enforced
+/// test that config option max_commitment_txs_per_block is enforced
 /// check individual blocks have correct txs. e.g.
-/// for 1 stake + 4 pledge total commitment txs with a limit of two per block, we should see 2 + 2 + 1
+/// 1 stake + 11 pledge commitment txs with a limit of two per block, we should see 2 +2 +2 +2 +0 +2 +2
+/// epoch blocks should include any new txs
+/// epoch blocks should contain a copy of all commitment txs from blocks in the epoch block range
 async fn commitment_txs_are_capped_per_block() -> eyre::Result<()> {
     let seconds_to_wait = 10;
     let max_commitment_txs_per_block: u64 = 2;

--- a/crates/types/configs/testnet.toml
+++ b/crates/types/configs/testnet.toml
@@ -18,6 +18,7 @@ num_partitions_per_slot = 1
 num_writes_before_sync = 1
 reset_state_on_restart = false
 max_data_txs_per_block = 100
+max_commitment_txs_per_block = 100
 block_migration_depth = 1
 mining_key = "f57554aff54acd4cfaa084f45a7062d5869c8dbb789f7d6a883fade660960303"
 num_capacity_partitions = 0

--- a/crates/types/src/config.rs
+++ b/crates/types/src/config.rs
@@ -397,6 +397,9 @@ pub struct MempoolConfig {
     /// Maximum number of data transactions that can be included in a single block
     pub max_data_txs_per_block: u64,
 
+    /// Maximum number of commitment transactions allowed in a single block
+    pub max_commitment_txs_per_block: u64,
+
     /// The number of blocks a given anchor (tx or block hash) is valid for.
     /// The anchor must be included within the last X blocks otherwise the transaction it anchors will drop.
     pub anchor_expiry_depth: u8,
@@ -527,6 +530,7 @@ impl ConsensusConfig {
             token_price_safe_range: Amount::percentage(dec!(1)).expect("valid percentage"),
             mempool: MempoolConfig {
                 max_data_txs_per_block: 100,
+                max_commitment_txs_per_block: 100,
                 anchor_expiry_depth: 10,
                 // TODO: Move the following to a node config
                 max_pending_pledge_items: 100,
@@ -946,6 +950,7 @@ mod tests {
 
         [mempool]
         max_data_txs_per_block = 100
+        max_commitment_txs_per_block = 100
         anchor_expiry_depth = 10
         max_pending_pledge_items = 100
         max_pledges_per_item = 100


### PR DESCRIPTION
**Describe the changes**
 - Introduce commitment tx limit per block.
 - epoch blocks are unaffacted by this PR as `block_producer` does not use the returned commitment txs from mempool's `handle_get_best_mempool_txs`
 - test added to confirm commitment txs rollover as expected

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.
