### PR TITLE
refactor: don't shut down the whole node within custom panic hook

### DIFF
--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -1360,7 +1360,7 @@ impl IrysNode {
         );
 
         // set up the vdf thread (with monitoring task)
-        let vdf_monitor_task = Self::init_vdf_thread(
+        let vdf_task = Self::init_vdf_thread(
             &config,
             vdf_shutdown_receiver,
             receivers.vdf_fast_forward,
@@ -1495,8 +1495,8 @@ impl IrysNode {
         let mut services = Vec::new();
         {
             // Services are shut down in FIFO order (first added = first to shut down)
-            // 1. VDF monitoring (shut down first to detect panics)
-            services.push(vdf_monitor_task);
+            // 1. VDF monitoring
+            services.push(vdf_task);
 
             // 2. Mining operations
             services.extend(price_oracle_handles.into_iter());

--- a/crates/chain/src/main.rs
+++ b/crates/chain/src/main.rs
@@ -1,5 +1,4 @@
 use irys_chain::{utils::load_config, IrysNode};
-use irys_testing_utils::setup_panic_hook;
 use tracing::{info, level_filters::LevelFilter};
 use tracing_error::ErrorLayer;
 use tracing_subscriber::{
@@ -40,7 +39,6 @@ async fn main() -> eyre::Result<()> {
         init_tracing().expect("initializing tracing should work");
     }
 
-    setup_panic_hook().expect("custom panic hook installation to succeed");
     reth_cli_util::sigsegv_handler::install();
     // load the config
     let config = load_config()?;

--- a/crates/chain/src/main.rs
+++ b/crates/chain/src/main.rs
@@ -1,4 +1,5 @@
 use irys_chain::{utils::load_config, IrysNode};
+use irys_testing_utils::setup_panic_hook_with_sigint;
 use tracing::{info, level_filters::LevelFilter};
 use tracing_error::ErrorLayer;
 use tracing_subscriber::{
@@ -39,6 +40,7 @@ async fn main() -> eyre::Result<()> {
         init_tracing().expect("initializing tracing should work");
     }
 
+    setup_panic_hook_with_sigint(false).expect("custom panic hook installation to succeed");
     reth_cli_util::sigsegv_handler::install();
     // load the config
     let config = load_config()?;
@@ -48,6 +50,7 @@ async fn main() -> eyre::Result<()> {
     let handle = IrysNode::new(config)?.start().await?;
     handle.start_mining()?;
     let reth_thread_handle = handle.reth_thread_handle.clone();
+
     // wait for the node to be shut down
     let shutdown_reason =
         tokio::task::spawn_blocking(|| reth_thread_handle.unwrap().join().unwrap()).await?;

--- a/crates/utils/testing-utils/src/utils.rs
+++ b/crates/utils/testing-utils/src/utils.rs
@@ -90,6 +90,10 @@ pub fn temporary_directory(name: Option<&str>, keep: bool) -> TempDir {
 }
 
 pub fn setup_panic_hook() -> eyre::Result<()> {
+    setup_panic_hook_with_sigint(true)
+}
+
+pub fn setup_panic_hook_with_sigint(trigger_sigint: bool) -> eyre::Result<()> {
     color_eyre::install()?;
 
     let original_hook = panic::take_hook();
@@ -145,10 +149,12 @@ pub fn setup_panic_hook() -> eyre::Result<()> {
 
         eprintln!("\x1b[1;31mPanic occurred, Aborting process\x1b[0m");
 
-        // Trigger SIGINT for orderly shutdown
-        let pid = unsafe { libc::getpid() };
-        unsafe {
-            libc::kill(pid, libc::SIGINT);
+        if trigger_sigint {
+            // Trigger SIGINT for orderly shutdown
+            let pid = unsafe { libc::getpid() };
+            unsafe {
+                libc::kill(pid, libc::SIGINT);
+            }
         }
     }));
 


### PR DESCRIPTION
**Describe the changes**
We have seen panics in block validatoin.
a panic in block validation task should be safe (block validation service can handle it), but it also triggers our custom panic hook which causes the node to shut down.

Fixes:
- vdf thread can be monitored & shut down as any other task
- removed custom panic hook
- fixed issue with block producer where it would panicw when no oracle data was present
