### PR TITLE
fix: bandaid on block migration

### DIFF
--- a/crates/actors/src/block_index_service.rs
+++ b/crates/actors/src/block_index_service.rs
@@ -86,9 +86,11 @@ impl BlockIndexServiceInner {
                 all_txs,
                 response,
             } => {
-                // Maintain simple ordering invariant (sequential heights)
+                // Maintain simple ordering invariant (sequential heights and consistent children)
                 if let Some((prev_height, prev_hash)) = &self.last_received_block {
-                    if block_header.height != prev_height + 1 {
+                    if block_header.height != prev_height + 1
+                        || &block_header.previous_block_hash != prev_hash
+                    {
                         let err = eyre!(
                             "Block migration out of order or with a gap: prev_height={}, prev_hash={}, current_height={}, current_hash={}",
                             prev_height,


### PR DESCRIPTION
**Describe the changes**
Before migrating a block, figure out the diff between the block we want to migrate, and the current latest migrated block - fetch enough parent blocks to fill the gap.