### PR TITLE
feat: return none instead of error when reading a chunk that hasn't been written

### DIFF
--- a/crates/domain/src/models/storage_module.rs
+++ b/crates/domain/src/models/storage_module.rs
@@ -1297,7 +1297,7 @@ impl StorageModule {
                     Ok(None) => return Ok(None),
                     Err(err) => return Err(eyre::eyre!("Database read should succeed: {:?}", err)),
                 };
-     
+
                 let path_buff = Base64::from(data_path);
                 let proof = get_leaf_proof(&path_buff)?;
                 // -1 as it starts with 0


### PR DESCRIPTION
* **Refactor**
  * Reading a missing chunk no longer returns an error, but `Ok(None)` unless it's an actual database error
