### PR TITLE
feat: add basic Hashing for commitment & epoch snapshots for easier debugging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5039,6 +5039,7 @@ dependencies = [
  "alloy-rpc-types",
  "assert_matches",
  "atomic-write-file",
+ "base58",
  "derive_more",
  "eyre",
  "irys-config",

--- a/crates/database/src/data_ledger.rs
+++ b/crates/database/src/data_ledger.rs
@@ -10,7 +10,7 @@ use std::ops::{Index, IndexMut};
 /// validation state at any given time.
 /// A slot in a data ledger containing one or more partition hashes
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Hash)]
 pub struct LedgerSlot {
     /// Assigned partition hashes
     pub partitions: Vec<H256>,
@@ -20,14 +20,14 @@ pub struct LedgerSlot {
     pub last_height: u64,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Hash)]
 pub struct ExpiringPartitionInfo {
     pub partition_hash: PartitionHash,
     pub ledger_id: DataLedger,
     pub slot_index: usize,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash)]
 /// Permanent ledger that persists across epochs
 pub struct PermanentLedger {
     /// Sequential ledger slots containing partition assignments
@@ -37,7 +37,7 @@ pub struct PermanentLedger {
     pub num_partitions_per_slot: u64,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash)]
 /// Temporary ledger that exists for a fixed number of epochs
 pub struct TermLedger {
     /// Sequential ledger slots containing partition assignments  
@@ -257,7 +257,7 @@ impl LedgerCore for TermLedger {
 /// This type separation ensures operations like partition expiration can only
 /// be performed on term ledgers, making any attempt to expire a permanent
 /// ledger partition fail at compile time.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash)]
 pub struct Ledgers {
     perm: PermanentLedger,
     term: Vec<TermLedger>,

--- a/crates/domain/Cargo.toml
+++ b/crates/domain/Cargo.toml
@@ -33,6 +33,7 @@ reth.workspace = true
 serde_json.workspace = true
 toml.workspace = true
 rug = "1"
+base58.workspace=true
 
 [dev-dependencies]
 test-log.workspace = true

--- a/crates/domain/src/models/block_tree.rs
+++ b/crates/domain/src/models/block_tree.rs
@@ -6,9 +6,7 @@ use irys_types::{
 };
 use reth_db::Database as _;
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
-    sync::Arc,
-    time::SystemTime,
+    collections::{BTreeMap, HashMap, HashSet}, sync::Arc, time::SystemTime
 };
 use tracing::debug;
 
@@ -428,9 +426,10 @@ impl BlockTree {
             .insert(hash);
 
         debug!(
-            "adding block: max_cumulative_difficulty: {} block.cumulative_diff: {} {}",
-            self.max_cumulative_difficulty.0, block.cumulative_diff, block.block_hash
+            "adding block: max_cumulative_difficulty: {} block.cumulative_diff: {} {}, commitment_snapshot_hash: {}, epoch_snapshot_hash: {}",
+            self.max_cumulative_difficulty.0, block.cumulative_diff, block.block_hash, &commitment_snapshot.get_hash(), &epoch_snapshot.get_hash()
         );
+        
         if block.cumulative_diff > self.max_cumulative_difficulty.0 {
             debug!(
                 "setting max_cumulative_difficulty ({}, {}) for height: {}",

--- a/crates/domain/src/models/block_tree.rs
+++ b/crates/domain/src/models/block_tree.rs
@@ -6,7 +6,9 @@ use irys_types::{
 };
 use reth_db::Database as _;
 use std::{
-    collections::{BTreeMap, HashMap, HashSet}, sync::Arc, time::SystemTime
+    collections::{BTreeMap, HashMap, HashSet},
+    sync::Arc,
+    time::SystemTime,
 };
 use tracing::debug;
 
@@ -429,7 +431,7 @@ impl BlockTree {
             "adding block: max_cumulative_difficulty: {} block.cumulative_diff: {} {}, commitment_snapshot_hash: {}, epoch_snapshot_hash: {}",
             self.max_cumulative_difficulty.0, block.cumulative_diff, block.block_hash, &commitment_snapshot.get_hash(), &epoch_snapshot.get_hash()
         );
-        
+
         if block.cumulative_diff > self.max_cumulative_difficulty.0 {
             debug!(
                 "setting max_cumulative_difficulty ({}, {}) for height: {}",

--- a/crates/domain/src/snapshots/commitment_snapshot.rs
+++ b/crates/domain/src/snapshots/commitment_snapshot.rs
@@ -1,6 +1,6 @@
 use irys_primitives::CommitmentType;
 use irys_types::{Address, CommitmentTransaction};
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, hash::{Hash as _, Hasher as _}};
 use tracing::debug;
 
 use super::EpochSnapshot;
@@ -14,12 +14,12 @@ pub enum CommitmentSnapshotStatus {
     InvalidPledgeCount, // The pledge count doesn't match the actual number of pledges
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Hash)]
 pub struct CommitmentSnapshot {
     pub commitments: BTreeMap<Address, MinerCommitments>,
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Hash)]
 pub struct MinerCommitments {
     pub stake: Option<CommitmentTransaction>,
     pub pledges: Vec<CommitmentTransaction>,
@@ -209,9 +209,10 @@ impl CommitmentSnapshot {
                     as u64;
                 if *pledge_count_before_executing != current_pledge_count {
                     tracing::error!(
-                        "Invalid pledge count for {}: expected {}, but miner has {} pledges",
+                        "Invalid pledge count for {}: expected {}, but miner {} has {} pledges",
                         commitment_tx.id,
                         pledge_count_before_executing,
+                        &signer,
                         current_pledge_count
                     );
                     return CommitmentSnapshotStatus::InvalidPledgeCount;
@@ -257,6 +258,16 @@ impl CommitmentSnapshot {
             }
         }
         false
+    }
+
+    // NON CANONICAL HASH
+    // SHOULD BE USED FOR DEBUGGING ONLY
+    pub fn get_hash(&self) -> String {
+        let mut hasher = std::hash::DefaultHasher::new();
+        self.hash(&mut hasher);
+        let res = hasher.finish();
+        use base58::ToBase58 as _;
+        res.to_le_bytes().to_base58()
     }
 }
 

--- a/crates/domain/src/snapshots/commitment_snapshot.rs
+++ b/crates/domain/src/snapshots/commitment_snapshot.rs
@@ -1,6 +1,9 @@
 use irys_primitives::CommitmentType;
 use irys_types::{Address, CommitmentTransaction};
-use std::{collections::BTreeMap, hash::{Hash as _, Hasher as _}};
+use std::{
+    collections::BTreeMap,
+    hash::{Hash as _, Hasher as _},
+};
 use tracing::debug;
 
 use super::EpochSnapshot;

--- a/crates/domain/src/snapshots/epoch_snapshot/commitment_state.rs
+++ b/crates/domain/src/snapshots/epoch_snapshot/commitment_state.rs
@@ -2,7 +2,7 @@ use irys_primitives::CommitmentStatus;
 use irys_types::{Address, IrysTransactionId, H256, U256};
 use std::collections::BTreeMap;
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Hash)]
 pub struct CommitmentStateEntry {
     pub id: IrysTransactionId,
     pub commitment_status: CommitmentStatus,
@@ -13,7 +13,7 @@ pub struct CommitmentStateEntry {
     pub amount: U256,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Hash)]
 pub struct CommitmentState {
     pub stake_commitments: BTreeMap<Address, CommitmentStateEntry>,
     pub pledge_commitments: BTreeMap<Address, Vec<CommitmentStateEntry>>,

--- a/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
+++ b/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
@@ -1092,15 +1092,19 @@ impl EpochSnapshot {
         self.all_active_partitions.hash(&mut hasher);
         self.unassigned_partitions.hash(&mut hasher);
         self.commitment_state.hash(&mut hasher);
-        self.previous_epoch_block.as_ref().map(|blk| blk.block_hash).unwrap_or(H256::zero()).hash(&mut hasher);
+        self.previous_epoch_block
+            .as_ref()
+            .map(|blk| blk.block_hash)
+            .unwrap_or(H256::zero())
+            .hash(&mut hasher);
         self.expired_partition_infos.hash(&mut hasher);
         self.epoch_height.hash(&mut hasher);
         use std::hash::Hasher as _;
-        
+
         let res = hasher.finish();
         use base58::ToBase58 as _;
         res.to_le_bytes().to_base58()
-        }
+    }
 }
 
 /// SHA256 hash the message parameter

--- a/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
+++ b/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
@@ -1081,6 +1081,26 @@ impl EpochSnapshot {
     pub fn is_staked(&self, miner_address: Address) -> bool {
         self.commitment_state.is_staked(miner_address)
     }
+
+    // NON CANONICAL HASH
+    // SHOULD BE USED FOR DEBUGGING ONLY
+    pub fn get_hash(&self) -> String {
+        let mut hasher = std::hash::DefaultHasher::new();
+        use std::hash::Hash as _;
+        self.ledgers.hash(&mut hasher);
+        self.partition_assignments.hash(&mut hasher);
+        self.all_active_partitions.hash(&mut hasher);
+        self.unassigned_partitions.hash(&mut hasher);
+        self.commitment_state.hash(&mut hasher);
+        self.previous_epoch_block.as_ref().map(|blk| blk.block_hash).unwrap_or(H256::zero()).hash(&mut hasher);
+        self.expired_partition_infos.hash(&mut hasher);
+        self.epoch_height.hash(&mut hasher);
+        use std::hash::Hasher as _;
+        
+        let res = hasher.finish();
+        use base58::ToBase58 as _;
+        res.to_le_bytes().to_base58()
+        }
 }
 
 /// SHA256 hash the message parameter

--- a/crates/domain/src/snapshots/epoch_snapshot/partition_assignments.rs
+++ b/crates/domain/src/snapshots/epoch_snapshot/partition_assignments.rs
@@ -7,7 +7,7 @@ use irys_types::{
 use tracing::debug;
 
 /// A state struct that can be wrapped with Arc<`RwLock`<>> to provide parallel read access
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash)]
 pub struct PartitionAssignments {
     /// Active data partition state mapped by partition hash
     pub data_partitions: BTreeMap<PartitionHash, PartitionAssignment>,

--- a/crates/types/src/partition.rs
+++ b/crates/types/src/partition.rs
@@ -19,6 +19,7 @@ pub type PartitionHash = H256;
     Copy,
     RlpDecodable,
     RlpEncodable,
+    Hash
 )]
 #[rlp(trailing)]
 pub struct PartitionAssignment {

--- a/crates/types/src/partition.rs
+++ b/crates/types/src/partition.rs
@@ -19,7 +19,7 @@ pub type PartitionHash = H256;
     Copy,
     RlpDecodable,
     RlpEncodable,
-    Hash
+    Hash,
 )]
 #[rlp(trailing)]
 pub struct PartitionAssignment {

--- a/crates/types/src/signature.rs
+++ b/crates/types/src/signature.rs
@@ -9,7 +9,7 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 //==============================================================================
 // IrysSignature
 //------------------------------------------------------------------------------
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Arbitrary)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Arbitrary, Hash)]
 /// Wrapper newtype around [`Signature`], with enforced [`Parity::NonEip155`] parity
 pub struct IrysSignature(Signature);
 

--- a/crates/types/src/transaction.rs
+++ b/crates/types/src/transaction.rs
@@ -256,7 +256,7 @@ pub type TxPathHash = H256;
     Compact,
     RlpEncodable,
     RlpDecodable,
-    Hash
+    Hash,
 )]
 #[rlp(trailing)]
 /// Stores deserialized fields from a JSON formatted commitment transaction.

--- a/crates/types/src/transaction.rs
+++ b/crates/types/src/transaction.rs
@@ -256,6 +256,7 @@ pub type TxPathHash = H256;
     Compact,
     RlpEncodable,
     RlpDecodable,
+    Hash
 )]
 #[rlp(trailing)]
 /// Stores deserialized fields from a JSON formatted commitment transaction.


### PR DESCRIPTION
**Describe the changes**
Add super basic Hashing for commitment & epoch snapshots for easier debugging (so it's easier to tell if there's a state mismatch)

**Additional Context**
This is primarily meant as an aid to track down the behaviour observed on testnet, but I suspect it'll have some utility beyond that given how complex the data model is.
