### PR TITLE
fix: change BlockBounds height from a u128 to a u64

### DIFF
--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -153,7 +153,7 @@ impl ChunkCacheService {
                     .read()
                     .get_block_bounds(ledger_id, LedgerChunkOffset::from(chunk_offset))
                     .expect("Should be able to get block bounds as max_chunk_offset was checked");
-                prune_height = Some((block_bounds.height - 1).try_into().unwrap());
+                prune_height = Some(block_bounds.height - 1);
             }
         }
 

--- a/crates/actors/src/storage_module_service.rs
+++ b/crates/actors/src/storage_module_service.rs
@@ -231,7 +231,7 @@ impl StorageModuleServiceInner {
 
         // For each storage module assigned to a data ledger, we need to update the data_root indexes
         // that may overlap the assigned slot so that it can index chunks
-        let mut blocks_to_migrate: BTreeMap<u128, BlockHash> = BTreeMap::new();
+        let mut blocks_to_migrate: BTreeMap<u64, BlockHash> = BTreeMap::new();
         for assigned_sm in assigned_modules {
             // Rebuild indexes
             let ledger_id = assigned_sm
@@ -316,7 +316,7 @@ impl StorageModuleServiceInner {
                     let bi = self.block_index.read();
                     for height in start_block..=end_block {
                         let block_hash = bi
-                            .get_item(height.try_into().unwrap())
+                            .get_item(height)
                             .expect("block item to be present in index")
                             .block_hash;
                         blocks_to_migrate.insert(height, block_hash);

--- a/crates/domain/src/models/block_index.rs
+++ b/crates/domain/src/models/block_index.rs
@@ -183,7 +183,7 @@ impl BlockIndex {
         block_bounds.start_chunk_offset = previous_item.ledgers[ledger_index].total_chunks;
         block_bounds.end_chunk_offset = found_item.ledgers[ledger_index].total_chunks;
         block_bounds.tx_root = found_item.ledgers[ledger_index].tx_root;
-        block_bounds.height = block_height as u128;
+        block_bounds.height = block_height;
 
         Ok(block_bounds)
     }
@@ -241,7 +241,7 @@ impl BlockIndex {
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct BlockBounds {
     /// Block height where these bounds apply
-    pub height: u128,
+    pub height: u64,
     /// Target ledger (Publish or Submit)
     pub ledger: DataLedger,
     /// First chunk offset included in this block (inclusive)


### PR DESCRIPTION
The rest of the codebase uses u64 for height

**Describe the changes**
A clear and concise description of what the bug fix, feature, or improvement is.

**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
