### PR TITLE
fix(efficient sampling): using ceiling calculation for recall ranges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5055,6 +5055,7 @@ dependencies = [
  "eyre",
  "irys-types",
  "openssl",
+ "rstest",
  "tracing",
 ]
 

--- a/crates/actors/src/mining.rs
+++ b/crates/actors/src/mining.rs
@@ -12,7 +12,7 @@ use crate::services::ServiceSenders;
 use actix::prelude::*;
 use actix::{Actor, Context, Handler, Message};
 use eyre::WrapErr as _;
-use irys_efficient_sampling::Ranges;
+use irys_efficient_sampling::{num_recall_ranges_in_partition, Ranges};
 use irys_storage::{ie, ii};
 use irys_types::block_production::Seed;
 use irys_types::{block_production::SolutionContext, H256, U256};
@@ -57,8 +57,7 @@ impl PartitionMiningActor {
             service_senders,
             packing_actor,
             ranges: Ranges::new(
-                (config.consensus.num_chunks_in_partition
-                    / config.consensus.num_chunks_in_recall_range)
+                num_recall_ranges_in_partition(&config.consensus)
                     .try_into()
                     .expect("Recall ranges number exceeds usize representation"),
             ),

--- a/crates/efficient-sampling/Cargo.toml
+++ b/crates/efficient-sampling/Cargo.toml
@@ -10,5 +10,8 @@ eyre.workspace = true
 openssl.workspace = true
 tracing.workspace = true
 
+[dev-dependencies]
+rstest.workspace = true
+
 [lints]
 workspace = true

--- a/crates/efficient-sampling/src/lib.rs
+++ b/crates/efficient-sampling/src/lib.rs
@@ -93,6 +93,10 @@ impl Ranges {
     }
 
     pub fn new(num_recall_ranges_in_partition: usize) -> Self {
+        assert!(
+            num_recall_ranges_in_partition > 0,
+            "num_recall_ranges_in_partition must be > 0 (misconfiguration: partition size and/or recall range size)"
+        );
         let mut ranges = Vec::with_capacity(num_recall_ranges_in_partition);
         for i in 0..num_recall_ranges_in_partition {
             ranges.push(i);

--- a/crates/efficient-sampling/src/lib.rs
+++ b/crates/efficient-sampling/src/lib.rs
@@ -169,7 +169,7 @@ pub fn reset_step(step_num: u64, num_recall_ranges_in_partition: u64) -> u64 {
 }
 
 pub fn num_recall_ranges_in_partition(config: &ConsensusConfig) -> u64 {
-    config.num_chunks_in_partition / config.num_chunks_in_recall_range
+    config.num_chunks_in_partition.div_ceil(config.num_chunks_in_recall_range)
 }
 
 //==============================================================================

--- a/crates/efficient-sampling/src/lib.rs
+++ b/crates/efficient-sampling/src/lib.rs
@@ -169,7 +169,9 @@ pub fn reset_step(step_num: u64, num_recall_ranges_in_partition: u64) -> u64 {
 }
 
 pub fn num_recall_ranges_in_partition(config: &ConsensusConfig) -> u64 {
-    config.num_chunks_in_partition.div_ceil(config.num_chunks_in_recall_range)
+    config
+        .num_chunks_in_partition
+        .div_ceil(config.num_chunks_in_recall_range)
 }
 
 //==============================================================================
@@ -179,6 +181,15 @@ pub fn num_recall_ranges_in_partition(config: &ConsensusConfig) -> u64 {
 mod tests {
     use super::*;
     use std::collections::hash_set::HashSet;
+
+    // Helper function to create test configs
+    fn create_test_config(chunks: u64, recall_range: u64) -> ConsensusConfig {
+        ConsensusConfig {
+            num_chunks_in_partition: chunks,
+            num_chunks_in_recall_range: recall_range,
+            ..ConsensusConfig::testing()
+        }
+    }
 
     #[test]
     fn test_efficient_sampling() {
@@ -243,5 +254,197 @@ mod tests {
             reset_step_num, 0,
             "Reset step number should be 0 for step 0"
         );
+    }
+
+    mod num_recall_ranges_tests {
+        use super::*;
+        use rstest::rstest;
+
+        #[rstest]
+        // Perfect division cases (no remainder)
+        #[case(1000, 100, 10, "Simple exact division")]
+        #[case(51_872_000, 800, 64_840, "Production mainnet config")]
+        #[case(10, 2, 5, "Default testing config")]
+        #[case(1, 1, 1, "Single chunk edge case")]
+        #[case(8, 4, 2, "Small exact division")]
+        #[case(1600, 800, 2, "Exact boundary for 2 ranges")]
+        // Division with remainder (ceiling division needed)
+        #[case(1000, 800, 2, "Must round up to 2")]
+        #[case(801, 800, 2, "Minimal remainder (1 chunk)")]
+        #[case(1599, 800, 2, "Maximum chunks still needing 2 ranges")]
+        #[case(1601, 800, 3, "Minimum chunks requiring 3 ranges")]
+        #[case(999, 1000, 1, "Partition smaller than recall range")]
+        #[case(101, 10, 11, "101 chunks / 10 per range = 11 ranges")]
+        #[case(199, 100, 2, "Nearly double with remainder")]
+        // Edge cases
+        #[case(1, 1000, 1, "Single chunk, large recall range")]
+        #[case(2, 1, 2, "Two ranges of size 1")]
+        #[case(100, 1, 100, "Many single-chunk ranges")]
+        #[case(3, 2, 2, "Small numbers with remainder")]
+        // Large numbers with remainders
+        #[case(10_000, 3_333, 4, "Large numbers with remainder")]
+        #[case(1_000_000, 333_333, 4, "Very large with remainder")]
+        #[case(123_456, 789, 157, "Random large numbers")]
+        fn test_num_recall_ranges_ceiling_division(
+            #[case] chunks: u64,
+            #[case] recall_range: u64,
+            #[case] expected: u64,
+            #[case] description: &str,
+        ) {
+            let config = create_test_config(chunks, recall_range);
+            let result = num_recall_ranges_in_partition(&config);
+            assert_eq!(
+                result, expected,
+                "{}: {}÷{} should equal {} but got {}",
+                description, chunks, recall_range, expected, result
+            );
+        }
+
+        #[test]
+        fn test_zero_chunks() {
+            let config = create_test_config(0, 800);
+            let result = num_recall_ranges_in_partition(&config);
+            assert_eq!(result, 0, "Zero chunks should result in zero ranges");
+        }
+
+        #[test]
+        fn test_large_number_handling() {
+            // Test with large numbers that might cause overflow in naive implementations
+            let config = create_test_config(u64::MAX - 1, u64::MAX);
+            let result = num_recall_ranges_in_partition(&config);
+            assert_eq!(result, 1, "Should handle near-maximum values");
+
+            // Test with large dividend and small divisor
+            let config2 = create_test_config(1_000_000_000, 3);
+            let result2 = num_recall_ranges_in_partition(&config2);
+            let expected2 = 1_000_000_000_u64.div_ceil(3);
+            assert_eq!(result2, expected2, "Should handle large dividend correctly");
+        }
+
+        #[test]
+        fn test_integration_with_ranges_struct() {
+            let configs_with_remainders = [
+                (1000, 800), // Should create Ranges with 2 ranges
+                (801, 800),  // Should create Ranges with 2 ranges
+                (1601, 800), // Should create Ranges with 3 ranges
+            ];
+
+            for (chunks, recall) in configs_with_remainders {
+                let config = create_test_config(chunks, recall);
+                let num_ranges = num_recall_ranges_in_partition(&config);
+
+                // Should be able to create a Ranges struct with this count
+                let ranges = Ranges::new(num_ranges as usize);
+                assert_eq!(
+                    ranges.num_recall_ranges_in_partition, num_ranges as usize,
+                    "Ranges struct should initialize with ceiling division result"
+                );
+
+                // Verify the ranges vector has the right capacity and contents
+                assert_eq!(ranges.ranges.len(), num_ranges as usize);
+                assert_eq!(ranges.last_range_pos, num_ranges as usize - 1);
+            }
+        }
+
+        #[rstest]
+        #[case(1, 11, 1, "Step 1 with 11 ranges")]
+        #[case(11, 11, 1, "Step 11 with 11 ranges")]
+        #[case(12, 11, 12, "Step 12 with 11 ranges (new cycle)")]
+        #[case(22, 11, 12, "Step 22 with 11 ranges")]
+        #[case(23, 11, 23, "Step 23 with 11 ranges (third cycle)")]
+        #[case(100, 11, 100, "Step 100 with 11 ranges")]
+        #[case(110, 11, 100, "Step 110 with 11 ranges")]
+        #[case(111, 11, 111, "Step 111 with 11 ranges")]
+        fn test_reset_step_with_ceiling_ranges(
+            #[case] step: u64,
+            #[case] num_ranges: u64,
+            #[case] expected_reset: u64,
+            #[case] description: &str,
+        ) {
+            let result = reset_step(step, num_ranges);
+            assert_eq!(
+                result, expected_reset,
+                "{}: reset_step({}, {}) should be {}",
+                description, step, num_ranges, expected_reset
+            );
+        }
+
+        #[test]
+        fn test_range_exhaustion_with_ceiling() {
+            let config = create_test_config(101, 10); // Results in 11 ranges
+            let num_ranges = num_recall_ranges_in_partition(&config);
+            assert_eq!(num_ranges, 11);
+
+            let partition_hash = H256::random();
+            let mut ranges = Ranges::new(num_ranges as usize);
+
+            // Generate seeds for each step
+            let mut seeds = Vec::new();
+            for _ in 0..num_ranges {
+                seeds.push(H256::random());
+            }
+
+            let mut got_ranges = HashSet::new();
+
+            // Exhaust all ranges
+            for i in 1..=num_ranges {
+                let range = ranges
+                    .get_recall_range(i, &seeds[(i - 1) as usize], &partition_hash)
+                    .unwrap();
+                assert!(
+                    (range as u64) < num_ranges,
+                    "Invalid range idx {} for {} ranges",
+                    range,
+                    num_ranges
+                );
+                assert!(
+                    !got_ranges.contains(&range),
+                    "Repeated range {} at step {}",
+                    range,
+                    i
+                );
+                got_ranges.insert(range);
+            }
+
+            // Verify all ranges were used
+            assert_eq!(
+                got_ranges.len(),
+                num_ranges as usize,
+                "Should have used all {} ranges",
+                num_ranges
+            );
+        }
+
+        #[test]
+        fn test_validation_with_partial_last_range() {
+            // Config with partial last range (101 chunks / 10 per range = 11 ranges)
+            let config = create_test_config(101, 10);
+            let num_ranges = num_recall_ranges_in_partition(&config) as usize;
+            let partition_hash = H256::random();
+
+            let mut seeds = H256List(Vec::new());
+            for _ in 0..num_ranges {
+                seeds.0.push(H256::random());
+            }
+
+            let mut ranges = Ranges::new(num_ranges);
+
+            for step in 1..=num_ranges {
+                let range = ranges
+                    .get_recall_range(step as u64, &seeds[step - 1], &partition_hash)
+                    .unwrap();
+                let res = recall_range_is_valid(
+                    range,
+                    num_ranges,
+                    &H256List(seeds.0[0..step].into()),
+                    &partition_hash,
+                );
+                assert!(
+                    res.is_ok(),
+                    "Validation should pass for step {} with partial last range",
+                    step
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
**Describe the changes**
  Before this PR:
  The num_recall_ranges_in_partition function used floor division (/), which caused the last chunks in a partition to be ignored when the partition size wasn't evenly divisible by the recall range size. For example, with 1000 chunks per partition and 800 chunks per recall range, the function would return one recall range, leaving the last 200 chunks unreachable. 

  This PR:
  - Changes num_recall_ranges_in_partition to use ceiling division (div_ceil), ensuring all chunks in a partition are covered by recall ranges
  - The fix ensures that when num_chunks_in_partition is not evenly divisible by num_chunks_in_recall_range, the result rounds up to include a final partial range covering the remaining chunks
  - Example: 1000 chunks / 800 chunk ranges now correctly returns two ranges (covering chunks 0-799 and 800-999) instead of 1


**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
