### PR TITLE
fix: better data_sync chunk request handling

### DIFF
--- a/crates/actors/src/data_sync_service/chunk_orchestrator.rs
+++ b/crates/actors/src/data_sync_service/chunk_orchestrator.rs
@@ -110,10 +110,18 @@ impl ChunkOrchestrator {
     }
 
     fn populate_request_queue(&mut self) {
-        // Retain only those pending chunk requests that are still Entropy
-        // removing those satisfied by other means (user upload, chunk migration, etc etc)
-        // and retain only those requests that are not Completed
+        // Retain in-flight requests (for telemetry tracking) and pending entropy requests.
+        // Remove completed requests and pending requests for chunks that changed type
+        // (satisfied via gossip/upload or invalidated by storage fault/expiry).
+
         self.chunk_requests.retain(|offset, cr| {
+            // Always retain in-flight requests
+            if matches!(cr.request_state, ChunkRequestState::Requested(..)) {
+                return true;
+            }
+
+            // For non-requested states, only retain if the chunk is still Entropy
+            // and not Completed
             matches!(
                 self.storage_module.get_chunk_type(offset),
                 Some(ChunkType::Entropy)


### PR DESCRIPTION
fix the pruning of chunk_requests so it doesn't prune in-flight data_synch chunk_request states ever.

fix the Result handling so it doesn't propagate to a panic.