### PR TITLE
feat: require ingress proofs from assigned miners

### DIFF
--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -12,7 +12,9 @@ use alloy_eips::eip7685::{Requests, RequestsOrHash};
 use alloy_rpc_types_engine::ExecutionData;
 use eyre::{ensure, eyre, OptionExt as _};
 use irys_database::db::IrysDatabaseExt as _;
-use irys_database::{block_header_by_hash, tx_header_by_txid, SystemLedger};
+use irys_database::{
+    block_header_by_hash, cached_data_root_by_data_root, tx_header_by_txid, SystemLedger,
+};
 use irys_domain::{
     BlockIndex, BlockIndexReadGuard, BlockTreeReadGuard, EmaSnapshot, EpochSnapshot,
     ExecutionPayloadCache,
@@ -22,10 +24,9 @@ use irys_primitives::CommitmentType;
 use irys_reth::shadow_tx::{ShadowTransaction, IRYS_SHADOW_EXEC, SHADOW_TX_DESTINATION_ADDR};
 use irys_reth_node_bridge::IrysRethNodeAdapter;
 use irys_reward_curve::HalvingCurve;
-use irys_storage::ii;
+use irys_storage::{ie, ii};
 use irys_types::storage_pricing::phantoms::{Irys, NetworkFee};
 use irys_types::storage_pricing::{calculate_perm_fee_from_config, Amount};
-use irys_types::BlockHash;
 use irys_types::{
     app_state::DatabaseProvider,
     calculate_difficulty, next_cumulative_diff,
@@ -34,16 +35,19 @@ use irys_types::{
     DataTransactionHeader, DataTransactionLedger, DifficultyAdjustmentConfig, IrysBlockHeader,
     PoaData, H256, U256,
 };
-use irys_types::{get_ingress_proofs, LedgerChunkOffset};
+use irys_types::{get_ingress_proofs, IngressProof, LedgerChunkOffset};
+use irys_types::{BlockHash, LedgerChunkRange};
 use irys_vdf::last_step_checkpoints_is_valid;
 use irys_vdf::state::VdfStateReadonly;
 use itertools::*;
+use nodit::InclusiveInterval;
 use openssl::sha;
 use reth::revm::primitives::FixedBytes;
 use reth::rpc::api::EngineApiClient as _;
 use reth::rpc::types::engine::ExecutionPayload;
 use reth_db::Database as _;
 use reth_ethereum_primitives::Block;
+use std::future::Future;
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
@@ -204,6 +208,8 @@ pub enum PreValidationError {
         "Incorrect Ingress proof count to publish a transaction. Expected: {expected}, Actual: {actual}"
     )]
     IngressProofCountMismatch { expected: usize, actual: usize },
+    #[error("Incorrect number of ingress proofs from assigned owners. Expected {expected}, Actual: {actual}")]
+    AssignedProofCountMismatch { expected: usize, actual: usize },
     #[error("Transaction {tx_id} has invalid ingress proof: {reason}")]
     InvalidIngressProof { tx_id: H256, reason: String },
     #[error("Ingress proof mismatch for transaction {tx_id}")]
@@ -1733,15 +1739,32 @@ pub async fn data_txs_are_valid(
                 }
             })?;
 
-            // Loop though all the ingress proofs for the published transaction and pre-validate them
-            for ingress_proof in tx_proofs.iter() {
-                // Validate ingress proof signature and data_root match the transaction
-                let _ = ingress_proof
-                    .pre_validate(&tx_header.data_root)
-                    .map_err(|e| PreValidationError::InvalidIngressProof {
-                        tx_id: tx_header.id,
-                        reason: e.to_string(),
-                    })?;
+            // Validate assigned ingress proofs and get counts
+            let (assigned_proofs, assigned_miners) = get_assigned_ingress_proofs(
+                &tx_proofs,
+                &tx_header,
+                |hash| mempool_block_retriever(hash, service_senders),
+                &block_tree_guard,
+                db,
+                config,
+            )
+            .await?;
+
+            let mut expected_assigned_proofs =
+                config.consensus.number_of_ingress_proofs_from_assignees as usize;
+
+            // While the protocol can require X number of assigned proofs, if there
+            // is less than that many assigned to the slot, it still needs to function.
+            if assigned_miners < expected_assigned_proofs {
+                warn!("Clamping expected_assigned_proofs from {} to {} to match number of assigned miners ", expected_assigned_proofs, assigned_miners);
+                expected_assigned_proofs = assigned_miners;
+            }
+
+            if assigned_proofs.len() < expected_assigned_proofs {
+                return Err(PreValidationError::AssignedProofCountMismatch {
+                    expected: expected_assigned_proofs,
+                    actual: assigned_proofs.len(),
+                });
             }
 
             if tx_proofs.len() != config.consensus.number_of_ingress_proofs_total as usize {
@@ -1974,6 +1997,191 @@ fn process_block_ledgers_with_states(
         }
     }
     Ok(())
+}
+
+async fn mempool_block_retriever(
+    hash: H256,
+    service_senders: &ServiceSenders,
+) -> Option<IrysBlockHeader> {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    service_senders
+        .mempool
+        .send(MempoolServiceMessage::GetBlockHeader(hash, false, tx))
+        .expect("MempoolServiceMessage should be delivered");
+    rx.await.expect("mempool service message should succeed")
+}
+
+pub async fn get_assigned_ingress_proofs<F, Fut>(
+    tx_proofs: &[IngressProof],
+    tx_header: &DataTransactionHeader,
+    mempool_block_retriever: F,
+    block_tree_guard: &BlockTreeReadGuard,
+    db: &DatabaseProvider,
+    config: &Config,
+) -> Result<(Vec<IngressProof>, usize), PreValidationError>
+where
+    F: Fn(H256) -> Fut + Clone, // Changed to Fn and added Clone
+    Fut: Future<Output = Option<IrysBlockHeader>>,
+{
+    // Returns (assigned_proofs, assigned_miners)
+    let mut assigned_proofs = Vec::new();
+    let mut assigned_miners = 0;
+
+    // Loop through all the ingress proofs for the published transaction and pre-validate them
+    for ingress_proof in tx_proofs.iter() {
+        // Validate ingress proof signature and data_root match the transaction
+        let proof_address = ingress_proof
+            .pre_validate(&tx_header.data_root)
+            .map_err(|e| PreValidationError::InvalidIngressProof {
+                tx_id: tx_header.id,
+                reason: e.to_string(),
+            })?;
+
+        // 1.) is the proof from a miner assigned to store the data in the submit ledger?
+
+        //  a) Get the block hashes from the cached data_root
+        let block_hashes = db
+            .view(|tx| cached_data_root_by_data_root(tx, tx_header.data_root))
+            .expect("creating a read tx should succeed")
+            .expect("db query should succeed")
+            .expect("CachedDataRoot should be found for data_root")
+            .block_set;
+
+        //  b) Get the submit ledger offset intervals for each of the blocks
+        let mut block_ranges = Vec::new();
+        for block_hash in block_hashes.iter() {
+            let block_range =
+                get_ledger_range(block_hash, mempool_block_retriever.clone(), db).await;
+            block_ranges.push(block_range);
+        }
+
+        //  c) Get the slots the proof address is assigned to store
+        let slot_indexes = get_submit_ledger_slot_assignments(&proof_address, &block_tree_guard);
+
+        // d) Get the ledger ranges of the slot indexes
+        let slot_ranges: HashMap<usize, LedgerChunkRange> = slot_indexes
+            .iter()
+            .map(|index| {
+                let num_chunks_in_partition = config.consensus.num_chunks_in_partition;
+                let start = *index as u64 * num_chunks_in_partition;
+                let end = start + num_chunks_in_partition;
+                let range = LedgerChunkRange(ie(
+                    LedgerChunkOffset::from(start),
+                    LedgerChunkOffset::from(end),
+                ));
+                (*index, range)
+            })
+            .collect();
+
+        // e) Get the number of unique addresses assigned to each slot
+        let slot_address_counts =
+            get_submit_ledger_slot_addresses(&slot_indexes, &block_tree_guard);
+
+        //  f) are there any intersections of block and slot ranges?
+        let mut is_intersected = false;
+        for block_range in &block_ranges {
+            for (slot_index, slot_range) in &slot_ranges {
+                if block_range.intersection(slot_range).is_some() {
+                    is_intersected = true;
+                    assigned_miners = *slot_address_counts.get(slot_index).unwrap();
+                    break;
+                }
+            }
+            if is_intersected {
+                assigned_proofs.push(ingress_proof.clone());
+                break;
+            }
+        }
+    }
+
+    Ok((assigned_proofs, assigned_miners))
+}
+
+async fn get_ledger_range<F, Fut>(
+    hash: &H256,
+    mempool_block_retriever: F,
+    db: &DatabaseProvider,
+) -> LedgerChunkRange
+where
+    F: Fn(H256) -> Fut + Clone, // Changed to Fn and added Clone
+    Fut: Future<Output = Option<IrysBlockHeader>>,
+{
+    let block = get_block_by_hash(hash, mempool_block_retriever.clone(), db).await;
+    let prev_block_hash = block.previous_block_hash;
+
+    if block.height == 0 {
+        LedgerChunkRange(ii(
+            LedgerChunkOffset::from(0),
+            LedgerChunkOffset::from(block.data_ledgers[DataLedger::Submit].total_chunks - 1),
+        ))
+    } else {
+        let prev_block = get_block_by_hash(&prev_block_hash, mempool_block_retriever, db).await;
+        LedgerChunkRange(ii(
+            LedgerChunkOffset::from(prev_block.data_ledgers[DataLedger::Submit].total_chunks),
+            LedgerChunkOffset::from(block.data_ledgers[DataLedger::Submit].total_chunks - 1),
+        ))
+    }
+}
+
+async fn get_block_by_hash<F, Fut>(
+    hash: &H256,
+    mempool_block_retriever: F,
+    db: &DatabaseProvider,
+) -> IrysBlockHeader
+where
+    F: FnOnce(H256) -> Fut, // This can stay FnOnce since it's only called once per invocation
+    Fut: Future<Output = Option<IrysBlockHeader>>,
+{
+    let block = mempool_block_retriever(*hash).await;
+
+    let block = if block.is_none() {
+        db.view(|tx| block_header_by_hash(tx, hash, false))
+            .expect("creating a read tx should succeed")
+            .expect("db query should succeed")
+            .expect("block should be in database if its not in retriever")
+    } else {
+        block.unwrap()
+    };
+
+    block
+}
+
+fn get_submit_ledger_slot_assignments(
+    address: &Address,
+    block_tree_guard: &BlockTreeReadGuard,
+) -> Vec<usize> {
+    let epoch_snapshot = block_tree_guard.read().canonical_epoch_snapshot();
+    let mut partition_assignments = epoch_snapshot.get_partition_assignments(*address);
+    partition_assignments.retain(|pa| pa.ledger_id == Some(DataLedger::Submit.into()));
+    partition_assignments
+        .iter()
+        .map(|pa| pa.slot_index.unwrap())
+        .collect()
+}
+
+fn get_submit_ledger_slot_addresses(
+    slot_indexes: &Vec<usize>,
+    block_tree_guard: &BlockTreeReadGuard,
+) -> HashMap<usize, usize> {
+    let epoch_snapshot = block_tree_guard.read().canonical_epoch_snapshot();
+
+    let mut num_addresses_per_slot: HashMap<usize, usize> = HashMap::new();
+
+    for slot_index in slot_indexes {
+        let num_addresses = epoch_snapshot
+            .partition_assignments
+            .data_partitions
+            .iter()
+            .filter(|(_hash, pa)| {
+                pa.ledger_id == Some(DataLedger::Submit.into())
+                    && pa.slot_index == Some(*slot_index)
+            })
+            .count();
+
+        num_addresses_per_slot.insert(*slot_index, num_addresses);
+    }
+
+    num_addresses_per_slot
 }
 
 #[cfg(test)]

--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -11,7 +11,7 @@ pub use facade::*;
 
 use crate::block_discovery::get_data_tx_in_parallel_inner;
 use crate::block_tree_service::{BlockMigratedEvent, ReorgEvent};
-use crate::block_validation::calculate_perm_storage_total_fee;
+use crate::block_validation::{calculate_perm_storage_total_fee, get_assigned_ingress_proofs};
 use crate::pledge_provider::MempoolPledgeProvider;
 use crate::services::ServiceSenders;
 use crate::shadow_tx_generator::PublishLedgerWithTxs;
@@ -744,7 +744,7 @@ impl Inner {
 
             let mut publish_txids: Vec<H256> = Vec::new();
 
-            // Loop tough all the data_roots with ingress proofs and find corresponding transaction ids
+            // Loop through all the data_roots with ingress proofs and find corresponding transaction ids
             for data_root in ingress_proofs.keys() {
                 let cached_data_root = cached_data_root_by_data_root(&read_tx, *data_root).unwrap();
                 if let Some(cached_data_root) = cached_data_root {
@@ -754,7 +754,7 @@ impl Inner {
                 }
             }
 
-            // Loop though all the pending tx to see which haven't been promoted
+            // Loop through all the pending tx to see which haven't been promoted
             let txs = self.handle_get_data_tx_message(publish_txids.clone()).await;
             // TODO: improve this
             let mut tx_headers = get_data_tx_in_parallel_inner(
@@ -771,7 +771,7 @@ impl Inner {
             .await
             .unwrap_or(vec![]);
 
-            // so the resulting publish_txs & proofs are sorted
+            // Sort the resulting publish_txs & proofs
             tx_headers.sort_by(|a, b| a.id.cmp(&b.id));
 
             for tx_header in &tx_headers {
@@ -790,32 +790,128 @@ impl Inner {
                 } else {
                     // If it's not promoted, validate the proofs
 
-                    // Get the proofs for this tx
-                    let proofs = ingress_proofs_by_data_root(&read_tx, tx_header.data_root)?;
+                    // Get all the proofs for this tx
+                    let all_proofs = ingress_proofs_by_data_root(&read_tx, tx_header.data_root)?;
 
-                    let mut tx_proofs = Vec::new();
-
-                    // Check for the correct number of ingress proofs
-                    if (proofs.len() as u64) < self.config.consensus.number_of_ingress_proofs_total
+                    // Check for minimum number of ingress proofs
+                    if (all_proofs.len() as u64)
+                        < self.config.consensus.number_of_ingress_proofs_total
                     {
-                        // Not enough ingress proofs to promote this tx
                         info!(
                             "Not promoting tx {} - insufficient proofs (got {} wanted {})",
                             &tx_header.id,
-                            &proofs.len(),
+                            &all_proofs.len(),
                             self.config.consensus.number_of_ingress_proofs_total
                         );
                         continue;
-                    } else {
-                        // Collect enough ingress proofs for promotion, but no more
-                        for i in 0..self.config.consensus.number_of_ingress_proofs_total {
-                            tx_proofs.push(proofs[i as usize].1.proof.clone());
-                        }
-
-                        // Update the lists for the publish ledger txid and tx_proofs share an index
-                        publish_txs.push(tx_header.clone());
-                        publish_proofs.append(&mut tx_proofs);
                     }
+
+                    // Convert to IngressProof vector for assignment checking
+                    let all_tx_proofs: Vec<IngressProof> = all_proofs
+                        .iter()
+                        .map(|(_, proof_entry)| proof_entry.proof.clone())
+                        .collect();
+
+                    // Get assigned and unassigned proofs using the existing utility function
+                    let (assigned_proofs, assigned_miners) = match get_assigned_ingress_proofs(
+                        &all_tx_proofs,
+                        &tx_header,
+                        |hash| self.handle_get_block_header_message(hash, false), // Closure captures self
+                        &self.block_tree_read_guard,
+                        &self.irys_db,
+                        &self.config,
+                    )
+                    .await
+                    {
+                        Ok(result) => result,
+                        Err(e) => {
+                            warn!(
+                                "Failed to get assigned proofs for tx {}: {}",
+                                &tx_header.id, e
+                            );
+                            continue;
+                        }
+                    };
+
+                    // Calculate expected assigned proofs, clamping to available miners
+                    let mut expected_assigned_proofs = self
+                        .config
+                        .consensus
+                        .number_of_ingress_proofs_from_assignees
+                        as usize;
+
+                    if assigned_miners < expected_assigned_proofs {
+                        warn!(
+                            "Clamping expected_assigned_proofs from {} to {} for tx {}",
+                            expected_assigned_proofs, assigned_miners, &tx_header.id
+                        );
+                        expected_assigned_proofs = assigned_miners;
+                    }
+
+                    // Check if we have enough assigned proofs
+                    if assigned_proofs.len() < expected_assigned_proofs {
+                        info!(
+                            "Not promoting tx {} - insufficient assigned proofs (got {} wanted {})",
+                            &tx_header.id,
+                            assigned_proofs.len(),
+                            expected_assigned_proofs
+                        );
+                        continue;
+                    }
+
+                    // Separate assigned and unassigned proofs
+                    let assigned_proof_set: HashSet<_> = assigned_proofs
+                        .iter()
+                        .map(|p| &p.proof.0) // Use signature as unique identifier
+                        .collect();
+
+                    let unassigned_proofs: Vec<IngressProof> = all_tx_proofs
+                        .iter()
+                        .filter(|p| !assigned_proof_set.contains(&p.proof.0))
+                        .cloned()
+                        .collect();
+
+                    // Build the final proof list
+                    let mut final_proofs = Vec::new();
+
+                    // First, add assigned proofs up to the total network limit
+                    // Use all available assigned proofs, but don't exceed the network total
+                    let total_network_limit =
+                        self.config.consensus.number_of_ingress_proofs_total as usize;
+                    let assigned_to_use = std::cmp::min(assigned_proofs.len(), total_network_limit);
+                    final_proofs.extend_from_slice(&assigned_proofs[..assigned_to_use]);
+
+                    // Then fill remaining slots with unassigned proofs if needed
+                    let remaining_slots = total_network_limit - final_proofs.len();
+                    if remaining_slots > 0 {
+                        let unassigned_to_use =
+                            std::cmp::min(unassigned_proofs.len(), remaining_slots);
+                        final_proofs.extend_from_slice(&unassigned_proofs[..unassigned_to_use]);
+                    }
+
+                    // Final check - do we have enough total proofs?
+                    if final_proofs.len()
+                        < self.config.consensus.number_of_ingress_proofs_total as usize
+                    {
+                        info!(
+                            "Not promoting tx {} - insufficient total proofs after assignment filtering (got {} wanted {})",
+                            &tx_header.id,
+                            final_proofs.len(),
+                            self.config.consensus.number_of_ingress_proofs_total
+                        );
+                        continue;
+                    }
+
+                    // Success - add this transaction and its proofs
+                    publish_txs.push(tx_header.clone());
+                    publish_proofs.extend(final_proofs.clone()); // Clone to avoid moving final_proofs
+
+                    info!(
+                        "Promoting tx {} with {} assigned proofs and {} total proofs",
+                        &tx_header.id,
+                        assigned_to_use, // Show actual assigned proofs used (capped by network limit)
+                        final_proofs.len()
+                    );
                 }
             }
         }

--- a/crates/actors/src/mempool_service/data_txs.rs
+++ b/crates/actors/src/mempool_service/data_txs.rs
@@ -185,7 +185,7 @@ impl Inner {
 
         // Cache the data_root in the database
         match self.irys_db.update_eyre(|db_tx| {
-            irys_database::cache_data_root(db_tx, &tx)?;
+            irys_database::cache_data_root(db_tx, &tx, None)?;
             Ok(())
         }) {
             Ok(()) => {

--- a/crates/actors/src/mempool_service/lifecycle.rs
+++ b/crates/actors/src/mempool_service/lifecycle.rs
@@ -77,6 +77,39 @@ impl Inner {
             }
         }
 
+        // Update `CachedDataRoots` so that this block_hash is cached for each data_root
+        let submit_txids = block.data_ledgers[DataLedger::Submit].tx_ids.0.clone();
+        let submit_tx_headers = self.handle_get_data_tx_message(submit_txids).await;
+
+        for (i, submit_tx) in submit_tx_headers.iter().enumerate() {
+            let Some(submit_tx) = submit_tx else {
+                error!(
+                    "No transaction header found for txid: {}",
+                    block.data_ledgers[DataLedger::Submit].tx_ids.0[i]
+                );
+                continue;
+            };
+
+            let data_root = submit_tx.data_root;
+            match self.irys_db.update_eyre(|db_tx| {
+                irys_database::cache_data_root(db_tx, &submit_tx, Some(&block))?;
+                Ok(())
+            }) {
+                Ok(()) => {
+                    info!(
+                        "Successfully cached data_root {:?} for tx {:?}",
+                        data_root, submit_tx.id
+                    );
+                }
+                Err(db_error) => {
+                    error!(
+                        "Failed to cache data_root {:?} for tx {:?}: {:?}",
+                        data_root, submit_tx.id, db_error
+                    );
+                }
+            };
+        }
+
         self.prune_pending_txs().await;
 
         Ok(())

--- a/crates/database/src/db_cache.rs
+++ b/crates/database/src/db_cache.rs
@@ -83,6 +83,9 @@ pub struct CachedDataRoot {
 
     /// The set of all tx.ids' that contain this `data_root`
     pub txid_set: Vec<H256>,
+
+    /// Block hashes for blocks containing transactions with this `data_root`
+    pub block_set: Vec<H256>,
 }
 
 #[derive(Clone, Debug, Eq, Default, PartialEq, Serialize, Deserialize, Arbitrary, Compact)]


### PR DESCRIPTION
Makes it possible for the protocol to require X amount of the total ingress proofs required to promote a transaction be from miners assigned to store that transactions data.

* Adds to the existing CachedDataRoot that store all the txids associated with a data_root, makes it also store the blocks hashes have this data_root in their submit ledger tx.
* Uses this info to check during promotion if the ingress proof is from a miner that was assigned to store it's data when it was added to a submit ledger.
* Handles the case where there's fewer miners assigned to a slot than the network requires as a minimum for promotion. In this case it falls back to accepting all assigned miners have provided proofs.
