### PR TITLE
fix: impose MAX_BLOCK_INDEX_QUERY_LIMIT on /v1/block_index

### DIFF
--- a/crates/api-server/src/routes/block_index.rs
+++ b/crates/api-server/src/routes/block_index.rs
@@ -2,11 +2,24 @@ use crate::ApiState;
 use actix_web::{http::header::ContentType, web, HttpResponse};
 use irys_types::{BlockIndexItem, BlockIndexQuery};
 
+/// Maximum number of blocks that can be requested in a single query.
+///
+/// A hard limit protects the API from requests that would otherwise
+/// require the server to iterate over a very large range of blocks,
+/// potentially leading to excessive memory usage or denial of service.
+const MAX_BLOCK_INDEX_QUERY_LIMIT: usize = 1_000;
+
 pub async fn block_index_route(
     state: web::Data<ApiState>,
     query: web::Query<BlockIndexQuery>,
 ) -> HttpResponse {
     let limit = query.limit;
+    if limit > MAX_BLOCK_INDEX_QUERY_LIMIT {
+        return HttpResponse::BadRequest().body(format!(
+            "limit exceeds maximum allowed value of {}",
+            MAX_BLOCK_INDEX_QUERY_LIMIT
+        ));
+    }
     let height = query.height;
 
     let block_index_read = state.block_index.read();


### PR DESCRIPTION
**Describe the changes**
 - impose MAX_BLOCK_INDEX_QUERY_LIMIT on /v1/block_index
 - currently set to 1000 blocks

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.
