### PR TITLE
fix: add packing backlog task, don't debug format generate_full_chunk errors

### DIFF
--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -1726,32 +1726,34 @@ impl IrysNode {
             .filter(|sm| sm.partition_assignment().is_some())
         {
             let uninitialized = sm.get_intervals(ChunkType::Uninitialized);
-            for interval in uninitialized {
-                let sender = service_senders.packing_sender();
-                if let Ok(req) = PackingRequest::new(sm.clone(), PartitionChunkRange(interval)) {
-                    match sender.try_send(req) {
-                        Ok(()) => {}
-                        Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                            tracing::event!(
-                                target: "irys::packing",
-                                tracing::Level::WARN,
-                                storage_module.id = %sm.id,
-                                packing.interval = ?interval,
-                                "Dropping packing request due to a saturated channel"
-                            );
-                        }
-                        Err(tokio::sync::mpsc::error::TrySendError::Closed(_req)) => {
+            let sender = service_senders.packing_sender();
+            let sm = sm.clone();
+
+            debug!(
+                "SM {} has {} Uninitialized intervals",
+                &sm.id,
+                &uninitialized.len()
+            );
+            // spawn a thread per SM (as packing queues are per-partition)
+            // this is to prevent packing requests getting dropped
+            // note: once we support submodules, this will probably need to change
+            runtime_handle.spawn(async move {
+                for interval in uninitialized {
+                    if let Ok(req) = PackingRequest::new(sm.clone(), PartitionChunkRange(interval))
+                    {
+                        if let Err(e) = sender.send(req).await {
                             tracing::event!(
                                 target: "irys::packing",
                                 tracing::Level::ERROR,
                                 storage_module.id = %sm.id,
                                 packing.interval = ?interval,
-                                "Packing channel closed; failed to enqueue repacking request"
+                                "Packing channel closed - {e}; failed to enqueue repacking request"
                             );
+                            return; // assume this is unrecoverable
                         }
                     }
                 }
-            }
+            });
         }
         (controllers, handles)
     }

--- a/crates/domain/src/models/storage_module.rs
+++ b/crates/domain/src/models/storage_module.rs
@@ -1232,7 +1232,7 @@ impl StorageModule {
             // gaps in storage) and should be handled gracefully by returning None
             // rather than propagating errors up to the API layer.
             Err(err) => {
-                debug!("Unable to find chunk at ledger offset: {err:?}");
+                debug!("Unable to find chunk at ledger offset: {err}");
                 Ok(None)
             }
         }


### PR DESCRIPTION

**Describe the changes**
- Adds a thread to buffer sending the on-startup packing requests for any holes in the node's SMs. This is to prevent requests from getting discarded due to the bounded channel capacity.
- Changes the formatting type for an error log from Debug to Display to reduce it's verbosity (remove the stacktrace)

**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
