### PR TITLE
feat: commitment shadow txs pay fees to the miner

### DIFF
--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -413,8 +413,12 @@ pub trait BlockProdStrategy {
         let shadow_txs = shadow_txs
             .generate_all(commitment_txs_to_bill, submit_txs)
             .map(|tx_result| {
-                let tx = tx_result?;
-                let mut tx_raw = compose_shadow_tx(self.inner().config.consensus.chain_id, &tx, 0);
+                let metadata = tx_result?;
+                let mut tx_raw = compose_shadow_tx(
+                    self.inner().config.consensus.chain_id,
+                    &metadata.shadow_tx,
+                    metadata.transaction_fee,
+                );
                 let signature = local_signer
                     .sign_transaction_sync(&mut tx_raw)
                     .expect("shadow tx must always be signable");

--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -414,11 +414,11 @@ pub trait BlockProdStrategy {
             .generate_all(commitment_txs_to_bill, submit_txs)
             .map(|tx_result| {
                 let tx = tx_result?;
-                let mut tx_raw = compose_shadow_tx(self.inner().config.consensus.chain_id, &tx);
+                let mut tx_raw = compose_shadow_tx(self.inner().config.consensus.chain_id, &tx, 0);
                 let signature = local_signer
                     .sign_transaction_sync(&mut tx_raw)
                     .expect("shadow tx must always be signable");
-                let tx = EthereumTxEnvelope::<TxEip4844>::Legacy(tx_raw.into_signed(signature))
+                let tx = EthereumTxEnvelope::<TxEip4844>::Eip1559(tx_raw.into_signed(signature))
                     .try_into_recovered()
                     .expect("shadow tx must always be signable");
 

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -586,6 +586,7 @@ async fn generate_expected_shadow_transactions_from_db<'a>(
     );
     let shadow_txs = shadow_txs
         .generate_all(&commitment_txs, &data_txs)
+        .map(|result| result.map(|metadata| metadata.shadow_tx))
         .collect::<Result<Vec<_>, _>>()?;
     Ok(shadow_txs)
 }

--- a/crates/actors/src/lib.rs
+++ b/crates/actors/src/lib.rs
@@ -21,6 +21,7 @@ pub use addresses::*;
 pub use block_producer::*;
 pub use data_sync_service::*;
 pub use reth_ethereum_primitives;
+pub use shadow_tx_generator::ShadowMetadata;
 pub use storage_module_service::*;
 
 pub use async_trait;

--- a/crates/actors/src/shadow_tx_generator.rs
+++ b/crates/actors/src/shadow_tx_generator.rs
@@ -9,6 +9,12 @@ use irys_types::{
 };
 use reth::revm::primitives::ruint::Uint;
 
+#[derive(Debug)]
+pub struct ShadowMetadata {
+    pub shadow_tx: ShadowTransaction,
+    pub transaction_fee: u128,
+}
+
 pub struct ShadowTxGenerator<'a> {
     pub block_height: &'a u64,
     pub reward_address: &'a Address,
@@ -35,7 +41,7 @@ impl<'a> ShadowTxGenerator<'a> {
         &'a self,
         commitment_txs: &'a [CommitmentTransaction],
         submit_txs: &'a [DataTransactionHeader],
-    ) -> impl std::iter::Iterator<Item = Result<ShadowTransaction>> + use<'a> {
+    ) -> impl std::iter::Iterator<Item = Result<ShadowMetadata>> + use<'a> {
         self.generate_shadow_tx_header()
             .chain(self.generate_commitment_shadow_transactions(commitment_txs))
             .chain(self.generate_data_storage_shadow_transactions(submit_txs))
@@ -44,28 +50,37 @@ impl<'a> ShadowTxGenerator<'a> {
     /// Generates the expected header shadow transactions for a given block
     pub fn generate_shadow_tx_header(
         &self,
-    ) -> impl std::iter::Iterator<Item = Result<ShadowTransaction>> {
-        std::iter::once(Ok(ShadowTransaction::new_v1(
-            TransactionPacket::BlockReward(BlockRewardIncrement {
-                amount: (*self.reward_amount).into(),
-            }),
-        )))
+    ) -> impl std::iter::Iterator<Item = Result<ShadowMetadata>> {
+        std::iter::once(Ok(ShadowMetadata {
+            shadow_tx: ShadowTransaction::new_v1(TransactionPacket::BlockReward(
+                BlockRewardIncrement {
+                    amount: (*self.reward_amount).into(),
+                },
+            )),
+            transaction_fee: 0, // Block rewards have no fee
+        }))
     }
 
     /// Generates the expected data shadow transactions for a given block
     pub fn generate_data_storage_shadow_transactions(
         &'a self,
         submit_txs: &'a [DataTransactionHeader],
-    ) -> impl std::iter::Iterator<Item = Result<ShadowTransaction>> + use<'a> {
+    ) -> impl std::iter::Iterator<Item = Result<ShadowMetadata>> + use<'a> {
         // create a storage fee shadow txs
         submit_txs.iter().map(move |tx| {
-            Ok(ShadowTransaction::new_v1(TransactionPacket::StorageFees(
-                BalanceDecrement {
-                    amount: Uint::from_le_bytes(tx.total_cost().to_le_bytes()),
-                    target: tx.signer,
-                    irys_ref: tx.id.into(),
-                },
-            )))
+            let total_cost = tx.total_cost();
+            Ok(ShadowMetadata {
+                shadow_tx: ShadowTransaction::new_v1(TransactionPacket::StorageFees(
+                    BalanceDecrement {
+                        amount: Uint::from_le_bytes(total_cost.to_le_bytes()),
+                        target: tx.signer,
+                        irys_ref: tx.id.into(),
+                    },
+                )),
+                // todo: We need to update DataTransactionHeader - separate out the fee that
+                // the miner receiver from the fee that gets burned from users account
+                transaction_fee: 0,
+            })
         })
     }
 
@@ -73,7 +88,7 @@ impl<'a> ShadowTxGenerator<'a> {
     pub fn generate_commitment_shadow_transactions(
         &'a self,
         commitment_txs: &'a [CommitmentTransaction],
-    ) -> impl std::iter::Iterator<Item = Result<ShadowTransaction>> + use<'a> {
+    ) -> impl std::iter::Iterator<Item = Result<ShadowMetadata>> + use<'a> {
         commitment_txs.iter().map(move |tx| {
             let commitment_value = Uint::from_le_bytes(tx.commitment_value().to_le_bytes());
             let fee = Uint::from(tx.fee);
@@ -109,29 +124,40 @@ impl<'a> ShadowTxGenerator<'a> {
                     }
                 };
 
+            let transaction_fee = tx.fee as u128;
+
             match tx.commitment_type {
-                irys_primitives::CommitmentType::Stake => Ok(ShadowTransaction::new_v1(
-                    TransactionPacket::Stake(BalanceDecrement {
-                        amount: total_cost,
-                        target: tx.signer,
-                        irys_ref: tx.id.into(),
-                    }),
-                )),
-                irys_primitives::CommitmentType::Pledge => Ok(ShadowTransaction::new_v1(
-                    TransactionPacket::Pledge(BalanceDecrement {
-                        amount: total_cost,
-                        target: tx.signer,
-                        irys_ref: tx.id.into(),
-                    }),
-                )),
+                irys_primitives::CommitmentType::Stake => Ok(ShadowMetadata {
+                    shadow_tx: ShadowTransaction::new_v1(TransactionPacket::Stake(
+                        BalanceDecrement {
+                            amount: total_cost,
+                            target: tx.signer,
+                            irys_ref: tx.id.into(),
+                        },
+                    )),
+                    transaction_fee,
+                }),
+                irys_primitives::CommitmentType::Pledge => Ok(ShadowMetadata {
+                    shadow_tx: ShadowTransaction::new_v1(TransactionPacket::Pledge(
+                        BalanceDecrement {
+                            amount: total_cost,
+                            target: tx.signer,
+                            irys_ref: tx.id.into(),
+                        },
+                    )),
+                    transaction_fee,
+                }),
                 irys_primitives::CommitmentType::Unpledge => {
-                    create_increment_or_decrement("unpledge").map(|result| {
-                        ShadowTransaction::new_v1(TransactionPacket::Unpledge(result))
+                    create_increment_or_decrement("unpledge").map(|result| ShadowMetadata {
+                        shadow_tx: ShadowTransaction::new_v1(TransactionPacket::Unpledge(result)),
+                        transaction_fee,
                     })
                 }
                 irys_primitives::CommitmentType::Unstake => {
-                    create_increment_or_decrement("unstake")
-                        .map(|result| ShadowTransaction::new_v1(TransactionPacket::Unstake(result)))
+                    create_increment_or_decrement("unstake").map(|result| ShadowMetadata {
+                        shadow_tx: ShadowTransaction::new_v1(TransactionPacket::Unstake(result)),
+                        transaction_fee,
+                    })
                 }
             }
         })

--- a/crates/actors/src/shadow_tx_generator.rs
+++ b/crates/actors/src/shadow_tx_generator.rs
@@ -48,7 +48,6 @@ impl<'a> ShadowTxGenerator<'a> {
         std::iter::once(Ok(ShadowTransaction::new_v1(
             TransactionPacket::BlockReward(BlockRewardIncrement {
                 amount: (*self.reward_amount).into(),
-                target: *self.reward_address,
             }),
         )))
     }

--- a/crates/irys-reth/src/evm.rs
+++ b/crates/irys-reth/src/evm.rs
@@ -8,7 +8,7 @@ use alloy_evm::block::{BlockExecutionError, BlockExecutor, ExecutableTx, OnState
 use alloy_evm::eth::receipt_builder::ReceiptBuilder as _;
 use alloy_evm::eth::EthBlockExecutor;
 use alloy_evm::{Database, Evm, FromRecoveredTx, FromTxWithEncoded};
-use alloy_primitives::{Bytes, FixedBytes, Log, LogData};
+use alloy_primitives::{Address, Bytes, FixedBytes, Log, LogData, U256};
 
 // External crate imports - Reth
 use reth::primitives::{SealedBlock, SealedHeader};
@@ -153,6 +153,10 @@ where
         let tx_envelope = tx.tx();
         let tx_envelope_input_buf = tx_envelope.input();
         let rlp_decoded_shadow_tx = ShadowTransaction::decode(&mut &tx_envelope_input_buf[..]);
+        let beneficiary = {
+            use revm::context::Block as _;
+            self.inner().evm().block().beneficiary()
+        };
 
         let Ok(shadow_tx) = rlp_decoded_shadow_tx else {
             // if the tx is not a shadow tx, execute it as a regular transaction
@@ -162,11 +166,29 @@ where
         };
         tracing::trace!(tx_hash = %tx.tx().hash(), "executing shadow transaction");
 
+        // Calculate and distribute priority fee to beneficiary BEFORE executing shadow tx
+        let priority_fee = tx_envelope.max_priority_fee_per_gas().unwrap_or(0);
+        let total_fee = U256::from(priority_fee);
+
+        // Get the target address from the shadow transaction
+        let fee_payer_address = match &shadow_tx {
+            ShadowTransaction::V1 { packet } => packet.fee_payer_address(),
+        };
+
+        // Distribute priority fees
+        self.distribute_priority_fee(
+            total_fee,
+            fee_payer_address,
+            beneficiary,
+            tx_envelope.hash(),
+        )?;
+
         // Process the shadow transaction
         let (new_account_state, target) =
-            self.process_shadow_transaction(&shadow_tx, tx_envelope.hash())?;
+            self.process_shadow_transaction(&shadow_tx, tx_envelope.hash(), beneficiary)?;
 
         let mut new_state = alloy_primitives::map::foldhash::HashMap::default();
+
         // at this point, the shadow tx has been processed, and it was valid *enough*
         // that we should generate a receipt for it even in a failure state
         let execution_result = match new_account_state {
@@ -186,14 +208,13 @@ where
                     status |= AccountStatus::Created;
                 };
 
-                new_state.insert(
-                    target,
-                    Account {
-                        info: plain_account.info,
-                        storage,
-                        status,
-                    },
-                );
+                let account = Account {
+                    info: plain_account.info,
+                    storage,
+                    status,
+                };
+
+                new_state.insert(target, account);
 
                 execution_result
             }
@@ -256,6 +277,7 @@ where
         &mut self,
         shadow_tx: &ShadowTransaction,
         tx_envelope_hash: &FixedBytes<32>,
+        beneficiary: Address,
     ) -> Result<(ShadowTransactionResult<<E as Evm>::HaltReason>, Address), BlockExecutionError>
     {
         let topic = shadow_tx.topic();
@@ -306,17 +328,17 @@ where
                 },
                 shadow_tx::TransactionPacket::BlockReward(block_reward_increment) => {
                     let log = Self::create_shadow_log(
-                        block_reward_increment.target,
+                        beneficiary,
                         vec![topic],
                         vec![
                             DynSolValue::Uint(block_reward_increment.amount, 256),
-                            DynSolValue::Address(block_reward_increment.target),
+                            DynSolValue::Address(beneficiary),
                         ],
                     );
-                    let target = block_reward_increment.target;
+                    let target = beneficiary;
                     let balance_increment = shadow_tx::BalanceIncrement {
                         amount: block_reward_increment.amount,
-                        target: block_reward_increment.target,
+                        target: beneficiary,
                         irys_ref: alloy_primitives::FixedBytes::ZERO,
                     };
                     let (plain_account, execution_result, account_existed) =
@@ -479,6 +501,243 @@ where
         let execution_result = Self::create_success_result(log);
 
         Ok(Ok((new_account_info, execution_result)))
+    }
+
+    /// Distributes priority fees from shadow transactions to the block beneficiary.
+    ///
+    /// # Priority Fee Distribution Flow
+    ///
+    /// Shadow transactions support EIP-1559 style priority fees that are distributed
+    /// to the block beneficiary (miner) BEFORE the shadow transaction is executed.
+    /// This preserves miner incentives while maintaining protocol-level operations.
+    ///
+    /// ## Process:
+    /// 1. Calculate total fee from `max_priority_fee_per_gas` (direct value, no gas multiplication)
+    /// 2. Extract fee payer address from shadow transaction (source of funds)
+    /// 3. Validate target has sufficient balance
+    /// 4. Deduct fee from target account
+    /// 5. Add fee to beneficiary account (create if needed)
+    /// 6. Commit state changes atomically
+    ///
+    /// ## Early Returns:
+    /// - No fee to distribute (fee is zero)
+    /// - No target address in shadow transaction
+    ///
+    /// ## Error Cases:
+    /// - Target account doesn't exist
+    /// - Target has insufficient balance
+    /// - Database operation failures
+    fn distribute_priority_fee(
+        &mut self,
+        total_fee: U256,
+        fee_payer_address: Option<Address>,
+        beneficiary: Address,
+        tx_hash: &FixedBytes<32>,
+    ) -> Result<(), BlockExecutionError> {
+        // Early return if no fee to distribute
+        if total_fee.is_zero() {
+            return Ok(());
+        }
+
+        // Early return if no target address
+        let Some(target) = fee_payer_address else {
+            tracing::trace!(
+                "No target address for shadow transaction, skipping priority fee distribution"
+            );
+            return Ok(());
+        };
+
+        tracing::debug!(
+            beneficiary = %beneficiary,
+            target = %target,
+            total_fee = %total_fee,
+            "Distributing priority fee"
+        );
+
+        // Prepare fee transfer
+        let (target_state, beneficiary_state) =
+            self.prepare_fee_transfer(target, beneficiary, total_fee, tx_hash)?;
+
+        // Commit the fee transfer
+        self.commit_fee_transfer(
+            target_state,
+            beneficiary_state,
+            target,
+            beneficiary,
+            total_fee,
+        );
+
+        Ok(())
+    }
+
+    /// Prepares the fee transfer by validating and creating state changes for both accounts.
+    ///
+    /// Returns the updated state for both target and beneficiary accounts.
+    fn prepare_fee_transfer(
+        &mut self,
+        target: Address,
+        beneficiary: Address,
+        total_fee: U256,
+        tx_hash: &FixedBytes<32>,
+    ) -> Result<(Account, Account), BlockExecutionError> {
+        let evm = self.inner.evm_mut();
+        let db = evm.db_mut();
+
+        // Deduct fee from target
+        let target_account = Self::deduct_fee_from_target(db, target, total_fee, tx_hash)?;
+        let target_state = Self::create_account_state(target_account, AccountStatus::Touched);
+
+        // Add fee to beneficiary
+        let (beneficiary_account, is_new) =
+            Self::add_fee_to_beneficiary(db, beneficiary, total_fee)?;
+        let mut status = AccountStatus::Touched;
+        if is_new {
+            status |= AccountStatus::Created;
+        }
+        let beneficiary_state = Self::create_account_state(beneficiary_account, status);
+
+        Ok((target_state, beneficiary_state))
+    }
+
+    /// Deducts the fee from the target account after validating sufficient balance.
+    ///
+    /// # Errors
+    /// - Returns `InvalidTransaction::NonceTooHigh` if target account doesn't exist
+    /// - Returns `InvalidTransaction::LackOfFundForMaxFee` if insufficient balance
+    fn deduct_fee_from_target(
+        db: &mut State<DB>,
+        target: Address,
+        fee: U256,
+        tx_hash: &FixedBytes<32>,
+    ) -> Result<PlainAccount, BlockExecutionError> {
+        // Load target account
+        let target_state = db
+            .load_cache_account(target)
+            .map_err(|_| create_internal_error("Could not load target account"))?;
+
+        // Validate account exists
+        let Some(existing) = target_state.account.as_ref() else {
+            tracing::warn!(
+                target = %target,
+                "Target account does not exist, cannot deduct priority fee"
+            );
+            return Err(create_invalid_tx_error(
+                *tx_hash,
+                InvalidTransaction::NonceTooHigh { tx: 0, state: 0 }, // Proxy for "account doesn't exist"
+            ));
+        };
+
+        let mut account = existing.clone();
+
+        // Validate sufficient balance
+        if account.info.balance < fee {
+            tracing::warn!(
+                target = %target,
+                balance = %account.info.balance,
+                required_fee = %fee,
+                "Target has insufficient balance for priority fee"
+            );
+            return Err(create_invalid_tx_error(
+                *tx_hash,
+                InvalidTransaction::LackOfFundForMaxFee {
+                    fee: Box::new(fee),
+                    balance: Box::new(account.info.balance),
+                },
+            ));
+        }
+
+        // Deduct fee
+        account.info.balance = account.info.balance.saturating_sub(fee);
+
+        tracing::trace!(
+            target = %target,
+            fee = %fee,
+            "Deducting priority fee from target"
+        );
+
+        Ok(account)
+    }
+
+    /// Adds the fee to the beneficiary account, creating it if necessary.
+    ///
+    /// Returns tuple of (account, is_new_account).
+    fn add_fee_to_beneficiary(
+        db: &mut State<DB>,
+        beneficiary: Address,
+        fee: U256,
+    ) -> Result<(PlainAccount, bool), BlockExecutionError> {
+        // Load beneficiary account
+        let beneficiary_state = db
+            .load_cache_account(beneficiary)
+            .map_err(|_| create_internal_error("Could not load beneficiary account"))?;
+
+        if let Some(existing) = beneficiary_state.account.as_ref() {
+            // Update existing account
+            let mut account = existing.clone();
+            let original_balance = account.info.balance;
+            account.info.balance = account.info.balance.saturating_add(fee);
+
+            tracing::trace!(
+                beneficiary = %beneficiary,
+                original_balance = %original_balance,
+                new_balance = %account.info.balance,
+                fee_amount = %fee,
+                "Incrementing beneficiary balance with priority fee"
+            );
+
+            Ok((account, false))
+        } else {
+            // Create new account
+            let mut account = PlainAccount::new_empty_with_storage(PlainStorage::default());
+            account.info.balance = fee;
+
+            tracing::debug!(
+                beneficiary = %beneficiary,
+                balance = %fee,
+                "Creating new beneficiary account with priority fee"
+            );
+
+            Ok((account, true))
+        }
+    }
+
+    /// Creates an Account state entry from a PlainAccount for database commit.
+    fn create_account_state(account: PlainAccount, status: AccountStatus) -> Account {
+        let storage = account
+            .storage
+            .iter()
+            .map(|(key, val)| (*key, EvmStorageSlot::new(*val)))
+            .collect();
+
+        Account {
+            info: account.info,
+            storage,
+            status,
+        }
+    }
+
+    /// Commits the fee transfer state changes to the database.
+    fn commit_fee_transfer(
+        &mut self,
+        target_state: Account,
+        beneficiary_state: Account,
+        target: Address,
+        beneficiary: Address,
+        total_fee: U256,
+    ) {
+        let mut state_changes = alloy_primitives::map::foldhash::HashMap::default();
+        state_changes.insert(target, target_state);
+        state_changes.insert(beneficiary, beneficiary_state);
+
+        let db = self.inner.evm_mut().db_mut();
+        db.commit(state_changes);
+
+        tracing::trace!(
+            beneficiary = %beneficiary,
+            target = %target,
+            fee = %total_fee,
+            "Committed priority fee distribution"
+        );
     }
 }
 

--- a/crates/irys-reth/src/evm.rs
+++ b/crates/irys-reth/src/evm.rs
@@ -509,18 +509,17 @@ where
     ///
     /// Shadow transactions support EIP-1559 style priority fees that are distributed
     /// to the block beneficiary (miner) BEFORE the shadow transaction is executed.
-    /// This preserves miner incentives while maintaining protocol-level operations.
     ///
     /// ## Process:
     /// 1. Calculate total fee from `max_priority_fee_per_gas` (direct value, no gas multiplication)
-    /// 2. Extract fee payer address from shadow transaction (source of funds)
-    /// 3. Validate target has sufficient balance
-    /// 4. Deduct fee from target account
-    /// 5. Add fee to beneficiary account (create if needed)
-    /// 6. Commit state changes atomically
+    /// 2. Validate target has sufficient balance
+    /// 3. Deduct fee from target account
+    /// 4. Add fee to beneficiary account (create a new one if needed)
+    /// 5. Commit state changes
     ///
     /// ## Early Returns:
-    /// - No fee to distribute (fee is zero)
+    /// - No fee to distribute (fee is zero).
+    ///   This is valid because enforcement of which shadow txs to include in the block is up to the consensus layer.
     /// - No target address in shadow transaction
     ///
     /// ## Error Cases:

--- a/crates/irys-reth/src/lib.rs
+++ b/crates/irys-reth/src/lib.rs
@@ -1929,6 +1929,8 @@ mod tests {
     }
 
     /// Test shadow tx priority fees go to different miner than tx signer
+    /// (This is to enable mining pools in the future, where a beneficiary
+    /// of a block may be a different entity that actually mined the block)
     #[test_log::test(tokio::test)]
     async fn test_shadow_tx_priority_fee_different_miner() -> eyre::Result<()> {
         let ctx = TestContext::new().await?;

--- a/crates/irys-reth/src/lib.rs
+++ b/crates/irys-reth/src/lib.rs
@@ -13,8 +13,8 @@
 
 use std::{sync::Arc, time::SystemTime};
 
-use alloy_consensus::TxLegacy;
-use alloy_eips::{eip7840::BlobParams, merge::EPOCH_SLOTS};
+use alloy_consensus::TxEip1559;
+use alloy_eips::{eip2930::AccessList, eip7840::BlobParams, merge::EPOCH_SLOTS};
 use alloy_primitives::{Address, TxKind, U256};
 pub use alloy_rlp;
 use alloy_rlp::{Decodable as _, Encodable as _};
@@ -71,20 +71,27 @@ pub mod payload_service_builder;
 pub mod shadow_tx;
 
 #[must_use]
-pub fn compose_shadow_tx(chain_id: u64, shadow_tx: &ShadowTransaction) -> TxLegacy {
+pub fn compose_shadow_tx(
+    chain_id: u64,
+    shadow_tx: &ShadowTransaction,
+    max_priority_fee_per_gas: u128,
+) -> TxEip1559 {
     // allocate 512 bytes for the shadow tx rlp, misc optimisation
     let mut shadow_tx_rlp = Vec::with_capacity(512);
     shadow_tx.encode(&mut shadow_tx_rlp);
-    TxLegacy {
-        // large enough to not be rejected by the payload builder
-        gas_limit: MINIMUM_GAS_LIMIT,
-        value: U256::ZERO,
+    TxEip1559 {
+        chain_id,
         // nonce is always 0 for shadow txs
         nonce: 0_u64,
         // large enough to not be rejected by the payload builder
-        gas_price: DEFAULT_TX_FEE_CAP_WEI,
-        chain_id: Some(chain_id),
+        gas_limit: MINIMUM_GAS_LIMIT,
+        // large enough to not be rejected by the payload builder
+        max_fee_per_gas: DEFAULT_TX_FEE_CAP_WEI,
+        // Use the provided priority fee
+        max_priority_fee_per_gas,
         to: TxKind::Call(Address::ZERO),
+        value: U256::ZERO,
+        access_list: AccessList::default(),
         input: shadow_tx_rlp.into(),
     }
 }
@@ -411,13 +418,13 @@ mod tests {
     use crate::test_utils::*;
     use crate::test_utils::{
         advance_blocks, block_reward, eth_payload_attributes_with_parent, get_balance, pledge,
-        sign_tx, stake, storage_fees, unpledge, unstake,
+        sign_tx, stake, storage_fees, unpledge, unstake, DEFAULT_PRIORITY_FEE,
     };
     use alloy_consensus::{EthereumTxEnvelope, SignableTransaction as _, TxEip4844};
     use alloy_eips::Encodable2718 as _;
     use alloy_network::{EthereumWallet, TxSigner};
     use alloy_primitives::Signature;
-    use alloy_primitives::{Address, Uint, B256};
+    use alloy_primitives::{Address, B256};
     use alloy_rpc_types_engine::ForkchoiceState;
     use alloy_signer_local::PrivateKeySigner;
     use reth::api::EngineApiMessageVersion;
@@ -443,14 +450,14 @@ mod tests {
         let ctx = TestContext::new().await?;
         let ((node, _shadow_tx_rx), ctx) = ctx.get_single_node()?;
 
-        let shadow_tx = block_reward(ctx.block_producer_a.address());
-        let mut shadow_tx_raw = compose_shadow_tx(1, &shadow_tx);
+        let shadow_tx = block_reward();
+        let mut shadow_tx_raw = compose_shadow_tx(1, &shadow_tx, DEFAULT_PRIORITY_FEE);
         let signed_tx = ctx
             .target_account
             .sign_transaction(&mut shadow_tx_raw)
             .await
             .unwrap();
-        let tx = EthereumTxEnvelope::<TxEip4844>::Legacy(shadow_tx_raw.into_signed(signed_tx))
+        let tx = EthereumTxEnvelope::<TxEip4844>::Eip1559(shadow_tx_raw.into_signed(signed_tx))
             .encoded_2718()
             .into();
 
@@ -474,7 +481,17 @@ mod tests {
     /// - The normal tx from node a is included in the block.
     #[test_log::test(tokio::test)]
     async fn stale_shadow_txs_dont_get_included_in_fcus() -> eyre::Result<()> {
-        let ctx = TestContext::new().await?;
+        // Get the block producer addresses for beneficiaries
+        let temp_ctx = TestContext::new().await?;
+        let beneficiary_a = temp_ctx.block_producer_a.address();
+        let _beneficiary_b = temp_ctx.block_producer_b.address();
+
+        // Create context with proper beneficiaries
+        let ctx = TestContext::new_with_payload_attributes(move |timestamp| {
+            // For this test, we'll use producer A as beneficiary
+            eth_payload_attributes_with_beneficiary(timestamp, beneficiary_a)
+        })
+        .await?;
         let (((mut node_a, shadow_tx_store_a), (mut node_b, shadow_tx_store_b)), ctx) =
             ctx.get_two_nodes()?;
 
@@ -492,7 +509,8 @@ mod tests {
 
         // Submit shadow transaction to node b
         let shadow_tx = create_shadow_tx(BLOCK_REWARD_ID, ctx.block_producer_b.address());
-        let shadow_tx = sign_shadow_tx(shadow_tx, &ctx.block_producer_b).await?;
+        let shadow_tx =
+            sign_shadow_tx(shadow_tx, &ctx.block_producer_b, DEFAULT_PRIORITY_FEE).await?;
         let shadow_tx_hash = *shadow_tx.hash();
         let _payload_node_b =
             advance_block(&mut node_b, &shadow_tx_store_b, vec![shadow_tx]).await?;
@@ -543,7 +561,15 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn block_with_shadow_txs_gets_broadcasted_between_peers() -> eyre::Result<()> {
-        let ctx = TestContext::new().await?;
+        // Create a temporary context to get the block producer address
+        let temp_ctx = TestContext::new().await?;
+        let beneficiary_address = temp_ctx.block_producer_a.address();
+
+        // Create context with block producer as beneficiary
+        let ctx = TestContext::new_with_payload_attributes(move |timestamp| {
+            eth_payload_attributes_with_beneficiary(timestamp, beneficiary_address)
+        })
+        .await?;
         let (((mut node_a, shadow_tx_store_a), (mut node_b, _shadow_tx_store_b)), ctx) =
             ctx.get_two_nodes()?;
 
@@ -554,8 +580,8 @@ mod tests {
             1,
             &ShadowTransaction::new_v1(TransactionPacket::BlockReward(BlockRewardIncrement {
                 amount,
-                target: ctx.block_producer_a.address(),
             })),
+            1_000_000_000,
         );
         let shadow_tx = sign_tx(shadow_tx, &ctx.block_producer_a).await;
         let shadow_tx_hash = *shadow_tx.hash();
@@ -580,13 +606,14 @@ mod tests {
             .assert_new_block(shadow_tx_hash, block_hash, block_number)
             .await?;
 
+        // The beneficiary receives only the block reward (no priority fee since BlockReward has no target)
         assert_balance_change(
             &node_b,
             ctx.block_producer_a.address(),
             initial_balance,
-            amount,
+            amount, // block reward only (no priority fee)
             true,
-            "Producer balance should increase",
+            "Producer balance should increase by block reward only",
         );
 
         Ok(())
@@ -596,9 +623,7 @@ mod tests {
     #[test_log::test(tokio::test)]
     #[rstest::rstest]
     #[case::unstake(unstake, signer_b())]
-    #[case::unstake_init_no_balance(unstake, signer_random())]
-    #[case::block_reward(block_reward, signer_b())]
-    #[case::block_reward_init_no_balance(block_reward, signer_random())]
+    #[case::unstake_init_no_balance(unstake, signer_c())]
     async fn incr_shadow_txs(
         #[case] shadow_tx: impl Fn(Address) -> ShadowTransaction,
         #[case] target_signer: Arc<dyn TxSigner<Signature> + Send + Sync>,
@@ -612,7 +637,8 @@ mod tests {
         let tx_count = 5;
         let shadow_tx = shadow_tx(target_signer.address());
         let shadow_tx_topic = shadow_tx.topic().into();
-        let shadow_tx = sign_shadow_tx(shadow_tx, &target_signer).await?;
+        let shadow_tx =
+            sign_shadow_tx(shadow_tx, &ctx.block_producer_a, DEFAULT_PRIORITY_FEE).await?;
         let shadow_txs = vec![shadow_tx.clone(); tx_count];
 
         let _block_payload =
@@ -621,21 +647,30 @@ mod tests {
         let block_execution = node.inner.provider.get_state(0..=1).unwrap().unwrap();
         assert_topic_present_in_logs(block_execution, shadow_tx_topic, tx_count as u64);
 
-        assert_balance_change(
-            &node,
-            target_signer.address(),
-            initial_balance,
-            U256::from(tx_count),
-            true,
-            "Target balance should increase",
+        // Target should gain from unstake but pay priority fees
+        // Each transaction has 1 Gwei priority fee
+        let total_priority_fees = U256::from(tx_count) * U256::from(1_000_000_000_u64);
+        let unstake_amount = U256::from(tx_count); // 1 wei per unstake tx
+
+        // Calculate expected balance change
+        let final_balance = get_balance(&node.inner, target_signer.address());
+        let _final_producer_balance = get_balance(&node.inner, ctx.block_producer_a.address());
+
+        // All accounts now have sufficient initial balance to pay fees
+        let expected_balance = initial_balance + unstake_amount - total_priority_fees;
+        assert_eq!(
+            final_balance, expected_balance,
+            "Target balance should be initial + unstake - fees"
         );
+        // In this test, beneficiary is the zero address (default), not the producer
+        // So producer balance should not change
         assert_balance_change(
             &node,
             ctx.block_producer_a.address(),
             initial_producer_balance,
             U256::ZERO,
             true,
-            "Producer balance should not change",
+            "Producer balance should not change (fees go to beneficiary)",
         );
         assert_nonce(
             &node,
@@ -665,7 +700,8 @@ mod tests {
         let tx_count = 2;
         let shadow_tx = shadow_tx(target_signer.address());
         let shadow_tx_topic = shadow_tx.topic().into();
-        let shadow_tx = sign_shadow_tx(shadow_tx, &target_signer).await?;
+        let shadow_tx =
+            sign_shadow_tx(shadow_tx, &ctx.block_producer_a, DEFAULT_PRIORITY_FEE).await?;
         let shadow_txs = vec![shadow_tx.clone(); tx_count];
         let tx_hashes = shadow_txs.iter().map(|tx| *tx.hash()).collect::<Vec<_>>();
         let block_payload =
@@ -680,24 +716,31 @@ mod tests {
         // Assert all txs have a corresponding log
         assert_topic_present_in_logs(block_execution, shadow_tx_topic, tx_count as u64);
 
-        // Assert balance for target is decremented
+        // Assert balance for target is decremented by both the shadow tx amount and priority fees
+        // Each transaction costs 1 wei (for stake/storage_fees) + 1 Gwei priority fee
+        let total_priority_fees = U256::from(tx_count) * U256::from(1_000_000_000_u64);
+        let shadow_tx_cost = U256::from(tx_count); // 1 wei per decrement tx
+        let total_cost = shadow_tx_cost + total_priority_fees;
+
         assert_balance_change(
             &node,
             target_signer.address(),
             initial_balance,
-            U256::from(tx_count),
+            total_cost,
             false, // is_decrement
-            "Target balance should be reduced",
+            "Target balance should be reduced by shadow tx amount plus priority fees",
         );
 
         // Assert balance for producer remains the same (shadow txs cost nothing)
+        // In this test, beneficiary is the zero address (default), not the producer
+        // So producer balance should not change
         assert_balance_change(
             &node,
             ctx.block_producer_a.address(),
             initial_producer_balance,
             U256::ZERO,
             true,
-            "Producer balance should not change",
+            "Producer balance should not change (fees go to beneficiary)",
         );
 
         assert_nonce(
@@ -729,7 +772,8 @@ mod tests {
 
         // Create shadow transactions with lower effective priority
         let shadow_tx = create_shadow_tx(UNSTAKE_ID, ctx.target_account.address());
-        let shadow_tx = sign_shadow_tx(shadow_tx, &ctx.block_producer_a).await?;
+        let shadow_tx =
+            sign_shadow_tx(shadow_tx, &ctx.block_producer_a, DEFAULT_PRIORITY_FEE).await?;
         let shadow_txs = vec![shadow_tx.clone(); 2];
         let shadow_tx_hashes = shadow_txs.iter().map(|tx| *tx.hash()).collect::<Vec<_>>();
 
@@ -767,7 +811,8 @@ mod tests {
             target: nonexistent_address,
             irys_ref: alloy_primitives::FixedBytes::ZERO,
         }));
-        let shadow_tx = sign_shadow_tx(shadow_tx, &ctx.block_producer_a).await?;
+        let shadow_tx =
+            sign_shadow_tx(shadow_tx, &ctx.block_producer_a, DEFAULT_PRIORITY_FEE).await?;
         let shadow_tx_hashes = vec![*shadow_tx.hash()];
 
         // Submit a normal transaction to ensure block is produced
@@ -821,7 +866,8 @@ mod tests {
             target: ctx.normal_signer.address(),
             irys_ref: alloy_primitives::FixedBytes::ZERO,
         }));
-        let shadow_tx = sign_shadow_tx(shadow_tx, &ctx.block_producer_a).await?;
+        let shadow_tx =
+            sign_shadow_tx(shadow_tx, &ctx.block_producer_a, DEFAULT_PRIORITY_FEE).await?;
         let shadow_tx_hashes = vec![*shadow_tx.hash()];
 
         // Produce a new block
@@ -855,6 +901,13 @@ mod tests {
     }
 
     #[rstest::fixture]
+    fn signer_c() -> Arc<dyn TxSigner<Signature> + Send + Sync> {
+        let wallets = Wallet::new(3).wallet_gen();
+        let signer_c = EthereumWallet::from(wallets[2].clone());
+        (signer_c.default_signer()) as _
+    }
+
+    #[rstest::fixture]
     fn signer_random() -> Arc<dyn TxSigner<Signature> + Send + Sync> {
         Arc::new(PrivateKeySigner::random())
     }
@@ -872,8 +925,9 @@ mod tests {
 
         for block_number in 1..=5 {
             // Block reward shadow tx
-            let shadow_tx = block_reward(ctx.block_producer_a.address());
-            let shadow_tx = sign_shadow_tx(shadow_tx, &ctx.block_producer_a).await?;
+            let shadow_tx = block_reward();
+            let shadow_tx =
+                sign_shadow_tx(shadow_tx, &ctx.block_producer_a, DEFAULT_PRIORITY_FEE).await?;
 
             // Normal tx
             let normal_tx_hash = create_and_submit_normal_tx(
@@ -911,14 +965,22 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn rollback_state_revert_on_fork_switch() -> eyre::Result<()> {
-        // Setup nodes and context
-        let ctx = TestContext::new().await?;
+        // Get the block producer address for beneficiary
+        let temp_ctx = TestContext::new().await?;
+        let beneficiary_address = temp_ctx.block_producer_a.address();
+
+        // Setup nodes and context with beneficiary
+        let ctx = TestContext::new_with_payload_attributes(move |timestamp| {
+            eth_payload_attributes_with_beneficiary(timestamp, beneficiary_address)
+        })
+        .await?;
         let (((mut node_a, shadow_tx_store_node_a), (mut node_b, shadow_tx_store_node_b)), ctx) =
             ctx.get_two_nodes()?;
-        let reward_address = Address::random();
+        // Use the beneficiary address instead of a random address for checking rewards
+        let reward_address = beneficiary_address;
 
         // Node A: advance 3 blocks, 2 shadow txs per block
-        let shadow_tx = block_reward(reward_address);
+        let shadow_tx = block_reward();
         let shadow_txs = vec![vec![shadow_tx; 2]; 3];
 
         let _block_hashes_a = advance_blocks(
@@ -936,7 +998,7 @@ mod tests {
         let node_a_reward_balance = get_balance(&node_a.inner, reward_address);
 
         // Node B: advance 4 blocks, 1 shadow tx per block
-        let shadow_tx = block_reward(reward_address);
+        let shadow_tx = block_reward();
         let shadow_txs = vec![vec![shadow_tx; 1]; 4];
         let _block_hashes_b = advance_blocks(
             &mut node_b,
@@ -982,7 +1044,12 @@ mod tests {
             "block hashes after sync must be equal"
         );
         assert_eq!(reward_balance_post_switch_node_a, reward_balance_node_b);
-        assert_eq!(reward_balance_post_switch_node_a, Uint::from(4));
+        // The beneficiary address starts with 1 ETH and gets:
+        // - 4 block rewards (1 wei each) = 4 wei
+        // - NO priority fees since block rewards have no target
+        let expected_balance =
+            U256::from_str_radix("1000000000000000000000000", 10).unwrap() + U256::from(4); // block rewards only
+        assert_eq!(reward_balance_post_switch_node_a, expected_balance);
         assert_ne!(
             node_a_reward_balance, reward_balance_node_b,
             "initial rewards differ on forks produced by each chain"
@@ -1020,13 +1087,19 @@ mod tests {
     /// 5. Verify final state: balance = initial + 2, nonce = 1 (reflecting the rollback and new block)
     #[test_log::test(tokio::test)]
     async fn rollback_state_on_safe_blocks() -> eyre::Result<()> {
-        // Setup custom payload attributes to control parent block hash
+        // Get the block producer address for beneficiary
+        let temp_ctx = TestContext::new().await?;
+        let beneficiary_address = temp_ctx.block_producer_a.address();
+
+        // Setup custom payload attributes to control parent block hash and beneficiary
         let parent_tracker = Arc::new(Mutex::new(B256::ZERO));
         let payload_attributes = {
             let parent_tracker = parent_tracker.clone();
             move |timestamp: u64| {
                 let parent = *parent_tracker.lock().unwrap();
-                eth_payload_attributes_with_parent(timestamp, parent)
+                let mut attrs = eth_payload_attributes_with_parent(timestamp, parent);
+                attrs.suggested_fee_recipient = beneficiary_address;
+                attrs
             }
         };
 
@@ -1042,8 +1115,10 @@ mod tests {
         tracing::info!("Phase 1: Building 4 blocks with block rewards");
         for block_number in 1..=4 {
             // Create block reward transaction
-            let block_reward_tx = block_reward(ctx.block_producer_a.address());
-            let block_reward_tx = sign_shadow_tx(block_reward_tx, &ctx.block_producer_a).await?;
+            let block_reward_tx = block_reward();
+            let block_reward_tx =
+                sign_shadow_tx(block_reward_tx, &ctx.block_producer_a, DEFAULT_PRIORITY_FEE)
+                    .await?;
 
             // Mine the block
             let payload =
@@ -1065,11 +1140,12 @@ mod tests {
             .best_block_number()
             .unwrap();
         assert_eq!(best_block, 4, "Should be at block 4");
+        // Each block reward transaction only gives 1 wei block reward (no priority fee since no target)
         assert_balance_change(
             &node,
             ctx.block_producer_a.address(),
             initial_balance,
-            U256::from(4),
+            U256::from(4), // 4 block rewards only
             true,
             "Balance should reflect 4 block rewards",
         );
@@ -1105,8 +1181,9 @@ mod tests {
         let fork_block_number = 2; // Building block 2 on top of block 1
                                    // Update parent tracker for payload attributes
         *parent_tracker.lock().unwrap() = rollback_target;
-        let fork_reward_tx = block_reward(ctx.block_producer_a.address());
-        let fork_reward_tx = sign_shadow_tx(fork_reward_tx, &ctx.block_producer_a).await?;
+        let fork_reward_tx = block_reward();
+        let fork_reward_tx =
+            sign_shadow_tx(fork_reward_tx, &ctx.block_producer_a, DEFAULT_PRIORITY_FEE).await?;
         let fork_payload = prepare_block(&mut node, &shadow_tx_store, vec![fork_reward_tx]).await?;
         let fork_block_hash = fork_payload.block().hash();
 
@@ -1162,11 +1239,12 @@ mod tests {
             final_best_block, fork_block_number,
             "Should be at fork block number"
         );
+        // Each block reward transaction only gives 1 wei block reward (no priority fee since no target)
         assert_balance_change(
             &node,
             ctx.block_producer_a.address(),
             initial_balance,
-            U256::from(2), // 1 from block 1 + 1 from fork block 2
+            U256::from(2), // 2 block rewards only
             true,
             "Balance should reflect rollback to block 1 + new fork block reward",
         );
@@ -1201,8 +1279,10 @@ mod tests {
 
         // Build 3 blocks with shadow transactions
         for block_number in 1..=3 {
-            let block_reward_tx = block_reward(ctx.block_producer_a.address());
-            let block_reward_tx = sign_shadow_tx(block_reward_tx, &ctx.block_producer_a).await?;
+            let block_reward_tx = block_reward();
+            let block_reward_tx =
+                sign_shadow_tx(block_reward_tx, &ctx.block_producer_a, DEFAULT_PRIORITY_FEE)
+                    .await?;
             shadow_txs.push(block_reward_tx.clone());
 
             let normal_tx = create_and_submit_normal_tx(
@@ -1281,15 +1361,15 @@ mod tests {
 
         // Phase 5: Try to submit the future shadow transactions directly to the pool
         // They should be rejected and never enter the pool
-        let future_shadow_tx_1 = block_reward(ctx.block_producer_a.address());
-        let mut tx_1_raw = compose_shadow_tx(1, &future_shadow_tx_1);
+        let future_shadow_tx_1 = block_reward();
+        let mut tx_1_raw = compose_shadow_tx(1, &future_shadow_tx_1, DEFAULT_PRIORITY_FEE);
         let signed_tx_1 = ctx
             .block_producer_a
             .sign_transaction(&mut tx_1_raw)
             .await
             .unwrap();
         let tx_1_envelope =
-            EthereumTxEnvelope::<TxEip4844>::Legacy(tx_1_raw.into_signed(signed_tx_1))
+            EthereumTxEnvelope::<TxEip4844>::Eip1559(tx_1_raw.into_signed(signed_tx_1))
                 .encoded_2718()
                 .into();
 
@@ -1342,32 +1422,41 @@ mod tests {
         let mut expected_tx_hashes = Vec::new();
 
         // 1. Block reward
-        let block_reward_tx = block_reward(address_a);
-        let block_reward_tx = sign_shadow_tx(block_reward_tx, &ctx.block_producer_a).await?;
+        let block_reward_tx = block_reward();
+        let block_reward_tx =
+            sign_shadow_tx(block_reward_tx, &ctx.block_producer_a, DEFAULT_PRIORITY_FEE).await?;
         expected_tx_hashes.push(*block_reward_tx.hash());
         shadow_txs.push(block_reward_tx);
 
         // 2. Unstake
         let unstake_tx = unstake(address_b);
-        let unstake_tx = sign_shadow_tx(unstake_tx, &ctx.block_producer_a).await?;
+        let unstake_tx =
+            sign_shadow_tx(unstake_tx, &ctx.block_producer_a, DEFAULT_PRIORITY_FEE).await?;
         expected_tx_hashes.push(*unstake_tx.hash());
         shadow_txs.push(unstake_tx);
 
         // 3. Storage fees
         let storage_fees_tx = storage_fees(address_c);
-        let storage_fees_tx = sign_shadow_tx(storage_fees_tx, &ctx.block_producer_a).await?;
+        let storage_fees_tx =
+            sign_shadow_tx(storage_fees_tx, &ctx.block_producer_a, DEFAULT_PRIORITY_FEE).await?;
         expected_tx_hashes.push(*storage_fees_tx.hash());
         shadow_txs.push(storage_fees_tx);
 
         // 4. Another block reward
-        let block_reward_2_tx = block_reward(address_b);
-        let block_reward_2_tx = sign_shadow_tx(block_reward_2_tx, &ctx.block_producer_a).await?;
+        let block_reward_2_tx = block_reward();
+        let block_reward_2_tx = sign_shadow_tx(
+            block_reward_2_tx,
+            &ctx.block_producer_a,
+            DEFAULT_PRIORITY_FEE,
+        )
+        .await?;
         expected_tx_hashes.push(*block_reward_2_tx.hash());
         shadow_txs.push(block_reward_2_tx);
 
         // 5. Stake transaction
         let stake_tx = stake(address_a);
-        let stake_tx = sign_shadow_tx(stake_tx, &ctx.block_producer_a).await?;
+        let stake_tx =
+            sign_shadow_tx(stake_tx, &ctx.block_producer_a, DEFAULT_PRIORITY_FEE).await?;
         expected_tx_hashes.push(*stake_tx.hash());
         shadow_txs.push(stake_tx);
 
@@ -1438,28 +1527,21 @@ mod tests {
         let ctx = TestContext::new().await?;
         let ((mut node, shadow_tx_store), ctx) = ctx.get_single_node()?;
 
-        let target_address = ctx.target_account.address();
-
-        // First, give the account some initial balance to allow pledge
-        let initial_funding = U256::from(10_000_000_000_000_000_000_u64); // 10 ETH
-        let block_reward_tx =
-            ShadowTransaction::new_v1(TransactionPacket::BlockReward(BlockRewardIncrement {
-                amount: initial_funding,
-                target: target_address,
-            }));
-        let block_reward_tx = sign_shadow_tx(block_reward_tx, &ctx.block_producer_a).await?;
-        mine_block(&mut node, &shadow_tx_store, vec![block_reward_tx]).await?;
-
+        let target_address = ctx.normal_signer.address();
         let initial_balance = get_balance(&node.inner, target_address);
+        assert!(
+            initial_balance > U256::ZERO,
+            "Target account should have initial balance"
+        );
 
-        // Create pledge transaction
-        let pledge_amount = U256::from(5_000_000_000_000_000_000_u64); // 5 ETH
+        // Create pledge transaction with a smaller amount to ensure it's less than initial balance
+        let pledge_amount = U256::from(1_000_000_000_000_000_u64); // 0.001 ETH
         let pledge_tx = ShadowTransaction::new_v1(TransactionPacket::Pledge(BalanceDecrement {
             amount: pledge_amount,
             target: target_address,
             irys_ref: alloy_primitives::FixedBytes::ZERO,
         }));
-        let pledge_tx = sign_shadow_tx(pledge_tx, &ctx.block_producer_a).await?;
+        let pledge_tx = sign_shadow_tx(pledge_tx, &ctx.normal_signer, DEFAULT_PRIORITY_FEE).await?;
         let pledge_tx_hash = *pledge_tx.hash();
 
         // Mine block with pledge transaction
@@ -1473,7 +1555,7 @@ mod tests {
             &node,
             target_address,
             initial_balance,
-            pledge_amount,
+            pledge_amount + U256::from(DEFAULT_PRIORITY_FEE),
             false,
             "Target balance should decrease after pledge",
         );
@@ -1487,22 +1569,17 @@ mod tests {
         let ctx = TestContext::new().await?;
         let ((mut node, shadow_tx_store), ctx) = ctx.get_single_node()?;
 
-        let target_address = ctx.target_account.address();
-
-        // First, give the account some balance with a block reward
-        let initial_balance_amount = U256::from(10_000_000_000_000_000_000_u64); // 10 ETH
-        let block_reward_tx =
-            ShadowTransaction::new_v1(TransactionPacket::BlockReward(BlockRewardIncrement {
-                amount: initial_balance_amount,
-                target: target_address,
-            }));
-        let block_reward_tx = sign_shadow_tx(block_reward_tx, &ctx.block_producer_a).await?;
-        mine_block(&mut node, &shadow_tx_store, vec![block_reward_tx]).await?;
+        // Use a funded account
+        let target_address = ctx.normal_signer.address();
 
         let balance_after_initial_funding = get_balance(&node.inner, target_address);
+        assert!(
+            balance_after_initial_funding > U256::ZERO,
+            "Target account should have initial balance"
+        );
 
         // Now create unpledge transaction
-        let unpledge_amount = U256::from(3_000_000_000_000_000_000_u64); // 3 ETH
+        let unpledge_amount = U256::from(1_000_000_000_000_000_u64); // 0.001 ETH
         let unpledge_tx = ShadowTransaction::new_v1(TransactionPacket::Unpledge(
             shadow_tx::EitherIncrementOrDecrement::BalanceIncrement(BalanceIncrement {
                 amount: unpledge_amount,
@@ -1510,7 +1587,8 @@ mod tests {
                 irys_ref: alloy_primitives::FixedBytes::ZERO,
             }),
         ));
-        let unpledge_tx = sign_shadow_tx(unpledge_tx, &ctx.block_producer_a).await?;
+        let unpledge_tx =
+            sign_shadow_tx(unpledge_tx, &ctx.block_producer_a, DEFAULT_PRIORITY_FEE).await?;
         let unpledge_tx_hash = *unpledge_tx.hash();
 
         // Mine block with unpledge transaction
@@ -1524,7 +1602,7 @@ mod tests {
             &node,
             target_address,
             balance_after_initial_funding,
-            unpledge_amount,
+            unpledge_amount - U256::from(DEFAULT_PRIORITY_FEE),
             true,
             "Target balance should increase after unpledge",
         );
@@ -1538,18 +1616,8 @@ mod tests {
         let ctx = TestContext::new().await?;
         let ((mut node, shadow_tx_store), ctx) = ctx.get_single_node()?;
 
-        let target_address = ctx.target_account.address();
-
-        // First, give the account some initial balance to allow pledge operations
-        let initial_funding = U256::from(5_000_000_000_000_000_000_u64); // 5 ETH
-        let block_reward_tx =
-            ShadowTransaction::new_v1(TransactionPacket::BlockReward(BlockRewardIncrement {
-                amount: initial_funding,
-                target: target_address,
-            }));
-        let block_reward_tx = sign_shadow_tx(block_reward_tx, &ctx.block_producer_a).await?;
-        mine_block(&mut node, &shadow_tx_store, vec![block_reward_tx]).await?;
-
+        // Use a funded account
+        let target_address = ctx.normal_signer.address();
         let initial_balance = get_balance(&node.inner, target_address);
 
         // Create multiple pledge and unpledge transactions
@@ -1558,19 +1626,22 @@ mod tests {
 
         // 1. Pledge transaction
         let pledge_tx = pledge(target_address);
-        let pledge_tx = sign_shadow_tx(pledge_tx, &ctx.block_producer_a).await?;
+        let pledge_tx =
+            sign_shadow_tx(pledge_tx, &ctx.block_producer_a, DEFAULT_PRIORITY_FEE).await?;
         expected_tx_hashes.push(*pledge_tx.hash());
         shadow_txs.push(pledge_tx);
 
         // 2. Another pledge transaction
         let pledge_tx2 = pledge(target_address);
-        let pledge_tx2 = sign_shadow_tx(pledge_tx2, &ctx.block_producer_a).await?;
+        let pledge_tx2 =
+            sign_shadow_tx(pledge_tx2, &ctx.block_producer_a, DEFAULT_PRIORITY_FEE).await?;
         expected_tx_hashes.push(*pledge_tx2.hash());
         shadow_txs.push(pledge_tx2);
 
         // 3. Unpledge transaction
         let unpledge_tx = unpledge(target_address);
-        let unpledge_tx = sign_shadow_tx(unpledge_tx, &ctx.block_producer_a).await?;
+        let unpledge_tx =
+            sign_shadow_tx(unpledge_tx, &ctx.block_producer_a, DEFAULT_PRIORITY_FEE).await?;
         expected_tx_hashes.push(*unpledge_tx.hash());
         shadow_txs.push(unpledge_tx);
 
@@ -1602,18 +1673,24 @@ mod tests {
             );
         }
 
-        // Verify final balance (2 pledge decrements - 1 unpledge increment = net -1)
+        // Calculate expected final balance accounting for priority fees
+        // Each transaction costs DEFAULT_PRIORITY_FEE
+        // Net operation: 2 pledge decrements (-2 wei) + 1 unpledge increment (+1 wei) = -1 wei
+        // Total priority fees: 3 * DEFAULT_PRIORITY_FEE
+        let total_priority_fees = U256::from(DEFAULT_PRIORITY_FEE) * U256::from(3);
+        let net_operation_change = U256::ONE; // Net decrease of 1 wei from operations
+        let expected_final_balance = initial_balance - net_operation_change - total_priority_fees;
+
         let final_balance = get_balance(&node.inner, target_address);
-        let expected_final_balance = initial_balance - U256::ONE; // 2 decrements - 1 increment = -1
         assert_eq!(
             final_balance, expected_final_balance,
-            "Final balance should reflect net effect of pledge/unpledge operations"
+            "Final balance should reflect net effect of pledge/unpledge operations plus priority fees"
         );
 
         Ok(())
     }
 
-    /// Test unpledge on non-existent account creates the account
+    /// Test unpledge on non-existent account is rejected
     #[test_log::test(tokio::test)]
     async fn test_unpledge_nonexistent_account() -> eyre::Result<()> {
         let ctx = TestContext::new().await?;
@@ -1639,24 +1716,47 @@ mod tests {
                 irys_ref: alloy_primitives::FixedBytes::ZERO,
             }),
         ));
-        let unpledge_tx = sign_shadow_tx(unpledge_tx, &ctx.block_producer_a).await?;
+        let unpledge_tx =
+            sign_shadow_tx(unpledge_tx, &ctx.block_producer_a, DEFAULT_PRIORITY_FEE).await?;
         let unpledge_tx_hash = *unpledge_tx.hash();
+
+        // Submit a normal transaction to ensure block is produced
+        let normal_tx_hash = create_and_submit_normal_tx(
+            &mut node,
+            0,
+            U256::from(1000),
+            1_000_000_000_u128,
+            Address::random(),
+            &ctx.normal_signer,
+        )
+        .await?;
 
         // Produce a new block
         let block_payload = mine_block(&mut node, &shadow_tx_store, vec![unpledge_tx]).await?;
 
-        // Verify the unpledge transaction IS included (balance increments can create accounts)
-        assert_txs_in_block(
+        // Verify the unpledge transaction is NOT included (rejected due to non-existent account)
+        assert_txs_not_in_block(
             &block_payload,
             &[unpledge_tx_hash],
-            "Unpledge transaction should be included and create account",
+            "Unpledge transaction for non-existent account should not be included in block",
         );
 
-        // Verify the account now exists with the unpledged balance
-        let final_balance = get_balance(&node.inner, nonexistent_address);
-        assert_eq!(
-            final_balance, unpledge_amount,
-            "Account should have been created with unpledged amount"
+        // Verify the normal transaction IS included
+        assert_txs_in_block(
+            &block_payload,
+            &[normal_tx_hash],
+            "Normal transaction should be included in block",
+        );
+
+        // Verify the account still doesn't exist
+        let final_account = node
+            .inner
+            .provider
+            .basic_account(&nonexistent_address)
+            .unwrap();
+        assert!(
+            final_account.is_none(),
+            "Non-existent account should remain non-existent after rejected unpledge"
         );
 
         Ok(())
@@ -1685,7 +1785,8 @@ mod tests {
             target: nonexistent_address,
             irys_ref: alloy_primitives::FixedBytes::ZERO,
         }));
-        let pledge_tx = sign_shadow_tx(pledge_tx, &ctx.block_producer_a).await?;
+        let pledge_tx =
+            sign_shadow_tx(pledge_tx, &ctx.block_producer_a, DEFAULT_PRIORITY_FEE).await?;
         let pledge_tx_hash = *pledge_tx.hash();
 
         // Submit a normal transaction to ensure block is produced
@@ -1718,6 +1819,222 @@ mod tests {
 
         Ok(())
     }
+
+    /// Test that shadow transactions with priority fees distribute fees to beneficiary
+    #[test_log::test(tokio::test)]
+    async fn test_shadow_tx_priority_fee_distribution() -> eyre::Result<()> {
+        // First create context to get block producer address
+        let temp_ctx = TestContext::new().await?;
+        let beneficiary_address = temp_ctx.block_producer_a.address();
+
+        // Set up context with block producer as beneficiary
+        let ctx = TestContext::new_with_payload_attributes(move |timestamp| {
+            eth_payload_attributes_with_beneficiary(timestamp, beneficiary_address)
+        })
+        .await?;
+        let ((mut node, shadow_tx_store), ctx) = ctx.get_single_node()?;
+
+        // Get initial balances
+        let beneficiary = beneficiary_address; // Miner is the beneficiary
+        let target_address = ctx.target_account.address();
+
+        // Fund the target account first to ensure it can pay priority fees
+        let funding_amount = U256::from(100_000_000_000_u128); // 100 Gwei
+        let fund_tx =
+            ShadowTransaction::new_v1(TransactionPacket::BlockReward(BlockRewardIncrement {
+                amount: funding_amount,
+            }));
+        let fund_tx = sign_shadow_tx(fund_tx, &ctx.block_producer_a, DEFAULT_PRIORITY_FEE).await?;
+        mine_block(&mut node, &shadow_tx_store, vec![fund_tx]).await?;
+
+        let initial_beneficiary_balance = get_balance(&node.inner, beneficiary);
+        let initial_target_balance = get_balance(&node.inner, target_address);
+
+        // Create shadow transaction with significant priority fee
+        let priority_fee_per_gas = 10_000_000_000_u128; // 10 Gwei
+                                                        // Use unstake instead of block_reward so there's a target for priority fee
+        let shadow_tx = unstake(target_address);
+        let shadow_tx_raw = compose_shadow_tx(1, &shadow_tx, priority_fee_per_gas);
+        let expected_priority_fee = U256::from(priority_fee_per_gas);
+
+        // Sign and prepare the transaction using the helper (signed by block producer)
+        let shadow_tx_pooled = sign_tx(shadow_tx_raw, &ctx.block_producer_a).await;
+
+        // Mine block with shadow transaction
+        let _block_payload =
+            mine_block(&mut node, &shadow_tx_store, vec![shadow_tx_pooled]).await?;
+
+        // Verify beneficiary received the priority fee
+        assert_balance_change(
+            &node,
+            beneficiary,
+            initial_beneficiary_balance,
+            expected_priority_fee,
+            true,
+            "Beneficiary should receive priority fee",
+        );
+
+        // Verify target balance changed: received unstake amount (1 wei) minus priority fee
+        let unstake_amount = U256::from(1); // unstake gives 1 wei
+        let net_decrease = expected_priority_fee - unstake_amount; // Fee is larger than unstake amount
+        assert_balance_change(
+            &node,
+            target_address,
+            initial_target_balance,
+            net_decrease,
+            false, // This is a decrease
+            "Target balance should decrease by net of priority fee minus unstake amount",
+        );
+
+        Ok(())
+    }
+
+    /// Test multiple shadow transactions accumulate priority fees correctly
+    #[test_log::test(tokio::test)]
+    async fn test_multiple_shadow_tx_priority_fees() -> eyre::Result<()> {
+        // First create context to get block producer address
+        let temp_ctx = TestContext::new().await?;
+        let beneficiary_address = temp_ctx.block_producer_a.address();
+
+        // Set up context with block producer as beneficiary
+        let ctx = TestContext::new_with_payload_attributes(move |timestamp| {
+            eth_payload_attributes_with_beneficiary(timestamp, beneficiary_address)
+        })
+        .await?;
+        let ((mut node, shadow_tx_store), ctx) = ctx.get_single_node()?;
+
+        let beneficiary = beneficiary_address; // Miner is the beneficiary
+        let target_address = ctx.target_account.address();
+
+        // Fund the target account first to ensure it can pay priority fees
+        let funding_amount = U256::from(100_000_000_000_u128); // 100 Gwei
+        let fund_tx =
+            ShadowTransaction::new_v1(TransactionPacket::BlockReward(BlockRewardIncrement {
+                amount: funding_amount,
+            }));
+        let fund_tx = sign_shadow_tx(fund_tx, &ctx.block_producer_a, DEFAULT_PRIORITY_FEE).await?;
+        mine_block(&mut node, &shadow_tx_store, vec![fund_tx]).await?;
+
+        let initial_beneficiary_balance = get_balance(&node.inner, beneficiary);
+        let initial_target_balance = get_balance(&node.inner, target_address);
+
+        // Create multiple shadow transactions with different priority fees
+        let mut shadow_txs = Vec::new();
+        let mut total_expected_fee = U256::ZERO;
+
+        // Mix transaction types - some with targets (unstake) and some without (block_reward)
+        // Transaction 1: Unstake (has target, so priority fee is distributed)
+        let priority_fee_1 = 1_000_000_000_u128; // 1 Gwei
+        let shadow_tx_1 = unstake(target_address);
+        let shadow_tx_raw_1 = compose_shadow_tx(1, &shadow_tx_1, priority_fee_1);
+        total_expected_fee += U256::from(priority_fee_1);
+        let shadow_tx_pooled_1 = sign_tx(shadow_tx_raw_1, &ctx.block_producer_a).await;
+        shadow_txs.push(shadow_tx_pooled_1);
+
+        // Transaction 2: Block reward (no target, so no priority fee distributed)
+        let priority_fee_2 = 2_000_000_000_u128; // 2 Gwei
+        let shadow_tx_2 = block_reward();
+        let shadow_tx_raw_2 = compose_shadow_tx(1, &shadow_tx_2, priority_fee_2);
+        // This fee won't be distributed since block reward has no target
+        let shadow_tx_pooled_2 = sign_tx(shadow_tx_raw_2, &ctx.block_producer_a).await;
+        shadow_txs.push(shadow_tx_pooled_2);
+
+        // Transaction 3: Stake (has target, so priority fee is distributed)
+        let priority_fee_3 = 3_000_000_000_u128; // 3 Gwei
+        let shadow_tx_3 = stake(target_address);
+        let shadow_tx_raw_3 = compose_shadow_tx(1, &shadow_tx_3, priority_fee_3);
+        total_expected_fee += U256::from(priority_fee_3);
+        let shadow_tx_pooled_3 = sign_tx(shadow_tx_raw_3, &ctx.block_producer_a).await;
+        shadow_txs.push(shadow_tx_pooled_3);
+
+        // Mine block with all shadow transactions
+        let _block_payload = mine_block(&mut node, &shadow_tx_store, shadow_txs).await?;
+
+        // Verify beneficiary received only fees from transactions with targets
+        // Only unstake (1 Gwei) and stake (3 Gwei) have targets, so total = 4 Gwei
+        let expected_beneficiary_fee = U256::from(priority_fee_1) + U256::from(priority_fee_3);
+        assert_balance_change(
+            &node,
+            beneficiary,
+            initial_beneficiary_balance,
+            expected_beneficiary_fee + U256::from(1), // fees + block reward amount
+            true,
+            "Beneficiary should receive fees only from transactions with targets plus block reward",
+        );
+
+        // Verify target balance changed by net of operations and fees
+        // Target receives: +1 wei (unstake) -1 wei (stake) -4 Gwei (fees) = -4 Gwei total
+        let net_target_change = U256::from(4_000_000_000_u64); // 4 Gwei deducted
+        assert_balance_change(
+            &node,
+            target_address,
+            initial_target_balance,
+            net_target_change,
+            false, // This is a decrease
+            "Target should pay priority fees for transactions where it's the target",
+        );
+
+        Ok(())
+    }
+
+    /// Test shadow tx priority fees go to different miner than tx signer
+    #[test_log::test(tokio::test)]
+    async fn test_shadow_tx_priority_fee_different_miner() -> eyre::Result<()> {
+        // Use block producer B as the miner/beneficiary
+        let temp_ctx = TestContext::new().await?;
+        let miner_address = temp_ctx.block_producer_b.address();
+
+        // Create context with block producer B as beneficiary
+        let ctx = TestContext::new_with_payload_attributes(move |timestamp| {
+            eth_payload_attributes_with_beneficiary(timestamp, miner_address)
+        })
+        .await?;
+        let ((mut node, shadow_tx_store), ctx) = ctx.get_single_node()?;
+
+        // Get initial balances
+        let initial_miner_balance = get_balance(&node.inner, miner_address);
+        let initial_signer_balance = get_balance(&node.inner, ctx.block_producer_a.address());
+
+        // Create shadow transaction with priority fee
+        let priority_fee_per_gas = 20_000_000_000_u128; // 20 Gwei
+                                                        // Use stake transaction which has a target
+        let target_address = ctx.block_producer_a.address(); // Producer A is the target
+        let shadow_tx = stake(target_address);
+        let shadow_tx_raw = compose_shadow_tx(1, &shadow_tx, priority_fee_per_gas);
+        let expected_priority_fee = U256::from(priority_fee_per_gas);
+
+        // Sign with block producer A (the target, not the miner)
+        let shadow_tx_pooled = sign_tx(shadow_tx_raw, &ctx.block_producer_a).await;
+
+        // Mine block
+        let _block_payload =
+            mine_block(&mut node, &shadow_tx_store, vec![shadow_tx_pooled]).await?;
+
+        // Verify miner (producer B) received the priority fee
+        let expected_total = expected_priority_fee; // priority fee only
+        assert_balance_change(
+            &node,
+            miner_address,
+            initial_miner_balance,
+            expected_total,
+            true,
+            "Miner (block producer B) should receive priority fee",
+        );
+
+        // Verify signer (producer A) balance decreased by stake amount + priority fee
+        let stake_amount = U256::from(1); // stake decrements 1 wei
+        let total_decrease = stake_amount + expected_priority_fee;
+        assert_balance_change(
+            &node,
+            ctx.block_producer_a.address(),
+            initial_signer_balance,
+            total_decrease,
+            false, // This is a decrease
+            "Signer (block producer A) balance should decrease by stake amount plus priority fee",
+        );
+
+        Ok(())
+    }
 }
 
 #[cfg(any(feature = "test-utils", test))]
@@ -1727,7 +2044,7 @@ pub mod test_utils {
     use crate::payload::DeterministicShadowTxKey;
     use crate::shadow_tx::{ShadowTransaction, TransactionPacket};
     use alloy_consensus::EthereumTxEnvelope;
-    use alloy_consensus::{SignableTransaction as _, TxEip4844, TxLegacy};
+    use alloy_consensus::{SignableTransaction as _, TxEip1559, TxEip4844, TxLegacy};
     use alloy_genesis::Genesis;
     use alloy_network::EthereumWallet;
     use alloy_network::TxSigner;
@@ -1736,6 +2053,9 @@ pub mod test_utils {
     use alloy_primitives::{TxKind, U256};
     use alloy_rpc_types::engine::PayloadAttributes;
     use reth::providers::CanonStateSubscriptions;
+
+    /// Default priority fee for shadow transactions in tests (1 Gwei)
+    pub const DEFAULT_PRIORITY_FEE: u128 = 1_000_000_000;
     use reth::{
         api::{FullNodePrimitives, PayloadAttributesBuilder},
         args::{DiscoveryArgs, NetworkArgs, RpcServerArgs},
@@ -1848,12 +2168,13 @@ pub mod test_utils {
         }
     }
 
-    /// Helper for creating and submitting shadow transactions
+    /// Helper for creating and signing shadow transactions with configurable priority fee.
     pub async fn sign_shadow_tx(
         shadow_tx: ShadowTransaction,
         signer: &Arc<dyn TxSigner<Signature> + Send + Sync>,
+        max_priority_fee_per_gas: u128,
     ) -> eyre::Result<EthPooledTransaction> {
-        let shadow_tx_raw = compose_shadow_tx(1, &shadow_tx);
+        let shadow_tx_raw = compose_shadow_tx(1, &shadow_tx, max_priority_fee_per_gas);
         let shadow_pooled_tx = sign_tx(shadow_tx_raw, signer).await;
         Ok(shadow_pooled_tx)
     }
@@ -1868,7 +2189,7 @@ pub mod test_utils {
     ) -> eyre::Result<Vec<EthPooledTransaction>> {
         let mut txs = Vec::new();
         for _ in 0..count {
-            let tx = sign_shadow_tx(shadow_tx.clone(), signer).await?;
+            let tx = sign_shadow_tx(shadow_tx.clone(), signer, DEFAULT_PRIORITY_FEE).await?;
             txs.push(tx);
         }
         shadow_tx_store.set_shadow_txs(key, txs.clone());
@@ -2097,7 +2418,7 @@ pub mod test_utils {
     pub fn create_shadow_tx(tx_type: u8, address: Address) -> ShadowTransaction {
         use crate::shadow_tx::*;
         match tx_type {
-            BLOCK_REWARD_ID => block_reward(address),
+            BLOCK_REWARD_ID => block_reward(),
             UNSTAKE_ID => unstake(address),
             STAKE_ID => stake(address),
             STORAGE_FEES_ID => storage_fees(address),
@@ -2161,7 +2482,8 @@ pub mod test_utils {
                     ShadowTransaction::V1 { packet } => ShadowTransaction::new_v1(packet),
                 };
 
-                let shadow_tx = sign_shadow_tx(updated_shadow_tx, signer).await?;
+                let shadow_tx =
+                    sign_shadow_tx(updated_shadow_tx, signer, DEFAULT_PRIORITY_FEE).await?;
                 shadow_txs.push(shadow_tx);
             }
 
@@ -2184,12 +2506,9 @@ pub mod test_utils {
     }
 
     /// Compose a shadow tx for block reward.
-    pub fn block_reward(address: Address) -> ShadowTransaction {
+    pub fn block_reward() -> ShadowTransaction {
         ShadowTransaction::new_v1(TransactionPacket::BlockReward(
-            shadow_tx::BlockRewardIncrement {
-                amount: U256::ONE,
-                target: address,
-            },
+            shadow_tx::BlockRewardIncrement { amount: U256::ONE },
         ))
     }
 
@@ -2295,12 +2614,25 @@ pub mod test_utils {
     }
 
     /// Sign a legacy transaction with the provided signer.
-    pub async fn sign_tx(
+    pub async fn sign_tx_legacy(
         mut tx_raw: TxLegacy,
         new_signer: &Arc<dyn alloy_network::TxSigner<Signature> + Send + Sync>,
     ) -> EthPooledTransaction<alloy_consensus::EthereumTxEnvelope<TxEip4844>> {
         let signed_tx = new_signer.sign_transaction(&mut tx_raw).await.unwrap();
         let tx = alloy_consensus::EthereumTxEnvelope::Legacy(tx_raw.into_signed(signed_tx))
+            .try_into_recovered()
+            .unwrap();
+
+        EthPooledTransaction::new(tx, 300)
+    }
+
+    /// Sign an EIP-1559 transaction with the provided signer.
+    pub async fn sign_tx(
+        mut tx_raw: TxEip1559,
+        new_signer: &Arc<dyn alloy_network::TxSigner<Signature> + Send + Sync>,
+    ) -> EthPooledTransaction<alloy_consensus::EthereumTxEnvelope<TxEip4844>> {
+        let signed_tx = new_signer.sign_transaction(&mut tx_raw).await.unwrap();
+        let tx = alloy_consensus::EthereumTxEnvelope::Eip1559(tx_raw.into_signed(signed_tx))
             .try_into_recovered()
             .unwrap();
 
@@ -2417,6 +2749,21 @@ pub mod test_utils {
             timestamp,
             prev_randao: B256::ZERO,
             suggested_fee_recipient: Address::ZERO,
+            withdrawals: Some(vec![]),
+            parent_beacon_block_root: Some(B256::ZERO),
+        };
+        EthPayloadBuilderAttributes::new(B256::ZERO, attributes)
+    }
+
+    /// Returns payload attributes with a custom beneficiary address.
+    pub fn eth_payload_attributes_with_beneficiary(
+        timestamp: u64,
+        beneficiary: Address,
+    ) -> EthPayloadBuilderAttributes {
+        let attributes = PayloadAttributes {
+            timestamp,
+            prev_randao: B256::ZERO,
+            suggested_fee_recipient: beneficiary,
             withdrawals: Some(vec![]),
             parent_beacon_block_root: Some(B256::ZERO),
         };


### PR DESCRIPTION
**Describe the changes**
- switched to using Eip1559 txs for shadow txs - they allow specifying the fee that must be given to the miner in the tx itself.
- During shadow tx processing give the fee to the miner of the block
- The fee is now provided by irys during shadow tx construction
- irys-reth will enforce that block rewards do not distribute fees

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.
