### PR TITLE
fix: peer list lock carried over an await point

### DIFF
--- a/crates/domain/src/models/peer_list.rs
+++ b/crates/domain/src/models/peer_list.rs
@@ -333,12 +333,14 @@ impl PeerList {
         evm_payload_hash: B256,
         use_trusted_peers_only: bool,
     ) -> Result<(), PeerNetworkError> {
-        let sender = self
-            .0
-            .read()
-            .expect("PeerListDataInner lock poisoned")
-            .peer_network_service_sender
-            .clone();
+        let sender = {
+            self
+                .0
+                .read()
+                .expect("PeerListDataInner lock poisoned")
+                .peer_network_service_sender
+                .clone()
+        };
         sender
             .request_payload_to_be_gossiped_from_network(evm_payload_hash, use_trusted_peers_only)
             .await


### PR DESCRIPTION
**Describe the changes**
This PR removes a slowdown in networking by destroying one of the peer list locks early

**Related Issue(s)**

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
