### PR TITLE
chore(backport): fix from master that asks the block body from the header source first

### DIFF
--- a/crates/p2p/src/gossip_client.rs
+++ b/crates/p2p/src/gossip_client.rs
@@ -1065,30 +1065,73 @@ impl GossipClient {
         peer_list: &PeerList,
     ) -> Result<(IrysPeerId, Arc<BlockBody>), PeerNetworkError> {
         let data_request = GossipDataRequestV2::BlockBody(header.block_hash);
-        match self
-            .pull_data_and_update_the_score(peer, data_request, Some(header), peer_list)
-            .await
-        {
-            Ok(response) => match response {
-                GossipResponse::Accepted(Some(data)) => match data {
-                    GossipDataV2::BlockBody(body) => Ok((peer.0, body)),
-                    _ => Err(PeerNetworkError::UnexpectedData(format!(
-                        "Expected BlockBody, got {:?}",
-                        data.data_type_and_id()
-                    ))),
+        for attempt in 0..2 {
+            match self
+                .pull_data_and_update_the_score(peer, data_request.clone(), Some(header), peer_list)
+                .await
+            {
+                Ok(response) => match response {
+                    GossipResponse::Accepted(Some(data)) => match data {
+                        GossipDataV2::BlockBody(body) => return Ok((peer.0, body)),
+                        _ => {
+                            return Err(PeerNetworkError::UnexpectedData(format!(
+                                "Expected BlockBody, got {:?}",
+                                data.data_type_and_id()
+                            )))
+                        }
+                    },
+                    GossipResponse::Accepted(None) => {
+                        return Err(PeerNetworkError::FailedToRequestData(format!(
+                            "Peer {} did not have the requested block body",
+                            peer.0
+                        )))
+                    }
+                    GossipResponse::Rejected(reason) => {
+                        warn!(
+                            "Peer {:?} rejected block body request: {:?}",
+                            peer.0, reason
+                        );
+                        match reason {
+                            RejectionReason::HandshakeRequired(reason) => {
+                                warn!("Block body request requires handshake: {:?}", reason);
+                                peer_list.initiate_handshake(
+                                    peer.1.address.api,
+                                    peer.1.address.gossip,
+                                    true,
+                                );
+                                if attempt == 0 {
+                                    debug!("Waiting for handshake to complete...");
+                                    tokio::time::sleep(HANDSHAKE_WAIT_TIMEOUT).await;
+                                    continue;
+                                }
+                            }
+                            RejectionReason::GossipDisabled => {
+                                peer_list.set_is_online_by_peer_id(&peer.0, false);
+                            }
+                            RejectionReason::InvalidCredentials
+                            | RejectionReason::ProtocolMismatch => {
+                                warn!(
+                                    "Peer {:?} rejected block body request with {:?}",
+                                    peer.0, reason
+                                );
+                            }
+                            _ => {}
+                        }
+                        return Err(PeerNetworkError::FailedToRequestData(format!(
+                            "Peer {:?} rejected block body request: {:?}",
+                            peer.0, reason
+                        )));
+                    }
                 },
-                GossipResponse::Accepted(None) => Err(PeerNetworkError::FailedToRequestData(
-                    format!("Peer {} did not have the requested block body", peer.0),
-                )),
-                GossipResponse::Rejected(reason) => Err(PeerNetworkError::FailedToRequestData(
-                    format!("Peer {} rejected block body request: {:?}", peer.0, reason),
-                )),
-            },
-            Err(err) => match err {
-                GossipError::PeerNetwork(e) => Err(e),
-                other => Err(PeerNetworkError::FailedToRequestData(other.to_string())),
-            },
+                Err(err) => match err {
+                    GossipError::PeerNetwork(e) => return Err(e),
+                    other => return Err(PeerNetworkError::FailedToRequestData(other.to_string())),
+                },
+            }
         }
+        Err(PeerNetworkError::FailedToRequestData(
+            "Failed to pull block body from peer after handshake retry".to_string(),
+        ))
     }
 
     pub async fn pull_payload_from_network(


### PR DESCRIPTION
**Describe the changes**

**Related Issue(s)**

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Protocol-version aware peer health checks and endpoint routing
  * Added block body retrieval directly from specific peers

* **Bug Fixes**
  * Improved block validation error reporting with block hash and failure reason context

* **Refactor**
  * Peer identity management moved from database to file-based storage for better initialization flow

* **Tests**
  * Enhanced block synchronization verification before validation
  * Increased timeout durations for restart stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->