### PR TITLE
fix: blocks remaining guard now updated after mining stopped

### DIFF
--- a/crates/chain/tests/utils.rs
+++ b/crates/chain/tests/utils.rs
@@ -1133,12 +1133,14 @@ impl IrysNodeTest<IrysNodeCtx> {
         let _block_hash = self
             .wait_until_height(height + num_blocks as u64, 60 * num_blocks)
             .await?;
+        // stop mining immediately after reaching the correct height
+        let stop_mining_result = self.node_ctx.stop_mining();
         self.node_ctx
             .service_senders
             .block_producer
             .send(BlockProducerCommand::SetTestBlocksRemaining(None))
             .unwrap();
-        self.node_ctx.stop_mining()
+        stop_mining_result
     }
 
     pub async fn mine_blocks_without_gossip(&self, num_blocks: usize) -> eyre::Result<()> {


### PR DESCRIPTION
**Describe the changes**
The Problem: Low chance of an extra block being mined.
If a `SolutionFound` arrives after the nth block height, but before `stop_mining()` takes effect, and after the guard was cleared to `None`, the producer will accept and mine one more block.

The fix:
Stop mining first, then clear the guard

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.
