### PR TITLE
feat: remove throttling on the p2p broadcasts on large sets of peers

### DIFF
--- a/crates/p2p/src/gossip_service.rs
+++ b/crates/p2p/src/gossip_service.rs
@@ -25,16 +25,13 @@ use irys_api_client::ApiClient;
 use irys_domain::chain_sync_state::ChainSyncState;
 use irys_domain::execution_payload_cache::ExecutionPayloadCache;
 use irys_domain::PeerList;
-use irys_types::{Address, Config, DatabaseProvider, GossipBroadcastMessage};
+use irys_types::{Address, Config, DatabaseProvider, GossipBroadcastMessage, P2PGossipConfig};
 use reth_tasks::{TaskExecutor, TaskManager};
 use std::net::TcpListener;
 use std::sync::Arc;
 use tokio::sync::mpsc::{channel, error::SendError, Receiver, Sender};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
-use tracing::{debug, error, info, warn, Span};
-
-const MAX_PEERS_PER_BROADCAST: usize = 5;
-const BROADCAST_INTERVAL: Duration = Duration::from_secs(1);
+use tracing::{debug, info, warn, Span};
 
 type TaskExecutionResult = Result<(), tokio::task::JoinError>;
 
@@ -103,6 +100,7 @@ pub struct P2PService {
     broadcast_data_receiver: Option<UnboundedReceiver<GossipBroadcastMessage>>,
     client: GossipClient,
     pub sync_state: ChainSyncState,
+    gossip_cfg: P2PGossipConfig,
 }
 
 impl P2PService {
@@ -133,6 +131,7 @@ impl P2PService {
             cache,
             broadcast_data_receiver: Some(broadcast_data_receiver),
             sync_state: ChainSyncState::new(true, false),
+            gossip_cfg: P2PGossipConfig::default(),
         }
     }
 
@@ -177,7 +176,7 @@ impl P2PService {
             self.sync_state.clone(),
             block_status_provider,
             execution_payload_provider.clone(),
-            config,
+            config.clone(),
             service_senders,
         );
 
@@ -207,8 +206,18 @@ impl P2PService {
                     InternalGossipError::BroadcastReceiverShutdown,
                 ))?;
 
-        let broadcast_task_handle =
-            spawn_broadcast_task(mempool_data_receiver, self, task_executor, peer_list);
+        // Load gossip config from NodeConfig
+        self.gossip_cfg = config.node_config.p2p_gossip;
+
+        // Wrap the service in an Arc so we can spawn a detached broadcast per message
+        let service_arc = Arc::new(self);
+
+        let broadcast_task_handle = spawn_broadcast_task(
+            mempool_data_receiver,
+            Arc::clone(&service_arc),
+            task_executor,
+            peer_list,
+        );
 
         let gossip_service_handle =
             spawn_watcher_task(server, server_handle, broadcast_task_handle, task_executor);
@@ -242,6 +251,13 @@ impl P2PService {
         //  randomly selected peers from the rest of the list.
         let mut peers = peer_list.all_peers_sorted_by_score();
 
+        if peers.is_empty() {
+            debug!(
+                "Node {:?}: No peers to broadcast to",
+                self.client.mining_address
+            );
+        }
+
         while !peers.is_empty() {
             // Remove peers that have seen the data since the last iteration
             let peers_that_seen_data = self.cache.peers_that_have_seen(&key)?;
@@ -257,40 +273,29 @@ impl P2PService {
                 break;
             }
 
-            let n = std::cmp::min(MAX_PEERS_PER_BROADCAST, peers.len());
-            let maybe_selected_peers = peers.get(0..n);
+            let n = std::cmp::min(self.gossip_cfg.broadcast_batch_size, peers.len());
+            let selected_peers = peers.drain(0..n);
 
-            if let Some(selected_peers) = maybe_selected_peers {
-                debug!(
-                    "Node {:?}: Peers selected for the current broadcast step: {:?}",
-                    self.client.mining_address, selected_peers
+            debug!(
+                "Node {:?}: Peers selected for the current broadcast step: {:?}",
+                self.client.mining_address, selected_peers
+            );
+            // Send data to selected peers
+            for (peer_miner_address, peer_entry) in selected_peers {
+                self.client.send_data_and_update_the_score_detached(
+                    (&peer_miner_address, &peer_entry),
+                    Arc::clone(&broadcast_data),
+                    peer_list,
+                    Arc::clone(&self.cache),
+                    key,
                 );
-                // Send data to selected peers
-                for (peer_miner_address, peer_entry) in selected_peers {
-                    self.client.send_data_and_update_the_score_detached(
-                        (peer_miner_address, peer_entry),
-                        Arc::clone(&broadcast_data),
-                        peer_list,
-                    );
-
-                    // Record as seen anyway, so we don't rebroadcast to them
-                    if let Err(error) = self.cache.record_seen(*peer_miner_address, key) {
-                        error!(
-                            "Failed to record data in cache for peer {}: {}",
-                            peer_miner_address, error
-                        );
-                    }
-                }
-            } else {
-                debug!(
-                    "Node {:?}, No peers selected for the current broadcast step",
-                    self.client.mining_address
-                );
-                break;
             }
-
-            tokio::time::sleep(BROADCAST_INTERVAL).await;
         }
+
+        tokio::time::sleep(Duration::from_millis(
+            self.gossip_cfg.broadcast_batch_throttle_interval,
+        ))
+        .await;
 
         debug!("Node {:?}: Broadcast finished", self.client.mining_address);
         Ok(())
@@ -299,7 +304,7 @@ impl P2PService {
 
 fn spawn_broadcast_task(
     mut mempool_data_receiver: UnboundedReceiver<GossipBroadcastMessage>,
-    service: P2PService,
+    service: std::sync::Arc<P2PService>,
     task_executor: &TaskExecutor,
     peer_list: PeerList,
 ) -> ServiceHandleWithShutdownSignal {
@@ -312,9 +317,14 @@ fn spawn_broadcast_task(
                     maybe_data = mempool_data_receiver.recv() => {
                         match maybe_data {
                             Some(broadcast_message) => {
-                                if let Err(error) = service.broadcast_data(broadcast_message, &peer_list).await {
-                                    warn!("Failed to broadcast data: {}", error);
-                                };
+                                // For each incoming message, spawn a detached task so broadcasts don't block each other
+                                let service = std::sync::Arc::clone(&service);
+                                let peer_list = peer_list.clone();
+                                tokio::spawn(async move {
+                                    if let Err(error) = service.broadcast_data(broadcast_message, &peer_list).await {
+                                        warn!("Failed to broadcast data: {}", error);
+                                    }
+                                });
                             },
                             None => break, // channel closed
                         }

--- a/crates/p2p/src/server.rs
+++ b/crates/p2p/src/server.rs
@@ -94,6 +94,7 @@ where
             Ok(peer_address) => peer_address,
             Err(error_response) => return error_response,
         };
+        server.peer_list.set_is_online(&source_miner_address, true);
 
         if let Err(error) = server.data_handler.handle_chunk(gossip_request).await {
             Self::handle_invalid_data(&source_miner_address, &error, &server.peer_list);
@@ -168,6 +169,7 @@ where
             Ok(peer_address) => peer_address,
             Err(error_response) => return error_response,
         };
+        server.peer_list.set_is_online(&source_miner_address, true);
 
         let this_node_id = server.data_handler.gossip_client.mining_address;
 
@@ -223,6 +225,7 @@ where
         {
             return error_response;
         };
+        server.peer_list.set_is_online(&source_miner_address, true);
 
         if let Err(error) = server
             .data_handler
@@ -261,6 +264,7 @@ where
             Ok(peer_address) => peer_address,
             Err(error_response) => return error_response,
         };
+        server.peer_list.set_is_online(&source_miner_address, true);
 
         if let Err(error) = server.data_handler.handle_transaction(gossip_request).await {
             Self::handle_invalid_data(&source_miner_address, &error, &server.peer_list);
@@ -295,6 +299,7 @@ where
             Ok(peer_address) => peer_address,
             Err(error_response) => return error_response,
         };
+        server.peer_list.set_is_online(&source_miner_address, true);
 
         if let Err(error) = server
             .data_handler
@@ -333,6 +338,7 @@ where
             Ok(peer_address) => peer_address,
             Err(error_response) => return error_response,
         };
+        server.peer_list.set_is_online(&source_miner_address, true);
 
         if let Err(error) = server
             .data_handler

--- a/crates/types/src/config/node.rs
+++ b/crates/types/src/config/node.rs
@@ -95,6 +95,14 @@ pub struct NodeConfig {
     /// P2P handshake parameters
     #[serde(default)]
     pub p2p_handshake: P2PHandshakeConfig,
+
+    /// Gossip/broadcast parameters
+    #[serde(default)]
+    pub p2p_gossip: P2PGossipConfig,
+
+    /// P2P pull/request parameters
+    #[serde(default)]
+    pub p2p_pull: P2PPullConfig,
 }
 
 /// # Node Operation Mode
@@ -307,6 +315,47 @@ impl Default for P2PHandshakeConfig {
     }
 }
 
+/// P2P gossip/broadcast configuration
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct P2PGossipConfig {
+    /// Maximum peers to target per broadcast step
+    pub broadcast_batch_size: usize,
+    /// Interval between broadcast steps in milliseconds
+    pub broadcast_batch_throttle_interval: u64,
+}
+
+impl Default for P2PGossipConfig {
+    fn default() -> Self {
+        Self {
+            broadcast_batch_size: 5,
+            broadcast_batch_throttle_interval: 1_000,
+        }
+    }
+}
+
+/// P2P pull/request configuration
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct P2PPullConfig {
+    /// How many top active peers to consider before random sampling
+    pub top_active_window: usize,
+    /// Number of peers to randomly sample (truncate) per pull attempt batch
+    pub sample_size: usize,
+    /// Maximum number of attempts to iterate over the sampled set
+    pub max_attempts: u32,
+}
+
+impl Default for P2PPullConfig {
+    fn default() -> Self {
+        Self {
+            top_active_window: 10,
+            sample_size: 5,
+            max_attempts: 5,
+        }
+    }
+}
+
 /// Default for `peer_filter_mode` when the field is not present in the provided TOML.
 /// This keeps legacy configurations working by defaulting to unrestricted mode.
 fn default_peer_filter_mode() -> PeerFilterMode {
@@ -506,6 +555,8 @@ impl NodeConfig {
             },
 
             p2p_handshake: P2PHandshakeConfig::default(),
+            p2p_gossip: P2PGossipConfig::default(),
+            p2p_pull: P2PPullConfig::default(),
             genesis_peer_discovery_timeout_millis: 10000,
             stake_pledge_drives: false,
         }
@@ -629,6 +680,8 @@ impl NodeConfig {
             },
 
             p2p_handshake: P2PHandshakeConfig::default(),
+            p2p_gossip: P2PGossipConfig::default(),
+            p2p_pull: P2PPullConfig::default(),
 
             genesis_peer_discovery_timeout_millis: 10000,
             stake_pledge_drives: false,


### PR DESCRIPTION
**Describe the changes**
This PR spawns a new task for each new gossip broadcast. Also, not p2p parameters can be configured through the config file.

**Related Issue(s)**

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
