### PR TITLE
fix: mark scheduled validation before scheduling

### DIFF
--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -77,6 +77,8 @@ pub enum PreValidationError {
     MerkleProofInvalid(String),
     #[error("Oracle price invalid")]
     OraclePriceInvalid,
+    #[error("Unable to update cache for scheduled validation at block_hash: {0}")]
+    UpdateCacheForScheduledValidationError(H256),
     #[error("PoA capacity chunk mismatch entropy_first={entropy_first:?} poa_first={poa_first:?}")]
     PoACapacityChunkMismatch {
         entropy_first: Option<u8>,


### PR DESCRIPTION
**Before this PR**, there was a race condition in the block validation scheduling process where blocks were sent for validation before being marked as scheduled in the cache. This might lead to an inconsistent state if the validation service processed the block before the cache was updated.

**This PR** fixes the race condition by reordering operations to mark blocks as "validation scheduled" in the cache before sending them to the validation service.  Additionally, it adds proper error handling for cache update failures by introducing a new `UpdateCacheForScheduledValidationError` variant and returning early if marking the block fails, preventing the validation message from being sent when the cache state is inconsistent.

**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
