### PR TITLE
perf: generate_ingress_proof_tree() and generate_ingress_proof() now accept slice

### DIFF
--- a/crates/types/src/ingress.rs
+++ b/crates/types/src/ingress.rs
@@ -91,8 +91,8 @@ impl Decompress for IngressProof {
     }
 }
 
-pub fn generate_ingress_proof_tree(
-    chunks: impl Iterator<Item = eyre::Result<ChunkBytes>>,
+pub fn generate_ingress_proof_tree<C: AsRef<[u8]>>(
+    chunks: impl Iterator<Item = eyre::Result<C>>,
     address: Address,
     and_regular: bool,
 ) -> eyre::Result<(Node, Option<Node>)> {
@@ -127,9 +127,9 @@ pub fn generate_ingress_proof(
     })
 }
 
-pub fn verify_ingress_proof(
-    proof: IngressProof,
-    chunks: impl Iterator<Item = eyre::Result<ChunkBytes>>,
+pub fn verify_ingress_proof<C: AsRef<[u8]>>(
+    proof: &IngressProof,
+    chunks: impl IntoIterator<Item = C>,
     chain_id: ChainId,
 ) -> eyre::Result<bool> {
     if chain_id != proof.chain_id {
@@ -143,7 +143,8 @@ pub fn verify_ingress_proof(
     let recovered_address = recover_signer(&sig[..].try_into()?, prehash.into())?;
 
     // re-compute the ingress proof & regular trees & roots
-    let (proof_root, regular_root) = generate_ingress_proof_tree(chunks, recovered_address, true)?;
+    let (proof_root, regular_root) =
+        generate_ingress_proof_tree(chunks.into_iter().map(Ok), recovered_address, true)?;
 
     let data_root = H256(
         regular_root
@@ -229,15 +230,15 @@ mod tests {
 
         // Verify the ingress proof
         assert!(verify_ingress_proof(
-            proof.clone(),
-            chunks.clone().into_iter().map(Ok),
+            &proof,
+            chunks.iter().as_slice(),
             chain_id
         )?);
         let mut reversed = chunks;
         reversed.reverse();
         assert!(!verify_ingress_proof(
-            proof,
-            reversed.into_iter().map(Ok),
+            &proof,
+            reversed.iter().as_slice(),
             chain_id
         )?);
 
@@ -287,15 +288,15 @@ mod tests {
 
         // Verify that testnet proof is valid for testnet
         assert!(verify_ingress_proof(
-            testnet_proof.clone(),
-            chunks.clone().into_iter().map(Ok),
+            &testnet_proof,
+            chunks.iter().as_slice(),
             testnet_chain_id
         )?);
 
         // Verify that mainnet proof is valid for mainnet
         assert!(verify_ingress_proof(
-            mainnet_proof,
-            chunks.clone().into_iter().map(Ok),
+            &mainnet_proof,
+            chunks.iter().as_slice(),
             mainnet_chain_id
         )?);
 
@@ -306,16 +307,16 @@ mod tests {
         // This should fail verification because the signature was created with testnet chain_id
         // but we're trying to verify it with mainnet chain_id
         assert!(!verify_ingress_proof(
-            replay_attack_proof.clone(),
-            chunks.clone().into_iter().map(Ok),
+            &replay_attack_proof,
+            chunks.iter().as_slice(),
             mainnet_chain_id
         )?);
 
         // This should fail verification because there's going to be a mismatch in chain_id
         // even if the proof is valid for testnet
         assert!(!verify_ingress_proof(
-            replay_attack_proof,
-            chunks.into_iter().map(Ok),
+            &replay_attack_proof,
+            chunks.iter().as_slice(),
             testnet_chain_id
         )?);
 

--- a/crates/types/src/ingress.rs
+++ b/crates/types/src/ingress.rs
@@ -11,9 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::irys::IrysSigner;
 
-use crate::{
-    generate_data_root, generate_ingress_leaves, ChunkBytes, DataRoot, IrysSignature, Node, H256,
-};
+use crate::{generate_data_root, generate_ingress_leaves, DataRoot, IrysSignature, Node, H256};
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq, Compact, Arbitrary)]
 
@@ -105,10 +103,10 @@ pub fn generate_ingress_proof_tree<C: AsRef<[u8]>>(
     ))
 }
 
-pub fn generate_ingress_proof(
+pub fn generate_ingress_proof<C: AsRef<[u8]>>(
     signer: &IrysSigner,
     data_root: DataRoot,
-    chunks: impl Iterator<Item = eyre::Result<ChunkBytes>>,
+    chunks: impl Iterator<Item = eyre::Result<C>>,
     chain_id: u64,
 ) -> eyre::Result<IngressProof> {
     let (root, _) = generate_ingress_proof_tree(chunks, signer.address(), false)?;
@@ -224,7 +222,7 @@ mod tests {
         let proof = generate_ingress_proof(
             &signer,
             data_root,
-            chunks.clone().into_iter().map(Ok),
+            chunks.iter().map(|c| Ok(c.as_slice())),
             chain_id,
         )?;
 
@@ -273,7 +271,7 @@ mod tests {
         let testnet_proof = generate_ingress_proof(
             &signer,
             data_root,
-            chunks.clone().into_iter().map(Ok),
+            chunks.iter().map(|c| Ok(c.as_slice())),
             testnet_chain_id,
         )?;
 
@@ -282,7 +280,7 @@ mod tests {
         let mainnet_proof = generate_ingress_proof(
             &signer,
             data_root,
-            chunks.clone().into_iter().map(Ok),
+            chunks.iter().map(|c| Ok(c.as_slice())),
             mainnet_chain_id,
         )?;
 

--- a/crates/types/src/transaction/fee_distribution.rs
+++ b/crates/types/src/transaction/fee_distribution.rs
@@ -439,7 +439,7 @@ mod tests {
         let proof1 = generate_ingress_proof(
             &signer1,
             data_root,
-            vec![vec![0_u8; 32]].into_iter().map(Ok),
+            [vec![0_u8; 32]].iter().map(|c| Ok(c.as_slice())),
             config.chain_id,
         )
         .unwrap();
@@ -447,7 +447,7 @@ mod tests {
         let proof2 = generate_ingress_proof(
             &signer2,
             data_root,
-            vec![vec![0_u8; 32]].into_iter().map(Ok),
+            [vec![0_u8; 32]].iter().map(|c| Ok(c.as_slice())),
             config.chain_id,
         )
         .unwrap();
@@ -539,7 +539,7 @@ mod tests {
                 generate_ingress_proof(
                     signer,
                     data_root,
-                    vec![vec![0_u8; 32]].into_iter().map(Ok),
+                    [vec![0_u8; 32]].iter().map(|c| Ok(c.as_slice())),
                     config.chain_id,
                 )
                 .unwrap()


### PR DESCRIPTION
**Describe the changes**
`generate_ingress_proof_tree()` and `generate_ingress_proof()` now accept slice without ownership.
 - avoids cloning the proof
 - accepts owned or borrowed arg

**Related Issue(s)**
Completes https://github.com/Irys-xyz/irys/issues/847
Performance improvement suggested in https://github.com/Irys-xyz/irys/pull/786 review

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

