### PR TITLE
fix: buffer advancement for optional is_online in PeerListItem::from_compact

### DIFF
--- a/crates/types/src/peer_list.rs
+++ b/crates/types/src/peer_list.rs
@@ -503,7 +503,7 @@ mod tests {
         let mut buf = bytes::BytesMut::with_capacity(64);
         item.to_compact(&mut buf);
         // Remove the optional is_online byte
-        assert!(buf.len() >= 1);
+        assert!(!buf.is_empty());
         buf.truncate(buf.len() - 1);
 
         let (decoded, remainder) = PeerListItem::from_compact(&buf[..], buf.len());
@@ -516,6 +516,6 @@ mod tests {
         assert_eq!(decoded.response_time, item.response_time);
         assert_eq!(decoded.address, item.address);
         assert_eq!(decoded.last_seen, item.last_seen);
-        assert_eq!(decoded.is_online, false);
+        assert!(!decoded.is_online);
     }
 }

--- a/crates/types/src/peer_list.rs
+++ b/crates/types/src/peer_list.rs
@@ -273,9 +273,7 @@ impl Compact for PeerListItem {
         let (api_address, consumed) = decode_address(buf);
         buf.advance(consumed);
 
-        // let (reth_peering_tcp, consumed) = decode_address(&buf[total_consumed..]);
         let (reth_peer_info, buf) = RethPeerInfo::from_compact(buf, buf.len());
-        // total_consumed += consumed;
 
         let address = PeerAddress {
             gossip: gossip_address,

--- a/crates/types/src/peer_list.rs
+++ b/crates/types/src/peer_list.rs
@@ -288,13 +288,13 @@ impl Compact for PeerListItem {
             0
         };
 
-        let total_consumed = 8;
+        let mut total_consumed = 8;
+        let mut is_online = false;
 
-        let is_online = if buf.len() > total_consumed {
-            buf[total_consumed] == 1
-        } else {
-            false
-        };
+        if buf.len() > total_consumed {
+            is_online = buf[total_consumed] == 1;
+            total_consumed += 1;
+        }
 
         (
             Self {


### PR DESCRIPTION
**Describe the changes**
- Fixes a decoding bug where `PeerListItem::from_compact` only advanced 8 bytes for `last_seen` but did not advance when the optional `is_online` byte was present, causing the returned remainder to incorrectly include the boolean.
- Update: track `total_consumed` and increment when `is_online` exists; default `is_online` to `false` when absent 
- Documentation: PeerListItem::from_compact() documentation added. Comments corrected in decode_address()
- Adds tests:
  - Ensures round-trip decode leaves no remainder.
  - Ensures decode works when the optional `is_online` byte is missing (no remainder, `is_online=false`).

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

