### PR TITLE
fix: add an optional timeout to get_commitment_tx_in_parallel

### DIFF
--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -1384,7 +1384,7 @@ async fn extract_commitment_txs(
                     "only commitment ledger supported"
                 );
 
-                get_commitment_tx_in_parallel(&ledger.tx_ids.0, &service_senders.mempool, db)
+                get_commitment_tx_in_parallel(&ledger.tx_ids.0, &service_senders.mempool, db, None)
                     .await?
             }
             [] => {
@@ -1526,7 +1526,7 @@ pub async fn commitment_txs_are_valid(
 
     // Fetch all actual commitment transactions from the block
     let actual_commitments =
-        get_commitment_tx_in_parallel(block_tx_ids, &service_senders.mempool, db)
+        get_commitment_tx_in_parallel(block_tx_ids, &service_senders.mempool, db, None)
             .await
             .map_err(|e| ValidationError::CommitmentTransactionFetchFailed(e.to_string()))?;
 

--- a/crates/api-server/src/routes/tx.rs
+++ b/crates/api-server/src/routes/tx.rs
@@ -5,6 +5,7 @@ use actix_web::{
     HttpResponse, Result,
 };
 use awc::http::StatusCode;
+use irys_actors::block_discovery::DEFAULT_MEMPOOL_TX_TIMEOUT;
 use irys_actors::{
     block_discovery::{get_commitment_tx_in_parallel, get_data_tx_in_parallel},
     mempool_service::{MempoolServiceMessage, TxIngressError},
@@ -155,8 +156,13 @@ pub async fn get_transaction(
     tx_id: H256,
 ) -> Result<IrysTransactionResponse, ApiError> {
     let vec = vec![tx_id];
-    if let Ok(mut result) =
-        get_commitment_tx_in_parallel(&vec, &state.mempool_service, &state.db).await
+    if let Ok(mut result) = get_commitment_tx_in_parallel(
+        &vec,
+        &state.mempool_service,
+        &state.db,
+        Some(DEFAULT_MEMPOOL_TX_TIMEOUT),
+    )
+    .await
     {
         if let Some(tx) = result.pop() {
             return Ok(IrysTransactionResponse::Commitment(tx));


### PR DESCRIPTION
**Describe the changes**
This PR adds a timeout to `get_commitment_tx_in_parallel`. Prior to this change timeout has been mandatory, which resulted in a non-deterministic behavior in the block validation.

**Related Issue(s)**

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
