### PR TITLE
feat: fees for commitment txs & mempool aware pledge counter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4999,6 +4999,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
+ "async-trait",
  "bytes",
  "eyre",
  "irys-config",
@@ -5284,6 +5285,7 @@ dependencies = [
  "alloy-signer",
  "alloy-signer-local",
  "arbitrary",
+ "async-trait",
  "base58",
  "base64-url",
  "borsh",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5266,6 +5266,7 @@ dependencies = [
  "color-eyre",
  "tempfile",
  "tracing",
+ "tracing-error",
  "tracing-subscriber 0.3.19",
 ]
 

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -759,7 +759,7 @@ mod tests {
             ..node_config.consensus_config()
         };
 
-        let commitments = add_genesis_commitments(&mut genesis_block, &config);
+        let commitments = add_genesis_commitments(&mut genesis_block, &config).await;
 
         let arc_genesis = Arc::new(genesis_block.clone());
         let signer = config.irys_signer();

--- a/crates/actors/src/mempool_service/mod.rs
+++ b/crates/actors/src/mempool_service/mod.rs
@@ -4,11 +4,13 @@ pub mod data_txs;
 pub mod facade;
 pub mod inner;
 pub mod lifecycle;
+pub mod pledge_provider;
 
 pub use chunks::*;
 pub use facade::*;
 pub use inner::*;
 use irys_domain::{BlockTreeReadGuard, StorageModulesReadGuard};
+pub use pledge_provider::*;
 
 use crate::block_tree_service::{BlockMigratedEvent, ReorgEvent};
 use crate::services::ServiceSenders;

--- a/crates/actors/src/mempool_service/pledge_provider.rs
+++ b/crates/actors/src/mempool_service/pledge_provider.rs
@@ -23,6 +23,7 @@ impl MempoolPledgeProvider {
     }
 }
 
+#[async_trait::async_trait]
 impl PledgeDataProvider for MempoolPledgeProvider {
     async fn pledge_count(&self, user_address: Address) -> usize {
         // Get the canonical pledge count from the blockchain state

--- a/crates/actors/src/mempool_service/pledge_provider.rs
+++ b/crates/actors/src/mempool_service/pledge_provider.rs
@@ -1,0 +1,75 @@
+use crate::mempool_service::AtomicMempoolState;
+use irys_domain::BlockTreeReadGuard;
+use irys_primitives::CommitmentType;
+use irys_types::{transaction::PledgeDataProvider, Address};
+
+/// A pledge data provider that combines both canonical chain state and mempool pending transactions
+/// to provide an accurate count of pledges for fee calculation.
+#[derive(Debug)]
+pub struct MempoolPledgeProvider {
+    mempool_state: AtomicMempoolState,
+    block_tree_read_guard: BlockTreeReadGuard,
+}
+
+impl MempoolPledgeProvider {
+    pub fn new(
+        mempool_state: AtomicMempoolState,
+        block_tree_read_guard: BlockTreeReadGuard,
+    ) -> Self {
+        Self {
+            mempool_state,
+            block_tree_read_guard,
+        }
+    }
+}
+
+impl PledgeDataProvider for MempoolPledgeProvider {
+    async fn pledge_count(&self, user_address: Address) -> usize {
+        // Get the canonical pledge count from the blockchain state
+        let canonical_count = {
+            let commitment_snapshot = self
+                .block_tree_read_guard
+                .read()
+                .canonical_commitment_snapshot();
+            commitment_snapshot
+                .commitments
+                .get(&user_address)
+                .map(|miner_commitments| miner_commitments.pledges.len())
+                .unwrap_or(0)
+        };
+
+        // Count pending pledge transactions in the mempool
+        let pending_pledges = {
+            let mempool = self.mempool_state.read().await;
+            mempool
+                .valid_commitment_tx
+                .get(&user_address)
+                .map(|txs| {
+                    txs.iter()
+                        .filter(|tx| tx.commitment_type == CommitmentType::Pledge)
+                        .count()
+                })
+                .unwrap_or(0)
+        };
+
+        // Count pending unpledge transactions in the mempool
+        let pending_unpledges = {
+            let mempool = self.mempool_state.read().await;
+            mempool
+                .valid_commitment_tx
+                .get(&user_address)
+                .map(|txs| {
+                    txs.iter()
+                        .filter(|tx| tx.commitment_type == CommitmentType::Unpledge)
+                        .count()
+                })
+                .unwrap_or(0)
+        };
+
+        // Calculate effective pledge count:
+        // canonical pledges + pending pledges - pending unpledges
+        canonical_count
+            .saturating_add(pending_pledges)
+            .saturating_sub(pending_unpledges)
+    }
+}

--- a/crates/actors/tests/epoch_service_tests.rs
+++ b/crates/actors/tests/epoch_service_tests.rs
@@ -42,7 +42,7 @@ async fn genesis_test() {
     // genesis block
     let mut genesis_block = IrysBlockHeader::new_mock_header();
     genesis_block.height = 0;
-    let commitments = add_genesis_commitments(&mut genesis_block, &config);
+    let commitments = add_genesis_commitments(&mut genesis_block, &config).await;
 
     // Create epoch service with random miner address
     let block_index: Arc<RwLock<BlockIndex>> = Arc::new(RwLock::new(
@@ -200,7 +200,7 @@ async fn add_slots_test() {
     genesis_block.height = 0;
     let num_blocks_in_epoch = config.consensus.epoch.num_blocks_in_epoch;
     let num_chunks_in_partition = config.consensus.num_chunks_in_partition;
-    let commitments = add_genesis_commitments(&mut genesis_block, &config);
+    let commitments = add_genesis_commitments(&mut genesis_block, &config).await;
 
     let storage_submodules_config =
         StorageSubmodulesConfig::load(config.node_config.base_directory.clone()).unwrap();
@@ -304,7 +304,7 @@ async fn partition_expiration_and_repacking_test() {
 
     let mut genesis_block = IrysBlockHeader::new_mock_header();
     genesis_block.height = 0;
-    let commitments = add_test_commitments(&mut genesis_block, 5, &config);
+    let commitments = add_test_commitments(&mut genesis_block, 5, &config).await;
 
     // Create a storage config for testing
     let num_blocks_in_epoch = config.consensus.epoch.num_blocks_in_epoch;
@@ -660,7 +660,7 @@ async fn epoch_blocks_reinitialization_test() {
     let mut genesis_block = IrysBlockHeader::new_mock_header();
     genesis_block.height = 0;
     let pledge_count = config.consensus.epoch.num_capacity_partitions.unwrap_or(31) as u8;
-    let commitments = add_test_commitments(&mut genesis_block, pledge_count, &config);
+    let commitments = add_test_commitments(&mut genesis_block, pledge_count, &config).await;
 
     let storage_submodules_config =
         StorageSubmodulesConfig::load(config.node_config.base_directory.clone()).unwrap();
@@ -848,7 +848,7 @@ async fn partitions_assignment_determinism_test() {
     genesis_block.last_epoch_hash = H256::zero(); // for partitions hash determinism
     genesis_block.height = 0;
     let pledge_count = 20;
-    let commitments = add_test_commitments(&mut genesis_block, pledge_count, &config);
+    let commitments = add_test_commitments(&mut genesis_block, pledge_count, &config).await;
 
     let storage_submodules_config = StorageSubmodulesConfig::load_for_test(base_path, 40).unwrap();
 

--- a/crates/api-server/src/lib.rs
+++ b/crates/api-server/src/lib.rs
@@ -37,6 +37,7 @@ pub struct ApiState {
     pub block_tree: BlockTreeReadGuard,
     pub block_index: BlockIndexReadGuard,
     pub sync_state: SyncState,
+    pub mempool_pledge_provider: Arc<irys_actors::mempool_service::MempoolPledgeProvider>,
 }
 
 impl ApiState {
@@ -73,6 +74,22 @@ pub fn routes() -> impl HttpServiceFactory {
         )
         .route("/peer_list", web::get().to(peer_list::peer_list_route))
         .route("/price/{ledger}/{size}", web::get().to(price::get_price))
+        .route(
+            "/price/commitment/stake",
+            web::get().to(price::get_stake_price),
+        )
+        .route(
+            "/price/commitment/unstake",
+            web::get().to(price::get_unstake_price),
+        )
+        .route(
+            "/price/commitment/pledge/{user_address}",
+            web::get().to(price::get_pledge_price),
+        )
+        .route(
+            "/price/commitment/unpledge/{user_address}",
+            web::get().to(price::get_unpledge_price),
+        )
         .route("/tx", web::post().to(tx::post_tx))
         .route("/tx/{tx_id}", web::get().to(tx::get_transaction_api))
         .route(

--- a/crates/api-server/src/lib.rs
+++ b/crates/api-server/src/lib.rs
@@ -73,7 +73,6 @@ pub fn routes() -> impl HttpServiceFactory {
             web::get().to(network_config::get_network_config),
         )
         .route("/peer_list", web::get().to(peer_list::peer_list_route))
-        .route("/price/{ledger}/{size}", web::get().to(price::get_price))
         .route(
             "/price/commitment/stake",
             web::get().to(price::get_stake_price),
@@ -90,6 +89,7 @@ pub fn routes() -> impl HttpServiceFactory {
             "/price/commitment/unpledge/{user_address}",
             web::get().to(price::get_unpledge_price),
         )
+        .route("/price/{ledger}/{size}", web::get().to(price::get_price))
         .route("/tx", web::post().to(tx::post_tx))
         .route("/tx/{tx_id}", web::get().to(tx::get_transaction_api))
         .route(

--- a/crates/api-server/src/routes/price.rs
+++ b/crates/api-server/src/routes/price.rs
@@ -9,9 +9,11 @@ use irys_types::{
         phantoms::{Irys, NetworkFee},
         Amount,
     },
-    DataLedger, U256,
+    transaction::PledgeDataProvider as _,
+    Address, DataLedger, U256,
 };
 use serde::{Deserialize, Serialize};
+use std::str::FromStr as _;
 
 use crate::ApiState;
 
@@ -21,6 +23,14 @@ pub struct PriceInfo {
     pub cost_in_irys: U256,
     pub ledger: u32,
     pub bytes: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CommitmentPriceInfo {
+    pub value: U256,
+    pub fee: u64,
+    pub user_address: Option<Address>,
 }
 
 pub async fn get_price(
@@ -86,4 +96,100 @@ fn cost_of_perm_storage(
         .add_multiplier(state.config.node_config.pricing.fee_percentage)?;
 
     Ok(price_with_network_reward)
+}
+
+pub async fn get_stake_price(state: web::Data<ApiState>) -> ActixResult<HttpResponse> {
+    let stake_value = state.config.consensus.stake_value;
+    let commitment_fee = state.config.consensus.mempool.commitment_fee;
+
+    Ok(HttpResponse::Ok().json(CommitmentPriceInfo {
+        value: stake_value.amount,
+        fee: commitment_fee,
+        user_address: None,
+    }))
+}
+
+pub async fn get_unstake_price(state: web::Data<ApiState>) -> ActixResult<HttpResponse> {
+    let stake_value = state.config.consensus.stake_value;
+    let commitment_fee = state.config.consensus.mempool.commitment_fee;
+
+    Ok(HttpResponse::Ok().json(CommitmentPriceInfo {
+        value: stake_value.amount,
+        fee: commitment_fee,
+        user_address: None,
+    }))
+}
+
+/// Parse and validate a user address from a string
+fn parse_user_address(address_str: &str) -> Result<Address, actix_web::Error> {
+    Address::from_str(address_str).map_err(|_| ErrorBadRequest("Invalid address format"))
+}
+
+/// Calculate the pledge value based on the pledge count and decay rate
+fn calculate_pledge_value(
+    base_value: Amount<Irys>,
+    decay_rate: Amount<irys_types::storage_pricing::phantoms::Percentage>,
+    pledge_count: usize,
+) -> U256 {
+    base_value
+        .apply_pledge_decay(pledge_count, decay_rate)
+        .map(|a| a.amount)
+        .unwrap_or(base_value.amount)
+}
+
+pub async fn get_pledge_price(
+    path: Path<String>,
+    state: web::Data<ApiState>,
+) -> ActixResult<HttpResponse> {
+    let user_address_str = path.into_inner();
+    let user_address = parse_user_address(&user_address_str)?;
+
+    // Use the MempoolPledgeProvider to get accurate pledge count
+    let pledge_count = state
+        .mempool_pledge_provider
+        .pledge_count(user_address)
+        .await;
+
+    // Calculate the pledge value with decay
+    let pledge_value = calculate_pledge_value(
+        state.config.consensus.pledge_base_value,
+        state.config.consensus.pledge_decay,
+        pledge_count,
+    );
+
+    let commitment_fee = state.config.consensus.mempool.commitment_fee;
+
+    Ok(HttpResponse::Ok().json(CommitmentPriceInfo {
+        value: pledge_value,
+        fee: commitment_fee,
+        user_address: Some(user_address),
+    }))
+}
+
+pub async fn get_unpledge_price(
+    path: Path<String>,
+    state: web::Data<ApiState>,
+) -> ActixResult<HttpResponse> {
+    let user_address_str = path.into_inner();
+    let user_address = parse_user_address(&user_address_str)?;
+
+    // Use the MempoolPledgeProvider to get accurate pledge count
+    let pledge_count = state
+        .mempool_pledge_provider
+        .pledge_count(user_address)
+        .await;
+
+    let refund_amount = calculate_pledge_value(
+        state.config.consensus.pledge_base_value,
+        state.config.consensus.pledge_decay,
+        pledge_count.saturating_sub(1),
+    );
+
+    let commitment_fee = state.config.consensus.mempool.commitment_fee;
+
+    Ok(HttpResponse::Ok().json(CommitmentPriceInfo {
+        value: refund_amount,
+        fee: commitment_fee,
+        user_address: Some(user_address),
+    }))
 }

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -31,8 +31,8 @@ use irys_database::db::RethDbWrapper;
 use irys_database::{add_genesis_commitments, database, get_genesis_commitments, SystemLedger};
 use irys_domain::{
     reth_provider, BlockIndex, BlockIndexReadGuard, BlockTreeReadGuard, ChunkProvider, ChunkType,
-    CommitmentSnapshotStatus, EpochReplayData, ExecutionPayloadCache, IrysRethProvider,
-    IrysRethProviderInner, PeerList, StorageModule, StorageModuleInfo, StorageModulesReadGuard,
+    EpochReplayData, ExecutionPayloadCache, IrysRethProvider, IrysRethProviderInner, PeerList,
+    StorageModule, StorageModuleInfo, StorageModulesReadGuard,
 };
 use irys_p2p::{
     BlockPool, BlockStatusProvider, GetPeerListGuard, P2PService, PeerNetworkService,
@@ -1671,7 +1671,7 @@ async fn stake_and_pledge(
 
     // now check the canonical state
 
-    let (is_historically_staked, mut commitment_snapshot) = {
+    let (is_historically_staked, commitment_snapshot) = {
         let block_tree_guard = block_tree_guard.read();
         let epoch_snapshot = block_tree_guard.canonical_epoch_snapshot();
         let is_historically_staked = epoch_snapshot.is_staked(address);

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -105,6 +105,7 @@ pub struct IrysNodeCtx {
     pub validation_enabled: Arc<AtomicBool>,
     pub block_pool: Arc<BlockPool<BlockDiscoveryFacadeImpl, MempoolServiceFacadeImpl>>,
     pub storage_modules_guard: StorageModulesReadGuard,
+    pub mempool_pledge_provider: Arc<irys_actors::mempool_service::MempoolPledgeProvider>,
 }
 
 impl IrysNodeCtx {
@@ -120,6 +121,7 @@ impl IrysNodeCtx {
             block_tree: self.block_tree_guard.clone(),
             block_index: self.block_index_guard.clone(),
             sync_state: self.sync_state.clone(),
+            mempool_pledge_provider: self.mempool_pledge_provider.clone(),
         }
     }
 
@@ -344,7 +346,7 @@ impl IrysNode {
         match node_mode {
             NodeMode::Genesis => {
                 // Create a new genesis block for network initialization
-                self.create_new_genesis_block(genesis_block.clone())
+                self.create_new_genesis_block(genesis_block.clone()).await
             }
             NodeMode::PeerSync | NodeMode::TrustedPeerSync => {
                 // Fetch genesis data from trusted peer when joining network
@@ -392,12 +394,12 @@ impl IrysNode {
         (genesis_block, commitments)
     }
 
-    fn create_new_genesis_block(
+    async fn create_new_genesis_block(
         &self,
         mut genesis_block: IrysBlockHeader,
     ) -> (IrysBlockHeader, Vec<CommitmentTransaction>) {
         // Generate genesis commitments from configuration
-        let commitments = get_genesis_commitments(&self.config);
+        let commitments = get_genesis_commitments(&self.config).await;
 
         // Calculate initial difficulty based on number of storage modules
         let storage_module_count = (commitments.len() - 1) as u64; // Subtract 1 for stake commitment
@@ -412,7 +414,7 @@ impl IrysNode {
         genesis_block.last_diff_timestamp = timestamp;
 
         // Add commitment transactions to genesis block
-        add_genesis_commitments(&mut genesis_block, &self.config);
+        add_genesis_commitments(&mut genesis_block, &self.config).await;
 
         // Note: commitments are persisted to DB in `persist_genesis_block_and_commitments()` later on
 
@@ -612,7 +614,8 @@ impl IrysNode {
         )
         .await?;
 
-        if config.node_config.stake_pledge_drives {
+        // Call stake_and_pledge after mempool service is initialized
+        if ctx.config.node_config.stake_pledge_drives {
             const MAX_WAIT_TIME: Duration = Duration::from_secs(10);
             let mut validation_tracker = BlockValidationTracker::new(
                 ctx.block_tree_guard.clone(),
@@ -633,10 +636,11 @@ impl IrysNode {
             // TODO: add code to proactively grab the latest head block from peers
             // this only really affects tests, as in a network deployment other nodes will be continuously mining & gossiping, which will trigger a sync to the network head
             stake_and_pledge(
-                config,
+                &ctx.config,
                 ctx.block_tree_guard.clone(),
                 ctx.storage_modules_guard.clone(),
                 latest_hash,
+                ctx.mempool_pledge_provider.clone(),
             )
             .await?;
         }
@@ -951,6 +955,24 @@ impl IrysNode {
         )?;
         let mempool_facade = MempoolServiceFacadeImpl::from(&service_senders);
 
+        // Get the mempool state to create the pledge provider
+        let (tx, rx) = oneshot::channel();
+        service_senders
+            .mempool
+            .send(irys_actors::mempool_service::MempoolServiceMessage::GetState(tx))
+            .map_err(|_| eyre::eyre!("Failed to send GetState message to mempool service"))?;
+
+        let mempool_state = rx
+            .await
+            .map_err(|_| eyre::eyre!("Failed to receive mempool state from mempool service"))?;
+
+        // Create the MempoolPledgeProvider
+        let mempool_pledge_provider =
+            Arc::new(irys_actors::mempool_service::MempoolPledgeProvider::new(
+                mempool_state,
+                block_tree_guard.clone(),
+            ));
+
         // spawn the chunk migration service
         Self::init_chunk_migration_service(
             &config,
@@ -1129,6 +1151,7 @@ impl IrysNode {
             block_pool,
             validation_enabled,
             storage_modules_guard,
+            mempool_pledge_provider: mempool_pledge_provider.clone(),
         };
 
         // Spawn the StorageModuleService to manage the life-cycle of storage modules
@@ -1216,7 +1239,7 @@ impl IrysNode {
                 peer_list: peer_list_guard,
                 db: irys_db,
                 reth_provider: reth_node.clone(),
-                block_tree: block_tree_guard,
+                block_tree: block_tree_guard.clone(),
                 block_index: block_index_guard.clone(),
                 config: config.clone(),
                 reth_http_url: reth_node
@@ -1224,6 +1247,7 @@ impl IrysNode {
                     .http_url()
                     .expect("Missing reth rpc url!"),
                 sync_state,
+                mempool_pledge_provider: mempool_pledge_provider.clone(),
             },
             http_listener,
         );
@@ -1627,6 +1651,7 @@ async fn stake_and_pledge(
     block_tree_guard: BlockTreeReadGuard,
     storage_modules_guard: StorageModulesReadGuard,
     latest_block_hash: BlockHash,
+    mempool_pledge_provider: Arc<irys_actors::mempool_service::MempoolPledgeProvider>,
 ) -> eyre::Result<()> {
     debug!("Checking Stake & Pledge status");
     // NOTE: this assumes we're caught up with the chain
@@ -1640,6 +1665,7 @@ async fn stake_and_pledge(
     let post_commitment_tx = async |commitment_tx: &CommitmentTransaction| {
         let client = awc::Client::default();
         let url = format!("{}/v1/commitment_tx", api_uri);
+
         client.post(url).send_json(commitment_tx).await
     };
 
@@ -1705,18 +1731,12 @@ async fn stake_and_pledge(
             &config.consensus,
             latest_block_hash,
             1,
-            &commitment_snapshot,
+            mempool_pledge_provider.as_ref(),
             address,
-        );
+        )
+        .await;
 
         let pledge_tx = signer.sign_commitment(pledge_tx)?;
-
-        // TODO: this is a hack, don't do this! should be removed by #559
-        let status = commitment_snapshot.add_commitment(&pledge_tx, true); // so the pledge value updates
-        if !matches!(status, CommitmentSnapshotStatus::Accepted) {
-            warn!("Unable verify pledge {} - {:?}", &pledge_tx.id, &status);
-            return Ok(());
-        }
 
         post_commitment_tx(&pledge_tx).await.unwrap();
         debug!(

--- a/crates/chain/tests/api/tx_commitments.rs
+++ b/crates/chain/tests/api/tx_commitments.rs
@@ -91,30 +91,13 @@ async fn heavy_test_commitments_3epochs_test() -> eyre::Result<()> {
         // Create stake commitment for first test signer
         let stake_tx1 = post_stake_commitment(&node, &signer1).await;
 
-        // Get the CommitmentSnapshot from the latest canonical block
-        let mut commitment_snapshot = node
-            .node_ctx
-            .block_tree_guard
-            .read()
-            .canonical_commitment_snapshot()
-            .as_ref()
-            .clone();
-
         // Create two pledge commitments for first test signer
         let pledge1 = &node
-            .post_pledge_commitment_with_snapshot(
-                &signer1,
-                H256::default(),
-                &mut commitment_snapshot,
-            )
+            .post_pledge_commitment_with_signer(&signer1, H256::default())
             .await;
 
         let pledge2 = &node
-            .post_pledge_commitment_with_snapshot(
-                &signer1,
-                H256::default(),
-                &mut commitment_snapshot,
-            )
+            .post_pledge_commitment_with_signer(&signer1, H256::default())
             .await;
 
         // Create stake commitment for second test signer
@@ -397,15 +380,14 @@ async fn heavy_test_commitments_basic_test() -> eyre::Result<()> {
 
     // ===== TEST CASE 2: Pledge Creation for Staked Address =====
     // Create a pledge commitment for the already staked address
-    use irys_domain::snapshots::commitment_snapshot::CommitmentSnapshot;
-    let empty_snapshot = CommitmentSnapshot::default();
     let pledge_tx = CommitmentTransaction::new_pledge(
         consensus,
         H256::default(),
         1,
-        &empty_snapshot,
+        node.node_ctx.mempool_pledge_provider.as_ref(),
         signer.address(),
-    );
+    )
+    .await;
     let pledge_tx = signer.sign_commitment(pledge_tx).unwrap();
     info!("Generated pledge_tx.id: {}", pledge_tx.id);
 
@@ -450,9 +432,10 @@ async fn heavy_test_commitments_basic_test() -> eyre::Result<()> {
         consensus,
         H256::default(),
         1,
-        &empty_snapshot,
+        node.node_ctx.mempool_pledge_provider.as_ref(),
         signer2.address(),
-    );
+    )
+    .await;
     let pledge_tx = signer2.sign_commitment(pledge_tx).unwrap();
     info!("Generated pledge_tx.id: {}", pledge_tx.id);
 
@@ -478,10 +461,10 @@ async fn post_stake_commitment(
     signer: &IrysSigner,
 ) -> CommitmentTransaction {
     let consensus = &node.node_ctx.config.consensus;
-    info!("Node consensus stake_fee: {:?}", consensus.stake_fee);
+    info!("Node consensus stake_fee: {:?}", consensus.stake_value);
     info!(
         "Node consensus stake_fee amount: {}",
-        consensus.stake_fee.amount
+        consensus.stake_value.amount
     );
     let stake_tx = CommitmentTransaction::new_stake(consensus, H256::default(), 1);
     info!("Created stake_tx with value: {:?}", stake_tx.value);
@@ -502,18 +485,14 @@ async fn post_pledge_commitment(
 ) -> CommitmentTransaction {
     let consensus = &node.node_ctx.config.consensus;
     // Get the CommitmentSnapshot from the latest canonical block
-    let commitment_snapshot = node
-        .node_ctx
-        .block_tree_guard
-        .read()
-        .canonical_commitment_snapshot();
     let pledge_tx = CommitmentTransaction::new_pledge(
         consensus,
         anchor,
         1,
-        &*commitment_snapshot,
+        node.node_ctx.mempool_pledge_provider.as_ref(),
         signer.address(),
-    );
+    )
+    .await;
     let pledge_tx = signer.sign_commitment(pledge_tx).unwrap();
     info!("Generated pledge_tx.id: {}", pledge_tx.id.0.to_base58());
 

--- a/crates/chain/tests/api/tx_duplicates.rs
+++ b/crates/chain/tests/api/tx_duplicates.rs
@@ -102,18 +102,14 @@ async fn heavy_test_rejection_of_duplicate_tx() -> eyre::Result<()> {
 
     // ===== TEST CASE 3: post duplicate pledge tx =====
     // Get the CommitmentSnapshot from the latest canonical block
-    let commitment_snapshot = node
-        .node_ctx
-        .block_tree_guard
-        .read()
-        .canonical_commitment_snapshot();
     let pledge_tx = CommitmentTransaction::new_pledge(
         consensus,
         anchor,
         1,
-        &*commitment_snapshot,
+        node.node_ctx.mempool_pledge_provider.as_ref(),
         signer.address(),
-    );
+    )
+    .await;
     let pledge_tx = signer.sign_commitment(pledge_tx).unwrap();
 
     // Post pledge commitment

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -15,6 +15,7 @@ use irys_reth_node_bridge::reth_e2e_test_utils::transaction::TransactionTestCont
 use irys_testing_utils::initialize_tracing;
 use irys_types::{irys::IrysSigner, IrysBlockHeader, NodeConfig};
 use irys_types::{IrysTransactionCommon as _, H256};
+use reth::rpc::types::TransactionTrait as _;
 use reth::{
     providers::{
         AccountReader as _, BlockReader as _, ReceiptProvider as _, TransactionsProvider as _,
@@ -351,18 +352,14 @@ async fn heavy_test_blockprod_with_evm_txs() -> eyre::Result<()> {
     // We expect 3 receipts: storage tx, evm tx, and block reward
     assert_eq!(block_txs.len(), 3);
     // Assert block reward (should be the first receipt)
-    let block_reward_systx =
-        ShadowTransaction::decode(&mut block_txs[0].as_legacy().unwrap().tx().input.as_ref())
-            .unwrap();
+    let block_reward_systx = ShadowTransaction::decode(&mut block_txs[0].input().as_ref()).unwrap();
     assert!(matches!(
         block_reward_systx.as_v1().unwrap(),
         TransactionPacket::BlockReward(_)
     ));
 
     // Assert storage tx is included in the receipts (should be the second receipt)
-    let storage_tx_systx =
-        ShadowTransaction::decode(&mut block_txs[1].as_legacy().unwrap().tx().input.as_ref())
-            .unwrap();
+    let storage_tx_systx = ShadowTransaction::decode(&mut block_txs[1].input().as_ref()).unwrap();
     assert!(matches!(
         storage_tx_systx.as_v1().unwrap(),
         TransactionPacket::StorageFees(_)
@@ -492,9 +489,7 @@ async fn heavy_test_unfunded_user_tx_rejected() -> eyre::Result<()> {
     );
 
     // Verify it's a block reward shadow transaction
-    let shadow_tx =
-        ShadowTransaction::decode(&mut block_txs[0].as_legacy().unwrap().tx().input.as_ref())
-            .unwrap();
+    let shadow_tx = ShadowTransaction::decode(&mut block_txs[0].input().as_ref()).unwrap();
     assert!(
         matches!(
             shadow_tx.as_v1().unwrap(),
@@ -574,9 +569,7 @@ async fn heavy_test_nonexistent_user_tx_rejected() -> eyre::Result<()> {
     );
 
     // Verify it's a block reward shadow transaction
-    let shadow_tx =
-        ShadowTransaction::decode(&mut block_txs[0].as_legacy().unwrap().tx().input.as_ref())
-            .unwrap();
+    let shadow_tx = ShadowTransaction::decode(&mut block_txs[0].input().as_ref()).unwrap();
     assert!(
         matches!(
             shadow_tx.as_v1().unwrap(),
@@ -835,8 +828,8 @@ async fn heavy_staking_pledging_txs_included() -> eyre::Result<()> {
 
     // Calculate expected balance change based on consensus config
     let consensus_config = genesis_config.consensus_config();
-    let stake_fee_amount = consensus_config.stake_fee.amount; // 0.1 token = 10^17 in U256
-    let pledge_fee_amount = consensus_config.pledge_base_fee.amount; // 0.1 token = 10^17 in U256
+    let stake_fee_amount = consensus_config.stake_value.amount; // 0.1 token = 10^17 in U256
+    let pledge_fee_amount = consensus_config.pledge_base_value.amount; // 0.1 token = 10^17 in U256
 
     // Each commitment transaction has:
     // - fee: DEFAULT_TX_FEE (passed to post_stake_commitment and post_pledge_commitment)
@@ -907,9 +900,8 @@ async fn heavy_staking_pledging_txs_included() -> eyre::Result<()> {
     );
 
     // First transaction should be block reward
-    let block_reward_tx =
-        ShadowTransaction::decode(&mut block_txs1[0].as_legacy().unwrap().tx().input.as_ref())
-            .expect("First transaction should be decodable as shadow transaction");
+    let block_reward_tx = ShadowTransaction::decode(&mut block_txs1[0].input().as_ref())
+        .expect("First transaction should be decodable as shadow transaction");
     assert!(
         matches!(
             block_reward_tx.as_v1().unwrap(),
@@ -919,14 +911,13 @@ async fn heavy_staking_pledging_txs_included() -> eyre::Result<()> {
     );
 
     // Second transaction should be stake
-    let stake_tx =
-        ShadowTransaction::decode(&mut block_txs1[1].as_legacy().unwrap().tx().input.as_ref())
-            .expect("Second transaction should be decodable as shadow transaction");
+    let stake_tx = ShadowTransaction::decode(&mut block_txs1[1].input().as_ref())
+        .expect("Second transaction should be decodable as shadow transaction");
     if let Some(TransactionPacket::Stake(bd)) = stake_tx.as_v1() {
         assert_eq!(bd.target, peer_signer.address());
         // Expected amount is DEFAULT_TX_FEE + stake_fee.amount (0.1 token = 10^17)
         let expected_stake_amount =
-            DEFAULT_TX_FEE + U256::from_le_bytes(consensus_config.stake_fee.amount.to_le_bytes());
+            DEFAULT_TX_FEE + U256::from_le_bytes(consensus_config.stake_value.amount.to_le_bytes());
         assert_eq!(
             bd.amount, expected_stake_amount,
             "Stake amount should be fee + stake_fee.amount"
@@ -936,14 +927,13 @@ async fn heavy_staking_pledging_txs_included() -> eyre::Result<()> {
     }
 
     // Third transaction should be pledge
-    let pledge_tx =
-        ShadowTransaction::decode(&mut block_txs1[2].as_legacy().unwrap().tx().input.as_ref())
-            .expect("Third transaction should be decodable as shadow transaction");
+    let pledge_tx = ShadowTransaction::decode(&mut block_txs1[2].input().as_ref())
+        .expect("Third transaction should be decodable as shadow transaction");
     if let Some(TransactionPacket::Pledge(bd)) = pledge_tx.as_v1() {
         assert_eq!(bd.target, peer_signer.address());
         // Expected amount is DEFAULT_TX_FEE + pledge_fee.amount (0.1 token = 10^17)
         let expected_pledge_amount = DEFAULT_TX_FEE
-            + U256::from_le_bytes(consensus_config.pledge_base_fee.amount.to_le_bytes());
+            + U256::from_le_bytes(consensus_config.pledge_base_value.amount.to_le_bytes());
         assert_eq!(
             bd.amount, expected_pledge_amount,
             "Pledge amount should be fee + pledge_fee.amount"
@@ -1323,7 +1313,6 @@ async fn commitment_txs_are_capped_per_block() -> eyre::Result<()> {
     // create and post stake commitment tx
     let stake_tx = new_stake_tx(&H256::zero(), &signer, &genesis_config.consensus_config());
     genesis_node.post_commitment_tx(&stake_tx).await?;
-
     let mut tx_ids: Vec<H256> = vec![stake_tx.id]; // txs used for anchor chain and later to check mempool ingress
     let mut commitment_snapshot = genesis_node
         .node_ctx
@@ -1334,7 +1323,7 @@ async fn commitment_txs_are_capped_per_block() -> eyre::Result<()> {
         .clone();
     for _ in 0..11 {
         let tx = genesis_node
-            .post_pledge_commitment_with_snapshot(&signer, H256::zero(), &mut commitment_snapshot)
+            .post_pledge_commitment_with_signer(&signer, H256::zero())
             .await;
         tx_ids.push(tx.id);
     }

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -1314,13 +1314,6 @@ async fn commitment_txs_are_capped_per_block() -> eyre::Result<()> {
     let stake_tx = new_stake_tx(&H256::zero(), &signer, &genesis_config.consensus_config());
     genesis_node.post_commitment_tx(&stake_tx).await?;
     let mut tx_ids: Vec<H256> = vec![stake_tx.id]; // txs used for anchor chain and later to check mempool ingress
-    let mut commitment_snapshot = genesis_node
-        .node_ctx
-        .block_tree_guard
-        .read()
-        .canonical_commitment_snapshot()
-        .as_ref()
-        .clone();
     for _ in 0..11 {
         let tx = genesis_node
             .post_pledge_commitment_with_signer(&signer, H256::zero())

--- a/crates/chain/tests/startup/auto_stake.rs
+++ b/crates/chain/tests/startup/auto_stake.rs
@@ -19,6 +19,7 @@ use tracing::debug;
 #[actix_web::test]
 async fn test_auto_stake_pledge(#[case] stake: bool, #[case] pledges: usize) -> eyre::Result<()> {
     use irys_testing_utils::initialize_tracing_with_backtrace;
+    use irys_types::U256;
 
     std::env::set_var("RUST_LOG", "debug,irys_database=off,irys_actors::storage_module_service=off,trie=off,irys_reth::evm=off,engine::root=off,storage::db::mdbx=off,reth_basic_payload_builder=off,providers::db=off,reth_payload_builder::service=off,irys_actors::broadcast_mining_service=off,reth_ethereum_payload_builder=off,provider::static_file=off,engine::persistence=off,provider::storage_writer=off,reth_engine_tree::persistence=off,irys_actors::cache_service=off,irys_vdf=off,irys_actors::vdf_service=off,eth_ethereum_payload_builder=off,reth_node_events::node=off,reth::cli=off,reth_engine_tree::tree=off,irys_actors::ema_service=off,irys_efficient_sampling=off,hyper_util::client::legacy::connect::http=off,hyper_util::client::legacy::pool=off,irys_database::migration::v0_to_v1=off,irys_storage::storage_module=off,actix_server::worker=off,irys::packing::update=off,engine::tree=off,irys_actors::mining=error,payload_builder=off,irys_actors::reth_service=off,irys_actors::packing=off,irys_actors::reth_service=off,irys::packing::progress=off,irys_chain::vdf=off,irys_vdf::vdf_state=off,irys_p2p::peer_list=error");
     initialize_tracing_with_backtrace();
@@ -66,10 +67,16 @@ async fn test_auto_stake_pledge(#[case] stake: bool, #[case] pledges: usize) -> 
 
     if pledges > 0 {
         let anchor = H256::zero();
+        let mut prev_price = U256::MAX;
         for _idx in 0..pledges {
-            genesis_node
+            let tx = genesis_node
                 .post_pledge_commitment_with_signer(&peer_signer, anchor)
                 .await;
+            assert!(
+                tx.value < prev_price,
+                "the price we pay for a pledge should go down with every tx"
+            );
+            prev_price = tx.value;
             already_processed_count += 1;
             // don't wait if we haven't posted a stake (stuck in the LRU)
             if stake {

--- a/crates/chain/tests/startup/auto_stake.rs
+++ b/crates/chain/tests/startup/auto_stake.rs
@@ -51,15 +51,6 @@ async fn test_auto_stake_pledge(#[case] stake: bool, #[case] pledges: usize) -> 
 
     let config = genesis_node.node_ctx.config.consensus.clone();
 
-    // Get the commitment snapshot from this block
-    let mut commitment_snapshot = genesis_node
-        .node_ctx
-        .block_tree_guard
-        .read()
-        .get_commitment_snapshot(&blk.block_hash)?
-        .as_ref()
-        .clone();
-
     if stake {
         let stake_tx = CommitmentTransaction::new_stake(&config, H256::zero(), 1);
         let stake_tx = peer_signer.sign_commitment(stake_tx)?;
@@ -77,11 +68,7 @@ async fn test_auto_stake_pledge(#[case] stake: bool, #[case] pledges: usize) -> 
         let anchor = H256::zero();
         for _idx in 0..pledges {
             genesis_node
-                .post_pledge_commitment_with_snapshot(
-                    &peer_signer,
-                    anchor,
-                    &mut commitment_snapshot,
-                )
+                .post_pledge_commitment_with_signer(&peer_signer, anchor)
                 .await;
             already_processed_count += 1;
             // don't wait if we haven't posted a stake (stuck in the LRU)

--- a/crates/config/templates/testnet_config.toml
+++ b/crates/config/templates/testnet_config.toml
@@ -1,8 +1,8 @@
 mode = "PeerSync"
 base_directory = ""
-mining_key = ""
+mining_key = "0000000000000000000000000000000000000000000000000000000000000001"
 trusted_peers = []
-reward_address = ""
+reward_address = "0x0000000000000000000000000000000000000000"
 stake_pledge_drives = false
 genesis_peer_discovery_timeout_millis = 10000
 
@@ -59,8 +59,8 @@ num_partitions_per_slot = 1
 entropy_packing_iterations = 1000
 number_of_ingress_proofs = 10
 safe_minimum_number_of_years = 200
-stake_fee = 20000.0
-pledge_base_fee = 950.0
+stake_value = 20000.0
+pledge_base_value = 950.0
 pledge_decay = 0.9
 
 [consensus.Custom.reth]
@@ -97,6 +97,7 @@ max_pending_chunk_items = 30
 max_chunks_per_item = 500
 max_valid_items = 10000
 max_invalid_items = 10000
+commitment_fee = 100
 
 [consensus.Custom.difficulty_adjustment]
 block_time = 12

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -26,6 +26,7 @@ reth-node-metrics.workspace = true
 reth-codecs.workspace = true
 paste.workspace = true
 strum.workspace = true
+async-trait.workspace = true
 
 [dev-dependencies]
 irys-config = { workspace = true, features = ["test-utils"] }

--- a/crates/database/src/system_ledger.rs
+++ b/crates/database/src/system_ledger.rs
@@ -139,6 +139,7 @@ pub async fn get_genesis_commitments(config: &Config) -> Vec<CommitmentTransacti
     // Empty pledge data provider for genesis block creation
     struct EmptyPledgeProvider;
 
+    #[async_trait::async_trait]
     impl PledgeDataProvider for EmptyPledgeProvider {
         async fn pledge_count(&self, _user_address: Address) -> usize {
             0
@@ -268,6 +269,7 @@ pub async fn add_test_commitments(
     // Empty pledge data provider for test commitments
     struct EmptyPledgeProvider;
 
+    #[async_trait::async_trait]
     impl PledgeDataProvider for EmptyPledgeProvider {
         async fn pledge_count(&self, _user_address: Address) -> usize {
             0

--- a/crates/database/src/system_ledger.rs
+++ b/crates/database/src/system_ledger.rs
@@ -100,14 +100,15 @@ impl IndexMut<SystemLedger> for Vec<SystemTransactionLedger> {
 ///
 /// # Panics
 /// Panics if signing the commitment transaction fails
-fn create_pledge_commitment_transaction(
+async fn create_pledge_commitment_transaction(
     signer: &IrysSigner,
     anchor: H256,
     config: &Config,
     provider: &impl PledgeDataProvider,
 ) -> CommitmentTransaction {
     let pledge_commitment =
-        CommitmentTransaction::new_pledge(&config.consensus, anchor, 1, provider, signer.address());
+        CommitmentTransaction::new_pledge(&config.consensus, anchor, 1, provider, signer.address())
+            .await;
 
     signer
         .sign_commitment(pledge_commitment)
@@ -134,12 +135,12 @@ fn create_pledge_commitment_transaction(
 /// # Panics
 /// Panics if fewer than 3 storage submodules are configured, as this is below
 /// the minimum required for network operation
-pub fn get_genesis_commitments(config: &Config) -> Vec<CommitmentTransaction> {
+pub async fn get_genesis_commitments(config: &Config) -> Vec<CommitmentTransaction> {
     // Empty pledge data provider for genesis block creation
     struct EmptyPledgeProvider;
 
     impl PledgeDataProvider for EmptyPledgeProvider {
-        fn pledge_count(&self, _user_address: Address) -> usize {
+        async fn pledge_count(&self, _user_address: Address) -> usize {
             0
         }
     }
@@ -176,7 +177,7 @@ pub fn get_genesis_commitments(config: &Config) -> Vec<CommitmentTransaction> {
     let empty_provider = EmptyPledgeProvider;
     for _i in 0..num_submodules {
         let pledge_tx =
-            create_pledge_commitment_transaction(&signer, anchor, config, &empty_provider);
+            create_pledge_commitment_transaction(&signer, anchor, config, &empty_provider).await;
 
         // We have to rotate the anchors on these TX so they produce unique signatures
         // and unique txids
@@ -221,11 +222,11 @@ fn get_or_create_commitment_ledger(
 /// to the Commitments system ledger.
 ///
 /// Returns the list of commitment transactions.
-pub fn add_genesis_commitments(
+pub async fn add_genesis_commitments(
     genesis_block: &mut IrysBlockHeader,
     config: &Config,
 ) -> Vec<CommitmentTransaction> {
-    let commitments = get_genesis_commitments(config);
+    let commitments = get_genesis_commitments(config).await;
     let commitment_ledger = get_or_create_commitment_ledger(genesis_block);
 
     // Add the commitment txids to the commitment ledger one by one
@@ -259,7 +260,7 @@ pub fn add_genesis_commitments(
 /// # Note
 /// This function is only available when compiled with test or test-utils features
 #[cfg(any(test, feature = "test-utils"))]
-pub fn add_test_commitments(
+pub async fn add_test_commitments(
     block_header: &mut IrysBlockHeader,
     pledge_count: u8,
     config: &Config,
@@ -268,7 +269,7 @@ pub fn add_test_commitments(
     struct EmptyPledgeProvider;
 
     impl PledgeDataProvider for EmptyPledgeProvider {
-        fn pledge_count(&self, _user_address: Address) -> usize {
+        async fn pledge_count(&self, _user_address: Address) -> usize {
             0
         }
     }
@@ -293,7 +294,7 @@ pub fn add_test_commitments(
     let empty_provider = EmptyPledgeProvider;
     for _i in 0..pledge_count {
         let pledge_tx =
-            create_pledge_commitment_transaction(&signer, anchor, config, &empty_provider);
+            create_pledge_commitment_transaction(&signer, anchor, config, &empty_provider).await;
         // We have to rotate the anchors on these TX so they produce unique signatures
         // and unique txids
         anchor = pledge_tx.id;

--- a/crates/domain/src/snapshots/commitment_snapshot.rs
+++ b/crates/domain/src/snapshots/commitment_snapshot.rs
@@ -1,5 +1,5 @@
 use irys_primitives::CommitmentType;
-use irys_types::{transaction::PledgeDataProvider, Address, CommitmentTransaction};
+use irys_types::{Address, CommitmentTransaction};
 use std::collections::BTreeMap;
 use tracing::debug;
 
@@ -209,14 +209,5 @@ impl CommitmentSnapshot {
         }
 
         commitment_tx
-    }
-}
-
-impl PledgeDataProvider for CommitmentSnapshot {
-    fn pledge_count(&self, user_address: Address) -> usize {
-        self.commitments
-            .get(&user_address)
-            .map(|c| c.pledges.len())
-            .unwrap_or(0)
     }
 }

--- a/crates/primitives/src/commitment.rs
+++ b/crates/primitives/src/commitment.rs
@@ -76,6 +76,7 @@ impl Decodable for CommitmentStatus {
 }
 
 // TODO: these need to be redone!
+// these do NOT start with 0, as RLP does not like "leading zeros"
 #[derive(
     PartialEq,
     Debug,
@@ -89,8 +90,7 @@ impl Decodable for CommitmentStatus {
     serde::Deserialize,
     arbitrary::Arbitrary,
 )]
-
-// these do NOT start with 0, as RLP does not like "leading zeros"
+#[serde(rename_all = "camelCase")]
 pub enum CommitmentType {
     #[default]
     Stake = 1,

--- a/crates/testing-utils/Cargo.toml
+++ b/crates/testing-utils/Cargo.toml
@@ -9,5 +9,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 tempfile.workspace = true
 color-eyre.workspace = true
+tracing-error.workspace = true
+
 [lints]
 workspace = true

--- a/crates/testing-utils/src/utils.rs
+++ b/crates/testing-utils/src/utils.rs
@@ -2,8 +2,10 @@ use std::{fs::create_dir_all, path::PathBuf, str::FromStr as _};
 pub use tempfile;
 use tempfile::TempDir;
 use tracing::debug;
+use tracing_error::ErrorLayer;
 use tracing_subscriber::{
     fmt::{self, SubscriberBuilder},
+    layer::SubscriberExt as _,
     util::SubscriberInitExt as _,
     EnvFilter,
 };
@@ -21,6 +23,7 @@ pub fn initialize_tracing_with_backtrace() {
         .with_env_filter(EnvFilter::from_default_env())
         .with_span_events(fmt::format::FmtSpan::NONE)
         .finish()
+        .with(ErrorLayer::default())
         .try_init();
     let _ = color_eyre::install();
 }

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -57,6 +57,7 @@ alloy-signer-local.workspace = true
 reth.workspace = true
 futures.workspace = true
 thiserror.workspace = true
+async-trait.workspace = true
 
 [dev-dependencies]
 test-fuzz.workspace = true

--- a/crates/types/src/config.rs
+++ b/crates/types/src/config.rs
@@ -148,14 +148,14 @@ pub struct ConsensusConfig {
         deserialize_with = "serde_utils::token_amount",
         serialize_with = "serde_utils::serializes_token_amount"
     )]
-    pub stake_fee: Amount<Irys>,
+    pub stake_value: Amount<Irys>,
 
     /// Base fee required for pledging operations in Irys tokens
     #[serde(
         deserialize_with = "serde_utils::token_amount",
         serialize_with = "serde_utils::serializes_token_amount"
     )]
-    pub pledge_base_fee: Amount<Irys>,
+    pub pledge_base_value: Amount<Irys>,
 
     /// Decay rate for pledge fees - subsequent pledges become cheaper
     #[serde(
@@ -451,6 +451,9 @@ pub struct MempoolConfig {
     /// Maximum number of invalid tx txids to keep track of
     /// Decreasing this will increase the amount of validation the node will have to perform
     pub max_invalid_items: usize,
+
+    /// Fee required for commitment transactions (stake, unstake, pledge, unpledge)
+    pub commitment_fee: u64,
 }
 
 /// # Gossip Network Configuration
@@ -572,6 +575,7 @@ impl ConsensusConfig {
                 max_chunks_per_item: 500,
                 max_invalid_items: 10_000,
                 max_valid_items: 10_000,
+                commitment_fee: 100,
             },
             vdf: VdfConfig {
                 // Reset VDF every ~50 blocks (50 blocks × 12 steps/block = 600 global steps)
@@ -643,8 +647,8 @@ impl ConsensusConfig {
                 inflation_cap: Amount::token(rust_decimal::Decimal::from(INFLATION_CAP)).unwrap(),
                 half_life_secs: (HALF_LIFE_YEARS * SECS_PER_YEAR).try_into().unwrap(),
             },
-            stake_fee: Amount::token(dec!(20000)).expect("valid token amount"),
-            pledge_base_fee: Amount::token(dec!(950)).expect("valid token amount"),
+            stake_value: Amount::token(dec!(20000)).expect("valid token amount"),
+            pledge_base_value: Amount::token(dec!(950)).expect("valid token amount"),
             pledge_decay: Amount::percentage(dec!(0.9)).expect("valid percentage"),
         }
     }
@@ -672,10 +676,9 @@ impl ConsensusConfig {
             block_migration_depth: 6,
             block_tree_depth: 50,
             entropy_packing_iterations: 1000,
-            stake_fee: Amount::token(dec!(20000)).expect("valid token amount"),
-            pledge_base_fee: Amount::token(dec!(950)).expect("valid token amount"),
+            stake_value: Amount::token(dec!(20000)).expect("valid token amount"),
+            pledge_base_value: Amount::token(dec!(950)).expect("valid token amount"),
             pledge_decay: Amount::percentage(dec!(0.9)).expect("valid percentage"),
-
             mempool: MempoolConfig {
                 max_data_txs_per_block: 100,
                 max_commitment_txs_per_block: 100,
@@ -687,6 +690,7 @@ impl ConsensusConfig {
                 max_chunks_per_item: 500,
                 max_invalid_items: 10_000,
                 max_valid_items: 10_000,
+                commitment_fee: 100,
             },
             vdf: VdfConfig {
                 // Reset VDF every ~50 blocks (50 blocks × 12 steps/block = 600 global steps)
@@ -1140,8 +1144,8 @@ mod tests {
         entropy_packing_iterations = 1000
         number_of_ingress_proofs = 10
         safe_minimum_number_of_years = 200
-        stake_fee = 20000.0
-        pledge_base_fee = 950.0
+        stake_value = 20000.0
+        pledge_base_value = 950.0
         pledge_decay = 0.9
 
         [reth]
@@ -1178,6 +1182,7 @@ mod tests {
         max_pending_anchor_items = 100
         max_invalid_items = 10000
         max_valid_items = 10000
+        commitment_fee = 100
 
 
 

--- a/crates/types/src/config.rs
+++ b/crates/types/src/config.rs
@@ -1311,4 +1311,27 @@ mod tests {
         let dec: NodeConfig = toml::from_str(&enc).unwrap();
         assert_eq!(cfg, dec);
     }
+
+    #[test]
+    fn test_parse_testnet_config_template() {
+        let template_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .join("config")
+            .join("templates")
+            .join("testnet_config.toml");
+
+        let template_content = std::fs::read_to_string(&template_path)
+            .expect("Failed to read testnet_config.toml template");
+
+        let config = toml::from_str::<NodeConfig>(&template_content)
+            .expect("Failed to parse testnet_config.toml template");
+
+        // Basic sanity checks - just verify it parsed successfully
+        assert_eq!(config.mode, NodeMode::PeerSync);
+
+        // Check consensus config fields
+        let consensus = config.consensus_config();
+        assert_eq!(consensus.chain_id, 1270);
+    }
 }

--- a/crates/types/src/transaction.rs
+++ b/crates/types/src/transaction.rs
@@ -611,6 +611,7 @@ impl From<DataTransactionHeader> for IrysTransactionResponse {
 }
 
 /// Trait for providing pledge count information for dynamic fee calculation
+#[async_trait::async_trait]
 pub trait PledgeDataProvider {
     /// Returns the number of existing pledges for a given user address
     async fn pledge_count(&self, user_address: Address) -> usize;
@@ -638,6 +639,7 @@ mod test_helpers {
         }
     }
 
+    #[async_trait::async_trait]
     impl PledgeDataProvider for MockPledgeProvider {
         async fn pledge_count(&self, user_address: Address) -> usize {
             self.pledge_counts.get(&user_address).copied().unwrap_or(0)

--- a/crates/types/src/transaction.rs
+++ b/crates/types/src/transaction.rs
@@ -1,10 +1,10 @@
-use crate::{
+pub use crate::{
     address_base58_stringify, optional_string_u64, string_u64, Address, Arbitrary, Base64, Compact,
     ConsensusConfig, IrysSignature, Node, Proof, Signature, TxIngressProof, H256, U256,
 };
 use alloy_primitives::keccak256;
 use alloy_rlp::{Encodable as _, RlpDecodable, RlpEncodable};
-use irys_primitives::CommitmentType;
+pub use irys_primitives::CommitmentType;
 use serde::{Deserialize, Serialize};
 
 pub type IrysTransactionId = H256;
@@ -248,7 +248,7 @@ impl CommitmentTransaction {
             commitment_type: CommitmentType::Stake,
             anchor,
             fee,
-            value: config.stake_fee.amount,
+            value: config.stake_value.amount,
             ..Self::new(config)
         }
     }
@@ -259,7 +259,7 @@ impl CommitmentTransaction {
             commitment_type: CommitmentType::Unstake,
             anchor,
             fee,
-            value: config.stake_fee.amount,
+            value: config.stake_value.amount,
             ..Self::new(config)
         }
     }
@@ -267,21 +267,21 @@ impl CommitmentTransaction {
     /// Create a new pledge transaction with decreasing cost per pledge.
     /// Cost = pledge_base_fee / ((existing_pledges + 1) ^ pledge_decay)
     /// The calculated cost is stored in the transaction's `value` field.
-    pub fn new_pledge(
+    pub async fn new_pledge(
         config: &ConsensusConfig,
         anchor: H256,
         fee: u64,
         provider: &impl PledgeDataProvider,
         signer_address: Address,
     ) -> Self {
-        let count = provider.pledge_count(signer_address);
+        let count = provider.pledge_count(signer_address).await;
 
         // Calculate: pledge_base_fee / ((count + 1) ^ pledge_decay)
         let value = config
-            .pledge_base_fee
+            .pledge_base_value
             .apply_pledge_decay(count, config.pledge_decay)
             .map(|a| a.amount)
-            .unwrap_or(config.pledge_base_fee.amount);
+            .unwrap_or(config.pledge_base_value.amount);
 
         Self {
             commitment_type: CommitmentType::Pledge,
@@ -295,14 +295,14 @@ impl CommitmentTransaction {
     /// Create a new unpledge transaction that refunds the most recent pledge's cost.
     /// Refund = cost of the last pledge made (existing_pledges - 1)
     /// Returns 0 if user has no pledges. The refund is in the `value` field.
-    pub fn new_unpledge(
+    pub async fn new_unpledge(
         config: &ConsensusConfig,
         anchor: H256,
         fee: u64,
         provider: &impl PledgeDataProvider,
         signer_address: Address,
     ) -> Self {
-        let count = provider.pledge_count(signer_address);
+        let count = provider.pledge_count(signer_address).await;
 
         // If user has no pledges, they get 0 back
         let value = if count == 0 {
@@ -311,10 +311,10 @@ impl CommitmentTransaction {
             // Calculate the value of the most recent pledge (count - 1)
             // This ensures unpledge matches the cost of the last pledge made
             config
-                .pledge_base_fee
+                .pledge_base_value
                 .apply_pledge_decay(count - 1, config.pledge_decay)
                 .map(|a| a.amount)
-                .unwrap_or(config.pledge_base_fee.amount)
+                .unwrap_or(config.pledge_base_value.amount)
         };
 
         Self {
@@ -613,7 +613,7 @@ impl From<DataTransactionHeader> for IrysTransactionResponse {
 /// Trait for providing pledge count information for dynamic fee calculation
 pub trait PledgeDataProvider {
     /// Returns the number of existing pledges for a given user address
-    fn pledge_count(&self, user_address: Address) -> usize;
+    async fn pledge_count(&self, user_address: Address) -> usize;
 }
 
 #[cfg(test)]
@@ -639,7 +639,7 @@ mod test_helpers {
     }
 
     impl PledgeDataProvider for MockPledgeProvider {
-        fn pledge_count(&self, user_address: Address) -> usize {
+        async fn pledge_count(&self, user_address: Address) -> usize {
             self.pledge_counts.get(&user_address).copied().unwrap_or(0)
         }
     }
@@ -822,6 +822,7 @@ mod pledge_decay_parametrized_tests {
     use rust_decimal::Decimal;
     use rust_decimal_macros::dec;
 
+    #[tokio::test]
     #[rstest]
     #[case(0, dec!(20000.0))]
     #[case(1, dec!(10717.7))]
@@ -848,13 +849,13 @@ mod pledge_decay_parametrized_tests {
     #[case(22, dec!(1189.8))]
     #[case(23, dec!(1145.0))]
     #[case(24, dec!(1103.7))]
-    fn test_pledge_cost_with_decay(
+    async fn test_pledge_cost_with_decay(
         #[case] existing_pledges: usize,
         #[case] expected_cost: Decimal,
     ) {
         // Setup config with $20,000 base fee and 0.9 decay rate
         let mut config = ConsensusConfig::testing();
-        config.pledge_base_fee = crate::storage_pricing::Amount::token(dec!(20000.0)).unwrap();
+        config.pledge_base_value = crate::storage_pricing::Amount::token(dec!(20000.0)).unwrap();
         config.pledge_decay = crate::storage_pricing::Amount::percentage(dec!(0.9)).unwrap();
 
         // Create provider with existing pledge count
@@ -864,7 +865,8 @@ mod pledge_decay_parametrized_tests {
 
         // Create a new pledge transaction
         let pledge_tx =
-            CommitmentTransaction::new_pledge(&config, H256::zero(), 1, &provider, signer_address);
+            CommitmentTransaction::new_pledge(&config, H256::zero(), 1, &provider, signer_address)
+                .await;
 
         // Convert actual value to decimal for comparison
         let actual_amount = Amount::<()>::new(pledge_tx.value)
@@ -874,6 +876,7 @@ mod pledge_decay_parametrized_tests {
         assert_eq!(actual_amount.round_dp(0), expected_cost.round_dp(0));
     }
 
+    #[tokio::test]
     #[rstest]
     #[case(0, dec!(0))]
     #[case(1, dec!(20000.0))]
@@ -900,13 +903,13 @@ mod pledge_decay_parametrized_tests {
     #[case(22,dec!(1238.3))]
     #[case(23,dec!(1189.8))]
     #[case(24,dec!(1145.0))]
-    fn test_unpledge_cost(
+    async fn test_unpledge_cost(
         #[case] existing_pledges: usize,
         #[case] expected_unpledge_value: Decimal,
     ) {
         // Setup config with 20,000 IRYS base fee and 0.9 decay rate (same as test_pledge_cost_with_decay)
         let mut config = ConsensusConfig::testing();
-        config.pledge_base_fee = crate::storage_pricing::Amount::token(dec!(20000.0)).unwrap();
+        config.pledge_base_value = crate::storage_pricing::Amount::token(dec!(20000.0)).unwrap();
         config.pledge_decay = crate::storage_pricing::Amount::percentage(dec!(0.9)).unwrap();
 
         // Create provider with existing pledge count
@@ -921,7 +924,8 @@ mod pledge_decay_parametrized_tests {
             1,
             &provider,
             signer_address,
-        );
+        )
+        .await;
 
         // Verify the commitment type is correct
         assert_eq!(unpledge_tx.commitment_type, CommitmentType::Unpledge);


### PR DESCRIPTION
**Describe the changes**

- when constructing pledge/unpledge txs we need to know the count of how many pledges a user has. Previous implementation did not acocunt for txs in the mempool. This PR fixes that
- Added API endpoint for getting commitment tx fees
- Fees field gets populated on CommitmentTransactions 
- Updated config to have static commitment tx processing fees (expressed in Irys)

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**

What this PR does **not** do:

- validation on the mempool is not part of this PR
- accounting for the fees on reth side is not part of this PR