### PR TITLE
fix: watch individual c_src files in irys-c build script

### DIFF
--- a/crates/c/build/main.rs
+++ b/crates/c/build/main.rs
@@ -6,7 +6,13 @@ fn main() {
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     let c_src = manifest_dir.join("c_src");
 
-    println!("cargo:rerun-if-changed={}", c_src.display());
+    // Watch individual files instead of the directory.
+    // Directory-level watches use mtime which can change even when rsync
+    // doesn't modify any files, triggering unnecessary full rebuilds.
+    for entry in std::fs::read_dir(&c_src).unwrap() {
+        let entry = entry.unwrap();
+        println!("cargo:rerun-if-changed={}", entry.path().display());
+    }
 
     let (lib_dir, include_dir) = build_openssl();
     let pkgconfig_dir = lib_dir.join("pkgconfig");


### PR DESCRIPTION
## Summary
- Replace directory-level `cargo:rerun-if-changed` with individual file watches in the `irys-c` build script
- The directory watch triggers on mtime changes even when no files change (e.g. rsync traversal during Docker incremental builds), causing `irys-c` to recompile and cascading a full rebuild of all 10 workspace crates
- With this fix, only `irys-chain` recompiles when only `chain.rs` changes

## Test plan
- [x] `cargo check -p irys-c` passes
- [x] `cargo clippy -p irys-c --all-targets` passes
- [x] Docker incremental build verified: editing only `chain.rs` now recompiles only `irys-chain` (confirmed via `CARGO_LOG=cargo::core::compiler::fingerprint=info`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build trigger behavior by switching from directory-level watchers to per-file watchers. This improvement reduces unnecessary full rebuilds by only triggering rebuilds when actual files are modified, resulting in faster build times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->