### PR TITLE
fix: stop mining on catchup

### DIFF
--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -79,7 +79,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 use tokio::runtime::{Handle, Runtime};
-use tokio::sync::mpsc::{self};
+use tokio::sync::mpsc::{self, Sender};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot::{self};
 use tracing::{debug, error, info, instrument, warn, Instrument as _, Span};
@@ -1146,6 +1146,7 @@ impl IrysNode {
             gossip_data_handler,
             (chain_sync_tx, chain_sync_rx),
             reth_service_actor.clone(),
+            service_senders.vdf_mining.clone(),
         );
 
         // set up IrysNodeCtx
@@ -1578,6 +1579,7 @@ impl IrysNode {
             UnboundedReceiver<SyncChainServiceMessage>,
         ),
         reth_service_addr: Addr<RethServiceActor>,
+        vdf_mining_state_sender: Sender<bool>,
     ) -> (SyncChainServiceFacade, TokioServiceHandle) {
         let facade = SyncChainServiceFacade::new(tx);
 
@@ -1589,6 +1591,7 @@ impl IrysNode {
             block_pool,
             gossip_data_handler,
             Some(reth_service_addr),
+            vdf_mining_state_sender,
         );
 
         let handle = ChainSyncService::spawn_service(inner, rx, runtime_handle);

--- a/crates/p2p/src/chain_sync.rs
+++ b/crates/p2p/src/chain_sync.rs
@@ -17,6 +17,7 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::mpsc::Sender;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::{interval, timeout};
 use tracing::{debug, error, info, instrument, warn, Instrument as _};
@@ -110,6 +111,8 @@ pub struct ChainSyncServiceInner<A: ApiClient, B: BlockDiscoveryFacade, M: Mempo
     is_sync_task_spawned: Arc<AtomicBool>,
     gossip_data_handler: Arc<GossipDataHandler<M, B, A>>,
     reth_service_actor: Option<Addr<RethServiceActor>>,
+    /// Sender to disable VDF mining when sync is in progress
+    vdf_mining_state_sender: Sender<bool>,
 }
 
 /// Main sync service that runs in its own tokio task
@@ -155,6 +158,7 @@ impl<B: BlockDiscoveryFacade, M: MempoolFacade> ChainSyncServiceInner<IrysApiCli
         block_pool: Arc<BlockPool<B, M>>,
         gossip_data_handler: Arc<GossipDataHandler<M, B, IrysApiClient>>,
         reth_service_actor: Option<Addr<RethServiceActor>>,
+        vdf_mining_state_sender: Sender<bool>,
     ) -> Self {
         Self::new_with_client(
             sync_state,
@@ -165,6 +169,7 @@ impl<B: BlockDiscoveryFacade, M: MempoolFacade> ChainSyncServiceInner<IrysApiCli
             block_pool,
             gossip_data_handler,
             reth_service_actor,
+            vdf_mining_state_sender,
         )
     }
 }
@@ -179,6 +184,7 @@ impl<A: ApiClient, B: BlockDiscoveryFacade, M: MempoolFacade> ChainSyncServiceIn
         block_pool: Arc<BlockPool<B, M>>,
         gossip_data_handler: Arc<GossipDataHandler<M, B, A>>,
         reth_service_actor: Option<Addr<RethServiceActor>>,
+        vdf_mining_state_sender: Sender<bool>,
     ) -> Self {
         Self {
             sync_state,
@@ -190,6 +196,7 @@ impl<A: ApiClient, B: BlockDiscoveryFacade, M: MempoolFacade> ChainSyncServiceIn
             is_sync_task_spawned: Arc::new(AtomicBool::new(false)),
             gossip_data_handler,
             reth_service_actor,
+            vdf_mining_state_sender,
         }
     }
 
@@ -229,6 +236,7 @@ impl<A: ApiClient, B: BlockDiscoveryFacade, M: MempoolFacade> ChainSyncServiceIn
         let is_sync_task_spawned = self.is_sync_task_spawned.clone();
         let block_pool = self.block_pool.clone();
         let reth_service_addr = self.reth_service_actor.clone();
+        let vdf_mining_state_sender = self.vdf_mining_state_sender.clone();
 
         tokio::spawn(
             async move {
@@ -236,6 +244,11 @@ impl<A: ApiClient, B: BlockDiscoveryFacade, M: MempoolFacade> ChainSyncServiceIn
                     .gossip_client
                     .hydrate_peers_online_status(&peer_list)
                     .await;
+
+                // Disable VDF mining when sync is in progress
+                if let Err(err) = vdf_mining_state_sender.send(false).await {
+                    error!("Sync task: Failed to disable VDF mining: {:?}", err);
+                }
 
                 if let Err(err) = block_pool
                     .repair_missing_payloads_if_any(reth_service_addr)
@@ -259,6 +272,10 @@ impl<A: ApiClient, B: BlockDiscoveryFacade, M: MempoolFacade> ChainSyncServiceIn
                 )
                 .await;
 
+                // Re-enable VDF mining after sync is done
+                if let Err(err) = vdf_mining_state_sender.send(true).await {
+                    error!("Sync task: Failed to re-enable VDF mining: {:?}", err);
+                }
                 is_sync_task_spawned.store(false, Ordering::Relaxed);
 
                 match &res {

--- a/crates/p2p/src/tests/block_pool/mod.rs
+++ b/crates/p2p/src/tests/block_pool/mod.rs
@@ -327,6 +327,7 @@ async fn should_process_block_with_intermediate_block_in_api() {
 
     let sync_state = ChainSyncState::new(false, false);
 
+    let vdf_mining_sender = service_senders.vdf_mining.clone();
     let block_pool = Arc::new(BlockPool::new(
         db.clone(),
         block_discovery_stub.clone(),
@@ -357,6 +358,7 @@ async fn should_process_block_with_intermediate_block_in_api() {
         block_pool.clone(),
         data_handler,
         None,
+        vdf_mining_sender,
     );
 
     let sync_service_handle = ChainSyncService::spawn_service(
@@ -533,6 +535,7 @@ async fn should_refuse_fresh_block_trying_to_build_old_chain() {
 
     let sync_state = ChainSyncState::new(false, false);
 
+    let vdf_mining_sender = service_senders.vdf_mining.clone();
     let block_pool = Arc::new(BlockPool::new(
         db.clone(),
         block_discovery_stub.clone(),
@@ -567,6 +570,7 @@ async fn should_refuse_fresh_block_trying_to_build_old_chain() {
         block_pool.clone(),
         data_handler,
         None,
+        vdf_mining_sender,
     );
 
     let sync_service_handle = ChainSyncService::spawn_service(

--- a/crates/p2p/src/tests/block_pool/mod.rs
+++ b/crates/p2p/src/tests/block_pool/mod.rs
@@ -367,7 +367,7 @@ async fn should_process_block_with_intermediate_block_in_api() {
         tokio::runtime::Handle::current(),
     );
 
-    // Set the fake server to mimic get_data -> gossip_service sends message to block pool
+    // Set the fake server to mimic get_data -> gossip_service sends a message to the block pool
     let block_for_server = block2.clone();
     let pool_for_server = block_pool.clone();
     gossip_server.set_on_pull_data_request(move |data_request| match data_request {


### PR DESCRIPTION
**Describe the changes**
This PR stops mining during catchup - before this fix slow miners could diverge while validating new incoming blocks

**Related Issue(s)**

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
