### PR TITLE
feat: term pricing

### DIFF
--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -1236,9 +1236,8 @@ pub fn calculate_perm_storage_total_fee(
     let epochs_for_storage = config
         .consensus
         .years_to_epochs(config.consensus.safe_minimum_number_of_years);
-    let cost_per_chunk_duration_adjusted = config
-        .consensus
-        .cost_per_chunk_per_epoch
+    let cost_per_chunk_per_epoch = config.consensus.cost_per_chunk_per_epoch()?;
+    let cost_per_chunk_duration_adjusted = cost_per_chunk_per_epoch
         .cost_per_replica(epochs_for_storage, config.consensus.decay_rate)?
         .replica_count(config.consensus.number_of_ingress_proofs)?;
 

--- a/crates/api-server/src/routes/price.rs
+++ b/crates/api-server/src/routes/price.rs
@@ -93,10 +93,8 @@ fn cost_of_perm_storage(
         .config
         .consensus
         .years_to_epochs(state.config.consensus.safe_minimum_number_of_years);
-    let cost_per_chunk_duration_adjusted = state
-        .config
-        .consensus
-        .cost_per_chunk_per_epoch
+    let cost_per_chunk_per_epoch = state.config.consensus.cost_per_chunk_per_epoch()?;
+    let cost_per_chunk_duration_adjusted = cost_per_chunk_per_epoch
         .cost_per_replica(epochs_for_storage, state.config.consensus.decay_rate)?
         .replica_count(state.config.consensus.number_of_ingress_proofs)?;
 

--- a/crates/chain/tests/api/pricing_endpoint.rs
+++ b/crates/chain/tests/api/pricing_endpoint.rs
@@ -17,19 +17,22 @@ async fn heavy_pricing_endpoint_a_lot_of_data() -> eyre::Result<()> {
 
     // Calculate the expected base storage fee
     let expected_base_fee = {
-        let cost_per_gb = ctx
+        let epochs_for_storage = ctx
             .node_ctx
             .config
             .consensus
-            .annual_cost_per_gb
-            .cost_per_replica(
-                ctx.node_ctx.config.consensus.safe_minimum_number_of_years,
-                ctx.node_ctx.config.consensus.decay_rate,
-            )?
+            .years_to_epochs(ctx.node_ctx.config.consensus.safe_minimum_number_of_years);
+        let cost_per_chunk_duration_adjusted = ctx
+            .node_ctx
+            .config
+            .consensus
+            .cost_per_chunk_per_epoch
+            .cost_per_replica(epochs_for_storage, ctx.node_ctx.config.consensus.decay_rate)?
             .replica_count(ctx.node_ctx.config.consensus.number_of_ingress_proofs)?;
 
-        cost_per_gb.base_network_fee(
+        cost_per_chunk_duration_adjusted.base_network_fee(
             U256::from(data_size_bytes),
+            ctx.node_ctx.config.consensus.chunk_size,
             // node just started up, using genesis ema price
             ctx.node_ctx.config.consensus.genesis_price,
         )?
@@ -80,20 +83,23 @@ async fn heavy_pricing_endpoint_small_data() -> eyre::Result<()> {
 
     // Calculate the expected base storage fee
     let expected_base_fee = {
-        let cost_per_gb = ctx
+        let epochs_for_storage = ctx
             .node_ctx
             .config
             .consensus
-            .annual_cost_per_gb
-            .cost_per_replica(
-                ctx.node_ctx.config.consensus.safe_minimum_number_of_years,
-                ctx.node_ctx.config.consensus.decay_rate,
-            )?
+            .years_to_epochs(ctx.node_ctx.config.consensus.safe_minimum_number_of_years);
+        let cost_per_chunk_duration_adjusted = ctx
+            .node_ctx
+            .config
+            .consensus
+            .cost_per_chunk_per_epoch
+            .cost_per_replica(epochs_for_storage, ctx.node_ctx.config.consensus.decay_rate)?
             .replica_count(ctx.node_ctx.config.consensus.number_of_ingress_proofs)?;
 
-        cost_per_gb.base_network_fee(
+        cost_per_chunk_duration_adjusted.base_network_fee(
             // the original data_size_bytes is too small to fill up a whole chunk
             U256::from(ctx.node_ctx.config.consensus.chunk_size),
+            ctx.node_ctx.config.consensus.chunk_size,
             // node just started up, using genesis ema price
             ctx.node_ctx.config.consensus.genesis_price,
         )?
@@ -167,20 +173,23 @@ async fn heavy_pricing_endpoint_round_data_chunk_up() -> eyre::Result<()> {
 
     // Calculate the expected base storage fee
     let expected_base_fee = {
-        let cost_per_gb = ctx
+        let epochs_for_storage = ctx
             .node_ctx
             .config
             .consensus
-            .annual_cost_per_gb
-            .cost_per_replica(
-                ctx.node_ctx.config.consensus.safe_minimum_number_of_years,
-                ctx.node_ctx.config.consensus.decay_rate,
-            )?
+            .years_to_epochs(ctx.node_ctx.config.consensus.safe_minimum_number_of_years);
+        let cost_per_chunk_duration_adjusted = ctx
+            .node_ctx
+            .config
+            .consensus
+            .cost_per_chunk_per_epoch
+            .cost_per_replica(epochs_for_storage, ctx.node_ctx.config.consensus.decay_rate)?
             .replica_count(ctx.node_ctx.config.consensus.number_of_ingress_proofs)?;
 
-        cost_per_gb.base_network_fee(
+        cost_per_chunk_duration_adjusted.base_network_fee(
             // round to the chunk size boundary
             U256::from(ctx.node_ctx.config.consensus.chunk_size * 2),
+            ctx.node_ctx.config.consensus.chunk_size,
             // node just started up, using genesis ema price
             ctx.node_ctx.config.consensus.genesis_price,
         )?

--- a/crates/chain/tests/api/pricing_endpoint.rs
+++ b/crates/chain/tests/api/pricing_endpoint.rs
@@ -22,11 +22,8 @@ async fn heavy_pricing_endpoint_a_lot_of_data() -> eyre::Result<()> {
             .config
             .consensus
             .years_to_epochs(ctx.node_ctx.config.consensus.safe_minimum_number_of_years);
-        let cost_per_chunk_duration_adjusted = ctx
-            .node_ctx
-            .config
-            .consensus
-            .cost_per_chunk_per_epoch
+        let cost_per_chunk_per_epoch = ctx.node_ctx.config.consensus.cost_per_chunk_per_epoch()?;
+        let cost_per_chunk_duration_adjusted = cost_per_chunk_per_epoch
             .cost_per_replica(epochs_for_storage, ctx.node_ctx.config.consensus.decay_rate)?
             .replica_count(ctx.node_ctx.config.consensus.number_of_ingress_proofs)?;
 
@@ -88,11 +85,8 @@ async fn heavy_pricing_endpoint_small_data() -> eyre::Result<()> {
             .config
             .consensus
             .years_to_epochs(ctx.node_ctx.config.consensus.safe_minimum_number_of_years);
-        let cost_per_chunk_duration_adjusted = ctx
-            .node_ctx
-            .config
-            .consensus
-            .cost_per_chunk_per_epoch
+        let cost_per_chunk_per_epoch = ctx.node_ctx.config.consensus.cost_per_chunk_per_epoch()?;
+        let cost_per_chunk_duration_adjusted = cost_per_chunk_per_epoch
             .cost_per_replica(epochs_for_storage, ctx.node_ctx.config.consensus.decay_rate)?
             .replica_count(ctx.node_ctx.config.consensus.number_of_ingress_proofs)?;
 
@@ -178,11 +172,8 @@ async fn heavy_pricing_endpoint_round_data_chunk_up() -> eyre::Result<()> {
             .config
             .consensus
             .years_to_epochs(ctx.node_ctx.config.consensus.safe_minimum_number_of_years);
-        let cost_per_chunk_duration_adjusted = ctx
-            .node_ctx
-            .config
-            .consensus
-            .cost_per_chunk_per_epoch
+        let cost_per_chunk_per_epoch = ctx.node_ctx.config.consensus.cost_per_chunk_per_epoch()?;
+        let cost_per_chunk_duration_adjusted = cost_per_chunk_per_epoch
             .cost_per_replica(epochs_for_storage, ctx.node_ctx.config.consensus.decay_rate)?
             .replica_count(ctx.node_ctx.config.consensus.number_of_ingress_proofs)?;
 

--- a/crates/config/templates/testnet_config.toml
+++ b/crates/config/templates/testnet_config.toml
@@ -52,12 +52,9 @@ chain_id = 1270
 token_price_safe_range = 1.0
 genesis_price = 1.0
 # Storage economics: Based on 0.01 USD/GB/year target
-# With 12s blocks, 100 blocks/epoch: 1 epoch = 20 min, 26,280 epochs/year
-# 1 GB = 4096 chunks
-# cost_per_chunk_per_epoch = 0.01 / 4096 / 26280 ≈ 9.3e-11 USD
-cost_per_chunk_per_epoch = 0.000000000093  # ~9.3e-11 USD per chunk per epoch
-# 1% annual decay → per-epoch decay ≈ 0.01 / 26280 ≈ 0.000038%
-decay_rate = 0.00000038  # ~0.000038% decay per epoch
+annual_cost_per_gb = 0.01  # $0.01 USD/GB/year
+# 1% annual decay
+decay_rate = 0.01  # 1% annual decay per year
 chunk_size = 262144
 block_migration_depth = 6
 block_tree_depth = 50

--- a/crates/config/templates/testnet_config.toml
+++ b/crates/config/templates/testnet_config.toml
@@ -51,8 +51,13 @@ peer_id = "0x0000000000000000000000000000000000000000000000000000000000000000000
 chain_id = 1270
 token_price_safe_range = 1.0
 genesis_price = 1.0
-annual_cost_per_gb = 0.01
-decay_rate = 0.01
+# Storage economics: Based on 0.01 USD/GB/year target
+# With 12s blocks, 100 blocks/epoch: 1 epoch = 20 min, 26,280 epochs/year
+# 1 GB = 4096 chunks
+# cost_per_chunk_per_epoch = 0.01 / 4096 / 26280 ≈ 9.3e-11 USD
+cost_per_chunk_per_epoch = 0.000000000093  # ~9.3e-11 USD per chunk per epoch
+# 1% annual decay → per-epoch decay ≈ 0.01 / 26280 ≈ 0.000038%
+decay_rate = 0.00000038  # ~0.000038% decay per epoch
 chunk_size = 262144
 block_migration_depth = 6
 block_tree_depth = 50
@@ -61,6 +66,7 @@ num_chunks_in_recall_range = 800
 num_partitions_per_slot = 1
 entropy_packing_iterations = 1000
 number_of_ingress_proofs = 10
+# Target storage duration in years
 safe_minimum_number_of_years = 200
 stake_value = 20000.0
 pledge_base_value = 950.0

--- a/crates/config/templates/testnet_config.toml
+++ b/crates/config/templates/testnet_config.toml
@@ -69,6 +69,7 @@ stake_value = 20000.0
 pledge_base_value = 950.0
 pledge_decay = 0.9
 immediate_tx_inclusion_reward_percent = 0.01
+minimum_term_fee_usd = 0.01  # $0.01 USD minimum for term storage
 
 [consensus.Custom.genesis]
 timestamp_millis = 0

--- a/crates/types/src/config.rs
+++ b/crates/types/src/config.rs
@@ -1,7 +1,7 @@
 use crate::{
     irys::IrysSigner,
     storage_pricing::{
-        phantoms::{CostPerChunk, CostPerGb, DecayRate, Irys, IrysPrice, Percentage, Usd},
+        phantoms::{CostPerChunk, CostPerChunkDurationAdjusted, CostPerGb, DecayRate, Irys, IrysPrice, Percentage, Usd},
         Amount,
     },
     PeerAddress, RethPeerInfo, H256,
@@ -182,6 +182,14 @@ pub struct ConsensusConfig {
         serialize_with = "serde_utils::serializes_percentage_amount"
     )]
     pub immediate_tx_inclusion_reward_percent: Amount<Percentage>,
+
+    /// Minimum term fee in USD that must be paid for term storage
+    /// If calculated fee is below this threshold, it will be rounded up
+    #[serde(
+        deserialize_with = "serde_utils::token_amount",
+        serialize_with = "serde_utils::serializes_token_amount"
+    )]
+    pub minimum_term_fee_usd: Amount<(CostPerChunkDurationAdjusted, Usd)>,
 
     /// Maximum future drift
     #[serde(
@@ -785,6 +793,7 @@ impl ConsensusConfig {
             pledge_decay: Amount::percentage(dec!(0.9)).expect("valid percentage"),
             immediate_tx_inclusion_reward_percent: Amount::percentage(dec!(0.05))
                 .expect("valid percentage"),
+            minimum_term_fee_usd: Amount::token(dec!(0.01)).expect("valid token amount"), // $0.01 USD minimum
             max_future_timestamp_drift_millis: 15_000,
         }
     }
@@ -909,6 +918,7 @@ impl ConsensusConfig {
             },
             immediate_tx_inclusion_reward_percent: Amount::percentage(dec!(0.05))
                 .expect("valid percentage"),
+            minimum_term_fee_usd: Amount::token(dec!(0.01)).expect("valid token amount"), // $0.01 USD minimum
             max_future_timestamp_drift_millis: 15_000,
         }
     }

--- a/crates/types/src/storage_pricing.rs
+++ b/crates/types/src/storage_pricing.rs
@@ -184,6 +184,10 @@ pub mod phantoms {
     #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
     pub struct CostPerChunk;
 
+    /// The cost of storing 1 GB of data.
+    #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+    pub struct CostPerGb;
+
     /// Currency denominator util type.
     #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
     pub struct Usd;

--- a/crates/types/src/transaction/fee_distribution.rs
+++ b/crates/types/src/transaction/fee_distribution.rs
@@ -26,7 +26,7 @@
 /// - 5% of term_fee for each ingress-proof provided. These rewards are included in the transaction's `perm_fee` field along with the base permanent storage cost.
 /// - perm_fee total value: Prepaid amount covering 200 years x 10 replicas with 1% annual decline in storage costs PLUS ingress proof rewards (5% of term_fee × number_of_ingress_proofs)
 use crate::ingress::IngressProof;
-use crate::storage_pricing::{mul_div, BPS_SCALE};
+use crate::storage_pricing::{mul_div, PRECISION_SCALE};
 pub use crate::{
     address_base58_stringify, optional_string_u64, string_u64, Address, Arbitrary, Base64, Compact,
     ConsensusConfig, IrysSignature, Node, Proof, Signature, H256, U256,
@@ -64,7 +64,7 @@ impl TermFeeCharges {
         let block_producer_reward = mul_div(
             term_fee,
             config.immediate_tx_inclusion_reward_percent.amount,
-            BPS_SCALE,
+            PRECISION_SCALE,
         )?;
 
         // The rest of the fee goes to the treasury
@@ -149,7 +149,7 @@ impl PublishFeeCharges {
         let per_ingress_reward = mul_div(
             term_fee,
             config.immediate_tx_inclusion_reward_percent.amount,
-            BPS_SCALE,
+            PRECISION_SCALE,
         )
         .unwrap_or(U256::from(0));
 


### PR DESCRIPTION
**Describe the changes**
- storage pricing module now works on basis of "cost of chunk per epoch" instead of "cost of gb per year". Calculation is done dynamically based on our configs block time, blocks in epoch
- pricing endpoint will compute term fee
- validation service and mempool will also compute term fee to check if the price make sense

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.
