### PR TITLE
test: stability slow_heavy_sync_chain_state_then_gossip_blocks

### DIFF
--- a/crates/chain/tests/multi_node/sync_chain_state.rs
+++ b/crates/chain/tests/multi_node/sync_chain_state.rs
@@ -594,8 +594,9 @@ async fn poll_peer_list(
     ctx_node: &IrysNodeTest<IrysNodeCtx>,
     desired_count_of_items: usize,
 ) -> Vec<PeerAddress> {
-    let max_attempts = 200;
-    for _ in 0..max_attempts {
+    // Increase the window to better accommodate CI variance
+    let max_attempts = 400;
+    for attempt in 0..max_attempts {
         sleep(Duration::from_millis(100)).await;
 
         let mut peer_results_genesis = peer_list_endpoint_request(&local_test_url(

--- a/crates/chain/tests/multi_node/sync_chain_state.rs
+++ b/crates/chain/tests/multi_node/sync_chain_state.rs
@@ -596,7 +596,7 @@ async fn poll_peer_list(
 ) -> Vec<PeerAddress> {
     // Increase the window to better accommodate CI variance
     let max_attempts = 400;
-    for attempt in 0..max_attempts {
+    for _attempt in 0..max_attempts {
         sleep(Duration::from_millis(100)).await;
 
         let mut peer_results_genesis = peer_list_endpoint_request(&local_test_url(
@@ -615,7 +615,7 @@ async fn poll_peer_list(
             Err(e) => {
                 debug!(
                     "Attempt {}: failed to parse peer list JSON on {}: {}",
-                    attempt, ctx_node.node_ctx.config.node_config.http.bind_port, e
+                    _attempt, ctx_node.node_ctx.config.node_config.http.bind_port, e
                 );
                 // Continue polling
             }

--- a/crates/chain/tests/multi_node/sync_chain_state.rs
+++ b/crates/chain/tests/multi_node/sync_chain_state.rs
@@ -1,15 +1,14 @@
 use crate::utils::{mine_blocks, AddTxError, IrysNodeTest};
 use irys_actors::mempool_service::TxIngressError;
+
 use irys_chain::{
-    peer_utilities::{
-        block_index_endpoint_request, info_endpoint_request, peer_list_endpoint_request,
-    },
+    peer_utilities::{block_index_endpoint_request, info_endpoint_request},
     IrysNodeCtx,
 };
 use irys_database::block_header_by_hash;
 use irys_types::{
     irys::IrysSigner, BlockIndexItem, DataTransaction, IrysTransactionId, NodeConfig, NodeInfo,
-    NodeMode, PeerAddress, SyncMode, H256,
+    NodeMode, SyncMode, H256,
 };
 use reth::rpc::eth::EthApiServer as _;
 use reth_db::Database as _;
@@ -283,34 +282,41 @@ async fn slow_heavy_sync_chain_state_then_gossip_blocks() -> eyre::Result<()> {
         )
         .await;
 
+        // Proactively announce peers to each other to converge peer lists deterministically
+        IrysNodeTest::announce_between(&ctx_peer1_node, &ctx_genesis_node)
+            .await
+            .expect("peer1 <-> genesis handshake");
+        IrysNodeTest::announce_between(&ctx_peer2_node, &ctx_genesis_node)
+            .await
+            .expect("peer2 <-> genesis handshake");
+        IrysNodeTest::announce_between(&ctx_peer1_node, &ctx_peer2_node)
+            .await
+            .expect("peer1 <-> peer2");
+
         // Check peer lists - each peer should see the genesis node and the other peer
-        let peer_list_items_1 = poll_peer_list(&ctx_peer1_node, 2).await;
-        let peer_list_items_2 = poll_peer_list(&ctx_peer2_node, 2).await;
 
         // Get the peer addresses for comparison
         let genesis_peer_addr = ctx_genesis_node.node_ctx.config.node_config.peer_address();
         let peer1_peer_addr = ctx_peer1_node.node_ctx.config.node_config.peer_address();
         let peer2_peer_addr = ctx_peer2_node.node_ctx.config.node_config.peer_address();
 
-        // Peer1 should see genesis and peer2
-        assert!(
-            peer_list_items_1.contains(&genesis_peer_addr),
-            "Peer1 should see genesis node"
-        );
-        assert!(
-            peer_list_items_1.contains(&peer2_peer_addr),
-            "Peer1 should see peer2"
-        );
-
-        // Peer2 should see genesis and peer1
-        assert!(
-            peer_list_items_2.contains(&genesis_peer_addr),
-            "Peer2 should see genesis node"
-        );
-        assert!(
-            peer_list_items_2.contains(&peer1_peer_addr),
-            "Peer2 should see peer1"
-        );
+        // Wait until all peers are mutually visible
+        ctx_peer1_node
+            .wait_until_sees_peer(&genesis_peer_addr, 400)
+            .await
+            .expect("Peer1 should see genesis node");
+        ctx_peer1_node
+            .wait_until_sees_peer(&peer2_peer_addr, 400)
+            .await
+            .expect("Peer1 should see peer2");
+        ctx_peer2_node
+            .wait_until_sees_peer(&genesis_peer_addr, 400)
+            .await
+            .expect("Peer2 should see genesis node");
+        ctx_peer2_node
+            .wait_until_sees_peer(&peer1_peer_addr, 400)
+            .await
+            .expect("Peer2 should see peer1");
 
         let result_peer2 = poll_until_fetch_at_block_index_height(
             "peer2".to_owned(),
@@ -587,39 +593,4 @@ async fn poll_until_fetch_at_block_index_height(
         }
     }
     result_peer
-}
-
-/// poll peer_list_endpoint until timeout or we get the expected result
-async fn poll_peer_list(
-    ctx_node: &IrysNodeTest<IrysNodeCtx>,
-    desired_count_of_items: usize,
-) -> Vec<PeerAddress> {
-    // Increase the window to better accommodate CI variance
-    let max_attempts = 400;
-    for _attempt in 0..max_attempts {
-        sleep(Duration::from_millis(100)).await;
-
-        let mut peer_results_genesis = peer_list_endpoint_request(&local_test_url(
-            &ctx_node.node_ctx.config.node_config.http.bind_port,
-        ))
-        .await;
-
-        match peer_results_genesis.json::<Vec<PeerAddress>>().await {
-            Ok(mut peer_list_items) => {
-                peer_list_items.sort(); // sort for deterministic comparisons
-                                        // Accept once we've reached at least the desired count
-                if peer_list_items.len() >= desired_count_of_items {
-                    return peer_list_items;
-                }
-            }
-            Err(e) => {
-                debug!(
-                    "Attempt {}: failed to parse peer list JSON on {}: {}",
-                    _attempt, ctx_node.node_ctx.config.node_config.http.bind_port, e
-                );
-                // Continue polling
-            }
-        }
-    }
-    panic!("never got the desired amount of items")
 }

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -20,6 +20,7 @@ use irys_actors::{
     mempool_service::{MempoolServiceMessage, MempoolTxs, TxIngressError},
     packing::wait_for_packing,
 };
+use irys_api_client::ApiClient as _;
 use irys_api_client::{ApiClientExt as _, IrysApiClient};
 use irys_api_server::routes::price::{CommitmentPriceInfo, PriceInfo};
 use irys_api_server::{create_listener, routes};
@@ -42,6 +43,7 @@ use irys_reth_node_bridge::ext::IrysRethRpcTestContextExt as _;
 use irys_storage::ii;
 use irys_testing_utils::utils::tempfile::TempDir;
 use irys_testing_utils::utils::temporary_directory;
+use irys_types::VersionRequest;
 use irys_types::{
     block_production::Seed, block_production::SolutionContext, irys::IrysSigner,
     partition::PartitionAssignment, Address, DataLedger, GossipBroadcastMessage, H256List,
@@ -1816,6 +1818,79 @@ impl IrysNodeTest<IrysNodeCtx> {
 
     pub fn get_peer_addr(&self) -> SocketAddr {
         self.node_ctx.config.node_config.peer_address().api
+    }
+
+    // Build a signed VersionRequest describing this node
+    pub fn build_version_request(&self) -> VersionRequest {
+        let mut vr = VersionRequest {
+            chain_id: self.node_ctx.config.consensus.chain_id,
+            address: self.node_ctx.config.node_config.peer_address(),
+            mining_address: self.node_ctx.config.node_config.reward_address,
+            ..VersionRequest::default()
+        };
+        self.node_ctx
+            .config
+            .irys_signer()
+            .sign_p2p_handshake(&mut vr)
+            .expect("sign p2p handshake");
+        vr
+    }
+
+    // Announce this node to another node (HTTP POST /v1/version)
+    pub async fn announce_to(&self, dst: &Self) -> eyre::Result<()> {
+        let vr = self.build_version_request();
+        self.get_api_client()
+            .post_version(dst.get_peer_addr(), vr)
+            .await?;
+        Ok(())
+    }
+
+    // Announce both ways between two nodes
+    pub async fn announce_between(
+        a: &Self,
+        b: &Self,
+    ) -> eyre::Result<()> {
+        a.announce_to(b).await?;
+        b.announce_to(a).await?;
+        Ok(())
+    }
+
+    // Announce full mesh among a list of nodes
+    pub async fn announce_mesh(nodes: &[&Self]) -> eyre::Result<()> {
+        for i in 0..nodes.len() {
+            for j in (i + 1)..nodes.len() {
+                Self::announce_between(nodes[i], nodes[j]).await?;
+            }
+        }
+        Ok(())
+    }
+
+    // Wait until this node's peer list includes the target peer address
+    pub async fn wait_until_sees_peer(
+        &self,
+        target: &PeerAddress,
+        max_attempts: usize,
+    ) -> eyre::Result<()> {
+        for _ in 0..max_attempts {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            let client = awc::Client::default();
+            let api_uri = self.node_ctx.config.node_config.local_api_url();
+            let url = format!("{}/v1/peer_list", api_uri);
+
+            if let Ok(mut resp) = client.get(url).send().await {
+                if let Ok(list) = resp.json::<Vec<PeerAddress>>().await {
+                    if list.contains(target) {
+                        return Ok(());
+                    }
+                }
+            }
+        }
+        eyre::bail!(
+            "peer {:?} not visible after {} attempts",
+            target,
+            max_attempts
+        )
     }
 
     pub async fn upload_chunks(&self, tx: &DataTransaction) -> eyre::Result<()> {

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -1846,10 +1846,7 @@ impl IrysNodeTest<IrysNodeCtx> {
     }
 
     // Announce both ways between two nodes
-    pub async fn announce_between(
-        a: &Self,
-        b: &Self,
-    ) -> eyre::Result<()> {
+    pub async fn announce_between(a: &Self, b: &Self) -> eyre::Result<()> {
         a.announce_to(b).await?;
         b.announce_to(a).await?;
         Ok(())


### PR DESCRIPTION
**Describe the changes**
 - Reworked the peer discovery so we deterministly send peer info between peers. This seems result in a more stable test but is also not a solution to the underlying problem.
 - Added some retry logic for malformed json, should that ever occur.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.
