### PR TITLE
fix: replace rug/gmp-mpfr-sys with pure-Rust num-bigfloat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5374,13 +5374,13 @@ dependencies = [
  "itertools 0.13.0",
  "lru 0.14.0",
  "nodit",
+ "num-bigfloat",
  "openssl",
  "proptest",
  "rand 0.8.5",
  "reth",
  "reth-db",
  "rstest",
- "rug",
  "rust_decimal",
  "rust_decimal_macros",
  "serde",
@@ -6755,6 +6755,17 @@ dependencies = [
  "num-iter",
  "num-rational",
  "num-traits",
+]
+
+[[package]]
+name = "num-bigfloat"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793a9a2afbf2b4fc1b9a47de731031b06ed362a5ede3681fbfbaeb2ad4faaa13"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+ "serde",
 ]
 
 [[package]]

--- a/crates/domain/Cargo.toml
+++ b/crates/domain/Cargo.toml
@@ -32,7 +32,7 @@ alloy-rpc-types.workspace = true
 reth.workspace = true
 serde_json.workspace = true
 toml.workspace = true
-rug = "1"
+num-bigfloat = "1"
 base58.workspace=true
 thiserror.workspace=true
 

--- a/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
+++ b/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
@@ -635,25 +635,24 @@ impl EpochSnapshot {
     /// Computes active capacity partitions available for pledges based on
     /// data partitions and scaling factor
     pub fn get_num_capacity_partitions(num_data_partitions: u64, config: &ConsensusConfig) -> u64 {
+        use num_bigfloat::BigFloat;
+
         // Every ledger needs at least one slot filled with data partitions
         let min_count = DataLedger::ALL.len() as u64 * config.num_partitions_per_slot;
         let base_count = std::cmp::max(num_data_partitions, min_count);
 
-        // Deterministic computation using rug with fixed precision and explicit rounding
-        let p: u32 = 128;
-        let base_f = rug::Float::with_val(p, base_count);
-        let log10 = rug::Float::with_val(p, base_f.log10());
-        let trunc = rug_truncate_to_3_decimals(&log10);
+        // Deterministic computation using num-bigfloat (pure Rust, ~40 decimal digits)
+        let base_f = BigFloat::from_u64(base_count);
+        let log10 = base_f.log10();
+        let trunc = bigfloat_truncate_to_3_decimals(&log10);
 
-        let scalar = rug::Float::with_val(p, config.epoch.capacity_scalar);
-        let scaled = rug::Float::with_val(p, trunc * scalar);
-        let scaled_trunc = rug_truncate_to_3_decimals(&scaled);
+        let scalar = BigFloat::from_u64(config.epoch.capacity_scalar);
+        let scaled = trunc * scalar;
+        let scaled_trunc = bigfloat_truncate_to_3_decimals(&scaled);
 
         // Deterministic ceil to integer, then convert to u64
-        let (ceil_int, _) = scaled_trunc
-            .to_integer_round(rug::float::Round::Up)
-            .expect("value must be finite (not NaN/Inf)");
-        ceil_int
+        scaled_trunc
+            .ceil()
             .to_u64()
             .expect("ceiled value must be in 0..=u64::MAX")
     }
@@ -1353,33 +1352,14 @@ fn hash_sha256(message: &[u8]) -> Result<[u8; 32], Error> {
     Ok(result)
 }
 
-/// Truncate a `rug::Float` value to exactly 3 decimal places deterministically.
+/// Truncate a `BigFloat` value to exactly 3 decimal places deterministically.
 ///
-/// Implementation details:
-/// - Uses the input's precision (`value.prec()`) to construct all intermediates,
-///   ensuring we don't accidentally lower precision during scaling.
-/// - Multiplies by 1000 to shift the third decimal place to the integer part.
-/// - Applies `Round::Down` (i.e., truncation toward negative infinity) to get the integer,
-///   which matches our previous "truncate" semantics and is deterministic across platforms.
-/// - Divides by 1000 to shift back to the original scale.
-///
-/// Why not round? We deliberately do not use rounding here because the capacity
-/// computation must be stable at 3-decimal granularity and avoid cross-platform
-/// f64 rounding/ULP differences. Truncation via MPFR (`rug`) with explicit
-/// `Round::Down` guarantees the same result on all platforms for the same input
-/// and precision.
-fn rug_truncate_to_3_decimals(value: &rug::Float) -> rug::Float {
-    // Preserve the input's precision for all intermediate calculations
-    let p = value.prec();
-
-    // Multiply by 1000 to bring 3 decimal places into the integer domain without allocating a Float
-
-    // Multiply and then truncate toward -inf to implement "truncate" semantics
-    let tmp = rug::Float::with_val(p, value * 1000);
-    let (int, _) = tmp.to_integer_round(rug::float::Round::Down).unwrap();
-
-    // Scale back down to 3-decimal fixed point
-    rug::Float::with_val(p, int) / 1000
+/// Multiplies by 1000, floors to integer, divides by 1000. Pure-Rust
+/// `num-bigfloat` (~40 decimal digits) is deterministic across all platforms.
+fn bigfloat_truncate_to_3_decimals(value: &num_bigfloat::BigFloat) -> num_bigfloat::BigFloat {
+    let thousand = num_bigfloat::BigFloat::from_u32(1000);
+    let tmp = *value * thousand;
+    tmp.floor() / thousand
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Replace `rug` (which depends on the C library `gmp-mpfr-sys`) with `num-bigfloat`, a pure-Rust arbitrary-precision float library
- Eliminates the slow C library compilation of GMP/MPFR during builds
- `num-bigfloat` provides ~40 decimal digits of precision (more than enough for the `log10` + truncate-to-3-decimals capacity calculation)
- Pure Rust = deterministic across all platforms without relying on MPFR

## Test plan
- [x] `cargo check -p irys-domain` passes
- [x] All 119 `irys-domain` tests pass
- [x] All 7 `epoch_snapshot_tests` integration tests pass
- [x] `rug` no longer appears in dependency tree (`cargo tree -p irys-domain -i rug` prints nothing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced the internal big-number arithmetic implementation to standardize deterministic floating-point calculations used for capacity estimation.
  * Truncation, rounding and ceiling behavior were reimplemented to ensure consistent, platform-independent results while preserving existing external behavior and outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->