### PR TITLE
feat: derive block rewards from consensus block_time

### DIFF
--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -492,14 +492,17 @@ pub async fn prevalidate_block(
         return Err(PreValidationError::EmaMismatch);
     }
 
-    // Check valid curve price
+    let target_block_time_seconds = config.consensus.difficulty_adjustment.block_time;
+
+    // Use height * target_block_time for consistent reward curve positioning
+    let previous_block_seconds = (previous_block.height() * target_block_time_seconds) as u128;
+    let current_block_seconds = previous_block_seconds + target_block_time_seconds as u128;
+
     let reward = reward_curve
-        .reward_between(
-            // adjust ms to sec
-            previous_block.timestamp.saturating_div(1000),
-            block.timestamp.saturating_div(1000),
-        )
+        .reward_between(previous_block_seconds, current_block_seconds)
         .map_err(|e| PreValidationError::RewardCurveError(e.to_string()))?;
+
+    // Check valid curve price
     if reward.amount != block.reward_amount {
         return Err(PreValidationError::RewardMismatch {
             got: block.reward_amount,

--- a/crates/chain/tests/block_production/block_validation.rs
+++ b/crates/chain/tests/block_production/block_validation.rs
@@ -37,10 +37,8 @@ async fn heavy_test_future_block_rejection() -> Result<()> {
         fn block_reward(
             &self,
             prev_block_header: &IrysBlockHeader,
-            _current_timestamp: u128,
         ) -> eyre::Result<Amount<irys_types::storage_pricing::phantoms::Irys>> {
-            self.prod
-                .block_reward(prev_block_header, self.invalid_timestamp)
+            self.prod.block_reward(prev_block_header)
         }
 
         async fn create_evm_block(


### PR DESCRIPTION
Sampling the reward curve for inflationary rewards should be based on the `consensus.block_time` not block timestamp 
