### PR TITLE
docs: add a deployment guide for mainnet beta nodes

### DIFF
--- a/MAINNET_BETA.md
+++ b/MAINNET_BETA.md
@@ -1,5 +1,5 @@
+# Irys Mainnet Beta 
 _Node Deployment Guide_
-#irys-chain/specs 
 # Requirements
 High level overview of the Irys Node Software requirements
 ## Operating System


### PR DESCRIPTION
Deployment guide (markdown) for mainnet beta
