### PR TITLE
feat: CLI rollback-blocks command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4958,6 +4958,7 @@ dependencies = [
  "irys-chain",
  "irys-config",
  "irys-database",
+ "irys-domain",
  "irys-reth-node-bridge",
  "irys-types",
  "reth-node-core",

--- a/crates/chain/src/main.rs
+++ b/crates/chain/src/main.rs
@@ -43,7 +43,7 @@ fn init_tracing() -> eyre::Result<()> {
     let subscriber = Registry::default();
     let filter = EnvFilter::builder()
         .with_default_directive(LevelFilter::INFO.into())
-        .try_from_env()?;
+        .from_env()?;
 
     let output_layer = tracing_subscriber::fmt::layer()
         .with_line_number(true)

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,5 +23,6 @@ irys-reth-node-bridge.workspace = true
 irys-chain.workspace = true
 irys-config.workspace = true
 tokio.workspace = true
+irys-domain.workspace = true
 [lints]
 workspace = true


### PR DESCRIPTION
**Describe the changes**
Adds a `rollback-blocks` command to the CLI, which just removes the provided number of blocks from the block index, after backing it up.
