### PR TITLE
fix(merkle): align naming

### DIFF
--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -929,20 +929,21 @@ pub fn poa_is_valid(
         )
         .map_err(|e| PreValidationError::MerkleProofInvalid(e.to_string()))?;
 
-        if !(tx_path_result.left_bound..=tx_path_result.right_bound)
+        if !(tx_path_result.min_byte_range..=tx_path_result.max_byte_range)
             .contains(&(block_chunk_offset * (config.chunk_size as u128)))
         {
             return Err(PreValidationError::PoAChunkOffsetOutOfTxBounds);
         }
 
         let tx_chunk_offset =
-            block_chunk_offset * (config.chunk_size as u128) - tx_path_result.left_bound;
+            block_chunk_offset * (config.chunk_size as u128) - tx_path_result.min_byte_range;
 
         // data_path validation
         let data_path_result = validate_path(tx_path_result.leaf_hash, &data_path, tx_chunk_offset)
             .map_err(|e| PreValidationError::MerkleProofInvalid(e.to_string()))?;
 
-        if !(data_path_result.left_bound..=data_path_result.right_bound).contains(&tx_chunk_offset)
+        if !(data_path_result.min_byte_range..=data_path_result.max_byte_range)
+            .contains(&tx_chunk_offset)
         {
             return Err(PreValidationError::PoAChunkOffsetOutOfDataChunksBounds);
         }
@@ -965,7 +966,7 @@ pub fn poa_is_valid(
         let (poa_chunk_pad_trimmed, _) = poa_chunk.split_at(
             (config
                 .chunk_size
-                .min((data_path_result.right_bound - data_path_result.left_bound) as u64))
+                .min((data_path_result.max_byte_range - data_path_result.min_byte_range) as u64))
                 as usize,
         );
 

--- a/crates/domain/tests/storage_module_index_tests.rs
+++ b/crates/domain/tests/storage_module_index_tests.rs
@@ -150,11 +150,11 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
     let tx_path = &proof.proof;
 
     // Tx:1 - Base case, write tx index data without any overlaps
-    let num_chunks_in_tx = (proof.offset + 1) as u64 / config.consensus.chunk_size;
+    let num_chunks_in_tx = (proof.last_byte_index + 1) as u64 / config.consensus.chunk_size;
     let (tx_ledger_range, tx_partition_range) = calculate_tx_ranges(
         LedgerChunkOffset::from(0),
         &partition_0_range,
-        proof.offset as u64,
+        proof.last_byte_index as u64,
         config.consensus.chunk_size,
     );
 
@@ -180,7 +180,7 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
 
     // Tx:2 - Overlapping case, tx chunks start in one submodule and go to another
     let start_chunk_offset = LedgerChunkOffset::from(num_chunks_in_tx);
-    let bytes_in_tx = proofs[1].offset as u64 - proof.offset as u64;
+    let bytes_in_tx = proofs[1].last_byte_index as u64 - proof.last_byte_index as u64;
     let (tx_ledger_range, tx_partition_range) = calculate_tx_ranges(
         start_chunk_offset,
         &partition_0_range,
@@ -222,9 +222,9 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
     // Tx:3 - Fill up the StorageModule leaving one empty chunk
     let tx_path = &proofs[2].proof;
     let data_root = tx_headers[2].data_root;
-    let offset = proofs[2].offset as u64;
+    let last_byte_index = proofs[2].last_byte_index as u64;
     let bytes_in_tx =
-        (offset + 1) - (*(tx_ledger_range.end() + 1_u64) * config.consensus.chunk_size);
+        (last_byte_index + 1) - (*(tx_ledger_range.end() + 1_u64) * config.consensus.chunk_size);
     let data_size = tx_headers[2].data_size;
     assert_eq!(bytes_in_tx, data_size);
     let start_chunk_offset = tx_ledger_range.end() + 1_u64;
@@ -269,9 +269,9 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
     let tx_path = &proofs[3].proof;
     let data_root = tx_headers[3].data_root;
     let data_size = tx_headers[3].data_size;
-    let offset = proofs[3].offset as u64;
+    let last_byte_index = proofs[3].last_byte_index as u64;
     let bytes_in_tx =
-        (offset + 1) - (*(tx_ledger_range.end() + 1_u64) * config.consensus.chunk_size);
+        (last_byte_index + 1) - (*(tx_ledger_range.end() + 1_u64) * config.consensus.chunk_size);
     assert_eq!(bytes_in_tx, data_size);
     let start_chunk_offset = tx_ledger_range.end() + 1_u64;
     let (tx_ledger_range, tx_partition_range) = calculate_tx_ranges(
@@ -317,8 +317,9 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
     let tx_path = &proofs[4].proof;
     let data_root = tx_headers[4].data_root;
     let data_size = tx_headers[4].data_size;
-    let offset = proofs[4].offset as u64;
-    let bytes_in_tx = (offset + 1) - ((*tx_ledger_range.end() + 1) * config.consensus.chunk_size);
+    let last_byte_index = proofs[4].last_byte_index as u64;
+    let bytes_in_tx =
+        (last_byte_index + 1) - ((*tx_ledger_range.end() + 1) * config.consensus.chunk_size);
     assert_eq!(bytes_in_tx, data_size);
     let start_chunk_offset = tx_ledger_range.end() + 1_u64;
     let (tx_ledger_range, tx_partition_range) = calculate_tx_ranges(
@@ -352,7 +353,8 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
         info!("num chunks in tx: {:?}", tx.proofs.len());
         for (i, proof) in tx.proofs.iter().enumerate() {
             let chunk_bytes = Base64(
-                tx.data.clone().unwrap().0[prev_byte_offset as usize..=proof.offset].to_vec(),
+                tx.data.clone().unwrap().0[prev_byte_offset as usize..=proof.last_byte_index]
+                    .to_vec(),
             );
 
             // verify the chunk length
@@ -373,7 +375,7 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
             };
 
             let _ = db.update_eyre(|tx| cache_chunk(tx, &chunk));
-            prev_byte_offset = proof.offset as u64 + 1; // Update for next iteration
+            prev_byte_offset = proof.last_byte_index as u64 + 1; // Update for next iteration
         }
     }
 

--- a/crates/types/src/block.rs
+++ b/crates/types/src/block.rs
@@ -1292,7 +1292,7 @@ mod tests {
 
         for proof in proofs {
             let encoded_proof = Base64(proof.proof.clone());
-            validate_path(tx_root.0, &encoded_proof, proof.offset as u128).unwrap();
+            validate_path(tx_root.0, &encoded_proof, proof.last_byte_index as u128).unwrap();
         }
     }
 


### PR DESCRIPTION
**Describe the changes**

- Use min_byte_range/max_byte_range fields.
- All merkle validation code updated to use consistent byte range terminology.


**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
