### PR TITLE
fix: wait_for_migrated_txs

### DIFF
--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -890,7 +890,7 @@ impl IrysNodeTest<IrysNodeCtx> {
             }
         }
         Err(eyre::eyre!(
-            "Failed waiting for confirmed txs. Waited {} seconds",
+            "Failed waiting for migrated txs. Waited {} seconds",
             seconds,
         ))
     }


### PR DESCRIPTION
**Describe the changes**

Fix logical bug involving `first()` and `pop()` where `wait_for_migrated_txs()` could return before seeing all txs. Fix was followed by performance improvements.

Note that we can early return prior to mining a block, so the behaviour is slightly changed from before this PR.

 - [4e1abe8](https://github.com/Irys-xyz/irys/pull/912/commits/4e1abe8e2d75f873876a12de1ea350958e0f2d45) fix: off by one error on how many seconds we wait_for_migrated_txs
 - [aca0eb1](https://github.com/Irys-xyz/irys/pull/912/commits/aca0eb12b8b7009e43d189950fd455b16ca22106) fix: pop() with last() is correct. pop() with first() is incorrect
 - [a6eaef8](https://github.com/Irys-xyz/irys/pull/912/commits/a6eaef894300bcf35acf0387b501e27b3cc25fed) perf: scoping read lock for earlier drop
 - [b21178f](https://github.com/Irys-xyz/irys/pull/912/commits/b21178f7682682c778f8fa9dba151a4051f69aa9) perf: check all remaining transactions each iteration
 - [f8f314e](https://github.com/Irys-xyz/irys/pull/912/commits/f8f314e868a225ef9dddd8357533e8146faf6671) perf: only mine and sleep when we are waiting on further txs
 - [46cae37](https://github.com/Irys-xyz/irys/pull/912/commits/46cae3723c03631dbb62269166a3572e3be239e9) perf: Vec to HashSet for faster retain()
 - [d680370](https://github.com/Irys-xyz/irys/pull/912/commits/d680370e511ec2fc2dc9da49aa0762272131142a) chore: use self.mine_block() in favour of mine_blocks()
 - [35acc0e](https://github.com/Irys-xyz/irys/pull/912/commits/35acc0ecc888131fb7364eaea2109b93272033f9) perf: return to one read lock per iteration as we now read many txs per iteration

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.
