### PR TITLE
fix: use the parent block's EMA snapshot instead of the childs

### DIFF
--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -1623,12 +1623,12 @@ pub async fn data_txs_are_valid(
     db: &DatabaseProvider,
     block_tree_guard: &BlockTreeReadGuard,
 ) -> Result<(), PreValidationError> {
-    // Get the block's EMA snapshot for fee calculations
+    // Get the parent block's EMA snapshot for fee calculations
     let block_ema = block_tree_guard
         .read()
-        .get_ema_snapshot(&block.block_hash)
+        .get_ema_snapshot(&block.previous_block_hash)
         .ok_or(PreValidationError::BlockEmaSnapshotNotFound {
-            block_hash: block.block_hash,
+            block_hash: block.previous_block_hash,
         })?;
 
     // Extract data transactions from both ledgers


### PR DESCRIPTION
**Describe the changes**
This PR fixes a bug where block validation was validating transactions for a block against it's EMA snapshot, instead of the EMA snapshot from the parent block. In cases where tx pricing was very precise, this would cause legitimate transactions to be rejected due to insufficient funds.



