### PR TITLE
fix: flaky heavy to slow_heavy_test_data_sync_with_different_peer_performane

### DIFF
--- a/crates/actors/tests/data_sync_test.rs
+++ b/crates/actors/tests/data_sync_test.rs
@@ -29,7 +29,7 @@ use tokio::sync::{mpsc::UnboundedReceiver, oneshot};
 use tracing::{debug, error};
 
 #[tokio::test]
-async fn slow_test_data_sync_with_different_peer_performance() {
+async fn slow_heavy_test_data_sync_with_different_peer_performance() {
     std::env::set_var("RUST_LOG", "debug,storage=off");
     let tmp_dir = setup_tracing_and_temp_dir(None, false);
 


### PR DESCRIPTION
**Describe the changes**
`slow_test_data_sync_with_different_peer_performane()` fails in CI often, but not locally. Adding `heavy` to `slow_heavy_test_data_sync_with_different_peer_performane` gives it the required resource to be stable.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

