### PR TITLE
fix: storage module partition hash should persist across Capacity/Ledger reassignments.

### DIFF
--- a/crates/actors/src/data_sync_service.rs
+++ b/crates/actors/src/data_sync_service.rs
@@ -422,9 +422,16 @@ impl DataSyncServiceInner {
             return Vec::new();
         }
 
-        // Extract partition assignment - safe to unwrap since orchestrators are only
-        // created for storage modules with valid data partition assignments
+        // Extract partition assignment
         let pa = storage_module.partition_assignment().unwrap();
+
+        // Check to see that the partition hash hasn't been re-assigned to capacity and no longer
+        // has any data to sync
+        if pa.ledger_id.is_none() {
+            // We don't remove the orchestrator for the partition because it's not hurting anything to keep it around...
+            return Vec::new();
+        }
+
         let ledger_id = pa.ledger_id.unwrap();
 
         // Find all peers that are assigned to store data for the same ledger slot

--- a/crates/actors/src/data_sync_service/chunk_orchestrator.rs
+++ b/crates/actors/src/data_sync_service/chunk_orchestrator.rs
@@ -88,8 +88,17 @@ impl ChunkOrchestrator {
     }
 
     pub fn tick(&mut self) -> eyre::Result<()> {
-        self.populate_request_queue();
-        self.dispatch_chunk_requests();
+        // Only need to tick the Orchestrator if the partition is still assigned to a ledger.
+        // Capacity partitions don't need to sync data.
+        if self
+            .storage_module
+            .partition_assignment()
+            .is_some_and(|pa| pa.ledger_id.is_some())
+        {
+            self.populate_request_queue();
+            self.dispatch_chunk_requests();
+        }
+
         Ok(())
     }
 

--- a/crates/chain/tests/api/tx_commitments.rs
+++ b/crates/chain/tests/api/tx_commitments.rs
@@ -57,6 +57,7 @@ async fn heavy_test_commitments_3epochs_test() -> eyre::Result<()> {
     let genesis_parts_before;
     let signer1_parts_before;
     let signer2_parts_before;
+    let sm_infos_before;
 
     let node = {
         // Start a test node with custom configuration
@@ -253,6 +254,13 @@ async fn heavy_test_commitments_3epochs_test() -> eyre::Result<()> {
             &signer2_address,
         ));
 
+        sm_infos_before = node
+            .node_ctx
+            .block_tree_guard
+            .read()
+            .canonical_epoch_snapshot()
+            .map_storage_modules_to_partition_assignments();
+
         node.wait_until_height_confirmed(6, 10).await?;
 
         node
@@ -323,6 +331,15 @@ async fn heavy_test_commitments_3epochs_test() -> eyre::Result<()> {
     assert_eq!(genesis_parts_after, genesis_parts_before);
     assert_eq!(signer1_parts_after, signer1_parts_before);
     assert_eq!(signer2_parts_after, signer2_parts_before);
+
+    let sm_infos_after = restarted_node
+        .node_ctx
+        .block_tree_guard
+        .read()
+        .canonical_epoch_snapshot()
+        .map_storage_modules_to_partition_assignments();
+
+    assert_eq!(sm_infos_before, sm_infos_after);
 
     // ===== TEST CLEANUP =====
     restarted_node.node_ctx.stop().await;

--- a/crates/chain/tests/api/tx_commitments.rs
+++ b/crates/chain/tests/api/tx_commitments.rs
@@ -7,7 +7,7 @@ use irys_chain::IrysNodeCtx;
 use irys_domain::{CommitmentSnapshotStatus, EpochSnapshot};
 use irys_testing_utils::initialize_tracing;
 use irys_types::{
-    irys::IrysSigner, Address, CommitmentTransaction, CommitmentType, NodeConfig, H256,
+    irys::IrysSigner, Address, CommitmentTransaction, CommitmentType, NodeConfig, H256, U256,
 };
 use std::sync::Arc;
 use tokio::time::Duration;
@@ -25,7 +25,7 @@ macro_rules! assert_ok {
 async fn heavy_test_commitments_3epochs_test() -> eyre::Result<()> {
     // ===== TEST ENVIRONMENT SETUP =====
     // Configure logging to reduce noise while keeping relevant commitment outputs
-    std::env::set_var("RUST_LOG", "debug,irys_database=off,irys_p2p::gossip_service=off,irys_actors::storage_module_service=off,trie=off,irys_reth::evm=off,engine::root=off,irys_p2p::peer_list=off,storage::db::mdbx=off,reth_basic_payload_builder=off,irys_gossip_service=off,providers::db=off,reth_payload_builder::service=off,irys_actors::broadcast_mining_service=off,reth_ethereum_payload_builder=off,provider::static_file=off,engine::persistence=off,provider::storage_writer=off,reth_engine_tree::persistence=off,irys_actors::cache_service=off,irys_vdf=off,irys_actors::block_tree_service=off,irys_actors::vdf_service=off,rys_gossip_service::service=off,eth_ethereum_payload_builder=off,reth_node_events::node=off,reth::cli=off,reth_engine_tree::tree=off,irys_actors::ema_service=off,irys_efficient_sampling=off,hyper_util::client::legacy::connect::http=off,hyper_util::client::legacy::pool=off,irys_database::migration::v0_to_v1=off,irys_storage::storage_module=off,actix_server::worker=off,irys::packing::update=off,engine::tree=off,irys_actors::mining=error,payload_builder=off,irys_actors::reth_service=off,irys_actors::packing=off,irys_actors::reth_service=off,irys::packing::progress=off,irys_chain::vdf=off,irys_vdf::vdf_state=off");
+    std::env::set_var("RUST_LOG", "debug,irys_database=off,irys_p2p::gossip_service=off,irys_actors::storage_module_service=debug,trie=off,irys_reth::evm=off,engine::root=off,irys_p2p::peer_list=off,storage::db::mdbx=off,reth_basic_payload_builder=off,irys_gossip_service=off,providers::db=off,reth_payload_builder::service=off,irys_actors::broadcast_mining_service=off,reth_ethereum_payload_builder=off,provider::static_file=off,engine::persistence=off,provider::storage_writer=off,reth_engine_tree::persistence=off,irys_actors::cache_service=off,irys_vdf=off,irys_actors::block_tree_service=off,irys_actors::vdf_service=off,rys_gossip_service::service=off,eth_ethereum_payload_builder=off,reth_node_events::node=off,reth::cli=off,reth_engine_tree::tree=off,irys_actors::ema_service=off,irys_efficient_sampling=off,hyper_util::client::legacy::connect::http=off,hyper_util::client::legacy::pool=off,irys_database::migration::v0_to_v1=off,irys_storage::storage_module=off,actix_server::worker=off,irys::packing::update=off,engine::tree=off,irys_actors::mining=error,payload_builder=off,irys_actors::reth_service=off,irys_actors::packing=off,irys_actors::reth_service=off,irys::packing::progress=off,irys_chain::vdf=off,irys_vdf::vdf_state=off");
     initialize_tracing();
 
     // ===== TEST PURPOSE: Multiple Epochs with Commitments =====
@@ -33,6 +33,7 @@ async fn heavy_test_commitments_3epochs_test() -> eyre::Result<()> {
     // 1. Stake and pledge commitments are correctly processed across multiple epoch transitions
     // 2. Partition assignments are properly created and maintained for all pledges
     // 3. The commitment state correctly tracks stake and pledge relationships
+    // 4. Capacity pledges can migrate to ledger slots and maintain their storage_module.id mappings
 
     // Configure a test network with accelerated epochs (2 blocks per epoch)
     let num_blocks_in_epoch = 2;
@@ -41,6 +42,8 @@ async fn heavy_test_commitments_3epochs_test() -> eyre::Result<()> {
     let block_migration_depth = num_blocks_in_epoch - 1;
     // set block migration depth so epoch blocks go to index correctly
     config.consensus.get_mut().block_migration_depth = block_migration_depth.try_into()?;
+    config.consensus.get_mut().num_chunks_in_partition = 20;
+    config.consensus.get_mut().num_chunks_in_recall_range = 5;
 
     // Create multiple signers to test different commitment scenarios
     let signer1 = IrysSigner::random_signer(&config.consensus_config());
@@ -118,14 +121,20 @@ async fn heavy_test_commitments_3epochs_test() -> eyre::Result<()> {
         let expected_ids = [stake_tx1.id, stake_tx2.id, pledge1.id, pledge2.id];
         let block_1 = node.get_block_by_height(1).await.unwrap();
         let commitments_1 = block_1.get_commitment_ledger_tx_ids();
-        debug!("Block - height: {:?}\n{:#?}", block_1.height, commitments_1,);
+        debug!(
+            "Block commitments - height: {:?}\n{:#?}",
+            block_1.height, commitments_1,
+        );
         assert_eq!(commitments_1.len(), 4);
         assert!(expected_ids.iter().all(|id| commitments_1.contains(id)));
 
         // Block height: 2 is an epoch block and should have the same commitments and no more
         let block_2 = node.get_block_by_height(2).await.unwrap();
         let commitments_2 = block_2.get_commitment_ledger_tx_ids();
-        debug!("Block - height: {:?}\n{:#?}", block_2.height, commitments_2);
+        debug!(
+            "Block commitments - height: {:?}\n{:#?}",
+            block_2.height, commitments_2
+        );
         assert_eq!(commitments_2.len(), expected_ids.len());
         assert!(expected_ids.iter().all(|id| commitments_2.contains(id)));
 
@@ -177,6 +186,39 @@ async fn heavy_test_commitments_3epochs_test() -> eyre::Result<()> {
         // Create pledge for second test signer
         let pledge3 = post_pledge_commitment(&node, &signer2, H256::default()).await;
         info!("signer2: {} post pledge: {}", signer2_address, pledge3.id);
+
+        // Add some data so that the submit ledger grows and a capacity
+        // partition is assigned to submit ledger slot 1
+
+        // Create data chunks for this partition to store
+        // Make sure the data chunks fill > 50% of a partition to trigger ledger growth
+        let num_chunks = config.consensus.get_mut().num_chunks_in_partition / 2 + 2;
+        let chunk_size = config.consensus.get_mut().chunk_size;
+
+        let mut data = Vec::with_capacity((chunk_size * num_chunks) as usize);
+        for chunk_index in 0..num_chunks {
+            let chunk_data = vec![chunk_index as u8; chunk_size as usize];
+            data.extend(chunk_data);
+        }
+
+        // DATA TX: Create the data transaction from the chunks
+        let mut data_tx = signer1
+            .create_transaction(data, Some(genesis_block.block_hash))
+            .expect("To make a data transaction");
+
+        data_tx.header.perm_fee = Some(U256::from(4_000_000_000_000u64));
+        data_tx.header.term_fee = U256::from(1_000_000_000u32);
+
+        // Sign the data transaction
+        let data_tx = signer1
+            .sign_transaction(data_tx)
+            .expect("data tx should be signable");
+
+        // Post the data transaction to the nodes mempool
+        node.post_data_tx_raw(&data_tx.header).await;
+
+        let res = node.wait_for_mempool(data_tx.header.id, 5).await;
+        assert_matches!(res, Ok(()));
 
         // Mine enough blocks to reach the second epoch boundary
         info!("MINE SECOND EPOCH BLOCK:");
@@ -518,6 +560,8 @@ async fn post_pledge_commitment(
     pledge_tx
 }
 
+/// Validates that the partition_hashes associated with pledges in the EpochSnapshot::commitment_state are reflected
+/// in the EpochSnapshot::partition_assignments which maps partition_hashes to ledger or capacity.
 fn validate_pledge_assignments(
     epoch_snapshot: Arc<EpochSnapshot>,
     address_name: &str,
@@ -548,7 +592,7 @@ fn validate_pledge_assignments(
     };
 
     debug!(
-        "\nGot partition_hashes from pledges for {} : address {}\nPartition Assignments in epoch_service:\n{:#?}\nPledge Status in CommitmentState:\n{:#?}",
+        "\nGot partition_hashes from pledges for {} : address {}\nPartition Assignments in epoch snapshot:\n{:#?}\nPledge Status in CommitmentState:\n{:#?}",
         address_name, address, partition_hashes, direct
     );
 

--- a/crates/chain/tests/api/tx_commitments.rs
+++ b/crates/chain/tests/api/tx_commitments.rs
@@ -206,8 +206,8 @@ async fn heavy_test_commitments_3epochs_test() -> eyre::Result<()> {
             .create_transaction(data, Some(genesis_block.block_hash))
             .expect("To make a data transaction");
 
-        data_tx.header.perm_fee = Some(U256::from(4_000_000_000_000u64));
-        data_tx.header.term_fee = U256::from(1_000_000_000u32);
+        data_tx.header.perm_fee = Some(U256::from(4_000_000_000_000_u64));
+        data_tx.header.term_fee = U256::from(1_000_000_000_u32);
 
         // Sign the data transaction
         let data_tx = signer1

--- a/crates/domain/src/models/storage_module.rs
+++ b/crates/domain/src/models/storage_module.rs
@@ -172,7 +172,7 @@ impl PackingParams {
     }
 }
 
-static PACKING_PARAMS_FILE_NAME: &str = "packing_params.toml";
+pub static PACKING_PARAMS_FILE_NAME: &str = "packing_params.toml";
 
 /// Manages chunk storage on a single physical drive
 #[derive(Debug)]

--- a/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
+++ b/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
@@ -1,5 +1,5 @@
 use super::{CommitmentState, CommitmentStateEntry, PartitionAssignments};
-use crate::{EpochBlockData, StorageModuleInfo};
+use crate::{EpochBlockData, PackingParams, StorageModuleInfo, PACKING_PARAMS_FILE_NAME};
 use base58::ToBase58 as _;
 use eyre::{Error, Result};
 use irys_config::submodules::StorageSubmodulesConfig;
@@ -17,6 +17,7 @@ use irys_types::{
 };
 use openssl::sha;
 use std::collections::{HashSet, VecDeque};
+use std::path::PathBuf;
 use tracing::{debug, error, trace, warn};
 
 /// Temporarily track all of the ledger definitions inside the epoch service actor
@@ -895,81 +896,148 @@ impl EpochSnapshot {
             .unwrap()
             .submodule_paths;
 
+        // Collect existing storage module packing info
+        let mut sm_packing_info = self.collect_packing_info(paths);
+        debug!("{:#?}", sm_packing_info);
+
         let mut module_infos = Vec::new();
 
         // STEP 1: Publish ledger
-        for pa in assignments
-            .iter()
-            .filter(|pa| pa.ledger_id == Some(DataLedger::Publish as u32))
-        {
-            let id = module_infos.len();
-            let path = match paths.get(id) {
-                Some(p) => p.clone(),
-                None => {
-                    error!("No available storage modules for partition assignment!");
-                    return module_infos;
-                }
-            };
-            module_infos.push(StorageModuleInfo {
-                id,
-                partition_assignment: Some(*pa),
-                submodules: vec![(partition_chunk_offset_ie!(0, num_chunks), path)],
-            });
-        }
+        self.process_storage_module_assignments(
+            &assignments,
+            &mut sm_packing_info,
+            &mut module_infos,
+            Some(DataLedger::Publish as u32),
+            miner,
+            num_chunks,
+        );
 
         // STEP 2: Submit ledger
-        for pa in assignments
-            .iter()
-            .filter(|pa| pa.ledger_id == Some(DataLedger::Submit as u32))
-        {
-            let id = module_infos.len();
-            let path = match paths.get(id) {
-                Some(p) => p.clone(),
-                None => {
-                    error!("No available storage modules for partition assignment!");
-                    return module_infos;
-                }
-            };
-            module_infos.push(StorageModuleInfo {
-                id,
-                partition_assignment: Some(*pa),
-                submodules: vec![(partition_chunk_offset_ie!(0, num_chunks), path)],
-            });
-        }
+        self.process_storage_module_assignments(
+            &assignments,
+            &mut sm_packing_info,
+            &mut module_infos,
+            Some(DataLedger::Submit as u32),
+            miner,
+            num_chunks,
+        );
 
-        // STEP 3: Capacity
-        let remaining = paths.len().saturating_sub(module_infos.len());
-        for pa in assignments
-            .iter()
-            .filter(|pa| pa.ledger_id.is_none())
-            .take(remaining)
-        {
-            let id = module_infos.len();
-            let path = match paths.get(id) {
-                Some(p) => p.clone(),
-                None => {
-                    error!("No available storage modules for partition assignment!");
-                    return module_infos;
-                }
-            };
-            module_infos.push(StorageModuleInfo {
-                id,
-                partition_assignment: Some(*pa),
-                submodules: vec![(partition_chunk_offset_ie!(0, num_chunks), path)],
-            });
-        }
+        // STEP 3: Capacity (with remaining slots limit)
+        self.process_storage_module_assignments(
+            &assignments,
+            &mut sm_packing_info,
+            &mut module_infos,
+            None, // Capacity assignments have no ledger_id
+            miner,
+            num_chunks,
+        );
 
         // STEP 4: Unassigned
-        for (idx, path) in paths.iter().enumerate().skip(module_infos.len()) {
-            // Create StorageModuleInfo entries without partition assignments
+        for (original_idx, (path, _)) in sm_packing_info
+            .iter()
+            .enumerate()
+            .filter(|(_, (_, params))| params.is_none())
+        {
             module_infos.push(StorageModuleInfo {
-                id: idx,
-                partition_assignment: None, // No partition assignment
+                id: original_idx,
+                partition_assignment: None,
                 submodules: vec![(partition_chunk_offset_ie!(0, num_chunks), path.clone())],
             });
         }
 
         module_infos
+    }
+
+    /// Loops though all the paths in the storage_submodules.toml and attempts to read the existing
+    /// packing params from that path, building a list of (PathBuf, Option<PackingParams>) whose
+    /// indexes map to the index of the path in the .toml
+    fn collect_packing_info(&self, paths: &[PathBuf]) -> Vec<(PathBuf, Option<PackingParams>)> {
+        paths
+            .iter()
+            .map(|path| {
+                let sub_base_path = self.config.node_config.base_directory.join(path.clone());
+                let params_path = sub_base_path.join(PACKING_PARAMS_FILE_NAME);
+
+                let params = if params_path.exists() {
+                    Some(PackingParams::from_toml(&params_path).expect("packing params to load"))
+                } else {
+                    None
+                };
+
+                (path.clone(), params)
+            })
+            .collect()
+    }
+
+    /// Processes partition assignments for a specific ledger, creating StorageModuleInfo entries and updating packing state.
+    /// The StorageModuleInfos will reference existing storage modules if that store the partition assignment or use the first
+    /// available storage module index with no partition assignments.
+    fn process_storage_module_assignments(
+        &self,
+        assignments: &[PartitionAssignment],
+        sm_packing_info: &mut Vec<(PathBuf, Option<PackingParams>)>,
+        module_infos: &mut Vec<StorageModuleInfo>,
+        target_ledger_id: Option<u32>,
+        miner: Address,
+        num_chunks: u32,
+    ) {
+        let filtered_assignments = assignments
+            .iter()
+            .filter(|pa| pa.ledger_id == target_ledger_id);
+
+        let assignments_to_process = filtered_assignments.collect::<Vec<_>>();
+
+        for pa in assignments_to_process {
+            let id = self.find_or_assign_storage_module(sm_packing_info, pa);
+
+            if id.is_none() {
+                error!("No available storage modules for partition assignment!");
+                return;
+            }
+
+            let id = id.unwrap();
+            let path = sm_packing_info[id].0.clone();
+
+            module_infos.push(StorageModuleInfo {
+                id,
+                partition_assignment: Some(*pa),
+                submodules: vec![(partition_chunk_offset_ie!(0, num_chunks), path)],
+            });
+
+            // Update packing info (so this storage module doesn't get assigned to something else)
+            sm_packing_info[id].1 = Some(PackingParams {
+                packing_address: miner,
+                partition_hash: Some(pa.partition_hash),
+                ledger: pa.ledger_id,
+                slot: pa.slot_index,
+            });
+        }
+    }
+
+    /// Finds storage module index for partition: returns existing assignment or first
+    /// available storage module index with no partition assignment.
+    fn find_or_assign_storage_module(
+        &self,
+        sm_packing_info: &[(PathBuf, Option<PackingParams>)],
+        pa: &PartitionAssignment,
+    ) -> Option<usize> {
+        // Try to find existing partition assignment
+        let existing_id = sm_packing_info.iter().position(|(_, params)| {
+            params
+                .as_ref()
+                .map_or(false, |pp| pp.partition_hash == Some(pa.partition_hash))
+        });
+
+        // If not found, find first available storage module index/id with no assignment
+        existing_id.or_else(|| {
+            sm_packing_info.iter().position(|(_, params)| match params {
+                // If there's no packing params its a fresh storage module
+                None => true,
+                // but on restart the storage module may have an "empty" packing params
+                // See StorageModule::new() for why.
+                Some(p) => p.partition_hash.is_none(),
+            })
+        })
     }
 
     /// Gets a partitions assignment to a data partition by partition hash

--- a/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
+++ b/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
@@ -975,7 +975,7 @@ impl EpochSnapshot {
     fn process_storage_module_assignments(
         &self,
         assignments: &[PartitionAssignment],
-        sm_packing_info: &mut Vec<(PathBuf, Option<PackingParams>)>,
+        sm_packing_info: &mut [(PathBuf, Option<PackingParams>)],
         module_infos: &mut Vec<StorageModuleInfo>,
         target_ledger_id: Option<u32>,
         miner: Address,
@@ -1025,7 +1025,7 @@ impl EpochSnapshot {
         let existing_id = sm_packing_info.iter().position(|(_, params)| {
             params
                 .as_ref()
-                .map_or(false, |pp| pp.partition_hash == Some(pa.partition_hash))
+                .is_some_and(|pp| pp.partition_hash == Some(pa.partition_hash))
         });
 
         // If not found, find first available storage module index/id with no assignment


### PR DESCRIPTION
Make sure storage modules preserve their `partition_hash` assignments across Capacity/DataLedger re-assignments.
