### PR TITLE
fix: Add new shadow tx version with solution hash binding

### DIFF
--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -402,6 +402,7 @@ pub trait BlockProdStrategy {
                 &mut publish_txs,
                 block_reward,
                 current_timestamp,
+                solution.solution_hash,
                 expired_ledger_fees,
             )
             .await?;
@@ -469,6 +470,7 @@ pub trait BlockProdStrategy {
         publish_txs: &mut PublishLedgerWithTxs,
         reward_amount: Amount<irys_types::storage_pricing::phantoms::Irys>,
         timestamp_ms: u128,
+        solution_hash: H256,
         expired_ledger_fees: BTreeMap<Address, (U256, RollingHash)>,
     ) -> eyre::Result<(EthBuiltPayload, U256)> {
         let block_height = prev_block_header.height + 1;
@@ -483,6 +485,7 @@ pub trait BlockProdStrategy {
             &self.inner().config.node_config.reward_address,
             &reward_amount.amount,
             prev_block_header,
+            &solution_hash,
             &self.inner().config.consensus,
             commitment_txs_to_bill,
             submit_txs,

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -19,7 +19,9 @@ use irys_domain::{
 };
 use irys_packing::{capacity_single::compute_entropy_chunk, xor_vec_u8_arrays_in_place};
 use irys_primitives::CommitmentType;
-use irys_reth::shadow_tx::{ShadowTransaction, IRYS_SHADOW_EXEC, SHADOW_TX_DESTINATION_ADDR};
+use irys_reth::shadow_tx::{
+    ShadowTransaction, TransactionPacket, IRYS_SHADOW_EXEC, SHADOW_TX_DESTINATION_ADDR,
+};
 use irys_reth_node_bridge::IrysRethNodeAdapter;
 use irys_reward_curve::HalvingCurve;
 use irys_storage::ii;
@@ -39,6 +41,7 @@ use irys_vdf::last_step_checkpoints_is_valid;
 use irys_vdf::state::VdfStateReadonly;
 use itertools::*;
 use openssl::sha;
+use reth::revm::primitives::FixedBytes;
 use reth::rpc::api::EngineApiClient as _;
 use reth::rpc::types::engine::ExecutionPayload;
 use reth_db::Database as _;
@@ -1027,7 +1030,7 @@ pub async fn shadow_transactions_are_valid(
     .await?;
 
     // 4. Validate they match
-    validate_shadow_transactions_match(actual_shadow_txs, expected_txs.into_iter())
+    validate_shadow_transactions_match(actual_shadow_txs, expected_txs.into_iter(), block)
 }
 
 /// Generates expected shadow transactions by looking up required data from the mempool or database
@@ -1094,6 +1097,7 @@ async fn generate_expected_shadow_transactions_from_db<'a>(
         &block.reward_address,
         &block.reward_amount,
         &prev_block,
+        &block.solution_hash,
         &config.consensus,
         &commitment_txs,
         &data_txs,
@@ -1193,6 +1197,7 @@ async fn extract_publish_ledger_with_txs(
 fn validate_shadow_transactions_match(
     actual: impl Iterator<Item = eyre::Result<ShadowTransaction>>,
     expected: impl Iterator<Item = ShadowTransaction>,
+    block_header: &IrysBlockHeader,
 ) -> eyre::Result<()> {
     // Validate each expected shadow transaction
     for (idx, data) in actual.zip_longest(expected).enumerate() {
@@ -1203,6 +1208,40 @@ fn validate_shadow_transactions_match(
             eyre::bail!("actual and expected shadow txs lens differ");
         };
         let actual = actual?;
+
+        // Add V2 solution hash validation
+        if let ShadowTransaction::V2 {
+            packet,
+            solution_hash,
+        } = &actual
+        {
+            // Verify solution hash matches the block
+            let expected_hash: FixedBytes<32> = block_header.solution_hash.into();
+            if *solution_hash != expected_hash {
+                eyre::bail!(
+                    "Invalid solution hash reference in shadow transaction at idx {}. Expected {:?}, got {:?}",
+                    idx,
+                    block_header.solution_hash,
+                    solution_hash
+                );
+            }
+
+            // Additional validation for BlockReward packets
+            if let TransactionPacket::BlockReward(reward) = packet {
+                if let Some(reward_solution_hash) = &reward.solution_hash {
+                    let expected_hash: FixedBytes<32> = block_header.solution_hash.into();
+                    if *reward_solution_hash != expected_hash {
+                        eyre::bail!(
+                            "Block reward solution hash mismatch at idx {}. Expected {:?}, got {:?}",
+                            idx,
+                            block_header.solution_hash,
+                            reward_solution_hash
+                        );
+                    }
+                }
+            }
+        }
+
         ensure!(
             actual == expected,
             "Shadow transaction mismatch at idx {}. expected {:?}, got {:?}",

--- a/crates/actors/src/shadow_tx_generator.rs
+++ b/crates/actors/src/shadow_tx_generator.rs
@@ -6,7 +6,7 @@ use irys_reth::shadow_tx::{
 use irys_types::{
     transaction::fee_distribution::{PublishFeeCharges, TermFeeCharges},
     Address, CommitmentTransaction, ConsensusConfig, DataTransactionHeader, IngressProofsList,
-    IrysBlockHeader, IrysTransactionCommon as _, U256,
+    IrysBlockHeader, IrysTransactionCommon as _, H256, U256,
 };
 use reth::revm::primitives::ruint::Uint;
 use std::collections::BTreeMap;
@@ -29,6 +29,7 @@ pub struct ShadowTxGenerator<'a> {
     pub reward_address: &'a Address,
     pub reward_amount: &'a U256,
     pub parent_block: &'a IrysBlockHeader,
+    pub solution_hash: &'a H256,
     pub config: &'a ConsensusConfig,
 
     // Transaction slices
@@ -53,6 +54,7 @@ impl<'a> ShadowTxGenerator<'a> {
         reward_address: &'a Address,
         reward_amount: &'a U256,
         parent_block: &'a IrysBlockHeader,
+        solution_hash: &'a H256,
         config: &'a ConsensusConfig,
         commitment_txs: &'a [CommitmentTransaction],
         submit_txs: &'a [DataTransactionHeader],
@@ -68,6 +70,7 @@ impl<'a> ShadowTxGenerator<'a> {
             reward_address,
             reward_amount,
             parent_block,
+            solution_hash,
             config,
             commitment_txs,
             submit_txs,
@@ -110,6 +113,7 @@ impl Iterator for ShadowTxGenerator<'_> {
                         shadow_tx: ShadowTransaction::new_v1(TransactionPacket::BlockReward(
                             BlockRewardIncrement {
                                 amount: (*self.reward_amount).into(),
+                                solution_hash: Some((*self.solution_hash).into()),
                             },
                         )),
                         transaction_fee: 0,
@@ -677,22 +681,27 @@ mod tests {
             proofs: None,
         };
 
+        let solution_hash = H256::zero();
+
         // Create expected shadow transactions
         let expected_shadow_txs: Vec<ShadowMetadata> = vec![ShadowMetadata {
             shadow_tx: ShadowTransaction::new_v1(TransactionPacket::BlockReward(
                 BlockRewardIncrement {
                     amount: reward_amount.into(),
+                    solution_hash: Some(solution_hash.into()),
                 },
             )),
             transaction_fee: 0,
         }];
 
         let empty_fees = BTreeMap::new();
+        let solution_hash = H256::zero();
         let generator = ShadowTxGenerator::new(
             &block_height,
             &reward_address,
             &reward_amount,
             &parent_block,
+            &solution_hash,
             &config,
             &[],
             &[],
@@ -750,6 +759,7 @@ mod tests {
                 shadow_tx: ShadowTransaction::new_v1(TransactionPacket::BlockReward(
                     BlockRewardIncrement {
                         amount: reward_amount.into(),
+                        solution_hash: Some(H256::zero().into()),
                     },
                 )),
                 transaction_fee: 0,
@@ -797,11 +807,13 @@ mod tests {
         ];
 
         let empty_fees = BTreeMap::new();
+        let solution_hash = H256::zero();
         let generator = ShadowTxGenerator::new(
             &block_height,
             &reward_address,
             &reward_amount,
             &parent_block,
+            &solution_hash,
             &config,
             &commitments,
             &[],
@@ -848,6 +860,7 @@ mod tests {
                 shadow_tx: ShadowTransaction::new_v1(TransactionPacket::BlockReward(
                     BlockRewardIncrement {
                         amount: reward_amount.into(),
+                        solution_hash: Some(H256::zero().into()),
                     },
                 )),
                 transaction_fee: 0,
@@ -869,11 +882,13 @@ mod tests {
         ];
 
         let empty_fees = BTreeMap::new();
+        let solution_hash = H256::zero();
         let mut generator = ShadowTxGenerator::new(
             &block_height,
             &reward_address,
             &reward_amount,
             &parent_block,
+            &solution_hash,
             &config,
             &[],
             &submit_txs,
@@ -991,6 +1006,7 @@ mod tests {
                 shadow_tx: ShadowTransaction::new_v1(TransactionPacket::BlockReward(
                     BlockRewardIncrement {
                         amount: reward_amount.into(),
+                        solution_hash: Some(H256::zero().into()),
                     },
                 )),
                 transaction_fee: 0,
@@ -1043,11 +1059,13 @@ mod tests {
         ];
 
         let empty_fees = BTreeMap::new();
+        let solution_hash = H256::zero();
         let generator = ShadowTxGenerator::new(
             &block_height,
             &reward_address,
             &reward_amount,
             &parent_block,
+            &solution_hash,
             &config,
             &[],
             &submit_txs,

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -1094,6 +1094,7 @@ async fn heavy_block_prod_will_not_build_on_invalid_blocks() -> eyre::Result<()>
             data_txs_with_proofs: &mut PublishLedgerWithTxs,
             reward_amount: Amount<irys_types::storage_pricing::phantoms::Irys>,
             timestamp_ms: u128,
+            solution_hash: H256,
             expired_ledger_fees: BTreeMap<Address, (irys_types::U256, RollingHash)>,
         ) -> eyre::Result<(EthBuiltPayload, irys_types::U256)> {
             // Tamper the EVM payload by reversing submit tx order (keeps PoA untouched)
@@ -1111,6 +1112,7 @@ async fn heavy_block_prod_will_not_build_on_invalid_blocks() -> eyre::Result<()>
                     data_txs_with_proofs,
                     reward_amount,
                     timestamp_ms,
+                    H256::zero(),
                     expired_ledger_fees,
                 )
                 .await

--- a/crates/chain/tests/block_production/block_validation.rs
+++ b/crates/chain/tests/block_production/block_validation.rs
@@ -1,6 +1,6 @@
 use crate::utils::IrysNodeTest;
 use eyre::Result;
-use irys_types::{NodeConfig, U256};
+use irys_types::{NodeConfig, U256, H256};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// This test ensures that if we attempt to submit a block with a timestamp
@@ -52,6 +52,7 @@ async fn heavy_test_future_block_rejection() -> Result<()> {
             data_txs_with_proofs: &mut PublishLedgerWithTxs,
             reward_amount: Amount<irys_types::storage_pricing::phantoms::Irys>,
             _timestamp_ms: u128,
+            _solution_hash: H256,
             expired_ledger_fees: std::collections::BTreeMap<
                 irys_types::Address,
                 (
@@ -69,6 +70,7 @@ async fn heavy_test_future_block_rejection() -> Result<()> {
                     data_txs_with_proofs,
                     reward_amount,
                     self.invalid_timestamp,
+                    H256::zero(),
                     expired_ledger_fees,
                 )
                 .await

--- a/crates/chain/tests/multi_node/validation.rs
+++ b/crates/chain/tests/multi_node/validation.rs
@@ -7,7 +7,7 @@ use irys_actors::{
 };
 use irys_types::{
     storage_pricing::Amount, CommitmentTransaction, DataTransactionHeader, IrysBlockHeader,
-    NodeConfig, U256,
+    NodeConfig, U256, H256,
 };
 use reth::payload::EthBuiltPayload;
 
@@ -35,6 +35,7 @@ async fn heavy_block_invalid_evm_block_reward_gets_rejected() -> eyre::Result<()
             data_txs_with_proofs: &mut PublishLedgerWithTxs,
             reward_amount: Amount<irys_types::storage_pricing::phantoms::Irys>,
             timestamp_ms: u128,
+            _solution_hash: H256,
             expired_ledger_fees: std::collections::BTreeMap<
                 irys_types::Address,
                 (
@@ -55,6 +56,7 @@ async fn heavy_block_invalid_evm_block_reward_gets_rejected() -> eyre::Result<()
                     // NOTE: Point of error - trying to give yourself extra funds in the evm state
                     invalid_reward_amount,
                     timestamp_ms,
+                    H256::zero(),
                     expired_ledger_fees,
                 )
                 .await
@@ -194,6 +196,7 @@ async fn heavy_block_shadow_txs_misalignment_block_rejected() -> eyre::Result<()
             data_txs_with_proofs: &mut PublishLedgerWithTxs,
             reward_amount: Amount<irys_types::storage_pricing::phantoms::Irys>,
             timestamp_ms: u128,
+            _solution_hash: H256,
             expired_ledger_fees: std::collections::BTreeMap<
                 irys_types::Address,
                 (
@@ -214,6 +217,7 @@ async fn heavy_block_shadow_txs_misalignment_block_rejected() -> eyre::Result<()
                     data_txs_with_proofs,
                     reward_amount,
                     timestamp_ms,
+                    H256::zero(),
                     expired_ledger_fees,
                 )
                 .await
@@ -291,6 +295,7 @@ async fn heavy_block_shadow_txs_different_order_of_txs() -> eyre::Result<()> {
             data_txs_with_proofs: &mut PublishLedgerWithTxs,
             reward_amount: Amount<irys_types::storage_pricing::phantoms::Irys>,
             timestamp_ms: u128,
+            _solution_hash: H256,
             expired_ledger_fees: std::collections::BTreeMap<
                 irys_types::Address,
                 (
@@ -315,6 +320,7 @@ async fn heavy_block_shadow_txs_different_order_of_txs() -> eyre::Result<()> {
                     data_txs_with_proofs,
                     reward_amount,
                     timestamp_ms,
+                    H256::zero(),
                     expired_ledger_fees,
                 )
                 .await

--- a/crates/irys-reth/src/evm.rs
+++ b/crates/irys-reth/src/evm.rs
@@ -191,12 +191,16 @@ where
         // Get the target address from the shadow transaction
         let fee_payer_address = match &shadow_tx {
             ShadowTransaction::V1 { packet } => packet.fee_payer_address(),
+            ShadowTransaction::V2 { packet, .. } => packet.fee_payer_address(),
         };
 
         // Check if this is a block reward transaction
         let is_block_reward = matches!(
             &shadow_tx,
             ShadowTransaction::V1 {
+                packet: shadow_tx::TransactionPacket::BlockReward(_),
+                ..
+            } | ShadowTransaction::V2 {
                 packet: shadow_tx::TransactionPacket::BlockReward(_),
                 ..
             }
@@ -328,7 +332,8 @@ where
         let topic = shadow_tx.topic();
 
         match shadow_tx {
-            shadow_tx::ShadowTransaction::V1 { packet, .. } => match packet {
+            shadow_tx::ShadowTransaction::V1 { packet, .. }
+            | shadow_tx::ShadowTransaction::V2 { packet, .. } => match packet {
                 shadow_tx::TransactionPacket::Unstake(either_inc_dec)
                 | shadow_tx::TransactionPacket::Unpledge(either_inc_dec) => match either_inc_dec {
                     shadow_tx::EitherIncrementOrDecrement::BalanceIncrement(balance_increment) => {
@@ -1306,12 +1311,16 @@ where
         // Get the target address from the shadow transaction
         let fee_payer_address = match &shadow_tx {
             ShadowTransaction::V1 { packet } => packet.fee_payer_address(),
+            ShadowTransaction::V2 { packet, .. } => packet.fee_payer_address(),
         };
 
         // Check if this is a block reward transaction
         let is_block_reward = matches!(
             &shadow_tx,
             ShadowTransaction::V1 {
+                packet: shadow_tx::TransactionPacket::BlockReward(_),
+                ..
+            } | ShadowTransaction::V2 {
                 packet: shadow_tx::TransactionPacket::BlockReward(_),
                 ..
             }
@@ -1668,7 +1677,8 @@ where
         let topic = shadow_tx.topic();
 
         match shadow_tx {
-            shadow_tx::ShadowTransaction::V1 { packet, .. } => match packet {
+            shadow_tx::ShadowTransaction::V1 { packet, .. }
+            | shadow_tx::ShadowTransaction::V2 { packet, .. } => match packet {
                 shadow_tx::TransactionPacket::Unstake(either_inc_dec)
                 | shadow_tx::TransactionPacket::Unpledge(either_inc_dec) => match either_inc_dec {
                     shadow_tx::EitherIncrementOrDecrement::BalanceIncrement(balance_increment) => {

--- a/crates/irys-reth/src/lib.rs
+++ b/crates/irys-reth/src/lib.rs
@@ -570,6 +570,7 @@ mod tests {
             1,
             &ShadowTransaction::new_v1(TransactionPacket::BlockReward(BlockRewardIncrement {
                 amount,
+                solution_hash: None,
             })),
             0, // Block rewards must have 0 priority fee
         );
@@ -1809,6 +1810,7 @@ mod tests {
         let fund_tx =
             ShadowTransaction::new_v1(TransactionPacket::BlockReward(BlockRewardIncrement {
                 amount: funding_amount,
+                solution_hash: None,
             }));
         let fund_tx = sign_shadow_tx(fund_tx, &ctx.block_producer_a, 0).await?; // Block rewards must have 0 priority fee
         mine_block(&mut node, &shadow_tx_store, vec![fund_tx]).await?;
@@ -1869,6 +1871,7 @@ mod tests {
         let fund_tx =
             ShadowTransaction::new_v1(TransactionPacket::BlockReward(BlockRewardIncrement {
                 amount: funding_amount,
+                solution_hash: None,
             }));
         let fund_tx = sign_shadow_tx(fund_tx, &ctx.block_producer_a, 0).await?; // Block rewards must have 0 priority fee
         mine_block(&mut node, &shadow_tx_store, vec![fund_tx]).await?;
@@ -2096,6 +2099,7 @@ mod tests {
         let fund_tx =
             ShadowTransaction::new_v1(TransactionPacket::BlockReward(BlockRewardIncrement {
                 amount: funding_amount,
+                solution_hash: None,
             }));
         let fund_tx = sign_shadow_tx(fund_tx, &ctx.block_producer_a, 0).await?; // Block rewards must have 0 priority fee
         mine_block(&mut node, &shadow_tx_store, vec![fund_tx]).await?;
@@ -2658,14 +2662,23 @@ pub mod test_utils {
                 // Use the shadow tx directly since metadata fields are removed
                 let updated_shadow_tx = match &shadow_tx {
                     ShadowTransaction::V1 { packet } => ShadowTransaction::new_v1(packet.clone()),
+                    ShadowTransaction::V2 {
+                        packet,
+                        solution_hash,
+                    } => ShadowTransaction::V2 {
+                        packet: packet.clone(),
+                        solution_hash: *solution_hash,
+                    },
                 };
 
                 // Block rewards must have 0 priority fee, others can use default
                 let priority_fee = match &shadow_tx {
-                    ShadowTransaction::V1 { packet } => match packet {
-                        TransactionPacket::BlockReward(_) => 0,
-                        _ => DEFAULT_PRIORITY_FEE,
-                    },
+                    ShadowTransaction::V1 { packet } | ShadowTransaction::V2 { packet, .. } => {
+                        match packet {
+                            TransactionPacket::BlockReward(_) => 0,
+                            _ => DEFAULT_PRIORITY_FEE,
+                        }
+                    }
                 };
 
                 let shadow_tx = sign_shadow_tx(updated_shadow_tx, signer, priority_fee).await?;
@@ -2693,7 +2706,10 @@ pub mod test_utils {
     /// Compose a shadow tx for block reward.
     pub fn block_reward() -> ShadowTransaction {
         ShadowTransaction::new_v1(TransactionPacket::BlockReward(
-            shadow_tx::BlockRewardIncrement { amount: U256::ONE },
+            shadow_tx::BlockRewardIncrement {
+                amount: U256::ONE,
+                solution_hash: None,
+            },
         ))
     }
 

--- a/crates/irys-reth/src/shadow_tx.rs
+++ b/crates/irys-reth/src/shadow_tx.rs
@@ -19,6 +19,7 @@ use std::sync::LazyLock;
 
 /// Version constants for ShadowTransaction
 pub const SHADOW_TX_VERSION_V1: u8 = 1;
+pub const SHADOW_TX_VERSION_V2: u8 = 2;
 
 /// Current version of ShadowTransaction
 pub const CURRENT_SHADOW_TX_VERSION: u8 = SHADOW_TX_VERSION_V1;
@@ -43,6 +44,13 @@ pub enum ShadowTransaction {
     V1 {
         /// The actual shadow transaction packet.
         packet: TransactionPacket,
+    },
+    /// Version 2 shadow transaction format with solution hash support
+    V2 {
+        /// The actual shadow transaction packet.
+        packet: TransactionPacket,
+        /// Solution hash for validation
+        solution_hash: FixedBytes<32>,
     },
 }
 
@@ -129,6 +137,7 @@ impl ShadowTransaction {
     pub fn version(&self) -> u8 {
         match self {
             Self::V1 { .. } => SHADOW_TX_VERSION_V1,
+            Self::V2 { .. } => SHADOW_TX_VERSION_V2,
         }
     }
 
@@ -137,6 +146,7 @@ impl ShadowTransaction {
     pub fn as_v1(&self) -> Option<&TransactionPacket> {
         match self {
             Self::V1 { packet, .. } => Some(packet),
+            Self::V2 { .. } => None,
         }
     }
 
@@ -145,6 +155,7 @@ impl ShadowTransaction {
     pub fn topic(&self) -> FixedBytes<32> {
         match self {
             Self::V1 { packet, .. } => packet.topic(),
+            Self::V2 { packet, .. } => packet.topic(),
         }
     }
 
@@ -206,6 +217,15 @@ impl BorshSerialize for ShadowTransaction {
                 writer.write_all(&[SHADOW_TX_VERSION_V1])?;
                 packet.serialize(writer)
             }
+            Self::V2 {
+                packet,
+                solution_hash,
+            } => {
+                writer.write_all(&[SHADOW_TX_VERSION_V2])?;
+                packet.serialize(writer)?;
+                writer.write_all(solution_hash.as_slice())?;
+                Ok(())
+            }
         }
     }
 }
@@ -218,6 +238,16 @@ impl BorshDeserialize for ShadowTransaction {
             SHADOW_TX_VERSION_V1 => {
                 let packet = TransactionPacket::deserialize_reader(reader)?;
                 Ok(Self::V1 { packet })
+            }
+            SHADOW_TX_VERSION_V2 => {
+                let packet = TransactionPacket::deserialize_reader(reader)?;
+                let mut hash_buf = [0_u8; 32];
+                reader.read_exact(&mut hash_buf)?;
+                let solution_hash = FixedBytes::<32>::from_slice(&hash_buf);
+                Ok(Self::V2 {
+                    packet,
+                    solution_hash,
+                })
             }
             _ => Err(borsh::io::Error::new(
                 borsh::io::ErrorKind::InvalidData,
@@ -466,24 +496,52 @@ impl BorshDeserialize for BalanceIncrement {
     // manual Borsh impls below
     arbitrary::Arbitrary,
 )]
+
 pub struct BlockRewardIncrement {
     /// Amount to increment to the beneficiary account.
     pub amount: U256,
+    /// Solution hash of the block being rewarded (V2 only)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub solution_hash: Option<FixedBytes<32>>,
 }
 
 impl BorshSerialize for BlockRewardIncrement {
     fn serialize<W: Write>(&self, writer: &mut W) -> borsh::io::Result<()> {
         writer.write_all(&self.amount.to_be_bytes::<32>())?;
+        // For Tx V2, include solution_hash
+        if let Some(hash) = &self.solution_hash {
+            writer.write_all(&[1_u8])?; // Flag indicating solution_hash is present
+            writer.write_all(hash.as_slice())?;
+        } else {
+            writer.write_all(&[0_u8])?; // Flag indicating no solution_hash
+        }
         Ok(())
     }
 }
-
 impl BorshDeserialize for BlockRewardIncrement {
     fn deserialize_reader<R: Read>(reader: &mut R) -> borsh::io::Result<Self> {
+        // Read amount (32 bytes, big-endian)
         let mut amount_buf = [0_u8; 32];
         reader.read_exact(&mut amount_buf)?;
         let amount = U256::from_be_bytes(amount_buf);
-        Ok(Self { amount })
+
+        // Read solution_hash presence flag
+        let mut has_solution_hash = [0_u8; 1];
+        reader.read_exact(&mut has_solution_hash)?;
+
+        let solution_hash = match has_solution_hash[0] {
+            1 => {
+                let mut hash_buf = [0_u8; 32];
+                reader.read_exact(&mut hash_buf)?;
+                Some(FixedBytes::<32>::from_slice(&hash_buf))
+            }
+            _ => None,
+        };
+
+        Ok(Self {
+            amount,
+            solution_hash,
+        })
     }
 }
 
@@ -498,6 +556,7 @@ mod tests {
     fn block_reward_roundtrip() {
         let tx = ShadowTransaction::new_v1(TransactionPacket::BlockReward(BlockRewardIncrement {
             amount: U256::from(123_u64),
+            solution_hash: None,
         }));
         let mut buf = Vec::new();
         tx.serialize(&mut buf).unwrap();
@@ -538,6 +597,7 @@ mod tests {
     fn decode_prefixed_roundtrip() {
         let tx = ShadowTransaction::new_v1(TransactionPacket::BlockReward(BlockRewardIncrement {
             amount: U256::from(1_u64),
+            solution_hash: None,
         }));
         let mut buf = Vec::from(IRYS_SHADOW_EXEC.as_slice());
         tx.serialize(&mut buf).unwrap();


### PR DESCRIPTION
**Describe the changes**
Before this PR, shadow transactions did not include a reference to the solution hash of the block being rewarded. This meant that the Irys block uniquely identified the EVM block via the `evm_block_hash` field, but the EVM block did not uniquely identify the Irys block.

  This PR:
  Introduces the shadow transaction V2 format that includes solution hash binding for block rewards. The changes ensure that:
  - Block reward shadow transactions now carry a reference to the solution hash
  - The solution hash is validated during block validation to ensure it matches the block header
  - Backwards compatibility is maintained with V1 shadow transactions
  - All shadow transaction processing paths (EVM execution, validation, generation) support the new V2 format

  - Added `SHADOW_TX_VERSION_V2` constant and new V2 variant to `ShadowTransaction` enum with solution_hash field
  - Updated `BlockRewardIncrement` to include an optional solution_hash field for V2 transactions
  - Modified shadow transaction generator to pass solution hash through the entire block production pipeline
  - Enhanced block validation to verify solution hash matches between shadow transactions and block headers
  - Updated all pattern matching across the codebase to handle both V1 and V2 transaction formats
  - Maintained full backwards compatibility with existing V1 transactions

**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [x] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
