### PR TITLE
fix(types): added string u64 serialization to u64 fields

### DIFF
--- a/crates/api-server/src/routes/price.rs
+++ b/crates/api-server/src/routes/price.rs
@@ -186,3 +186,52 @@ pub async fn get_unpledge_price(
         user_address: Some(user_address),
     }))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_price_info_bytes_serialization() {
+        let price_info = PriceInfo {
+            perm_fee: U256::from(1000),
+            term_fee: U256::from(2000),
+            ledger: 1,
+            bytes: u64::MAX,
+        };
+
+        let json = serde_json::to_string(&price_info).unwrap();
+        assert!(json.contains(&format!("\"bytes\":\"{}\"", u64::MAX)));
+
+        let deserialized: PriceInfo = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.bytes, u64::MAX);
+    }
+
+    #[test]
+    fn test_price_info_javascript_compatibility() {
+        const JS_MAX_SAFE_INTEGER: u64 = (1_u64 << 53) - 1; // 2^53 - 1
+        let above_safe_limit = JS_MAX_SAFE_INTEGER + 1;
+
+        let price_info = PriceInfo {
+            perm_fee: U256::from(1000),
+            term_fee: U256::from(2000),
+            ledger: 1,
+            bytes: above_safe_limit,
+        };
+
+        let json = serde_json::to_string(&price_info).unwrap();
+
+        // Should be string, not number
+        assert!(json.contains(&format!("\"bytes\":\"{}\"", above_safe_limit)));
+
+        // Test JavaScript parsing would work
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        if let Some(bytes_str) = parsed.get("bytes").and_then(|v| v.as_str()) {
+            let parsed_bytes: u64 = bytes_str.parse().unwrap();
+            assert_eq!(parsed_bytes, above_safe_limit);
+        } else {
+            panic!("bytes should be serialized as string");
+        }
+    }
+}

--- a/crates/api-server/src/routes/price.rs
+++ b/crates/api-server/src/routes/price.rs
@@ -4,6 +4,7 @@ use actix_web::{
     HttpResponse, Result as ActixResult,
 };
 use irys_types::{
+    serialization::string_u64,
     storage_pricing::{calculate_perm_fee_from_config, calculate_term_fee},
     transaction::{CommitmentTransaction, PledgeDataProvider as _},
     Address, DataLedger, U256,
@@ -19,6 +20,7 @@ pub struct PriceInfo {
     pub perm_fee: U256,
     pub term_fee: U256,
     pub ledger: u32,
+    #[serde(with = "string_u64")]
     pub bytes: u64,
 }
 

--- a/crates/chain/src/peer_utilities.rs
+++ b/crates/chain/src/peer_utilities.rs
@@ -62,10 +62,7 @@ pub async fn fetch_genesis_block(
         .await
         .expect("expected a valid json deserialize");
 
-    let fetched_genesis_block = fetch_block(peer, client, block_index_genesis.first().unwrap())
-        .await
-        .unwrap();
-    Some(fetched_genesis_block)
+    fetch_block(peer, client, block_index_genesis.first().unwrap()).await
 }
 
 pub async fn fetch_genesis_commitments(

--- a/crates/types/src/block.rs
+++ b/crates/types/src/block.rs
@@ -6,9 +6,11 @@ use crate::block_production::SolutionContext;
 use crate::storage_pricing::{phantoms::IrysPrice, phantoms::Usd, Amount};
 use crate::{
     generate_data_root, generate_leaves_from_data_roots, option_u64_stringify,
-    partition::PartitionHash, resolve_proofs, string_u128, u64_stringify, Arbitrary, Base64,
-    Compact, Config, DataRootLeave, DataTransactionHeader, H256List, IngressProofsList,
-    IrysSignature, Proof, H256, U256,
+    partition::PartitionHash,
+    resolve_proofs,
+    serialization::{optional_string_u64, string_u64},
+    string_u128, u64_stringify, Arbitrary, Base64, Compact, Config, DataRootLeave,
+    DataTransactionHeader, H256List, IngressProofsList, IrysSignature, Proof, H256, U256,
 };
 use actix::MessageResponse;
 use alloy_primitives::{keccak256, Address, TxHash, B256};
@@ -46,6 +48,7 @@ pub struct VDFLimiterInfo {
     /// The output of the latest step - the source of the entropy for the mining nonces.
     pub output: H256,
     /// The global sequence number of the nonce limiter step at which the block was found.
+    #[serde(with = "string_u64")]
     pub global_step_number: u64,
     /// The hash of the latest block mined below the current reset line.
     pub seed: H256,
@@ -181,6 +184,7 @@ pub struct IrysBlockHeader {
     pub signature: IrysSignature,
 
     /// The block height.
+    #[serde(with = "string_u64")]
     pub height: u64,
 
     /// Difficulty threshold used to produce the current block.
@@ -456,7 +460,7 @@ pub struct DataTransactionLedger {
     #[serde(default, with = "u64_stringify")]
     pub total_chunks: u64,
     /// This ledger expires after how many epochs
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", with = "optional_string_u64")]
     pub expires: Option<u64>,
     /// When transactions are promoted they must include their ingress proofs
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -805,6 +809,7 @@ pub struct BlockIndexItem {
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
 pub struct LedgerIndexItem {
     /// The total number of chunks in this ledger since genesis
+    #[serde(with = "string_u64")]
     pub total_chunks: u64, // 8 bytes
     /// The merkle root of the TX that apply to this ledger in the current block
     pub tx_root: H256, // 32 bytes

--- a/crates/types/src/block.rs
+++ b/crates/types/src/block.rs
@@ -1197,4 +1197,54 @@ mod tests {
     fn mock_header() -> IrysBlockHeader {
         IrysBlockHeader::new_mock_header()
     }
+
+    #[test]
+    fn test_block_header_serialization() {
+        let mut header = IrysBlockHeader::default();
+        header.height = u64::MAX;
+
+        let json = serde_json::to_string(&header).unwrap();
+        assert!(json.contains(&format!("\"height\":\"{}\"", u64::MAX)));
+
+        let deserialized: IrysBlockHeader = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.height, u64::MAX);
+    }
+
+    #[test]
+    fn test_vdf_limiter_info_serialization() {
+        let mut vdf_info = VDFLimiterInfo::default();
+        vdf_info.global_step_number = u64::MAX;
+
+        let json = serde_json::to_string(&vdf_info).unwrap();
+        assert!(json.contains(&format!("\"globalStepNumber\":\"{}\"", u64::MAX)));
+
+        let deserialized: VDFLimiterInfo = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.global_step_number, u64::MAX);
+    }
+
+    #[test]
+    fn test_ledger_index_item_serialization() {
+        let mut ledger_item = LedgerIndexItem::default();
+        ledger_item.max_chunk_offset = u64::MAX;
+
+        let json = serde_json::to_string(&ledger_item).unwrap();
+        assert!(json.contains(&format!("\"maxChunkOffset\":\"{}\"", u64::MAX)));
+
+        let deserialized: LedgerIndexItem = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.max_chunk_offset, u64::MAX);
+    }
+
+    #[test]
+    fn test_data_transaction_ledger_expires_serialization() {
+        use serde_json;
+
+        let mut ledger = DataTransactionLedger::default();
+        ledger.expires = Some(u64::MAX);
+
+        let json = serde_json::to_string(&ledger).unwrap();
+        assert!(json.contains(&format!("\"expires\":\"{}\"", u64::MAX)));
+
+        let deserialized: DataTransactionLedger = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.expires, Some(u64::MAX));
+    }
 }

--- a/crates/types/src/block.rs
+++ b/crates/types/src/block.rs
@@ -1229,15 +1229,15 @@ mod tests {
     #[test]
     fn test_ledger_index_item_serialization() {
         let ledger_item = LedgerIndexItem {
-            max_chunk_offset: u64::MAX,
+            total_chunks: u64::MAX,
             ..Default::default()
         };
 
         let json = serde_json::to_string(&ledger_item).unwrap();
-        assert!(json.contains(&format!("\"maxChunkOffset\":\"{}\"", u64::MAX)));
+        assert!(json.contains(&format!("\"totalChunks\":\"{}\"", u64::MAX)));
 
         let deserialized: LedgerIndexItem = serde_json::from_str(&json).unwrap();
-        assert_eq!(deserialized.max_chunk_offset, u64::MAX);
+        assert_eq!(deserialized.total_chunks, u64::MAX);
     }
 
     #[test]

--- a/crates/types/src/block.rs
+++ b/crates/types/src/block.rs
@@ -1200,8 +1200,10 @@ mod tests {
 
     #[test]
     fn test_block_header_serialization() {
-        let mut header = IrysBlockHeader::default();
-        header.height = u64::MAX;
+        let header = IrysBlockHeader {
+            height: u64::MAX,
+            ..Default::default()
+        };
 
         let json = serde_json::to_string(&header).unwrap();
         assert!(json.contains(&format!("\"height\":\"{}\"", u64::MAX)));
@@ -1212,8 +1214,10 @@ mod tests {
 
     #[test]
     fn test_vdf_limiter_info_serialization() {
-        let mut vdf_info = VDFLimiterInfo::default();
-        vdf_info.global_step_number = u64::MAX;
+        let vdf_info = VDFLimiterInfo {
+            global_step_number: u64::MAX,
+            ..Default::default()
+        };
 
         let json = serde_json::to_string(&vdf_info).unwrap();
         assert!(json.contains(&format!("\"globalStepNumber\":\"{}\"", u64::MAX)));
@@ -1224,8 +1228,10 @@ mod tests {
 
     #[test]
     fn test_ledger_index_item_serialization() {
-        let mut ledger_item = LedgerIndexItem::default();
-        ledger_item.max_chunk_offset = u64::MAX;
+        let ledger_item = LedgerIndexItem {
+            max_chunk_offset: u64::MAX,
+            ..Default::default()
+        };
 
         let json = serde_json::to_string(&ledger_item).unwrap();
         assert!(json.contains(&format!("\"maxChunkOffset\":\"{}\"", u64::MAX)));
@@ -1238,8 +1244,10 @@ mod tests {
     fn test_data_transaction_ledger_expires_serialization() {
         use serde_json;
 
-        let mut ledger = DataTransactionLedger::default();
-        ledger.expires = Some(u64::MAX);
+        let ledger = DataTransactionLedger {
+            expires: Some(u64::MAX),
+            ..Default::default()
+        };
 
         let json = serde_json::to_string(&ledger).unwrap();
         assert!(json.contains(&format!("\"expires\":\"{}\"", u64::MAX)));

--- a/crates/types/src/block.rs
+++ b/crates/types/src/block.rs
@@ -460,7 +460,11 @@ pub struct DataTransactionLedger {
     #[serde(default, with = "u64_stringify")]
     pub total_chunks: u64,
     /// This ledger expires after how many epochs
-    #[serde(skip_serializing_if = "Option::is_none", with = "optional_string_u64")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "optional_string_u64"
+    )]
     pub expires: Option<u64>,
     /// When transactions are promoted they must include their ingress proofs
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1234,7 +1238,7 @@ mod tests {
         };
 
         let json = serde_json::to_string(&ledger_item).unwrap();
-        assert!(json.contains(&format!("\"totalChunks\":\"{}\"", u64::MAX)));
+        assert!(json.contains(&format!("\"total_chunks\":\"{}\"", u64::MAX)));
 
         let deserialized: LedgerIndexItem = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.total_chunks, u64::MAX);

--- a/crates/types/src/version.rs
+++ b/crates/types/src/version.rs
@@ -1,4 +1,7 @@
-use crate::{decode_address, encode_address, serialization::string_u64, Arbitrary, IrysSignature, RethPeerInfo, H256};
+use crate::{
+    decode_address, encode_address, serialization::string_u64, Arbitrary, IrysSignature,
+    RethPeerInfo, H256,
+};
 use alloy_primitives::{keccak256, Address};
 use bytes::Buf as _;
 use reth_codecs::Compact;
@@ -346,7 +349,9 @@ pub struct NodeInfo {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Config, IrysSignature, NodeConfig, VersionRequest};
+    use super::NodeInfo;
+    use crate::{Config, IrysSignature, NodeConfig, VersionRequest, H256};
+    use serde_json;
 
     #[test]
     fn should_sign_and_verify_signature() {
@@ -366,5 +371,78 @@ mod tests {
             !version_request.verify_signature(),
             "Signature should be invalid after reset"
         );
+    }
+
+    #[test]
+    fn test_large_u64_serialization() {
+        let large_value = u64::MAX;
+        let node_info = NodeInfo {
+            version: "1.0.0".to_string(),
+            peer_count: 10,
+            chain_id: large_value,
+            height: large_value,
+            block_hash: H256::zero(),
+            block_index_height: large_value,
+            block_index_hash: H256::zero(),
+            pending_blocks: large_value,
+            is_syncing: false,
+            current_sync_height: 0,
+        };
+
+        let json = serde_json::to_string(&node_info).unwrap();
+
+        // Verify all u64 fields are serialized as strings
+        assert!(json.contains(&format!("\"chainId\":\"{}\"", large_value)));
+        assert!(json.contains(&format!("\"height\":\"{}\"", large_value)));
+        assert!(json.contains(&format!("\"blockIndexHeight\":\"{}\"", large_value)));
+        assert!(json.contains(&format!("\"pendingBlocks\":\"{}\"", large_value)));
+
+        // Verify no numeric serialization for large values
+        assert!(!json.contains(&format!("\"chainId\":{}", large_value)));
+
+        // Verify deserialization
+        let deserialized: NodeInfo = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.chain_id, large_value);
+        assert_eq!(deserialized.height, large_value);
+    }
+
+    // Test JavaScript parsing would  work, this tries to simulate what would happen in a JavaScript environment
+    #[test]
+    fn test_javascript_max_safe_integer() {
+        const JS_MAX_SAFE_INTEGER: u64 = (1_u64 << 53) - 1; // 2^53 - 1
+        let above_safe_limit = JS_MAX_SAFE_INTEGER + 1;
+
+        let node_info = NodeInfo {
+            height: above_safe_limit,
+            chain_id: above_safe_limit,
+            ..Default::default()
+        };
+
+        let json = serde_json::to_string(&node_info).unwrap();
+
+        // Should be string, not number
+        assert!(json.contains(&format!("\"height\":\"{}\"", above_safe_limit)));
+        assert!(json.contains(&format!("\"chainId\":\"{}\"", above_safe_limit)));
+
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        if let Some(height_str) = parsed.get("height").and_then(|v| v.as_str()) {
+            let parsed_height: u64 = height_str.parse().unwrap();
+            assert_eq!(parsed_height, above_safe_limit);
+        } else {
+            panic!("height should be serialized as string");
+        }
+    }
+
+    #[test]
+    fn test_backwards_compatibility() {
+        // Test that we can still deserialize old numeric format for small values
+        let old_json = r#"{"version":"1.0.0","peerCount":10,"chainId":"12345","height":"67890","blockHash":"5TLJx8LqeDGxJ6b6R4JWfZFmPunoM9VgpGDVo9fHaxKD","blockIndexHeight":"0","blockIndexHash":"5TLJx8LqeDGxJ6b6R4JWfZFmPunoM9VgpGDVo9fHaxKD","pendingBlocks":"0","isSyncing":false,"currentSyncHeight":0}"#;
+
+        let result: Result<NodeInfo, _> = serde_json::from_str(old_json);
+        assert!(result.is_ok());
+
+        let node_info = result.unwrap();
+        assert_eq!(node_info.chain_id, 12345);
+        assert_eq!(node_info.height, 67890);
     }
 }

--- a/crates/types/src/version.rs
+++ b/crates/types/src/version.rs
@@ -436,7 +436,7 @@ mod tests {
     #[test]
     fn test_backwards_compatibility() {
         // Test that we can still deserialize old numeric format for small values
-        let old_json = r#"{"version":"1.0.0","peerCount":10,"chainId":"12345","height":"67890","blockHash":"5TLJx8LqeDGxJ6b6R4JWfZFmPunoM9VgpGDVo9fHaxKD","blockIndexHeight":"0","blockIndexHash":"5TLJx8LqeDGxJ6b6R4JWfZFmPunoM9VgpGDVo9fHaxKD","pendingBlocks":"0","isSyncing":false,"currentSyncHeight":0}"#;
+        let old_json = r#"{"version":"1.0.0","peerCount":10,"chainId":"12345","height":"67890","blockHash":"5TLJx8LqeDGxJ6b6R4JWfZFmPunoM9VgpGDVo9fHexKD","blockIndexHeight":"0","blockIndexHash":"5TLJx8LqeDGxJ6b6R4JWfZFmPunoM9VgpGDVo9fHexKD","pendingBlocks":"0","isSyncing":false,"currentSyncHeight":0}"#;
 
         let result: Result<NodeInfo, _> = serde_json::from_str(old_json);
         assert!(result.is_ok());

--- a/crates/types/src/version.rs
+++ b/crates/types/src/version.rs
@@ -1,4 +1,4 @@
-use crate::{decode_address, encode_address, Arbitrary, IrysSignature, RethPeerInfo, H256};
+use crate::{decode_address, encode_address, serialization::string_u64, Arbitrary, IrysSignature, RethPeerInfo, H256};
 use alloy_primitives::{keccak256, Address};
 use bytes::Buf as _;
 use reth_codecs::Compact;
@@ -330,11 +330,15 @@ pub enum RejectionReason {
 pub struct NodeInfo {
     pub version: String,
     pub peer_count: usize,
+    #[serde(with = "string_u64")]
     pub chain_id: u64,
+    #[serde(with = "string_u64")]
     pub height: u64,
     pub block_hash: H256,
+    #[serde(with = "string_u64")]
     pub block_index_height: u64,
     pub block_index_hash: H256,
+    #[serde(with = "string_u64")]
     pub pending_blocks: u64,
     pub is_syncing: bool,
     pub current_sync_height: usize,


### PR DESCRIPTION
**Describe the changes**
**Before this PR:**
u64 fields in API responses and type definitions were serialised as numbers, which could cause precision loss or overflow issues in JavaScript clients when values exceeded JavaScript's safe integer limit (2^53 - 1). This created potential compatibility issues for frontend applications consuming the API.

**This PR:**
Implements string serialisation for u64 fields across the codebase using the `string_u64` serde module, ensuring that large integer values are safely transmitted as strings in JSON responses while maintaining backwards compatibility.

## Changes Made

### API Server
- Updated `PriceInfo` struct in `routes/price.rs` to serialise `bytes` field as string
- Added comprehensive tests for u64 serialisation in price endpoints

### Types Module  
- Applied `string_u64` serialisation to multiple structs:
  - Block-related fields (height, timestamp, nonce)
  - Transaction fields (data_size, reward, target_height)
  - Version and chunk-related u64 fields
- Added extensive test coverage for string u64 serialisation


**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
