### PR TITLE
fix(efficient-sampling): use inclusive candidate count in sampling modulo

### DIFF
--- a/crates/efficient-sampling/src/lib.rs
+++ b/crates/efficient-sampling/src/lib.rs
@@ -81,10 +81,13 @@ impl Ranges {
             );
             let mut rng = SimpleRNG::new(rng_seed);
 
-            let last_range_pos_u32 = u32::try_from(self.last_range_pos).map_err(|_| {
-                eyre::eyre!("last_range_pos {} exceeds u32::MAX", self.last_range_pos)
+            let choice_count = u32::try_from(self.last_range_pos + 1).map_err(|_| {
+                eyre::eyre!(
+                    "last_range_pos + 1 ({}) exceeds u32::MAX",
+                    self.last_range_pos + 1
+                )
             })?;
-            let next_range_pos = usize::try_from(rng.next() % last_range_pos_u32)
+            let next_range_pos = usize::try_from(rng.next() % choice_count)
                 .map_err(|_| eyre::eyre!("range position exceeds usize"))?;
             let range = self.ranges[next_range_pos];
             self.ranges[next_range_pos] = self.ranges[self.last_range_pos]; // overwrite returned range with last one
@@ -249,6 +252,30 @@ mod tests {
         }
 
         assert_eq!(num_recall_ranges, ranges.last_range_pos + 1);
+    }
+
+    #[test]
+    fn test_two_range_sampling_not_biased() {
+        let partition_hash = H256::random();
+        let mut first_draws = HashSet::new();
+
+        for seed_byte in 0..=255_u8 {
+            let mut ranges = Ranges::new(2).unwrap();
+            let mut seed = H256::zero();
+            seed.0[0] = seed_byte;
+            let range = ranges.get_recall_range(1, &seed, &partition_hash).unwrap();
+            first_draws.insert(range);
+            if first_draws.len() > 1 {
+                break;
+            }
+        }
+
+        assert!(
+            first_draws.len() > 1,
+            "With 2 ranges, different seeds should produce different first draws. \
+             Got only {:?} across 256 seeds — sampling is biased.",
+            first_draws
+        );
     }
 
     #[test]

--- a/crates/efficient-sampling/src/lib.rs
+++ b/crates/efficient-sampling/src/lib.rs
@@ -256,7 +256,7 @@ mod tests {
 
     #[test]
     fn test_two_range_sampling_not_biased() {
-        let partition_hash = H256::random();
+        let partition_hash = H256([7_u8; 32]);
         let mut first_draws = HashSet::new();
 
         for seed_byte in 0..=255_u8 {


### PR DESCRIPTION
## Summary

**Before:**
`Ranges::next_recall_range` used `last_range_pos` as the modulo base when selecting a random slot. `last_range_pos` is an inclusive index, so `rng.next() % last_range_pos` produced values in `[0, last_range_pos - 1]`, excluding the last live slot from every random draw. With 2 ranges, `% 1` always returned 0, making the first draw deterministic regardless of seed.

**After:**
The modulo base is `last_range_pos + 1`, covering all valid positions `[0, last_range_pos]` inclusive. The `as usize` cast is replaced with `usize::try_from()`.

## Changes

### `crates/efficient-sampling/src/lib.rs`
- Change modulo base from `self.last_range_pos` to `self.last_range_pos + 1` in `next_recall_range`
- Replace `as usize` cast with `usize::try_from()` for the random position result
- Add `test_two_range_sampling_not_biased` regression test verifying that 2-range sampling produces different first draws across different seeds

## Testing
- [x] Tests added/updated
- [x] Edge cases covered (2-range case where bias was most visible)

## Related
- Fixes #1213
- Related to #1206

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized random selection algorithm to improve accuracy and reduce potential bias in sampling operations
  * Enhanced error reporting with more precise and descriptive messages for overflow conditions

* **Tests**
  * Expanded test coverage with additional validation tests for sampling consistency across various scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->