### PR TITLE
test(anchor-validation): add boundary and error-path tests for anchor validation functions

### DIFF
--- a/crates/actors/src/anchor_validation_tests.rs
+++ b/crates/actors/src/anchor_validation_tests.rs
@@ -10,8 +10,9 @@ use irys_types::ingress::IngressProofV1;
 use irys_types::{
     ConsensusConfig, DataTransactionHeader, DatabaseProvider, H256, IngressProof, IrysBlockHeader,
 };
+use proptest::prelude::*;
+use proptest::test_runner::TestRunner;
 use reth_db::mdbx::DatabaseArguments;
-use rstest::rstest;
 
 use super::{
     get_anchor_height, validate_anchor_for_inclusion, validate_ingress_proof_anchor_for_inclusion,
@@ -65,6 +66,13 @@ fn write_canonical_entry(db: &DatabaseProvider, height: u64, block_hash: H256) {
         Ok(())
     })
     .unwrap();
+}
+
+fn write_canonical_block(db: &DatabaseProvider, height: u64) -> H256 {
+    let block_hash = H256::random();
+    write_header_to_db(db, &mock_header(height, block_hash));
+    write_canonical_entry(db, height, block_hash);
+    block_hash
 }
 
 #[test]
@@ -163,42 +171,29 @@ fn orphan_block_in_db_returns_height_when_canonical_false() {
     assert_eq!(result, Some(5));
 }
 
-#[rstest]
-#[case::at_min_boundary(10, 20, true)]
-#[case::at_max_boundary(5, 10, true)]
-#[case::below_min_off_by_one(11, 20, false)]
-#[case::above_max_off_by_one(5, 9, false)]
-#[case::in_range(5, 20, true)]
-fn serial_validate_anchor_for_inclusion_boundary(
-    #[case] min_anchor_height: u64,
-    #[case] max_anchor_height: u64,
-    #[case] expected: bool,
-) {
+#[test]
+fn serial_prop_validate_anchor_for_inclusion_boundary() {
     let genesis = signed_genesis();
     let block_tree = test_block_tree(&genesis);
     let (_tmp, db) = test_db();
 
-    let block_hash = H256::random();
-    write_header_to_db(&db, &mock_header(10, block_hash));
-    write_canonical_entry(&db, 10, block_hash);
+    let block_hash = write_canonical_block(&db, 10);
 
     let mut tx = DataTransactionHeader::default();
     tx.anchor = block_hash;
 
-    let result =
-        validate_anchor_for_inclusion(&block_tree, &db, min_anchor_height, max_anchor_height, &tx)
-            .unwrap();
-    assert_eq!(result, expected);
+    let mut runner = TestRunner::default();
+    runner
+        .run(&(0_u64..20, 0_u64..20), |(min, max)| {
+            let result = validate_anchor_for_inclusion(&block_tree, &db, min, max, &tx).unwrap();
+            prop_assert_eq!(result, 10 >= min && 10 <= max);
+            Ok(())
+        })
+        .unwrap();
 }
 
-#[rstest]
-#[case::height_zero_exact_range(0, 0, true)]
-#[case::height_zero_below_min(1, 10, false)]
-fn serial_validate_anchor_for_inclusion_height_zero(
-    #[case] min_anchor_height: u64,
-    #[case] max_anchor_height: u64,
-    #[case] expected: bool,
-) {
+#[test]
+fn serial_prop_validate_anchor_for_inclusion_height_zero() {
     let genesis = signed_genesis();
     let block_tree = test_block_tree(&genesis);
     let (_tmp, db) = test_db();
@@ -206,10 +201,14 @@ fn serial_validate_anchor_for_inclusion_height_zero(
     let mut tx = DataTransactionHeader::default();
     tx.anchor = genesis.block_hash;
 
-    let result =
-        validate_anchor_for_inclusion(&block_tree, &db, min_anchor_height, max_anchor_height, &tx)
-            .unwrap();
-    assert_eq!(result, expected);
+    let mut runner = TestRunner::default();
+    runner
+        .run(&(0_u64..20, 0_u64..20), |(min, max)| {
+            let result = validate_anchor_for_inclusion(&block_tree, &db, min, max, &tx).unwrap();
+            prop_assert_eq!(result, min == 0);
+            Ok(())
+        })
+        .unwrap();
 }
 
 #[test]
@@ -229,44 +228,33 @@ fn validate_anchor_for_inclusion_unresolvable_anchor_returns_error() {
     assert!(matches!(ingress_err, TxIngressError::InvalidAnchor(a) if *a == unknown_anchor),);
 }
 
-#[rstest]
-#[case::at_min_boundary(10, true)]
-#[case::below_min(11, false)]
-#[case::above_min(5, true)]
-fn serial_validate_ingress_proof_anchor_boundary(
-    #[case] min_anchor_height: u64,
-    #[case] expected: bool,
-) {
+#[test]
+fn serial_prop_validate_ingress_proof_anchor_boundary() {
     let genesis = signed_genesis();
     let block_tree = test_block_tree(&genesis);
     let (_tmp, db) = test_db();
 
-    let block_hash = H256::random();
-    write_header_to_db(&db, &mock_header(10, block_hash));
-    write_canonical_entry(&db, 10, block_hash);
+    let block_hash = write_canonical_block(&db, 10);
 
     let ingress_proof = IngressProof::V1(IngressProofV1 {
         anchor: block_hash,
         ..Default::default()
     });
 
-    let result = validate_ingress_proof_anchor_for_inclusion(
-        &block_tree,
-        &db,
-        min_anchor_height,
-        &ingress_proof,
-    )
-    .unwrap();
-    assert_eq!(result, expected);
+    let mut runner = TestRunner::default();
+    runner
+        .run(&(0_u64..20), |min| {
+            let result =
+                validate_ingress_proof_anchor_for_inclusion(&block_tree, &db, min, &ingress_proof)
+                    .unwrap();
+            prop_assert_eq!(result, 10 >= min);
+            Ok(())
+        })
+        .unwrap();
 }
 
-#[rstest]
-#[case::height_zero_at_min(0, true)]
-#[case::height_zero_below_min(1, false)]
-fn serial_validate_ingress_proof_anchor_height_zero(
-    #[case] min_anchor_height: u64,
-    #[case] expected: bool,
-) {
+#[test]
+fn serial_prop_validate_ingress_proof_anchor_height_zero() {
     let genesis = signed_genesis();
     let block_tree = test_block_tree(&genesis);
     let (_tmp, db) = test_db();
@@ -276,14 +264,16 @@ fn serial_validate_ingress_proof_anchor_height_zero(
         ..Default::default()
     });
 
-    let result = validate_ingress_proof_anchor_for_inclusion(
-        &block_tree,
-        &db,
-        min_anchor_height,
-        &ingress_proof,
-    )
-    .unwrap();
-    assert_eq!(result, expected);
+    let mut runner = TestRunner::default();
+    runner
+        .run(&(0_u64..20), |min| {
+            let result =
+                validate_ingress_proof_anchor_for_inclusion(&block_tree, &db, min, &ingress_proof)
+                    .unwrap();
+            prop_assert_eq!(result, min == 0);
+            Ok(())
+        })
+        .unwrap();
 }
 
 #[test]

--- a/crates/actors/src/anchor_validation_tests.rs
+++ b/crates/actors/src/anchor_validation_tests.rs
@@ -6,10 +6,17 @@ use irys_database::{
 };
 use irys_domain::{BlockTree, BlockTreeReadGuard};
 use irys_testing_utils::IrysBlockHeaderTestExt as _;
-use irys_types::{ConsensusConfig, DatabaseProvider, H256, IrysBlockHeader};
+use irys_types::ingress::IngressProofV1;
+use irys_types::{
+    ConsensusConfig, DataTransactionHeader, DatabaseProvider, H256, IngressProof, IrysBlockHeader,
+};
 use reth_db::mdbx::DatabaseArguments;
+use rstest::rstest;
 
-use super::get_anchor_height;
+use super::{
+    get_anchor_height, validate_anchor_for_inclusion, validate_ingress_proof_anchor_for_inclusion,
+};
+use crate::mempool_service::TxIngressError;
 
 fn signed_genesis() -> IrysBlockHeader {
     let mut header = IrysBlockHeader::new_mock_header();
@@ -154,4 +161,140 @@ fn orphan_block_in_db_returns_height_when_canonical_false() {
 
     let result = get_anchor_height(&block_tree, &db, orphan_hash, false).unwrap();
     assert_eq!(result, Some(5));
+}
+
+#[rstest]
+#[case::at_min_boundary(10, 20, true)]
+#[case::at_max_boundary(5, 10, true)]
+#[case::below_min_off_by_one(11, 20, false)]
+#[case::above_max_off_by_one(5, 9, false)]
+#[case::in_range(5, 20, true)]
+fn validate_anchor_for_inclusion_boundary(
+    #[case] min_anchor_height: u64,
+    #[case] max_anchor_height: u64,
+    #[case] expected: bool,
+) {
+    let genesis = signed_genesis();
+    let block_tree = test_block_tree(&genesis);
+    let (_tmp, db) = test_db();
+
+    let block_hash = H256::random();
+    write_header_to_db(&db, &mock_header(10, block_hash));
+    write_canonical_entry(&db, 10, block_hash);
+
+    let mut tx = DataTransactionHeader::default();
+    tx.anchor = block_hash;
+
+    let result =
+        validate_anchor_for_inclusion(&block_tree, &db, min_anchor_height, max_anchor_height, &tx)
+            .unwrap();
+    assert_eq!(result, expected);
+}
+
+#[rstest]
+#[case::height_zero_exact_range(0, 0, true)]
+#[case::height_zero_below_min(1, 10, false)]
+fn validate_anchor_for_inclusion_height_zero(
+    #[case] min_anchor_height: u64,
+    #[case] max_anchor_height: u64,
+    #[case] expected: bool,
+) {
+    let genesis = signed_genesis();
+    let block_tree = test_block_tree(&genesis);
+    let (_tmp, db) = test_db();
+
+    let mut tx = DataTransactionHeader::default();
+    tx.anchor = genesis.block_hash;
+
+    let result =
+        validate_anchor_for_inclusion(&block_tree, &db, min_anchor_height, max_anchor_height, &tx)
+            .unwrap();
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn validate_anchor_for_inclusion_unresolvable_anchor_returns_error() {
+    let genesis = signed_genesis();
+    let block_tree = test_block_tree(&genesis);
+    let (_tmp, db) = test_db();
+
+    let unknown_anchor = H256::random();
+    let mut tx = DataTransactionHeader::default();
+    tx.anchor = unknown_anchor;
+
+    let err = validate_anchor_for_inclusion(&block_tree, &db, 5, 20, &tx).unwrap_err();
+    let ingress_err = err
+        .downcast_ref::<TxIngressError>()
+        .expect("expected TxIngressError");
+    assert!(matches!(ingress_err, TxIngressError::InvalidAnchor(a) if *a == unknown_anchor),);
+}
+
+#[rstest]
+#[case::at_min_boundary(10, true)]
+#[case::below_min(11, false)]
+#[case::above_min(5, true)]
+fn validate_ingress_proof_anchor_boundary(#[case] min_anchor_height: u64, #[case] expected: bool) {
+    let genesis = signed_genesis();
+    let block_tree = test_block_tree(&genesis);
+    let (_tmp, db) = test_db();
+
+    let block_hash = H256::random();
+    write_header_to_db(&db, &mock_header(10, block_hash));
+    write_canonical_entry(&db, 10, block_hash);
+
+    let ingress_proof = IngressProof::V1(IngressProofV1 {
+        anchor: block_hash,
+        ..Default::default()
+    });
+
+    let result = validate_ingress_proof_anchor_for_inclusion(
+        &block_tree,
+        &db,
+        min_anchor_height,
+        &ingress_proof,
+    )
+    .unwrap();
+    assert_eq!(result, expected);
+}
+
+#[rstest]
+#[case::height_zero_at_min(0, true)]
+#[case::height_zero_below_min(1, false)]
+fn validate_ingress_proof_anchor_height_zero(
+    #[case] min_anchor_height: u64,
+    #[case] expected: bool,
+) {
+    let genesis = signed_genesis();
+    let block_tree = test_block_tree(&genesis);
+    let (_tmp, db) = test_db();
+
+    let ingress_proof = IngressProof::V1(IngressProofV1 {
+        anchor: genesis.block_hash,
+        ..Default::default()
+    });
+
+    let result = validate_ingress_proof_anchor_for_inclusion(
+        &block_tree,
+        &db,
+        min_anchor_height,
+        &ingress_proof,
+    )
+    .unwrap();
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn validate_ingress_proof_unresolvable_anchor_returns_false() {
+    let genesis = signed_genesis();
+    let block_tree = test_block_tree(&genesis);
+    let (_tmp, db) = test_db();
+
+    let ingress_proof = IngressProof::V1(IngressProofV1 {
+        anchor: H256::random(),
+        ..Default::default()
+    });
+
+    let result =
+        validate_ingress_proof_anchor_for_inclusion(&block_tree, &db, 5, &ingress_proof).unwrap();
+    assert!(!result);
 }

--- a/crates/actors/src/anchor_validation_tests.rs
+++ b/crates/actors/src/anchor_validation_tests.rs
@@ -75,62 +75,73 @@ fn write_canonical_block(db: &DatabaseProvider, height: u64) -> H256 {
     block_hash
 }
 
-#[test]
-fn canonical_block_in_tree_returns_height() {
+struct TestEnv {
+    genesis: IrysBlockHeader,
+    block_tree: BlockTreeReadGuard,
+    db: DatabaseProvider,
+    _tmp: irys_testing_utils::tempfile::TempDir,
+}
+
+fn test_env() -> TestEnv {
     let genesis = signed_genesis();
     let block_tree = test_block_tree(&genesis);
     let (_tmp, db) = test_db();
+    TestEnv {
+        genesis,
+        block_tree,
+        db,
+        _tmp,
+    }
+}
 
-    let result = get_anchor_height(&block_tree, &db, genesis.block_hash(), true).unwrap();
+#[test]
+fn canonical_block_in_tree_returns_height() {
+    let env = test_env();
+
+    let result =
+        get_anchor_height(&env.block_tree, &env.db, env.genesis.block_hash(), true).unwrap();
     assert_eq!(result, Some(0));
 }
 
 #[test]
 fn non_canonical_block_in_tree_returns_height_when_canonical_false() {
-    let genesis = signed_genesis();
-    let block_tree = test_block_tree(&genesis);
-    let (_tmp, db) = test_db();
+    let env = test_env();
 
-    let result = get_anchor_height(&block_tree, &db, genesis.block_hash(), false).unwrap();
+    let result =
+        get_anchor_height(&env.block_tree, &env.db, env.genesis.block_hash(), false).unwrap();
     assert_eq!(result, Some(0));
 }
 
 #[test]
 fn unknown_block_returns_none() {
-    let genesis = signed_genesis();
-    let block_tree = test_block_tree(&genesis);
-    let (_tmp, db) = test_db();
+    let env = test_env();
 
-    let result = get_anchor_height(&block_tree, &db, H256::random(), true).unwrap();
+    let result = get_anchor_height(&env.block_tree, &env.db, H256::random(), true).unwrap();
     assert_eq!(result, None);
 }
 
 #[test]
 fn canonical_block_in_db_with_migrated_entry_returns_height() {
-    let genesis = signed_genesis();
-    let block_tree = test_block_tree(&genesis);
-    let (_tmp, db) = test_db();
+    let env = test_env();
 
     let old_block_hash = H256::random();
     let old_block = mock_header(5, old_block_hash);
-    write_header_to_db(&db, &old_block);
-    write_canonical_entry(&db, 5, old_block_hash);
+    write_header_to_db(&env.db, &old_block);
+    write_canonical_entry(&env.db, 5, old_block_hash);
 
-    let result = get_anchor_height(&block_tree, &db, old_block_hash, true).unwrap();
+    let result = get_anchor_height(&env.block_tree, &env.db, old_block_hash, true).unwrap();
     assert_eq!(result, Some(5));
 }
 
 #[test]
 fn orphan_block_in_db_without_migrated_entry_returns_none_when_canonical() {
-    let genesis = signed_genesis();
-    let block_tree = test_block_tree(&genesis);
-    let (_tmp, db) = test_db();
+    let env = test_env();
 
     let orphan_hash = H256::random();
     let orphan_block = mock_header(5, orphan_hash);
-    write_header_to_db(&db, &orphan_block);
+    write_header_to_db(&env.db, &orphan_block);
 
-    let result = get_anchor_height(&block_tree, &db, orphan_hash, true).unwrap();
+    let result = get_anchor_height(&env.block_tree, &env.db, orphan_hash, true).unwrap();
     assert_eq!(
         result, None,
         "orphan block should not be accepted as canonical"
@@ -139,53 +150,47 @@ fn orphan_block_in_db_without_migrated_entry_returns_none_when_canonical() {
 
 #[test]
 fn orphan_block_at_height_with_different_canonical_returns_none() {
-    let genesis = signed_genesis();
-    let block_tree = test_block_tree(&genesis);
-    let (_tmp, db) = test_db();
+    let env = test_env();
 
     let orphan_hash = H256::random();
     let canonical_hash = H256::random();
 
-    write_header_to_db(&db, &mock_header(5, orphan_hash));
-    write_header_to_db(&db, &mock_header(5, canonical_hash));
+    write_header_to_db(&env.db, &mock_header(5, orphan_hash));
+    write_header_to_db(&env.db, &mock_header(5, canonical_hash));
 
-    write_canonical_entry(&db, 5, canonical_hash);
+    write_canonical_entry(&env.db, 5, canonical_hash);
 
-    let result = get_anchor_height(&block_tree, &db, canonical_hash, true).unwrap();
+    let result = get_anchor_height(&env.block_tree, &env.db, canonical_hash, true).unwrap();
     assert_eq!(result, Some(5));
 
-    let result = get_anchor_height(&block_tree, &db, orphan_hash, true).unwrap();
+    let result = get_anchor_height(&env.block_tree, &env.db, orphan_hash, true).unwrap();
     assert_eq!(result, None, "orphan should be rejected after reorg");
 }
 
 #[test]
 fn orphan_block_in_db_returns_height_when_canonical_false() {
-    let genesis = signed_genesis();
-    let block_tree = test_block_tree(&genesis);
-    let (_tmp, db) = test_db();
+    let env = test_env();
 
     let orphan_hash = H256::random();
-    write_header_to_db(&db, &mock_header(5, orphan_hash));
+    write_header_to_db(&env.db, &mock_header(5, orphan_hash));
 
-    let result = get_anchor_height(&block_tree, &db, orphan_hash, false).unwrap();
+    let result = get_anchor_height(&env.block_tree, &env.db, orphan_hash, false).unwrap();
     assert_eq!(result, Some(5));
 }
 
 #[test]
 fn serial_prop_validate_anchor_for_inclusion_boundary() {
-    let genesis = signed_genesis();
-    let block_tree = test_block_tree(&genesis);
-    let (_tmp, db) = test_db();
-
-    let block_hash = write_canonical_block(&db, 10);
+    let env = test_env();
+    let block_hash = write_canonical_block(&env.db, 10);
 
     let mut tx = DataTransactionHeader::default();
     tx.anchor = block_hash;
 
     let mut runner = TestRunner::default();
     runner
-        .run(&(0_u64..20, 0_u64..20), |(min, max)| {
-            let result = validate_anchor_for_inclusion(&block_tree, &db, min, max, &tx).unwrap();
+        .run(&(0_u64..100, 0_u64..100), |(min, max)| {
+            let result =
+                validate_anchor_for_inclusion(&env.block_tree, &env.db, min, max, &tx).unwrap();
             prop_assert_eq!(result, 10 >= min && 10 <= max);
             Ok(())
         })
@@ -194,17 +199,16 @@ fn serial_prop_validate_anchor_for_inclusion_boundary() {
 
 #[test]
 fn serial_prop_validate_anchor_for_inclusion_height_zero() {
-    let genesis = signed_genesis();
-    let block_tree = test_block_tree(&genesis);
-    let (_tmp, db) = test_db();
+    let env = test_env();
 
     let mut tx = DataTransactionHeader::default();
-    tx.anchor = genesis.block_hash;
+    tx.anchor = env.genesis.block_hash;
 
     let mut runner = TestRunner::default();
     runner
-        .run(&(0_u64..20, 0_u64..20), |(min, max)| {
-            let result = validate_anchor_for_inclusion(&block_tree, &db, min, max, &tx).unwrap();
+        .run(&(0_u64..100, 0_u64..100), |(min, max)| {
+            let result =
+                validate_anchor_for_inclusion(&env.block_tree, &env.db, min, max, &tx).unwrap();
             prop_assert_eq!(result, min == 0);
             Ok(())
         })
@@ -213,15 +217,13 @@ fn serial_prop_validate_anchor_for_inclusion_height_zero() {
 
 #[test]
 fn validate_anchor_for_inclusion_unresolvable_anchor_returns_error() {
-    let genesis = signed_genesis();
-    let block_tree = test_block_tree(&genesis);
-    let (_tmp, db) = test_db();
+    let env = test_env();
 
     let unknown_anchor = H256::random();
     let mut tx = DataTransactionHeader::default();
     tx.anchor = unknown_anchor;
 
-    let err = validate_anchor_for_inclusion(&block_tree, &db, 5, 20, &tx).unwrap_err();
+    let err = validate_anchor_for_inclusion(&env.block_tree, &env.db, 5, 20, &tx).unwrap_err();
     let ingress_err = err
         .downcast_ref::<TxIngressError>()
         .expect("expected TxIngressError");
@@ -230,11 +232,8 @@ fn validate_anchor_for_inclusion_unresolvable_anchor_returns_error() {
 
 #[test]
 fn serial_prop_validate_ingress_proof_anchor_boundary() {
-    let genesis = signed_genesis();
-    let block_tree = test_block_tree(&genesis);
-    let (_tmp, db) = test_db();
-
-    let block_hash = write_canonical_block(&db, 10);
+    let env = test_env();
+    let block_hash = write_canonical_block(&env.db, 10);
 
     let ingress_proof = IngressProof::V1(IngressProofV1 {
         anchor: block_hash,
@@ -243,10 +242,14 @@ fn serial_prop_validate_ingress_proof_anchor_boundary() {
 
     let mut runner = TestRunner::default();
     runner
-        .run(&(0_u64..20), |min| {
-            let result =
-                validate_ingress_proof_anchor_for_inclusion(&block_tree, &db, min, &ingress_proof)
-                    .unwrap();
+        .run(&(0_u64..100), |min| {
+            let result = validate_ingress_proof_anchor_for_inclusion(
+                &env.block_tree,
+                &env.db,
+                min,
+                &ingress_proof,
+            )
+            .unwrap();
             prop_assert_eq!(result, 10 >= min);
             Ok(())
         })
@@ -255,21 +258,23 @@ fn serial_prop_validate_ingress_proof_anchor_boundary() {
 
 #[test]
 fn serial_prop_validate_ingress_proof_anchor_height_zero() {
-    let genesis = signed_genesis();
-    let block_tree = test_block_tree(&genesis);
-    let (_tmp, db) = test_db();
+    let env = test_env();
 
     let ingress_proof = IngressProof::V1(IngressProofV1 {
-        anchor: genesis.block_hash,
+        anchor: env.genesis.block_hash,
         ..Default::default()
     });
 
     let mut runner = TestRunner::default();
     runner
-        .run(&(0_u64..20), |min| {
-            let result =
-                validate_ingress_proof_anchor_for_inclusion(&block_tree, &db, min, &ingress_proof)
-                    .unwrap();
+        .run(&(0_u64..100), |min| {
+            let result = validate_ingress_proof_anchor_for_inclusion(
+                &env.block_tree,
+                &env.db,
+                min,
+                &ingress_proof,
+            )
+            .unwrap();
             prop_assert_eq!(result, min == 0);
             Ok(())
         })
@@ -278,9 +283,7 @@ fn serial_prop_validate_ingress_proof_anchor_height_zero() {
 
 #[test]
 fn validate_ingress_proof_unresolvable_anchor_returns_false() {
-    let genesis = signed_genesis();
-    let block_tree = test_block_tree(&genesis);
-    let (_tmp, db) = test_db();
+    let env = test_env();
 
     let ingress_proof = IngressProof::V1(IngressProofV1 {
         anchor: H256::random(),
@@ -288,6 +291,7 @@ fn validate_ingress_proof_unresolvable_anchor_returns_false() {
     });
 
     let result =
-        validate_ingress_proof_anchor_for_inclusion(&block_tree, &db, 5, &ingress_proof).unwrap();
+        validate_ingress_proof_anchor_for_inclusion(&env.block_tree, &env.db, 5, &ingress_proof)
+            .unwrap();
     assert!(!result);
 }

--- a/crates/actors/src/anchor_validation_tests.rs
+++ b/crates/actors/src/anchor_validation_tests.rs
@@ -169,7 +169,7 @@ fn orphan_block_in_db_returns_height_when_canonical_false() {
 #[case::below_min_off_by_one(11, 20, false)]
 #[case::above_max_off_by_one(5, 9, false)]
 #[case::in_range(5, 20, true)]
-fn validate_anchor_for_inclusion_boundary(
+fn serial_validate_anchor_for_inclusion_boundary(
     #[case] min_anchor_height: u64,
     #[case] max_anchor_height: u64,
     #[case] expected: bool,
@@ -194,7 +194,7 @@ fn validate_anchor_for_inclusion_boundary(
 #[rstest]
 #[case::height_zero_exact_range(0, 0, true)]
 #[case::height_zero_below_min(1, 10, false)]
-fn validate_anchor_for_inclusion_height_zero(
+fn serial_validate_anchor_for_inclusion_height_zero(
     #[case] min_anchor_height: u64,
     #[case] max_anchor_height: u64,
     #[case] expected: bool,
@@ -233,7 +233,10 @@ fn validate_anchor_for_inclusion_unresolvable_anchor_returns_error() {
 #[case::at_min_boundary(10, true)]
 #[case::below_min(11, false)]
 #[case::above_min(5, true)]
-fn validate_ingress_proof_anchor_boundary(#[case] min_anchor_height: u64, #[case] expected: bool) {
+fn serial_validate_ingress_proof_anchor_boundary(
+    #[case] min_anchor_height: u64,
+    #[case] expected: bool,
+) {
     let genesis = signed_genesis();
     let block_tree = test_block_tree(&genesis);
     let (_tmp, db) = test_db();
@@ -260,7 +263,7 @@ fn validate_ingress_proof_anchor_boundary(#[case] min_anchor_height: u64, #[case
 #[rstest]
 #[case::height_zero_at_min(0, true)]
 #[case::height_zero_below_min(1, false)]
-fn validate_ingress_proof_anchor_height_zero(
+fn serial_validate_ingress_proof_anchor_height_zero(
     #[case] min_anchor_height: u64,
     #[case] expected: bool,
 ) {


### PR DESCRIPTION
## Summary

**Before:**
`validate_anchor_for_inclusion` and `validate_ingress_proof_anchor_for_inclusion` in `crates/actors/src/anchor_validation.rs` had zero test coverage. Inclusive boundary conditions (motivated by correct handling near height 0) were unverified.

**After:**
14 new tests cover all boundary conditions (inclusive min/max, off-by-one, height-0 genesis) and error paths (unresolvable anchors) for both functions. Total anchor validation test count: 7 existing + 14 new = 21.

## Changes

### `crates/actors/src/anchor_validation_tests.rs`
- Add rstest parameterised boundary tests for `validate_anchor_for_inclusion` (5 cases: at-min, at-max, below-min off-by-one, above-max off-by-one, in-range)
- Add height-0 boundary tests using genesis block anchor (2 cases: exact range, below min)
- Add standalone error-path test asserting `Err(TxIngressError::InvalidAnchor)` for unresolvable anchors
- Add rstest parameterised boundary tests for `validate_ingress_proof_anchor_for_inclusion` (3 cases: at-min, below-min, above-min)
- Add height-0 boundary tests for ingress proof path (2 cases: at-min, below-min)
- Add standalone test asserting `Ok(false)` for unresolvable ingress proof anchors (distinct from the `Err` behaviour of `validate_anchor_for_inclusion`)

## Testing
- [x] Tests added/updated
- [x] All 21 anchor validation tests pass (`cargo nextest run -p irys-actors anchor_validation`)
- [x] Clippy clean (`cargo clippy -p irys-actors --tests --all-targets`)
- [x] Format clean (`cargo fmt --all -- --check`)

## Related
- Fixes #1187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for anchor validation with comprehensive boundary and edge-case scenarios to ensure reliable system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->