### PR TITLE
feat: separate sync and node mode

### DIFF
--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -355,7 +355,7 @@ impl IrysNode {
                 // Create a new genesis block for network initialization
                 self.create_new_genesis_block(genesis_block.clone()).await
             }
-            NodeMode::PeerSync | NodeMode::TrustedPeerSync => {
+            NodeMode::Peer => {
                 // Fetch genesis data from trusted peer when joining network
                 self.fetch_genesis_from_trusted_peer().await
             }
@@ -520,7 +520,7 @@ impl IrysNode {
     pub async fn start(self) -> eyre::Result<IrysNodeCtx> {
         // Determine node startup mode
         let config = &self.config;
-        let node_mode = &config.node_config.mode;
+        let node_mode = &config.node_config.node_mode;
         // Start with base genesis and update fields
         let (chain_spec, genesis_block) = IrysChainSpecBuilder::from_config(&self.config).build();
 

--- a/crates/chain/src/main.rs
+++ b/crates/chain/src/main.rs
@@ -24,7 +24,7 @@ async fn main() -> eyre::Result<()> {
     let config = load_config()?;
 
     // start the node
-    info!("starting the node, mode: {:?}", &config.mode);
+    info!("starting the node, mode: {:?}", &config.node_mode);
     let handle = IrysNode::new(config)?.start().await?;
     handle.start_mining().await?;
     let reth_thread_handle = handle.reth_thread_handle.clone();

--- a/crates/chain/src/utils.rs
+++ b/crates/chain/src/utils.rs
@@ -36,10 +36,10 @@ pub fn load_config() -> eyre::Result<NodeConfig> {
 
     let is_genesis = std::env::var("GENESIS")
         .map(|_| true)
-        .unwrap_or(matches!(config.mode, NodeMode::Genesis));
+        .unwrap_or(matches!(config.node_mode, NodeMode::Genesis));
 
     if is_genesis {
-        config.mode = NodeMode::Genesis;
+        config.node_mode = NodeMode::Genesis;
     }
 
     Ok(config)

--- a/crates/chain/tests/block_production/reset_seed.rs
+++ b/crates/chain/tests/block_production/reset_seed.rs
@@ -3,7 +3,7 @@ use irys_actors::mempool_service::TxIngressError;
 use irys_chain::IrysNodeCtx;
 use irys_types::{
     irys::IrysSigner, BlockHash, ConsensusConfig, ConsensusOptions, DataTransaction,
-    IrysBlockHeader, IrysTransactionId, NodeConfig, NodeMode,
+    IrysBlockHeader, IrysTransactionId, NodeConfig, NodeMode, SyncMode,
 };
 use std::collections::HashMap;
 use tracing::{debug, warn};
@@ -106,7 +106,8 @@ async fn slow_heavy_reset_seeds_should_be_correctly_applied_by_the_miner_and_ver
     let mut ctx_peer1_node = ctx_genesis_node.testing_peer();
     // Setting up mode to full validation sync to check that the reset seed is applied correctly
     //  and all blocks are validated successfully
-    ctx_peer1_node.mode = NodeMode::PeerSync;
+    ctx_peer1_node.node_mode = NodeMode::Peer;
+    ctx_peer1_node.sync_mode = SyncMode::Full;
     let ctx_peer1_node = IrysNodeTest::new(ctx_peer1_node.clone())
         .start_with_name("PEER1")
         .await;

--- a/crates/chain/tests/multi_node/sync_chain_state.rs
+++ b/crates/chain/tests/multi_node/sync_chain_state.rs
@@ -9,7 +9,7 @@ use irys_chain::{
 use irys_database::block_header_by_hash;
 use irys_types::{
     irys::IrysSigner, BlockIndexItem, DataTransaction, IrysTransactionId, NodeConfig, NodeInfo,
-    NodeMode, PeerAddress, H256,
+    NodeMode, PeerAddress, SyncMode, H256,
 };
 use reth::rpc::eth::EthApiServer as _;
 use reth_db::Database as _;
@@ -220,7 +220,8 @@ async fn slow_heavy_sync_chain_state_then_gossip_blocks() -> eyre::Result<()> {
         .await;
 
     let mut ctx_peer2_node = ctx_genesis_node.testing_peer();
-    ctx_peer2_node.mode = NodeMode::TrustedPeerSync;
+    ctx_peer2_node.node_mode = NodeMode::Peer;
+    ctx_peer2_node.sync_mode = SyncMode::Trusted;
     let ctx_peer2_node = IrysNodeTest::new(ctx_peer2_node.clone())
         .start_with_name("PEER2")
         .await;

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -43,8 +43,8 @@ use irys_testing_utils::utils::tempfile::TempDir;
 use irys_testing_utils::utils::temporary_directory;
 use irys_types::{
     block_production::Seed, block_production::SolutionContext, irys::IrysSigner,
-    partition::PartitionAssignment, Address, DataLedger, GossipBroadcastMessage, H256List, H256,
-    U256,
+    partition::PartitionAssignment, Address, DataLedger, GossipBroadcastMessage, H256List,
+    SyncMode, H256, U256,
 };
 use irys_types::{
     Base64, ChunkBytes, CommitmentTransaction, Config, ConsensusConfig, DataTransaction,
@@ -293,15 +293,16 @@ impl IrysNodeTest<()> {
         Self::new_genesis(config)
     }
 
-    /// Start a new test node in peer-sync mode
+    /// Start a new test node in peer-sync mode with full block validation
     pub fn new(mut config: NodeConfig) -> Self {
-        config.mode = NodeMode::PeerSync;
+        config.node_mode = NodeMode::Peer;
+        config.sync_mode = SyncMode::Full;
         Self::new_inner(config)
     }
 
     /// Start a new test node in genesis mode
     pub fn new_genesis(mut config: NodeConfig) -> Self {
-        config.mode = NodeMode::Genesis;
+        config.node_mode = NodeMode::Genesis;
         Self::new_inner(config)
     }
 
@@ -372,7 +373,7 @@ impl IrysNodeTest<IrysNodeCtx> {
 
         let node_config = &self.node_ctx.config.node_config;
 
-        if node_config.mode == NodeMode::PeerSync {
+        if node_config.node_mode == NodeMode::Peer {
             panic!("Can only create a peer from a genesis config");
         }
 
@@ -387,7 +388,8 @@ impl IrysNodeTest<IrysNodeCtx> {
         peer_config.gossip.public_port = 0;
 
         // Make sure to mark this config as a peer
-        peer_config.mode = NodeMode::PeerSync;
+        peer_config.node_mode = NodeMode::Peer;
+        peer_config.sync_mode = SyncMode::Full;
 
         // Add the genesis node details as a trusted peer
         peer_config.trusted_peers = vec![

--- a/crates/config/templates/testnet_config.toml
+++ b/crates/config/templates/testnet_config.toml
@@ -1,4 +1,5 @@
-mode = "PeerSync"
+node_mode = "Peer"
+sync_mode = "Full"
 base_directory = ""
 mining_key = "0000000000000000000000000000000000000000000000000000000000000001"
 trusted_peers = []

--- a/crates/p2p/src/chain_sync.rs
+++ b/crates/p2p/src/chain_sync.rs
@@ -8,7 +8,8 @@ use irys_api_client::{ApiClient, IrysApiClient};
 use irys_domain::chain_sync_state::ChainSyncState;
 use irys_domain::{BlockIndexReadGuard, PeerList};
 use irys_types::{
-    BlockHash, BlockIndexItem, BlockIndexQuery, Config, EvmBlockHash, NodeMode, TokioServiceHandle,
+    BlockHash, BlockIndexItem, BlockIndexQuery, Config, EvmBlockHash, NodeMode, SyncMode,
+    TokioServiceHandle,
 };
 use rand::prelude::SliceRandom as _;
 use reth::tasks::shutdown::Shutdown;
@@ -536,7 +537,7 @@ async fn sync_chain<B: BlockDiscoveryFacade, M: MempoolFacade, A: ApiClient>(
     config: &irys_types::Config,
     gossip_data_handler: Arc<GossipDataHandler<M, B, A>>,
 ) -> ChainSyncResult<()> {
-    let node_mode = config.node_config.mode;
+    let sync_mode = config.node_config.sync_mode;
     let genesis_peer_discovery_timeout_millis =
         config.node_config.genesis_peer_discovery_timeout_millis;
     // Check if gossip reception is enabled before starting sync
@@ -551,29 +552,28 @@ async fn sync_chain<B: BlockDiscoveryFacade, M: MempoolFacade, A: ApiClient>(
     if start_sync_from_height == 0 {
         start_sync_from_height = 1;
     }
-    let is_trusted_mode = matches!(node_mode, NodeMode::TrustedPeerSync);
+    let is_trusted_mode = matches!(sync_mode, SyncMode::Trusted);
 
     sync_state.set_syncing_from(start_sync_from_height);
     sync_state.set_trusted_sync(is_trusted_mode);
 
-    let is_in_genesis_mode = matches!(node_mode, NodeMode::Genesis);
-
-    if matches!(node_mode, NodeMode::TrustedPeerSync) {
-        sync_state.set_trusted_sync(true);
-    } else {
-        sync_state.set_trusted_sync(false);
-    }
-
-    debug!("Sync task: Starting a chain sync task, waiting for active peers. Mode: {:?}, starting from height: {}, trusted mode: {}", node_mode, start_sync_from_height, sync_state.is_trusted_sync());
-
-    if is_in_genesis_mode && sync_state.sync_target_height() <= 1 {
+    let is_a_genesis_node = matches!(config.node_config.node_mode, NodeMode::Genesis);
+    if is_a_genesis_node && sync_state.sync_target_height() <= 1 {
         debug!("Sync task: The node is a genesis node with no blocks, skipping the sync task");
         sync_state.finish_sync();
         return Ok(());
     }
 
-    let fetch_index_from_the_trusted_peer = !is_in_genesis_mode;
-    if is_in_genesis_mode {
+    if matches!(sync_mode, SyncMode::Trusted) {
+        sync_state.set_trusted_sync(true);
+    } else {
+        sync_state.set_trusted_sync(false);
+    }
+
+    debug!("Sync task: Starting a chain sync task, waiting for active peers. Mode: {:?}, starting from height: {}, trusted mode: {}", sync_mode, start_sync_from_height, sync_state.is_trusted_sync());
+
+    let fetch_index_from_the_trusted_peer = !is_trusted_mode;
+    if is_a_genesis_node {
         warn!("Sync task: Because the node is a genesis node, waiting for active peers for {}, and if no peers are added, then skipping the sync task", genesis_peer_discovery_timeout_millis);
         match timeout(
             Duration::from_millis(genesis_peer_discovery_timeout_millis),
@@ -623,11 +623,6 @@ async fn sync_chain<B: BlockDiscoveryFacade, M: MempoolFacade, A: ApiClient>(
         }
         Err(err) => {
             error!("Sync task: Failed to fetch block index: {}", err);
-            if is_in_genesis_mode {
-                warn!("Sync task: No peers available, skipping the sync task");
-                sync_state.finish_sync();
-                return Ok(());
-            }
             return Err(err);
         }
     };
@@ -1105,7 +1100,7 @@ mod tests {
             };
 
             let mut node_config = NodeConfig::testing();
-            node_config.mode = NodeMode::PeerSync;
+            node_config.sync_mode = SyncMode::Full;
             node_config.trusted_peers = vec![fake_peer_address];
             node_config.genesis_peer_discovery_timeout_millis = 10;
             let config = Config::new(node_config);
@@ -1240,7 +1235,7 @@ mod tests {
             ));
 
             let mut node_config = NodeConfig::testing();
-            node_config.mode = NodeMode::Genesis;
+            node_config.node_mode = NodeMode::Genesis;
             node_config.trusted_peers = vec![];
             node_config.genesis_peer_discovery_timeout_millis = 10;
             let config = Config::new(node_config);

--- a/crates/types/src/config.rs
+++ b/crates/types/src/config.rs
@@ -260,7 +260,10 @@ pub struct RethChainSpec {
 #[serde(deny_unknown_fields)]
 pub struct NodeConfig {
     /// Determines how the node joins and interacts with the network
-    pub mode: NodeMode,
+    pub node_mode: NodeMode,
+
+    /// The synchronization mode for the node
+    pub sync_mode: SyncMode,
 
     /// The base directory where to look for artifact data
     #[serde(default = "default_irys_path")]
@@ -336,10 +339,22 @@ pub enum NodeMode {
     Genesis,
 
     /// Join an existing network by connecting to trusted peers
-    PeerSync,
+    Peer,
+}
 
-    /// Trusted peer mode, where the node only connects to trusted peers
-    TrustedPeerSync,
+/// # Node Synchronization Mode
+///
+/// Defines the method the node uses to synchronize with the network.
+/// Trusted mode allows for faster sync by relying on trusted peers,
+/// while Full mode ensures complete validation of all blocks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub enum SyncMode {
+    /// Fast sync mode, downloads index from the trusted peers and skips
+    /// heavy parts of the block validation
+    Trusted,
+    /// Full sync mode, fully validates all blocks
+    Full,
 }
 
 /// # Consensus Configuration Source
@@ -953,7 +968,8 @@ impl NodeConfig {
         consensus.genesis.miner_address = reward_address;
         consensus.genesis.reward_address = reward_address;
         Self {
-            mode: NodeMode::Genesis,
+            node_mode: NodeMode::Genesis,
+            sync_mode: SyncMode::Full,
             consensus: ConsensusOptions::Custom(consensus),
             base_directory: default_irys_path(),
 
@@ -1049,7 +1065,8 @@ impl NodeConfig {
         consensus.genesis.miner_address = reward_address;
         consensus.genesis.reward_address = reward_address;
         Self {
-            mode: NodeMode::PeerSync,
+            node_mode: NodeMode::Peer,
+            sync_mode: SyncMode::Full,
             consensus: ConsensusOptions::Custom(consensus),
             base_directory: default_irys_path(),
 
@@ -1597,7 +1614,7 @@ mod tests {
             .expect("Failed to parse testnet_config.toml template");
 
         // Basic sanity checks - just verify it parsed successfully
-        assert_eq!(config.mode, NodeMode::PeerSync);
+        assert_eq!(config.node_mode, NodeMode::Peer);
 
         // Check consensus config fields
         let consensus = config.consensus_config();

--- a/crates/types/src/config.rs
+++ b/crates/types/src/config.rs
@@ -1505,7 +1505,8 @@ mod tests {
     #[test]
     fn test_deserialize_config_from_toml() {
         let toml_data = r#"
-        mode = "Genesis"
+        node_mode = "Genesis"
+        sync_mode = "Full"
         base_directory = "~/.tmp/.irys"
         consensus = "Testing"
         mining_key = "db793353b633df950842415065f769699541160845d73db902eadee6bc5042d0"


### PR DESCRIPTION
**Describe the changes**
To allow genesis node to perform fast sync on restart, `NodeMode` has been separated into two: `NodeMode` and `SyncMode`

**Related Issue(s)**

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
