### PR TITLE
fix(xtask/flaky): preserve terminal output when saving flaky results to file

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,8 +1,7 @@
 use cargo_metadata::{MetadataCommand, Package};
 use clap::{Parser, Subcommand};
 use std::fs;
-use std::io::{BufRead as _, BufReader, Write as _};
-use std::process::{Command, Stdio};
+use std::io::Write as _;
 use xshell::{cmd, Cmd, Shell};
 
 const CARGO_FLAKE_VERSION: &str = "0.0.5";
@@ -251,14 +250,6 @@ fn run_command(command: Commands, sh: &Shell) -> eyre::Result<()> {
                 cmd!(sh, "cargo build --workspace --tests").remove_and_run()?;
             }
 
-            println!("Running cargo-flake to detect flaky tests");
-
-            // Install cargo-flake if not already installed
-            cmd!(
-                sh,
-                "cargo install --locked --version {CARGO_FLAKE_VERSION} cargo-flake"
-            )
-            .remove_and_run()?;
 
             // Build command arguments
             let mut command_args = vec!["flake".to_string()];
@@ -300,8 +291,6 @@ fn run_command(command: Commands, sh: &Shell) -> eyre::Result<()> {
                     .format("%Y-%m-%d-%H-%M-%S");
                 let output_file = format!("target/flaky-test-output-{}.txt", timestamp);
 
-                println!("Streaming output to: {}", output_file);
-
                 // Create output file and write header
                 let mut file = fs::File::create(&output_file)?;
                 writeln!(file, "=== Flaky Test Run - {} ===", timestamp)?;
@@ -317,58 +306,45 @@ fn run_command(command: Commands, sh: &Shell) -> eyre::Result<()> {
                 }
                 writeln!(file)?;
                 writeln!(file)?;
+                file.flush()?;
+                drop(file);
 
-                // Spawn cargo command with streaming output to file
-                let mut child = Command::new("cargo")
-                    .args(&command_args)
+                // Use script to preserve TTY behavior for progress bars
+                println!("Running cargo-flake to detect flaky tests");
+                println!("Streaming output to: {}", output_file);
+                
+                // Install cargo-flake first
+                cmd!(
+                    sh,
+                    "cargo install --locked --version {CARGO_FLAKE_VERSION} cargo-flake"
+                )
+                .remove_and_run()?;
+                
+                // Use script command to preserve TTY and tee to save output
+                // script -q -e -c command outputs to stdout while preserving TTY behavior
+                let script_command = format!(
+                    "script -q -e -c 'cargo {}' /dev/stdout | tee -a '{}'",
+                    command_args.join(" "), 
+                    output_file
+                );
+                
+                cmd!(sh, "bash -c {script_command}")
                     .env("RUST_BACKTRACE", "1")
-                    .stdout(Stdio::piped())
-                    .stderr(Stdio::piped())
-                    .spawn()?;
-
-                // Stream stdout
-                if let Some(stdout) = child.stdout.take() {
-                    let reader = BufReader::new(stdout);
-                    for line in reader.lines() {
-                        let line = line?;
-                        println!("{}", line);
-                        writeln!(file, "{}", line)?;
-                        file.flush()?;
-                    }
-                }
-
-                // Stream stderr
-                if let Some(stderr) = child.stderr.take() {
-                    let reader = BufReader::new(stderr);
-                    for line in reader.lines() {
-                        let line = line?;
-                        eprintln!("{}", line);
-                        writeln!(file, "{}", line)?;
-                    }
-                    file.flush()?;
-                }
-
-                // Wait for command to complete
-                let status = child.wait()?;
-                if !status.success() {
-                    return Err(eyre::eyre!(
-                        "cargo-flake failed with exit code: {:?}",
-                        status.code()
-                    ));
-                }
+                    .run()?;
             } else {
-                // Run command without file output - just pass through to terminal
-                let status = Command::new("cargo")
-                    .args(&command_args)
+                // Run command without file output - show output in terminal
+                println!("Running cargo-flake to detect flaky tests");
+                
+                // Install cargo-flake if not already installed
+                cmd!(
+                    sh,
+                    "cargo install --locked --version {CARGO_FLAKE_VERSION} cargo-flake"
+                )
+                .remove_and_run()?;
+                
+                cmd!(sh, "cargo {command_args...}")
                     .env("RUST_BACKTRACE", "1")
-                    .status()?;
-
-                if !status.success() {
-                    return Err(eyre::eyre!(
-                        "cargo-flake failed with exit code: {:?}",
-                        status.code()
-                    ));
-                }
+                    .run()?;
             }
         }
     };


### PR DESCRIPTION
**Describe the changes**
Previous implementation would just stream results to a file which made it difficult to see progress during CI runs. This imp tries to maintain the progress bar output as well as save the results to file.  

**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
