### PR TITLE
fix: reject users pd tx if he can't cover the funds

### DIFF
--- a/crates/irys-reth/src/evm.rs
+++ b/crates/irys-reth/src/evm.rs
@@ -749,10 +749,12 @@ where
                         available = %fee_payer_balance,
                         "PD transaction rejected: insufficient balance for PD fees"
                     );
-                    return Err(EVMError::Transaction(InvalidTransaction::LackOfFundForMaxFee {
-                        fee: Box::new(total_pd_fees),
-                        balance: Box::new(fee_payer_balance),
-                    }));
+                    return Err(EVMError::Transaction(
+                        InvalidTransaction::LackOfFundForMaxFee {
+                            fee: Box::new(total_pd_fees),
+                            balance: Box::new(fee_payer_balance),
+                        },
+                    ));
                 }
 
                 // Strip the PD header from calldata before executing the tx logic.


### PR DESCRIPTION
**Describe the changes**
- reject users pd tx if he can't cover the funds

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.