### PR TITLE
perf(irys-signer): cache IrysSigner in Config, memoise address

### DIFF
--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -827,7 +827,7 @@ pub trait BlockProdStrategy {
     ) -> Result<(EthBuiltPayload, U256), BlockProductionError> {
         let block_height = prev_block_header.height + 1;
         let local_signer =
-            LocalSigner::from_signing_key(self.inner().config.irys_signer().signer.clone()); // clone: need owned SigningKey for LocalSigner; block production path, not hot loop
+            LocalSigner::from_signing_key(self.inner().config.irys_signer().signing_key().clone()); // clone: need owned SigningKey for LocalSigner; block production path, not hot loop
 
         // Get treasury balance from previous block
         let initial_treasury_balance = prev_block_header.treasury;

--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -826,7 +826,8 @@ pub trait BlockProdStrategy {
         solution_hash: H256,
     ) -> Result<(EthBuiltPayload, U256), BlockProductionError> {
         let block_height = prev_block_header.height + 1;
-        let local_signer = LocalSigner::from(self.inner().config.irys_signer().signer);
+        let local_signer =
+            LocalSigner::from_signing_key(self.inner().config.irys_signer().signer.clone()); // clone: need owned SigningKey for LocalSigner; block production path, not hot loop
 
         // Get treasury balance from previous block
         let initial_treasury_balance = prev_block_header.treasury;

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -568,7 +568,7 @@ impl InnerCacheTask {
                     &self.block_tree_guard,
                     &self.db,
                     &self.config,
-                    &signer,
+                    signer,
                     proof,
                     &self.gossip_broadcast,
                     &self.cache_sender,

--- a/crates/actors/src/chunk_ingress_service/chunks.rs
+++ b/crates/actors/src/chunk_ingress_service/chunks.rs
@@ -774,7 +774,7 @@ pub fn generate_ingress_proof(
     data_root: DataRoot,
     size: u64,
     chunk_size: u64,
-    signer: IrysSigner,
+    signer: &IrysSigner,
     chain_id: ChainId,
     anchor: H256,
 ) -> eyre::Result<IngressProof> {
@@ -838,7 +838,7 @@ pub fn generate_ingress_proof(
 
         // generate the ingress proof hash
         let proof = irys_types::ingress::generate_ingress_proof(
-            &signer, data_root, iter, chain_id, anchor,
+            signer, data_root, iter, chain_id, anchor,
         )?;
 
         Ok((proof, total_data_size, chunk_count))
@@ -851,7 +851,7 @@ pub fn generate_ingress_proof(
     assert_eq!(actual_data_size, size);
     assert_eq!(actual_chunk_count, expected_chunk_count);
 
-    db.update(|rw_tx| irys_database::store_ingress_proof_checked(rw_tx, &proof, &signer))??;
+    db.update(|rw_tx| irys_database::store_ingress_proof_checked(rw_tx, &proof, signer))??;
 
     Ok(proof)
 }

--- a/crates/actors/src/chunk_ingress_service/ingress_proofs.rs
+++ b/crates/actors/src/chunk_ingress_service/ingress_proofs.rs
@@ -319,7 +319,7 @@ pub fn generate_and_store_ingress_proof(
     gossip_sender: &tokio::sync::mpsc::UnboundedSender<Traced<GossipBroadcastMessageV2>>,
     cache_sender: &CacheServiceSender,
 ) -> Result<IngressProof, IngressProofGenerationError> {
-    let signer: IrysSigner = config.irys_signer();
+    let signer = config.irys_signer();
 
     // Only staked nodes should generate ingress proofs
     let epoch_snapshot = block_tree_guard.read().canonical_epoch_snapshot();

--- a/crates/chain-tests/src/api/client.rs
+++ b/crates/chain-tests/src/api/client.rs
@@ -39,12 +39,12 @@ async fn check_transaction_endpoints(
     let _header = ctx.mine_block().await.expect("expected mined block");
 
     let tx = ctx
-        .create_signed_data_tx(&ctx.node_ctx.config.irys_signer(), vec![1, 2, 3])
+        .create_signed_data_tx(ctx.node_ctx.config.irys_signer(), vec![1, 2, 3])
         .await
         .unwrap();
     let tx_id = tx.header.id;
     let tx_2 = ctx
-        .create_signed_data_tx(&ctx.node_ctx.config.irys_signer(), vec![4, 5, 6])
+        .create_signed_data_tx(ctx.node_ctx.config.irys_signer(), vec![4, 5, 6])
         .await
         .unwrap();
     let tx_2_id = tx_2.header.id;
@@ -153,7 +153,7 @@ async fn api_client_wait_for_promotion_errors_for_missing_tx() {
 
     // Create a tx but do NOT post it; waiting for promotion should error out
     let tx = ctx
-        .create_signed_data_tx(&ctx.node_ctx.config.irys_signer(), vec![7, 8, 9])
+        .create_signed_data_tx(ctx.node_ctx.config.irys_signer(), vec![7, 8, 9])
         .await
         .unwrap();
 
@@ -186,7 +186,7 @@ async fn api_client_wait_for_promotion_happy_path() {
     // Create a full data tx, upload chunks, and post header
     let tx = ctx
         .create_signed_data_tx(
-            &ctx.node_ctx.config.irys_signer(),
+            ctx.node_ctx.config.irys_signer(),
             vec![1, 2, 3, 4, 5, 6, 7, 8],
         )
         .await
@@ -240,7 +240,7 @@ async fn api_tx_status_lifecycle() {
 
     // Create and post a transaction
     let tx = ctx
-        .create_signed_data_tx(&ctx.node_ctx.config.irys_signer(), vec![1, 2, 3])
+        .create_signed_data_tx(ctx.node_ctx.config.irys_signer(), vec![1, 2, 3])
         .await
         .unwrap();
     let tx_id = tx.header.id;
@@ -346,7 +346,7 @@ async fn api_tx_status_finalized_survives_restart() {
 
     // Create and post a transaction
     let tx = ctx
-        .create_signed_data_tx(&ctx.node_ctx.config.irys_signer(), vec![1, 2, 3])
+        .create_signed_data_tx(ctx.node_ctx.config.irys_signer(), vec![1, 2, 3])
         .await
         .unwrap();
     let tx_id = tx.header.id;
@@ -453,7 +453,7 @@ async fn api_tx_status_confirmed_survives_restart() {
 
     // Create and post a transaction
     let tx = ctx
-        .create_signed_data_tx(&ctx.node_ctx.config.irys_signer(), vec![1, 2, 3])
+        .create_signed_data_tx(ctx.node_ctx.config.irys_signer(), vec![1, 2, 3])
         .await
         .unwrap();
     let tx_id = tx.header.id;
@@ -618,7 +618,7 @@ async fn api_double_promotion_after_restart() {
     // Create a Publish-eligible data tx (with fees), upload chunks, and post header
     let tx = ctx
         .create_signed_data_tx(
-            &ctx.node_ctx.config.irys_signer(),
+            ctx.node_ctx.config.irys_signer(),
             vec![1, 2, 3, 4, 5, 6, 7, 8],
         )
         .await

--- a/crates/chain-tests/src/block_production/analytics.rs
+++ b/crates/chain-tests/src/block_production/analytics.rs
@@ -130,7 +130,7 @@ async fn test_blockprod_with_evm_txs() -> eyre::Result<()> {
     let alloy_providers = accounts
         .iter()
         .map(|a| {
-            let signer: PrivateKeySigner = a.signing_key().clone().into();
+            let signer: PrivateKeySigner = a.signing_key().clone().into(); // clone: need owned key for PrivateKeySigner conversion
             ProviderBuilder::new()
                 .wallet(EthereumWallet::from(signer))
                 .connect_http(

--- a/crates/chain-tests/src/block_production/analytics.rs
+++ b/crates/chain-tests/src/block_production/analytics.rs
@@ -1,0 +1,281 @@
+use alloy_core::primitives::{ruint::aliases::U256, Bytes, TxKind};
+use alloy_eips::eip2718::Encodable2718 as _;
+use alloy_genesis::GenesisAccount;
+use alloy_network::EthereumWallet;
+use alloy_provider::Provider as _;
+use alloy_provider::ProviderBuilder;
+use alloy_signer_local::LocalSigner;
+use alloy_signer_local::PrivateKeySigner;
+use irys_reth_node_bridge::reth_e2e_test_utils::transaction::TransactionTestContext;
+use k256::ecdsa::SigningKey;
+use rand::Rng as _;
+use reth::rpc::types::TransactionRequest;
+use std::time::Duration;
+use tokio::time::sleep;
+use tracing::info;
+
+use irys_types::NodeConfig;
+use irys_types::TxChunkOffset;
+use irys_types::UnpackedChunk;
+use irys_types::{irys::IrysSigner, serialization::*, DataTransaction, SimpleRNG};
+
+use crate::utils::IrysNodeTest;
+
+// network simulation test for analytics
+#[ignore]
+#[tokio::test]
+async fn test_blockprod_with_evm_txs() -> eyre::Result<()> {
+    // SAFETY: test code; env var set before other threads spawn.
+    unsafe { std::env::set_var("RUST_LOG", "debug") };
+
+    let mut config = NodeConfig::testing();
+    config.consensus.get_mut().chunk_size = 32;
+    config.consensus.get_mut().num_chunks_in_partition = 1000;
+    config.consensus.get_mut().num_chunks_in_recall_range = 2;
+    config.consensus.get_mut().num_partitions_per_slot = 1;
+    config.storage.num_writes_before_sync = 1;
+    config.consensus.get_mut().entropy_packing_iterations = 1_000;
+    config.consensus.get_mut().block_migration_depth = 1; // Testnet / single node config;
+    let account1 = IrysSigner::random_signer(&config.consensus_config());
+    let account2 = IrysSigner::random_signer(&config.consensus_config());
+    let account3 = IrysSigner::random_signer(&config.consensus_config());
+    config.consensus.extend_genesis_accounts(vec![
+        (
+            account1.address(),
+            GenesisAccount {
+                balance: U256::from(69000000000000000000000_u128),
+                ..Default::default()
+            },
+        ),
+        (
+            account2.address(),
+            GenesisAccount {
+                balance: U256::from(4200000000000000000000000_u128),
+                ..Default::default()
+            },
+        ),
+        (
+            account3.address(),
+            GenesisAccount {
+                balance: U256::from(6900000000000000000000000_u128),
+                ..Default::default()
+            },
+        ),
+    ]);
+    let node = IrysNodeTest::new_genesis(config.clone()).start().await;
+
+    let http_url = format!(
+        "http://127.0.0.1:{}",
+        node.node_ctx.config.node_config.http.bind_port
+    );
+
+    // server should be running
+    // check with request to `/v1/info`
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10_000))
+        .build()
+        .expect("failed to build reqwest client");
+
+    let _response = client
+        .get(format!("{}/v1/info", http_url))
+        .send()
+        .await
+        .unwrap();
+
+    let anchor = node.get_anchor().await?;
+
+    let generate_tx_with_size = |a: &IrysSigner,
+                                 data_size: usize,
+                                 perm_fee: irys_types::U256,
+                                 term_fee: irys_types::U256|
+     -> eyre::Result<(DataTransaction, Vec<u8>)> {
+        let mut data_bytes = vec![0_u8; data_size];
+        rand::thread_rng().fill(&mut data_bytes[..]);
+
+        let tx = a.create_publish_transaction(
+            data_bytes.clone(),
+            anchor,
+            perm_fee.into(),
+            term_fee.into(),
+        )?;
+        let tx = a.sign_transaction(tx)?;
+        Ok((tx, data_bytes))
+    };
+
+    let upload_header = |tx: &DataTransaction| {
+        client
+            .post(format!("{}/v1/tx", http_url))
+            .json(&tx.header)
+            .send()
+    };
+
+    // Generate initial transactions with correct pricing
+    let mut pending_txs = vec![];
+    for account in [&account1, &account2, &account3] {
+        let data_size = rand::thread_rng().gen_range(1..=100);
+        let price_info = node
+            .get_data_price(irys_types::DataLedger::Publish, data_size as u64)
+            .await
+            .expect("Failed to get price");
+        let tx_with_data =
+            generate_tx_with_size(account, data_size, price_info.perm_fee, price_info.term_fee)?;
+        pending_txs.push((tx_with_data, 0));
+    }
+    upload_header(&pending_txs[0].0 .0).await.unwrap();
+    upload_header(&pending_txs[1].0 .0).await.unwrap();
+    upload_header(&pending_txs[2].0 .0).await.unwrap();
+
+    let accounts = [account1, account2, account3];
+
+    let alloy_providers = accounts
+        .iter()
+        .map(|a| {
+            let signer: PrivateKeySigner = a.signing_key().clone().into();
+            ProviderBuilder::new()
+                .wallet(EthereumWallet::from(signer))
+                .connect_http(
+                    format!(
+                        "http://127.0.0.1:{}/v1/execution-rpc",
+                        node.node_ctx.config.node_config.http.bind_port
+                    )
+                    .parse()
+                    .unwrap(),
+                )
+        })
+        .collect::<Vec<_>>();
+
+    for i in 0..20 {
+        let mut simple_rng = SimpleRNG::new(i);
+
+        for (i, a) in accounts.iter().enumerate() {
+            let es: LocalSigner<SigningKey> = a.clone().into();
+            let to_index: usize =
+                <u32 as TryInto<usize>>::try_into(simple_rng.next_range(3)).unwrap();
+
+            let alloy_provider = alloy_providers.get(to_index).unwrap();
+
+            let evm_tx_req = TransactionRequest {
+                to: Some(TxKind::Call(
+                    accounts.get(to_index).unwrap().alloy_address(), /* config.mining_signer.address() */
+                )),
+                max_fee_per_gas: Some(20e9 as u128),
+                max_priority_fee_per_gas: Some(20e9 as u128),
+                gas: Some(21000),
+                value: Some(U256::from(simple_rng.next_range(20_000))),
+                nonce: Some(
+                    alloy_provider
+                        .get_transaction_count(a.alloy_address())
+                        .await?,
+                ),
+                chain_id: Some(node.node_ctx.config.consensus.chain_id),
+                ..Default::default()
+            };
+
+            let tx_env = TransactionTestContext::sign_tx(es, evm_tx_req).await;
+            let signed_tx: Bytes = tx_env.encoded_2718().into();
+            let _ = alloy_provider
+                .send_raw_transaction(&signed_tx)
+                .await
+                .unwrap();
+
+            // reth_context
+            //     .rpc
+            //     .inject_tx(signed_tx)
+            //     .await
+            //     .expect("tx should be accepted");
+            // evm_txs.insert(*tx_env.tx_hash(), tx_env.clone());
+
+            let ((ref mut tx, ref mut data_bytes), ref mut num_chunks_uploaded) =
+                pending_txs.get_mut(i).unwrap();
+            // let chunks_left = tx.chunks.len() - *num_chunks_uploaded;
+
+            // upload the remaining chunks
+            for (tx_chunk_offset, chunk_node) in tx.chunks.iter().enumerate() {
+                if tx_chunk_offset < *num_chunks_uploaded && tx_chunk_offset != *num_chunks_uploaded
+                {
+                    continue;
+                }
+
+                let data_root = tx.header.data_root;
+                let data_size = tx.header.data_size;
+                let min = chunk_node.min_byte_range;
+                let max = chunk_node.max_byte_range;
+                let data_path = Base64(tx.proofs[tx_chunk_offset].proof.clone());
+
+                let chunk = UnpackedChunk {
+                    data_root,
+                    data_size,
+                    data_path,
+                    bytes: Base64(data_bytes[min..max].to_vec()),
+                    tx_offset: TxChunkOffset::from(
+                        TryInto::<u32>::try_into(tx_chunk_offset).expect("Value exceeds u32::MAX"),
+                    ),
+                };
+
+                // Make a POST request with JSON payload
+                let resp = client
+                    .post(format!("{}/v1/chunk", http_url))
+                    .json(&chunk)
+                    .send()
+                    .await
+                    .unwrap();
+                assert_eq!(resp.status(), reqwest::StatusCode::OK);
+            }
+
+            // create a new tx, upload *some* of it's chunks
+            let new_data_size = rand::thread_rng().gen_range(1..=100);
+            let new_price_info = node
+                .get_data_price(irys_types::DataLedger::Publish, new_data_size as u64)
+                .await
+                .expect("Failed to get price");
+            (*tx, *data_bytes) = generate_tx_with_size(
+                a,
+                new_data_size,
+                new_price_info.perm_fee,
+                new_price_info.term_fee,
+            )
+            .expect("Failed to generate tx");
+
+            *num_chunks_uploaded = simple_rng
+                .next_range((tx.chunks.len() + 1).try_into().unwrap())
+                .try_into()
+                .unwrap();
+
+            upload_header(tx).await.unwrap();
+
+            for (tx_chunk_offset, chunk_node) in
+                tx.chunks.iter().take(*num_chunks_uploaded).enumerate()
+            {
+                let data_root = tx.header.data_root;
+                let data_size = tx.header.data_size;
+                let min = chunk_node.min_byte_range;
+                let max = chunk_node.max_byte_range;
+                let data_path = Base64(tx.proofs[tx_chunk_offset].proof.clone());
+
+                let chunk = UnpackedChunk {
+                    data_root,
+                    data_size,
+                    data_path,
+                    bytes: Base64(data_bytes[min..max].to_vec()),
+                    tx_offset: (tx_chunk_offset as u32).into(),
+                };
+
+                let resp = client
+                    .post(format!("{}/v1/chunk", http_url))
+                    .json(&chunk)
+                    .send()
+                    .await
+                    .unwrap();
+
+                assert_eq!(resp.status(), reqwest::StatusCode::OK);
+            }
+        }
+
+        node.mine_block().await?;
+        info!("Finished step {}", &i);
+    }
+
+    sleep(Duration::from_secs(u64::MAX)).await;
+
+    Ok(())
+}

--- a/crates/chain-tests/src/block_production/unpledge_refund.rs
+++ b/crates/chain-tests/src/block_production/unpledge_refund.rs
@@ -684,7 +684,7 @@ async fn heavy3_unpledge_all_partitions_refund_flow() -> eyre::Result<()> {
         &genesis_node,
         &peer_node,
         consensus,
-        &genesis_signer,
+        genesis_signer,
         assigned_partitions,
     )
     .await?;

--- a/crates/chain-tests/src/block_production/unstake_refund.rs
+++ b/crates/chain-tests/src/block_production/unstake_refund.rs
@@ -589,7 +589,7 @@ async fn heavy_unstake_rejected_with_pending_pledge() -> eyre::Result<()> {
         &genesis_node,
         &peer_node,
         consensus.clone(),
-        &peer_signer,
+        peer_signer,
         {
             let sms = peer_node.node_ctx.storage_modules_guard.read();
             sms.iter().cloned().collect::<Vec<_>>()

--- a/crates/chain-tests/src/data_sync/sync_partition_data_tests.rs
+++ b/crates/chain-tests/src/data_sync/sync_partition_data_tests.rs
@@ -66,7 +66,7 @@ async fn spiky_slow_heavy4_sync_partition_data_between_peers_test() -> eyre::Res
     let data: Vec<u8> = chunks.concat();
 
     let data_tx = genesis_node
-        .post_publish_data_tx(&genesis_signer, data)
+        .post_publish_data_tx(genesis_signer, data)
         .await?;
 
     stake_and_pledge_signer(&genesis_node, &signer1, 3).await?;

--- a/crates/chain-tests/src/external/block_production.rs
+++ b/crates/chain-tests/src/external/block_production.rs
@@ -54,11 +54,11 @@ async fn continuous_blockprod_evm_tx() -> eyre::Result<()> {
         IrysAddress::from_slice(expected_addr.as_slice())
     );
     let account1_address = hex::decode(DEV2_ADDRESS)?;
-    let account1 = IrysSigner {
-        signer: SigningKey::from_slice(hex::decode(DEV2_PRIVATE_KEY)?.as_slice())?,
-        chain_id: node.node_ctx.config.consensus.chain_id,
-        chunk_size: node.node_ctx.config.consensus.chunk_size,
-    };
+    let account1 = IrysSigner::new(
+        SigningKey::from_slice(hex::decode(DEV2_PRIVATE_KEY)?.as_slice())?,
+        node.node_ctx.config.consensus.chain_id,
+        node.node_ctx.config.consensus.chunk_size,
+    );
     assert_eq!(
         account1.address(),
         IrysAddress::from_slice(account1_address.as_slice())

--- a/crates/chain-tests/src/external/utils/signer.rs
+++ b/crates/chain-tests/src/external/utils/signer.rs
@@ -18,11 +18,7 @@ impl TestSigner {
         let key_bytes = hex::decode(private_key_hex.trim_start_matches("0x"))?;
         let signing_key = SigningKey::from_slice(&key_bytes)?;
 
-        let irys_signer = IrysSigner {
-            signer: signing_key,
-            chain_id: config.chain_id,
-            chunk_size: config.chunk_size,
-        };
+        let irys_signer = IrysSigner::new(signing_key, config.chain_id, config.chunk_size);
 
         let address = irys_signer.address();
 

--- a/crates/chain-tests/src/integration/data_size.rs
+++ b/crates/chain-tests/src/integration/data_size.rs
@@ -48,7 +48,7 @@ async fn heavy_test_overlapping_data_sizes() -> eyre::Result<()> {
 
     // Compose a valid transaction with all of the chunks and accurate data_size
     let valid_tx = genesis_node
-        .create_signed_data_tx(&genesis_signer, data.clone())
+        .create_signed_data_tx(genesis_signer, data.clone())
         .await?;
 
     // Use the data_root of that transaction to compose another with a single chunk data_size

--- a/crates/chain-tests/src/integration/data_size.rs
+++ b/crates/chain-tests/src/integration/data_size.rs
@@ -48,7 +48,7 @@ async fn heavy_test_overlapping_data_sizes() -> eyre::Result<()> {
 
     // Compose a valid transaction with all of the chunks and accurate data_size
     let valid_tx = genesis_node
-        .create_signed_data_tx(genesis_signer, data.clone())
+        .create_signed_data_tx(genesis_signer, data.clone()) // clone: data reused in later assertions
         .await?;
 
     // Use the data_root of that transaction to compose another with a single chunk data_size

--- a/crates/chain-tests/src/multi_node/fork_recovery.rs
+++ b/crates/chain-tests/src/multi_node/fork_recovery.rs
@@ -115,7 +115,7 @@ async fn heavy4_fork_recovery_submit_tx_test() -> eyre::Result<()> {
         .post_data_tx(
             genesis_node.get_anchor().await?,
             data3,
-            &genesis_node.node_ctx.config.irys_signer(),
+            genesis_node.node_ctx.config.irys_signer(),
         )
         .await;
 

--- a/crates/chain-tests/src/multi_node/mempool_tests.rs
+++ b/crates/chain-tests/src/multi_node/mempool_tests.rs
@@ -703,7 +703,7 @@ async fn heavy3_mempool_submit_tx_fork_recovery_test() -> eyre::Result<()> {
         .post_data_tx(
             genesis_node.get_anchor().await?,
             data3,
-            &genesis_node.node_ctx.config.irys_signer(),
+            genesis_node.node_ctx.config.irys_signer(),
         )
         .await;
 
@@ -1114,7 +1114,7 @@ async fn heavy3_mempool_publish_fork_recovery_test(
         .post_data_tx(
             a_node.get_anchor().await?,
             [[1; 32], [1; 32], [1; 32]].concat(),
-            &a_signer,
+            a_signer,
         )
         .await;
 

--- a/crates/chain-tests/src/multi_node/peer_discovery.rs
+++ b/crates/chain-tests/src/multi_node/peer_discovery.rs
@@ -34,11 +34,11 @@ async fn peer_discovery() -> eyre::Result<()> {
         0x88, 0x99,
     ];
     let signing_key = k256::ecdsa::SigningKey::from_bytes((&key_bytes).into()).unwrap();
-    let signer = IrysSigner {
-        signer: signing_key,
-        chain_id: config.consensus_config().chain_id,
-        chunk_size: config.consensus_config().chunk_size,
-    };
+    let signer = IrysSigner::new(
+        signing_key,
+        config.consensus_config().chain_id,
+        config.consensus_config().chunk_size,
+    );
     config.consensus.extend_genesis_accounts(vec![(
         signer.address(),
         GenesisAccount {

--- a/crates/chain-tests/src/multi_node/peer_discovery.rs
+++ b/crates/chain-tests/src/multi_node/peer_discovery.rs
@@ -34,11 +34,8 @@ async fn peer_discovery() -> eyre::Result<()> {
         0x88, 0x99,
     ];
     let signing_key = k256::ecdsa::SigningKey::from_bytes((&key_bytes).into()).unwrap();
-    let signer = IrysSigner::new(
-        signing_key,
-        config.consensus_config().chain_id,
-        config.consensus_config().chunk_size,
-    );
+    let consensus = config.consensus_config();
+    let signer = IrysSigner::new(signing_key, consensus.chain_id, consensus.chunk_size);
     config.consensus.extend_genesis_accounts(vec![(
         signer.address(),
         GenesisAccount {

--- a/crates/chain-tests/src/multi_node/peer_discovery.rs
+++ b/crates/chain-tests/src/multi_node/peer_discovery.rs
@@ -73,7 +73,7 @@ async fn peer_discovery() -> eyre::Result<()> {
     // different IP addresses
     let miner_signer_1 = IrysSigner::random_signer(&config.consensus_config());
     let mut version_request = HandshakeRequestV2 {
-        chain_id: miner_signer_1.chain_id,
+        chain_id: miner_signer_1.chain_id(),
         address: PeerAddress {
             gossip: "127.0.0.1:8080".parse().expect("valid socket address"),
             api: "127.0.0.1:8081".parse().expect("valid socket address"),
@@ -206,7 +206,7 @@ async fn peer_discovery() -> eyre::Result<()> {
     let version_json = serde_json::json!({
         "version": "0.1.0",
         "protocol_version": "V2",
-        "chain_id": miner_signer_2.chain_id,
+        "chain_id": miner_signer_2.chain_id(),
         "address": {
             "gossip": "127.0.0.2:8080",
             "api": "127.0.0.2:8081",
@@ -247,7 +247,7 @@ async fn peer_discovery() -> eyre::Result<()> {
 
     let miner_signer_3 = IrysSigner::random_signer(&config.consensus_config());
     let mut version_request = HandshakeRequestV2 {
-        chain_id: miner_signer_3.chain_id,
+        chain_id: miner_signer_3.chain_id(),
         address: PeerAddress {
             gossip: "127.0.0.3:8080".parse().expect("valid socket address"),
             api: "127.0.0.3:8081".parse().expect("valid socket address"),

--- a/crates/chain-tests/src/partition_assignments/sm_reassignment_tests.rs
+++ b/crates/chain-tests/src/partition_assignments/sm_reassignment_tests.rs
@@ -64,7 +64,7 @@ async fn spiky_heavy_sm_reassignment_with_restart_test() -> eyre::Result<()> {
     // 2. Post a data_tx that will cause the submit ledger to add a slot (9 chunks worth of bytes)
     let data = vec![255_u8; 9 * chunk_size];
     let data_tx = genesis_node
-        .post_publish_data_tx(&genesis_signer, data)
+        .post_publish_data_tx(genesis_signer, data)
         .await?;
     genesis_node.post_data_tx_raw(&data_tx.header).await;
 

--- a/crates/chain-tests/src/utils.rs
+++ b/crates/chain-tests/src/utils.rs
@@ -662,7 +662,7 @@ impl IrysNodeTest<IrysNodeCtx> {
         }
 
         let mut peer_config = node_config.clone();
-        peer_config.mining_key = peer_signer.signer.clone();
+        peer_config.mining_key = peer_signer.signing_key().clone(); // clone: peer_signer still needed for address
         peer_config.reward_address = peer_signer.address();
 
         // Set peer mode and expected genesis hash via consensus config

--- a/crates/chain-tests/src/validation/poa_cases.rs
+++ b/crates/chain-tests/src/validation/poa_cases.rs
@@ -57,7 +57,7 @@ async fn multi_slot_poa_test() -> eyre::Result<()> {
             data.extend_from_slice(chunk);
         }
         let tx = genesis_node
-            .create_signed_data_tx(&genesis_signer, data)
+            .create_signed_data_tx(genesis_signer, data)
             .await
             .expect("to create a signed data tx");
         txs.push(tx);

--- a/crates/chain/src/utils.rs
+++ b/crates/chain/src/utils.rs
@@ -22,7 +22,7 @@ pub fn load_config() -> eyre::Result<NodeConfig> {
                 let mut config = NodeConfig::testnet();
                 let signer = config.new_random_signer();
                 config.reward_address = signer.address();
-                config.mining_key = signer.signer;
+                config.mining_key = signer.into_signing_key();
                 let mut file = std::fs::File::create(&config_path)?;
                 std::io::Write::write_all(&mut file, toml::to_string(&config)?.as_bytes())?;
                 eyre::bail!("Config file created - please edit it before restarting (see SETUP.md)")

--- a/crates/database/src/system_ledger.rs
+++ b/crates/database/src/system_ledger.rs
@@ -88,7 +88,7 @@ pub async fn get_genesis_commitments(config: &Config) -> Vec<CommitmentTransacti
     let mut anchor = stake_commitment.id();
     for i in 0..num_submodules {
         let pledge_tx =
-            create_pledge_commitment_transaction(&signer, anchor, config, &(i as u64)).await;
+            create_pledge_commitment_transaction(signer, anchor, config, &(i as u64)).await;
 
         // We have to rotate the anchors on these TX so they produce unique signatures
         // and unique txids
@@ -180,7 +180,7 @@ pub async fn add_test_commitments(
     config: &Config,
 ) -> (Vec<CommitmentTransaction>, U256) {
     let signer = config.irys_signer();
-    add_test_commitments_for_signer(block_header, &signer, pledge_count, config).await
+    add_test_commitments_for_signer(block_header, signer, pledge_count, config).await
 }
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/p2p/src/tests/util.rs
+++ b/crates/p2p/src/tests/util.rs
@@ -263,7 +263,7 @@ impl GossipServiceTestFixture {
         node_config.http.public_port = gossip_port;
         node_config.http.bind_port = gossip_port;
         let random_signer = IrysSigner::random_signer(&node_config.consensus_config());
-        node_config.mining_key = random_signer.signer;
+        node_config.mining_key = random_signer.into_signing_key();
         // Generate a distinct peer_id for this test fixture
         // peer_id is separate from mining_address in V2
         let config = Config::new_with_random_peer_id(node_config);

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -17,6 +17,11 @@ pub struct Config(Arc<CombinedConfigInner>);
 impl Config {
     pub fn new(node_config: NodeConfig, peer_id: IrysPeerId) -> Self {
         let consensus = node_config.consensus_config();
+        let irys_signer = IrysSigner::new(
+            node_config.mining_key.clone(), // clone: moving into cached signer while NodeConfig retains ownership
+            consensus.chain_id,
+            consensus.chunk_size,
+        );
 
         Self(Arc::new(CombinedConfigInner {
             consensus,
@@ -24,6 +29,7 @@ impl Config {
             vdf: node_config.vdf(),
             node_config,
             peer_id,
+            irys_signer,
         }))
     }
 
@@ -49,16 +55,12 @@ impl Config {
             vdf: inner.vdf.clone(),
             mempool: inner.mempool.clone(),
             peer_id: inner.peer_id,
+            irys_signer: inner.irys_signer.clone(), // clone: propagating cached signer into new Arc
         }))
     }
 
-    pub fn irys_signer(&self) -> IrysSigner {
-        // TODO: store the IrysSigner somewhere so we don't have to clone it all the time (& also memoize the address)
-        IrysSigner {
-            signer: self.node_config.mining_key.clone(),
-            chain_id: self.consensus.chain_id,
-            chunk_size: self.consensus.chunk_size,
-        }
+    pub fn irys_signer(&self) -> &IrysSigner {
+        &self.0.irys_signer
     }
 
     /// Get the number of ingress proofs required at a given timestamp (in seconds).
@@ -190,6 +192,7 @@ pub struct CombinedConfigInner {
     pub vdf: VdfConfig,
     pub mempool: MempoolConfig,
     pub peer_id: IrysPeerId,
+    pub irys_signer: IrysSigner,
 }
 
 impl From<&NodeConfig> for VdfConfig {

--- a/crates/types/src/config/node.rs
+++ b/crates/types/src/config/node.rs
@@ -918,10 +918,11 @@ impl NodeConfig {
     }
 
     pub fn signer(&self) -> IrysSigner {
+        let consensus = self.consensus_config();
         IrysSigner::new(
             self.mining_key.clone(), // clone: NodeConfig retains ownership of mining_key
-            self.consensus_config().chain_id,
-            self.consensus_config().chunk_size,
+            consensus.chain_id,
+            consensus.chunk_size,
         )
     }
 
@@ -954,7 +955,7 @@ impl NodeConfig {
 
     #[cfg(any(test, feature = "test-utils"))]
     pub fn testing_with_signer(signer: &IrysSigner) -> Self {
-        let mining_key = signer.signer.clone();
+        let mining_key = signer.signing_key().clone(); // clone: NodeConfig retains separate ownership of mining_key
         let reward_address = signer.address();
         let mut consensus = ConsensusConfig::testing();
         consensus.genesis.miner_address = reward_address;
@@ -1103,7 +1104,7 @@ impl NodeConfig {
         let mut consensus = ConsensusConfig::testnet();
         let signer = IrysSigner::new(mining_key, consensus.chain_id, consensus.chunk_size);
 
-        let mining_key = signer.signer.clone();
+        let mining_key = signer.signing_key().clone(); // clone: NodeConfig retains separate ownership of mining_key
         let reward_address = signer.address();
         consensus.genesis.miner_address = reward_address;
         consensus.genesis.reward_address = reward_address;

--- a/crates/types/src/config/node.rs
+++ b/crates/types/src/config/node.rs
@@ -918,11 +918,11 @@ impl NodeConfig {
     }
 
     pub fn signer(&self) -> IrysSigner {
-        IrysSigner {
-            signer: self.mining_key.clone(),
-            chain_id: self.consensus_config().chain_id,
-            chunk_size: self.consensus_config().chunk_size,
-        }
+        IrysSigner::new(
+            self.mining_key.clone(), // clone: NodeConfig retains ownership of mining_key
+            self.consensus_config().chain_id,
+            self.consensus_config().chunk_size,
+        )
     }
 
     pub fn local_api_url(&self) -> String {
@@ -1088,11 +1088,7 @@ impl NodeConfig {
                 .expect("valid hex"),
         )
         .expect("valid key");
-        let signer = IrysSigner {
-            signer: mining_key,
-            chain_id: 0,
-            chunk_size: 0,
-        };
+        let signer = IrysSigner::new(mining_key, 0, 0);
 
         Self::testing_with_signer(&signer)
     }
@@ -1105,11 +1101,7 @@ impl NodeConfig {
         )
         .expect("valid key");
         let mut consensus = ConsensusConfig::testnet();
-        let signer = IrysSigner {
-            signer: mining_key,
-            chain_id: consensus.chain_id,
-            chunk_size: consensus.chunk_size,
-        };
+        let signer = IrysSigner::new(mining_key, consensus.chain_id, consensus.chunk_size);
 
         let mining_key = signer.signer.clone();
         let reward_address = signer.address();

--- a/crates/types/src/irys.rs
+++ b/crates/types/src/irys.rs
@@ -13,33 +13,42 @@ use eyre::Result;
 use k256::ecdsa::SigningKey;
 
 #[derive(Debug, Clone)]
-
 pub struct IrysSigner {
     pub signer: SigningKey,
     pub chain_id: u64,
     pub chunk_size: u64,
+    address: IrysAddress,
 }
 
 /// Encapsulates an Irys API for doing client type things, making transactions,
 /// signing them, posting them etc.
 impl IrysSigner {
+    pub fn new(signer: SigningKey, chain_id: u64, chunk_size: u64) -> Self {
+        let address = secret_key_to_address(&signer).into();
+        Self {
+            signer,
+            chain_id,
+            chunk_size,
+            address,
+        }
+    }
+
     pub fn random_signer(config: &crate::ConsensusConfig) -> Self {
         use rand::rngs::OsRng;
-
-        Self {
-            signer: k256::ecdsa::SigningKey::random(&mut OsRng),
-            chain_id: config.chain_id,
-            chunk_size: config.chunk_size,
-        }
+        Self::new(
+            k256::ecdsa::SigningKey::random(&mut OsRng),
+            config.chain_id,
+            config.chunk_size,
+        )
     }
 
     /// Returns the address associated with the signer's signing key
     pub fn address(&self) -> IrysAddress {
-        secret_key_to_address(&self.signer).into()
+        self.address
     }
 
     pub fn alloy_address(&self) -> Address {
-        secret_key_to_address(&self.signer)
+        self.address.to_alloy_address()
     }
 
     /// Creates a transaction from a data iterator (which can yield any size Vec), with an optional anchor and flag for if the input data should be stored in the `data` field.

--- a/crates/types/src/irys.rs
+++ b/crates/types/src/irys.rs
@@ -14,9 +14,9 @@ use k256::ecdsa::SigningKey;
 
 #[derive(Debug, Clone)]
 pub struct IrysSigner {
-    pub signer: SigningKey,
-    pub chain_id: u64,
-    pub chunk_size: u64,
+    signer: SigningKey,
+    chain_id: u64,
+    chunk_size: u64,
     address: IrysAddress,
 }
 
@@ -49,6 +49,22 @@ impl IrysSigner {
 
     pub fn alloy_address(&self) -> Address {
         self.address.to_alloy_address()
+    }
+
+    pub fn signing_key(&self) -> &SigningKey {
+        &self.signer
+    }
+
+    pub fn chain_id(&self) -> u64 {
+        self.chain_id
+    }
+
+    pub fn chunk_size(&self) -> u64 {
+        self.chunk_size
+    }
+
+    pub fn into_signing_key(self) -> SigningKey {
+        self.signer
     }
 
     /// Creates a transaction from a data iterator (which can yield any size Vec), with an optional anchor and flag for if the input data should be stored in the `data` field.

--- a/crates/types/src/signature.rs
+++ b/crates/types/src/signature.rs
@@ -225,12 +225,11 @@ mod tests {
         // spellchecker:on
 
         let testing_config = ConsensusConfig::testing();
-        let irys_signer = IrysSigner {
-            signer: SigningKey::from_slice(hex::decode(DEV_PRIVATE_KEY).unwrap().as_slice())
-                .unwrap(),
-            chain_id: testing_config.chain_id,
-            chunk_size: testing_config.chunk_size,
-        };
+        let irys_signer = IrysSigner::new(
+            SigningKey::from_slice(hex::decode(DEV_PRIVATE_KEY).unwrap().as_slice()).unwrap(),
+            testing_config.chain_id,
+            testing_config.chunk_size,
+        );
 
         let original_header =
             DataTransactionHeader::V1(crate::DataTransactionHeaderV1WithMetadata {
@@ -311,12 +310,11 @@ mod tests {
         const SIG_BS58: &str = "AwxMVRKDEnExepqnuCuFBXkiEWkg59whzZGnrGTCsYo2TQhVUUWe4ufescKiLxGVTdndCjVixGAXUvVAjEhid3nEe";
         // spellchecker:on
         let testing_config = ConsensusConfig::testing();
-        let irys_signer = IrysSigner {
-            signer: SigningKey::from_slice(hex::decode(DEV_PRIVATE_KEY).unwrap().as_slice())
-                .unwrap(),
-            chain_id: testing_config.chain_id,
-            chunk_size: testing_config.chunk_size,
-        };
+        let irys_signer = IrysSigner::new(
+            SigningKey::from_slice(hex::decode(DEV_PRIVATE_KEY).unwrap().as_slice()).unwrap(),
+            testing_config.chain_id,
+            testing_config.chunk_size,
+        );
 
         let mut transaction = CommitmentTransaction::V2(crate::CommitmentV2WithMetadata {
             tx: crate::CommitmentTransactionV2 {

--- a/crates/types/src/transaction.rs
+++ b/crates/types/src/transaction.rs
@@ -518,11 +518,14 @@ impl IrysTransactionCommon for DataTransactionHeader {
         use alloy_primitives::keccak256;
 
         // Store the signer address
-        self.signer = IrysAddress::from_public_key(signer.signer.verifying_key());
+        self.signer = IrysAddress::from_public_key(signer.signing_key().verifying_key());
 
         // Create the signature hash and sign it
         let prehash = self.signature_hash();
-        let signature: Signature = signer.signer.sign_prehash_recoverable(&prehash)?.into();
+        let signature: Signature = signer
+            .signing_key()
+            .sign_prehash_recoverable(&prehash)?
+            .into();
 
         self.signature = IrysSignature::new(signature);
 
@@ -600,7 +603,10 @@ impl IrysTransactionCommon for CommitmentTransaction {
 
         // Create the signature hash and sign it
         let prehash = self.signature_hash();
-        let signature: Signature = signer.signer.sign_prehash_recoverable(&prehash)?.into();
+        let signature: Signature = signer
+            .signing_key()
+            .sign_prehash_recoverable(&prehash)?
+            .into();
 
         self.set_signature(IrysSignature::new(signature));
 

--- a/crates/types/src/transaction.rs
+++ b/crates/types/src/transaction.rs
@@ -1083,11 +1083,11 @@ mod tests {
     #[test]
     fn test_tx_encode_and_signing() {
         let config = ConsensusConfig::testing();
-        let signer = IrysSigner {
-            signer: SigningKey::random(&mut rand::thread_rng()),
-            chain_id: config.chain_id,
-            chunk_size: config.chunk_size,
-        };
+        let signer = IrysSigner::new(
+            SigningKey::random(&mut rand::thread_rng()),
+            config.chain_id,
+            config.chunk_size,
+        );
 
         // Test signing the header directly using the outer versioned type
         let header = mock_header(&config);
@@ -1107,11 +1107,11 @@ mod tests {
     #[test]
     fn test_commitment_tx_encode_and_signing() {
         let config = ConsensusConfig::testing();
-        let signer = IrysSigner {
-            signer: SigningKey::random(&mut rand::thread_rng()),
-            chain_id: config.chain_id,
-            chunk_size: config.chunk_size,
-        };
+        let signer = IrysSigner::new(
+            SigningKey::random(&mut rand::thread_rng()),
+            config.chain_id,
+            config.chunk_size,
+        );
 
         // Test signing the outer versioned type directly
         let tx = mock_commitment_tx(&config);
@@ -1129,11 +1129,11 @@ mod tests {
     fn test_data_transaction_signature_validation() {
         // setup
         let config = ConsensusConfig::testing();
-        let signer = IrysSigner {
-            signer: SigningKey::random(&mut rand::thread_rng()),
-            chain_id: config.chain_id,
-            chunk_size: config.chunk_size,
-        };
+        let signer = IrysSigner::new(
+            SigningKey::random(&mut rand::thread_rng()),
+            config.chain_id,
+            config.chunk_size,
+        );
 
         let tx = DataTransaction {
             header: mock_header(&config),
@@ -1158,11 +1158,11 @@ mod tests {
     fn test_commitment_transaction_signature_validation() {
         // setup
         let config = ConsensusConfig::testing();
-        let signer = IrysSigner {
-            signer: SigningKey::random(&mut rand::thread_rng()),
-            chain_id: config.chain_id,
-            chunk_size: config.chunk_size,
-        };
+        let signer = IrysSigner::new(
+            SigningKey::random(&mut rand::thread_rng()),
+            config.chain_id,
+            config.chunk_size,
+        );
 
         let tx = mock_commitment_tx(&config);
 

--- a/crates/types/src/version.rs
+++ b/crates/types/src/version.rs
@@ -1055,11 +1055,7 @@ mod tests {
                 .expect("valid hex"),
         )
         .expect("valid key");
-        let testing_signer = IrysSigner {
-            signer: testing_key,
-            chain_id: 0,
-            chunk_size: 0,
-        };
+        let testing_signer = IrysSigner::new(testing_key, 0, 0);
         config.genesis.miner_address = testing_signer.address();
         config.genesis.reward_address = testing_signer.address();
 
@@ -1079,11 +1075,8 @@ mod tests {
         ];
         let genesis_signing_key =
             k256::ecdsa::SigningKey::from_bytes((&genesis_key_bytes).into()).unwrap();
-        let genesis_signer = IrysSigner {
-            signer: genesis_signing_key,
-            chain_id: config.chain_id,
-            chunk_size: config.chunk_size,
-        };
+        let genesis_signer =
+            IrysSigner::new(genesis_signing_key, config.chain_id, config.chunk_size);
 
         // Add genesis account to match test
         use alloy_core::primitives::U256;
@@ -1104,11 +1097,7 @@ mod tests {
             0xc3, 0xd2, 0xe1, 0xf0,
         ];
         let signing_key = k256::ecdsa::SigningKey::from_bytes((&key_bytes).into()).unwrap();
-        let signer = IrysSigner {
-            signer: signing_key,
-            chain_id: config.chain_id,
-            chunk_size: config.chunk_size,
-        };
+        let signer = IrysSigner::new(signing_key, config.chain_id, config.chunk_size);
 
         let mining_addr = signer.address();
 


### PR DESCRIPTION
## Summary

**Before:**
`Config::irys_signer()` constructed a new `IrysSigner` on every call, cloning `SigningKey` each time. `IrysSigner::address()` performed EC point multiplication (`secret_key_to_address`) on every invocation. Both sat on the chunk ingress hot path.

**After:**
`IrysSigner` caches the derived address at construction. `Config` caches a single `IrysSigner` instance in `CombinedConfigInner` and returns `&IrysSigner` instead of an owned value. No per-call cloning or EC multiplication on the ingress path.

## Changes

### `crates/types/src/irys.rs`
- Added private `address: IrysAddress` field to `IrysSigner`, computed once via `secret_key_to_address` in the new `IrysSigner::new()` constructor
- `address()` and `alloy_address()` return the cached value instead of recomputing
- `random_signer()` delegates to `IrysSigner::new()`

### `crates/types/src/config/mod.rs`
- Added `irys_signer: IrysSigner` field to `CombinedConfigInner`
- `Config::new()` builds the signer once at construction
- `Config::irys_signer()` returns `&IrysSigner` (was `IrysSigner`)
- `Config::with_expected_genesis_hash()` propagates the cached signer

### `crates/types/src/config/node.rs`
- `NodeConfig::signer()` and test helpers updated to use `IrysSigner::new()`

### Call-site updates (19 files)
- All struct-literal `IrysSigner { signer, chain_id, chunk_size }` constructions replaced with `IrysSigner::new(signer, chain_id, chunk_size)`
- All callers of `config.irys_signer()` updated from owned to borrowed (`&IrysSigner`)
- `block_producer.rs:810`: explicit `.signer.clone()` for `LocalSigner` conversion (non-hot path)
- Removed explicit `: IrysSigner` type annotation in `ingress_proofs.rs`

## Technical Notes

- **Performance**: eliminates one `SigningKey::clone()` and one EC point multiplication per chunk ingress call
- **Breaking changes**: `Config::irys_signer()` now returns `&IrysSigner` instead of `IrysSigner`. `IrysSigner` can no longer be constructed via struct literal (must use `IrysSigner::new()`).
- **Architecture**: follows the same caching pattern already used for `VdfConfig` and `MempoolConfig` in `CombinedConfigInner`

## Testing
- [x] `cargo check --workspace` compiles cleanly
- [x] `cargo clippy --workspace --tests --all-targets` produces no warnings
- [x] Existing test suites pass (irys-types, irys-actors, irys-chain)

## Related
- Fixes #1127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated signer construction and caching to avoid repeated address derivation, streamline ownership semantics, and reduce redundant work across the codebase.
  * Updated internal APIs and tests to use the new signer model for more efficient signing and fewer allocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->