### PR TITLE
feat: allow promotions when miner count < required proofs

### DIFF
--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -809,14 +809,27 @@ impl Inner {
                     let all_proofs = ingress_proofs_by_data_root(&read_tx, tx_header.data_root)?;
 
                     // Check for minimum number of ingress proofs
-                    if (all_proofs.len() as u64)
-                        < self.config.consensus.number_of_ingress_proofs_total
-                    {
+                    let total_miners = self
+                        .block_tree_read_guard
+                        .read()
+                        .canonical_epoch_snapshot()
+                        .commitment_state
+                        .stake_commitments
+                        .len();
+
+                    // Take the smallest value, the configured total proofs count or the number
+                    // of staked miners that can produce a valid proof.
+                    let proofs_per_tx = std::cmp::min(
+                        self.config.consensus.number_of_ingress_proofs_total as usize,
+                        total_miners,
+                    );
+
+                    if all_proofs.len() < proofs_per_tx {
                         info!(
                             "Not promoting tx {} - insufficient proofs (got {} wanted {})",
                             &tx_header.id,
                             &all_proofs.len(),
-                            self.config.consensus.number_of_ingress_proofs_total
+                            proofs_per_tx
                         );
                         continue;
                     }

--- a/crates/chain/tests/promotion/promotion_with_multiple_proofs.rs
+++ b/crates/chain/tests/promotion/promotion_with_multiple_proofs.rs
@@ -18,7 +18,9 @@ async fn slow_heavy_promotion_with_multiple_proofs_test() -> eyre::Result<()> {
     let mut config = NodeConfig::testing()
         .with_consensus(|consensus| {
             consensus.chunk_size = 32;
-            consensus.number_of_ingress_proofs_total = 3;
+            // Set the total number of proofs required to promote above the number of nodes (3)
+            // to validate the clamping to 3 proofs to promote.
+            consensus.number_of_ingress_proofs_total = 5;
             consensus.number_of_ingress_proofs_from_assignees = 2;
             consensus.num_partitions_per_slot = 3;
             consensus.epoch.num_blocks_in_epoch = 3;


### PR DESCRIPTION
Makes sure we can still promote even when there's less miners than the consensus # of proofs required to promote. (important for early bootstrapping of the network)
