### PR TITLE
fix(cache): add no eviction strategy and made default

### DIFF
--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -295,6 +295,9 @@ impl ChunkCacheService {
                     debug!("Cache within size limits, no eviction needed");
                 }
             }
+            CacheEvictionStrategy::NoEviction => {
+                debug!("No eviction strategy configured, skipping cache eviction");
+            }
         }
 
         Ok(())

--- a/crates/config/templates/mainnet_config.toml
+++ b/crates/config/templates/mainnet_config.toml
@@ -45,8 +45,7 @@ gpu_packing_batch_size = 1024
 cache_clean_lag = 2
 
 [cache.eviction_strategy]
-type = "size_based"
-max_cache_size_bytes = 10737418240 # 10 GB
+type = "no_eviction"
 
 [[oracles]]
 type = "coingecko"

--- a/crates/config/templates/testnet_config.toml
+++ b/crates/config/templates/testnet_config.toml
@@ -45,8 +45,7 @@ gpu_packing_batch_size = 1024
 cache_clean_lag = 2
 
 [cache.eviction_strategy]
-type = "size_based"
-max_cache_size_bytes = 10737418240  # 10 GB
+type = "no_eviction"
 
 [[oracles]]
 type = "coingecko"

--- a/crates/types/src/config/node.rs
+++ b/crates/types/src/config/node.rs
@@ -430,6 +430,10 @@ pub enum CacheEvictionStrategy {
         #[serde(default = "default_max_cache_size_bytes")]
         max_cache_size_bytes: u64,
     },
+
+    /// No eviction: cache data is never automatically evicted
+    /// Only data_root pruning based on expiry/inclusion will occur
+    NoEviction,
 }
 
 const fn default_max_cache_size_bytes() -> u64 {
@@ -438,9 +442,7 @@ const fn default_max_cache_size_bytes() -> u64 {
 
 impl Default for CacheEvictionStrategy {
     fn default() -> Self {
-        Self::SizeBased {
-            max_cache_size_bytes: DEFAULT_MAX_CACHE_SIZE_BYTES,
-        }
+        Self::NoEviction
     }
 }
 

--- a/docker/configs/irys-1.toml
+++ b/docker/configs/irys-1.toml
@@ -49,8 +49,7 @@ gpu_packing_batch_size = 1024
 cache_clean_lag = 2
 
 [cache.eviction_strategy]
-type = "size_based"
-max_cache_size_bytes = 10737418240  # 10 GB
+type = "no_eviction"
 
 [oracle]
 type = "mock"

--- a/docker/configs/irys-2.toml
+++ b/docker/configs/irys-2.toml
@@ -50,8 +50,7 @@ gpu_packing_batch_size = 1024
 cache_clean_lag = 2
 
 [cache.eviction_strategy]
-type = "size_based"
-max_cache_size_bytes = 10737418240  # 10 GB
+type = "no_eviction"
 
 [oracle]
 type = "mock"

--- a/docker/tests/data-sync/configs/irys-1.toml
+++ b/docker/tests/data-sync/configs/irys-1.toml
@@ -65,8 +65,7 @@ gpu_packing_batch_size = 1024
 cache_clean_lag = 2
 
 [cache.eviction_strategy]
-type = "size_based"
-max_cache_size_bytes = 10737418240  # 10 GB
+type = "no_eviction"
 
 [oracle]
 type = "mock"

--- a/docker/tests/data-sync/configs/irys-2.toml
+++ b/docker/tests/data-sync/configs/irys-2.toml
@@ -65,8 +65,7 @@ gpu_packing_batch_size = 1024
 cache_clean_lag = 2
 
 [cache.eviction_strategy]
-type = "size_based"
-max_cache_size_bytes = 10737418240  # 10 GB
+type = "no_eviction"
 
 [oracle]
 type = "mock"

--- a/docker/tests/data-sync/configs/irys-3.toml
+++ b/docker/tests/data-sync/configs/irys-3.toml
@@ -65,8 +65,7 @@ gpu_packing_batch_size = 1024
 cache_clean_lag = 2
 
 [cache.eviction_strategy]
-type = "size_based"
-max_cache_size_bytes = 10737418240  # 10 GB
+type = "no_eviction"
 
 [oracle]
 type = "mock"


### PR DESCRIPTION
**Describe the changes**
Add no eviction strategy and make it default to disable size-based eviction

**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
