### PR TITLE
feat: misc testing tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ sudo chmod 644 /Library/LaunchDaemons/limit.maxfiles.plist
 sudo launchctl load -w /Library/LaunchDaemons/limit.maxfiles.plist
 ```
 ## Misc
-use the `IRYS_CUSTOM_TMP_DIR` env var while *COMPILING* to change the temporary directory used for tests from ./.tmp to whatever path you like. it can also be set to an env var to lookup and resolve as a path at runtime.
+use the `IRYS_CUSTOM_TMP_DIR` env var to change the temporary directory used for tests from ./.tmp to whatever path you like. it can also be set to another env var to lookup and resolve as a path at runtime.

--- a/crates/actors/tests/data_sync_test.rs
+++ b/crates/actors/tests/data_sync_test.rs
@@ -28,6 +28,7 @@ use tempfile::TempDir;
 use tokio::sync::{mpsc::UnboundedReceiver, oneshot};
 use tracing::{debug, error};
 
+#[ignore = "flaky, non critical function test"]
 #[tokio::test]
 async fn slow_heavy_test_data_sync_with_different_peer_performance() {
     std::env::set_var("RUST_LOG", "debug,storage=off");

--- a/crates/p2p/src/tests/util.rs
+++ b/crates/p2p/src/tests/util.rs
@@ -23,6 +23,7 @@ use irys_domain::execution_payload_cache::{ExecutionPayloadCache, RethBlockProvi
 use irys_domain::{BlockIndex, BlockIndexReadGuard, BlockTree, BlockTreeReadGuard, PeerList};
 use irys_primitives::Address;
 use irys_storage::irys_consensus_data_db::open_or_create_irys_consensus_data_db;
+use irys_testing_utils::tempfile::TempDir;
 use irys_testing_utils::utils::setup_tracing_and_temp_dir;
 use irys_types::irys::IrysSigner;
 use irys_types::{
@@ -420,6 +421,8 @@ pub(crate) struct GossipServiceTestFixture {
     pub gossip_receiver: Option<mpsc::UnboundedReceiver<GossipBroadcastMessage>>,
     pub _sync_rx: Option<UnboundedReceiver<SyncChainServiceMessage>>,
     pub sync_tx: UnboundedSender<SyncChainServiceMessage>,
+    // needs to be held so the directory is removed correctly
+    pub _temp_dir: TempDir,
 }
 
 impl GossipServiceTestFixture {
@@ -521,7 +524,7 @@ impl GossipServiceTestFixture {
         let (sync_tx, sync_rx) = mpsc::unbounded_channel::<SyncChainServiceMessage>();
 
         Self {
-            // temp_dir,
+            _temp_dir: temp_dir,
             gossip_port,
             api_port,
             execution: RethPeerInfo::default(),

--- a/crates/utils/testing-utils/src/utils.rs
+++ b/crates/utils/testing-utils/src/utils.rs
@@ -39,7 +39,7 @@ pub fn setup_tracing_and_temp_dir(name: Option<&str>, keep: bool) -> TempDir {
 pub const CARGO_MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
 
 pub fn tmp_base_dir() -> PathBuf {
-    if let Some(custom_tmp) = option_env!("IRYS_CUSTOM_TMP_DIR") {
+    if let Ok(custom_tmp) = &std::env::var("IRYS_CUSTOM_TMP_DIR") {
         // try to parse the value as a path
         let path = PathBuf::from(custom_tmp);
         if path.is_absolute()


### PR DESCRIPTION
**Describe the changes**
- change `IRYS_CUSTOM_TMP_DIR` to be runtime not compile time
- add temp_dir to the gossip test fixture so it gets removed properly
- disable slow_heavy_test_data_sync_with_different_peer_performance


