### PR TITLE
fix: additional tx_offset validation to prevent overflows

### DIFF
--- a/crates/api-server/src/routes/post_chunk.rs
+++ b/crates/api-server/src/routes/post_chunk.rs
@@ -68,6 +68,10 @@ pub async fn post_chunk(
                     Ok(HttpResponse::build(StatusCode::BAD_REQUEST)
                         .body(format!("Invalid data_size field : {err:?}")))
                 }
+                CriticalChunkIngressError::InvalidOffset(ref msg) => {
+                    Ok(HttpResponse::build(StatusCode::BAD_REQUEST)
+                        .body(format!("Invalid tx_offset: {msg}")))
+                }
 
                 CriticalChunkIngressError::ServiceUninitialized => {
                     Ok(HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
@@ -94,6 +98,10 @@ pub async fn post_chunk(
                 AdvisoryChunkIngressError::PreHeaderOffsetExceedsCap => {
                     Ok(HttpResponse::build(StatusCode::OK)
                         .body(format!("Pre-header chunk tx_offset exceeds cap: {err:?}")))
+                }
+                AdvisoryChunkIngressError::PreHeaderInvalidOffset(ref msg) => {
+                    Ok(HttpResponse::build(StatusCode::OK)
+                        .body(format!("Pre-header chunk invalid tx_offset: {msg}")))
                 }
                 AdvisoryChunkIngressError::Other(err) => Ok(
                     HttpResponse::build(StatusCode::OK).body(format!("Internal error: {err:?}"))

--- a/crates/p2p/src/gossip_data_handler.rs
+++ b/crates/p2p/src/gossip_data_handler.rs
@@ -111,6 +111,9 @@ where
                             CriticalChunkIngressError::InvalidDataSize => Err(
                                 GossipError::InvalidData(InvalidDataError::ChunkInvalidDataSize),
                             ),
+                            CriticalChunkIngressError::InvalidOffset(msg) => Err(
+                                GossipError::InvalidData(InvalidDataError::ChunkInvalidOffset(msg)),
+                            ),
                             // ===== Internal errors
                             CriticalChunkIngressError::DatabaseError => {
                                 Err(GossipError::Internal(InternalGossipError::Database(
@@ -142,6 +145,11 @@ where
                             AdvisoryChunkIngressError::PreHeaderOffsetExceedsCap => {
                                 Err(GossipError::Advisory(AdvisoryGossipError::ChunkIngress(
                                     AdvisoryChunkIngressError::PreHeaderOffsetExceedsCap,
+                                )))
+                            }
+                            AdvisoryChunkIngressError::PreHeaderInvalidOffset(msg) => {
+                                Err(GossipError::Advisory(AdvisoryGossipError::ChunkIngress(
+                                    AdvisoryChunkIngressError::PreHeaderInvalidOffset(msg),
                                 )))
                             }
                             AdvisoryChunkIngressError::Other(other) => {

--- a/crates/p2p/src/types.rs
+++ b/crates/p2p/src/types.rs
@@ -159,6 +159,8 @@ pub enum InvalidDataError {
     ChunkInvalidChunkSize,
     #[error("Invalid chunk data size")]
     ChunkInvalidDataSize,
+    #[error("Invalid chunk tx_offset: {0}")]
+    ChunkInvalidOffset(String),
     #[error("Invalid block: {0}")]
     InvalidBlock(String),
     #[error("Invalid block signature")]


### PR DESCRIPTION
**Describe the changes**

**Before:**
Chunks with `tx_offset` values exceeding valid bounds for their `data_size` were not explicitly rejected, allowing potential overflow in byte offset calculations.

**After:**
Adds explicit bounds checking via `is_valid_offset()` and `end_byte_offset_checked()` methods. Invalid offsets are rejected early in the ingress pipeline with appropriate error types.

## Changes

### `crates/types/src/chunk.rs`
- Added `max_valid_offset(chunk_size)` method to compute the maximum valid offset for a given data_size
- Added `is_valid_offset(chunk_size)` method to validate tx_offset bounds
- Added `end_byte_offset_checked(chunk_size)` method with overflow protection (returns `Option<u64>`)
- Added rstest parameterised tests for all new validation methods

### `crates/actors/src/mempool_service/chunks.rs`
- Added `InvalidOffset(String)` variant to `CriticalChunkIngressError` for post-header validation
- Added `PreHeaderInvalidOffset(String)` variant to `AdvisoryChunkIngressError` for pre-header validation
- Pre-header chunks: validates offset against claimed data_size (advisory error, returns 200 OK)
- Post-header chunks: validates offset against confirmed data_size (critical error, returns 400)
- Added `end_byte_offset_checked()` for safe byte offset calculation

### `crates/api-server/src/routes/post_chunk.rs`
- Added handler for `CriticalChunkIngressError::InvalidOffset` returning HTTP 400
- Added handler for `AdvisoryChunkIngressError::PreHeaderInvalidOffset` returning HTTP 200

### `crates/p2p/src/gossip_data_handler.rs` & `types.rs`
- Added `ChunkInvalidOffset(String)` to `InvalidDataError` enum
- Added handlers for both critical and advisory offset errors in the gossip handler


**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
