### PR TITLE
Update GitHub Actions in CI Workflows

### DIFF
--- a/.github/workflows/flaky.yml
+++ b/.github/workflows/flaky.yml
@@ -44,7 +44,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && github.ref == 'refs/heads/master')
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           clean: true  # Always start with clean workspace

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -148,7 +148,7 @@ jobs:
     if: ${{ needs.gate.outputs.should-run == 'true' }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -165,7 +165,7 @@ jobs:
     if: ${{ needs.gate.outputs.should-run == 'true' }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -185,7 +185,7 @@ jobs:
     if: ${{ needs.gate.outputs.should-run == 'true' }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -202,7 +202,7 @@ jobs:
     if: ${{ needs.gate.outputs.should-run == 'true' }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -219,7 +219,7 @@ jobs:
     if: ${{ needs.gate.outputs.should-run == 'true' }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -239,7 +239,7 @@ jobs:
     if: ${{ needs.gate.outputs.should-run == 'true' }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -255,7 +255,7 @@ jobs:
     if: ${{ needs.gate.outputs.should-run == 'true' }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: crate-ci/typos@v1.29.7
         with:
           files: .


### PR DESCRIPTION
Updates actions/checkout@v4 to actions/checkout@v5 across CI workflows.

Upgrade to actions/checkout@v5 for improved performance and stability.

Reference:
Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0
