### PR TITLE
feat: change the IngressProofs table to be a DupSort table

### DIFF
--- a/crates/chain/tests/external/api.rs
+++ b/crates/chain/tests/external/api.rs
@@ -123,9 +123,9 @@ async fn external_api() -> eyre::Result<()> {
 
     info!(
         "got ingress proof for data root {}",
-        &ingress_proof.data_root
+        &ingress_proof.proof.data_root
     );
-    assert_eq!(&ingress_proof.data_root, &recv_tx.data_root);
+    assert_eq!(&ingress_proof.proof.data_root, &recv_tx.data_root);
 
     let id: String = tx_id.as_bytes().to_base58();
 

--- a/crates/chain/tests/external/programmable_data_basic.rs
+++ b/crates/chain/tests/external/programmable_data_basic.rs
@@ -172,9 +172,9 @@ async fn test_programmable_data_basic_external() -> eyre::Result<()> {
 
     info!(
         "got ingress proof for data root {}",
-        &ingress_proof.data_root
+        &ingress_proof.proof.data_root
     );
-    assert_eq!(&ingress_proof.data_root, &recv_tx.data_root);
+    assert_eq!(&ingress_proof.proof.data_root, &recv_tx.data_root);
 
     let id: String = tx_id.as_bytes().to_base58();
 

--- a/crates/chain/tests/multi_node/mempool_tests.rs
+++ b/crates/chain/tests/multi_node/mempool_tests.rs
@@ -873,8 +873,8 @@ async fn heavy_mempool_publish_fork_recovery_test() -> eyre::Result<()> {
 
     let mut a_blk1_tx1_published = a_blk1_tx1.header.clone();
     a_blk1_tx1_published.ingress_proofs = Some(TxIngressProof {
-        proof: a_blk1_tx1_proof1.proof,
-        signature: a_blk1_tx1_proof1.signature,
+        proof: a_blk1_tx1_proof1.proof.proof,
+        signature: a_blk1_tx1_proof1.proof.signature,
     });
 
     // assert that a_blk1_tx1 shows back up in get_best_mempool_txs (treated as if it wasn't promoted)
@@ -936,8 +936,8 @@ async fn heavy_mempool_publish_fork_recovery_test() -> eyre::Result<()> {
         .clone()
         .unwrap()
         .ne(&IngressProofsList(vec![TxIngressProof {
-            proof: a_blk1_tx1_proof1.proof,
-            signature: a_blk1_tx1_proof1.signature
+            proof: a_blk1_tx1_proof1.proof.proof,
+            signature: a_blk1_tx1_proof1.proof.signature
         }])));
 
     // now we gossip B3 back to A

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -702,7 +702,7 @@ impl IrysNodeTest<IrysNodeCtx> {
             if let Some(tx_header) = oneshot_rx.await.unwrap().first().unwrap() {
                 //read its ingressproof(s)
                 if let Some(proof) = ro_tx.get::<IngressProofs>(tx_header.data_root).unwrap() {
-                    assert_eq!(proof.data_root, tx_header.data_root);
+                    assert_eq!(proof.proof.data_root, tx_header.data_root);
                     tracing::info!("Proofs available after {} attempts", attempts);
                     unconfirmed_promotions.pop();
                 };

--- a/crates/database/src/tables.rs
+++ b/crates/database/src/tables.rs
@@ -5,10 +5,9 @@ use crate::{
     db_cache::{CachedChunk, CachedChunkIndexEntry, CachedDataRoot},
     submodule::tables::{ChunkOffsets, ChunkPathHashes},
 };
-use irys_types::{
-    ingress::IngressProof, ChunkPathHash, DataRoot, DataTransactionHeader, IrysBlockHeader, H256,
-};
+use irys_types::ingress::CachedIngressProof;
 use irys_types::{Address, Base64, CommitmentTransaction, PeerListItem};
+use irys_types::{ChunkPathHash, DataRoot, DataTransactionHeader, IrysBlockHeader, H256};
 use reth_codecs::Compact;
 use reth_db::{table::DupSort, tables, DatabaseError, TableSet};
 use reth_db::{TableType, TableViewer};
@@ -79,6 +78,8 @@ add_wrapper_struct!((CommitmentTransaction, CompactCommitment));
 add_wrapper_struct!((PeerListItem, CompactPeerListItem));
 add_wrapper_struct!((Base64, CompactBase64));
 
+add_wrapper_struct!((CachedIngressProof, CompactCachedIngressProof));
+
 impl_compression_for_compact!(
     CompactIrysBlockHeader,
     CompactTxHeader,
@@ -93,7 +94,8 @@ impl_compression_for_compact!(
     RelativeStartOffsets,
     DataRootLRUEntry,
     GlobalChunkOffset,
-    CompactBase64
+    CompactBase64,
+    CompactCachedIngressProof
 );
 
 use paste::paste;
@@ -147,7 +149,8 @@ table CachedChunks {
 /// Indexes Ingress proofs by their data_root
 table IngressProofs {
     type Key = DataRoot;
-    type Value = IngressProof;
+    type Value = CompactCachedIngressProof;
+    type SubKey = Address;
 }
 
 /// Maps an ingress proof (by data_root) to the latest possible height it could be used at, given known transactions.


### PR DESCRIPTION
**Describe the changes**
This PR changes the IngressProof table into a DupSort table.
This is done so we can have multiple address -> ingress proof stored under a single DataRoot key, and allows for easier management and ingress proof collection.

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.
