### PR TITLE
feat: prune CachedDataRoots at submit ledger term expiry

### DIFF
--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -884,6 +884,16 @@ impl BlockTreeServiceInner {
             mining_broadcaster_addr.do_send(BroadcastPartitionsExpiration(H256List(
                 expired_partition_hashes,
             )));
+
+            // Let the cache service know some term ledger slots expired
+            if let Err(e) = self.service_senders.chunk_cache.send(
+                crate::cache_service::CacheServiceAction::OnEpochProcessed(
+                    epoch_snapshot.clone(),
+                    None,
+                ),
+            ) {
+                error!("Failed to send EpochProcessed event to CacheService: {}", e);
+            }
         }
 
         // Let the node know about any newly assigned partition hashes to local storage modules

--- a/crates/chain/tests/promotion/data_promotion_double.rs
+++ b/crates/chain/tests/promotion/data_promotion_double.rs
@@ -1,5 +1,5 @@
+use crate::utils::post_chunk;
 use crate::utils::{get_block_parent, verify_published_chunk, IrysNodeTest};
-use crate::utils::{mine_blocks, post_chunk};
 use actix_web::test::{self, call_service, TestRequest};
 use alloy_core::primitives::U256;
 use alloy_genesis::GenesisAccount;
@@ -376,10 +376,8 @@ async fn slow_heavy_double_root_data_promotion_test() {
 
     // println!("\n{:?}", unpacked_chunk);
 
-    mine_blocks(&node.node_ctx, 5).await.unwrap();
-    // ensure the ingress proof is gone
-    let ingress_proofs = db.view(walk_all::<IngressProofs, _>).unwrap().unwrap();
-    assert_eq!(ingress_proofs.len(), 0);
+    // Because it takes multiple ingress proofs to promote a tx, we keep ingress
+    // proofs around until their data_roots expire out of the Submit ledger
 
     node.node_ctx.stop().await;
 }

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -136,19 +136,11 @@ pub fn cache_data_root<T: DbTx + DbTxMut>(
 ) -> eyre::Result<Option<CachedDataRoot>> {
     let key = tx_header.data_root;
 
-    // Calculate the duration since UNIX_EPOCH
-    let now = SystemTime::now();
-    let duration_since_epoch = now
-        .duration_since(UNIX_EPOCH)
-        .expect("should be able to compute duration since UNIX_EPOCH");
-    let timestamp = duration_since_epoch.as_millis();
-
     // Access the current cached entry from the database
     let result = tx.get::<CachedDataRoots>(key)?;
 
     // Create or update the CachedDataRoot
     let mut cached_data_root = result.unwrap_or_else(|| CachedDataRoot {
-        timestamp,
         data_size: tx_header.data_size,
         txid_set: vec![tx_header.id],
     });
@@ -157,7 +149,6 @@ pub fn cache_data_root<T: DbTx + DbTxMut>(
     if !cached_data_root.txid_set.contains(&tx_header.id) {
         cached_data_root.txid_set.push(tx_header.id);
     }
-    cached_data_root.timestamp = timestamp;
 
     // Update the database with the modified or new entry
     tx.put::<CachedDataRoots>(key, cached_data_root.clone())?;

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -26,7 +26,6 @@ use reth_db::{
     ClientVersion, DatabaseEnv, DatabaseError,
 };
 use reth_node_metrics::recorder::install_prometheus_recorder;
-use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::{debug, warn};
 
 /// Opens up an existing database or creates a new one at the specified path. Creates tables if

--- a/crates/database/src/db_cache.rs
+++ b/crates/database/src/db_cache.rs
@@ -78,11 +78,6 @@ fn global_chunk_offset_compact_roundtrip() {
 
 #[derive(Clone, Debug, Eq, Default, PartialEq, Serialize, Deserialize, Arbitrary, Compact)]
 pub struct CachedDataRoot {
-    /// Unlike a unix timestamp which stores the number of seconds since
-    /// `UNIX_EPOCH`, this timestamp stores the number of milliseconds. Similar
-    /// to javascript timestamps.
-    pub timestamp: u128,
-
     /// Total size (in bytes) of the data represented by the `data_root`
     pub data_size: u64,
 

--- a/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
+++ b/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
@@ -951,6 +951,19 @@ impl EpochSnapshot {
         ledgers.get_expiring_term_partitions(epoch_height)
     }
 
+    pub fn get_first_unexpired_slot_index(&self, ledger_id: DataLedger) -> usize {
+        let slots = self.ledgers[ledger_id].get_slots();
+
+        // Try to find the first unexpired slot
+        for i in 0..slots.len() {
+            if !slots[i].is_expired {
+                return i;
+            }
+        }
+        // This should only be the case with the published/permanent ledger data
+        0
+    }
+
     /// Loops though all the paths in the storage_submodules.toml and attempts to read the existing
     /// packing params from that path, building a list of (PathBuf, Option<PackingParams>) whose
     /// indexes map to the index of the path in the .toml


### PR DESCRIPTION
* only expire data_roots and IngressProofs from the cache when the blocks that added them expire out of the submit ledger
* remove `timestamp` from the `CachedDataRoot` struct as it wasn't used, expiry is based on block_height
* update tests accordingly