### PR TITLE
feat: perm refunds

### DIFF
--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -32,10 +32,10 @@ use irys_reth_node_bridge::node::NodeProvider;
 use irys_reward_curve::HalvingCurve;
 use irys_types::{
     app_state::DatabaseProvider, block_production::SolutionContext, calculate_difficulty,
-    next_cumulative_diff, storage_pricing::Amount, AdjustmentStats, Base64,
-    CommitmentTransaction, Config, DataLedger, DataTransactionHeader, DataTransactionLedger,
-    GossipBroadcastMessage, H256List, IrysBlockHeader, PoaData, Signature, SystemTransactionLedger,
-    TokioServiceHandle, VDFLimiterInfo, H256, U256,
+    next_cumulative_diff, storage_pricing::Amount, AdjustmentStats, Base64, CommitmentTransaction,
+    Config, DataLedger, DataTransactionHeader, DataTransactionLedger, GossipBroadcastMessage,
+    H256List, IrysBlockHeader, PoaData, Signature, SystemTransactionLedger, TokioServiceHandle,
+    VDFLimiterInfo, H256, U256,
 };
 use irys_vdf::state::VdfStateReadonly;
 use ledger_expiry::LedgerExpiryBalanceDiff;

--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -64,10 +64,9 @@ use eyre::OptionExt as _;
 use irys_database::{block_header_by_hash, db::IrysDatabaseExt as _};
 use irys_domain::{BlockIndex, EpochSnapshot};
 use irys_types::{
-    app_state::DatabaseProvider,
-    fee_distribution::TermFeeCharges,
-    ledger_chunk_offset_ii, Address, BlockIndexItem, Config, DataLedger, DataTransactionHeader,
-    IrysBlockHeader, IrysTransactionId, LedgerChunkOffset, LedgerChunkRange, H256, U256,
+    app_state::DatabaseProvider, fee_distribution::TermFeeCharges, ledger_chunk_offset_ii, Address,
+    BlockIndexItem, Config, DataLedger, DataTransactionHeader, IrysBlockHeader, IrysTransactionId,
+    LedgerChunkOffset, LedgerChunkRange, H256, U256,
 };
 use nodit::{interval::ii, InclusiveInterval as _};
 use std::collections::BTreeMap;
@@ -669,7 +668,7 @@ fn aggregate_balance_diff(
                     .and_modify(|refund_vec| {
                         refund_vec.push((data_tx.id, perm_fee));
                     })
-                    .or_insert_with(|| vec![]);
+                    .or_default();
             }
         }
     }

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -1086,7 +1086,10 @@ async fn generate_expected_shadow_transactions_from_db<'a>(
         .in_current_span()
         .await?
     } else {
-        BTreeMap::new()
+        ledger_expiry::LedgerExpiryBalanceDiff {
+            miner_balance_increment: BTreeMap::new(),
+            user_perm_fee_refunds: BTreeMap::new(),
+        }
     };
 
     let mut shadow_tx_generator = ShadowTxGenerator::new(

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -3,9 +3,10 @@ use alloy_eips::eip2718::Encodable2718 as _;
 use alloy_eips::HashOrNumber;
 use alloy_genesis::GenesisAccount;
 use irys_actors::{
-    async_trait, mempool_service::TxIngressError, reth_ethereum_primitives,
-    shadow_tx_generator::PublishLedgerWithTxs, shadow_tx_generator::RollingHash, BlockProdStrategy,
-    BlockProducerInner, ProductionStrategy,
+    async_trait, block_producer::ledger_expiry::LedgerExpiryBalanceDiff,
+    mempool_service::TxIngressError, reth_ethereum_primitives,
+    shadow_tx_generator::PublishLedgerWithTxs, BlockProdStrategy, BlockProducerInner,
+    ProductionStrategy,
 };
 use irys_database::SystemLedger;
 use irys_domain::{BlockState, ChainState, EmaSnapshot};
@@ -16,8 +17,8 @@ use irys_reth_node_bridge::irys_reth::shadow_tx::{
 use irys_reth_node_bridge::reth_e2e_test_utils::transaction::TransactionTestContext;
 use irys_testing_utils::initialize_tracing;
 use irys_types::{
-    irys::IrysSigner, storage_pricing::Amount, Address, CommitmentTransaction,
-    DataTransactionHeader, IrysBlockHeader, IrysTransactionCommon as _, NodeConfig, H256,
+    irys::IrysSigner, storage_pricing::Amount, CommitmentTransaction, DataTransactionHeader,
+    IrysBlockHeader, IrysTransactionCommon as _, NodeConfig, H256,
 };
 use reth::payload::EthBuiltPayload;
 use reth::rpc::types::TransactionTrait as _;
@@ -27,7 +28,7 @@ use reth::{
     },
     rpc::types::TransactionRequest,
 };
-use std::{collections::BTreeMap, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 use tokio::time::sleep;
 use tracing::info;
 
@@ -1094,7 +1095,7 @@ async fn heavy_block_prod_will_not_build_on_invalid_blocks() -> eyre::Result<()>
             data_txs_with_proofs: &mut PublishLedgerWithTxs,
             reward_amount: Amount<irys_types::storage_pricing::phantoms::Irys>,
             timestamp_ms: u128,
-            expired_ledger_fees: BTreeMap<Address, (irys_types::U256, RollingHash)>,
+            expired_ledger_fees: LedgerExpiryBalanceDiff,
         ) -> eyre::Result<(EthBuiltPayload, irys_types::U256)> {
             // Tamper the EVM payload by reversing submit tx order (keeps PoA untouched)
             let mut submit_txs = submit_txs.to_vec();

--- a/crates/chain/tests/block_production/block_validation.rs
+++ b/crates/chain/tests/block_production/block_validation.rs
@@ -12,8 +12,9 @@ async fn heavy_test_future_block_rejection() -> Result<()> {
     // ------------------------------------------------------------------
     use crate::utils::solution_context;
     use irys_actors::{
-        async_trait, reth_ethereum_primitives, shadow_tx_generator::PublishLedgerWithTxs,
-        BlockProdStrategy, BlockProducerInner, ProductionStrategy,
+        async_trait, block_producer::ledger_expiry::LedgerExpiryBalanceDiff,
+        reth_ethereum_primitives, shadow_tx_generator::PublishLedgerWithTxs, BlockProdStrategy,
+        BlockProducerInner, ProductionStrategy,
     };
     use irys_domain::EmaSnapshot;
     use irys_types::{
@@ -52,13 +53,7 @@ async fn heavy_test_future_block_rejection() -> Result<()> {
             data_txs_with_proofs: &mut PublishLedgerWithTxs,
             reward_amount: Amount<irys_types::storage_pricing::phantoms::Irys>,
             _timestamp_ms: u128,
-            expired_ledger_fees: std::collections::BTreeMap<
-                irys_types::Address,
-                (
-                    irys_types::U256,
-                    irys_actors::shadow_tx_generator::RollingHash,
-                ),
-            >,
+            expired_ledger_fees: LedgerExpiryBalanceDiff,
         ) -> eyre::Result<(EthBuiltPayload, U256)> {
             self.prod
                 .create_evm_block(

--- a/crates/chain/tests/multi_node/validation.rs
+++ b/crates/chain/tests/multi_node/validation.rs
@@ -2,8 +2,9 @@ use std::sync::Arc;
 
 use crate::utils::{read_block_from_state, solution_context, BlockValidationOutcome, IrysNodeTest};
 use irys_actors::{
-    async_trait, reth_ethereum_primitives, shadow_tx_generator::PublishLedgerWithTxs,
-    BlockProdStrategy, BlockProducerInner, ProductionStrategy,
+    async_trait, block_producer::ledger_expiry::LedgerExpiryBalanceDiff, reth_ethereum_primitives,
+    shadow_tx_generator::PublishLedgerWithTxs, BlockProdStrategy, BlockProducerInner,
+    ProductionStrategy,
 };
 use irys_types::{
     storage_pricing::Amount, CommitmentTransaction, DataTransactionHeader, IrysBlockHeader,
@@ -35,13 +36,7 @@ async fn heavy_block_invalid_evm_block_reward_gets_rejected() -> eyre::Result<()
             data_txs_with_proofs: &mut PublishLedgerWithTxs,
             reward_amount: Amount<irys_types::storage_pricing::phantoms::Irys>,
             timestamp_ms: u128,
-            expired_ledger_fees: std::collections::BTreeMap<
-                irys_types::Address,
-                (
-                    irys_types::U256,
-                    irys_actors::shadow_tx_generator::RollingHash,
-                ),
-            >,
+            expired_ledger_fees: LedgerExpiryBalanceDiff,
         ) -> eyre::Result<(EthBuiltPayload, U256)> {
             let invalid_reward_amount = Amount::new(reward_amount.amount.pow(2_u64.into()));
 
@@ -194,13 +189,7 @@ async fn heavy_block_shadow_txs_misalignment_block_rejected() -> eyre::Result<()
             data_txs_with_proofs: &mut PublishLedgerWithTxs,
             reward_amount: Amount<irys_types::storage_pricing::phantoms::Irys>,
             timestamp_ms: u128,
-            expired_ledger_fees: std::collections::BTreeMap<
-                irys_types::Address,
-                (
-                    irys_types::U256,
-                    irys_actors::shadow_tx_generator::RollingHash,
-                ),
-            >,
+            expired_ledger_fees: LedgerExpiryBalanceDiff,
         ) -> eyre::Result<(EthBuiltPayload, U256)> {
             let mut submit_txs = submit_txs.to_vec();
             submit_txs.push(self.extra_tx.clone());
@@ -291,13 +280,7 @@ async fn heavy_block_shadow_txs_different_order_of_txs() -> eyre::Result<()> {
             data_txs_with_proofs: &mut PublishLedgerWithTxs,
             reward_amount: Amount<irys_types::storage_pricing::phantoms::Irys>,
             timestamp_ms: u128,
-            expired_ledger_fees: std::collections::BTreeMap<
-                irys_types::Address,
-                (
-                    irys_types::U256,
-                    irys_actors::shadow_tx_generator::RollingHash,
-                ),
-            >,
+            expired_ledger_fees: LedgerExpiryBalanceDiff,
         ) -> eyre::Result<(EthBuiltPayload, U256)> {
             let mut submit_txs = submit_txs.to_vec();
             // NOTE: We reverse the order of txs, this means

--- a/crates/chain/tests/validation/data_tx_pricing.rs
+++ b/crates/chain/tests/validation/data_tx_pricing.rs
@@ -1,8 +1,8 @@
 use crate::utils::{read_block_from_state, solution_context, BlockValidationOutcome, IrysNodeTest};
 use irys_actors::{
-    async_trait, block_tree_service::BlockTreeServiceMessage,
-    shadow_tx_generator::PublishLedgerWithTxs, BlockProdStrategy, BlockProducerInner,
-    ProductionStrategy,
+    async_trait, block_producer::ledger_expiry::LedgerExpiryBalanceDiff,
+    block_tree_service::BlockTreeServiceMessage, shadow_tx_generator::PublishLedgerWithTxs,
+    BlockProdStrategy, BlockProducerInner, ProductionStrategy,
 };
 use irys_chain::IrysNodeCtx;
 use irys_types::storage_pricing::Amount;
@@ -56,13 +56,7 @@ async fn slow_heavy_block_insufficient_perm_fee_gets_rejected() -> eyre::Result<
             Vec<CommitmentTransaction>,
             Vec<DataTransactionHeader>,
             PublishLedgerWithTxs,
-            std::collections::BTreeMap<
-                irys_types::Address,
-                (
-                    irys_types::U256,
-                    irys_actors::shadow_tx_generator::RollingHash,
-                ),
-            >,
+            LedgerExpiryBalanceDiff,
         )> {
             // Return malicious tx in Submit ledger (would normally be waiting for proofs)
             Ok((
@@ -73,7 +67,10 @@ async fn slow_heavy_block_insufficient_perm_fee_gets_rejected() -> eyre::Result<
                     txs: vec![],
                     proofs: None,
                 }, // No Publish ledger txs
-                std::collections::BTreeMap::new(), // No expired ledger fees
+                LedgerExpiryBalanceDiff {
+                    miner_balance_increment: std::collections::BTreeMap::new(),
+                    user_perm_fee_refunds: std::collections::BTreeMap::new(),
+                }, // No expired ledger fees
             ))
         }
     }

--- a/crates/chain/tests/validation/mod.rs
+++ b/crates/chain/tests/validation/mod.rs
@@ -4,9 +4,9 @@ use std::sync::Arc;
 
 use crate::utils::{read_block_from_state, solution_context, BlockValidationOutcome, IrysNodeTest};
 use irys_actors::{
-    async_trait, block_tree_service::BlockTreeServiceMessage,
-    shadow_tx_generator::PublishLedgerWithTxs, BlockProdStrategy, BlockProducerInner,
-    ProductionStrategy,
+    async_trait, block_producer::ledger_expiry::LedgerExpiryBalanceDiff,
+    block_tree_service::BlockTreeServiceMessage, shadow_tx_generator::PublishLedgerWithTxs,
+    BlockProdStrategy, BlockProducerInner, ProductionStrategy,
 };
 use irys_chain::IrysNodeCtx;
 use irys_database::SystemLedger;
@@ -65,13 +65,7 @@ async fn heavy_block_invalid_stake_value_gets_rejected() -> eyre::Result<()> {
             Vec<CommitmentTransaction>,
             Vec<DataTransactionHeader>,
             PublishLedgerWithTxs,
-            std::collections::BTreeMap<
-                irys_types::Address,
-                (
-                    irys_types::U256,
-                    irys_actors::shadow_tx_generator::RollingHash,
-                ),
-            >,
+            LedgerExpiryBalanceDiff,
         )> {
             Ok((
                 vec![SystemTransactionLedger {
@@ -84,7 +78,10 @@ async fn heavy_block_invalid_stake_value_gets_rejected() -> eyre::Result<()> {
                     txs: vec![],
                     proofs: None,
                 },
-                std::collections::BTreeMap::new(),
+                LedgerExpiryBalanceDiff {
+                    miner_balance_increment: std::collections::BTreeMap::new(),
+                    user_perm_fee_refunds: std::collections::BTreeMap::new(),
+                },
             ))
         }
     }
@@ -171,13 +168,7 @@ async fn heavy_block_invalid_pledge_value_gets_rejected() -> eyre::Result<()> {
             Vec<CommitmentTransaction>,
             Vec<DataTransactionHeader>,
             PublishLedgerWithTxs,
-            std::collections::BTreeMap<
-                irys_types::Address,
-                (
-                    irys_types::U256,
-                    irys_actors::shadow_tx_generator::RollingHash,
-                ),
-            >,
+            LedgerExpiryBalanceDiff,
         )> {
             Ok((
                 vec![SystemTransactionLedger {
@@ -190,7 +181,10 @@ async fn heavy_block_invalid_pledge_value_gets_rejected() -> eyre::Result<()> {
                     txs: vec![],
                     proofs: None,
                 },
-                std::collections::BTreeMap::new(),
+                LedgerExpiryBalanceDiff {
+                    miner_balance_increment: std::collections::BTreeMap::new(),
+                    user_perm_fee_refunds: std::collections::BTreeMap::new(),
+                },
             ))
         }
     }
@@ -277,13 +271,7 @@ async fn heavy_block_wrong_commitment_order_gets_rejected() -> eyre::Result<()> 
             Vec<CommitmentTransaction>,
             Vec<DataTransactionHeader>,
             PublishLedgerWithTxs,
-            std::collections::BTreeMap<
-                irys_types::Address,
-                (
-                    irys_types::U256,
-                    irys_actors::shadow_tx_generator::RollingHash,
-                ),
-            >,
+            LedgerExpiryBalanceDiff,
         )> {
             Ok((
                 vec![SystemTransactionLedger {
@@ -296,7 +284,10 @@ async fn heavy_block_wrong_commitment_order_gets_rejected() -> eyre::Result<()> 
                     txs: vec![],
                     proofs: None,
                 },
-                std::collections::BTreeMap::new(),
+                LedgerExpiryBalanceDiff {
+                    miner_balance_increment: std::collections::BTreeMap::new(),
+                    user_perm_fee_refunds: std::collections::BTreeMap::new(),
+                },
             ))
         }
     }
@@ -394,13 +385,7 @@ async fn heavy_block_epoch_commitment_mismatch_gets_rejected() -> eyre::Result<(
             Vec<CommitmentTransaction>,
             Vec<DataTransactionHeader>,
             PublishLedgerWithTxs,
-            std::collections::BTreeMap<
-                irys_types::Address,
-                (
-                    irys_types::U256,
-                    irys_actors::shadow_tx_generator::RollingHash,
-                ),
-            >,
+            LedgerExpiryBalanceDiff,
         )> {
             Ok((
                 vec![SystemTransactionLedger {
@@ -413,7 +398,10 @@ async fn heavy_block_epoch_commitment_mismatch_gets_rejected() -> eyre::Result<(
                     txs: vec![],
                     proofs: None,
                 },
-                std::collections::BTreeMap::new(),
+                LedgerExpiryBalanceDiff {
+                    miner_balance_increment: std::collections::BTreeMap::new(),
+                    user_perm_fee_refunds: std::collections::BTreeMap::new(),
+                },
             ))
         }
     }
@@ -619,13 +607,7 @@ async fn heavy_block_duplicate_ingress_proof_signers_gets_rejected() -> eyre::Re
             Vec<CommitmentTransaction>,
             Vec<DataTransactionHeader>,
             PublishLedgerWithTxs,
-            std::collections::BTreeMap<
-                irys_types::Address,
-                (
-                    irys_types::U256,
-                    irys_actors::shadow_tx_generator::RollingHash,
-                ),
-            >,
+            LedgerExpiryBalanceDiff,
         )> {
             // Create publish ledger with duplicate proofs from the same signer for one transaction
             // This tests that each transaction must have unique signers
@@ -644,7 +626,10 @@ async fn heavy_block_duplicate_ingress_proof_signers_gets_rejected() -> eyre::Re
                     txs: vec![self.data_tx.clone()],
                     proofs: Some(proofs),
                 },
-                std::collections::BTreeMap::new(),
+                LedgerExpiryBalanceDiff {
+                    miner_balance_increment: std::collections::BTreeMap::new(),
+                    user_perm_fee_refunds: std::collections::BTreeMap::new(),
+                },
             ))
         }
     }
@@ -817,13 +802,7 @@ async fn heavy_block_epoch_missing_commitments_gets_rejected() -> eyre::Result<(
             Vec<CommitmentTransaction>,
             Vec<DataTransactionHeader>,
             PublishLedgerWithTxs,
-            std::collections::BTreeMap<
-                irys_types::Address,
-                (
-                    irys_types::U256,
-                    irys_actors::shadow_tx_generator::RollingHash,
-                ),
-            >,
+            LedgerExpiryBalanceDiff,
         )> {
             Ok((
                 vec![SystemTransactionLedger {
@@ -836,7 +815,10 @@ async fn heavy_block_epoch_missing_commitments_gets_rejected() -> eyre::Result<(
                     txs: vec![],
                     proofs: None,
                 },
-                std::collections::BTreeMap::new(),
+                LedgerExpiryBalanceDiff {
+                    miner_balance_increment: std::collections::BTreeMap::new(),
+                    user_perm_fee_refunds: std::collections::BTreeMap::new(),
+                },
             ))
         }
     }

--- a/crates/irys-reth/src/evm.rs
+++ b/crates/irys-reth/src/evm.rs
@@ -415,7 +415,8 @@ where
                     ))
                 }
                 shadow_tx::TransactionPacket::TermFeeReward(balance_increment)
-                | shadow_tx::TransactionPacket::IngressProofReward(balance_increment) => {
+                | shadow_tx::TransactionPacket::IngressProofReward(balance_increment)
+                | shadow_tx::TransactionPacket::PermFeeRefund(balance_increment) => {
                     let log = Self::create_shadow_log(
                         balance_increment.target,
                         vec![topic],
@@ -1754,7 +1755,8 @@ where
                     ))
                 }
                 shadow_tx::TransactionPacket::TermFeeReward(balance_increment)
-                | shadow_tx::TransactionPacket::IngressProofReward(balance_increment) => {
+                | shadow_tx::TransactionPacket::IngressProofReward(balance_increment)
+                | shadow_tx::TransactionPacket::PermFeeRefund(balance_increment) => {
                     let log = Self::create_shadow_log(
                         balance_increment.target,
                         vec![topic],

--- a/crates/irys-reth/src/shadow_tx.rs
+++ b/crates/irys-reth/src/shadow_tx.rs
@@ -591,7 +591,7 @@ mod tests {
             irys_ref: FixedBytes::<32>::from_slice(&[0xcc; 32]),
         }));
         let topic = tx.topic();
-        let expected_topic = FixedBytes::<32>::from(keccak256("SHADOW_TX_PERM_FEE_REFUND"));
+        let expected_topic = keccak256("SHADOW_TX_PERM_FEE_REFUND");
         assert_eq!(topic, expected_topic, "topic mismatch");
     }
 }


### PR DESCRIPTION
**Describe the changes**
On epoch blocks we expire the term ledger partition (already implemented). During this process, if a tx was not promoted to the publish ledger, then we must refund back the perm fee.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
