### PR TITLE
feat: migrate chunk_migration_service to tokio service

### DIFF
--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -2,7 +2,7 @@ use crate::{
     block_index_service::BlockIndexService,
     block_validation::PreValidationError,
     broadcast_mining_service::{BroadcastMiningService, BroadcastPartitionsExpiration},
-    chunk_migration_service::ChunkMigrationService,
+    chunk_migration_service::ChunkMigrationServiceMessage,
     mempool_service::MempoolServiceMessage,
     reth_service::{BlockHashType, ForkChoiceUpdateMessage, RethServiceActor},
     services::ServiceSenders,
@@ -24,6 +24,7 @@ use irys_types::{
 };
 use reth::tasks::shutdown::Shutdown;
 use std::{
+    collections::HashMap,
     sync::{Arc, RwLock},
     time::SystemTime,
 };
@@ -320,9 +321,14 @@ impl BlockTreeServiceInner {
             .get_data_ledger_tx_headers_from_mempool(&block_header, DataLedger::Publish)
             .await?;
 
+        // TODO: Migrate block_index to use the HashMap so we don't have to close these headers
         let mut all_txs = vec![];
-        all_txs.extend(publish_txs);
-        all_txs.extend(submit_txs);
+        all_txs.extend(publish_txs.clone());
+        all_txs.extend(submit_txs.clone());
+
+        let mut all_txs_map: HashMap<DataLedger, Vec<DataTransactionHeader>> = HashMap::new();
+        all_txs_map.insert(DataLedger::Submit, submit_txs);
+        all_txs_map.insert(DataLedger::Publish, publish_txs);
 
         info!(
             "Migrating to block_index - hash: {} height: {}",
@@ -332,15 +338,27 @@ impl BlockTreeServiceInner {
         // HACK
         System::set_current(self.system.clone());
 
-        let chunk_migration = ChunkMigrationService::from_registry();
+        let arc_block = Arc::new(block_header);
+        let arc_all_txs = Arc::new(all_txs);
+
+        // Let block_index know about the migrated block
+        // TODO: Make block index a tokio service
         let block_index = BlockIndexService::from_registry();
         let block_finalized_message = BlockMigrationMessage {
-            block_header: Arc::new(block_header),
-            all_txs: Arc::new(all_txs),
+            block_header: arc_block.clone(),
+            all_txs: arc_all_txs.clone(),
         };
-
         block_index.do_send(block_finalized_message.clone());
-        chunk_migration.do_send(block_finalized_message);
+
+        // Let the chunk_migration_service know about the block migration
+        self.service_senders
+            .chunk_migration
+            .send(ChunkMigrationServiceMessage::BlockMigrated(
+                arc_block,
+                Arc::new(all_txs_map),
+            ))
+            .map_err(|e| eyre::eyre!("Failed to send BlockMigrated message: {}", e))?;
+
         Ok(())
     }
 

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -346,9 +346,9 @@ impl BlockTreeServiceInner {
         let block_index = BlockIndexService::from_registry();
         let block_finalized_message = BlockMigrationMessage {
             block_header: arc_block.clone(),
-            all_txs: arc_all_txs.clone(),
+            all_txs: arc_all_txs,
         };
-        block_index.do_send(block_finalized_message.clone());
+        block_index.do_send(block_finalized_message);
 
         // Let the chunk_migration_service know about the block migration
         self.service_senders

--- a/crates/actors/src/chunk_migration_service.rs
+++ b/crates/actors/src/chunk_migration_service.rs
@@ -1,4 +1,4 @@
-use actix::prelude::*;
+use crate::{cache_service::CacheServiceAction, services::ServiceSenders};
 use eyre::eyre;
 use irys_database::{
     cached_chunk_by_chunk_offset,
@@ -12,16 +12,21 @@ use irys_storage::{ie, ii, InclusiveInterval as _};
 use irys_types::{
     app_state::DatabaseProvider, Base64, Config, DataLedger, DataRoot, DataTransactionHeader,
     DataTransactionLedger, IrysBlockHeader, LedgerChunkOffset, LedgerChunkRange, Proof,
-    TxChunkOffset, UnpackedChunk, H256,
+    TokioServiceHandle, TxChunkOffset, UnpackedChunk, H256,
 };
-use std::sync::{Arc, RwLock};
+use reth::tasks::shutdown::Shutdown;
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+use tokio::sync::mpsc::UnboundedReceiver;
 use tracing::{error, instrument};
 
-use crate::services::Stop;
-use crate::{
-    block_producer::BlockMigrationMessage, cache_service::CacheServiceAction,
-    services::ServiceSenders,
-};
+pub struct ChunkMigrationService {
+    shutdown: Shutdown,
+    msg_rx: UnboundedReceiver<ChunkMigrationServiceMessage>,
+    inner: ChunkMigrationServiceInner,
+}
 
 /// Central coordinator for chunk storage operations.
 ///
@@ -31,7 +36,7 @@ use crate::{
 /// - Coordinates chunk reads/writes
 /// - Manages storage state transitions
 #[derive(Debug)]
-pub struct ChunkMigrationService {
+pub struct ChunkMigrationServiceInner {
     /// Tracks block boundaries and offsets for locating chunks in ledgers
     pub block_index: Option<Arc<RwLock<BlockIndex>>>,
     /// Configuration parameters for storage system
@@ -44,23 +49,20 @@ pub struct ChunkMigrationService {
     pub service_senders: Option<ServiceSenders>,
 }
 
-impl Default for ChunkMigrationService {
-    fn default() -> Self {
-        unimplemented!("don't rely on `Default` impl");
-    }
+pub enum ChunkMigrationServiceMessage {
+    BlockMigrated(
+        Arc<IrysBlockHeader>,
+        Arc<HashMap<DataLedger, Vec<DataTransactionHeader>>>,
+    ),
 }
 
-impl Actor for ChunkMigrationService {
-    type Context = Context<Self>;
-}
-
-impl ChunkMigrationService {
+impl ChunkMigrationServiceInner {
     pub fn new(
         block_index: Arc<RwLock<BlockIndex>>,
-        config: Config,
         storage_modules_guard: &StorageModulesReadGuard,
         db: DatabaseProvider,
         service_senders: ServiceSenders,
+        config: Config,
     ) -> Self {
         println!("service started: chunk_migration");
         Self {
@@ -71,34 +73,30 @@ impl ChunkMigrationService {
             service_senders: Some(service_senders),
         }
     }
-}
 
-/// Adds this actor the the local service registry
-impl Supervised for ChunkMigrationService {}
-
-impl SystemService for ChunkMigrationService {
-    fn service_started(&mut self, _ctx: &mut Context<Self>) {
-        println!("chunk_migration service started");
+    pub async fn handle_message(&mut self, msg: ChunkMigrationServiceMessage) -> eyre::Result<()> {
+        match msg {
+            ChunkMigrationServiceMessage::BlockMigrated(block_header, all_txs) => {
+                self.on_block_migrated(block_header, all_txs).await?;
+            }
+        }
+        Ok(())
     }
-}
 
-impl Handler<BlockMigrationMessage> for ChunkMigrationService {
-    type Result = ResponseFuture<eyre::Result<()>>;
-
-    #[instrument(skip_all, fields(
-    height = %block.height, // instrument seems to be just wrapping the Boxed future
-    hash = %block.block_hash
-))]
-    fn handle(&mut self, msg: BlockMigrationMessage, _: &mut Context<Self>) -> Self::Result {
+    async fn on_block_migrated(
+        &mut self,
+        block_header: Arc<IrysBlockHeader>,
+        all_txs: Arc<HashMap<DataLedger, Vec<DataTransactionHeader>>>,
+    ) -> eyre::Result<()> {
         // Early return if not initialized
         if self.block_index.is_none() || self.db.is_none() {
             error!("chunk_migration service not initialized");
-            return Box::pin(async move { Err(eyre!("chunk_migration service not initialized")) });
+            return Err(eyre!("chunk_migration service not initialized"));
         }
 
         // Collect working variables to move into the closure
-        let block = msg.block_header;
-        let all_txs = msg.all_txs;
+        let block = block_header;
+        let all_txs = all_txs;
         let block_index = self.block_index.clone().unwrap();
         let chunk_size = self.config.consensus.chunk_size as usize;
         let storage_modules = Arc::new(self.storage_modules_guard.clone());
@@ -106,12 +104,12 @@ impl Handler<BlockMigrationMessage> for ChunkMigrationService {
         let service_senders = self.service_senders.clone().unwrap();
 
         // Extract transactions for each ledger
-        let submit_tx_count = block.data_ledgers[DataLedger::Submit].tx_ids.len();
-        let submit_txs = all_txs[..submit_tx_count].to_vec();
-        let publish_txs = all_txs[submit_tx_count..].to_vec();
+        let submit_txs = all_txs.get(&DataLedger::Submit);
+        let publish_txs = all_txs.get(&DataLedger::Publish);
         let block_height = block.height;
-        Box::pin(async move {
-            // Process Submit ledger transactions
+
+        // Process Submit ledger transactions
+        if let Some(submit_txs) = submit_txs {
             process_ledger_transactions(
                 &block,
                 DataLedger::Submit,
@@ -123,8 +121,10 @@ impl Handler<BlockMigrationMessage> for ChunkMigrationService {
             )
             // TODO: fix this & child functions so they forward errors?
             .map_err(|()| eyre!("Unexpected error processing submit ledger transactions"))?;
+        }
 
-            // Process Publish ledger transactions
+        // Process Publish ledger transactions
+        if let Some(publish_txs) = publish_txs {
             process_ledger_transactions(
                 &block,
                 DataLedger::Publish,
@@ -135,22 +135,14 @@ impl Handler<BlockMigrationMessage> for ChunkMigrationService {
                 &db,
             )
             .map_err(|()| eyre!("Unexpected error processing publish ledger transactions"))?;
+        }
 
-            // forward the finalization message to the cache service for cleanup
-            let _ = service_senders
-                .chunk_cache
-                .send(CacheServiceAction::OnBlockMigrated(block_height, None));
+        // forward the finalization message to the cache service for cleanup
+        let _ = service_senders
+            .chunk_cache
+            .send(CacheServiceAction::OnBlockMigrated(block_height, None));
 
-            Ok(())
-        })
-    }
-}
-
-impl Handler<Stop> for ChunkMigrationService {
-    type Result = ();
-
-    fn handle(&mut self, _msg: Stop, ctx: &mut Self::Context) {
-        ctx.stop();
+        Ok(())
     }
 }
 
@@ -374,4 +366,79 @@ fn write_chunk_to_module(
         })?;
     }
     Ok(())
+}
+
+impl ChunkMigrationService {
+    pub fn spawn_service(
+        rx: UnboundedReceiver<ChunkMigrationServiceMessage>,
+        block_index: Arc<RwLock<BlockIndex>>,
+        storage_modules_guard: &StorageModulesReadGuard,
+        db: DatabaseProvider,
+        service_senders: ServiceSenders,
+        config: &Config,
+        runtime_handle: tokio::runtime::Handle,
+    ) -> TokioServiceHandle {
+        let config = config.clone();
+        let service_senders = service_senders.clone();
+        // let block_index = block_index.clone();
+        let storage_modules_guard = storage_modules_guard.clone();
+        let (shutdown_tx, shutdown_rx) = reth::tasks::shutdown::signal();
+
+        let handle = runtime_handle.spawn(async move {
+            let data_sync_service = Self {
+                shutdown: shutdown_rx,
+                msg_rx: rx,
+                inner: ChunkMigrationServiceInner::new(
+                    block_index,
+                    &storage_modules_guard,
+                    db,
+                    service_senders,
+                    config,
+                ),
+            };
+            data_sync_service
+                .start()
+                .await
+                .expect("DataSync Service encountered an irrecoverable error")
+        });
+
+        TokioServiceHandle {
+            name: "data_sync_service".to_string(),
+            handle,
+            shutdown_signal: shutdown_tx,
+        }
+    }
+
+    async fn start(mut self) -> eyre::Result<()> {
+        tracing::info!("starting DataSync Service");
+
+        loop {
+            tokio::select! {
+                biased;
+
+                _ = &mut self.shutdown => {
+                    tracing::info!("Shutdown signal received for DataSync Service");
+                    break;
+                }
+
+                msg = self.msg_rx.recv() => {
+                    match msg {
+                        Some(msg) => self.inner.handle_message(msg).await?,
+                        None => {
+                            tracing::warn!("Message channel closed unexpectedly");
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Process remaining messages before shutdown
+        while let Ok(msg) = self.msg_rx.try_recv() {
+            self.inner.handle_message(msg).await?;
+        }
+
+        tracing::info!("shutting down DataSync Service gracefully");
+        Ok(())
+    }
 }

--- a/crates/actors/src/services.rs
+++ b/crates/actors/src/services.rs
@@ -5,6 +5,7 @@ use crate::{
         BlockMigratedEvent, BlockStateUpdated, BlockTreeServiceMessage, ReorgEvent,
     },
     cache_service::CacheServiceAction,
+    chunk_migration_service::ChunkMigrationServiceMessage,
     mempool_service::MempoolServiceMessage,
     validation_service::ValidationServiceMessage,
     DataSyncServiceMessage, StorageModuleServiceMessage,
@@ -55,6 +56,7 @@ impl ServiceSenders {
 #[derive(Debug)]
 pub struct ServiceReceivers {
     pub chunk_cache: UnboundedReceiver<CacheServiceAction>,
+    pub chunk_migration: UnboundedReceiver<ChunkMigrationServiceMessage>,
     pub mempool: UnboundedReceiver<MempoolServiceMessage>,
     pub vdf_mining: Receiver<bool>,
     pub vdf_fast_forward: UnboundedReceiver<VdfStep>,
@@ -74,6 +76,7 @@ pub struct ServiceReceivers {
 #[derive(Debug)]
 pub struct ServiceSendersInner {
     pub chunk_cache: UnboundedSender<CacheServiceAction>,
+    pub chunk_migration: UnboundedSender<ChunkMigrationServiceMessage>,
     pub mempool: UnboundedSender<MempoolServiceMessage>,
     pub vdf_mining: Sender<bool>,
     pub vdf_fast_forward: UnboundedSender<VdfStep>,
@@ -94,7 +97,8 @@ impl ServiceSendersInner {
     #[must_use]
     pub fn init() -> (Self, ServiceReceivers) {
         let (chunk_cache_sender, chunk_cache_receiver) = unbounded_channel::<CacheServiceAction>();
-
+        let (chunk_migration_sender, chunk_migration_receiver) =
+            unbounded_channel::<ChunkMigrationServiceMessage>();
         let (mempool_sender, mempool_receiver) = unbounded_channel::<MempoolServiceMessage>();
         // enabling/disabling VDF mining thread
         let (vdf_mining_sender, vdf_mining_receiver) = channel::<bool>(1);
@@ -122,6 +126,7 @@ impl ServiceSendersInner {
 
         let senders = Self {
             chunk_cache: chunk_cache_sender,
+            chunk_migration: chunk_migration_sender,
             mempool: mempool_sender,
             vdf_mining: vdf_mining_sender,
             vdf_fast_forward: vdf_fast_forward_sender,
@@ -139,6 +144,7 @@ impl ServiceSendersInner {
         };
         let receivers = ServiceReceivers {
             chunk_cache: chunk_cache_receiver,
+            chunk_migration: chunk_migration_receiver,
             mempool: mempool_receiver,
             vdf_mining: vdf_mining_receiver,
             vdf_fast_forward: vdf_fast_forward_receiver,


### PR DESCRIPTION
* Converts the `ChunkMigrationService` to a tokio service. 
* Improves the parameters of the `BlockMigrated` message to scale to multiple data ledgers.