### PR TITLE
fix: add debug logging if we fail to get the parent block from the block tree post child block pre-validation

### DIFF
--- a/crates/domain/src/models/block_tree.rs
+++ b/crates/domain/src/models/block_tree.rs
@@ -53,9 +53,9 @@ pub struct BlockTree {
 pub struct BlockMetadata {
     // todo: wrap into Arc to avoid expensive clones
     pub block: IrysBlockHeader,
-    chain_state: ChainState,
-    timestamp: SystemTime,
-    children: HashSet<H256>,
+    pub chain_state: ChainState,
+    pub timestamp: SystemTime,
+    pub children: HashSet<H256>,
     pub epoch_snapshot: Arc<EpochSnapshot>,
     pub commitment_snapshot: Arc<CommitmentSnapshot>,
     pub ema_snapshot: Arc<EmaSnapshot>,


### PR DESCRIPTION
**Describe the changes**
adds debug logging if we fail to get the parent block from the block tree post child block pre-validation

**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
