### PR TITLE
fix: add non-zero balance checks and moved tx ingestion to post-val

### DIFF
--- a/crates/actors/src/validation_service/active_validations.rs
+++ b/crates/actors/src/validation_service/active_validations.rs
@@ -81,6 +81,8 @@ impl PartialOrd for BlockPriorityMeta {
 #[derive(Debug)]
 pub(super) struct ConcurrentValidationResult {
     pub block_hash: BlockHash,
+    pub block: Arc<IrysBlockHeader>,
+    pub transactions: Arc<crate::block_discovery::BlockTransactions>,
     pub validation_result: ValidationResult,
 }
 
@@ -341,14 +343,17 @@ impl ValidationCoordinator {
             match &result {
                 VdfValidationResult::Valid => {
                     let block_hash = task.block.block_hash;
+                    let block = Arc::clone(&task.block);
+                    let transactions = Arc::clone(&task.transactions);
 
                     self.concurrent_tasks.spawn(
                         async move {
-                            // Execute the validation and return the result
                             let validation_result = task.execute_concurrent().await;
 
                             ConcurrentValidationResult {
                                 block_hash,
+                                block,
+                                transactions,
                                 validation_result,
                             }
                         }

--- a/crates/chain/tests/multi_node/mempool_tests.rs
+++ b/crates/chain/tests/multi_node/mempool_tests.rs
@@ -2510,7 +2510,7 @@ async fn commitment_tx_valid_higher_fee_test(
 
 #[rstest::rstest]
 #[case::stake_enough_balance(irys_types::U256::from(20000000000000000000100_u128 /* stake cost */), 1, 0)]
-#[case::stake_not_enough_balance(irys_types::U256::from(0), 0, 0)]
+#[case::stake_not_enough_balance(irys_types::U256::from(1), 0, 0)]
 #[case::pledge_15_enough_balance_for_1(
     irys_types::U256::from(20000000000000000000100_u128 /*stake cost*/ + 950000000000000000100_u128 /* pledge 1 */  ),
     2, // stake & 1 pledge

--- a/crates/p2p/src/tests/integration/mod.rs
+++ b/crates/p2p/src/tests/integration/mod.rs
@@ -279,12 +279,17 @@ async fn heavy_should_fetch_missing_transactions_for_block() -> eyre::Result<()>
     tokio::time::sleep(Duration::from_millis(3000)).await;
 
     {
-        // Check that service 2 received and processed the transactions
-        let service2_mempool_txs = fixture2.mempool_txs.read().expect("to read transactions");
+        // Check that service 2 received the block (with transactions) for validation.
+        // Note: Transactions are now ingested into mempool AFTER validation succeeds
+        // via BlockTransactionsValidated, not during block_pool processing.
+        let service2_discovery_blocks = fixture2
+            .discovery_blocks
+            .read()
+            .expect("to read discovery blocks");
         eyre::ensure!(
-            service2_mempool_txs.len() == 2,
-            "Expected 2 transactions in service 2 mempool after block processing, but found {}",
-            service2_mempool_txs.len()
+            service2_discovery_blocks.len() == 1,
+            "Expected 1 block in service 2 discovery after block processing, but found {}",
+            service2_discovery_blocks.len()
         );
     };
 


### PR DESCRIPTION
**Describe the changes**
**Before:**
Gossip transactions were ingested into the mempool in `block_pool.rs` before block validation, allowing inclusion of unfunded txs. 

**After:**
Transaction ingestion moved to post-validation via `BlockTransactionsValidated` message. Gossip path now rejects transactions from zero-balance accounts.

## Changes
- Added `BlockTransactionsValidated` message type for post-validation tx ingestion
- Added `handle_block_transactions_validated()` handler in `lifecycle.rs`
- Added `ingest_validated_commitment_tx()` and `ingest_validated_data_tx()` functions that bypass gossip-path balance checks
- Added `validate_gossip_nonzero_balance()` in `data_txs.rs` - rejects data txs from zero-balance accounts
- Added `validate_commitment_gossip_nonzero_balance()` in `commitment_txs.rs` - rejects commitment txs from zero-balance accounts
- Removed direct mempool ingestion calls (`handle_data_transaction_ingress_gossip`, `handle_commitment_transaction_ingress_gossip`)
- Added lightweight data root caching via `irys_database::cache_data_root()` before validation (required for publish tx ingress proof validation)
- Added logic in `validation_service.rs` to send `BlockTransactionsValidated` to the mempool on successful validation
- Updated `ConcurrentValidationResult` in `active_validations.rs` to include `block` and `transactions` fields

**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Reject gossip transactions from zero-balance accounts to reduce DoS risk.

* **New Features**
  * Mempool now accepts validated block transactions after block validation, decoupling ingestion from earlier block processing.

* **Improvements**
  * Cache data roots before validation and clarify separation between discovery and ingestion stages.

* **Tests**
  * Updated tests to expect ingestion after validation rather than during initial block processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->