### PR TITLE
feat: add custom timestamping panic hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5263,6 +5263,7 @@ dependencies = [
 name = "irys-testing-utils"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "color-eyre",
  "tempfile",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4913,7 +4913,6 @@ dependencies = [
  "assert_matches",
  "awc",
  "base58",
- "color-eyre",
  "core_affinity",
  "eyre",
  "futures",

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -30,7 +30,6 @@ irys-api-client.workspace = true
 irys-reward-curve.workspace = true
 irys-primitives.workspace = true
 base58.workspace = true
-color-eyre.workspace = true
 tracing-error.workspace = true
 eyre.workspace = true
 rand.workspace = true

--- a/crates/chain/src/main.rs
+++ b/crates/chain/src/main.rs
@@ -1,4 +1,5 @@
 use irys_chain::{utils::load_config, IrysNode};
+use irys_testing_utils::setup_panic_hook;
 use tracing::info;
 use tracing_error::ErrorLayer;
 use tracing_subscriber::{
@@ -9,7 +10,7 @@ use tracing_subscriber::{
 async fn main() -> eyre::Result<()> {
     // init logging
     init_tracing().expect("initializing tracing should work");
-    color_eyre::install().expect("color eyre could not be installed");
+    setup_panic_hook().expect("custom panic hook installation to succeed");
 
     // load the config
     let config = load_config()?;

--- a/crates/testing-utils/Cargo.toml
+++ b/crates/testing-utils/Cargo.toml
@@ -10,6 +10,7 @@ tracing-subscriber.workspace = true
 tempfile.workspace = true
 color-eyre.workspace = true
 tracing-error.workspace = true
+chrono = { version = "0.4.41", default-features = false, features = ["now"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
**Describe the changes**
This PR adds a custom color-eyre wrapping panic hook that prints timestamps before the color-eyre hook runs, so that we get timestamps with our panics.
