### PR TITLE
feat: make slot partition assignments require unique mining addresses

### DIFF
--- a/crates/actors/tests/epoch_snapshot_tests.rs
+++ b/crates/actors/tests/epoch_snapshot_tests.rs
@@ -1035,7 +1035,7 @@ async fn partitions_assignment_determinism_test() {
         panic!("Should have an assignment");
     };
 
-    let publish_slot_1 = H256::from_base58("2HVmW86qVyKTw1DYJMX6NoNvVxATLNZHSAyMceEWPtLC");
+    let publish_slot_1 = H256::from_base58("3FQ7mPXwHhmNVD74DqNATHCex4wrtSQEBaa1FYeBEneN");
 
     epoch_snapshot.partition_assignments.print_assignments();
 
@@ -1079,7 +1079,7 @@ async fn partitions_assignment_determinism_test() {
         panic!("Should have an assignment");
     };
 
-    let submit_slot_2 = H256::from_base58("8sRHV12yycwpUSzean97JemQrzAXSSQWMmC4Jx3xUXzQ");
+    let submit_slot_2 = H256::from_base58("4jNP3tGi9hxAGsR6WnkM1dbrWG68E7wzP1JZ58QvHnXk");
 
     if let Some(submit_assignment) = epoch_snapshot
         .partition_assignments

--- a/crates/actors/tests/epoch_snapshot_tests.rs
+++ b/crates/actors/tests/epoch_snapshot_tests.rs
@@ -13,10 +13,13 @@ use irys_actors::{
     BlockFinalizedMessage,
 };
 use irys_config::StorageSubmodulesConfig;
-use irys_database::{add_genesis_commitments, add_test_commitments};
+use irys_database::{
+    add_genesis_commitments, add_test_commitments, add_test_commitments_for_signer,
+};
 use irys_domain::{BlockIndex, EpochBlockData, EpochSnapshot, StorageModule, StorageModuleVec};
 use irys_storage::ie;
 use irys_testing_utils::utils::setup_tracing_and_temp_dir;
+use irys_types::irys::IrysSigner;
 use irys_types::PartitionChunkRange;
 use irys_types::{partition::PartitionAssignment, DataLedger, IrysBlockHeader, H256};
 use irys_types::{
@@ -25,6 +28,7 @@ use irys_types::{
 use irys_types::{Config, U256};
 use irys_types::{H256List, NodeConfig};
 use irys_vdf::state::{VdfState, VdfStateReadonly};
+use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
 use std::{any::Any, sync::atomic::AtomicU64, time::Duration};
 use tokio::time::sleep;
@@ -259,6 +263,110 @@ async fn add_slots_test() {
     assert_eq!(pub_slots.len(), 3);
     assert_eq!(sub_slots.len(), 7);
     println!("Ledger State: {:#?}", epoch_snapshot.ledgers);
+}
+
+#[actix::test]
+async fn unique_addresses_per_slot_test() {
+    std::env::set_var("RUST_LOG", "debug");
+
+    let tmp_dir = setup_tracing_and_temp_dir(Some("unique_addresses_per_slot_test"), false);
+    let base_path = tmp_dir.path().to_path_buf();
+    let mut genesis_block = IrysBlockHeader::new_mock_header();
+    let consensus_config = ConsensusConfig {
+        chunk_size: 32,
+        num_chunks_in_partition: 10,
+        num_chunks_in_recall_range: 2,
+        num_partitions_per_slot: 10, // <- relevant to this test
+        block_migration_depth: 1,    // Testnet / single node config
+        chain_id: 333,
+        epoch: EpochConfig {
+            capacity_scalar: 100,
+            num_blocks_in_epoch: 100,
+            num_capacity_partitions: Some(123),
+            submit_ledger_epoch_length: 5,
+        },
+        ..ConsensusConfig::testing()
+    };
+    let mut testing_config = NodeConfig::testing();
+    testing_config.base_directory = base_path;
+    testing_config.consensus = ConsensusOptions::Custom(consensus_config);
+    let config = Config::new(testing_config);
+    let genesis_signer = config.irys_signer();
+    genesis_block.height = 0;
+    let mut commitments = add_genesis_commitments(&mut genesis_block, &config).await;
+
+    // Create some other signers to simulate other pledged and staked addresses
+    let signer1 = IrysSigner::random_signer(&config.consensus);
+    let signer2 = IrysSigner::random_signer(&config.consensus);
+
+    // Give them both 10 pledged partitions
+    let mut comm1 =
+        add_test_commitments_for_signer(&mut genesis_block, &signer1, 10, &config).await;
+    let mut comm2 =
+        add_test_commitments_for_signer(&mut genesis_block, &signer2, 10, &config).await;
+
+    commitments.append(&mut comm1);
+    commitments.append(&mut comm2);
+
+    let storage_submodules_config =
+        StorageSubmodulesConfig::load(config.node_config.base_directory.clone()).unwrap();
+
+    let epoch_snapshot = EpochSnapshot::new(
+        &storage_submodules_config,
+        genesis_block.clone(),
+        commitments,
+        &config,
+    );
+
+    debug!("{:#?}", epoch_snapshot.ledgers);
+
+    let publish_slot = &epoch_snapshot.ledgers.get_slots(DataLedger::Publish)[0];
+    let submit_slot = &epoch_snapshot.ledgers.get_slots(DataLedger::Submit)[0];
+
+    // Publish and submit slots should have exactly 3 partitions (not 10) because that's
+    // how many uniquely staked addresses there are.
+    assert_eq!(publish_slot.partitions.len(), 3);
+    assert_eq!(submit_slot.partitions.len(), 3);
+
+    // Collect mining addresses from publish_slot partitions
+    let publish_mining_addresses: Vec<_> = publish_slot
+        .partitions
+        .iter()
+        .map(|partition_hash| {
+            epoch_snapshot
+                .get_data_partition_assignment(*partition_hash)
+                .unwrap()
+                .miner_address
+        })
+        .collect();
+
+    // Convert to HashSet for easier assertion (assuming you have 3 expected addresses)
+    let publish_addresses_set: HashSet<_> = publish_mining_addresses.iter().collect();
+
+    // Assert that all 3 expected addresses are in the collected addresses
+    assert!(publish_addresses_set.contains(&genesis_signer.address()));
+    assert!(publish_addresses_set.contains(&signer1.address()));
+    assert!(publish_addresses_set.contains(&signer2.address()));
+
+    // Collect mining addresses from submit_slot partitions
+    let submit_mining_addresses: Vec<_> = submit_slot
+        .partitions
+        .iter()
+        .map(|partition_hash| {
+            epoch_snapshot
+                .get_data_partition_assignment(*partition_hash)
+                .unwrap()
+                .miner_address
+        })
+        .collect();
+
+    // Convert to HashSet for easier assertion (assuming you have 3 expected addresses)
+    let submit_addresses_set: HashSet<_> = submit_mining_addresses.iter().collect();
+
+    // Assert that all 3 expected addresses are in the collected addresses
+    assert!(submit_addresses_set.contains(&genesis_signer.address()));
+    assert!(submit_addresses_set.contains(&signer1.address()));
+    assert!(submit_addresses_set.contains(&signer2.address()));
 }
 
 #[actix::test]

--- a/crates/database/src/system_ledger.rs
+++ b/crates/database/src/system_ledger.rs
@@ -256,9 +256,18 @@ pub async fn add_test_commitments(
     config: &Config,
 ) -> Vec<CommitmentTransaction> {
     let signer = config.irys_signer();
+    add_test_commitments_for_signer(block_header, &signer, pledge_count, config).await
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+pub async fn add_test_commitments_for_signer(
+    block_header: &mut IrysBlockHeader,
+    signer: &IrysSigner,
+    pledge_count: u8,
+    config: &Config,
+) -> Vec<CommitmentTransaction> {
     let mut commitments: Vec<CommitmentTransaction> = Vec::new();
     let mut anchor = H256::random();
-
     if block_header.is_genesis() {
         // Create a stake commitment tx for the genesis block producer.
         let stake_commitment = CommitmentTransaction::new_stake(&config.consensus, H256::default());

--- a/crates/database/src/system_ledger.rs
+++ b/crates/database/src/system_ledger.rs
@@ -282,7 +282,7 @@ pub async fn add_test_commitments_for_signer(
 
     for i in 0..(pledge_count as usize) {
         let pledge_tx =
-            create_pledge_commitment_transaction(&signer, anchor, config, &(i as u64)).await;
+            create_pledge_commitment_transaction(signer, anchor, config, &(i as u64)).await;
         // We have to rotate the anchors on these TX so they produce unique signatures
         // and unique txids
         anchor = pledge_tx.id;

--- a/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
+++ b/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
@@ -385,7 +385,7 @@ impl EpochSnapshot {
             .partition_assignments
             .capacity_partitions
             .iter()
-            .map(|(hash, assignment)| (*hash, assignment.clone()))
+            .map(|(hash, assignment)| (*hash, *assignment))
             .collect();
 
         // Sort partitions by hash using `sort_unstable_by_key` for better performance.

--- a/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
+++ b/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
@@ -16,7 +16,7 @@ use irys_types::{
     PartitionChunkOffset,
 };
 use openssl::sha;
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 use tracing::{debug, error, trace, warn};
 
 /// Temporarily track all of the ledger definitions inside the epoch service actor
@@ -379,17 +379,18 @@ impl EpochSnapshot {
     fn backfill_missing_partitions(&mut self) {
         debug!("Backfilling missing partitions...");
         // Start with a sorted list of capacity partitions (sorted by hash)
+        // Now collecting both the hash and the partition assignment
 
-        let mut capacity_partitions: Vec<_> = self
+        let mut capacity_partitions: Vec<(H256, PartitionAssignment)> = self
             .partition_assignments
             .capacity_partitions
-            .keys()
-            .copied()
+            .iter()
+            .map(|(hash, assignment)| (*hash, assignment.clone()))
             .collect();
 
-        // Sort partitions using `sort_unstable` for better performance.
+        // Sort partitions by hash using `sort_unstable_by_key` for better performance.
         // Stability isn't needed/affected as each partition hash is unique.
-        capacity_partitions.sort_unstable();
+        capacity_partitions.sort_unstable_by_key(|(hash, _)| *hash);
 
         // Use the previous epoch hash as a seed/entropy to the prng
         let seed = self.epoch_block.last_epoch_hash.to_u32();
@@ -403,26 +404,46 @@ impl EpochSnapshot {
     }
 
     /// Process slot needs for a given ledger, assigning partitions to each slot
-    /// as needed.
+    /// as needed. Accounts for not assigning the same mining address to multiple
+    /// replicas of a single slot.
     pub fn process_slot_needs(
         &mut self,
         ledger: DataLedger,
-        capacity_partitions: &mut Vec<H256>,
+        capacity_partitions: &mut Vec<(H256, PartitionAssignment)>,
         rng: &mut SimpleRNG,
     ) {
         debug!("Processing slot needs for ledger {:?}", &ledger);
         // Get slot needs for the specified ledger
         let slot_needs = self.ledgers.get_slot_needs(ledger);
 
-        let mut capacity_count: u32 = capacity_partitions
-            .len()
-            .try_into()
-            .expect("Value exceeds u32::MAX");
-
         // Iterate over slots that need partitions and assign them
         for (slot_index, num_needed) in slot_needs {
+            // Build a set of the mining addresses already assigned to this slot
+            let slot = self
+                .ledgers
+                .get_slots(ledger)
+                .get(slot_index)
+                .expect("slot index should exist in the ledger");
+
+            let mut assigned_addresses: HashSet<_> = HashSet::new();
+            for partition_hash in &slot.partitions {
+                let pa = self
+                    .get_data_partition_assignment(*partition_hash)
+                    .expect("a partition in a data ledger slot should have a partition assignment");
+
+                assigned_addresses.insert(pa.miner_address);
+            }
+
+            // Create a slot specific view of the capacity partitions
+            let mut slot_capacity_partitions = capacity_partitions.clone();
+
+            // Filter out any mining addresses already in the slot from the slot specific capacity view
+            slot_capacity_partitions.retain(|(_, partition_assignment)| {
+                !assigned_addresses.contains(&partition_assignment.miner_address)
+            });
+
             for _ in 0..num_needed {
-                if capacity_count == 0 {
+                if slot_capacity_partitions.is_empty() {
                     warn!(
                         "No available capacity partitions (needs {}) for slot {} of ledger {:?}",
                         &num_needed, &slot_index, &ledger
@@ -431,12 +452,19 @@ impl EpochSnapshot {
                 }
 
                 // Pick a random capacity partition hash and assign it
-                let part_index = rng.next_range(capacity_count) as usize;
-                let partition_hash = capacity_partitions.swap_remove(part_index);
-                capacity_count -= 1;
+                let part_index = rng.next_range(slot_capacity_partitions.len() as u32) as usize;
+                let (partition_hash, pa) = capacity_partitions.swap_remove(part_index);
 
                 // Update local PartitionAssignment state and add to data_partitions
                 self.assign_partition_to_slot(partition_hash, ledger, slot_index);
+
+                // Remove any partitions belonging to the assigned miner from the slot capacity view
+                // So no more partitions from this miner will be assigned to this slot
+                slot_capacity_partitions
+                    .retain(|(_, part_assign)| part_assign.miner_address != pa.miner_address);
+
+                // Remove the specific assigned partition hash from the global capacity partitions list
+                capacity_partitions.retain(|(part_hash, _)| (*part_hash) != partition_hash);
 
                 // Push the newly assigned partition hash to the appropriate slot
                 // in the ledger

--- a/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
+++ b/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
@@ -453,7 +453,7 @@ impl EpochSnapshot {
 
                 // Pick a random capacity partition hash and assign it
                 let part_index = rng.next_range(slot_capacity_partitions.len() as u32) as usize;
-                let (partition_hash, pa) = capacity_partitions.swap_remove(part_index);
+                let (partition_hash, pa) = slot_capacity_partitions.swap_remove(part_index);
 
                 // Update local PartitionAssignment state and add to data_partitions
                 self.assign_partition_to_slot(partition_hash, ledger, slot_index);
@@ -469,8 +469,8 @@ impl EpochSnapshot {
                 // Push the newly assigned partition hash to the appropriate slot
                 // in the ledger
                 debug!(
-                    "Assigning partition hash {} to slot {} for  {:?}",
-                    &partition_hash, &slot_index, &ledger
+                    "Assigning partition hash {} to slot {} for {:?} addr: {}",
+                    partition_hash, &slot_index, &ledger, pa.miner_address
                 );
 
                 self.ledgers


### PR DESCRIPTION
When backfilling ledger slots with capacity partition hashes, the epoch snapshot now operates on a subset of the set of all assigned capacity partitions that excludes any partition_hashes assigned to miners that already have a partition assigned to the slot.

Adds a test method to stake and pledge additional signers in the genesis block (@JesseTheRobot , this might be useful configuring testnet)

Also adds a test to ensure `mining_address` uniqueness is being enforced per slot.

Note: as this new strategy for picking a random capacity partition from the subset of all capacity partitions changes the picking order, we have broken determinism from the old partition assignment strategy and the partition_determinism_test is updated to enshrine the new sequence.