### PR TITLE
fix: prevent commit, via early return from f() if Err returned

### DIFF
--- a/crates/database/src/db.rs
+++ b/crates/database/src/db.rs
@@ -207,13 +207,15 @@ mod tests {
     use super::*;
     use crate::submodule::{create_or_open_submodule_db, tables::DataSizeByDataRoot};
     use eyre::WrapErr as _;
+    use irys_testing_utils::temporary_directory;
     use irys_types::H256;
     use reth_db::transaction::DbTxMut as _;
 
     #[test]
     fn update_eyre_no_commit_on_error() -> eyre::Result<()> {
         //create instance of DatabaseEnv with a test database
-        let db = create_or_open_submodule_db("test_database")
+        let temp_dir = temporary_directory(None, false);
+        let db = create_or_open_submodule_db(temp_dir)
             .wrap_err("Failed to open test DB")
             .unwrap();
 

--- a/crates/database/src/db.rs
+++ b/crates/database/src/db.rs
@@ -204,8 +204,6 @@ impl<K: TransactionKind, T: DupSort> IrysDupCursorExt<T> for Cursor<K, T> {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
     use super::*;
     use crate::submodule::{create_or_open_submodule_db, tables::DataSizeByDataRoot};
     use eyre::WrapErr as _;

--- a/crates/database/src/db.rs
+++ b/crates/database/src/db.rs
@@ -208,13 +208,13 @@ mod tests {
 
     use super::*;
     use crate::submodule::{create_or_open_submodule_db, tables::DataSizeByDataRoot};
-    use eyre::WrapErr;
+    use eyre::WrapErr as _;
     use irys_types::H256;
-    use reth_db::transaction::DbTxMut; // for demonstration
+    use reth_db::transaction::DbTxMut as _;
 
     #[test]
     fn update_eyre_no_commit_on_error() -> eyre::Result<()> {
-        // We'll need a test instance of DatabaseEnv
+        //create instance of DatabaseEnv with a test database
         let db = create_or_open_submodule_db("test_database")
             .wrap_err("Failed to open test DB")
             .unwrap();

--- a/crates/database/src/db.rs
+++ b/crates/database/src/db.rs
@@ -139,10 +139,9 @@ impl IrysDatabaseExt for DatabaseEnv {
     {
         let tx = self.tx_mut()?;
 
-        let res = f(&tx);
+        let res = f(&tx)?;
         tx.commit()?;
-
-        res
+        Ok(res)
     }
 
     /// Takes a function and passes a read-only transaction into it, making sure it's closed in the
@@ -153,10 +152,9 @@ impl IrysDatabaseExt for DatabaseEnv {
     {
         let tx = self.tx()?;
 
-        let res = f(&tx);
+        let res = f(&tx)?;
         tx.commit()?;
-
-        res
+        Ok(res)
     }
 }
 

--- a/crates/database/src/db.rs
+++ b/crates/database/src/db.rs
@@ -239,8 +239,7 @@ mod tests {
             "Expected an error from update_eyre closure"
         );
 
-        // Verify no commit has occurred, i.e. there are still zero rows in the db table
-        std::thread::sleep(Duration::from_secs(1));
+        // Verify no commit has occurred, i.e. there are still initial_db_rows rows in the db table
         assert_eq!(
             read_tx
                 .cursor_read::<DataSizeByDataRoot>()?


### PR DESCRIPTION
**Describe the changes**
 - database commits will no longer occur if f() errors in `update_eyre()` or `view_eyre()`

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.
