### PR TITLE
fix: remove price validation for promoted txs

### DIFF
--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -1873,13 +1873,13 @@ pub async fn data_txs_are_valid(
         }
     }
 
-    // Step 5: Validate all transactions (including same-block promotions)
-    let all_txs = publish_txs
-        .iter()
-        .map(|tx| (tx, DataLedger::Publish))
-        .chain(submit_txs.iter().map(|tx| (tx, DataLedger::Submit)));
+    // Step 5: Validate all SUBMIT tx (including same-block promotions)
+    let all_txs = publish_txs.iter().map(|tx| (tx, DataLedger::Submit));
 
+    // DO NOT INCLUDE ANY LOGIC OTHER THAN PRICING VALIDATION HERE
+    // IT ONLY RUNS FOR NON-PROMOTED TXS
     for (tx, current_ledger) in all_txs {
+        debug_assert_eq!(current_ledger, DataLedger::Submit);
         // All data transactions must have ledger_id set to Publish
         // TODO: support other term ledgers here
         if tx.ledger_id != DataLedger::Publish as u32 {
@@ -1946,24 +1946,17 @@ pub async fn data_txs_are_valid(
             },
         )?;
 
-        match current_ledger {
-            DataLedger::Publish => {
-                // no special publish-ledger-only asserts here
-            }
-            DataLedger::Submit => {
-                // Submit ledger transactions should not have ingress proofs, that's why they are in the submit ledger
-                // (they're waiting for proofs to arrive)
-                if tx.promoted_height.is_some() {
-                    // TODO: This should be a hard error, but the test infrastructure currently
-                    // creates transactions with ingress proofs that get placed in Submit ledger.
-                    // This needs to be fixed in the block production logic to properly place
-                    // transactions with proofs in the Publish ledger.
-                    tracing::warn!(
-                        "Transaction {} in Submit ledger should not have a promoted_height",
-                        tx.id
-                    );
-                }
-            }
+        // Submit ledger transactions should not have ingress proofs, that's why they are in the submit ledger
+        // (they're waiting for proofs to arrive)
+        if tx.promoted_height.is_some() {
+            // TODO: This should be a hard error, but the test infrastructure currently
+            // creates transactions with ingress proofs that get placed in Submit ledger.
+            // This needs to be fixed in the block production logic to properly place
+            // transactions with proofs in the Publish ledger.
+            tracing::warn!(
+                "Transaction {} in Submit ledger should not have a promoted_height",
+                tx.id
+            );
         }
     }
 


### PR DESCRIPTION
**Describe the changes**
Removes price validation code for DataLedger::Publish transactions, as their price validation happened when they entered the submit ledger.

**Related Issue(s)**
Fixes the perm_fee block validation errors on testnet

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
