### PR TITLE
feat: add a special case for the genesis node so it doesn't exit if it's in a trusted sync mode and can't fetch the index

### DIFF
--- a/crates/p2p/src/chain_sync.rs
+++ b/crates/p2p/src/chain_sync.rs
@@ -629,10 +629,17 @@ async fn sync_chain<B: BlockDiscoveryFacade, M: MempoolFacade, A: ApiClient>(
                 Err(ChainSyncError::Network(
                     "No trusted peers available".to_string(),
                 ))
-            }
+            };
         }
 
-        if let Err(err) = check_and_update_full_validation_switch_height(config, peer_list, &api_client, &sync_state).await {
+        if let Err(err) = check_and_update_full_validation_switch_height(
+            config,
+            peer_list,
+            &api_client,
+            &sync_state,
+        )
+        .await
+        {
             if is_a_genesis_node {
                 warn!("Since the node is a genesis node, skipping the sync task due to being unable to verify the full validation switch height from trusted peers: {}", err);
             } else {

--- a/crates/p2p/src/chain_sync.rs
+++ b/crates/p2p/src/chain_sync.rs
@@ -621,13 +621,24 @@ async fn sync_chain<B: BlockDiscoveryFacade, M: MempoolFacade, A: ApiClient>(
     if is_trusted_mode {
         let trusted_peers = peer_list.trusted_peers();
         if trusted_peers.is_empty() {
-            return Err(ChainSyncError::Network(
-                "No trusted peers available".to_string(),
-            ));
+            return if is_a_genesis_node {
+                sync_state.mark_processed(sync_state.sync_target_height());
+                sync_state.finish_sync();
+                Ok(())
+            } else {
+                Err(ChainSyncError::Network(
+                    "No trusted peers available".to_string(),
+                ))
+            }
         }
 
-        check_and_update_full_validation_switch_height(config, peer_list, &api_client, &sync_state)
-            .await?;
+        if let Err(err) = check_and_update_full_validation_switch_height(config, peer_list, &api_client, &sync_state).await {
+            if is_a_genesis_node {
+                warn!("Since the node is a genesis node, skipping the sync task due to being unable to verify the full validation switch height from trusted peers: {}", err);
+            } else {
+                return Err(err);
+            }
+        }
     }
 
     let block_index = match get_block_index(
@@ -648,10 +659,10 @@ async fn sync_chain<B: BlockDiscoveryFacade, M: MempoolFacade, A: ApiClient>(
             error!("Sync task: Failed to fetch block index: {}", err);
             if is_a_genesis_node {
                 warn!("Sync task: Because the node is a genesis node, skipping the sync task due to being unable to fetch the index from peers");
-                sync_state.finish_sync();
-                return Ok(());
+                vec![]
+            } else {
+                return Err(err);
             }
-            return Err(err);
         }
     };
 


### PR DESCRIPTION
**Describe the changes**
This PR adds special case when running a node in Genesis mode with sync mode send to Trusted, so the genesis will continue a normal startup sequence if there's nobody else in the network

**Related Issue(s)**

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
