### PR TITLE
fix: during payload repair don't consider payload existing if it is in the cache

### DIFF
--- a/crates/domain/src/models/execution_payload_cache.rs
+++ b/crates/domain/src/models/execution_payload_cache.rs
@@ -194,7 +194,7 @@ impl ExecutionPayloadCache {
     }
 
     /// Checks if the execution payload is stored in the EVM node.
-    pub async fn is_stored_in_reth(&self, evm_block_hash: &B256) -> bool {
+    pub fn is_stored_in_reth(&self, evm_block_hash: &B256) -> bool {
         self.reth_payload_provider
             .evm_block(*evm_block_hash)
             .is_some()

--- a/crates/domain/src/models/execution_payload_cache.rs
+++ b/crates/domain/src/models/execution_payload_cache.rs
@@ -172,7 +172,11 @@ impl ExecutionPayloadCache {
         }
     }
 
-    pub async fn get_locally_stored_sealed_block(
+    /// Tries to get the sealed block from the local cache first, and if not found, fetches it from
+    /// the EVM node. This method does not request the payload from the network if it is not found
+    /// locally, use [ExecutionPayloadCache::wait_for_sealed_block] instead if you want to
+    /// request the payload from the network.
+    pub async fn get_sealed_block_from_cache(
         &self,
         evm_block_hash: &B256,
     ) -> Option<SealedBlock<Block>> {
@@ -187,6 +191,14 @@ impl ExecutionPayloadCache {
             let block = self.reth_payload_provider.evm_block(*evm_block_hash)?;
             Some(block.seal_slow())
         }
+    }
+
+    /// Checks if the execution payload is stored in the EVM node.
+    pub async fn is_stored_in_reth(
+        &self,
+        evm_block_hash: &B256,
+    ) -> bool {
+        self.reth_payload_provider.evm_block(*evm_block_hash).is_some()
     }
 
     /// Waits for the execution payload to arrive over gossip. This method will first check the local
@@ -215,7 +227,7 @@ impl ExecutionPayloadCache {
         evm_block_hash: &B256,
         request_only_from_trusted_peers: bool,
     ) -> Option<SealedBlock<Block>> {
-        if let Some(sealed_block) = self.get_locally_stored_sealed_block(evm_block_hash).await {
+        if let Some(sealed_block) = self.get_sealed_block_from_cache(evm_block_hash).await {
             return Some(sealed_block);
         }
 
@@ -285,7 +297,7 @@ impl ExecutionPayloadCache {
         timeout: std::time::Duration,
     ) {
         if self
-            .get_locally_stored_sealed_block(&evm_block_hash)
+            .get_sealed_block_from_cache(&evm_block_hash)
             .await
             .is_none()
         {

--- a/crates/domain/src/models/execution_payload_cache.rs
+++ b/crates/domain/src/models/execution_payload_cache.rs
@@ -194,11 +194,10 @@ impl ExecutionPayloadCache {
     }
 
     /// Checks if the execution payload is stored in the EVM node.
-    pub async fn is_stored_in_reth(
-        &self,
-        evm_block_hash: &B256,
-    ) -> bool {
-        self.reth_payload_provider.evm_block(*evm_block_hash).is_some()
+    pub async fn is_stored_in_reth(&self, evm_block_hash: &B256) -> bool {
+        self.reth_payload_provider
+            .evm_block(*evm_block_hash)
+            .is_some()
     }
 
     /// Waits for the execution payload to arrive over gossip. This method will first check the local

--- a/crates/p2p/src/block_pool.rs
+++ b/crates/p2p/src/block_pool.rs
@@ -436,9 +436,8 @@ where
 
             let prev_payload_exists = self
                 .execution_payload_provider
-                .get_locally_stored_sealed_block(&block.evm_block_hash)
-                .await
-                .is_some();
+                .is_stored_in_reth(&block.evm_block_hash)
+                .await;
 
             // Found a block with a payload or reached the genesis block
             if prev_payload_exists || block.height <= 1 {
@@ -724,7 +723,7 @@ where
             {
                 Ok(()) => {
                     let gossip_payload = execution_payload_provider
-                        .get_locally_stored_sealed_block(&evm_block_hash)
+                        .get_sealed_block_from_cache(&evm_block_hash)
                         .await
                         .map(GossipBroadcastMessage::from);
 

--- a/crates/p2p/src/block_pool.rs
+++ b/crates/p2p/src/block_pool.rs
@@ -436,8 +436,7 @@ where
 
             let prev_payload_exists = self
                 .execution_payload_provider
-                .is_stored_in_reth(&block.evm_block_hash)
-                .await;
+                .is_stored_in_reth(&block.evm_block_hash);
 
             // Found a block with a payload or reached the genesis block
             if prev_payload_exists || block.height <= 1 {
@@ -454,7 +453,10 @@ where
 
         // The last block in the list is the oldest block with a missing payload
         while let Some(block) = blocks_with_missing_payloads.pop() {
-            debug!("Repairing missing payload for block {:?}", block.block_hash);
+            debug!(
+                "Repairing a missing payload for the block {:?}",
+                block.block_hash
+            );
             self.validate_and_submit_reth_payload(&block, reth_service.clone())
                 .await?;
         }

--- a/crates/p2p/src/tests/integration/mod.rs
+++ b/crates/p2p/src/tests/integration/mod.rs
@@ -490,7 +490,7 @@ async fn heavy_should_gossip_execution_payloads() -> eyre::Result<()> {
 
     let local_sealed_block = fixture2
         .execution_payload_provider
-        .get_locally_stored_sealed_block(&block.evm_block_hash)
+        .get_sealed_block_from_cache(&block.evm_block_hash)
         .await
         .expect("to get execution payload stored on peer 1 from peer 2");
     assert_eq!(local_sealed_block, evm_block.seal_slow());


### PR DESCRIPTION
**Describe the changes**
Payload repair process might fail if the payload is in the cache, but not in reth. This PR changes payload search to only include reth.

**Related Issue(s)**

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
