### PR TITLE
fix: peer id and health check naming consistency

### DIFF
--- a/crates/p2p/src/gossip_data_handler.rs
+++ b/crates/p2p/src/gossip_data_handler.rs
@@ -374,7 +374,7 @@ where
         let Some(peer_info) = self.peer_list.get_peer(&source_peer_id) else {
             // This shouldn't happen, but we still should have a safeguard just in case
             let error_msg = format!(
-                "Peer with address {} is not found in the peer list, which should never happen, as we just fetched the data from that peer (block {})",
+                "Peer with peer_id {} is not found in the peer list, which should never happen, as we just fetched the data from that peer (block {})",
                 source_peer_id, block_hash
             );
             error!("Sync task: {}", error_msg);
@@ -424,7 +424,7 @@ where
 
         let Some(peer_info) = self.peer_list.get_peer(&source_peer_id) else {
             let error_msg = format!(
-                "Peer with address {} is not found in the peer list, which should never happen, as we just fetched the data from it (block {})",
+                "Peer with peer_id {} is not found in the peer list, which should never happen, as we just fetched the data from it (block {})",
                 source_peer_id, block_hash
             );
             error!("Sync task: {}", error_msg);
@@ -751,7 +751,7 @@ where
 
         let Some(_peer_info) = self.peer_list.get_peer(&source_peer_id) else {
             let error_msg = format!(
-                "Peer with address {} is not found in the peer list, which should never happen, as we just fetched the data from that peer (block {})",
+                "Peer with peer_id {} is not found in the peer list, which should never happen, as we just fetched the data from that peer (block {})",
                 source_peer_id, block_hash
             );
             error!("Sync task: {}", error_msg);

--- a/crates/p2p/src/peer_network_service.rs
+++ b/crates/p2p/src/peer_network_service.rs
@@ -766,7 +766,7 @@ impl PeerNetworkService {
                                 last_error = Some(GossipError::PeerNetwork(
                                     PeerNetworkError::FailedToRequestData(format!(
                                         "Peer {:?} reported invalid data for request {:?}",
-                                        peer.0, data_request
+                                        peer_id, data_request
                                     )),
                                 ));
                             }
@@ -774,7 +774,7 @@ impl PeerNetworkService {
                                 last_error = Some(GossipError::PeerNetwork(
                                     PeerNetworkError::FailedToRequestData(format!(
                                         "Peer {:?} rate limited the request {:?}",
-                                        peer.0, data_request
+                                        peer_id, data_request
                                     )),
                                 ));
                             }
@@ -782,7 +782,7 @@ impl PeerNetworkService {
                                 last_error = Some(GossipError::PeerNetwork(
                                     PeerNetworkError::FailedToRequestData(format!(
                                         "Peer {:?} unable to verify our origin of request {:?}",
-                                        peer.0, data_request
+                                        peer_id, data_request
                                     )),
                                 ));
                             }
@@ -791,7 +791,7 @@ impl PeerNetworkService {
                                 last_error = Some(GossipError::PeerNetwork(
                                     PeerNetworkError::FailedToRequestData(format!(
                                         "Peer {:?} rejected data request {:?} with {:?}",
-                                        peer.0, data_request, reason
+                                        peer_id, data_request, reason
                                     )),
                                 ));
                             }
@@ -799,7 +799,7 @@ impl PeerNetworkService {
                                 last_error = Some(GossipError::PeerNetwork(
                                     PeerNetworkError::FailedToRequestData(format!(
                                         "Peer {:?} has unsupported protocol version {}",
-                                        peer.0, unsupported_version
+                                        peer_id, unsupported_version
                                     )),
                                 ));
                             }
@@ -807,7 +807,7 @@ impl PeerNetworkService {
                                 last_error = Some(GossipError::PeerNetwork(
                                     PeerNetworkError::FailedToRequestData(format!(
                                         "Peer {:?} does not support requested feature for {:?}",
-                                        peer.0, data_request
+                                        peer_id, data_request
                                     )),
                                 ));
                             }


### PR DESCRIPTION
**Describe the changes**
This PR fixes naming consistency for peer address/id and health check route

**Related Issue(s)**

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More precise error reporting for network data fetches and health checks, including clearer identification of peers when failures occur.
  * Improved handling of rejected data pulls and missing-peer cases to avoid silent failures.

* **Refactor**
  * Health checks and data requests are now protocol-version aware (V1/V2), improving compatibility across peers.
  * Peer identification is consistently shown as peer IDs in logs and diagnostics; handshake flows now trigger when required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->