### PR TITLE
fix: add genesis_timestamp == 0 guard in InitState

### DIFF
--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -395,7 +395,11 @@ impl IrysNode {
                     .fetch_genesis_from_trusted_peer(expected_genesis_hash)
                     .await;
                 let timestamp_secs = block.timestamp_secs().as_secs();
-
+                // TODO: we should enforce this
+                // assert_eq!(
+                //     timestamp_secs,
+                //     (self.config.consensus.genesis.timestamp_millis / 1000) as u64
+                // );
                 Ok((
                     block,
                     commitments,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -9,6 +9,7 @@ use irys_types::{Config, NodeConfig, H256};
 use reth_node_core::version::default_client_version;
 use reth_node_types::NodeTypesWithDBAdapter;
 use reth_provider::{providers::StaticFileProvider, ProviderFactory};
+use std::time::SystemTime;
 use std::{path::PathBuf, sync::Arc};
 use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt as _;
@@ -105,6 +106,10 @@ async fn main() -> eyre::Result<()> {
             let timestamp_secs =
                 std::time::Duration::from_millis(config.consensus.genesis.timestamp_millis as u64)
                     .as_secs();
+            if timestamp_secs == 0 {
+                panic!("GENESIS TIMESTAMP MUST BE A CONCRETE VALUE FOR INIT STATE TO WORK! current time (ms) is: {}", &SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_millis())
+            }
+            info!("Using timestamp {} (secs)", &timestamp_secs);
             let chain_spec = irys_chain_spec(
                 config.consensus.chain_id,
                 &config.consensus.reth,


### PR DESCRIPTION
**Describe the changes**

This is required as otherwise the genesis timestamp used to initialise the Reth genesis block will drift from the timestamp used to re-create it when the node launches

**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
