### PR TITLE
refactor(anchor_validation): split get_anchor_height into canonical and any-block variants

### DIFF
--- a/crates/actors/src/anchor_validation.rs
+++ b/crates/actors/src/anchor_validation.rs
@@ -5,49 +5,50 @@ use irys_types::ingress::IngressProof;
 use irys_types::{H256, IrysTransactionCommon, app_state::DatabaseProvider};
 use tracing::{debug, warn};
 
-/// Resolves an anchor (block hash) to its height.
-/// If the anchor is not found, returns `Ok(None)`.
+/// Resolves a canonical anchor (block hash) to its height.
+/// Returns `Ok(None)` if the anchor is unknown or non-canonical.
 ///
-/// When `canonical=true`: checks the block tree's canonical chain first, then falls back
-/// to the database with a `MigratedBlockHashes` cross-check to ensure the block is
-/// actually canonical (not an orphan from a resolved fork).
+/// Checks the block tree's canonical chain first, then falls back to the
+/// database with a `MigratedBlockHashes` cross-check to ensure the block
+/// is actually canonical (not an orphan from a resolved fork).
+#[tracing::instrument(level = "trace", skip_all, fields(anchor = %anchor))]
+pub fn get_canonical_anchor_height(
+    block_tree: &BlockTreeReadGuard,
+    db: &DatabaseProvider,
+    anchor: H256,
+) -> eyre::Result<Option<u64>> {
+    if let Some(height) = block_tree
+        .read()
+        .get_canonical_chain()
+        .0
+        .iter()
+        .find(|b| b.block_hash() == anchor)
+        .map(BlockTreeEntry::height)
+    {
+        return Ok(Some(height));
+    }
+
+    db.view_eyre(|tx| irys_database::canonical_block_height_by_hash(tx, &anchor))
+}
+
+/// Resolves any known anchor (block hash) to its height, including orphaned blocks.
+/// Returns `Ok(None)` if the anchor is completely unknown.
 ///
-/// When `canonical=false`: checks the block tree for any known block, then falls back to
-/// `IrysBlockHeaders` without canonical verification (used by mempool expiry).
-#[tracing::instrument(level = "trace", skip_all, fields(anchor = %anchor, canonical = canonical))]
+/// Checks the block tree for any known block first, then falls back to
+/// `IrysBlockHeaders` without canonical verification (used by mempool expiry
+/// and ingress proof validation).
+#[tracing::instrument(level = "trace", skip_all, fields(anchor = %anchor))]
 pub fn get_anchor_height(
     block_tree: &BlockTreeReadGuard,
     db: &DatabaseProvider,
     anchor: H256,
-    canonical: bool,
 ) -> eyre::Result<Option<u64>> {
-    // Fast path: check the in-memory block tree first.
-    if let Some(height) = {
-        let guard = block_tree.read();
-        if canonical {
-            guard
-                .get_canonical_chain()
-                .0
-                .iter()
-                .find(|b| b.block_hash() == anchor)
-                .map(BlockTreeEntry::height)
-        } else {
-            guard.get_block(&anchor).map(|h| h.height)
-        }
-    } {
+    if let Some(height) = block_tree.read().get_block(&anchor).map(|h| h.height) {
         return Ok(Some(height));
     }
 
-    // Slow path: consult the database for blocks pruned from the tree.
-    if canonical {
-        // Cross-check IrysBlockHeaders against MigratedBlockHashes in one
-        // read transaction to ensure the block is actually canonical.
-        db.view_eyre(|tx| irys_database::canonical_block_height_by_hash(tx, &anchor))
-    } else {
-        // Non-canonical lookup (e.g. mempool expiry): accept any known block.
-        let hdr = db.view_eyre(|tx| irys_database::block_header_by_hash(tx, &anchor, false))?;
-        Ok(hdr.map(|h| h.height))
-    }
+    let hdr = db.view_eyre(|tx| irys_database::block_header_by_hash(tx, &anchor, false))?;
+    Ok(hdr.map(|h| h.height))
 }
 
 /// Validates that a transaction's anchor falls within `[min_anchor_height, max_anchor_height]`.
@@ -63,7 +64,7 @@ pub fn validate_anchor_for_inclusion(
     let tx_id = tx.id();
     let anchor = tx.anchor();
     // transaction anchors must be canonical for inclusion
-    let anchor_height = match get_anchor_height(block_tree, db, anchor, true).map_err(|e| {
+    let anchor_height = match get_canonical_anchor_height(block_tree, db, anchor).map_err(|e| {
         TxIngressError::DatabaseError(format!("Error getting anchor height for {}: {}", anchor, e))
     })? {
         Some(height) => height,
@@ -104,7 +105,7 @@ pub fn validate_ingress_proof_anchor_for_inclusion(
     ingress_proof: &IngressProof,
 ) -> eyre::Result<bool> {
     let anchor = ingress_proof.anchor;
-    let anchor_height = match get_anchor_height(block_tree, db, anchor, true).map_err(|e| {
+    let anchor_height = match get_canonical_anchor_height(block_tree, db, anchor).map_err(|e| {
         TxIngressError::DatabaseError(format!("Error getting anchor height for {}: {}", anchor, e))
     })? {
         Some(height) => height,

--- a/crates/actors/src/anchor_validation_tests.rs
+++ b/crates/actors/src/anchor_validation_tests.rs
@@ -9,7 +9,7 @@ use irys_testing_utils::IrysBlockHeaderTestExt as _;
 use irys_types::{ConsensusConfig, DatabaseProvider, H256, IrysBlockHeader};
 use reth_db::mdbx::DatabaseArguments;
 
-use super::get_anchor_height;
+use super::{get_anchor_height, get_canonical_anchor_height};
 
 fn signed_genesis() -> IrysBlockHeader {
     let mut header = IrysBlockHeader::new_mock_header();
@@ -66,7 +66,7 @@ fn canonical_block_in_tree_returns_height() {
     let block_tree = test_block_tree(&genesis);
     let (_tmp, db) = test_db();
 
-    let result = get_anchor_height(&block_tree, &db, genesis.block_hash(), true).unwrap();
+    let result = get_canonical_anchor_height(&block_tree, &db, genesis.block_hash()).unwrap();
     assert_eq!(result, Some(0));
 }
 
@@ -76,7 +76,7 @@ fn non_canonical_block_in_tree_returns_height_when_canonical_false() {
     let block_tree = test_block_tree(&genesis);
     let (_tmp, db) = test_db();
 
-    let result = get_anchor_height(&block_tree, &db, genesis.block_hash(), false).unwrap();
+    let result = get_anchor_height(&block_tree, &db, genesis.block_hash()).unwrap();
     assert_eq!(result, Some(0));
 }
 
@@ -86,7 +86,7 @@ fn unknown_block_returns_none() {
     let block_tree = test_block_tree(&genesis);
     let (_tmp, db) = test_db();
 
-    let result = get_anchor_height(&block_tree, &db, H256::random(), true).unwrap();
+    let result = get_canonical_anchor_height(&block_tree, &db, H256::random()).unwrap();
     assert_eq!(result, None);
 }
 
@@ -101,7 +101,7 @@ fn canonical_block_in_db_with_migrated_entry_returns_height() {
     write_header_to_db(&db, &old_block);
     write_canonical_entry(&db, 5, old_block_hash);
 
-    let result = get_anchor_height(&block_tree, &db, old_block_hash, true).unwrap();
+    let result = get_canonical_anchor_height(&block_tree, &db, old_block_hash).unwrap();
     assert_eq!(result, Some(5));
 }
 
@@ -115,7 +115,7 @@ fn orphan_block_in_db_without_migrated_entry_returns_none_when_canonical() {
     let orphan_block = mock_header(5, orphan_hash);
     write_header_to_db(&db, &orphan_block);
 
-    let result = get_anchor_height(&block_tree, &db, orphan_hash, true).unwrap();
+    let result = get_canonical_anchor_height(&block_tree, &db, orphan_hash).unwrap();
     assert_eq!(
         result, None,
         "orphan block should not be accepted as canonical"
@@ -136,10 +136,10 @@ fn orphan_block_at_height_with_different_canonical_returns_none() {
 
     write_canonical_entry(&db, 5, canonical_hash);
 
-    let result = get_anchor_height(&block_tree, &db, canonical_hash, true).unwrap();
+    let result = get_canonical_anchor_height(&block_tree, &db, canonical_hash).unwrap();
     assert_eq!(result, Some(5));
 
-    let result = get_anchor_height(&block_tree, &db, orphan_hash, true).unwrap();
+    let result = get_canonical_anchor_height(&block_tree, &db, orphan_hash).unwrap();
     assert_eq!(result, None, "orphan should be rejected after reorg");
 }
 
@@ -152,6 +152,6 @@ fn orphan_block_in_db_returns_height_when_canonical_false() {
     let orphan_hash = H256::random();
     write_header_to_db(&db, &mock_header(5, orphan_hash));
 
-    let result = get_anchor_height(&block_tree, &db, orphan_hash, false).unwrap();
+    let result = get_anchor_height(&block_tree, &db, orphan_hash).unwrap();
     assert_eq!(result, Some(5));
 }

--- a/crates/actors/src/anchor_validation_tests.rs
+++ b/crates/actors/src/anchor_validation_tests.rs
@@ -71,7 +71,7 @@ fn canonical_block_in_tree_returns_height() {
 }
 
 #[test]
-fn non_canonical_block_in_tree_returns_height_when_canonical_false() {
+fn any_block_in_tree_returns_height() {
     let genesis = signed_genesis();
     let block_tree = test_block_tree(&genesis);
     let (_tmp, db) = test_db();
@@ -144,7 +144,7 @@ fn orphan_block_at_height_with_different_canonical_returns_none() {
 }
 
 #[test]
-fn orphan_block_in_db_returns_height_when_canonical_false() {
+fn orphan_block_in_db_returns_height() {
     let genesis = signed_genesis();
     let block_tree = test_block_tree(&genesis);
     let (_tmp, db) = test_db();

--- a/crates/actors/src/chunk_ingress_service/ingress_proofs.rs
+++ b/crates/actors/src/chunk_ingress_service/ingress_proofs.rs
@@ -149,7 +149,6 @@ impl ChunkIngressServiceInner {
             block_tree_read_guard,
             irys_db,
             ingress_proof.anchor,
-            false, /* does not need to be canonical */
         )
         .map_err(|db_err| IngressProofError::DatabaseError(db_err.to_string()))?
         {

--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -371,13 +371,10 @@ impl Inner {
                 TxIngressError::Other("empty canonical chain in block tree".to_owned())
             })?;
 
-        // let anchor_height = self.get_anchor_height(tx_id, anchor).await?;
-
         let anchor_height = match crate::anchor_validation::get_anchor_height(
             &self.block_tree_read_guard,
             &self.irys_db,
             anchor,
-            false, /* does not need to be canonical */
         )
         .map_err(|e| {
             TxIngressError::DatabaseError(format!(

--- a/crates/actors/src/mempool_service/lifecycle.rs
+++ b/crates/actors/src/mempool_service/lifecycle.rs
@@ -159,7 +159,6 @@ impl Inner {
             &self.block_tree_read_guard,
             &self.irys_db,
             tx.anchor(),
-            false, /* does not need to be canonical */
         ) {
             Ok(Some(h)) => h,
             // if we don't know about the anchor, we should prune

--- a/crates/chain-tests/src/validation/anchor_canonical_reorg.rs
+++ b/crates/chain-tests/src/validation/anchor_canonical_reorg.rs
@@ -2,7 +2,7 @@
 //! blocks after a reorg by using `MigratedBlockHashes` as canonical authority.
 
 use crate::utils::IrysNodeTest;
-use irys_actors::anchor_validation::get_anchor_height;
+use irys_actors::anchor_validation::{get_anchor_height, get_canonical_anchor_height};
 use irys_types::{H256, NodeConfig};
 use std::sync::Arc;
 use tracing::debug;
@@ -11,8 +11,8 @@ use tracing::debug;
 /// canonical anchors. This test:
 /// 1. Starts two mining peers that build competing forks
 /// 2. Triggers a reorg by extending the losing peer's chain
-/// 3. Phase 1 (in-tree): verifies that the orphan is rejected for canonical=true
-///    but still findable with canonical=false while in the block tree
+/// 3. Phase 1 (in-tree): verifies that the orphan is rejected by `get_canonical_anchor_height`
+///    but still findable with `get_anchor_height` while in the block tree
 /// 4. Phase 2 (DB fallback): mines extra blocks to prune height 3 from the tree,
 ///    then verifies the orphan is rejected via DB cross-check and the canonical
 ///    block is found via MigratedBlockHashes
@@ -22,7 +22,7 @@ async fn heavy_test_anchor_rejects_orphan_after_reorg() -> eyre::Result<()> {
     let seconds_to_wait = 15;
     let block_migration_depth = 1;
     // Small tree depth forces blocks at height 3 to be pruned once tip reaches ~7,
-    // ensuring the assertions exercise the DB fallback path in get_anchor_height.
+    // ensuring the assertions exercise the DB fallback path in get_canonical_anchor_height.
     let block_tree_depth = 3;
 
     let mut genesis_config = NodeConfig::testing_with_epochs(num_blocks_in_epoch);
@@ -178,18 +178,18 @@ async fn heavy_test_anchor_rejects_orphan_after_reorg() -> eyre::Result<()> {
     let db = &genesis_node.node_ctx.db;
 
     // Phase 1: while the orphan is still in the block tree (pre-prune).
-    // canonical=true should reject it (block tree filters by canonical chain).
-    let orphan_result = get_anchor_height(block_tree, db, orphaned_hash, true)?;
+    // get_canonical_anchor_height should reject it (filters by canonical chain).
+    let orphan_result = get_canonical_anchor_height(block_tree, db, orphaned_hash)?;
     assert_eq!(
         orphan_result, None,
         "orphaned fork block should not be accepted as canonical anchor"
     );
 
-    // canonical=false finds the orphan via get_block() while it's still in the tree.
-    let non_canonical_result = get_anchor_height(block_tree, db, orphaned_hash, false)?;
+    // get_anchor_height finds the orphan via get_block() while it's still in the tree.
+    let non_canonical_result = get_anchor_height(block_tree, db, orphaned_hash)?;
     assert!(
         non_canonical_result.is_some(),
-        "orphaned block should still be found with canonical=false (in-tree)"
+        "orphaned block should still be found with get_anchor_height (in-tree)"
     );
 
     // Phase 2: mine extra blocks to prune height 3 from the tree (block_tree_depth=3
@@ -200,16 +200,16 @@ async fn heavy_test_anchor_rejects_orphan_after_reorg() -> eyre::Result<()> {
         .wait_for_block_at_height(8, seconds_to_wait)
         .await?;
 
-    // canonical=true: orphan was never migrated to MigratedBlockHashes, so the
-    // DB cross-check correctly rejects it.
-    let orphan_after_prune = get_anchor_height(block_tree, db, orphaned_hash, true)?;
+    // get_canonical_anchor_height: orphan was never migrated to MigratedBlockHashes,
+    // so the DB cross-check correctly rejects it.
+    let orphan_after_prune = get_canonical_anchor_height(block_tree, db, orphaned_hash)?;
     assert_eq!(
         orphan_after_prune, None,
         "orphaned block should be rejected via DB fallback after pruning"
     );
 
-    // canonical=true: the winning fork's block was migrated and should be found via DB.
-    let canonical_result = get_anchor_height(block_tree, db, canonical_hash, true)?;
+    // get_canonical_anchor_height: the winning fork's block was migrated and should be found via DB.
+    let canonical_result = get_canonical_anchor_height(block_tree, db, canonical_hash)?;
     assert!(
         canonical_result.is_some(),
         "canonical block should be accepted as anchor via DB fallback"


### PR DESCRIPTION
## Summary

**Before:**
`get_anchor_height` used a `canonical: bool` parameter to dispatch two semantically different lookup paths (canonical-only via `MigratedBlockHashes` cross-check vs any-block via `IrysBlockHeaders`). Call sites passed `true` or `false` with no indication of intent without reading the function signature.

**After:**
Two named functions replace the boolean-dispatched original: `get_canonical_anchor_height` (canonical chain lookup with DB cross-check) and `get_anchor_height` (any-block lookup including orphans). Call-site intent is now explicit in the function name.

## Changes

### Core split (`anchor_validation.rs`)
- Replaced single `get_anchor_height(block_tree, db, anchor, canonical: bool)` with two functions
- `get_canonical_anchor_height`: checks canonical chain in block tree, falls back to `canonical_block_height_by_hash` DB lookup
- `get_anchor_height`: checks any block in tree via `get_block`, falls back to `block_header_by_hash` DB lookup
- Dropped `canonical = canonical` from `#[tracing::instrument]` fields (function name conveys the variant)

### Call-site updates (`irys-actors`)
- `validate_anchor_for_inclusion`: `get_anchor_height(..., true)` to `get_canonical_anchor_height(...)`
- `validate_ingress_proof_anchor_for_inclusion`: `get_anchor_height(..., true)` to `get_canonical_anchor_height(...)`
- `mempool_service.rs`: dropped `false` arg, deleted dead commented-out code at line 374
- `mempool_service/lifecycle.rs`: dropped `false` arg
- `chunk_ingress_service/ingress_proofs.rs`: dropped `false` arg

### Unit tests (`anchor_validation_tests.rs`)
- Updated import to include both functions
- 6 test calls changed from `get_anchor_height(..., true)` to `get_canonical_anchor_height(...)`
- 2 test calls changed from `get_anchor_height(..., false)` to `get_anchor_height(...)` (3-arg)

### Integration test (`anchor_canonical_reorg.rs`)
- Updated import to include both functions
- 3 canonical calls and 1 non-canonical call updated
- Inline comments updated to reference function names instead of `canonical=true`/`canonical=false`

## Technical Notes

- **Breaking changes**: Public API of `get_anchor_height` changed (4 args to 3). Compiler enforces all call sites are updated since there is no overloading in Rust.
- **Dead code**: Removed commented-out line in `mempool_service.rs`

## Testing
- [x] Unit tests updated (7 tests, all passing)
- [x] Integration test updated (`anchor_canonical_reorg.rs`)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

## Related
- Fixes #1193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Split anchor lookup into distinct canonical and non-canonical resolution paths to make validation behavior clearer and more predictable.
  * Updated validation logic throughout the codebase and refreshed tests to reflect the new, clearer semantics for canonical vs in-memory anchor checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->