### PR TITLE
fix: Added chunk LRU to prevent over-gossiping

### DIFF
--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -36,7 +36,7 @@ use irys_types::{
         phantoms::{Irys, NetworkFee},
         Amount,
     },
-    Address, Base64, CommitmentTransaction, CommitmentValidationError, DataRoot,
+    Address, Base64, ChunkPathHash, CommitmentTransaction, CommitmentValidationError, DataRoot,
     DataTransactionHeader, MempoolConfig, TxChunkOffset, UnpackedChunk,
 };
 use irys_types::{IngressProofsList, TokioServiceHandle};
@@ -1023,6 +1023,8 @@ pub struct MempoolState {
     pub recent_invalid_tx: LruCache<H256, ()>,
     /// Tracks recent valid txids from either data or commitment
     pub recent_valid_tx: LruCache<H256, ()>,
+    /// Tracks recently processed chunk hashes to prevent re-gossip
+    pub recent_valid_chunks: LruCache<ChunkPathHash, ()>,
     /// LRU caches for out of order gossip data
     pub pending_chunks: LruCache<DataRoot, LruCache<TxChunkOffset, UnpackedChunk>>,
     pub pending_pledges: LruCache<Address, LruCache<IrysTransactionId, CommitmentTransaction>>,
@@ -1043,6 +1045,7 @@ pub fn create_state(config: &MempoolConfig) -> MempoolState {
         valid_commitment_tx: BTreeMap::new(),
         recent_invalid_tx: LruCache::new(NonZeroUsize::new(config.max_invalid_items).unwrap()),
         recent_valid_tx: LruCache::new(NonZeroUsize::new(config.max_valid_items).unwrap()),
+        recent_valid_chunks: LruCache::new(NonZeroUsize::new(config.max_valid_chunks).unwrap()),
         pending_chunks: LruCache::new(NonZeroUsize::new(max_pending_chunk_items).unwrap()),
         pending_pledges: LruCache::new(NonZeroUsize::new(max_pending_pledge_items).unwrap()),
     }

--- a/crates/config/templates/testnet_config.toml
+++ b/crates/config/templates/testnet_config.toml
@@ -108,8 +108,11 @@ max_pending_pledge_items = 100
 max_pledges_per_item = 100
 max_pending_chunk_items = 30
 max_chunks_per_item = 500
+max_preheader_chunks_per_item = 64
+max_preheader_data_path_bytes = 65536
 max_valid_items = 10000
 max_invalid_items = 10000
+max_valid_chunks = 10000
 commitment_fee = 100
 
 [consensus.Custom.difficulty_adjustment]

--- a/crates/types/src/config.rs
+++ b/crates/types/src/config.rs
@@ -545,6 +545,10 @@ pub struct MempoolConfig {
     /// Decreasing this will increase the amount of validation the node will have to perform
     pub max_invalid_items: usize,
 
+    /// Maximum number of valid chunk hashes to keep track of
+    /// Prevents re-processing and re-gossipping of recently seen chunks
+    pub max_valid_chunks: usize,
+
     /// Fee required for commitment transactions (stake, unstake, pledge, unpledge)
     pub commitment_fee: u64,
 }
@@ -685,6 +689,7 @@ impl ConsensusConfig {
                 max_preheader_data_path_bytes: 64 * 1024,
                 max_invalid_items: 10_000,
                 max_valid_items: 10_000,
+                max_valid_chunks: 10_000,
                 commitment_fee: 100,
             },
             vdf: VdfConfig {
@@ -814,6 +819,7 @@ impl ConsensusConfig {
                 max_preheader_data_path_bytes: 64 * 1024,
                 max_invalid_items: 10_000,
                 max_valid_items: 10_000,
+                max_valid_chunks: 10_000,
                 commitment_fee: 100,
             },
             vdf: VdfConfig {
@@ -1440,6 +1446,7 @@ mod tests {
         max_preheader_data_path_bytes = 65536
         max_invalid_items = 10000
         max_valid_items = 10000
+        max_valid_chunks = 10000
         commitment_fee = 100
 
 


### PR DESCRIPTION
**Describe the changes**
 Before this PR, the mempool service would re-process and re-gossip chunks that had already been successfully processed, leading to unnecessary network traffic and redundant processing overhead. This can occur when the same chunk is received multiple times from different peers.

  This PR adds an LRU cache to track recently processed chunk hashes in the mempool service, preventing duplicate chunk processing and re-gossiping. The implementation:
  - Introduces a recent_valid_chunks LRU cache with configurable size (max_valid_chunks)
  - Checks incoming chunks against the cache before processing
  - Adds successfully processed chunks to the cache after validation
  - Defaults to tracking the last 10,000 processed chunks to balance memory usage with deduplication effectiveness

  This optimisation reduces unnecessary network gossip and improves mempool performance by avoiding redundant chunk validation and propagation.


**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
