### PR TITLE
feat(gossip): add retries to gossip client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1702,6 +1702,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.16",
+ "instant",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "tokio",
+]
+
+[[package]]
 name = "backon"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4724,6 +4738,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "interprocess"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5064,6 +5087,7 @@ dependencies = [
  "actix-rt",
  "actix-web",
  "async-trait",
+ "backoff",
  "eyre",
  "irys-actors",
  "irys-api-client",

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -29,6 +29,7 @@ lru.workspace = true
 async-trait = "0.1"
 reth.workspace = true
 moka.workspace = true
+backoff = { version = "0.4", features = ["tokio"] }
 
 [dev-dependencies]
 irys-testing-utils.workspace = true

--- a/crates/p2p/src/gossip_client.rs
+++ b/crates/p2p/src/gossip_client.rs
@@ -31,7 +31,7 @@ pub enum GossipClientError {
 #[derive(Debug, Clone)]
 pub struct GossipClient {
     pub mining_address: Address,
-    client: Client,
+    client: Arc<Client>,
 }
 
 // TODO: Remove this when PeerList is no longer an actix service
@@ -46,10 +46,12 @@ impl GossipClient {
     pub fn new(timeout: Duration, mining_address: Address) -> Self {
         Self {
             mining_address,
-            client: Client::builder()
-                .timeout(timeout)
-                .build()
-                .expect("Failed to create reqwest client"),
+            client: Arc::new(
+                Client::builder()
+                    .timeout(timeout)
+                    .build()
+                    .expect("Failed to create reqwest client"),
+            ),
         }
     }
 


### PR DESCRIPTION
**Describe the changes**
@DanMacDonald @JesseTheRobot @antouhou - not sure if this is wanted or needed, but it seemed like low-hanging fruit in the p2p crate.  

(Note: the strategy levels and values are very finger-in-the-air and would need someone with more domain knowledge to supply sensible values)

Prior to this PR

The gossip client had no retry mechanism for network communications. When network requests failed due to transient issues (such as network timeouts or temporary server errors), they would immediately fail without any attempt to recover. 

  This PR

  Implements comprehensive retry logic with exponential backoff for all gossip client  network operations:

  Core Retry Implementation:
  - Integrated the backoff crate (v0.4) with tokio feature for async retry support
  - Replaced direct network calls with a retry_notify wrapper that automatically retries transient failures
  - Added intelligent HTTP status classification to distinguish between retryable (5xx,  429) and permanent (4xx) errors

  Backoff Strategy System:
  - Created three distinct backoff strategies based on data criticality:
    - Critical (50ms initial, 1s max, 30s total): For Block and CommitmentTransaction -  consensus-critical data
    - Normal (100ms initial, 2s max, 10s total): For Transaction and ExecutionPayload - standard operations
    - Light (200ms initial, 5s max, 5s total): For Chunk and IngressProof - less time-sensitive data
  - Automatic strategy selection based on GossipData type in send_data() method

  Enhanced Observability:
  - Implemented retry_notify instead of basic retry to log all retry attempts  
  - Structured logging with duration and error details for each retry: warn!(?dur, %err, "retrying after {:?}", dur)
  - Separate retry logging for different operation types (get_data, health check,  send_data)

  Performance Optimisation:
  - Wrapped reqwest::Client in Arc<Client> to reduce cloning overhead
  - Changed expensive Client clones to cheap Arc reference count increments
  - Maintains the same API surface while significantly reducing memory allocations during retries

  Methods Enhanced with Retry Logic:
  - make_get_data_request_and_update_the_score(): Retries data requests with backoff
  - check_health(): Retries health checks, treating server errors as transient
  - send_data_internal(): Core retry logic for all gossip data transmission
  - All methods now handle both network errors and HTTP status errors appropriately

  This implementation enhances the gossip network's resilience to temporary failures while providing detailed visibility into retry behaviour, ultimately improving the reliability of peer-to-peer communication within the network.


**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
