### PR TITLE
feat: add ?poa=<bool> query param to /v1/block/{...}

### DIFF
--- a/crates/api-server/src/routes/block.rs
+++ b/crates/api-server/src/routes/block.rs
@@ -13,9 +13,20 @@ use serde::{Deserialize, Serialize};
 use std::{fmt::Display, str::FromStr};
 use tokio::sync::oneshot;
 
+fn default_true() -> bool {
+    true
+}
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct GetBlockQuery {
+    #[serde(default = "default_true")]
+    poa: bool,
+}
+
 pub async fn get_block(
     state: web::Data<ApiState>,
     path: web::Path<String>,
+    query: web::Query<GetBlockQuery>,
 ) -> Result<Json<CombinedBlockHeader>, ApiError> {
     let tag_param = BlockParam::from_str(&path).map_err(|_| ApiError::ErrNoId {
         id: path.to_string(),
@@ -60,18 +71,21 @@ pub async fn get_block(
         }
         BlockParam::Hash(hash) => hash,
     };
-    get_block_by_hash(&state, block_hash).await
+    get_block_by_hash(&state, block_hash, query.poa).await
 }
 
 async fn get_block_by_hash(
     state: &web::Data<ApiState>,
     block_hash: H256,
+    with_poa: bool,
 ) -> Result<Json<CombinedBlockHeader>, ApiError> {
     let irys_header = {
         let (tx, rx) = oneshot::channel();
         state
             .mempool_service
-            .send(MempoolServiceMessage::GetBlockHeader(block_hash, true, tx))
+            .send(MempoolServiceMessage::GetBlockHeader(
+                block_hash, with_poa, tx,
+            ))
             .expect("expected send to mempool to succeed");
         let mempool_response = rx.await.map_err(|e| {
             tracing::error!("Mempool response error: {}", e);
@@ -83,7 +97,7 @@ async fn get_block_by_hash(
             Some(h) => h,
             None => state
                 .db
-                .view_eyre(|tx| block_header_by_hash(tx, &block_hash, true))
+                .view_eyre(|tx| block_header_by_hash(tx, &block_hash, with_poa))
                 .map_err(|e| {
                     tracing::error!("DB error when reading block header: {}", e);
                     ApiError::Internal {

--- a/crates/chain/tests/api/external_api.rs
+++ b/crates/chain/tests/api/external_api.rs
@@ -1,14 +1,15 @@
 //! endpoint tests
 use crate::{
     api::{
-        block_index_endpoint_request, chunk_endpoint_request, info_endpoint_request,
-        network_config_endpoint_request, peer_list_endpoint_request, version_endpoint_request,
+        block_index_endpoint_request, chunk_endpoint_request, client_request,
+        info_endpoint_request, network_config_endpoint_request, peer_list_endpoint_request,
+        version_endpoint_request,
     },
     utils::IrysNodeTest,
 };
 use actix_web::http::header::ContentType;
 use irys_testing_utils::initialize_tracing;
-use irys_types::{BlockIndexItem, NodeInfo};
+use irys_types::{BlockIndexItem, IrysBlockHeader, NodeInfo};
 use reqwest::StatusCode;
 use tracing::info;
 
@@ -99,6 +100,10 @@ async fn heavy_external_api() -> eyre::Result<()> {
             remaining.min(limit)
         }
     }
+
+    let response = client_request(&format!("{}/v1/block/1?poa=false", &address)).await;
+    let json: IrysBlockHeader = response.json().await.unwrap();
+    assert!(json.poa.chunk.is_none());
 
     // tests should check total number of json objects returned are equal to the expected number.
     for limit in 0..2 {


### PR DESCRIPTION
**Describe the changes**
Adds a query param to explicitly enable/disable PoA chunk inclusion in the returned block header.


**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Ideally, no PoA would be the default but I suspect we have a few too many callsites to make that feasible.
ideally we'd also not use query params, as they're not super cache friendly (maybe a /v1/block/full/{...} route?)
