### PR TITLE
fix(observability): resolve Tempo span drops and local-blocks WAL loop

### DIFF
--- a/docker/observation/configs/otel-collector/config.yaml
+++ b/docker/observation/configs/otel-collector/config.yaml
@@ -26,7 +26,8 @@ connectors:
 processors:
   batch:
     timeout: 1s
-    send_batch_size: 1024
+    send_batch_size: 512
+    send_batch_max_size: 1024
 
 exporters:
   # Elasticsearch for logs - uses irys-logs index with ILM retention
@@ -49,6 +50,14 @@ exporters:
     endpoint: tempo:4317
     tls:
       insecure: true
+    retry_on_failure:
+      enabled: true
+      initial_interval: 1s
+      max_interval: 10s
+    sending_queue:
+      enabled: true
+      num_consumers: 4
+      queue_size: 500
 
   # Prometheus for metrics via remote write
   prometheusremotewrite:

--- a/docker/observation/configs/tempo/tempo.yaml
+++ b/docker/observation/configs/tempo/tempo.yaml
@@ -13,6 +13,7 @@ distributor:
       protocols:
         grpc:
           endpoint: 0.0.0.0:4317
+          max_recv_msg_size_mib: 16
         http:
           endpoint: 0.0.0.0:4318
 
@@ -53,6 +54,8 @@ metrics_generator:
     remote_write:
       - url: http://prometheus:9090/api/v1/write
         send_exemplars: true
+  traces_storage:
+    path: /var/tempo/generator/traces
 
 overrides:
   defaults:


### PR DESCRIPTION
**Describe the changes**
  Before: Tempo's 4MB gRPC limit dropped ~507k spans/30min; missing traces_storage path caused WAL init loop.
  After: 16MB gRPC limit, traces_storage path added, OTEL exporter hardened with retry/queue.


**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced trace collection with automatic retry logic and message buffering for improved reliability and data integrity.
  * Increased maximum message size capacity for gRPC communication to handle larger data payloads.
  * Added dedicated trace storage for metrics generation to improve analytics processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->