### PR TITLE
feat: update reth fork to include changes to the compact macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8040,7 +8040,7 @@ checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
 [[package]]
 name = "reth"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -8086,7 +8086,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8110,7 +8110,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8141,7 +8141,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8161,7 +8161,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8175,7 +8175,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "ahash 0.8.12",
  "alloy-chains",
@@ -8246,7 +8246,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8256,7 +8256,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8274,7 +8274,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8294,7 +8294,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "convert_case 0.7.1",
  "proc-macro2",
@@ -8305,7 +8305,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8319,7 +8319,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8332,7 +8332,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8344,7 +8344,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8368,7 +8368,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8394,7 +8394,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8423,7 +8423,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8452,7 +8452,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8467,7 +8467,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8493,7 +8493,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8517,7 +8517,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -8541,7 +8541,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8576,7 +8576,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8624,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8655,7 +8655,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8684,7 +8684,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8708,7 +8708,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "futures",
  "pin-project",
@@ -8731,7 +8731,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8783,7 +8783,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8810,7 +8810,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8826,7 +8826,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8841,7 +8841,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -8861,7 +8861,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8872,7 +8872,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8900,7 +8900,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8921,7 +8921,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8980,7 +8980,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8996,7 +8996,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9014,7 +9014,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9027,7 +9027,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9054,7 +9054,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9072,7 +9072,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9082,7 +9082,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9105,7 +9105,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9124,7 +9124,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9137,7 +9137,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9155,7 +9155,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9193,7 +9193,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9207,7 +9207,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "serde",
  "serde_json",
@@ -9217,7 +9217,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "bytes",
  "futures",
@@ -9265,7 +9265,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "bitflags 2.9.1",
  "byteorder",
@@ -9282,7 +9282,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "bindgen",
  "cc",
@@ -9291,7 +9291,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "futures",
  "metrics",
@@ -9303,7 +9303,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-primitives",
 ]
@@ -9311,7 +9311,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9325,7 +9325,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9380,7 +9380,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-admin",
@@ -9403,7 +9403,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9426,7 +9426,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9441,7 +9441,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9455,7 +9455,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9472,7 +9472,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9496,7 +9496,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9561,7 +9561,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9611,7 +9611,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-eips",
  "alloy-rpc-types-engine",
@@ -9647,7 +9647,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9671,7 +9671,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "eyre",
  "http 1.3.1",
@@ -9692,7 +9692,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9705,7 +9705,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9724,7 +9724,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9757,7 +9757,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9776,7 +9776,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9786,7 +9786,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "c-kzg",
@@ -9800,7 +9800,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9832,7 +9832,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9877,7 +9877,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9905,7 +9905,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9919,7 +9919,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9938,7 +9938,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9965,7 +9965,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9978,7 +9978,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10053,7 +10053,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10081,7 +10081,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10119,7 +10119,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10149,7 +10149,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10192,7 +10192,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10234,7 +10234,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.3.1",
@@ -10248,7 +10248,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10264,7 +10264,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-types-compat"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10277,7 +10277,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10323,7 +10323,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10350,7 +10350,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10364,7 +10364,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10384,7 +10384,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10396,7 +10396,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10420,7 +10420,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10436,7 +10436,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -10454,7 +10454,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10470,7 +10470,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10480,7 +10480,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "clap",
  "eyre",
@@ -10495,7 +10495,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10534,7 +10534,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10559,7 +10559,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10585,7 +10585,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -10598,7 +10598,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10623,7 +10623,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10641,7 +10641,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.4.8"
-source = "git+https://github.com/Irys-xyz/reth?rev=5ab0d995399d0105597502988d0a25b1f2ed674c#5ab0d995399d0105597502988d0a25b1f2ed674c"
+source = "git+https://github.com/Irys-xyz/reth?rev=dce78f6ad0b694993a646d8b730407fae59da29b#dce78f6ad0b694993a646d8b730407fae59da29b"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,8 +120,16 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 
 # OpenTelemetry
 opentelemetry = { version = "0.31.0", features = ["trace", "logs"] }
-opentelemetry-otlp = { version = "0.31.0", features = ["trace", "logs", "http-proto"] }
-opentelemetry_sdk = { version = "0.31.0", features = ["rt-tokio", "trace", "logs"] }
+opentelemetry-otlp = { version = "0.31.0", features = [
+  "trace",
+  "logs",
+  "http-proto",
+] }
+opentelemetry_sdk = { version = "0.31.0", features = [
+  "rt-tokio",
+  "trace",
+  "logs",
+] }
 opentelemetry-appender-tracing = { version = "0.31.0" }
 tracing-opentelemetry = "0.32.0"
 opentelemetry-semantic-conventions = "0.31.0"
@@ -179,43 +187,43 @@ alloy-signer-local = { version = "1.0.9", default-features = false }
 
 # Reth crates
 
-reth = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-chainspec = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-e2e-test-utils = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-engine-local = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-ethereum-engine-primitives = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-ethereum-forks = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-evm-ethereum = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-node-ethereum = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-ethereum-primitives = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-evm = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-network = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-node-api = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-node-builder = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-node-core = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-node-metrics = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-payload-builder = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-primitives-traits = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-primitives = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-rpc-eth-api = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-codecs = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-db-api = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-db = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-provider = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-tasks = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-tracing = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-transaction-pool = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-trie-db = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-cli-commands = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-storage-api = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-basic-payload-builder = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-payload-builder-primitives = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-payload-primitives = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-revm = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-chain-state = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-errors = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-ethereum-payload-builder = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
-reth-cli-util = { git = "https://github.com/Irys-xyz/reth", rev = "5ab0d995399d0105597502988d0a25b1f2ed674c" }
+reth = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-chainspec = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-e2e-test-utils = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-engine-local = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-ethereum-engine-primitives = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-ethereum-forks = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-evm-ethereum = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-node-ethereum = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-ethereum-primitives = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-evm = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-network = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-node-api = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-node-builder = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-node-core = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-node-metrics = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-payload-builder = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-primitives-traits = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-primitives = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-rpc-eth-api = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-codecs = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-db-api = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-db = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-provider = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-tasks = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-tracing = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-transaction-pool = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-trie-db = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-cli-commands = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-storage-api = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-basic-payload-builder = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-payload-builder-primitives = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-payload-primitives = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-revm = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-chain-state = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-errors = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-ethereum-payload-builder = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
+reth-cli-util = { git = "https://github.com/Irys-xyz/reth", rev = "dce78f6ad0b694993a646d8b730407fae59da29b" }
 
 
 # just used (for local testing)


### PR DESCRIPTION
**Describe the changes**
updates our Reth fork to include changes to the compact macro to remove the restriction of "unknown types must be last" (and therefore we can't have two unknown types in the struct)
[Reth fork commit](https://github.com/Irys-xyz/reth/commit/dce78f6ad0b694993a646d8b730407fae59da29b)
