### PR TITLE
docs: add docs for EVM tx gas limits

### DIFF
--- a/docs/99-reference/07-chain.md
+++ b/docs/99-reference/07-chain.md
@@ -2,4 +2,6 @@
 
 ## EVM - Gas Limit
 
-The default/target gas limit is configured as 30 million gas per block on testnet & mainnet. As the network matures, we plan to increase this target up to 60+ million gas per block. There is currently no per-transaction gas limit, the only effective gas limit is that enforced by the block.
+The default/target gas limit is configured as 30 million gas per block on testnet & mainnet.\
+As the network matures, we plan to increase this target up to 60+ million gas per block. There is currently no per-transaction gas limit, the only effective gas limit is that enforced by the block.\
+The gas limit is configured here: [crates/types/src/config/consensus.rs](../../crates/types/src/config/consensus.rs#L485)


### PR DESCRIPTION
**Describe the changes**
Adds some docs covering the EVM tx gas limit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new reference documentation describing chain configuration and EVM gas limit behavior.
  * Specified current target gas limit of 30 million gas per block on testnet and mainnet, with potential to increase to 60+ million as the network matures.
  * Clarified there is no per-transaction gas limit; the block enforces the effective gas limit.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->