### PR TITLE
feat: internal is syncing flag

### DIFF
--- a/crates/chain/src/main.rs
+++ b/crates/chain/src/main.rs
@@ -1,6 +1,6 @@
 use irys_chain::{utils::load_config, IrysNode};
 use irys_testing_utils::setup_panic_hook;
-use tracing::info;
+use tracing::{info, level_filters::LevelFilter};
 use tracing_error::ErrorLayer;
 use tracing_subscriber::{
     layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter, Layer as _, Registry,

--- a/crates/domain/src/models/chain_sync_state.rs
+++ b/crates/domain/src/models/chain_sync_state.rs
@@ -39,7 +39,6 @@ impl ChainSyncState {
     }
 
     pub fn set_syncing_from(&self, height: usize) {
-        self.set_is_syncing(true);
         self.set_sync_target_height(height);
         self.mark_processed(height.saturating_sub(1));
     }

--- a/crates/p2p/src/chain_sync.rs
+++ b/crates/p2p/src/chain_sync.rs
@@ -322,7 +322,6 @@ impl<T: ApiClient, B: BlockDiscoveryFacade, M: MempoolFacade> ChainSyncService<T
                     shutdown: shutdown_rx,
                     msg_rx: rx,
                     inner,
-                    is_sync_task_spawned: AtomicBool::new(false),
                 };
                 service
                     .start()

--- a/crates/p2p/src/chain_sync.rs
+++ b/crates/p2p/src/chain_sync.rs
@@ -495,6 +495,7 @@ async fn sync_chain(
     }
     let is_trusted_mode = matches!(node_mode, NodeMode::TrustedPeerSync);
 
+    sync_state.set_syncing_from(start_sync_from_height);
     sync_state.set_trusted_sync(is_trusted_mode);
 
     let is_in_genesis_mode = matches!(node_mode, NodeMode::Genesis);
@@ -551,7 +552,7 @@ async fn sync_chain(
     let block_index = match get_block_index(
         peer_list,
         &api_client,
-        start_sync_from_height,
+        sync_state.sync_target_height(),
         BLOCK_BATCH_SIZE,
         5,
         fetch_index_from_the_trusted_peer,
@@ -588,7 +589,7 @@ async fn sync_chain(
         sync_state.finish_sync();
         return Ok(());
     } else {
-        sync_state.set_syncing_from(start_sync_from_height);
+        sync_state.set_is_syncing(true);
     }
 
     while let Some(block) = block_queue.pop_front() {


### PR DESCRIPTION
**Describe the changes**
This PR adds a new flag to the syncing service that used to mark that the sync task has been spawned. This is different from is_syncing flag in the sync state, which is set to true by the syncing task after it determines that there are blocks that are available for syncing.

**Related Issue(s)**

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**

