### PR TITLE
fix: add the correct mining address to the info route

### DIFF
--- a/crates/api-server/src/lib.rs
+++ b/crates/api-server/src/lib.rs
@@ -13,7 +13,7 @@ use irys_actors::{mempool_service::MempoolServiceMessage, pledge_provider::Mempo
 use irys_domain::chain_sync_state::ChainSyncState;
 use irys_domain::{BlockIndexReadGuard, BlockTreeReadGuard, ChunkProvider, PeerList};
 use irys_reth_node_bridge::node::RethNodeProvider;
-use irys_types::{app_state::DatabaseProvider, Config, PeerAddress};
+use irys_types::{app_state::DatabaseProvider, Address, Config, PeerAddress};
 use routes::{
     block, block_index, block_tree, commitment, full_config, get_chunk, index, ledger, mempool,
     mining, network_config, peer_list, post_chunk, post_version, price, proxy::proxy, storage, tx,
@@ -46,6 +46,7 @@ pub struct ApiState {
     pub sync_state: ChainSyncState,
     pub mempool_pledge_provider: Arc<MempoolPledgeProvider>,
     pub started_at: Instant,
+    pub mining_address: Address,
 }
 
 impl ApiState {

--- a/crates/api-server/src/routes/index.rs
+++ b/crates/api-server/src/routes/index.rs
@@ -5,7 +5,7 @@ use actix_web::{
     HttpResponse,
 };
 use irys_domain::get_canonical_chain;
-use irys_types::{Address, NodeInfo, H256};
+use irys_types::{NodeInfo, H256};
 
 pub async fn info_route(state: web::Data<ApiState>) -> HttpResponse {
     let (block_index_height, block_index_hash) = {
@@ -33,7 +33,7 @@ pub async fn info_route(state: web::Data<ApiState>) -> HttpResponse {
         is_syncing: state.sync_state.is_syncing(),
         current_sync_height: state.sync_state.sync_target_height(),
         uptime_secs: state.started_at.elapsed().as_secs(),
-        mining_address: Address::ZERO,
+        mining_address: state.mining_address,
     };
 
     HttpResponse::Ok()

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -138,6 +138,7 @@ impl IrysNodeCtx {
             sync_state: self.sync_state.clone(),
             mempool_pledge_provider: self.mempool_pledge_provider.clone(),
             started_at: self.started_at,
+            mining_address: self.config.node_config.miner_address(),
         }
     }
 
@@ -1430,6 +1431,7 @@ impl IrysNode {
                 sync_state,
                 mempool_pledge_provider,
                 started_at: irys_node_ctx.started_at,
+                mining_address: irys_node_ctx.config.node_config.miner_address(),
             },
             http_listener,
         );


### PR DESCRIPTION
Fixes the info route so it includes the actual mining address instead of Address::ZERO
