### PR TITLE
fix: SM/epoch replay/partition assignment logic when on-disk packing params are from a future epoch block

### DIFF
--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -884,6 +884,7 @@ impl BlockTreeServiceInner {
         if let Err(e) = self.service_senders.storage_modules.send(
             StorageModuleServiceMessage::PartitionAssignmentsUpdated {
                 storage_module_infos: storage_module_infos.into(),
+                update_height: epoch_block.height,
             },
         ) {
             error!("Failed to send partition assignments update: {}", e);

--- a/crates/actors/src/storage_module_service.rs
+++ b/crates/actors/src/storage_module_service.rs
@@ -32,6 +32,7 @@ use crate::{
 pub enum StorageModuleServiceMessage {
     PartitionAssignmentsUpdated {
         storage_module_infos: Arc<Vec<StorageModuleInfo>>,
+        update_height: u64,
     },
 }
 
@@ -78,13 +79,15 @@ impl StorageModuleServiceInner {
         match msg {
             StorageModuleServiceMessage::PartitionAssignmentsUpdated {
                 storage_module_infos,
-            } => self.handle_partition_assignments_update(storage_module_infos),
+                update_height,
+            } => self.handle_partition_assignments_update(storage_module_infos, update_height),
         }
     }
 
     fn handle_partition_assignments_update(
         &mut self,
         storage_module_infos: Arc<Vec<StorageModuleInfo>>,
+        update_height: u64,
     ) -> eyre::Result<()> {
         let span = Span::current();
         let _span = span.enter();
@@ -101,11 +104,11 @@ impl StorageModuleServiceInner {
             let existing = current_modules
                 .iter()
                 .find(|sm| sm.id == sm_info.id)
-                .expect("StorageModuleInfo should only reference valid storage module ids");
+                .unwrap_or_else(|| panic!("StorageModuleInfo should only reference valid storage module ids - ID: {}, current info: {:#?}, sms: {:#?}, infos: {:#?}", &sm_info.id, &sm_info, &current_modules, &storage_module_infos));
 
             // Did this storage module get assigned a new partition_hash ?
             if existing.partition_assignment().is_none() && sm_info.partition_assignment.is_some() {
-                existing.assign_partition(sm_info.partition_assignment.unwrap());
+                existing.assign_partition(sm_info.partition_assignment.unwrap(), update_height);
                 // Record this storage module as updated
                 updated_modules.push(existing.clone());
 
@@ -153,7 +156,7 @@ impl StorageModuleServiceInner {
                 {
                     // Update the storage modules partition assignment (and packing params toml)
                     // to match ledger/capacity reassignment
-                    existing.assign_partition(info_pa);
+                    existing.assign_partition(info_pa, update_height);
 
                     // Record this storage module as updated
                     updated_modules.push(existing.clone());

--- a/crates/domain/src/models/storage_module.rs
+++ b/crates/domain/src/models/storage_module.rs
@@ -150,12 +150,13 @@ impl StorageModuleInfo {
     }
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq, Copy)]
 pub struct PackingParams {
     pub packing_address: Address,
     pub partition_hash: Option<H256>,
     pub ledger: Option<u32>,
     pub slot: Option<usize>,
+    pub last_updated_height: Option<u64>,
 }
 
 impl PackingParams {
@@ -385,7 +386,7 @@ impl StorageModule {
         })
     }
 
-    pub fn assign_partition(&self, partition_assignment: PartitionAssignment) {
+    pub fn assign_partition(&self, partition_assignment: PartitionAssignment, update_height: u64) {
         let mut pa = self.partition_assignment.write().unwrap();
         *pa = Some(partition_assignment);
 
@@ -396,6 +397,7 @@ impl StorageModule {
                 partition_hash: Some(partition_assignment.partition_hash),
                 ledger: partition_assignment.ledger_id,
                 slot: partition_assignment.slot_index,
+                last_updated_height: Some(update_height),
             };
 
             let params_path = submodule.path.join(PACKING_PARAMS_FILE_NAME);

--- a/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
+++ b/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
@@ -20,7 +20,7 @@ use std::path::PathBuf;
 use tracing::{debug, error, trace, warn};
 
 /// Temporarily track all of the ledger definitions inside the epoch service actor
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EpochSnapshot {
     /// Protocol-managed data ledgers (one permanent, N term)
     pub ledgers: Ledgers,
@@ -42,23 +42,8 @@ pub struct EpochSnapshot {
     pub previous_epoch_block: Option<IrysBlockHeader>,
     /// Partition hashes that expired with this snapshot
     pub expired_partition_hashes: Vec<PartitionHash>,
-}
-
-impl Clone for EpochSnapshot {
-    fn clone(&self) -> Self {
-        Self {
-            ledgers: self.ledgers.clone(),
-            partition_assignments: self.partition_assignments.clone(),
-            all_active_partitions: self.all_active_partitions.clone(),
-            unassigned_partitions: self.unassigned_partitions.clone(),
-            storage_submodules_config: self.storage_submodules_config.clone(),
-            config: self.config.clone(),
-            commitment_state: self.commitment_state.clone(),
-            epoch_block: self.epoch_block.clone(),
-            previous_epoch_block: self.previous_epoch_block.clone(),
-            expired_partition_hashes: self.expired_partition_hashes.clone(),
-        }
-    }
+    /// Epoch block height this snapshot was computed for
+    pub height: u64,
 }
 
 impl Default for EpochSnapshot {
@@ -76,6 +61,7 @@ impl Default for EpochSnapshot {
             epoch_block: IrysBlockHeader::default(),
             previous_epoch_block: None,
             expired_partition_hashes: Vec::new(),
+            height: IrysBlockHeader::default().height,
         }
     }
 }
@@ -112,6 +98,7 @@ impl EpochSnapshot {
             epoch_block: genesis_block.clone(),
             previous_epoch_block: None,
             expired_partition_hashes: Vec::new(),
+            height: genesis_block.height,
         };
 
         match new_self.perform_epoch_tasks(&None, &genesis_block, commitments) {
@@ -233,6 +220,8 @@ impl EpochSnapshot {
     ) -> Result<(), EpochSnapshotError> {
         // Validate the epoch blocks
         self.is_epoch_block(new_epoch_block)?;
+
+        self.height = new_epoch_block.height;
 
         // Skip previous block validation for genesis block (height 0)
         if new_epoch_block.height <= self.config.consensus.epoch.num_blocks_in_epoch {
@@ -895,7 +884,7 @@ impl EpochSnapshot {
 
         // Collect existing storage module packing info
         let mut sm_packing_info = self.collect_packing_info(paths);
-        debug!("{:#?}", sm_packing_info);
+        debug!("Packing info: {:#?}", &sm_packing_info);
 
         let mut module_infos = Vec::new();
 
@@ -930,10 +919,16 @@ impl EpochSnapshot {
         );
 
         // STEP 4: Unassigned
-        for (original_idx, (path, _)) in sm_packing_info
-            .iter()
-            .enumerate()
-            .filter(|(_, (_, params))| params.is_none())
+        for (original_idx, (path, _)) in
+            sm_packing_info
+                .iter()
+                .enumerate()
+                .filter(|(_, (_, params))| {
+                    params.is_none()
+                        || params.is_some_and(|pa| {
+                            pa.last_updated_height.unwrap_or(self.height + 1) > self.height
+                        })
+                })
         {
             module_infos.push(StorageModuleInfo {
                 id: original_idx,
@@ -1007,6 +1002,7 @@ impl EpochSnapshot {
                 partition_hash: Some(pa.partition_hash),
                 ledger: pa.ledger_id,
                 slot: pa.slot_index,
+                last_updated_height: Some(self.height),
             });
         }
     }
@@ -1095,6 +1091,7 @@ mod tests {
             epoch_block: IrysBlockHeader::default(),
             previous_epoch_block: None,
             expired_partition_hashes: Vec::new(),
+            height: 0,
         };
 
         // Allocate four slots in the submit ledger so `slot_count()` returns 4.


### PR DESCRIPTION
i.e if a node is reset, we can start with our SM's having packing information from a future epoch block we haven't synchronised up to yet

**Describe the changes**
A clear and concise description of what the bug fix, feature, or improvement is.

**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
