### PR TITLE
feat: replace block fast-track with disabling vdf validation

### DIFF
--- a/crates/actors/src/block_discovery.rs
+++ b/crates/actors/src/block_discovery.rs
@@ -96,7 +96,11 @@ pub enum BlockDiscoveryInternalError {
 
 #[async_trait::async_trait]
 pub trait BlockDiscoveryFacade: Clone + Unpin + Send + Sync + 'static {
-    async fn handle_block(&self, block: Arc<IrysBlockHeader>) -> Result<(), BlockDiscoveryError>;
+    async fn handle_block(
+        &self,
+        block: Arc<IrysBlockHeader>,
+        skip_vdf: bool,
+    ) -> Result<(), BlockDiscoveryError>;
 }
 
 #[derive(Debug, Clone)]
@@ -112,10 +116,10 @@ impl BlockDiscoveryFacadeImpl {
 
 #[async_trait]
 impl BlockDiscoveryFacade for BlockDiscoveryFacadeImpl {
-    async fn handle_block(&self, block: Arc<IrysBlockHeader>) -> Result<(), BlockDiscoveryError> {
+    async fn handle_block(&self, block: Arc<IrysBlockHeader>, skip_vdf: bool) -> Result<(), BlockDiscoveryError> {
         let (tx, rx) = oneshot::channel();
         self.sender
-            .send(BlockDiscoveryMessage::BlockDiscovered(block, Some(tx)))
+            .send(BlockDiscoveryMessage::BlockDiscovered(block, skip_vdf, Some(tx)))
             .map_err(BlockDiscoveryInternalError::SenderError)?;
 
         rx.await.map_err(BlockDiscoveryInternalError::RecvError)?
@@ -125,7 +129,7 @@ impl BlockDiscoveryFacade for BlockDiscoveryFacadeImpl {
 /// a network peer, this message is broadcast.
 #[derive(Message, Debug, Clone)]
 #[rtype(result = "Result<(), BlockDiscoveryError>")]
-pub struct BlockDiscoveredMessage(pub Arc<IrysBlockHeader>);
+pub struct BlockDiscoveredMessage(pub Arc<IrysBlockHeader>, pub bool);
 
 /// Sent when a discovered block is pre-validated
 #[derive(Message, Debug, Clone)]
@@ -234,8 +238,8 @@ impl BlockDiscoveryService {
     #[tracing::instrument(skip_all)]
     async fn handle_message(&self, msg: BlockDiscoveryMessage) -> eyre::Result<()> {
         match msg {
-            BlockDiscoveryMessage::BlockDiscovered(irys_block_header, sender) => {
-                let result = self.inner.clone().block_discovered(irys_block_header).await;
+            BlockDiscoveryMessage::BlockDiscovered(irys_block_header, skip_vdf, sender) => {
+                let result = self.inner.clone().block_discovered(irys_block_header, skip_vdf).await;
                 if let Some(sender) = sender {
                     if let Err(e) = sender.send(result) {
                         tracing::error!("sender error: {:?}", e);
@@ -253,6 +257,7 @@ impl BlockDiscoveryService {
 pub enum BlockDiscoveryMessage {
     BlockDiscovered(
         Arc<IrysBlockHeader>,
+        bool,
         Option<oneshot::Sender<Result<(), BlockDiscoveryError>>>,
     ),
 }
@@ -261,6 +266,7 @@ impl BlockDiscoveryServiceInner {
     pub async fn block_discovered(
         &self,
         block: Arc<IrysBlockHeader>,
+        skip_vdf: bool,
     ) -> Result<(), BlockDiscoveryError> {
         // Validate discovered block
         let new_block_header = block;
@@ -643,6 +649,7 @@ impl BlockDiscoveryServiceInner {
                     .send(BlockTreeServiceMessage::BlockPreValidated {
                         block: new_block_header.clone(),
                         commitment_txs: arc_commitment_txs,
+                        skip_vdf_validation: skip_vdf,
                         response: oneshot_tx,
                     })
                     .map_err(|channel_error| {

--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -763,7 +763,7 @@ pub trait BlockProdStrategy {
         match self
             .inner()
             .block_discovery
-            .handle_block(Arc::clone(&block))
+            .handle_block(Arc::clone(&block), false)
             .await
         {
             Ok(()) => Ok(()),

--- a/crates/actors/src/validation_service.rs
+++ b/crates/actors/src/validation_service.rs
@@ -48,7 +48,7 @@ pub enum VdfValidationResult {
 #[derive(Debug)]
 pub enum ValidationServiceMessage {
     /// Validate a block
-    ValidateBlock { block: Arc<IrysBlockHeader> },
+    ValidateBlock { block: Arc<IrysBlockHeader>, skip_vdf_validation: bool }
 }
 
 /// Main validation service structure
@@ -185,16 +185,14 @@ impl ValidationService {
                 // Receive new validation messages (only when validation is enabled)
                 msg = self.msg_rx.recv() => {
                     match msg {
-                        Some(msg) => {
-                            // Transform message to validation task
-                            let Some(task) = self.inner.clone().create_validation_task(msg, &active_validations) else {
+                        Some(ValidationServiceMessage::ValidateBlock { block, skip_vdf_validation }) => {
+                            let Some(task) = self.inner.clone().create_validation_task(block, &active_validations, skip_vdf_validation) else {
                                 // validation task was not created. The task failed during vdf validation
                                 continue;
                             };
 
                             // push this task to the VDF pending queue
                             active_validations.vdf_pending_queue.push(task.block.block_hash, std::cmp::Reverse(task));
-
                         }
                         None => {
                             // Channel closed
@@ -253,28 +251,25 @@ impl ValidationServiceInner {
     #[instrument(skip_all, fields(block_hash, block_height))]
     fn create_validation_task(
         self: Arc<Self>,
-        msg: ValidationServiceMessage,
+        block: Arc<IrysBlockHeader>,
         active_validations: &ActiveValidations,
+        skip_vdf_validation: bool,
     ) -> Option<BlockValidationTask> {
-        match msg {
-            ValidationServiceMessage::ValidateBlock { block } => {
-                let block_hash = block.block_hash;
-                let block_height = block.height;
+        let block_hash = block.block_hash;
+        let block_height = block.height;
 
-                tracing::Span::current().record("block_hash", tracing::field::display(&block_hash));
-                tracing::Span::current().record("block_height", block_height);
+        tracing::Span::current().record("block_hash", tracing::field::display(&block_hash));
+        tracing::Span::current().record("block_height", block_height);
 
-                debug!("validating block");
+        debug!("validating block");
 
-                // schedule validation task
-                let block_tree_guard = self.block_tree_guard.clone();
+        // schedule validation task
+        let block_tree_guard = self.block_tree_guard.clone();
 
-                let priority: std::cmp::Reverse<active_validations::BlockPriorityMeta> =
-                    active_validations.calculate_priority(&block);
-                let task = BlockValidationTask::new(block, self, block_tree_guard, priority.0);
-                Some(task)
-            }
-        }
+        let priority: std::cmp::Reverse<active_validations::BlockPriorityMeta> =
+            active_validations.calculate_priority(&block);
+        let task = BlockValidationTask::new(block, self, block_tree_guard, priority.0, skip_vdf_validation);
+        Some(task)
     }
 
     #[instrument(skip_all, fields(%step=desired_step_number))]
@@ -307,6 +302,7 @@ impl ValidationServiceInner {
         self: Arc<Self>,
         block: &IrysBlockHeader,
         cancel: Arc<AtomicU8>,
+        skip_vdf_validation: bool,
     ) -> eyre::Result<()> {
         debug!("Verifying VDF info");
 
@@ -330,21 +326,24 @@ impl ValidationServiceInner {
             vdf_info.prev_output,
         );
 
-        // Spawn VDF validation task
+        // Spawn VDF validation task unless skipping
         let vdf_ff = self.service_senders.vdf_fast_forward.clone();
         let vdf_state = self.vdf_state.clone();
-        {
+        if !skip_vdf_validation {
             let vdf_info = vdf_info.clone();
+            let this_inner = Arc::clone(&self);
             tokio::task::spawn_blocking(move || {
                 vdf_steps_are_valid(
-                    &self.pool,
+                    &this_inner.pool,
                     &vdf_info,
-                    &self.config.consensus.vdf,
-                    &self.vdf_state,
+                    &this_inner.config.consensus.vdf,
+                    &this_inner.vdf_state,
                     cancel,
                 )
             })
             .await??;
+        } else {
+            debug!("Skipping vdf_steps_are_valid for block {:?}", block.block_hash);
         }
 
         // Fast forward VDF steps

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -1272,7 +1272,7 @@ impl IrysNodeTest<IrysNodeCtx> {
         irys_block_header: &IrysBlockHeader,
     ) -> eyre::Result<()> {
         match BlockDiscoveryFacadeImpl::new(peer.node_ctx.service_senders.block_discovery.clone())
-            .handle_block(Arc::new(irys_block_header.clone()))
+            .handle_block(Arc::new(irys_block_header.clone()), false)
             .await
         {
             Ok(_) => Ok(()),
@@ -1357,7 +1357,7 @@ impl IrysNodeTest<IrysNodeCtx> {
 
         // Deliver block header
         BlockDiscoveryFacadeImpl::new(peer.node_ctx.service_senders.block_discovery.clone())
-            .handle_block(Arc::new(irys_block_header.clone()))
+            .handle_block(Arc::new(irys_block_header.clone()), false)
             .await
             .map_err(|e| eyre::eyre!("{e:?}"))?;
 

--- a/crates/chain/tests/validation/mod.rs
+++ b/crates/chain/tests/validation/mod.rs
@@ -17,6 +17,7 @@ async fn send_block_to_block_tree(
     node_ctx: &IrysNodeCtx,
     block: Arc<IrysBlockHeader>,
     commitment_txs: Vec<CommitmentTransaction>,
+    skip_vdf_validation: bool,
 ) -> eyre::Result<()> {
     let (response_tx, response_rx) = tokio::sync::oneshot::channel();
 
@@ -26,6 +27,7 @@ async fn send_block_to_block_tree(
         .send(BlockTreeServiceMessage::BlockPreValidated {
             block,
             commitment_txs: Arc::new(commitment_txs),
+            skip_vdf_validation,
             response: response_tx,
         })?;
 
@@ -112,7 +114,8 @@ async fn heavy_block_invalid_stake_value_gets_rejected() -> eyre::Result<()> {
         .unwrap();
 
     // Send block directly to block tree service for validation
-    send_block_to_block_tree(&genesis_node.node_ctx, block.clone(), vec![invalid_pledge]).await?;
+    send_block_to_block_tree(&genesis_node.node_ctx, block.clone(), vec![invalid_pledge], false)
+        .await?;
 
     let outcome = read_block_from_state(&genesis_node.node_ctx, &block.block_hash).await;
     assert_eq!(outcome, BlockValidationOutcome::Discarded);
@@ -203,7 +206,8 @@ async fn heavy_block_invalid_pledge_value_gets_rejected() -> eyre::Result<()> {
         .unwrap();
 
     // Send block directly to block tree service for validation
-    send_block_to_block_tree(&genesis_node.node_ctx, block.clone(), vec![invalid_pledge]).await?;
+    send_block_to_block_tree(&genesis_node.node_ctx, block.clone(), vec![invalid_pledge], false)
+        .await?;
 
     let outcome = read_block_from_state(&genesis_node.node_ctx, &block.block_hash).await;
     assert_eq!(outcome, BlockValidationOutcome::Discarded);
@@ -305,7 +309,13 @@ async fn heavy_block_wrong_commitment_order_gets_rejected() -> eyre::Result<()> 
     block = Arc::new(irys_block);
 
     // Send block directly to block tree service for validation
-    send_block_to_block_tree(&genesis_node.node_ctx, block.clone(), vec![pledge, stake]).await?;
+    send_block_to_block_tree(
+        &genesis_node.node_ctx,
+        block.clone(),
+        vec![pledge, stake],
+        false,
+    )
+    .await?;
 
     let outcome = read_block_from_state(&genesis_node.node_ctx, &block.block_hash).await;
     assert_eq!(outcome, BlockValidationOutcome::Discarded);
@@ -398,6 +408,7 @@ async fn heavy_block_epoch_commitment_mismatch_gets_rejected() -> eyre::Result<(
         &genesis_node.node_ctx,
         block.clone(),
         vec![wrong_commitment],
+        false,
     )
     .await?;
 
@@ -492,7 +503,7 @@ async fn heavy_block_epoch_missing_commitments_gets_rejected() -> eyre::Result<(
     dbg!(&block);
 
     // Send block directly to block tree service for validation
-    send_block_to_block_tree(&genesis_node.node_ctx, block.clone(), vec![]).await?;
+    send_block_to_block_tree(&genesis_node.node_ctx, block.clone(), vec![], false).await?;
 
     let outcome = read_block_from_state(&genesis_node.node_ctx, &block.block_hash).await;
     assert_eq!(outcome, BlockValidationOutcome::Discarded);

--- a/crates/p2p/src/tests/util.rs
+++ b/crates/p2p/src/tests/util.rs
@@ -159,7 +159,8 @@ pub(crate) struct BlockDiscoveryStub {
 impl BlockDiscoveryFacade for BlockDiscoveryStub {
     async fn handle_block(
         &self,
-        block: Arc<IrysBlockHeader>,
+    block: Arc<IrysBlockHeader>,
+    _skip_vdf: bool,
     ) -> std::result::Result<(), BlockDiscoveryError> {
         self.blocks
             .write()


### PR DESCRIPTION
**Describe the changes**
This PR replaces a separate block validation fast-track with going a normal validation route, but with adding a new flag to skip VDF validation

**Related Issue(s)**

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
