### PR TITLE
feat: add a progress/time based exit condition for `wait_for_processed_block_to_reach_target`

### DIFF
--- a/crates/p2p/src/sync.rs
+++ b/crates/p2p/src/sync.rs
@@ -190,7 +190,7 @@ impl SyncState {
         let target = Arc::clone(&self.sync_target_height);
         let highest_processed_block = Arc::clone(&self.highest_processed_block);
         tokio::spawn(async move {
-            let progress_timeout = Duration::from_millis(60_000);
+            let progress_timeout = Duration::from_secs(60);
             let mut last_made_progress = Instant::now();
             let mut prev_hpb = 0;
             loop {

--- a/crates/p2p/src/sync.rs
+++ b/crates/p2p/src/sync.rs
@@ -204,8 +204,10 @@ impl SyncState {
                 // If this function never resolves, no new blocks can arrive over gossip in that case.
 
                 if hpb + 1 >= target {
-                    break; // synchronised
-                } else if made_progress && last_made_progress.elapsed() > progress_timeout {
+                    // synchronised
+                    break;
+                } else if !made_progress && last_made_progress.elapsed() > progress_timeout {
+                    // didn't make any progress in the last `progress_timeout` duration
                     warn!(
                         "Did not make sync process from {} in {}ms",
                         &hpb,

--- a/crates/p2p/src/sync.rs
+++ b/crates/p2p/src/sync.rs
@@ -7,9 +7,9 @@ use rand::prelude::SliceRandom as _;
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::time::timeout;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, instrument, warn};
 
 const MAX_PROCESSING_BLOCKS_QUEUE_SIZE: usize = 100;
 const BLOCK_BATCH_SIZE: usize = 10;
@@ -179,6 +179,7 @@ impl SyncState {
     }
 
     /// Waits for the highest pre-validated block to reach target sync height
+    /// This has a progress/time based early out - if we don't make at least a block's worth of progress in `progress_timeout`, we return early
     pub async fn wait_for_processed_block_to_reach_target(&self) {
         // If already synced, return immediately
         if !self.is_syncing() {
@@ -189,14 +190,39 @@ impl SyncState {
         let target = Arc::clone(&self.sync_target_height);
         let highest_processed_block = Arc::clone(&self.highest_processed_block);
         tokio::spawn(async move {
-            // We need to add 1 to the highest processed block. For the cases when the node
-            // starts fully caught up, no new blocks are added to the index, and the
-            // target is always going to be one more than the highest processed block.
-            // If this function never resolves, no new blocks can arrive over gossip in that case.
-            while target.load(Ordering::Relaxed)
-                > highest_processed_block.load(Ordering::Relaxed) + 1
-            {
-                tokio::time::sleep(Duration::from_millis(100)).await;
+            let progress_timeout = Duration::from_millis(60_000);
+            let mut last_made_progress = Instant::now();
+            let mut prev_hpb = 0;
+            loop {
+                let target = target.load(Ordering::Relaxed);
+                let hpb = highest_processed_block.load(Ordering::Relaxed);
+                let made_progress = hpb > prev_hpb;
+
+                // We need to add 1 to the highest processed block. For the cases when the node
+                // starts fully caught up, no new blocks are added to the index, and the
+                // target is always going to be one more than the highest processed block.
+                // If this function never resolves, no new blocks can arrive over gossip in that case.
+
+                if hpb + 1 >= target {
+                    break; // synchronised
+                } else if made_progress && last_made_progress.elapsed() > progress_timeout {
+                    warn!(
+                        "Did not make sync process from {} in {}ms",
+                        &hpb,
+                        &progress_timeout.as_millis()
+                    );
+                    break; // progression timeout
+                } else {
+                    if made_progress {
+                        debug!(
+                            "Progressed: {} -> {} (target: {})",
+                            &prev_hpb, &hpb, &target
+                        );
+                        last_made_progress = Instant::now();
+                        prev_hpb = hpb;
+                    };
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
             }
         })
         .await
@@ -216,6 +242,7 @@ impl SyncState {
     }
 }
 
+#[instrument(skip_all, err)]
 pub async fn sync_chain(
     sync_state: SyncState,
     api_client: impl ApiClient,


### PR DESCRIPTION
**Describe the changes**
This PR adds a simple progress/time based exit condition to `wait_for_processed_block_to_reach_target`
this works by resetting a 60s timer every time the highest processed block increases - if the timer expires, `sync_chain` early exits. This is to prevent cases where a node can't sync a chain causing the node to hang indefinitely.

