### PR TITLE
Dmac/dont sync empty ledgers

### DIFF
--- a/crates/actors/src/data_sync_service/chunk_orchestrator.rs
+++ b/crates/actors/src/data_sync_service/chunk_orchestrator.rs
@@ -11,7 +11,7 @@ use std::{
     sync::{Arc, RwLock},
     time::Instant,
 };
-use tracing::{debug, Instrument as _};
+use tracing::{debug, info, Instrument as _};
 
 #[derive(Debug, PartialEq)]
 pub enum ChunkRequestState {
@@ -222,6 +222,7 @@ impl ChunkOrchestrator {
         storage_capacity_remaining < (target_throughput / 10)
     }
 
+    #[tracing::instrument(skip_all)]
     pub fn get_max_chunk_offset(&self) -> Option<(PartitionChunkOffset, LedgerChunkOffset)> {
         // Find the maximum LedgerRelativeOffset of this storage module
         let ledger_range = self
@@ -231,7 +232,7 @@ impl ChunkOrchestrator {
 
         // Fetch the most recently migrated block
         // We only want to download migrated chunks from other peers
-        let max_chunk_offset: u64 = {
+        let max_chunk_offset: Option<u64> = {
             let tree = self.block_tree.read();
             let (canonical, _) = tree.get_canonical_chain();
             let block_migration_depth =
@@ -250,10 +251,22 @@ impl ChunkOrchestrator {
                     .iter()
                     .find(|dl| dl.ledger_id == self.ledger_id)
                     .expect("should be able to look up data_ledger by id");
-                data_ledger.total_chunks.saturating_sub(1)
+
+                // info!("block: {:#?}", block);
+
+                if data_ledger.total_chunks == 0 {
+                    None
+                } else {
+                    Some(data_ledger.total_chunks.saturating_sub(1))
+                }
             } else {
-                0
+                None
             }
+        };
+
+        // If we couldn't find a valid max_chunk_offset return None
+        let Some(max_chunk_offset) = max_chunk_offset else {
+            return None;
         };
 
         // is the max chunk offset before the start of this storage module (can happen at head of chain)

--- a/crates/chain/tests/block_production/block_production.rs
+++ b/crates/chain/tests/block_production/block_production.rs
@@ -75,7 +75,7 @@ async fn heavy_test_blockprod() -> eyre::Result<()> {
     let node = node.start().await;
     let data_bytes = "Hello, world!".as_bytes().to_vec();
     let tx = node
-        .create_publish_data_tx(&user_account, data_bytes.clone())
+        .post_publish_data_tx(&user_account, data_bytes.clone())
         .await?;
 
     let (irys_block, reth_exec_env) = mine_block(&node.node_ctx).await?.unwrap();
@@ -358,7 +358,7 @@ async fn heavy_test_blockprod_with_evm_txs() -> eyre::Result<()> {
     let data_bytes = "Hello, world!".as_bytes().to_vec();
 
     let irys_tx = node
-        .create_publish_data_tx(&account1, data_bytes.clone())
+        .post_publish_data_tx(&account1, data_bytes.clone())
         .await?;
 
     let (irys_block, reth_exec_env) = mine_block(&node.node_ctx).await?.unwrap();
@@ -521,7 +521,7 @@ async fn heavy_test_unfunded_user_tx_rejected() -> eyre::Result<()> {
     // Attempt to create and submit a transaction from the unfunded user
     let data_bytes = "Hello, world!".as_bytes().to_vec();
     let tx_result = node
-        .create_publish_data_tx(&unfunded_user, data_bytes.clone())
+        .post_publish_data_tx(&unfunded_user, data_bytes.clone())
         .await;
 
     // Verify that the transaction was rejected due to insufficient funds
@@ -602,7 +602,7 @@ async fn heavy_test_nonexistent_user_tx_rejected() -> eyre::Result<()> {
     // Attempt to create and submit a transaction from the nonexistent user
     let data_bytes = "Hello, world!".as_bytes().to_vec();
     let tx_result = node
-        .create_publish_data_tx(&nonexistent_user, data_bytes.clone())
+        .post_publish_data_tx(&nonexistent_user, data_bytes.clone())
         .await;
 
     // Verify that the transaction was rejected due to insufficient funds
@@ -704,9 +704,7 @@ async fn heavy_test_just_enough_funds_tx_included() -> eyre::Result<()> {
     let node = node.start().await;
 
     // Create and submit a transaction from the user
-    let tx = node
-        .create_publish_data_tx(&user, data_bytes.clone())
-        .await?;
+    let tx = node.post_publish_data_tx(&user, data_bytes.clone()).await?;
 
     // Verify the transaction was accepted and cost is exactly the balance
     assert_eq!(

--- a/crates/chain/tests/block_production/reset_seed.rs
+++ b/crates/chain/tests/block_production/reset_seed.rs
@@ -144,7 +144,7 @@ async fn generate_test_transaction_and_add_to_block(
 ) -> HashMap<IrysTransactionId, irys_types::DataTransaction> {
     let data_bytes = "Test transaction!".as_bytes().to_vec();
     let mut irys_txs: HashMap<IrysTransactionId, DataTransaction> = HashMap::new();
-    match node.create_publish_data_tx(account, data_bytes).await {
+    match node.post_publish_data_tx(account, data_bytes).await {
         Ok(tx) => {
             irys_txs.insert(tx.header.id, tx);
         }

--- a/crates/chain/tests/block_production/testing_primitives.rs
+++ b/crates/chain/tests/block_production/testing_primitives.rs
@@ -54,7 +54,7 @@ async fn heavy_test_mine_tx() {
     let data = "Hello, world!".as_bytes().to_vec();
     info!("height: {}", height);
     let tx = irys_node
-        .create_publish_data_tx(&account, data)
+        .post_publish_data_tx(&account, data)
         .await
         .unwrap();
     irys_node.mine_block().await.unwrap();

--- a/crates/chain/tests/data_sync/sync_partition_data_tests.rs
+++ b/crates/chain/tests/data_sync/sync_partition_data_tests.rs
@@ -65,9 +65,8 @@ async fn slow_heavy_sync_partition_data_between_peers_test() -> eyre::Result<()>
     let data: Vec<u8> = chunks.concat();
 
     let data_tx = genesis_node
-        .create_publish_data_tx(&genesis_signer, data)
+        .post_publish_data_tx(&genesis_signer, data)
         .await?;
-    genesis_node.post_data_tx_raw(&data_tx.header).await;
 
     stake_and_pledge_signer(&genesis_node, &signer1, 3).await?;
     stake_and_pledge_signer(&genesis_node, &signer2, 3).await?;

--- a/crates/chain/tests/multi_node/sync_chain_state.rs
+++ b/crates/chain/tests/multi_node/sync_chain_state.rs
@@ -523,7 +523,7 @@ async fn generate_test_transaction_and_add_to_block(
 ) -> HashMap<IrysTransactionId, irys_types::DataTransaction> {
     let data_bytes = "Test transaction!".as_bytes().to_vec();
     let mut irys_txs: HashMap<IrysTransactionId, DataTransaction> = HashMap::new();
-    match node.create_publish_data_tx(account, data_bytes).await {
+    match node.post_publish_data_tx(account, data_bytes).await {
         Ok(tx) => {
             irys_txs.insert(tx.header.id, tx);
         }

--- a/crates/chain/tests/multi_node/validation.rs
+++ b/crates/chain/tests/multi_node/validation.rs
@@ -229,7 +229,7 @@ async fn heavy_block_shadow_txs_misalignment_block_rejected() -> eyre::Result<()
         .testing_peer_with_assignments(&peer_signer)
         .await?;
     let extra_tx = peer_node
-        .create_publish_data_tx(&peer_signer, "Hello, world!".as_bytes().to_vec())
+        .post_publish_data_tx(&peer_signer, "Hello, world!".as_bytes().to_vec())
         .await?;
 
     // produce an invalid block
@@ -326,10 +326,10 @@ async fn heavy_block_shadow_txs_different_order_of_txs() -> eyre::Result<()> {
         .testing_peer_with_assignments(&peer_signer)
         .await?;
     let _extra_tx_a = peer_node
-        .create_publish_data_tx(&peer_signer, "Hello, world!".as_bytes().to_vec())
+        .post_publish_data_tx(&peer_signer, "Hello, world!".as_bytes().to_vec())
         .await?;
     let _extra_tx_b = peer_node
-        .create_publish_data_tx(&peer_signer, "Hello, Irys!".as_bytes().to_vec())
+        .post_publish_data_tx(&peer_signer, "Hello, Irys!".as_bytes().to_vec())
         .await?;
 
     // produce an invalid block

--- a/crates/chain/tests/partition_assignments/sm_reassignment_tests.rs
+++ b/crates/chain/tests/partition_assignments/sm_reassignment_tests.rs
@@ -61,7 +61,7 @@ async fn heavy_sm_reassignment_with_restart_test() -> eyre::Result<()> {
     // 2. Post a data_tx that will cause the submit ledger to add a slot (9 chunks worth of bytes)
     let data = vec![255_u8; 9 * chunk_size];
     let data_tx = genesis_node
-        .create_publish_data_tx(&genesis_signer, data)
+        .post_publish_data_tx(&genesis_signer, data)
         .await?;
     genesis_node.post_data_tx_raw(&data_tx.header).await;
 

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -1445,7 +1445,7 @@ impl IrysNodeTest<IrysNodeCtx> {
             .await
     }
 
-    pub async fn create_publish_data_tx(
+    pub async fn post_publish_data_tx(
         &self,
         account: &IrysSigner,
         data: Vec<u8>,


### PR DESCRIPTION
Fixes a bug where ChunkOrchestrator would inteperet a `total_chunks` of 0 as `max_chunkj_offset` of 0 and try to sync the zeroth chunk.

Renames `create_publish_data_tx()` to `post_publish_data_tx()` to better reflect it's operation.
