### PR TITLE
fix: add retrying other peers to the block index if the index is empty

### DIFF
--- a/crates/p2p/src/chain_sync.rs
+++ b/crates/p2p/src/chain_sync.rs
@@ -1278,7 +1278,6 @@ async fn get_block_index(
                         "Peer {:?} returned an empty index, trying all other peers",
                         miner_address
                     );
-                    to_remove = Some(*miner_address);
 
                     // Try all remaining peers
                     for (other_miner_address, other_peer) in peers_to_fetch_index_from.iter() {


### PR DESCRIPTION
**Describe the changes**
Add retrying other peers to the block index if the index is empty to avoid peers that didn't set is_syncing flag correctly for whatever reason

**Related Issue(s)**

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
