### PR TITLE
chore: add gitignore for .claude/local, add CLAUDE.md instruction to read it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ emission_simulation.csv
 ecosystem.config.js
 docker/build-output/
 .worktrees/
-.claude/local
+.claude/local/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,4 +108,4 @@ Never add "Co-Authored-By" lines to commit messages.
 
 ### Local changes
 
-NOTE: all the above instructions can be overridden & added to as instructed in `./.claude/local/CLAUDE.md` - read it and follow any listed instructions before continuing.
+NOTE: all the above instructions can be overridden and added to as instructed in `./.claude/local/CLAUDE.md` - if it exists, read it and follow any listed instructions before continuing.


### PR DESCRIPTION
**Describe the changes**
gitignores .claude/local to allow for environment-specific customisations via .claude/local/CLAUDE.md


**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
lmk if anyone else has a better way to do this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to exclude local development override files from version control.

* **Documentation**
  * Added a "Local changes" section explaining how to create and follow local instruction overrides for your environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->