### PR TITLE
feat(bench): add additional benchmarks

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -92,7 +92,7 @@ jobs:
     runs-on: [self-hosted, misc-runner]
     needs: gate
     if: ${{ needs.gate.outputs.should-run == 'true' }}
-    timeout-minutes: 30
+    timeout-minutes: 90
     permissions:
       contents: write
       pull-requests: write

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5212,6 +5212,7 @@ dependencies = [
  "alloy-primitives",
  "arbitrary",
  "bytes",
+ "criterion",
  "eyre",
  "irys-config",
  "irys-testing-utils",
@@ -5255,6 +5256,7 @@ dependencies = [
  "assert_matches",
  "atomic-write-file",
  "base58",
+ "criterion",
  "derive_more",
  "eyre",
  "irys-config",
@@ -5289,6 +5291,7 @@ dependencies = [
 name = "irys-efficient-sampling"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "eyre",
  "irys-types",
  "openssl",
@@ -5341,6 +5344,7 @@ dependencies = [
  "actix-web",
  "async-trait",
  "bytes",
+ "criterion",
  "dashmap",
  "eyre",
  "futures",
@@ -5381,6 +5385,7 @@ dependencies = [
 name = "irys-packing"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "eyre",
  "irys-c",
  "irys-types",
@@ -5456,6 +5461,7 @@ dependencies = [
  "arbitrary",
  "borsh",
  "bytes",
+ "criterion",
  "either",
  "eyre",
  "futures",
@@ -5537,6 +5543,7 @@ name = "irys-reward-curve"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "criterion",
  "csv",
  "eyre",
  "irys-types",
@@ -5629,6 +5636,7 @@ dependencies = [
  "bytemuck",
  "bytes",
  "chrono",
+ "criterion",
  "derive_more",
  "eyre",
  "fixed-hash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5261,6 +5261,7 @@ dependencies = [
  "eyre",
  "irys-config",
  "irys-database",
+ "irys-domain",
  "irys-packing",
  "irys-reth-node-bridge",
  "irys-storage",

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -30,8 +30,21 @@ strum.workspace = true
 irys-config = { workspace = true, features = ["test-utils"] }
 test-log.workspace = true
 rand.workspace = true
+criterion.workspace = true
 proptest.workspace = true
 rstest.workspace = true
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "chunk_cache_bench"
+harness = false
+
+[[bench]]
+name = "block_index_bench"
+harness = false
+
+[[bench]]
+name = "ingress_proof_bench"
+harness = false

--- a/crates/database/benches/block_index_bench.rs
+++ b/crates/database/benches/block_index_bench.rs
@@ -1,0 +1,147 @@
+//! Benchmark: Block index insert, read, and delete operations
+//!
+//! Regression signal: insert_block_index_items_for_block per-block cost,
+//! block_index_item_by_height read latency, and delete_block_index_range
+//! rollback cost by range size.
+
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use irys_database::{
+    IrysDatabaseArgs as _, block_index_item_by_height, db::IrysDatabaseExt as _,
+    delete_block_index_range, insert_block_index_items_for_block, open_or_create_db,
+    tables::IrysTables,
+};
+use irys_testing_utils::utils::TempDirBuilder;
+use irys_types::IrysBlockHeader;
+use reth_db::{Database as _, mdbx::DatabaseArguments};
+
+fn bench_insert_block_index(c: &mut Criterion) {
+    let mut group = c.benchmark_group("block_index/insert");
+    let db_path = TempDirBuilder::new().build();
+    let db = open_or_create_db(
+        db_path.path(),
+        IrysTables::ALL,
+        DatabaseArguments::irys_testing().unwrap(),
+    )
+    .unwrap();
+
+    let mut height_counter = 0_u64;
+
+    group.bench_function(BenchmarkId::from_parameter("single_block"), |b| {
+        b.iter_batched(
+            || {
+                height_counter += 1;
+                let mut header = IrysBlockHeader::new_mock_header();
+                header.height = height_counter;
+                header.block_hash.0[0] = u8::try_from(height_counter % 256).unwrap();
+                header
+            },
+            |header| {
+                db.update(|tx| {
+                    insert_block_index_items_for_block(tx, black_box(&header)).unwrap();
+                    Ok::<(), reth_db::DatabaseError>(())
+                })
+                .unwrap()
+                .unwrap();
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+fn bench_read_block_index(c: &mut Criterion) {
+    let mut group = c.benchmark_group("block_index/read");
+
+    for count in [10_u64, 100, 1000] {
+        let db_path = TempDirBuilder::new().build();
+        let db = open_or_create_db(
+            db_path.path(),
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing().unwrap(),
+        )
+        .unwrap();
+
+        db.update(|tx| {
+            for i in 1..=count {
+                let mut header = IrysBlockHeader::new_mock_header();
+                header.height = i;
+                header.block_hash.0[0] = u8::try_from(i % 256).unwrap();
+                insert_block_index_items_for_block(tx, &header).unwrap();
+            }
+            Ok::<(), reth_db::DatabaseError>(())
+        })
+        .unwrap()
+        .unwrap();
+
+        let target_height = count / 2;
+
+        group.bench_function(
+            BenchmarkId::from_parameter(format!("{count}_blocks")),
+            |b| {
+                b.iter(|| {
+                    db.view_eyre(|tx| black_box(block_index_item_by_height(tx, &target_height)))
+                        .unwrap()
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_delete_block_index_range(c: &mut Criterion) {
+    let mut group = c.benchmark_group("block_index/delete_range");
+
+    for range_size in [10_u64, 100, 1000] {
+        group.bench_function(
+            BenchmarkId::from_parameter(format!("{range_size}_blocks")),
+            |b| {
+                b.iter_batched(
+                    || {
+                        let db_path = TempDirBuilder::new().build();
+                        let db = open_or_create_db(
+                            db_path.path(),
+                            IrysTables::ALL,
+                            DatabaseArguments::irys_testing().unwrap(),
+                        )
+                        .unwrap();
+
+                        db.update(|tx| {
+                            for i in 1..=range_size {
+                                let mut header = IrysBlockHeader::new_mock_header();
+                                header.height = i;
+                                header.block_hash.0[0] = u8::try_from(i % 256).unwrap();
+                                insert_block_index_items_for_block(tx, &header).unwrap();
+                            }
+                            Ok::<(), reth_db::DatabaseError>(())
+                        })
+                        .unwrap()
+                        .unwrap();
+
+                        (db, db_path)
+                    },
+                    |(db, _db_path)| {
+                        db.update(|tx| {
+                            delete_block_index_range(tx, black_box(1..=range_size)).unwrap();
+                            Ok::<(), reth_db::DatabaseError>(())
+                        })
+                        .unwrap()
+                        .unwrap();
+                    },
+                    criterion::BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_insert_block_index,
+    bench_read_block_index,
+    bench_delete_block_index_range,
+);
+criterion_main!(benches);

--- a/crates/database/benches/chunk_cache_bench.rs
+++ b/crates/database/benches/chunk_cache_bench.rs
@@ -1,0 +1,105 @@
+//! Benchmark: Chunk cache write and read operations
+//!
+//! Regression signal: cache_chunk_verified write throughput and
+//! cached_chunk_by_chunk_offset read latency.
+//! These run per-chunk during data ingestion and PoA mining.
+
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use irys_database::{
+    IrysDatabaseArgs as _, cache_chunk_verified, cached_chunk_by_chunk_offset,
+    db::IrysDatabaseExt as _, open_or_create_db, tables::IrysTables,
+};
+use irys_testing_utils::utils::TempDirBuilder;
+use irys_types::{Base64, DataRoot, H256, MAX_CHUNK_SIZE, TxChunkOffset, UnpackedChunk};
+use reth_db::{Database as _, mdbx::DatabaseArguments};
+
+fn make_chunk(data_root: DataRoot, offset: u32) -> UnpackedChunk {
+    let mut data = vec![0xAB_u8; MAX_CHUNK_SIZE];
+    data[0] = u8::try_from(offset % 256).unwrap();
+    UnpackedChunk {
+        data_root,
+        data_size: u64::try_from(MAX_CHUNK_SIZE).unwrap(),
+        data_path: Base64(vec![u8::try_from(offset % 256).unwrap(); 64]),
+        bytes: Base64(data),
+        tx_offset: TxChunkOffset(offset),
+    }
+}
+
+fn bench_cache_chunk_write(c: &mut Criterion) {
+    let mut group = c.benchmark_group("chunk_cache/write");
+    let db_path = TempDirBuilder::new().build();
+    let db = open_or_create_db(
+        db_path.path(),
+        IrysTables::ALL,
+        DatabaseArguments::irys_testing().unwrap(),
+    )
+    .unwrap();
+
+    let data_root = H256::from([0xCD; 32]);
+    let mut offset_counter = 0_u32;
+
+    group.bench_function(BenchmarkId::from_parameter("single_chunk"), |b| {
+        b.iter_batched(
+            || {
+                offset_counter += 1;
+                make_chunk(data_root, offset_counter)
+            },
+            |chunk| {
+                db.update(|tx| {
+                    black_box(cache_chunk_verified(tx, &chunk).unwrap());
+                    Ok::<(), reth_db::DatabaseError>(())
+                })
+                .unwrap()
+                .unwrap();
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+fn bench_cache_chunk_read(c: &mut Criterion) {
+    let mut group = c.benchmark_group("chunk_cache/read");
+
+    for count in [1_u32, 10, 100] {
+        let db_path = TempDirBuilder::new().build();
+        let db = open_or_create_db(
+            db_path.path(),
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing().unwrap(),
+        )
+        .unwrap();
+
+        let data_root = H256::from([0xCD; 32]);
+
+        db.update(|tx| {
+            for i in 0..count {
+                let chunk = make_chunk(data_root, i);
+                cache_chunk_verified(tx, &chunk).unwrap();
+            }
+            Ok::<(), reth_db::DatabaseError>(())
+        })
+        .unwrap()
+        .unwrap();
+
+        let target_offset = TxChunkOffset(0);
+
+        group.bench_function(
+            BenchmarkId::from_parameter(format!("{count}_chunks")),
+            |b| {
+                b.iter(|| {
+                    db.view_eyre(|tx| {
+                        black_box(cached_chunk_by_chunk_offset(tx, data_root, target_offset))
+                    })
+                    .unwrap()
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_cache_chunk_write, bench_cache_chunk_read);
+criterion_main!(benches);

--- a/crates/database/benches/chunk_cache_bench.rs
+++ b/crates/database/benches/chunk_cache_bench.rs
@@ -11,7 +11,7 @@ use irys_database::{
 };
 use irys_testing_utils::utils::TempDirBuilder;
 use irys_types::{Base64, DataRoot, H256, MAX_CHUNK_SIZE, TxChunkOffset, UnpackedChunk};
-use reth_db::{Database as _, mdbx::DatabaseArguments};
+use reth_db::{Database as _, mdbx::DatabaseArguments, transaction::DbTxMut as _};
 
 fn make_chunk(data_root: DataRoot, offset: u32) -> UnpackedChunk {
     let mut data = vec![0xAB_u8; MAX_CHUNK_SIZE];
@@ -37,6 +37,19 @@ fn bench_cache_chunk_write(c: &mut Criterion) {
 
     let data_root = H256::from([0xCD; 32]);
     let mut offset_counter = 0_u32;
+
+    db.update(|tx| {
+        tx.put::<irys_database::tables::CachedDataRoots>(
+            data_root,
+            irys_database::db_cache::CachedDataRoot {
+                data_size: u64::try_from(MAX_CHUNK_SIZE).unwrap(),
+                ..Default::default()
+            },
+        )?;
+        Ok::<(), reth_db::DatabaseError>(())
+    })
+    .unwrap()
+    .unwrap();
 
     group.bench_function(BenchmarkId::from_parameter("single_chunk"), |b| {
         b.iter_batched(
@@ -74,6 +87,13 @@ fn bench_cache_chunk_read(c: &mut Criterion) {
         let data_root = H256::from([0xCD; 32]);
 
         db.update(|tx| {
+            tx.put::<irys_database::tables::CachedDataRoots>(
+                data_root,
+                irys_database::db_cache::CachedDataRoot {
+                    data_size: u64::try_from(MAX_CHUNK_SIZE).unwrap(),
+                    ..Default::default()
+                },
+            )?;
             for i in 0..count {
                 let chunk = make_chunk(data_root, i);
                 cache_chunk_verified(tx, &chunk).unwrap();

--- a/crates/database/benches/ingress_proof_bench.rs
+++ b/crates/database/benches/ingress_proof_bench.rs
@@ -14,61 +14,62 @@ use reth_db::{mdbx::DatabaseArguments, transaction::DbTxMut as _};
 
 fn bench_store_ingress_proof(c: &mut Criterion) {
     let mut group = c.benchmark_group("ingress_proof/store");
+    let data_root = H256::from([0xCD; 32]);
+
+    let new_proof = IngressProof::V1(IngressProofV1 {
+        data_root,
+        proof: H256::from([0xFF; 32]),
+        ..Default::default()
+    });
 
     for num_existing in [0_u32, 1, 10] {
-        let db_path = TempDirBuilder::new().build();
-        let db = open_or_create_db(
-            db_path.path(),
-            IrysTables::ALL,
-            DatabaseArguments::irys_testing().unwrap(),
-        )
-        .unwrap();
-
-        let data_root = H256::from([0xCD; 32]);
-
-        db.update_eyre(|tx| {
-            tx.put::<irys_database::tables::CachedDataRoots>(
-                data_root,
-                irys_database::db_cache::CachedDataRoot {
-                    data_size: 256 * 1024,
-                    ..Default::default()
-                },
-            )?;
-
-            for i in 0..num_existing {
-                let existing_addr = IrysAddress::from([u8::try_from(i + 1).unwrap(); 20]);
-                let proof = IngressProof::V1(IngressProofV1 {
-                    data_root,
-                    proof: H256::from([u8::try_from(i + 1).unwrap(); 32]),
-                    ..Default::default()
-                });
-                store_external_ingress_proof_checked(tx, &proof, existing_addr)?;
-            }
-            Ok(())
-        })
-        .unwrap();
-
-        let new_proof = IngressProof::V1(IngressProofV1 {
-            data_root,
-            proof: H256::from([0xFF; 32]),
-            ..Default::default()
-        });
-
         group.bench_function(
             BenchmarkId::from_parameter(format!("{num_existing}_existing")),
             |b| {
                 b.iter_batched(
                     || {
+                        let db_path = TempDirBuilder::new().build();
+                        let db = open_or_create_db(
+                            db_path.path(),
+                            IrysTables::ALL,
+                            DatabaseArguments::irys_testing().unwrap(),
+                        )
+                        .unwrap();
+
+                        db.update_eyre(|tx| {
+                            tx.put::<irys_database::tables::CachedDataRoots>(
+                                data_root,
+                                irys_database::db_cache::CachedDataRoot {
+                                    data_size: 256 * 1024,
+                                    ..Default::default()
+                                },
+                            )?;
+
+                            for i in 0..num_existing {
+                                let existing_addr =
+                                    IrysAddress::from([u8::try_from(i + 1).unwrap(); 20]);
+                                let proof = IngressProof::V1(IngressProofV1 {
+                                    data_root,
+                                    proof: H256::from([u8::try_from(i + 1).unwrap(); 32]),
+                                    ..Default::default()
+                                });
+                                store_external_ingress_proof_checked(tx, &proof, existing_addr)?;
+                            }
+                            Ok(())
+                        })
+                        .unwrap();
+
                         let addr = IrysAddress::from([0xAB; 20]);
-                        (new_proof.clone(), addr) // clone: need owned copy per iteration
+                        (db_path, db, new_proof.clone(), addr) // clone: need owned copy per iteration
                     },
-                    |(proof, addr)| {
+                    |(db_path, db, proof, addr): (_, _, IngressProof, _)| {
+                        let _keep_alive = db_path;
                         db.update_eyre(|tx| {
                             black_box(store_external_ingress_proof_checked(tx, &proof, addr))
                         })
                         .unwrap();
                     },
-                    criterion::BatchSize::SmallInput,
+                    criterion::BatchSize::LargeInput,
                 );
             },
         );

--- a/crates/database/benches/ingress_proof_bench.rs
+++ b/crates/database/benches/ingress_proof_bench.rs
@@ -1,0 +1,81 @@
+//! Benchmark: Ingress proof store operation
+//!
+//! Regression signal: store_external_ingress_proof_checked cost per proof.
+//! Uses the delete-then-insert DupSort pattern. Per ingress proof during validation.
+
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use irys_database::{
+    IrysDatabaseArgs as _, db::IrysDatabaseExt as _, open_or_create_db,
+    store_external_ingress_proof_checked, tables::IrysTables,
+};
+use irys_testing_utils::utils::TempDirBuilder;
+use irys_types::{H256, IngressProof, IrysAddress, ingress::IngressProofV1};
+use reth_db::{mdbx::DatabaseArguments, transaction::DbTxMut as _};
+
+fn bench_store_ingress_proof(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ingress_proof/store");
+
+    for num_existing in [0_u32, 1, 10] {
+        let db_path = TempDirBuilder::new().build();
+        let db = open_or_create_db(
+            db_path.path(),
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing().unwrap(),
+        )
+        .unwrap();
+
+        let data_root = H256::from([0xCD; 32]);
+
+        db.update_eyre(|tx| {
+            tx.put::<irys_database::tables::CachedDataRoots>(
+                data_root,
+                irys_database::db_cache::CachedDataRoot {
+                    data_size: 256 * 1024,
+                    ..Default::default()
+                },
+            )?;
+
+            for i in 0..num_existing {
+                let existing_addr = IrysAddress::from([u8::try_from(i + 1).unwrap(); 20]);
+                let proof = IngressProof::V1(IngressProofV1 {
+                    data_root,
+                    proof: H256::from([u8::try_from(i + 1).unwrap(); 32]),
+                    ..Default::default()
+                });
+                store_external_ingress_proof_checked(tx, &proof, existing_addr)?;
+            }
+            Ok(())
+        })
+        .unwrap();
+
+        let new_proof = IngressProof::V1(IngressProofV1 {
+            data_root,
+            proof: H256::from([0xFF; 32]),
+            ..Default::default()
+        });
+
+        group.bench_function(
+            BenchmarkId::from_parameter(format!("{num_existing}_existing")),
+            |b| {
+                b.iter_batched(
+                    || {
+                        let addr = IrysAddress::from([0xAB; 20]);
+                        (new_proof.clone(), addr) // clone: need owned copy per iteration
+                    },
+                    |(proof, addr)| {
+                        db.update_eyre(|tx| {
+                            black_box(store_external_ingress_proof_checked(tx, &proof, addr))
+                        })
+                        .unwrap();
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_store_ingress_proof);
+criterion_main!(benches);

--- a/crates/domain/Cargo.toml
+++ b/crates/domain/Cargo.toml
@@ -45,6 +45,7 @@ rust_decimal.workspace = true
 rust_decimal_macros.workspace = true
 irys-testing-utils.workspace = true
 irys-types = { workspace = true, features = ["test-utils"] }
+irys-domain = { path = ".", features = ["test-utils"] }
 criterion.workspace = true
 
 [lints]
@@ -53,4 +54,3 @@ workspace = true
 [[bench]]
 name = "block_tree_bench"
 harness = false
-required-features = ["test-utils"]

--- a/crates/domain/Cargo.toml
+++ b/crates/domain/Cargo.toml
@@ -45,6 +45,12 @@ rust_decimal.workspace = true
 rust_decimal_macros.workspace = true
 irys-testing-utils.workspace = true
 irys-types = { workspace = true, features = ["test-utils"] }
+criterion.workspace = true
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "block_tree_bench"
+harness = false
+required-features = ["test-utils"]

--- a/crates/domain/benches/block_tree_bench.rs
+++ b/crates/domain/benches/block_tree_bench.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Arc;
 
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BatchSize, BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use irys_domain::{BlockTree, CommitmentSnapshot, dummy_ema_snapshot, dummy_epoch_snapshot};
 use irys_testing_utils::IrysBlockHeaderTestExt as _;
 use irys_types::{BlockBody, ConsensusConfig, H256, IrysBlockHeader, SealedBlock, U256};
@@ -39,7 +39,7 @@ fn seal_block(header: &mut IrysBlockHeader) -> Arc<SealedBlock> {
     Arc::new(SealedBlock::new(header.clone(), body).expect("sealing block")) // clone: SealedBlock takes ownership
 }
 
-fn build_linear_chain(depth: usize) -> (BlockTree, Vec<IrysBlockHeader>) {
+fn build_linear_chain(depth: usize) -> (BlockTree, H256) {
     let config = ConsensusConfig::testing();
     let genesis = random_block(U256::from(0));
     let mut tree = BlockTree::new(&genesis, config);
@@ -54,36 +54,41 @@ fn build_linear_chain(depth: usize) -> (BlockTree, Vec<IrysBlockHeader>) {
         .unwrap();
     tree.mark_tip(&genesis.block_hash).unwrap();
 
-    let mut blocks = vec![genesis];
+    let mut previous = genesis;
+    let mut tip_hash = previous.block_hash;
 
     for i in 1..depth {
         let mut block = extend_chain(
             random_block(U256::from(u64::try_from(i).unwrap())),
-            &blocks[i - 1],
+            &previous,
         );
         let sealed = seal_block(&mut block);
         tree.add_block(&sealed, comm.clone(), epoch.clone(), ema.clone()) // clone: Arc, cheap
             .unwrap();
-        tree.mark_tip(&block.block_hash).unwrap();
-        blocks.push(block);
+        if i < depth - 1 {
+            tree.mark_tip(&block.block_hash).unwrap();
+        }
+        tip_hash = block.block_hash;
+        previous = block;
     }
 
-    (tree, blocks)
+    (tree, tip_hash)
 }
 
 fn bench_mark_tip_linear(c: &mut Criterion) {
     let mut group = c.benchmark_group("block_tree/mark_tip");
 
     for depth in [10_usize, 100, 500] {
-        let (mut tree, blocks) = build_linear_chain(depth);
-        let tip_hash = blocks.last().unwrap().block_hash;
-
         group.bench_function(
             BenchmarkId::from_parameter(format!("{depth}_blocks")),
             |b| {
-                b.iter(|| {
-                    black_box(tree.mark_tip(&tip_hash).unwrap());
-                });
+                b.iter_batched(
+                    || build_linear_chain(depth),
+                    |(mut tree, tip_hash)| {
+                        black_box(tree.mark_tip(&tip_hash).unwrap());
+                    },
+                    BatchSize::SmallInput,
+                );
             },
         );
     }

--- a/crates/domain/benches/block_tree_bench.rs
+++ b/crates/domain/benches/block_tree_bench.rs
@@ -1,0 +1,95 @@
+//! Benchmark: BlockTree::mark_tip — fork choice and cache rebuild
+//!
+//! Regression signal: mark_tip latency by chain depth. Covers
+//! update_longest_chain_cache internally. Per received block during validation.
+
+use std::sync::Arc;
+
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use irys_domain::{BlockTree, CommitmentSnapshot, dummy_ema_snapshot, dummy_epoch_snapshot};
+use irys_testing_utils::IrysBlockHeaderTestExt as _;
+use irys_types::{BlockBody, ConsensusConfig, H256, IrysBlockHeader, SealedBlock, U256};
+
+fn random_block(cumulative_diff: U256) -> IrysBlockHeader {
+    let mut block = IrysBlockHeader::new_mock_header();
+    block.solution_hash = H256::random();
+    block.height = 0;
+    block.cumulative_diff = cumulative_diff;
+    block.test_sign();
+    block
+}
+
+fn extend_chain(
+    mut new_block: IrysBlockHeader,
+    previous_block: &IrysBlockHeader,
+) -> IrysBlockHeader {
+    new_block.previous_block_hash = previous_block.block_hash();
+    new_block.height = previous_block.height() + 1;
+    new_block.previous_cumulative_diff = previous_block.cumulative_diff;
+    new_block.test_sign();
+    new_block
+}
+
+fn seal_block(header: &mut IrysBlockHeader) -> Arc<SealedBlock> {
+    header.ensure_test_signed();
+    let body = BlockBody {
+        block_hash: header.block_hash,
+        ..Default::default()
+    };
+    Arc::new(SealedBlock::new(header.clone(), body).expect("sealing block")) // clone: SealedBlock takes ownership
+}
+
+fn build_linear_chain(depth: usize) -> (BlockTree, Vec<IrysBlockHeader>) {
+    let config = ConsensusConfig::testing();
+    let genesis = random_block(U256::from(0));
+    let mut tree = BlockTree::new(&genesis, config);
+
+    let comm = Arc::new(CommitmentSnapshot::default());
+    let ema = dummy_ema_snapshot();
+    let epoch = dummy_epoch_snapshot();
+
+    let mut sealed_genesis = genesis.clone(); // clone: need owned copy for seal_block
+    let sealed = seal_block(&mut sealed_genesis);
+    tree.add_block(&sealed, comm.clone(), epoch.clone(), ema.clone()) // clone: Arc, cheap
+        .unwrap();
+    tree.mark_tip(&genesis.block_hash).unwrap();
+
+    let mut blocks = vec![genesis];
+
+    for i in 1..depth {
+        let mut block = extend_chain(
+            random_block(U256::from(u64::try_from(i).unwrap())),
+            &blocks[i - 1],
+        );
+        let sealed = seal_block(&mut block);
+        tree.add_block(&sealed, comm.clone(), epoch.clone(), ema.clone()) // clone: Arc, cheap
+            .unwrap();
+        tree.mark_tip(&block.block_hash).unwrap();
+        blocks.push(block);
+    }
+
+    (tree, blocks)
+}
+
+fn bench_mark_tip_linear(c: &mut Criterion) {
+    let mut group = c.benchmark_group("block_tree/mark_tip");
+
+    for depth in [10_usize, 100, 500] {
+        let (mut tree, blocks) = build_linear_chain(depth);
+        let tip_hash = blocks.last().unwrap().block_hash;
+
+        group.bench_function(
+            BenchmarkId::from_parameter(format!("{depth}_blocks")),
+            |b| {
+                b.iter(|| {
+                    black_box(tree.mark_tip(&tip_hash).unwrap());
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_mark_tip_linear);
+criterion_main!(benches);

--- a/crates/efficient-sampling/Cargo.toml
+++ b/crates/efficient-sampling/Cargo.toml
@@ -12,8 +12,13 @@ tracing.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true
+criterion.workspace = true
 proptest.workspace = true
 test-log.workspace = true
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "sampling_bench"
+harness = false

--- a/crates/efficient-sampling/benches/sampling_bench.rs
+++ b/crates/efficient-sampling/benches/sampling_bench.rs
@@ -34,7 +34,7 @@ fn bench_next_recall_range(c: &mut Criterion) {
             BenchmarkId::from_parameter(format!("{num_ranges}_ranges")),
             |b| {
                 b.iter_batched(
-                    || Ranges::new(num_ranges),
+                    || Ranges::new(num_ranges).expect("ranges"),
                     |mut ranges| ranges.next_recall_range(1, &seeds[0], &partition_hash),
                     criterion::BatchSize::SmallInput,
                 );
@@ -54,7 +54,7 @@ fn bench_reconstruct(c: &mut Criterion) {
 
         group.bench_function(BenchmarkId::from_parameter(format!("gap_{gap}")), |b| {
             b.iter_batched(
-                || Ranges::new(64_840),
+                || Ranges::new(64_840).expect("ranges"),
                 |mut ranges| ranges.reconstruct(&step_seeds, &partition_hash),
                 criterion::BatchSize::SmallInput,
             );
@@ -71,8 +71,10 @@ fn bench_recall_range_is_valid(c: &mut Criterion) {
         let seeds = make_seeds(num_steps);
         let step_seeds = H256List(seeds);
 
-        let mut ranges = Ranges::new(64_840);
-        ranges.reconstruct(&step_seeds, &partition_hash);
+        let mut ranges = Ranges::new(64_840).expect("ranges");
+        ranges
+            .reconstruct(&step_seeds, &partition_hash)
+            .expect("reconstruct");
         let expected_range = ranges.get_last_recall_range().unwrap();
 
         group.bench_function(

--- a/crates/efficient-sampling/benches/sampling_bench.rs
+++ b/crates/efficient-sampling/benches/sampling_bench.rs
@@ -1,0 +1,101 @@
+//! Benchmark: Efficient sampling — recall range computation
+//!
+//! Regression signal: next_recall_range per-step cost, reconstruct cost
+//! by step gap, and recall_range_is_valid validation cost.
+//! These are on the mining critical path and have zero existing benchmarks.
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use irys_efficient_sampling::{Ranges, recall_range_is_valid};
+use irys_types::{H256, H256List};
+
+fn fixed_partition_hash() -> H256 {
+    H256::from([0xCD; 32])
+}
+
+fn make_seeds(count: usize) -> Vec<H256> {
+    (0..count)
+        .map(|i| {
+            let mut bytes = [0_u8; 32];
+            bytes[0] = u8::try_from(i % 256).unwrap();
+            bytes[1] = u8::try_from((i >> 8) % 256).unwrap();
+            bytes[2] = u8::try_from((i >> 16) % 256).unwrap();
+            H256::from(bytes)
+        })
+        .collect()
+}
+
+fn bench_next_recall_range(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sampling/next_recall_range");
+    let partition_hash = fixed_partition_hash();
+    let seeds = make_seeds(1);
+
+    for num_ranges in [10_usize, 100, 64_840] {
+        group.bench_function(
+            BenchmarkId::from_parameter(format!("{num_ranges}_ranges")),
+            |b| {
+                b.iter_batched(
+                    || Ranges::new(num_ranges),
+                    |mut ranges| {
+                        ranges.next_recall_range(1, &seeds[0], &partition_hash);
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_reconstruct(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sampling/reconstruct");
+    let partition_hash = fixed_partition_hash();
+
+    for gap in [1_usize, 10, 100, 1000] {
+        let seeds = make_seeds(gap);
+        let step_seeds = H256List(seeds);
+
+        group.bench_function(BenchmarkId::from_parameter(format!("gap_{gap}")), |b| {
+            b.iter_batched(
+                || Ranges::new(64_840),
+                |mut ranges| {
+                    ranges.reconstruct(&step_seeds, &partition_hash);
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+fn bench_recall_range_is_valid(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sampling/recall_range_is_valid");
+    let partition_hash = fixed_partition_hash();
+
+    for num_steps in [1_usize, 10, 100] {
+        let seeds = make_seeds(num_steps);
+        let step_seeds = H256List(seeds);
+
+        let mut ranges = Ranges::new(64_840);
+        ranges.reconstruct(&step_seeds, &partition_hash);
+        let expected_range = ranges.get_last_recall_range().unwrap();
+
+        group.bench_function(
+            BenchmarkId::from_parameter(format!("{num_steps}_steps")),
+            |b| {
+                b.iter(|| {
+                    recall_range_is_valid(expected_range, 64_840, &step_seeds, &partition_hash)
+                        .expect("valid range")
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_next_recall_range,
+    bench_reconstruct,
+    bench_recall_range_is_valid,
+);
+criterion_main!(benches);

--- a/crates/efficient-sampling/benches/sampling_bench.rs
+++ b/crates/efficient-sampling/benches/sampling_bench.rs
@@ -35,9 +35,7 @@ fn bench_next_recall_range(c: &mut Criterion) {
             |b| {
                 b.iter_batched(
                     || Ranges::new(num_ranges),
-                    |mut ranges| {
-                        ranges.next_recall_range(1, &seeds[0], &partition_hash);
-                    },
+                    |mut ranges| ranges.next_recall_range(1, &seeds[0], &partition_hash),
                     criterion::BatchSize::SmallInput,
                 );
             },
@@ -57,9 +55,7 @@ fn bench_reconstruct(c: &mut Criterion) {
         group.bench_function(BenchmarkId::from_parameter(format!("gap_{gap}")), |b| {
             b.iter_batched(
                 || Ranges::new(64_840),
-                |mut ranges| {
-                    ranges.reconstruct(&step_seeds, &partition_hash);
-                },
+                |mut ranges| ranges.reconstruct(&step_seeds, &partition_hash),
                 criterion::BatchSize::SmallInput,
             );
         });

--- a/crates/irys-reth/Cargo.toml
+++ b/crates/irys-reth/Cargo.toml
@@ -70,9 +70,14 @@ futures.workspace = true
 alloy-signer-local.workspace = true
 reth-db = { workspace = true, features = ["test-utils"] }
 alloy-rpc-types-trace.workspace = true
+criterion.workspace = true
 
 [features]
 test-utils = ["reth-e2e-test-utils"]
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "shadow_tx_bench"
+harness = false

--- a/crates/irys-reth/benches/shadow_tx_bench.rs
+++ b/crates/irys-reth/benches/shadow_tx_bench.rs
@@ -1,0 +1,81 @@
+//! Benchmark: Shadow transaction encoding and decoding
+//!
+//! Regression signal: Borsh serialization throughput for protocol actions.
+//! Encode runs 1-20x per block; decode runs per tx during EVM execution.
+//! detect_and_decode fast-reject must be near-zero for non-shadow txs.
+
+use alloy_primitives::{Address, FixedBytes, U256};
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use irys_reth::shadow_tx::{
+    BlockRewardIncrement, SHADOW_TX_DESTINATION_ADDR, ShadowTransaction, TransactionPacket,
+    detect_and_decode_from_parts, encode_prefixed_input, try_decode_prefixed,
+};
+
+fn make_block_reward_tx() -> ShadowTransaction {
+    ShadowTransaction::V1 {
+        packet: TransactionPacket::BlockReward(BlockRewardIncrement {
+            amount: U256::from(1_000_000_u64),
+        }),
+        solution_hash: FixedBytes::from([0xAB; 32]),
+    }
+}
+
+fn bench_encode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("shadow_tx/encode");
+    let tx = make_block_reward_tx();
+
+    group.bench_function(BenchmarkId::from_parameter("BlockReward"), |b| {
+        b.iter(|| black_box(encode_prefixed_input(&tx)));
+    });
+
+    group.finish();
+}
+
+fn bench_decode_roundtrip(c: &mut Criterion) {
+    let mut group = c.benchmark_group("shadow_tx/decode");
+    let tx = make_block_reward_tx();
+    let encoded = encode_prefixed_input(&tx);
+
+    group.bench_function(BenchmarkId::from_parameter("BlockReward"), |b| {
+        b.iter(|| black_box(try_decode_prefixed(&encoded).expect("decode")));
+    });
+
+    group.finish();
+}
+
+fn bench_detect_and_decode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("shadow_tx/detect_and_decode");
+    let tx = make_block_reward_tx();
+    let encoded = encode_prefixed_input(&tx);
+    let shadow_addr = Some(*SHADOW_TX_DESTINATION_ADDR);
+
+    group.bench_function(BenchmarkId::from_parameter("shadow_tx"), |b| {
+        b.iter(|| {
+            black_box(
+                detect_and_decode_from_parts(shadow_addr, &encoded)
+                    .expect("decode")
+                    .expect("should be Some for shadow tx"),
+            )
+        });
+    });
+
+    let non_shadow_addr = Some(Address::from([0x01; 20]));
+    group.bench_function(BenchmarkId::from_parameter("non_shadow_reject"), |b| {
+        b.iter(|| black_box(detect_and_decode_from_parts(non_shadow_addr, &encoded)));
+    });
+
+    let non_shadow_data = vec![0_u8; 100];
+    group.bench_function(BenchmarkId::from_parameter("no_prefix_reject"), |b| {
+        b.iter(|| black_box(detect_and_decode_from_parts(shadow_addr, &non_shadow_data)));
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_encode,
+    bench_decode_roundtrip,
+    bench_detect_and_decode
+);
+criterion_main!(benches);

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -47,8 +47,13 @@ async-trait = "0.1"
 proptest.workspace = true
 rstest.workspace = true
 syn.workspace = true
+criterion.workspace = true
 tempfile.workspace = true
 test-log.workspace = true
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "p2p_bench"
+harness = false

--- a/crates/p2p/benches/p2p_bench.rs
+++ b/crates/p2p/benches/p2p_bench.rs
@@ -16,29 +16,33 @@ use irys_types::{
 
 fn bench_check_request(c: &mut Criterion) {
     let mut group = c.benchmark_group("p2p/check_request");
-    let tracker = DataRequestTracker::new();
-
-    let peer = IrysPeerId::from(IrysAddress::from([0x01; 20]));
     let dedup_window_ms: u128 = 10;
+    let peer = IrysPeerId::from(IrysAddress::from([0x01; 20]));
 
     group.bench_function(BenchmarkId::from_parameter("first_request"), |b| {
         b.iter_batched(
             || {
+                let tracker = DataRequestTracker::new();
                 let mut addr_bytes = [0_u8; 20];
                 addr_bytes.copy_from_slice(&H256::random().0[..20]);
-                IrysPeerId::from(IrysAddress::from(addr_bytes))
+                let fresh_peer = IrysPeerId::from(IrysAddress::from(addr_bytes));
+                (tracker, fresh_peer)
             },
-            |fresh_peer| {
-                black_box(tracker.check_request(&fresh_peer, dedup_window_ms));
-            },
+            |(tracker, fresh_peer)| black_box(tracker.check_request(&fresh_peer, dedup_window_ms)),
             criterion::BatchSize::SmallInput,
         );
     });
 
     group.bench_function(BenchmarkId::from_parameter("repeat_request"), |b| {
-        b.iter(|| {
-            black_box(tracker.check_request(&peer, dedup_window_ms));
-        });
+        b.iter_batched(
+            || {
+                let tracker = DataRequestTracker::new();
+                tracker.check_request(&peer, dedup_window_ms);
+                tracker
+            },
+            |tracker| black_box(tracker.check_request(&peer, dedup_window_ms)),
+            criterion::BatchSize::SmallInput,
+        );
     });
 
     group.finish();

--- a/crates/p2p/benches/p2p_bench.rs
+++ b/crates/p2p/benches/p2p_bench.rs
@@ -1,0 +1,91 @@
+//! Benchmark: P2P rate limiting and gossip serialisation
+//!
+//! Regression signal: check_request per-request cost (DashMap + sliding window),
+//! pre_serialize_for_broadcast per-payload JSON serialisation cost.
+//! check_request runs per P2P data request; pre_serialize amortises across peers.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use irys_p2p::{DataRequestTracker, GossipClient};
+use irys_types::v2::GossipDataV2;
+use irys_types::{
+    Base64, BlockBody, H256, IrysAddress, IrysBlockHeader, IrysPeerId, TxChunkOffset, UnpackedChunk,
+};
+
+fn bench_check_request(c: &mut Criterion) {
+    let mut group = c.benchmark_group("p2p/check_request");
+    let tracker = DataRequestTracker::new();
+
+    let peer = IrysPeerId::from(IrysAddress::from([0x01; 20]));
+    let dedup_window_ms: u128 = 10;
+
+    group.bench_function(BenchmarkId::from_parameter("first_request"), |b| {
+        b.iter_batched(
+            || {
+                let mut addr_bytes = [0_u8; 20];
+                addr_bytes.copy_from_slice(&H256::random().0[..20]);
+                IrysPeerId::from(IrysAddress::from(addr_bytes))
+            },
+            |fresh_peer| {
+                black_box(tracker.check_request(&fresh_peer, dedup_window_ms));
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function(BenchmarkId::from_parameter("repeat_request"), |b| {
+        b.iter(|| {
+            black_box(tracker.check_request(&peer, dedup_window_ms));
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_pre_serialize(c: &mut Criterion) {
+    let mut group = c.benchmark_group("p2p/pre_serialize");
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let handle = rt.handle().clone(); // clone: Handle is cheap (Arc internally)
+
+    let mining_address = IrysAddress::from([0xAB; 20]);
+    let peer_id = IrysPeerId::from(mining_address);
+    let client = GossipClient::new(Duration::from_secs(5), mining_address, peer_id, handle);
+
+    let chunk = GossipDataV2::Chunk(Arc::new(UnpackedChunk {
+        data_root: H256::from([0xCD; 32]),
+        data_size: 256 * 1024,
+        data_path: Base64(vec![0_u8; 64]),
+        bytes: Base64(vec![0xAB_u8; 256 * 1024]),
+        tx_offset: TxChunkOffset(0),
+    }));
+
+    let block_header = GossipDataV2::BlockHeader(Arc::new(IrysBlockHeader::new_mock_header()));
+
+    let block_body = GossipDataV2::BlockBody(Arc::new(BlockBody::default()));
+
+    group.bench_function(BenchmarkId::from_parameter("chunk_256KB"), |b| {
+        b.iter(|| {
+            black_box(client.pre_serialize_for_broadcast(&chunk));
+        });
+    });
+
+    group.bench_function(BenchmarkId::from_parameter("block_header"), |b| {
+        b.iter(|| {
+            black_box(client.pre_serialize_for_broadcast(&block_header));
+        });
+    });
+
+    group.bench_function(BenchmarkId::from_parameter("block_body"), |b| {
+        b.iter(|| {
+            black_box(client.pre_serialize_for_broadcast(&block_body));
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_check_request, bench_pre_serialize);
+criterion_main!(benches);

--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -30,5 +30,6 @@ pub use gossip_service::ServiceHandleWithShutdownSignal;
 pub use gossip_service::spawn_p2p_server_watcher_task;
 pub use irys_vdf::vdf_utils::fast_forward_vdf_steps_from_block;
 pub use peer_network_service::{PeerListServiceError, spawn_peer_network_service};
+pub use rate_limiting::DataRequestTracker;
 pub use server::GossipServer;
 pub use types::{GossipError, GossipResponse, GossipResult, GossipRoutes, RejectionReason};

--- a/crates/packing/Cargo.toml
+++ b/crates/packing/Cargo.toml
@@ -22,6 +22,7 @@ eyre.workspace = true
 
 [dev-dependencies]
 irys-types = { workspace = true, features = ["test-utils"] }
+criterion.workspace = true
 proptest.workspace = true
 rstest.workspace = true
 serde_json.workspace = true
@@ -32,3 +33,7 @@ nvidia = ["irys-c/nvidia"]
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "packing_bench"
+harness = false

--- a/crates/packing/benches/packing_bench.rs
+++ b/crates/packing/benches/packing_bench.rs
@@ -85,22 +85,25 @@ fn bench_entropy_rust_vs_c(c: &mut Criterion) {
     {
         let mut group = c.benchmark_group("packing/entropy_rust");
         for tier in &tiers {
-            let mut entropy = Vec::with_capacity(CHUNK_SIZE);
             group.sample_size(tier.sample_size);
             group.measurement_time(tier.measurement_time);
             group.throughput(Throughput::Bytes(CHUNK_SIZE_U64));
             group.bench_function(BenchmarkId::from_parameter(tier.name), |b| {
-                b.iter(|| {
-                    capacity_single::compute_entropy_chunk(
-                        mining_address,
-                        chunk_offset,
-                        partition_hash_bytes.0,
-                        tier.iterations,
-                        CHUNK_SIZE,
-                        &mut entropy,
-                        tier.chain_id,
-                    );
-                });
+                b.iter_batched(
+                    || Vec::with_capacity(CHUNK_SIZE),
+                    |mut entropy| {
+                        capacity_single::compute_entropy_chunk(
+                            mining_address,
+                            chunk_offset,
+                            partition_hash_bytes.0,
+                            tier.iterations,
+                            CHUNK_SIZE,
+                            &mut entropy,
+                            tier.chain_id,
+                        );
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
             });
         }
         group.finish();
@@ -110,21 +113,24 @@ fn bench_entropy_rust_vs_c(c: &mut Criterion) {
     {
         let mut group = c.benchmark_group("packing/entropy_c");
         for tier in &tiers {
-            let mut entropy = Vec::with_capacity(CHUNK_SIZE);
             group.sample_size(tier.sample_size);
             group.measurement_time(tier.measurement_time);
             group.throughput(Throughput::Bytes(CHUNK_SIZE_U64));
             group.bench_function(BenchmarkId::from_parameter(tier.name), |b| {
-                b.iter(|| {
-                    capacity_pack_range_c(
-                        mining_address,
-                        chunk_offset,
-                        partition_hash,
-                        &mut entropy,
-                        tier.iterations,
-                        tier.chain_id,
-                    );
-                });
+                b.iter_batched(
+                    || Vec::with_capacity(CHUNK_SIZE),
+                    |mut entropy| {
+                        capacity_pack_range_c(
+                            mining_address,
+                            chunk_offset,
+                            partition_hash,
+                            &mut entropy,
+                            tier.iterations,
+                            tier.chain_id,
+                        );
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
             });
         }
         group.finish();

--- a/crates/packing/benches/packing_bench.rs
+++ b/crates/packing/benches/packing_bench.rs
@@ -24,19 +24,11 @@ struct PackingTier {
     measurement_time: Duration,
 }
 
-fn build_packing_tiers() -> [PackingTier; 3] {
-    let testing = ConsensusConfig::testing();
+fn build_packing_tiers() -> [PackingTier; 2] {
     let testnet = ConsensusConfig::testnet();
     let mainnet = ConsensusConfig::mainnet();
 
     [
-        PackingTier {
-            name: "testing",
-            iterations: testing.entropy_packing_iterations,
-            chain_id: testing.chain_id,
-            sample_size: 100,
-            measurement_time: Duration::from_secs(5),
-        },
         PackingTier {
             name: "testnet",
             iterations: testnet.entropy_packing_iterations,

--- a/crates/packing/benches/packing_bench.rs
+++ b/crates/packing/benches/packing_bench.rs
@@ -1,0 +1,226 @@
+//! Benchmark: Packing operations — XOR, entropy generation, Rust vs C
+//!
+//! Regression signal: XOR throughput (SIMD vectorization), entropy generation
+//! cost per chunk, and Rust vs C implementation comparison.
+//! Packing runs per-chunk during storage initialization and mining.
+
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use irys_packing::{
+    capacity_pack_range_c, capacity_pack_range_with_data, capacity_pack_range_with_data_c,
+    capacity_single, packing_xor_vec_u8, xor_vec_u8_arrays_in_place,
+};
+use irys_types::{ConsensusConfig, H256, IrysAddress};
+
+const CHUNK_SIZE_U64: u64 = 256 * 1024;
+const CHUNK_SIZE: usize = CHUNK_SIZE_U64 as usize;
+
+struct PackingTier {
+    name: &'static str,
+    iterations: u32,
+    chain_id: u64,
+    sample_size: usize,
+    measurement_time: Duration,
+}
+
+fn build_packing_tiers() -> [PackingTier; 3] {
+    let testing = ConsensusConfig::testing();
+    let testnet = ConsensusConfig::testnet();
+    let mainnet = ConsensusConfig::mainnet();
+
+    [
+        PackingTier {
+            name: "testing",
+            iterations: testing.entropy_packing_iterations,
+            chain_id: testing.chain_id,
+            sample_size: 100,
+            measurement_time: Duration::from_secs(5),
+        },
+        PackingTier {
+            name: "testnet",
+            iterations: testnet.entropy_packing_iterations,
+            chain_id: testnet.chain_id,
+            sample_size: 10,
+            measurement_time: Duration::from_secs(30),
+        },
+        PackingTier {
+            name: "mainnet",
+            iterations: mainnet.entropy_packing_iterations,
+            chain_id: mainnet.chain_id,
+            sample_size: 10,
+            measurement_time: Duration::from_secs(60),
+        },
+    ]
+}
+
+fn bench_xor_in_place(c: &mut Criterion) {
+    let mut group = c.benchmark_group("packing/xor_in_place");
+    let mut a = vec![0xAA_u8; CHUNK_SIZE];
+    let b = vec![0x55_u8; CHUNK_SIZE];
+
+    group.throughput(Throughput::Bytes(CHUNK_SIZE_U64));
+    group.bench_function(BenchmarkId::from_parameter("256KB"), |bench| {
+        bench.iter(|| {
+            xor_vec_u8_arrays_in_place(&mut a, &b);
+        });
+    });
+    group.finish();
+}
+
+fn bench_packing_xor_owned(c: &mut Criterion) {
+    let mut group = c.benchmark_group("packing/xor_owned");
+    let data = vec![0x55_u8; CHUNK_SIZE];
+
+    group.throughput(Throughput::Bytes(CHUNK_SIZE_U64));
+    group.bench_function(BenchmarkId::from_parameter("256KB"), |bench| {
+        bench.iter(|| {
+            let entropy = vec![0xAA_u8; CHUNK_SIZE];
+            black_box(packing_xor_vec_u8(entropy, &data))
+        });
+    });
+    group.finish();
+}
+
+fn bench_entropy_rust_vs_c(c: &mut Criterion) {
+    let tiers = build_packing_tiers();
+    let mining_address = IrysAddress::from([0xAB; 20]);
+    let partition_hash_bytes = H256::from([0xCD; 32]);
+    let partition_hash = partition_hash_bytes;
+    let chunk_offset: u64 = 0;
+
+    // Rust implementation
+    {
+        let mut group = c.benchmark_group("packing/entropy_rust");
+        for tier in &tiers {
+            let mut entropy = Vec::with_capacity(CHUNK_SIZE);
+            group.sample_size(tier.sample_size);
+            group.measurement_time(tier.measurement_time);
+            group.throughput(Throughput::Bytes(CHUNK_SIZE_U64));
+            group.bench_function(BenchmarkId::from_parameter(tier.name), |b| {
+                b.iter(|| {
+                    capacity_single::compute_entropy_chunk(
+                        mining_address,
+                        chunk_offset,
+                        partition_hash_bytes.0,
+                        tier.iterations,
+                        CHUNK_SIZE,
+                        &mut entropy,
+                        tier.chain_id,
+                    );
+                });
+            });
+        }
+        group.finish();
+    }
+
+    // C implementation
+    {
+        let mut group = c.benchmark_group("packing/entropy_c");
+        for tier in &tiers {
+            let mut entropy = Vec::with_capacity(CHUNK_SIZE);
+            group.sample_size(tier.sample_size);
+            group.measurement_time(tier.measurement_time);
+            group.throughput(Throughput::Bytes(CHUNK_SIZE_U64));
+            group.bench_function(BenchmarkId::from_parameter(tier.name), |b| {
+                b.iter(|| {
+                    capacity_pack_range_c(
+                        mining_address,
+                        chunk_offset,
+                        partition_hash,
+                        &mut entropy,
+                        tier.iterations,
+                        tier.chain_id,
+                    );
+                });
+            });
+        }
+        group.finish();
+    }
+}
+
+fn bench_batch_pack(c: &mut Criterion) {
+    let tiers = build_packing_tiers();
+    let mining_address = IrysAddress::from([0xAB; 20]);
+    let partition_hash_bytes = H256::from([0xCD; 32]);
+    let partition_hash = partition_hash_bytes;
+
+    for batch_size in [1_usize, 32] {
+        // Rust batch
+        {
+            let mut group = c.benchmark_group(format!("packing/batch_rust/{batch_size}_chunks"));
+            for tier in &tiers {
+                group.sample_size(tier.sample_size);
+                group.measurement_time(tier.measurement_time);
+                group.throughput(Throughput::Bytes(
+                    u64::try_from(batch_size).unwrap() * CHUNK_SIZE_U64,
+                ));
+                group.bench_function(BenchmarkId::from_parameter(tier.name), |b| {
+                    b.iter_batched(
+                        || {
+                            (0..batch_size)
+                                .map(|_| vec![0_u8; CHUNK_SIZE])
+                                .collect::<Vec<Vec<u8>>>()
+                        },
+                        |mut data| {
+                            capacity_pack_range_with_data(
+                                &mut data,
+                                mining_address,
+                                0,
+                                partition_hash,
+                                CHUNK_SIZE,
+                                tier.iterations,
+                                tier.chain_id,
+                            );
+                        },
+                        criterion::BatchSize::LargeInput,
+                    );
+                });
+            }
+            group.finish();
+        }
+
+        // C batch
+        {
+            let mut group = c.benchmark_group(format!("packing/batch_c/{batch_size}_chunks"));
+            for tier in &tiers {
+                group.sample_size(tier.sample_size);
+                group.measurement_time(tier.measurement_time);
+                group.throughput(Throughput::Bytes(
+                    u64::try_from(batch_size).unwrap() * CHUNK_SIZE_U64,
+                ));
+                group.bench_function(BenchmarkId::from_parameter(tier.name), |b| {
+                    b.iter_batched(
+                        || {
+                            (0..batch_size)
+                                .map(|_| vec![0_u8; CHUNK_SIZE])
+                                .collect::<Vec<Vec<u8>>>()
+                        },
+                        |mut data| {
+                            capacity_pack_range_with_data_c(
+                                &mut data,
+                                mining_address,
+                                0,
+                                partition_hash,
+                                tier.iterations,
+                                tier.chain_id,
+                                CHUNK_SIZE,
+                            );
+                        },
+                        criterion::BatchSize::LargeInput,
+                    );
+                });
+            }
+            group.finish();
+        }
+    }
+}
+
+criterion_group!(
+    benches,
+    bench_xor_in_place,
+    bench_packing_xor_owned,
+    bench_entropy_rust_vs_c,
+    bench_batch_pack,
+);
+criterion_main!(benches);

--- a/crates/reward-curve/Cargo.toml
+++ b/crates/reward-curve/Cargo.toml
@@ -25,8 +25,13 @@ csv = { workspace = true, optional = true }
 
 [dev-dependencies]
 rstest.workspace = true
+criterion.workspace = true
 proptest.workspace = true
 test-log.workspace = true
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "reward_bench"
+harness = false

--- a/crates/reward-curve/benches/reward_bench.rs
+++ b/crates/reward-curve/benches/reward_bench.rs
@@ -27,11 +27,7 @@ fn bench_reward_between(c: &mut Criterion) {
         (0, SECS_PER_YEAR, "1_year"),
         (0, 10 * SECS_PER_YEAR, "10_years"),
         (3 * SECS_PER_YEAR, 5 * SECS_PER_YEAR, "across_half_life"),
-        (
-            240 * SECS_PER_YEAR,
-            241 * SECS_PER_YEAR,
-            "large_t_underflow",
-        ),
+        (240 * SECS_PER_YEAR, 241 * SECS_PER_YEAR, "large_t"),
     ];
 
     for (prev, new, label) in cases {

--- a/crates/reward-curve/benches/reward_bench.rs
+++ b/crates/reward-curve/benches/reward_bench.rs
@@ -1,0 +1,46 @@
+//! Benchmark: Reward curve — emission calculation
+//!
+//! Regression signal: reward_between latency (covers decay_factor internally).
+//! Called per block production for miner reward calculation.
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use irys_reward_curve::HalvingCurve;
+use irys_types::{U256, storage_pricing::Amount};
+
+const SECS_PER_YEAR: u128 = 365 * 24 * 60 * 60;
+const INF_SUPPLY: u128 = 100_000_000;
+const HALF_LIFE_YEARS: u128 = 4;
+
+fn test_curve() -> HalvingCurve {
+    HalvingCurve {
+        inflation_cap: Amount::new(U256::from(INF_SUPPLY)),
+        half_life_secs: HALF_LIFE_YEARS * SECS_PER_YEAR,
+    }
+}
+
+fn bench_reward_between(c: &mut Criterion) {
+    let mut group = c.benchmark_group("reward/reward_between");
+    let curve = test_curve();
+
+    let cases = [
+        (0_u128, 1, "1_second"),
+        (0, SECS_PER_YEAR, "1_year"),
+        (0, 10 * SECS_PER_YEAR, "10_years"),
+        (3 * SECS_PER_YEAR, 5 * SECS_PER_YEAR, "across_half_life"),
+        (
+            240 * SECS_PER_YEAR,
+            241 * SECS_PER_YEAR,
+            "large_t_underflow",
+        ),
+    ];
+
+    for (prev, new, label) in cases {
+        group.bench_function(BenchmarkId::from_parameter(label), |b| {
+            b.iter(|| curve.reward_between(prev, new).expect("reward calc"));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_reward_between);
+criterion_main!(benches);

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -66,9 +66,22 @@ test-fuzz.workspace = true
 rstest.workspace = true
 pretty_assertions.workspace = true
 assert_matches.workspace = true
+criterion.workspace = true
 
 [build-dependencies]
 build-print = "0"
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "solution_hash_bench"
+harness = false
+
+[[bench]]
+name = "merkle_bench"
+harness = false
+
+[[bench]]
+name = "pricing_bench"
+harness = false

--- a/crates/types/benches/merkle_bench.rs
+++ b/crates/types/benches/merkle_bench.rs
@@ -48,11 +48,14 @@ fn bench_generate_data_root(c: &mut Criterion) {
         group.bench_function(
             BenchmarkId::from_parameter(format!("{count}_chunks")),
             |b| {
-                b.iter(|| {
-                    let leaves = generate_leaves_from_chunks(chunks.iter().map(|c| Ok(c.clone())))
-                        .expect("leaf generation");
-                    black_box(generate_data_root(leaves).expect("data root"))
-                });
+                b.iter_batched(
+                    || {
+                        generate_leaves_from_chunks(chunks.iter().map(|c| Ok(c.clone())))
+                            .expect("leaf generation")
+                    },
+                    |leaves| black_box(generate_data_root(leaves).expect("data root")),
+                    criterion::BatchSize::SmallInput,
+                );
             },
         );
     }
@@ -92,12 +95,16 @@ fn bench_generate_leaves(c: &mut Criterion) {
         group.bench_function(
             BenchmarkId::from_parameter(format!("{count}_chunks")),
             |b| {
-                b.iter(|| {
-                    black_box(
-                        generate_leaves_from_chunks(chunks.iter().map(|c| Ok(c.clone())))
-                            .expect("leaf generation"),
-                    )
-                });
+                b.iter_batched(
+                    || chunks.iter().map(|c| Ok(c.clone())).collect::<Vec<_>>(),
+                    |owned_chunks| {
+                        black_box(
+                            generate_leaves_from_chunks(owned_chunks.into_iter())
+                                .expect("leaf generation"),
+                        )
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
             },
         );
     }

--- a/crates/types/benches/merkle_bench.rs
+++ b/crates/types/benches/merkle_bench.rs
@@ -1,0 +1,114 @@
+//! Benchmark: Merkle proof generation and validation
+//!
+//! Regression signal: validate_path and generate_data_root throughput.
+//! These scale with chunk count and are on the block validation critical path.
+
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use irys_types::{
+    Base64, ChunkBytes, MAX_CHUNK_SIZE, generate_data_root, generate_leaves_from_chunks,
+    resolve_proofs, validate_path,
+};
+
+fn make_chunks(count: usize) -> Vec<ChunkBytes> {
+    (0..count)
+        .map(|i| {
+            let mut chunk = vec![0_u8; MAX_CHUNK_SIZE];
+            chunk[0] = u8::try_from(i % 256).unwrap();
+            chunk[1] = u8::try_from((i >> 8) % 256).unwrap();
+            chunk
+        })
+        .collect()
+}
+
+/// Builds a merkle tree and returns (root_id, proofs) for use in validate_path benchmarks.
+fn build_tree_and_proofs(chunks: &[ChunkBytes]) -> ([u8; 32], Vec<(Base64, u128)>) {
+    let leaves =
+        generate_leaves_from_chunks(chunks.iter().map(|c| Ok(c.clone()))).expect("leaf generation");
+    let root = generate_data_root(leaves).expect("data root");
+    let root_id = root.id;
+
+    let proofs = resolve_proofs(root, None).expect("resolve proofs");
+    let proof_pairs: Vec<(Base64, u128)> = proofs
+        .into_iter()
+        .map(|p| {
+            let target = u128::try_from(p.last_byte_index).unwrap();
+            (Base64(p.proof), target)
+        })
+        .collect();
+
+    (root_id, proof_pairs)
+}
+
+fn bench_generate_data_root(c: &mut Criterion) {
+    let mut group = c.benchmark_group("merkle/chunks_to_data_root");
+
+    for count in [1, 32, 256] {
+        let chunks = make_chunks(count);
+        group.throughput(Throughput::Elements(u64::try_from(count).unwrap()));
+        group.bench_function(
+            BenchmarkId::from_parameter(format!("{count}_chunks")),
+            |b| {
+                b.iter(|| {
+                    let leaves = generate_leaves_from_chunks(chunks.iter().map(|c| Ok(c.clone())))
+                        .expect("leaf generation");
+                    black_box(generate_data_root(leaves).expect("data root"))
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_validate_path(c: &mut Criterion) {
+    let mut group = c.benchmark_group("merkle/validate_path");
+
+    for count in [1, 32, 256] {
+        let chunks = make_chunks(count);
+        let (root_id, proofs) = build_tree_and_proofs(&chunks);
+
+        let (ref proof_bytes, target) = proofs[0];
+
+        group.throughput(Throughput::Elements(1));
+        group.bench_function(
+            BenchmarkId::from_parameter(format!("{count}_chunks")),
+            |b| {
+                b.iter(|| {
+                    black_box(validate_path(root_id, proof_bytes, target).expect("valid path"))
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_generate_leaves(c: &mut Criterion) {
+    let mut group = c.benchmark_group("merkle/generate_leaves");
+
+    for count in [1, 32, 256] {
+        let chunks = make_chunks(count);
+        group.throughput(Throughput::Elements(u64::try_from(count).unwrap()));
+        group.bench_function(
+            BenchmarkId::from_parameter(format!("{count}_chunks")),
+            |b| {
+                b.iter(|| {
+                    black_box(
+                        generate_leaves_from_chunks(chunks.iter().map(|c| Ok(c.clone())))
+                            .expect("leaf generation"),
+                    )
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_generate_data_root,
+    bench_validate_path,
+    bench_generate_leaves,
+);
+criterion_main!(benches);

--- a/crates/types/benches/pricing_bench.rs
+++ b/crates/types/benches/pricing_bench.rs
@@ -40,16 +40,17 @@ fn bench_calculate_perm_fee(c: &mut Criterion) {
     let config = make_config();
     let irys_price: Amount<(IrysPrice, Usd)> = Amount::token(dec!(1.0)).expect("valid price");
     let bytes = config.chunk_size;
-    let term_fee = calculate_term_fee(
-        bytes,
-        config.epoch.submit_ledger_epoch_length,
-        &config,
-        10,
-        irys_price,
-    )
-    .expect("term fee");
 
     for (proofs, label) in [(1_u64, "1_proof"), (10, "10_proofs"), (100, "100_proofs")] {
+        let term_fee = calculate_term_fee(
+            bytes,
+            config.epoch.submit_ledger_epoch_length,
+            &config,
+            proofs,
+            irys_price,
+        )
+        .expect("term fee");
+
         group.bench_function(BenchmarkId::from_parameter(label), |b| {
             b.iter(|| {
                 black_box(

--- a/crates/types/benches/pricing_bench.rs
+++ b/crates/types/benches/pricing_bench.rs
@@ -1,0 +1,86 @@
+//! Benchmark: Storage pricing functions
+//!
+//! Regression signal: calculate_term_fee and exp_neg_fp18 latency.
+//! Called per data tx during validation and per block for reward computation.
+
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use irys_types::{
+    ConsensusConfig, U256,
+    storage_pricing::{
+        Amount, calculate_perm_fee_from_config, calculate_term_fee, exp_neg_fp18,
+        phantoms::{IrysPrice, Usd},
+    },
+};
+use rust_decimal_macros::dec;
+
+fn make_config() -> ConsensusConfig {
+    ConsensusConfig::testing()
+}
+
+fn bench_calculate_term_fee(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pricing/calculate_term_fee");
+    let config = make_config();
+    let irys_price: Amount<(IrysPrice, Usd)> = Amount::token(dec!(1.0)).expect("valid price");
+    let bytes = config.chunk_size;
+
+    for (epochs, label) in [(1_u64, "1_epoch"), (10, "10_epochs"), (100, "100_epochs")] {
+        group.bench_function(BenchmarkId::from_parameter(label), |b| {
+            b.iter(|| {
+                black_box(
+                    calculate_term_fee(bytes, epochs, &config, 10, irys_price).expect("fee calc"),
+                )
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_calculate_perm_fee(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pricing/calculate_perm_fee");
+    let config = make_config();
+    let irys_price: Amount<(IrysPrice, Usd)> = Amount::token(dec!(1.0)).expect("valid price");
+    let bytes = config.chunk_size;
+    let term_fee = calculate_term_fee(
+        bytes,
+        config.epoch.submit_ledger_epoch_length,
+        &config,
+        10,
+        irys_price,
+    )
+    .expect("term fee");
+
+    for (proofs, label) in [(1_u64, "1_proof"), (10, "10_proofs"), (100, "100_proofs")] {
+        group.bench_function(BenchmarkId::from_parameter(label), |b| {
+            b.iter(|| {
+                black_box(
+                    calculate_perm_fee_from_config(bytes, &config, proofs, irys_price, term_fee)
+                        .expect("perm fee calc"),
+                )
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_exp_neg_fp18(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pricing/exp_neg_fp18");
+
+    for (x_val, label) in [
+        (U256::from(1_000_000_000_000_000_u64), "small"),
+        (U256::from(500_000_000_000_000_000_u64), "medium"),
+        (U256::from(693_147_180_559_945_309_u64), "ln2"),
+    ] {
+        group.bench_function(BenchmarkId::from_parameter(label), |b| {
+            b.iter(|| black_box(exp_neg_fp18(x_val).expect("exp_neg")));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_calculate_term_fee,
+    bench_calculate_perm_fee,
+    bench_exp_neg_fp18,
+);
+criterion_main!(benches);

--- a/crates/types/benches/solution_hash_bench.rs
+++ b/crates/types/benches/solution_hash_bench.rs
@@ -1,0 +1,33 @@
+//! Benchmark: compute_solution_hash
+//!
+//! Regression signal: SHA256(chunk + offset + seed) throughput.
+//! Called ~512x per mining attempt — the single hottest crypto call.
+
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use irys_types::{H256, MAX_CHUNK_SIZE, compute_solution_hash};
+
+const CHUNK_SIZE: u64 = MAX_CHUNK_SIZE as u64;
+
+fn bench_solution_hash(c: &mut Criterion) {
+    let mut group = c.benchmark_group("solution_hash");
+
+    let seed = H256::from([0xAB; 32]);
+    let offset: u32 = 42;
+
+    let chunk_256k = vec![0xCD_u8; CHUNK_SIZE as usize];
+    group.throughput(Throughput::Bytes(CHUNK_SIZE));
+    group.bench_function(BenchmarkId::from_parameter("256KB_chunk"), |b| {
+        b.iter(|| black_box(compute_solution_hash(&chunk_256k, offset, &seed)));
+    });
+
+    // Benchmark with empty chunk (lower bound — hash overhead only)
+    group.throughput(Throughput::Elements(1));
+    group.bench_function(BenchmarkId::from_parameter("empty_chunk"), |b| {
+        b.iter(|| black_box(compute_solution_hash(&[], offset, &seed)));
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_solution_hash);
+criterion_main!(benches);

--- a/crates/vdf/benches/vdf_bench.rs
+++ b/crates/vdf/benches/vdf_bench.rs
@@ -164,11 +164,39 @@ fn bench_apply_reset_seed(c: &mut Criterion) {
     });
 }
 
+/// Benchmarks vdf_sha with a single checkpoint to isolate the inner
+/// compress_n_rounds loop from checkpoint bookkeeping overhead.
+fn bench_vdf_sha_inner_loop(c: &mut Criterion) {
+    let tiers = build_tiers();
+    let mut group = c.benchmark_group("vdf_sha_inner_loop");
+
+    for tier in &tiers {
+        let total_iters = u64::try_from(tier.config.num_checkpoints_in_vdf_step).unwrap()
+            * tier.config.num_iterations_per_checkpoint();
+
+        group.sample_size(tier.sample_size);
+        group.measurement_time(tier.measurement_time);
+        group.bench_function(BenchmarkId::from_parameter(tier.name), |b| {
+            let mut checkpoints = vec![H256::default(); 1];
+            b.iter(|| {
+                let salt = U256::from(0);
+                let mut seed = fixed_seed();
+                vdf_sha(salt, &mut seed, 1, total_iters, &mut checkpoints);
+                std::hint::black_box(&checkpoints);
+                seed
+            });
+        });
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_vdf_sha,
     bench_vdf_sha_verification,
     bench_parallel_verification,
     bench_apply_reset_seed,
+    bench_vdf_sha_inner_loop,
 );
 criterion_main!(benches);

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -33,6 +33,9 @@ enum Commands {
             conflicts_with = "rerun_failures"
         )]
         coverage: bool,
+        /// Include benchmark targets
+        #[clap(long, default_value_t = false)]
+        benches: bool,
         /// Only run tests that failed in the previous run
         #[clap(long, default_value_t = false)]
         rerun_failures: bool,
@@ -187,6 +190,7 @@ fn run_command(command: Commands, sh: &Shell) -> eyre::Result<()> {
         Commands::Test {
             args,
             coverage,
+            benches,
             rerun_failures,
             clean,
             no_update_failures,
@@ -342,6 +346,10 @@ fn run_command(command: Commands, sh: &Shell) -> eyre::Result<()> {
             }
             nextest_args.push("--tests".to_string());
             nextest_args.push("--all-targets".to_string());
+
+            if benches {
+                nextest_args.push("--benches".to_string());
+            }
 
             // Validate passthrough args don't conflict with xtask-injected flags.
             let user_has_config_file = args
@@ -617,6 +625,7 @@ fn run_command(command: Commands, sh: &Shell) -> eyre::Result<()> {
                 run_command(
                     Commands::Test {
                         coverage: false,
+                        benches: false,
                         rerun_failures: false,
                         clean: false,
                         no_update_failures: false,


### PR DESCRIPTION
**Describe the changes**
A clear and concise description of what the bug fix, feature, or improvement is.

**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added numerous Criterion performance benchmarks covering sampling, shadow transactions, packing, reward calculations, Merkle operations, storage pricing/fees, solution-hash computation, VDF inner-loop, database workloads (block/index/chunk/ingress), and block-tree mark-tip performance.

* **Chores**
  * Enabled Criterion as a dev-dependency across crates and registered multiple new custom benchmark targets and suites for focused performance measurement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->