### PR TITLE
feat: misc fixes for the js-client to get commitments working

### DIFF
--- a/crates/api-server/src/lib.rs
+++ b/crates/api-server/src/lib.rs
@@ -24,7 +24,7 @@ use std::{
     time::Instant,
 };
 use tokio::sync::mpsc::UnboundedSender;
-use tracing::{debug, info};
+use tracing::{info, warn};
 
 use crate::routes::anchor;
 
@@ -170,8 +170,9 @@ pub fn run_server(app_state: ApiState, listener: TcpListener) -> Server {
                 JsonConfig::default()
                     .limit(1024 * 1024) // Set JSON payload limit to 1MB
                     .error_handler(|err, req| {
-                        debug!("JSON decode error for req {:?} - {:?}", &req.path(), &err);
-                        InternalError::from_response(err, HttpResponse::BadRequest().finish())
+                        warn!("JSON decode error for req {:?} - {:?}", &req.path(), &err);
+                        let error_message = format!("JSON decode/parse error: {}", err);
+                        InternalError::from_response(err, HttpResponse::BadRequest().body(error_message))
                             .into()
                     }),
             )

--- a/crates/api-server/src/routes/price.rs
+++ b/crates/api-server/src/routes/price.rs
@@ -3,6 +3,7 @@ use actix_web::{
     web::{self, Path},
     HttpResponse, Result as ActixResult,
 };
+use base58::FromBase58 as _;
 use irys_types::{
     serialization::string_u64,
     storage_pricing::{calculate_perm_fee_from_config, calculate_term_fee},
@@ -136,7 +137,16 @@ pub async fn get_unstake_price(state: web::Data<ApiState>) -> ActixResult<HttpRe
 
 /// Parse and validate a user address from a string
 fn parse_user_address(address_str: &str) -> Result<Address, actix_web::Error> {
-    Address::from_str(address_str).map_err(|_| ErrorBadRequest("Invalid address format"))
+    // try Base58 format first
+    if let Ok(decoded) = address_str.from_base58() {
+        if let Ok(arr) = TryInto::<[u8; 20]>::try_into(decoded.as_slice()) {
+            return Ok(Address::from(&arr));
+        }
+    }
+    
+    // fall back to hex/EVM address format
+    Address::from_str(address_str)
+        .map_err(|_| ErrorBadRequest("Invalid address format"))
 }
 
 pub async fn get_pledge_price(

--- a/crates/chain/tests/external/api.rs
+++ b/crates/chain/tests/external/api.rs
@@ -26,7 +26,7 @@ const DEV_ADDRESS: &str = "64f1a2829e0e698c18e7792d6e74f67d89aa0a32";
 /// Run this test, until you see `waiting for tx header...`, then start the JS client test
 /// that's it!, just kill this test once the JS client test finishes.
 async fn external_api() -> eyre::Result<()> {
-    std::env::set_var("RUST_LOG", "info,irys_actors::mining=error,irys_actors::packing=error,irys_chain::vdf=off,irys_vdf::vdf_state=off");
+    std::env::set_var("RUST_LOG", "debug,irys_actors::mining=error,irys_actors::packing=error,irys_chain::vdf=off,irys_vdf::vdf_state=off");
     initialize_tracing();
     let mut testing_config = NodeConfig::testing();
     testing_config.http.bind_port = 8080; // external test, should never be run concurrently
@@ -51,9 +51,10 @@ async fn external_api() -> eyre::Result<()> {
             },
         ),
         (
+            // below is the wallet hardcoded in the JS client test
             Address::from_slice(hex::decode(DEV_ADDRESS)?.as_slice()),
             GenesisAccount {
-                balance: U256::from(4200000000000000000_u128),
+                balance: U256::from(42000000000000000000000000000000_u128),
                 ..Default::default()
             },
         ),
@@ -88,21 +89,8 @@ async fn external_api() -> eyre::Result<()> {
 
     info!("waiting for tx header...");
 
-    let recv_tx = loop {
-        let (oneshot_tx, oneshot_rx) = tokio::sync::oneshot::channel();
-        node.node_ctx
-            .service_senders
-            .mempool
-            .send(MempoolServiceMessage::GetBestMempoolTxs(None, oneshot_tx))?;
-        match oneshot_rx.await {
-            Ok(Ok(mempool_tx)) if !mempool_tx.submit_tx.is_empty() => {
-                break mempool_tx.submit_tx[0].clone();
-            }
-            _ => {
-                sleep(Duration::from_millis(100)).await;
-            }
-        }
-    };
+    let (submit, _publish, _commitment) = node.wait_for_mempool_best_txs_shape(1, 0, 1, 999999).await?;
+    let recv_tx = submit.first().unwrap();
 
     info!(
         "got tx {:?}- waiting for chunks & ingress proof generation...",

--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -13,6 +13,7 @@ use awc::{body::MessageBody, http::StatusCode};
 use eyre::{eyre, OptionExt as _};
 use futures::future::select;
 use irys_actors::block_discovery::{BlockDiscoveryFacade as _, BlockDiscoveryFacadeImpl};
+use irys_actors::shadow_tx_generator::PublishLedgerWithTxs;
 use irys_actors::{
     block_producer::BlockProducerCommand,
     block_tree_service::ReorgEvent,
@@ -1395,7 +1396,7 @@ impl IrysNodeTest<IrysNodeCtx> {
         publish_txs: usize,
         commitment_txs: usize,
         seconds_to_wait: u32,
-    ) -> eyre::Result<()> {
+    ) -> eyre::Result<(Vec<DataTransactionHeader>, PublishLedgerWithTxs, Vec<CommitmentTransaction>)> {
         let mempool_service = self.node_ctx.service_senders.mempool.clone();
         let mut retries = 0;
         let max_retries = seconds_to_wait; // 1 second per retry
@@ -1418,25 +1419,20 @@ impl IrysNodeTest<IrysNodeCtx> {
             prev = (submit_tx.len(), publish_tx.txs.len(), commitment_tx.len());
 
             if prev == expected {
-                break;
+                info!("mempool state valid after {} retries", &retries);
+               return Ok((submit_tx, publish_tx, commitment_tx))
             }
             debug!("got {:?} expected {:?} - txs: {:?}", &prev, expected, &txs);
 
             tokio::time::sleep(Duration::from_secs(1)).await;
             retries += 1;
         }
-
-        if retries == max_retries {
             Err(eyre::eyre!(
                 "Failed to validate mempool state after {} retries (state (submit, publish, commitment) {:?}, expected: {:?})",
                 retries,
                 &prev,
                 &expected
             ))
-        } else {
-            info!("mempool state valid after {} retries", &retries);
-            Ok(())
-        }
     }
 
     // Get the best txs from the mempool, based off the account state at the optional parent EVM block

--- a/crates/primitives/src/commitment.rs
+++ b/crates/primitives/src/commitment.rs
@@ -1,6 +1,9 @@
+use std::str::FromStr;
+
 use alloy_rlp::{Decodable, Encodable, Error as RlpError};
 use bytes::Buf as _;
 use reth_codecs::Compact;
+use serde::{Deserialize as _, Deserializer};
 
 #[derive(
     PartialEq,
@@ -76,17 +79,18 @@ pub enum CommitmentType {
     #[default]
     Stake,
     Pledge {
-        #[serde(rename = "pledgeCountBeforeExecuting")]
+        #[serde(rename = "pledgeCountBeforeExecuting", with = "string_u64")]
         pledge_count_before_executing: u64,
     },
     Unpledge {
-        #[serde(rename = "pledgeCountBeforeExecuting")]
+        #[serde(rename = "pledgeCountBeforeExecuting",  with = "string_u64")]
         pledge_count_before_executing: u64,
     },
     Unstake,
 }
 
 impl Encodable for CommitmentType {
+    // TODO: this is not really spec compliant (afaict)
     fn encode(&self, out: &mut dyn bytes::BufMut) {
         match self {
             Self::Stake => {
@@ -244,6 +248,50 @@ impl reth_codecs::Compact for CommitmentType {
         }
     }
 }
+
+
+
+// TODO: remove - below is duplicated from types/serialization
+pub mod string_u64 {
+    use serde::{Deserializer, Serializer};
+
+    use super::*;
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        string_or_number_to_int(deserializer)
+    }
+
+    pub fn serialize<S>(value: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&value.to_string())
+    }
+}
+
+
+fn string_or_number_to_int<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: FromStr + serde::Deserialize<'de>,
+    T::Err: std::fmt::Display,
+{
+    #[derive(serde::Deserialize)]
+    #[serde(untagged)]
+    enum StringOrNumber<T> {
+        String(String),
+        Number(T),
+    }
+
+    match StringOrNumber::deserialize(deserializer)? {
+        StringOrNumber::String(s) => T::from_str(&s).map_err(serde::de::Error::custom),
+        StringOrNumber::Number(n) => Ok(n),
+    }
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/crates/types/src/serialization.rs
+++ b/crates/types/src/serialization.rs
@@ -827,6 +827,8 @@ pub mod string_u128 {
     }
 }
 
+// note: U256 doesn't have a string_ serialisation mod, as it doesn't need one
+
 fn string_or_number_to_int<'de, D, T>(deserializer: D) -> Result<T, D::Error>
 where
     D: Deserializer<'de>,

--- a/crates/types/src/transaction.rs
+++ b/crates/types/src/transaction.rs
@@ -9,6 +9,7 @@ use alloy_rlp::{Encodable as _, RlpDecodable, RlpEncodable};
 pub use irys_primitives::CommitmentType;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use tracing::error;
 
 pub mod fee_distribution;
 
@@ -62,7 +63,7 @@ pub enum CommitmentValidationError {
 /// Stores deserialized fields from a JSON formatted Irys transaction header.
 /// will decode from strings or numeric literals for u64 fields, due to JS's max safe int being 2^53-1 instead of 2^64
 /// We include the Irys prefix to differentiate from EVM transactions.
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase")]
 pub struct DataTransactionHeader {
     /// A 256-bit hash of the transaction signature.
     #[rlp(skip)]
@@ -78,7 +79,7 @@ pub struct DataTransactionHeader {
     pub anchor: H256,
 
     /// The ecdsa/secp256k1 public key of the transaction signer
-    #[serde(default, with = "address_base58_stringify")]
+    #[serde( with = "address_base58_stringify")]
     pub signer: Address,
 
     /// The merkle root of the transactions data chunks
@@ -261,7 +262,7 @@ pub type TxPathHash = H256;
 )]
 #[rlp(trailing)]
 /// Stores deserialized fields from a JSON formatted commitment transaction.
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase")]
 pub struct CommitmentTransaction {
     // NOTE: both rlp skip AND rlp default must be present in order for field skipping to work
     #[rlp(skip)]
@@ -274,7 +275,7 @@ pub struct CommitmentTransaction {
     pub anchor: H256,
 
     /// The ecdsa/secp256k1 public key of the transaction signer
-    #[serde(default, with = "address_base58_stringify")]
+    #[serde(with = "address_base58_stringify")]
     pub signer: Address,
 
     /// The type of commitment Stake/UnStake Pledge/UnPledge


### PR DESCRIPTION
**Describe the changes**
A collection of misc fixes/tweaks for issues discovered while getting the js-client posting commitment transactions.
- Return the JSON parse/deserialization error in the HTTP response body
- Change the log level for a JSON deserialization failure to `warn`
- Support both Base58 and hex address encodings for the stake & pledge price routes
- Modify the external API test to increase balance and to use wait_for_mempool_best_txs_shape
- Improve `wait_for_mempool_best_txs_shape` to return the items once it matches the requested shape
- Tighten serde(default) usage (this was causing some funny bugs where a commitment tx, when posted to the data tx route, would be successfully deserialised as a data tx - and then rejected for an invalid signature) 
- Adds string_u64 to CommitmentType ser/des 


**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.
