### PR TITLE
fix: correct U256 RLP encoding, realign JS signatures

### DIFF
--- a/crates/chain/tests/external/api.rs
+++ b/crates/chain/tests/external/api.rs
@@ -6,6 +6,7 @@ use irys_actors::mempool_service::MempoolServiceMessage;
 use irys_actors::packing::wait_for_packing;
 use irys_api_server::routes::tx::TxOffset;
 use irys_database::tables::IngressProofs;
+use irys_testing_utils::initialize_tracing;
 use irys_types::{irys::IrysSigner, Address, NodeConfig};
 use reth_db::transaction::DbTx as _;
 use reth_db::Database as _;
@@ -25,10 +26,11 @@ const DEV_ADDRESS: &str = "64f1a2829e0e698c18e7792d6e74f67d89aa0a32";
 /// Run this test, until you see `waiting for tx header...`, then start the JS client test
 /// that's it!, just kill this test once the JS client test finishes.
 async fn external_api() -> eyre::Result<()> {
-    std::env::set_var("RUST_LOG", "debug,irys_actors::mining=error,irys_actors::packing=error,irys_chain::vdf=off,irys_vdf::vdf_state=off");
-
+    std::env::set_var("RUST_LOG", "info,irys_actors::mining=error,irys_actors::packing=error,irys_chain::vdf=off,irys_vdf::vdf_state=off");
+    initialize_tracing();
     let mut testing_config = NodeConfig::testing();
     testing_config.http.bind_port = 8080; // external test, should never be run concurrently
+    testing_config.http.bind_ip = "0.0.0.0".to_string();
 
     let account1 = IrysSigner::random_signer(&testing_config.consensus_config());
     let mut node = IrysNodeTest::new_genesis(testing_config.clone());
@@ -57,6 +59,7 @@ async fn external_api() -> eyre::Result<()> {
         ),
     ]);
     let node = node.start().await;
+    info!("started node {}", &node.cfg.http.bind_port);
 
     node.node_ctx.stop_mining()?;
     wait_for_packing(
@@ -87,14 +90,11 @@ async fn external_api() -> eyre::Result<()> {
 
     let recv_tx = loop {
         let (oneshot_tx, oneshot_rx) = tokio::sync::oneshot::channel();
-        let response = node
+        node
             .node_ctx
             .service_senders
             .mempool
-            .send(MempoolServiceMessage::GetBestMempoolTxs(None, oneshot_tx));
-        if let Err(e) = response {
-            tracing::error!("channel closed, unable to send to mempool: {:?}", e);
-        }
+            .send(MempoolServiceMessage::GetBestMempoolTxs(None, oneshot_tx))?;
         match oneshot_rx.await {
             Ok(Ok(mempool_tx)) if !mempool_tx.submit_tx.is_empty() => {
                 break mempool_tx.submit_tx[0].clone();
@@ -104,6 +104,7 @@ async fn external_api() -> eyre::Result<()> {
             }
         }
     };
+
     info!(
         "got tx {:?}- waiting for chunks & ingress proof generation...",
         &recv_tx.id

--- a/crates/primitives/src/commitment.rs
+++ b/crates/primitives/src/commitment.rs
@@ -49,32 +49,6 @@ impl TryFrom<u8> for CommitmentStatus {
     }
 }
 
-impl Encodable for CommitmentStatus {
-    fn encode(&self, out: &mut dyn bytes::BufMut) {
-        match self {
-            Self::Pending => out.put_u8(Self::Pending as u8),
-            Self::Active => out.put_u8(Self::Active as u8),
-            Self::Inactive => out.put_u8(Self::Inactive as u8),
-            Self::Slashed => out.put_u8(Self::Slashed as u8),
-        };
-    }
-    fn length(&self) -> usize {
-        1
-    }
-}
-
-impl Decodable for CommitmentStatus {
-    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        let _v = buf.to_vec();
-        let enc_stake_status = u8::decode(&mut &buf[..])?;
-        buf.advance(1);
-        let id = Self::try_from(enc_stake_status)
-            .or(Err(RlpError::Custom("unknown stake status id")))?;
-        let _v2 = buf.to_vec();
-        Ok(id)
-    }
-}
-
 // Type discriminants for CommitmentType encoding
 const COMMITMENT_TYPE_STAKE: u8 = 1;
 const COMMITMENT_TYPE_PLEDGE: u8 = 2;

--- a/crates/types/src/serialization.rs
+++ b/crates/types/src/serialization.rs
@@ -196,19 +196,19 @@ impl Decode for U256 {
     }
 }
 
+// NOTE: RLP has specific standards for encoding numbers
+// so we defer to the correct impl used by alloy's U256
 impl Encodable for U256 {
     #[inline]
     fn encode(&self, out: &mut dyn bytes::BufMut) {
-        let mut buffer = [0_u8; 32];
-        self.to_big_endian(&mut buffer);
-        buffer.encode(out);
+        let int: alloy_primitives::U256 = (*self).into();
+        int.encode(out);
     }
 }
 
 impl Decodable for U256 {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        let res = <[u8; 32]>::decode(buf)?;
-        Ok(Self::from_big_endian(&res))
+        alloy_primitives::U256::decode(buf).map(Into::into)
     }
 }
 
@@ -891,6 +891,43 @@ mod tests {
 
         // Assert
         assert_eq!(data, decoded);
+    }
+
+    #[test]
+    fn test_option_u256_rlp() {
+        #[derive(Debug, Eq, PartialEq, RlpEncodable, RlpDecodable)]
+        #[rlp(trailing)]
+        struct Test {
+            a: U256,
+            b: Option<U256>
+
+        }
+
+        let data1 = Test {
+            a: U256::from(42_u64),
+            b: Some(U256::zero())
+        };
+
+        let data2 = Test {
+            a: U256::from(42_u64),
+            b: None
+        };
+
+        let mut buffer1 = vec![];
+        data1.encode(&mut buffer1);
+        let decoded = Test::decode(&mut &buffer1[..]).unwrap();
+        // Some(0) is decoded as None
+        assert_ne!(data1, decoded);
+
+        let mut buffer2 = vec![];
+        data2.encode(&mut buffer2);
+        // unequal(!) encodings
+        // note: why? seems like if we serialise a Some value it gets an additional trailing `128` on the binary
+        // note: if we really needed to have `0`, we could modify the encoding u256 uses to treat 0 as a different value
+        assert_eq!(buffer1, buffer2);
+        let decoded2 = Test::decode(&mut &buffer2[..]).unwrap();
+        // but decodes "correctly"
+        assert_eq!(decoded2, data2);
     }
 
     #[test]

--- a/crates/types/src/signature.rs
+++ b/crates/types/src/signature.rs
@@ -182,10 +182,10 @@ mod tests {
     const DEV_ADDRESS: &str = "64f1a2829e0e698c18e7792d6e74f67d89aa0a32";
 
     // from the JS Client - `txSigningParity`
-    const SIG_HEX: &str = "0xe735ff5a5e0eefdf5c5298f919ff5b94f35804f44c5db842db078dcbc7b5d499544cfbf8ffcb4113dea13433d5a739f354cb4551cf5384c9e9bb290d39d39b891b";
+    const SIG_HEX: &str = "0x09ce0a2661221ff591aca987dcebb5ec141d91df64e14dc6ca47c5e0a8be81660a105294723d0201e4989f58cdd51b164ba7bdfc2355c69c4ce6b3c5b0c7a5221c";
     // BS58 (JSON, hence the escaped quotes) encoded signature
     const SIG_BS58: &str =
-        "\"MQQ4dsjqX4iU5F34h6SSLKE1YVHV9Hk2XBnJCprchLdmG71dq1nZStc12oMc7bHjnFo6emHQ1oDpnkCZQEShGDQwL\"";
+        "\"sBf5Lkht1uvPSbkTc5UcWtcEf58Tw6xpVhBJnDEe4xYns4EV3hVKC5Mn2tY7R8VF9LKm1L5JARSMQhUqSaFzGGCT\"";
 
     // spellchecker:on
 
@@ -204,17 +204,18 @@ mod tests {
             anchor: H256::from([1_u8; 32]),
             signer: Address::ZERO,
             data_root: H256::from([3_u8; 32]),
-            data_size: 1024,
+            data_size: 242,
             header_size: 0,
-            term_fee: U256::from(100_u64),
-            perm_fee: Some(U256::from(1_u64)),
+            term_fee: U256::from(99_u64),
+            perm_fee: Some(U256::from(98_u64)),
             ledger_id: 0,
-            bundle_format: Some(0),
+            bundle_format: None,
             chain_id: testing_config.chain_id,
             version: 0,
             promoted_height: None,
             signature: Default::default(),
         };
+        
         let transaction = DataTransaction {
             header: original_header,
             ..Default::default()

--- a/crates/types/src/transaction.rs
+++ b/crates/types/src/transaction.rs
@@ -109,6 +109,7 @@ pub struct DataTransactionHeader {
     pub signature: IrysSignature,
 
     #[serde(default, with = "optional_string_u64")]
+    /// WARNING: None == Some(0) for RLP!!
     pub bundle_format: Option<u64>,
 
     /// Funds the storage of the transaction for the next 200+ years (protocol-enforced cost)


### PR DESCRIPTION
**Describe the changes**
This PR:
- Fixes RLP encode/decode for U256 to use the correct impl used by alloy_primitives:U256
- Removes an unused Encodable impl for CommitmentStatus
- Adds a test that demonstrates the RLP None Some(0) encoding equivalence issue
- Adjusts & corrects the signatures used in `signature_signing_serialization`
- Tweaks the external API test


**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.


