### PR TITLE
fix: removed feature flags from PackingType enum

### DIFF
--- a/crates/packing/src/lib.rs
+++ b/crates/packing/src/lib.rs
@@ -190,8 +190,15 @@ pub fn capacity_pack_range_with_data_cuda_c(
 #[derive(PartialEq)]
 pub enum PackingType {
     CPU,
-    #[cfg(feature = "nvidia")]
+    #[expect(
+        dead_code,
+        reason = "variant may be unused without the 'nvidia' feature"
+    )]
     CUDA,
+    #[expect(
+        dead_code,
+        reason = "variant reserved; may be unused until support is added"
+    )]
     AMD,
 }
 


### PR DESCRIPTION
**Describe the changes**
 - removed feature flags from PackingType enum
 - added explanations for not unused variants

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.
