### PR TITLE
feat: Add optional `reputation_threshold` config

### DIFF
--- a/crates/types/src/config.rs
+++ b/crates/types/src/config.rs
@@ -262,6 +262,10 @@ pub struct NodeConfig {
 
     /// Specifies which consensus rules the node follows
     pub consensus: ConsensusOptions,
+
+    /// Reputation threshold below which peer connections are dropped
+    /// set to none for no threshold and no peer connection is dropped
+    pub reputation_threshold: Option<u16>,
 }
 
 impl From<NodeConfig> for Config {
@@ -911,6 +915,7 @@ impl NodeConfig {
 
             genesis_peer_discovery_timeout_millis: 10000,
             stake_pledge_drives: false,
+            reputation_threshold: None,
         }
     }
 
@@ -1014,6 +1019,7 @@ impl NodeConfig {
 
             genesis_peer_discovery_timeout_millis: 10000,
             stake_pledge_drives: false,
+            reputation_threshold: None,
         }
     }
 
@@ -1364,6 +1370,7 @@ mod tests {
         reward_address = "0x64f1a2829e0e698c18e7792d6e74f67d89aa0a32"
         genesis_peer_discovery_timeout_millis = 10000
         stake_pledge_drives = false
+        reputation_threshold = 20
 
         [[trusted_peers]]
         gossip = "127.0.0.1:8081"


### PR DESCRIPTION
Allow removal of PeerItem from the `PeerList` by adding a low reputation check alongside the inactive peers health check.

Add `remove_peer` method to the `PeerList`
Add unit test `test_peer_reputation_threshold`

**Describe the changes**
This adds a check which runs the same interval as the inactive peer health check and checks repputation scores of the peer list, if the reputation is below threshold then we remove the cache entry and gossip ip entry and rest of the entires. Add one unit test for the change, let me know if I should add other changes, this is my first time contributing 

**Related Issue(s)**
https://github.com/Irys-xyz/irys/issues/211

**Checklist**

- [x] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
I tried to implement what is described in the 4th point of the epic https://github.com/Irys-xyz/irys/issues/211 
