### PR TITLE
feat: super basic hash over the EMA snapshot for easy cross-node validation

### DIFF
--- a/crates/domain/src/models/block_tree.rs
+++ b/crates/domain/src/models/block_tree.rs
@@ -431,8 +431,8 @@ impl BlockTree {
             .insert(hash);
 
         debug!(
-            "adding block: max_cumulative_difficulty: {} block.cumulative_diff: {} {}, commitment_snapshot_hash: {}, epoch_snapshot_hash: {}",
-            self.max_cumulative_difficulty.0, block.cumulative_diff, block.block_hash, &commitment_snapshot.get_hash(), &epoch_snapshot.get_hash()
+            "adding block: max_cumulative_difficulty: {} block.cumulative_diff: {} {}, commitment_snapshot_hash: {}, epoch_snapshot_hash: {}, ema_snapshot_hash: {}",
+            self.max_cumulative_difficulty.0, block.cumulative_diff, block.block_hash, &commitment_snapshot.get_hash(), &epoch_snapshot.get_hash(), &ema_snapshot.get_hash()
         );
 
         if block.cumulative_diff > self.max_cumulative_difficulty.0 {

--- a/crates/domain/src/snapshots/ema_snapshot.rs
+++ b/crates/domain/src/snapshots/ema_snapshot.rs
@@ -56,7 +56,7 @@ use irys_types::{
 use std::sync::Arc;
 
 /// Snapshot of EMA-related pricing data for a specific block.
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, Hash)]
 pub struct EmaSnapshot {
     /// EMA price to use for public pricing operations (from block 2 intervals ago).
     /// This is the "stable" price that external systems and users see.
@@ -256,6 +256,17 @@ impl EmaSnapshot {
     /// Get the EMA price that should be used for public pricing.
     pub fn ema_for_public_pricing(&self) -> IrysTokenPrice {
         self.ema_price_2_intervals_ago
+    }
+
+    // NON CANONICAL HASH
+    // SHOULD BE USED FOR DEBUGGING ONLY
+    pub fn get_hash(&self) -> String {
+        use std::hash::{DefaultHasher, Hash as _, Hasher as _};
+        let mut hasher = DefaultHasher::new();
+        self.hash(&mut hasher);
+        let res = hasher.finish();
+        use base58::ToBase58 as _;
+        res.to_le_bytes().to_base58()
     }
 }
 

--- a/crates/types/src/storage_pricing.rs
+++ b/crates/types/src/storage_pricing.rs
@@ -34,7 +34,7 @@ const TAYLOR_TERMS: u32 = 30;
 ///
 /// The actual scale is defined by the usage: pr
 #[derive(
-    Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Arbitrary, Default,
+    Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Arbitrary, Default, Hash,
 )]
 pub struct Amount<T> {
     pub amount: U256,
@@ -181,7 +181,7 @@ pub mod phantoms {
     pub struct CostPerGb;
 
     /// Currency denominator util type.
-    #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+    #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Arbitrary, Hash)]
     pub struct Usd;
 
     /// Currency denominator util type.
@@ -200,7 +200,7 @@ pub mod phantoms {
     pub struct NetworkFee;
 
     /// Price of the $IRYS token.
-    #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
+    #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Arbitrary, Hash)]
     pub struct IrysPrice;
 
     /// Cost per storing 1 chunk of data. Includes adjustment for storage duration.


### PR DESCRIPTION
**Describe the changes**
Adds `Hash` derives and a `get_hash` method to the EmaSnapshot (and related types) so we can easily compare the state across nodes for debugging.
