### PR TITLE
fix(mempool): remove permanent blacklisting for unknown anchor tx

### DIFF
--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -454,9 +454,6 @@ impl Inner {
         })? {
             Some(height) => height,
             None => {
-                self.mempool_state
-                    .mark_tx_as_invalid(tx_id, format!("Unknown anchor: {}", anchor))
-                    .await;
                 return Err(TxIngressError::InvalidAnchor(anchor).into());
             }
         };
@@ -1427,9 +1424,6 @@ impl Inner {
             })? {
             Some(height) => height,
             None => {
-                self.mempool_state
-                    .mark_tx_as_invalid(tx_id, format!("Unknown anchor: {}", anchor))
-                    .await;
                 return Err(TxIngressError::InvalidAnchor(anchor));
             }
         };


### PR DESCRIPTION
**Describe the changes**
Before: Transactions with unknown anchors were permanently blacklisted, preventing re-gossip even after the anchor arrived.

After: Removes blacklisting for unknown anchors. Transactions can be re-gossiped once the anchor propagates.

**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
