### PR TITLE
feat: walk peers post-sync and ask them to gossip their known blocks

### DIFF
--- a/crates/domain/src/models/chain_sync_state.rs
+++ b/crates/domain/src/models/chain_sync_state.rs
@@ -82,10 +82,10 @@ impl ChainSyncState {
         self.sync_target_height.load(Ordering::Relaxed)
     }
 
-    /// Increments sync height by 1 and returns the new height
-    pub fn increment_sync_target_height(&self) -> usize {
-        self.sync_target_height.fetch_add(1, Ordering::Relaxed) + 1
-    }
+    // /// Increments sync height by 1 and returns the new height
+    // pub fn increment_sync_target_height(&self) -> usize {
+    //     self.sync_target_height.fetch_add(1, Ordering::Relaxed) + 1
+    // }
 
     /// [`crate::block_pool::BlockPool`] marks block as processed once the
     /// BlockDiscovery finished the pre-validation and scheduled the block for full validation

--- a/crates/p2p/src/block_pool.rs
+++ b/crates/p2p/src/block_pool.rs
@@ -560,7 +560,7 @@ where
                 );
                 return Ok(ProcessBlockResult::ParentRequestFailed);
             } else {
-                return Ok(ProcessBlockResult::ParentRequested)
+                return Ok(ProcessBlockResult::ParentRequested);
             }
         }
 

--- a/crates/p2p/src/block_pool.rs
+++ b/crates/p2p/src/block_pool.rs
@@ -61,6 +61,20 @@ impl From<PeerNetworkError> for BlockPoolError {
     }
 }
 
+#[derive(Debug, Copy, Clone)]
+pub enum ProcessBlockResult {
+    /// Block has been processed successfully
+    Processed,
+    /// Block has been added to the pool, waiting for the parent block
+    ParentRequested,
+    /// Block has been added to the pool, but the parent block is already in the cache, so no request was made
+    ParentAlreadyInCache,
+    /// Block has been added to the pool, and the request for the parent block failed
+    ParentRequestFailed,
+    /// Block has been added to the pool, but no request for the parent block was made (too far ahead of canonical)
+    ParentTooFarAhead,
+}
+
 #[derive(Debug, Clone)]
 pub struct BlockPool<B, M>
 where
@@ -458,7 +472,7 @@ where
         &self,
         block_header: Arc<IrysBlockHeader>,
         skip_validation_for_fast_track: bool,
-    ) -> Result<(), BlockPoolError> {
+    ) -> Result<ProcessBlockResult, BlockPoolError> {
         check_block_status(
             &self.block_status_provider,
             block_header.block_hash,
@@ -515,7 +529,7 @@ where
                     "Parent block {:?} is already in the cache, skipping the request",
                     prev_block_hash
                 );
-                return Ok(());
+                return Ok(ProcessBlockResult::ParentAlreadyInCache);
             }
 
             let canonical_height = self.block_status_provider.canonical_height();
@@ -529,7 +543,7 @@ where
                     current_block_hash, current_block_height, canonical_height
                 );
 
-                return Ok(());
+                return Ok(ProcessBlockResult::ParentTooFarAhead);
             }
 
             // Use the sync service to request parent block (fire and forget)
@@ -544,9 +558,10 @@ where
                     "BlockPool: Failed to send RequestBlockFromTheNetwork message: {:?}",
                     send_err
                 );
+                return Ok(ProcessBlockResult::ParentRequestFailed);
+            } else {
+                return Ok(ProcessBlockResult::ParentRequested)
             }
-
-            return Ok(());
         }
 
         if skip_validation_for_fast_track {
@@ -634,7 +649,7 @@ where
             );
         }
 
-        Ok(())
+        Ok(ProcessBlockResult::Processed)
     }
 
     pub(crate) async fn pull_and_seal_execution_payload(

--- a/crates/p2p/src/block_pool.rs
+++ b/crates/p2p/src/block_pool.rs
@@ -62,7 +62,7 @@ impl From<PeerNetworkError> for BlockPoolError {
 }
 
 #[derive(Debug, Copy, Clone)]
-pub enum ProcessBlockResult {
+pub(crate) enum ProcessBlockResult {
     /// Block has been processed successfully
     Processed,
     /// Block has been added to the pool, waiting for the parent block

--- a/crates/p2p/src/chain_sync.rs
+++ b/crates/p2p/src/chain_sync.rs
@@ -13,7 +13,7 @@ use irys_types::{
 };
 use rand::prelude::SliceRandom as _;
 use reth::tasks::shutdown::Shutdown;
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -838,8 +838,17 @@ async fn sync_chain<B: BlockDiscoveryFacade, M: MempoolFacade, A: ApiClient>(
         .in_current_span()
         .await;
     sync_state.finish_sync();
+
+
+
     info!("Sync task: Gossip service sync task completed");
     Ok(())
+}
+
+async fn pull_highest_blocks_from() {
+    let already_requested = HashSet::new();
+
+
 }
 
 async fn check_and_update_full_validation_switch_height(

--- a/crates/p2p/src/gossip_data_handler.rs
+++ b/crates/p2p/src/gossip_data_handler.rs
@@ -351,16 +351,15 @@ where
             return Err(GossipError::InvalidPeer("Expected peer to be in the peer list since we just fetched the block from it, but it was not found".into()));
         };
 
-        self
-            .handle_block_header(
-                GossipRequest {
-                    miner_address: source_address,
-                    data: irys_block.as_ref().clone(),
-                },
-                peer_info.address.api,
-                peer_info.address.gossip,
-            )
-            .await
+        self.handle_block_header(
+            GossipRequest {
+                miner_address: source_address,
+                data: irys_block.as_ref().clone(),
+            },
+            peer_info.address.api,
+            peer_info.address.gossip,
+        )
+        .await
     }
 
     pub(crate) async fn handle_block_header(

--- a/crates/p2p/src/gossip_data_handler.rs
+++ b/crates/p2p/src/gossip_data_handler.rs
@@ -332,6 +332,37 @@ where
         .await
     }
 
+    /// Pulls a block from a specific peer and sends it to the BlockPool for processing
+    pub async fn pull_and_process_block_from_peer(
+        &self,
+        block_hash: BlockHash,
+        peer: &(irys_types::Address, PeerListItem),
+    ) -> GossipResult<()> {
+        let (source_address, irys_block) = self
+            .gossip_client
+            .pull_block_from_peer(block_hash, peer, &self.peer_list)
+            .await?;
+
+        let Some(peer_info) = self.peer_list.peer_by_mining_address(&source_address) else {
+            error!(
+                "Sync task: Peer with address {:?} is not found in the peer list, which should never happen, as we just fetched the data from it",
+                source_address
+            );
+            return Err(GossipError::InvalidPeer("Expected peer to be in the peer list since we just fetched the block from it, but it was not found".into()));
+        };
+
+        self
+            .handle_block_header(
+                GossipRequest {
+                    miner_address: source_address,
+                    data: irys_block.as_ref().clone(),
+                },
+                peer_info.address.api,
+                peer_info.address.gossip,
+            )
+            .await
+    }
+
     pub(crate) async fn handle_block_header(
         &self,
         block_header_request: GossipRequest<IrysBlockHeader>,


### PR DESCRIPTION
**Describe the changes**
This PR adds a new function that asks known peers of the highest blocks they know about and asks to gossip them back.

**Related Issue(s)**

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
