### PR TITLE
feat: remove prevalidated_blocks and prevalidated_blocks_poa from the mempool

### DIFF
--- a/crates/actors/src/block_discovery.rs
+++ b/crates/actors/src/block_discovery.rs
@@ -537,15 +537,6 @@ impl BlockDiscoveryServiceInner {
 
         match validation_result {
             Ok(()) => {
-                // add block to mempool
-                mempool_sender
-                    .send(MempoolServiceMessage::IngestBlocks {
-                        prevalidated_blocks: vec![new_block_header.clone()],
-                    })
-                    .map_err(|channel_error| {
-                        BlockDiscoveryInternalError::MempoolRequestFailed(channel_error.to_string())
-                    })?;
-
                 // all txs
                 let mut all_txs = submit_txs;
                 all_txs.extend_from_slice(&publish_txs);

--- a/crates/actors/src/mempool_service/facade.rs
+++ b/crates/actors/src/mempool_service/facade.rs
@@ -5,8 +5,7 @@ use crate::mempool_service::{
 use crate::services::ServiceSenders;
 use eyre::eyre;
 use irys_types::{
-    chunk::UnpackedChunk, Base64, CommitmentTransaction, DataTransactionHeader, IrysBlockHeader,
-    H256,
+    chunk::UnpackedChunk, CommitmentTransaction, DataTransactionHeader, IrysBlockHeader, H256,
 };
 use irys_types::{Address, IngressProof};
 use std::collections::HashSet;
@@ -47,8 +46,6 @@ pub trait MempoolFacade: Clone + Send + Sync + 'static {
         &self,
         irys_block_header: Arc<IrysBlockHeader>,
     ) -> Result<usize, TxIngressError>;
-
-    async fn insert_poa_chunk(&self, block_hash: H256, chunk_data: Base64) -> eyre::Result<()>;
 
     async fn remove_from_blacklist(&self, tx_ids: Vec<H256>) -> eyre::Result<()>;
 
@@ -221,17 +218,6 @@ impl MempoolFacade for MempoolServiceFacadeImpl {
                 block: irys_block_header,
             })
             .map_err(|e| TxIngressError::Other(format!("Failed to send BlockMigratedEvent: {}", e)))
-    }
-
-    async fn insert_poa_chunk(&self, block_hash: H256, chunk_data: Base64) -> eyre::Result<()> {
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        self.service
-            .send(MempoolServiceMessage::InsertPoAChunk(
-                block_hash, chunk_data, tx,
-            ))
-            .map_err(|send_error| eyre!("{send_error:?}"))?;
-
-        rx.await.map_err(|recv_error| eyre!("{recv_error:?}"))
     }
 
     async fn remove_from_blacklist(&self, tx_ids: Vec<H256>) -> eyre::Result<()> {

--- a/crates/p2p/src/tests/util.rs
+++ b/crates/p2p/src/tests/util.rs
@@ -173,10 +173,6 @@ impl MempoolFacade for MempoolStub {
         Ok(1)
     }
 
-    async fn insert_poa_chunk(&self, _block_hash: H256, _chunk_data: Base64) -> Result<()> {
-        Ok(())
-    }
-
     async fn remove_from_blacklist(&self, _tx_ids: Vec<H256>) -> eyre::Result<()> {
         Ok(())
     }


### PR DESCRIPTION
**Describe the changes**
Removes both prevalidated_blocks and prevalidated_blocks_poa from the mempool.
Note: this PR does not remove the GetHeader method from the mempool service, as it's used a lot and we can defer the removal for now. instead, I changed the logic to just fetch the chunk from the block tree.
