### PR TITLE
fix: Added funding check for commitment txs

### DIFF
--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -1192,6 +1192,9 @@ pub enum TxIngressError {
     /// Commitment transaction validation error
     #[error("Commitment validation failed: {0}")]
     CommitmentValidationError(#[from] CommitmentValidationError),
+    /// Failed to fetch account balance from RPC
+    #[error("Failed to fetch balance for address {address}: {reason}")]
+    BalanceFetchError { address: String, reason: String },
 }
 
 impl TxIngressError {

--- a/crates/api-server/src/routes/commitment.rs
+++ b/crates/api-server/src/routes/commitment.rs
@@ -79,6 +79,15 @@ pub async fn post_commitment_tx(
             TxIngressError::InvalidLedger(_) => {
                 Ok(HttpResponse::build(StatusCode::BAD_REQUEST).body(format!("{:?}", err)))
             }
+            TxIngressError::BalanceFetchError { address, reason } => {
+                tracing::error!("API: Balance fetch error for {}: {}", address, reason);
+                Ok(
+                    HttpResponse::build(StatusCode::SERVICE_UNAVAILABLE).body(format!(
+                        "Unable to verify balance for {}: {}",
+                        address, reason
+                    )),
+                )
+            }
         };
     }
 

--- a/crates/api-server/src/routes/tx.rs
+++ b/crates/api-server/src/routes/tx.rs
@@ -84,6 +84,15 @@ pub async fn post_tx(
             }
             TxIngressError::InvalidLedger(_) => Ok(HttpResponse::build(StatusCode::BAD_REQUEST)
                 .body(format!("Invalid ledger ID: {:?}", err))),
+            TxIngressError::BalanceFetchError { address, reason } => {
+                tracing::error!("API: Balance fetch error for {}: {}", address, reason);
+                Ok(
+                    HttpResponse::build(StatusCode::SERVICE_UNAVAILABLE).body(format!(
+                        "Unable to verify balance for {}: {}",
+                        address, reason
+                    )),
+                )
+            }
         };
     }
 

--- a/crates/p2p/src/types.rs
+++ b/crates/p2p/src/types.rs
@@ -83,6 +83,12 @@ impl From<TxIngressError> for GossipError {
             TxIngressError::CommitmentValidationError(commitment_validation_error) => {
                 Self::CommitmentValidation(commitment_validation_error)
             }
+            TxIngressError::BalanceFetchError { address, reason } => {
+                Self::Internal(InternalGossipError::Unknown(format!(
+                    "Failed to fetch balance for {}: {}",
+                    address, reason
+                )))
+            }
         }
     }
 }


### PR DESCRIPTION
**Describe the changes**
Before this PR commitment, transactions were not checked for sufficient funding.

This PR adds:
- a `validate_funding` method to check the balance
- an additional `BalanceFetchError` variant for TxIngressError
- and logic to use the previous to check balance proir to including the tx in the mempool


**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [x] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
