### PR TITLE
chore(ci): upgrade checkout to v5

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ jobs:
     outputs:
       should-run: ${{ steps.set-output.outputs.should-run }}  # register we have some output other actions should reference
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Need full history for comparison
         # this script checks whether we should run on the current commit, based on:


### PR DESCRIPTION
**Describe the changes**
bumps checkout to v5 for future-proofing against Node 24 runner updates.
requires runner v2.327.1+.
workflows compile the same.

ref: https://github.com/actions/checkout/releases/tag/v5.0.0

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**

