### PR TITLE
chore: cc.flag("-O3 -ffast-math");

### DIFF
--- a/crates/c/build/capacity.rs
+++ b/crates/c/build/capacity.rs
@@ -24,7 +24,7 @@ pub(crate) fn build_capacity(c_src: &Path, _ssl_inc_dir: &Path) {
     }
 
     cc.flag("-fPIC");
-    cc.flag("-Ofast");
+    cc.flag("-O3 -ffast-math");
     cc.flag("-g0");
     cc.flag("-march=native");
     cc.file(c_src.join("capacity_single.c"));

--- a/crates/c/build/vdf.rs
+++ b/crates/c/build/vdf.rs
@@ -29,7 +29,7 @@ pub(crate) fn build_vdf(c_src: &Path, _ssl_inc_dir: &Path) {
 
     cc.flag("-fPIC");
     cc.flag("-std=c++17");
-    cc.flag("-Ofast");
+    cc.flag("-O3 -ffast-math");
     cc.flag("-g0");
     cc.flag("-march=native");
     cc.file(c_src.join("vdf.cpp")).compile("vdf");


### PR DESCRIPTION
**Describe the changes**
Fix compiler warning
```
warning: irys-c@0.1.0: clang++: warning: argument '-Ofast' is deprecated; use '-O3 -ffast-math' for the same behavior, or '-O3' to enable only conforming optimizations [-Wdeprecated-ofast]
warning: irys-c@0.1.0: clang: warning: argument '-Ofast' is deprecated; use '-O3 -ffast-math' for the same behavior, or '-O3' to enable only conforming optimizations [-Wdeprecated-ofast]
```

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.
