### PR TITLE
feat: add storage module reassignment and restart integration test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5250,6 +5250,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "color-eyre",
+ "libc",
  "tempfile",
  "tracing",
  "tracing-error",

--- a/crates/chain/tests/mod.rs
+++ b/crates/chain/tests/mod.rs
@@ -4,6 +4,7 @@ pub mod ema_pricing;
 mod external;
 pub mod integration;
 pub mod multi_node;
+pub mod partition_assignments;
 pub mod programmable_data;
 pub mod promotion;
 pub mod startup;

--- a/crates/chain/tests/partition_assignments/mod.rs
+++ b/crates/chain/tests/partition_assignments/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(test)]
+pub mod sm_reassignment_tests;

--- a/crates/chain/tests/partition_assignments/sm_reassignment_tests.rs
+++ b/crates/chain/tests/partition_assignments/sm_reassignment_tests.rs
@@ -50,7 +50,7 @@ async fn heavy_sm_reassignment_with_restart_test() -> eyre::Result<()> {
     let partition_assignments = epoch_snapshot.get_partition_assignments(genesis_signer.address());
     let capacity_pa = partition_assignments
         .iter()
-        .find(|pa| pa.ledger_id == None)
+        .find(|pa| pa.ledger_id.is_none())
         .unwrap();
     let submit_pa = partition_assignments
         .iter()
@@ -63,7 +63,7 @@ async fn heavy_sm_reassignment_with_restart_test() -> eyre::Result<()> {
     let _block1 = genesis_node.mine_block().await?;
 
     // 2. Post a data_tx that will cause the submit ledger to add a slot (9 chunks worth of bytes)
-    let data = vec![255u8; 9 * chunk_size];
+    let data = vec![255_u8; 9 * chunk_size];
     let data_tx = genesis_node
         .create_publish_data_tx(&genesis_signer, data)
         .await?;

--- a/crates/chain/tests/partition_assignments/sm_reassignment_tests.rs
+++ b/crates/chain/tests/partition_assignments/sm_reassignment_tests.rs
@@ -1,0 +1,119 @@
+use assert_matches::assert_matches;
+use irys_testing_utils::initialize_tracing;
+use irys_types::NodeConfig;
+use tracing::debug;
+
+use crate::utils::IrysNodeTest;
+
+// 1. Start a node
+// 2. Post a data_tx that will cause the submit ledger to add a slot
+// 3. Mine enough blocks to cross the epoch boundary
+// 4. Verify the nodes capacity partition is now assigned to the submit ledger.
+// 5. Mine enough epochs to expire the first slot out of the submit ledger
+// 6. Verify the partition_hash is assigned to capacity and that the storage module matches
+#[actix_web::test]
+async fn heavy_sm_reassignment_with_restart_test() -> eyre::Result<()> {
+    std::env::set_var(
+        "RUST_LOG",
+        "debug,storage::db=off,irys_domain::models::block_tree=off,actix_web=off,engine=off,trie=off,pruner=off,irys_actors::reth_service=off,provider=off,hyper=off,reqwest=off,irys_vdf=off,irys_actors::cache_service=off,irys_p2p=off,irys_actors::mining=off,irys_efficient_sampling=off,reth::cli=off,payload_builder=off",
+    );
+    initialize_tracing();
+
+    let seconds_to_wait = 10;
+    let mut genesis_config = NodeConfig::testing();
+
+    let chunk_size: usize = 32;
+    genesis_config.consensus.get_mut().chunk_size = chunk_size as u64;
+    genesis_config.consensus.get_mut().num_chunks_in_partition = 10;
+    genesis_config.consensus.get_mut().epoch.num_blocks_in_epoch = 4;
+    genesis_config
+        .consensus
+        .get_mut()
+        .epoch
+        .submit_ledger_epoch_length = 2;
+
+    // 1. Start a node
+    let genesis_node = IrysNodeTest::new_genesis(genesis_config.clone())
+        .start_and_wait_for_packing("GENESIS", seconds_to_wait)
+        .await;
+    let genesis_signer = genesis_node.node_ctx.config.irys_signer();
+    genesis_node.stop_mining().await;
+    genesis_config.fund_genesis_accounts(vec![&genesis_signer]);
+
+    // Retrieve the nodes capacity partition_hash
+    let epoch_snapshot = genesis_node
+        .node_ctx
+        .block_tree_guard
+        .read()
+        .canonical_epoch_snapshot();
+    let partition_assignments = epoch_snapshot.get_partition_assignments(genesis_signer.address());
+    let capacity_pa = partition_assignments
+        .iter()
+        .find(|pa| pa.ledger_id == None)
+        .unwrap();
+    let submit_pa = partition_assignments
+        .iter()
+        .find(|pa| pa.ledger_id == Some(1))
+        .unwrap();
+    debug!("Capacity Partition: {:#?}", capacity_pa);
+    debug!("Submit Partition: {:#?}", submit_pa);
+
+    // Mine a block
+    let _block1 = genesis_node.mine_block().await?;
+
+    // 2. Post a data_tx that will cause the submit ledger to add a slot (9 chunks worth of bytes)
+    let data = vec![255u8; 9 * chunk_size];
+    let data_tx = genesis_node
+        .create_publish_data_tx(&genesis_signer, data)
+        .await?;
+    genesis_node.post_data_tx_raw(&data_tx.header).await;
+
+    //3. Mine enough blocks to cross the epoch boundary
+    assert_matches!(genesis_node.mine_blocks(4).await, Ok(()));
+    genesis_node.wait_until_height(5, seconds_to_wait).await?;
+
+    // 4. Verify the nodes capacity partition is now assigned to the submit ledger in slot_index:1
+    let data_pa = genesis_node
+        .node_ctx
+        .block_tree_guard
+        .read()
+        .canonical_epoch_snapshot()
+        .get_data_partition_assignment(capacity_pa.partition_hash)
+        .expect("to retrieve the partition assignment");
+    assert!(data_pa.ledger_id.is_some() && data_pa.slot_index == Some(1));
+
+    // 5. Mine enough epochs to expire the first slot out of the submit ledger
+    assert_matches!(genesis_node.mine_blocks(3).await, Ok(()));
+
+    // 6. Verify the submit partition_hash is assigned to capacity and then reassigned to submit slot 2
+    let reassigned_pa = genesis_node
+        .node_ctx
+        .block_tree_guard
+        .read()
+        .canonical_epoch_snapshot()
+        .get_data_partition_assignment(submit_pa.partition_hash)
+        .expect("to retrieve the partition assignment");
+    assert!(reassigned_pa.ledger_id == Some(1) && reassigned_pa.slot_index == Some(2));
+
+    let stopped_node = genesis_node.stop().await;
+    let restarted_node = stopped_node.start().await;
+
+    // Wait for the restarted node to mine a block
+    let _block = restarted_node.mine_block().await?;
+
+    // Verify all it's partition assignments are correct
+    let new_reassigned_pa = restarted_node
+        .node_ctx
+        .block_tree_guard
+        .read()
+        .canonical_epoch_snapshot()
+        .get_data_partition_assignment(reassigned_pa.partition_hash)
+        .expect("to retrieve the partition assignment");
+
+    assert_eq!(new_reassigned_pa, reassigned_pa);
+
+    // Wind down test with graceful shutdown
+    restarted_node.stop().await;
+
+    Ok(())
+}

--- a/crates/domain/src/models/storage_module.rs
+++ b/crates/domain/src/models/storage_module.rs
@@ -38,7 +38,7 @@
 
 use atomic_write_file::AtomicWriteFile;
 use derive_more::derive::{Deref, DerefMut};
-use eyre::{bail, ensure, eyre, Context as _, OptionExt as _, Result};
+use eyre::{ensure, eyre, Context as _, OptionExt as _, Result};
 use irys_database::{
     db::IrysDatabaseExt as _,
     submodule::{
@@ -303,47 +303,13 @@ impl StorageModule {
                     // if we have an assignment, check that the partition hash matches
                     if let Some(ph) = params.partition_hash {
                         ensure!(
-                        params.partition_hash == Some(pa.partition_hash),
-                        "Partition hash mismatch:\nexpected: {}\nfound   : {}\n\nError: Submodule partition assignments are out of sync with genesis block. \
-                        This occurs when a new genesis block is created with a different last_epoch_hash, but submodules still have partition_hashes \
-                        assigned from the previous genesis. To fix: clear the contents of the submodule directories and let them be repacked with the current genesis",
-                        pa.partition_hash,
-                        ph,
-                    );
-
-                        // check we have the correct ledger & slot info
-                        match (params.ledger, params.slot, pa.ledger_id, pa.slot_index) {
-                            // if this is a capacity assignment, do nothing
-                            (None, None, None, None) => {},
-                            // if this is a "new" data assignment, write it
-                            (None, None, Some(pa_ledger), Some(pa_slot)) => {
-                                // we update & write the params to disk
-                                params.ledger = Some(pa_ledger);
-                                params.slot = Some(pa_slot);
-                                params.last_updated_height = Some(0);
-                                params.write_to_disk(&params_path);
-                            }
-                            // if we have an existing data assignment, validate the two match
-                            (
-                                Some(params_ledger),
-                                Some(params_slot),
-                                Some(pa_ledger),
-                                Some(pa_slot),
-                            ) => {
-                                ensure!(
-                                    params_ledger == pa_ledger,
-                                    "Module and assignment ledger ID mismatch\n Module: {:?}, got ledger {}, expected ledger {}",
-                                    &sub_base_path, &params_ledger, &pa_ledger
-                                );
-                                ensure!(
-                                    params_slot == pa_slot,
-                                    "Module and assignment slot index mismatch\n Module: {:?}, got slot {}, expected slot {}",
-                                    &sub_base_path, &params_slot, &pa_slot
-                                );
-                            }
-                            // shouldn't happen
-                            invalid => bail!("Invalid match case for {:?} (param ledger, slot, assignment ledger, slot) {:?} ", &sub_base_path, invalid),
-                        }
+                            params.partition_hash == Some(pa.partition_hash),
+                            "Partition hash mismatch:\nexpected: {}\nfound   : {}\n\nError: Submodule partition assignments are out of sync with genesis block. \
+                            This occurs when a new genesis block is created with a different last_epoch_hash, but submodules still have partition_hashes \
+                            assigned from the previous genesis. To fix: clear the contents of the submodule directories and let them be repacked with the current genesis",
+                            pa.partition_hash,
+                            ph,
+                        );
                     } else {
                         // we don't have the partition hash on disk
                         // so we need to write the new params to disk

--- a/crates/testing-utils/Cargo.toml
+++ b/crates/testing-utils/Cargo.toml
@@ -11,6 +11,6 @@ tempfile.workspace = true
 color-eyre.workspace = true
 tracing-error.workspace = true
 chrono = { version = "0.4.41", default-features = false, features = ["now"] }
-
+libc = "0.2.172"                                                              # same version as was already in the lockfile
 [lints]
 workspace = true

--- a/crates/testing-utils/src/utils.rs
+++ b/crates/testing-utils/src/utils.rs
@@ -88,7 +88,17 @@ pub fn setup_panic_hook() -> eyre::Result<()> {
         // abort the process
         eprintln!("\x1b[1;31mPanic occurred, Aborting process\x1b[0m");
         // TODO: maybe change this so that the panic hook can trigger an orderly shutdown
-        std::process::exit(1)
+
+        // this will trigger the existing control-c signal detection
+        let pid = unsafe { libc::getpid() };
+        unsafe {
+            libc::kill(pid, libc::SIGINT);
+        }
+
+        // sleeping the thread will cause SIGINT to not function correctly
+        // std::thread::sleep(std::time::Duration::from_secs(10));
+        // eprintln!("Waited 15s, force exiting...");
+        // std::process::exit(1)
     }));
 
     Ok(())


### PR DESCRIPTION
Make sure we can restart a node after partitions have been reassigned multiple times.

(Adds a test for this scenario)
