### PR TITLE
docs: amended hash comment in DataTransactionHeader

### DIFF
--- a/crates/types/src/transaction.rs
+++ b/crates/types/src/transaction.rs
@@ -61,7 +61,7 @@ pub enum CommitmentValidationError {
 /// We include the Irys prefix to differentiate from EVM transactions.
 #[serde(rename_all = "camelCase", default)]
 pub struct DataTransactionHeader {
-    /// A SHA-256 hash of the transaction signature.
+    /// A 256-bit hash of the transaction signature.
     #[rlp(skip)]
     #[rlp(default)]
     // NOTE: both rlp skip AND rlp default must be present in order for field skipping to work


### PR DESCRIPTION
**Describe the changes**

  The id field in DataTransactionHeader had a comment stating it was "A SHA-256 hash of the transaction signature", but the actual implementation uses keccak256 throughout the codebase. This created a mismatch between documentation and implementation that could lead to integration confusion.

  Changed the comment to the more accurate and generic "A 256-bit hash of the transaction signature" to align with the keccak256 implementation used in the codebase.

  Changes

  - Updated comment for DataTransactionHeader.id field from "SHA-256 hash" to "256-bit hash"

**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
