### PR TITLE
fix: ask the source of the header for the block body first

### DIFF
--- a/crates/p2p/src/gossip_client.rs
+++ b/crates/p2p/src/gossip_client.rs
@@ -1173,30 +1173,73 @@ impl GossipClient {
         peer_list: &PeerList,
     ) -> Result<(IrysPeerId, Arc<BlockBody>), PeerNetworkError> {
         let data_request = GossipDataRequestV2::BlockBody(header.block_hash);
-        match self
-            .pull_data_and_update_the_score(peer, data_request, Some(header), peer_list)
-            .await
-        {
-            Ok(response) => match response {
-                GossipResponse::Accepted(Some(data)) => match data {
-                    GossipDataV2::BlockBody(body) => Ok((peer.0, body)),
-                    _ => Err(PeerNetworkError::UnexpectedData(format!(
-                        "Expected BlockBody, got {:?}",
-                        data.data_type_and_id()
-                    ))),
+        for attempt in 0..2 {
+            match self
+                .pull_data_and_update_the_score(peer, data_request.clone(), Some(header), peer_list)
+                .await
+            {
+                Ok(response) => match response {
+                    GossipResponse::Accepted(Some(data)) => match data {
+                        GossipDataV2::BlockBody(body) => return Ok((peer.0, body)),
+                        _ => {
+                            return Err(PeerNetworkError::UnexpectedData(format!(
+                                "Expected BlockBody, got {:?}",
+                                data.data_type_and_id()
+                            )))
+                        }
+                    },
+                    GossipResponse::Accepted(None) => {
+                        return Err(PeerNetworkError::FailedToRequestData(format!(
+                            "Peer {} did not have the requested block body",
+                            peer.0
+                        )))
+                    }
+                    GossipResponse::Rejected(reason) => {
+                        warn!(
+                            "Peer {:?} rejected block body request: {:?}",
+                            peer.0, reason
+                        );
+                        match reason {
+                            RejectionReason::HandshakeRequired(reason) => {
+                                warn!("Block body request requires handshake: {:?}", reason);
+                                peer_list.initiate_handshake(
+                                    peer.1.address.api,
+                                    peer.1.address.gossip,
+                                    true,
+                                );
+                                if attempt == 0 {
+                                    debug!("Waiting for handshake to complete...");
+                                    tokio::time::sleep(HANDSHAKE_WAIT_TIMEOUT).await;
+                                    continue;
+                                }
+                            }
+                            RejectionReason::GossipDisabled => {
+                                peer_list.set_is_online_by_peer_id(&peer.0, false);
+                            }
+                            RejectionReason::InvalidCredentials
+                            | RejectionReason::ProtocolMismatch => {
+                                warn!(
+                                    "Peer {:?} rejected block body request with {:?}",
+                                    peer.0, reason
+                                );
+                            }
+                            _ => {}
+                        }
+                        return Err(PeerNetworkError::FailedToRequestData(format!(
+                            "Peer {:?} rejected block body request: {:?}",
+                            peer.0, reason
+                        )));
+                    }
                 },
-                GossipResponse::Accepted(None) => Err(PeerNetworkError::FailedToRequestData(
-                    format!("Peer {} did not have the requested block body", peer.0),
-                )),
-                GossipResponse::Rejected(reason) => Err(PeerNetworkError::FailedToRequestData(
-                    format!("Peer {} rejected block body request: {:?}", peer.0, reason),
-                )),
-            },
-            Err(err) => match err {
-                GossipError::PeerNetwork(e) => Err(e),
-                other => Err(PeerNetworkError::FailedToRequestData(other.to_string())),
-            },
+                Err(err) => match err {
+                    GossipError::PeerNetwork(e) => return Err(e),
+                    other => return Err(PeerNetworkError::FailedToRequestData(other.to_string())),
+                },
+            }
         }
+        Err(PeerNetworkError::FailedToRequestData(
+            "Failed to pull block body from peer after handshake retry".to_string(),
+        ))
     }
 
     pub async fn pull_payload_from_network(

--- a/crates/p2p/src/gossip_data_handler.rs
+++ b/crates/p2p/src/gossip_data_handler.rs
@@ -1180,7 +1180,7 @@ where
         let block_hash = header.block_hash;
 
         // Try fetching from the source peer first (the peer that sent us the header)
-        if let Some(source_peer_item) = self.peer_list.peer_by_id(&source_peer_id) {
+        if let Some(source_peer_item) = self.peer_list.get_peer(&source_peer_id) {
             debug!(
                 "Trying to fetch block body for block {} height {} from source peer {}",
                 block_hash, header.height, source_peer_id
@@ -1227,6 +1227,11 @@ where
                     );
                 }
             }
+        } else {
+            debug!(
+                "Source peer {} not found in peer list, skipping source-first fetch for block {} height {}",
+                source_peer_id, block_hash, header.height
+            );
         }
 
         debug!(
@@ -1248,12 +1253,12 @@ where
                 )
                 .await
             {
-                Ok((source_peer_id, irys_block_body)) => {
+                Ok((body_source_peer, irys_block_body)) => {
                     match irys_block_body.tx_ids_match_the_header(header) {
                         Ok(true) => {
                             debug!(
                                 "Fetched block body for block {} height {} from peer {:?}",
-                                block_hash, header.height, source_peer_id
+                                block_hash, header.height, body_source_peer
                             );
                             return Ok((*irys_block_body).clone());
                         }
@@ -1267,17 +1272,17 @@ where
                                 InvalidDataError::BlockBodyTransactionsMismatch,
                             );
                             self.peer_list.decrease_peer_score_by_peer_id(
-                                &source_peer_id,
+                                &body_source_peer,
                                 ScoreDecreaseReason::BogusData(
                                     "Mismatching transactions between header and body".into(),
                                 ),
                             );
                             debug!(
                                 "Penalized peer {} for serving bad block body",
-                                source_peer_id
+                                body_source_peer
                             );
 
-                            failed_attempts.push((Some(source_peer_id), error));
+                            failed_attempts.push((Some(body_source_peer), error));
                         }
                         Err(e) => {
                             warn!(
@@ -1287,7 +1292,7 @@ where
                             let error = GossipError::Internal(InternalGossipError::Unknown(
                                 format!("Error checking block body match: {}", e),
                             ));
-                            failed_attempts.push((Some(source_peer_id), error));
+                            failed_attempts.push((Some(body_source_peer), error));
                         }
                     }
                 }


### PR DESCRIPTION
**Describe the changes**
This PR modifies block body pulling function to ask the header source first, reducing network errors

**Related Issue(s)**

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prefer fetching block bodies from the peer that provided the header, with automatic network fallback and transient-retry including handshake attempts; richer error feedback when retrieval is accepted/absent/rejected.

* **Bug Fixes**
  * Penalize peers that supply mismatching block bodies; aggregate per-attempt failures and improve logging for attempts, successes, mismatches, and final failure summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->