### PR TITLE
refactor(block-tree): replace tuple return types with named structs

### DIFF
--- a/crates/actors/src/anchor_validation.rs
+++ b/crates/actors/src/anchor_validation.rs
@@ -27,7 +27,7 @@ pub fn get_anchor_height(
         if canonical {
             guard
                 .get_canonical_chain()
-                .0
+                .entries
                 .iter()
                 .find(|b| b.block_hash() == anchor)
                 .map(BlockTreeEntry::height)

--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -462,23 +462,23 @@ pub trait BlockProdStrategy {
         solution: &SolutionContext,
     ) -> ParentCheckResult {
         let tree = self.inner().block_tree_guard.read();
-        let (_max_difficulty, current_best) = tree.get_max_cumulative_difficulty_block();
+        let max_diff = tree.get_max_cumulative_difficulty_block();
 
         // Check if parent is still the best
-        if current_best == *parent_hash {
+        if max_diff.block_hash == *parent_hash {
             return ParentCheckResult::ParentStillBest;
         }
 
         // Parent changed - get new parent's VDF step
         let new_parent_vdf_step = tree
-            .get_block(&current_best)
+            .get_block(&max_diff.block_hash)
             .map(|b| b.vdf_limiter_info.global_step_number)
             .unwrap_or(0);
 
         // Check if solution is too old (at or before new parent's VDF step)
         if solution.vdf_step <= new_parent_vdf_step {
             return ParentCheckResult::SolutionInvalid {
-                new_parent: current_best,
+                new_parent: max_diff.block_hash,
                 reason: InvalidReason::VdfTooOld {
                     parent_vdf_step: new_parent_vdf_step,
                     solution_vdf_step: solution.vdf_step,
@@ -488,7 +488,7 @@ pub trait BlockProdStrategy {
 
         // Parent changed but solution is valid - must rebuild on new parent
         ParentCheckResult::MustRebuild {
-            new_parent: current_best,
+            new_parent: max_diff.block_hash,
         }
     }
 

--- a/crates/actors/src/block_producer/block_validation_tracker.rs
+++ b/crates/actors/src/block_producer/block_validation_tracker.rs
@@ -42,12 +42,11 @@ impl BlockValidationTracker {
             let tree = block_tree_guard.read();
             tree.get_max_block_info()
         };
-        let (target_hash, target_height) = (info.block_hash, info.height);
 
         Self {
             state: ValidationState::Tracking {
-                target_hash,
-                target_height,
+                target_hash: info.block_hash,
+                target_height: info.height,
             },
             block_tree_guard,
             block_state_rx,

--- a/crates/actors/src/block_producer/block_validation_tracker.rs
+++ b/crates/actors/src/block_producer/block_validation_tracker.rs
@@ -38,11 +38,11 @@ impl BlockValidationTracker {
         let block_state_rx = service_senders.subscribe_block_state_updates();
 
         // Get initial blockchain state
-        let (target_hash, target_height) = {
+        let info = {
             let tree = block_tree_guard.read();
-            let (hash, height, _) = tree.get_max_block_info();
-            (hash, height)
+            tree.get_max_block_info()
         };
+        let (target_hash, target_height) = (info.block_hash, info.height);
 
         Self {
             state: ValidationState::Tracking {
@@ -80,32 +80,32 @@ impl BlockValidationTracker {
             };
 
             // Check current blockchain state
-            let (max_hash, max_height, can_build) = {
+            let info = {
                 let tree = self.block_tree_guard.read();
                 tree.get_max_block_info()
             };
 
             // If best block is validated, done
-            if can_build {
+            if info.can_build_upon {
                 self.state = ValidationState::Validated {
-                    block_hash: max_hash,
-                    block_height: max_height,
+                    block_hash: info.block_hash,
+                    block_height: info.height,
                 };
                 continue;
             }
 
             // Switch target if max-difficulty block changed
-            if max_hash != target_hash {
+            if info.block_hash != target_hash {
                 debug!(
                     block_validation.old_target = %target_hash,
                     block_validation.old_height = target_height,
-                    block_validation.new_target = %max_hash,
-                    block_validation.new_height = max_height,
+                    block_validation.new_target = %info.block_hash,
+                    block_validation.new_height = info.height,
                     "Target block changed during validation wait"
                 );
                 self.state = ValidationState::Tracking {
-                    target_hash: max_hash,
-                    target_height: max_height,
+                    target_hash: info.block_hash,
+                    target_height: info.height,
                 };
             }
 

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -635,7 +635,7 @@ impl BlockTreeServiceInner {
                         debug!("old_canonical({}) - {}", o.height(), o.block_hash());
                     }
 
-                    for o in new_canonical.0.iter() {
+                    for o in new_canonical.entries.iter() {
                         debug!("new_canonical({}) - {}", o.height(), o.block_hash());
                     }
 
@@ -644,7 +644,7 @@ impl BlockTreeServiceInner {
                     // Trim both chains back to their common ancestor to isolate the divergent portions
                     let (old_fork, new_fork) = prune_chains_at_ancestor(
                         old_canonical,
-                        new_canonical.0,
+                        new_canonical.entries,
                         fork_hash,
                         fork_height,
                     );

--- a/crates/actors/src/block_tree_service/test_utils.rs
+++ b/crates/actors/src/block_tree_service/test_utils.rs
@@ -191,7 +191,7 @@ pub fn create_and_apply_fork(
     // Get the fork parent block
     let fork_parent = {
         let tree = block_tree_guard.read();
-        let (chain, _) = tree.get_canonical_chain();
+        let chain = tree.get_canonical_chain().entries;
         let fork_parent_hash = chain
             .iter()
             .find(|entry| entry.height() == common_ancestor_height)
@@ -208,7 +208,7 @@ pub fn create_and_apply_fork(
     let mut fork_prices = Vec::new();
     {
         let tree = block_tree_guard.read();
-        let (chain, _) = tree.get_canonical_chain();
+        let chain = tree.get_canonical_chain().entries;
 
         // Collect prices from genesis (height 0) up to and including the fork point
         for entry in chain.iter() {
@@ -282,7 +282,7 @@ pub fn create_and_apply_fork(
 
     let data = block_tree_guard.read();
     assert_eq!(
-        data.get_canonical_chain().0.len(),
+        data.get_canonical_chain().entries.len(),
         (fork_height + 1) as usize
     );
 

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -162,7 +162,7 @@ impl InnerCacheTask {
         }
 
         if prune_height.is_none() {
-            let (canonical, _) = self.block_tree_guard.read().get_canonical_chain();
+            let canonical = self.block_tree_guard.read().get_canonical_chain().entries;
 
             let found_block = canonical.iter().rev().find_map(|block_entry| {
                 let block = block_entry.header();

--- a/crates/actors/src/data_sync_service/chunk_orchestrator.rs
+++ b/crates/actors/src/data_sync_service/chunk_orchestrator.rs
@@ -256,7 +256,7 @@ impl ChunkOrchestrator {
         // We only want to download migrated chunks from other peers
         let max_chunk_offset: Option<u64> = {
             let tree = self.block_tree.read();
-            let (canonical, _) = tree.get_canonical_chain();
+            let canonical = tree.get_canonical_chain().entries;
             let block_migration_depth =
                 self.config.consensus_config().block_migration_depth as usize;
 

--- a/crates/actors/src/mempool_service/data_txs.rs
+++ b/crates/actors/src/mempool_service/data_txs.rs
@@ -266,7 +266,7 @@ impl Inner {
         // All captured from the same read guard to avoid mixing data from different chain states.
         let (ema_snapshot, latest_block_timestamp_secs, latest_height) = {
             let tree = self.block_tree_read_guard.read();
-            let (canonical, _) = tree.get_canonical_chain();
+            let canonical = tree.get_canonical_chain().entries;
             let last_block_entry = canonical
                 .last()
                 .ok_or_else(|| TxIngressError::Other("Empty canonical chain".to_string()))?;
@@ -428,7 +428,7 @@ impl Inner {
         // Get latest block's timestamp for hardfork params
         let latest_block_timestamp_secs = {
             let tree = self.block_tree_read_guard.read();
-            let (canonical, _) = tree.get_canonical_chain();
+            let canonical = tree.get_canonical_chain().entries;
             let last_block_entry = canonical
                 .last()
                 .ok_or_else(|| TxIngressError::Other("Empty canonical chain".to_string()))?;

--- a/crates/actors/src/tx_selector/mod.rs
+++ b/crates/actors/src/tx_selector/mod.rs
@@ -110,7 +110,7 @@ pub async fn select_best_txs(
 
         // Get the canonical chain bounded by the parent block to avoid including
         // blocks beyond the parent when building on a non-tip parent.
-        let (full_canonical, _) = tree.get_canonical_chain();
+        let full_canonical = tree.get_canonical_chain().entries;
 
         let Some(parent_pos) = full_canonical
             .iter()

--- a/crates/actors/src/validation_service/active_validations.rs
+++ b/crates/actors/src/validation_service/active_validations.rs
@@ -1413,7 +1413,7 @@ mod tests {
         // Add an extension block at height 4 (extends canonical tip)
         let (ext_header, ext_sealed) = {
             let mut tree = block_tree_guard.write();
-            let (canonical_chain, _) = tree.get_canonical_chain();
+            let canonical_chain = tree.get_canonical_chain().entries;
             let tip = canonical_chain.last().unwrap();
 
             let mut header = IrysBlockHeader::new_mock_header();
@@ -1463,7 +1463,7 @@ mod tests {
         // Create a fork from height 2 that becomes the new canonical chain
         {
             let mut tree = block_tree_guard.write();
-            let (canonical_chain, _) = tree.get_canonical_chain();
+            let canonical_chain = tree.get_canonical_chain().entries;
             let fork_parent = canonical_chain.iter().find(|e| e.height() == 2).unwrap();
 
             let mut last_hash = fork_parent.block_hash();
@@ -1607,7 +1607,7 @@ mod tests {
         // Add an extension block and set as current
         let ext_header = {
             let mut tree = block_tree_guard.write();
-            let (canonical_chain, _) = tree.get_canonical_chain();
+            let canonical_chain = tree.get_canonical_chain().entries;
             let tip = canonical_chain.last().unwrap();
 
             let mut header = IrysBlockHeader::new_mock_header();

--- a/crates/actors/src/validation_service/active_validations.rs
+++ b/crates/actors/src/validation_service/active_validations.rs
@@ -422,7 +422,7 @@ impl<S: VdfSpawnStrategy> ValidationCoordinator<S> {
     /// Check if block extends canonical tip
     #[instrument(level = "trace", skip_all, fields(block.hash = %block_hash))]
     fn is_canonical_extension(&self, block_hash: &BlockHash, block_tree: &BlockTree) -> bool {
-        let (canonical_chain, _) = block_tree.get_canonical_chain();
+        let canonical_chain = block_tree.get_canonical_chain().entries;
         let canonical_tip = canonical_chain.last().unwrap().block_hash();
 
         let mut current = *block_hash;
@@ -796,7 +796,7 @@ mod tests {
         // Create canonical extension blocks (extending from canonical tip at height 3)
         let extension_blocks = {
             let mut tree = block_tree_guard.write();
-            let (canonical_chain, _) = tree.get_canonical_chain();
+            let canonical_chain = tree.get_canonical_chain().entries;
             let tip = canonical_chain.last().unwrap();
 
             let mut blocks = Vec::new();
@@ -853,7 +853,7 @@ mod tests {
         // These will compete with the canonical block at height 3
         let fork_blocks = {
             let mut tree = block_tree_guard.write();
-            let (canonical_chain, _) = tree.get_canonical_chain();
+            let canonical_chain = tree.get_canonical_chain().entries;
             let fork_parent = canonical_chain.iter().find(|e| e.height() == 2).unwrap();
 
             let mut blocks = Vec::new();

--- a/crates/api-server/src/routes/block.rs
+++ b/crates/api-server/src/routes/block.rs
@@ -43,7 +43,7 @@ pub async fn get_block(
                 .block_tree
                 .read()
                 .get_canonical_chain()
-                .0
+                .entries
                 .iter()
                 .find_map(|e| {
                     if e.height() == height {

--- a/crates/api-server/src/routes/mining.rs
+++ b/crates/api-server/src/routes/mining.rs
@@ -39,7 +39,7 @@ pub async fn get_mining_info(app_state: Data<ApiState>) -> Result<Json<MiningInf
         .map_err(ApiError::canonical_chain_error)?;
 
     let latest_block_entry = canonical_chain
-        .0
+        .entries
         .last()
         .ok_or(ApiError::EmptyCanonicalChain)?;
 

--- a/crates/api-server/src/routes/price.rs
+++ b/crates/api-server/src/routes/price.rs
@@ -58,7 +58,7 @@ pub async fn get_price(
         DataLedger::Publish => {
             // Get the latest EMA for pricing calculations from the canonical chain
             let tree = state.block_tree.read();
-            let (canonical, _) = tree.get_canonical_chain();
+            let canonical = tree.get_canonical_chain().entries;
             let last_block_entry = canonical
                 .last()
                 .ok_or(("Empty canonical chain", StatusCode::BAD_REQUEST))?;

--- a/crates/api-server/src/routes/supply.rs
+++ b/crates/api-server/src/routes/supply.rs
@@ -48,7 +48,7 @@ pub async fn supply(state: web::Data<ApiState>) -> impl Responder {
 
 fn get_latest_block(state: &ApiState) -> Result<IrysBlockHeader> {
     let tree = state.block_tree.read();
-    let (canonical, _) = tree.get_canonical_chain();
+    let canonical = tree.get_canonical_chain().entries;
 
     let last_entry = canonical
         .last()

--- a/crates/chain-tests/src/block_production/block_production.rs
+++ b/crates/chain-tests/src/block_production/block_production.rs
@@ -1175,7 +1175,7 @@ async fn block_prod_will_not_build_on_invalid_blocks() -> eyre::Result<()> {
         .block_tree_guard
         .read()
         .get_max_cumulative_difficulty_block()
-        .1;
+        .block_hash;
     let new_block_state = *node
         .node_ctx
         .block_tree_guard
@@ -1372,11 +1372,12 @@ async fn spiky_heavy3_test_always_build_on_max_difficulty_block() -> eyre::Resul
     );
 
     // Sanity check: canonical tip should now be the newly produced block.
-    let (_, tip_hash) = peer_node
+    let tip_hash = peer_node
         .node_ctx
         .block_tree_guard
         .read()
-        .get_max_cumulative_difficulty_block();
+        .get_max_cumulative_difficulty_block()
+        .block_hash;
     assert_eq!(tip_hash, normal_block.block_hash);
 
     // Cleanup nodes.

--- a/crates/chain-tests/src/ema_pricing/ema_pricing.rs
+++ b/crates/chain-tests/src/ema_pricing/ema_pricing.rs
@@ -59,9 +59,10 @@ async fn test_genesis_ema_price_is_respected_for_2_intervals() -> eyre::Result<(
         let header = ctx.get_block_by_height(expected_height).await?;
 
         // Get the current EMA price from the block tree
-        let (chain, ..) = get_canonical_chain(ctx.node_ctx.block_tree_guard.clone())
+        let chain = get_canonical_chain(ctx.node_ctx.block_tree_guard.clone())
             .await
-            .unwrap();
+            .unwrap()
+            .entries;
         let tip_hash = chain.last().unwrap().block_hash();
         let ema_snapshot = ctx
             .node_ctx
@@ -177,9 +178,10 @@ async fn heavy_test_oracle_price_too_high_gets_capped() -> eyre::Result<()> {
     ctx.wait_until_height(header_3.height, 10).await?;
 
     // assert that all of the prices are the max allowed ones (guaranteed by the mock oracle reporting inflated values)
-    let (chain, ..) = get_canonical_chain(ctx.node_ctx.block_tree_guard.clone())
+    let chain = get_canonical_chain(ctx.node_ctx.block_tree_guard.clone())
         .await
-        .unwrap();
+        .unwrap()
+        .entries;
     assert_eq!(chain.len(), 4, "expected genesis + 3 new blocks");
     let genesis_block =
         get_block(ctx.node_ctx.block_tree_guard.clone(), chain[0].block_hash()).unwrap();

--- a/crates/chain-tests/src/multi_node/fork_recovery.rs
+++ b/crates/chain-tests/src/multi_node/fork_recovery.rs
@@ -287,11 +287,11 @@ async fn heavy4_fork_recovery_submit_tx_test() -> eyre::Result<()> {
 
     println!("\nreorg_tx: {:?}", reorg_tx.header.id);
     println!("canonical_before:");
-    for entry in &canon_before.0 {
+    for entry in &canon_before.entries {
         println!("  {:?}", entry)
     }
     println!("canonical_after:");
-    for entry in &canon.0 {
+    for entry in &canon.entries {
         println!("  {:?}", entry)
     }
 
@@ -326,12 +326,15 @@ async fn heavy4_fork_recovery_submit_tx_test() -> eyre::Result<()> {
     println!("old_fork:\n  {:?}", old_fork);
     println!("new_fork:\n  {:?}", new_fork);
 
-    assert_eq!(old_fork, vec![canon_before.0.last().unwrap().block_hash()]);
+    assert_eq!(
+        old_fork,
+        vec![canon_before.entries.last().unwrap().block_hash()]
+    );
     assert_eq!(
         new_fork,
         vec![
-            canon.0[canon.0.len() - 2].block_hash(),
-            canon.0.last().unwrap().block_hash()
+            canon.entries[canon.entries.len() - 2].block_hash(),
+            canon.entries.last().unwrap().block_hash()
         ]
     );
 
@@ -539,7 +542,7 @@ async fn heavy_shallow_fork_triggers_migration_prune_and_fcu() -> eyre::Result<(
         // Stage 7: block tree does not contain pruned block
         {
             let block_tree_guard = node.node_ctx.block_tree_guard.read();
-            let (canonical_entries, _) = block_tree_guard.get_canonical_chain();
+            let canonical_entries = block_tree_guard.get_canonical_chain().entries;
             let last_entry = canonical_entries.first().unwrap();
             let last_entry = block_tree_guard
                 .get_block(&last_entry.block_hash())

--- a/crates/chain-tests/src/multi_node/mempool_tests.rs
+++ b/crates/chain-tests/src/multi_node/mempool_tests.rs
@@ -902,9 +902,9 @@ async fn heavy3_mempool_submit_tx_fork_recovery_test() -> eyre::Result<()> {
     );
 
     debug!("reorg_tx: {:?}", reorg_tx.header.id);
-    debug!("canonical_before: {:?}", &canon_before.0);
+    debug!("canonical_before: {:?}", &canon_before.entries);
 
-    debug!("canonical_after: {:?}", &canon.0);
+    debug!("canonical_after: {:?}", &canon.entries);
 
     // Validate the ReorgEvent with the canonical chains
     let old_fork: Vec<_> = reorg_event
@@ -923,12 +923,15 @@ async fn heavy3_mempool_submit_tx_fork_recovery_test() -> eyre::Result<()> {
     debug!("old_fork:  {:?}", old_fork);
     debug!("new_fork:  {:?}", new_fork);
 
-    assert_eq!(old_fork, vec![canon_before.0.last().unwrap().block_hash()]);
+    assert_eq!(
+        old_fork,
+        vec![canon_before.entries.last().unwrap().block_hash()]
+    );
     assert_eq!(
         new_fork,
         vec![
-            canon.0[canon.0.len() - 2].block_hash(),
-            canon.0.last().unwrap().block_hash()
+            canon.entries[canon.entries.len() - 2].block_hash(),
+            canon.entries.last().unwrap().block_hash()
         ]
     );
 

--- a/crates/chain-tests/src/startup/startup.rs
+++ b/crates/chain-tests/src/startup/startup.rs
@@ -27,9 +27,10 @@ async fn heavy_test_can_resume_from_genesis_startup_with_ctx() -> eyre::Result<(
     let ctx = ctx.stop().await.start().await;
 
     // assert -- expect that the non genesis node can continue with the genesis data
-    let (chain, ..) = get_canonical_chain(ctx.node_ctx.block_tree_guard.clone())
+    let chain = get_canonical_chain(ctx.node_ctx.block_tree_guard.clone())
         .await
-        .unwrap();
+        .unwrap()
+        .entries;
     assert_eq!(
         header_1.height,
         chain.last().unwrap().height(),
@@ -41,9 +42,10 @@ async fn heavy_test_can_resume_from_genesis_startup_with_ctx() -> eyre::Result<(
         "we expect the genesis block + 1 new block (the second block does not get saved)"
     );
     ctx.mine_block().await?;
-    let (chain, ..) = get_canonical_chain(ctx.node_ctx.block_tree_guard.clone())
+    let chain = get_canonical_chain(ctx.node_ctx.block_tree_guard.clone())
         .await
-        .unwrap();
+        .unwrap()
+        .entries;
     assert_eq!(chain.len(), 3, "we expect the genesis block + 2 new blocks");
 
     ctx.stop().await;
@@ -83,9 +85,10 @@ async fn heavy_test_can_resume_from_genesis_startup_no_ctx() -> eyre::Result<()>
     let ctx = node.start().await;
 
     // assert -- expect that the non genesis node can continue with the genesis data
-    let (chain, ..) = get_canonical_chain(ctx.node_ctx.block_tree_guard.clone())
+    let chain = get_canonical_chain(ctx.node_ctx.block_tree_guard.clone())
         .await
-        .unwrap();
+        .unwrap()
+        .entries;
     assert_eq!(
         header_1.height,
         chain.last().unwrap().height(),
@@ -97,9 +100,10 @@ async fn heavy_test_can_resume_from_genesis_startup_no_ctx() -> eyre::Result<()>
         "we expect the genesis block + 1 new block (the second block does not get saved)"
     );
     ctx.mine_block().await?;
-    let (chain, ..) = get_canonical_chain(ctx.node_ctx.block_tree_guard.clone())
+    let chain = get_canonical_chain(ctx.node_ctx.block_tree_guard.clone())
         .await
-        .unwrap();
+        .unwrap()
+        .entries;
     assert_eq!(chain.len(), 3, "we expect the genesis block + 2 new blocks");
 
     ctx.stop().await;

--- a/crates/chain-tests/src/utils.rs
+++ b/crates/chain-tests/src/utils.rs
@@ -450,7 +450,7 @@ impl IrysNodeTest<IrysNodeCtx> {
             canonical_tip_hash,
             canonical_chain_len,
             not_onchain_count,
-            max_diff_height,
+            max_cumulative_diff,
             max_diff_hash,
         ) = {
             let tree = self.node_ctx.block_tree_guard.read();
@@ -553,7 +553,7 @@ impl IrysNodeTest<IrysNodeCtx> {
             canonical_tip,
             canonical_chain_len,
             not_onchain_count,
-            max_diff_height,
+            max_cumulative_diff,
             max_diff_hash,
             block_index_tip,
             block_index_submit_total_chunks,
@@ -1189,7 +1189,7 @@ impl IrysNodeTest<IrysNodeCtx> {
             let latest_block = canonical_chain.entries.last().unwrap();
 
             let latest_height = latest_block.height();
-            let not_onchain_count = canonical_chain.not_onchain_count as u64;
+            let not_onchain_count = u64::try_from(canonical_chain.not_onchain_count).unwrap();
             if (latest_height - not_onchain_count) >= target_height {
                 info!(
                     "reached height {} after {} retries",

--- a/crates/chain-tests/src/utils.rs
+++ b/crates/chain-tests/src/utils.rs
@@ -454,19 +454,20 @@ impl IrysNodeTest<IrysNodeCtx> {
             max_diff_hash,
         ) = {
             let tree = self.node_ctx.block_tree_guard.read();
-            let (canonical_chain, not_onchain_count) = tree.get_canonical_chain();
-            let canonical_tip = canonical_chain
+            let chain = tree.get_canonical_chain();
+            let canonical_tip = chain
+                .entries
                 .last()
                 .map(|entry| (entry.height(), entry.block_hash()));
-            let (max_diff_height, max_diff_hash) = tree.get_max_cumulative_difficulty_block();
+            let max_diff = tree.get_max_cumulative_difficulty_block();
 
             (
                 canonical_tip.map(|(height, _)| height),
                 canonical_tip.map(|(_, block_hash)| block_hash),
-                canonical_chain.len(),
-                not_onchain_count,
-                max_diff_height,
-                max_diff_hash,
+                chain.entries.len(),
+                chain.not_onchain_count,
+                max_diff.cumulative_diff,
+                max_diff.block_hash,
             )
         };
 
@@ -1028,12 +1029,12 @@ impl IrysNodeTest<IrysNodeCtx> {
             let canonical_chain = get_canonical_chain(self.node_ctx.block_tree_guard.clone())
                 .await
                 .unwrap();
-            let latest_block = canonical_chain.0.last().unwrap();
+            let latest_block = canonical_chain.entries.last().unwrap();
 
             if latest_block.height() >= target_height {
                 // Get the specific block at target height, not the latest
                 if let Some(target_block) = canonical_chain
-                    .0
+                    .entries
                     .iter()
                     .find(|b| b.height() == target_height)
                 {
@@ -1090,7 +1091,7 @@ impl IrysNodeTest<IrysNodeCtx> {
             let canonical_chain =
                 get_canonical_chain(self.node_ctx.block_tree_guard.clone()).await?;
             if let Some(block) = canonical_chain
-                .0
+                .entries
                 .iter()
                 .find(|b| b.height() == target_height)
             {
@@ -1185,10 +1186,10 @@ impl IrysNodeTest<IrysNodeCtx> {
             let canonical_chain = get_canonical_chain(self.node_ctx.block_tree_guard.clone())
                 .await
                 .unwrap();
-            let latest_block = canonical_chain.0.last().unwrap();
+            let latest_block = canonical_chain.entries.last().unwrap();
 
             let latest_height = latest_block.height();
-            let not_onchain_count = canonical_chain.1 as u64;
+            let not_onchain_count = canonical_chain.not_onchain_count as u64;
             if (latest_height - not_onchain_count) >= target_height {
                 info!(
                     "reached height {} after {} retries",
@@ -1483,7 +1484,7 @@ impl IrysNodeTest<IrysNodeCtx> {
         get_canonical_chain(self.node_ctx.block_tree_guard.clone())
             .await
             .unwrap()
-            .0
+            .entries
             .last()
             .unwrap()
             .height()
@@ -1495,7 +1496,7 @@ impl IrysNodeTest<IrysNodeCtx> {
             .block_tree_guard
             .read()
             .get_max_cumulative_difficulty_block()
-            .1;
+            .block_hash;
         self.node_ctx
             .block_tree_guard
             .read()
@@ -1764,7 +1765,7 @@ impl IrysNodeTest<IrysNodeCtx> {
         for attempt in 1..=max_seconds {
             let canonical_chain =
                 get_canonical_chain(self.node_ctx.block_tree_guard.clone()).await?;
-            for entry in canonical_chain.0.iter().rev() {
+            for entry in canonical_chain.entries.iter().rev() {
                 let block_hash = entry.block_hash();
                 if let Ok(block) = self.get_block_by_hash(&block_hash)
                     && block.data_ledgers[ledger].tx_ids.0.contains(&txid)
@@ -2408,7 +2409,7 @@ impl IrysNodeTest<IrysNodeCtx> {
         get_canonical_chain(self.node_ctx.block_tree_guard.clone())
             .await
             .unwrap()
-            .0
+            .entries
             .iter()
             .find(|e| e.height() == height)
             .and_then(|e| {
@@ -3518,7 +3519,7 @@ impl IrysNodeTest<IrysNodeCtx> {
             .block_tree_guard
             .read()
             .get_canonical_chain()
-            .0
+            .entries
     }
 
     /// Get the EMA snapshot for a given block hash
@@ -3694,7 +3695,7 @@ pub async fn solution_context_with_poa_chunk(
 
         let reset_seed = {
             let read = node_ctx.block_tree_guard.read();
-            let parent_hash = read.get_max_cumulative_difficulty_block().1;
+            let parent_hash = read.get_max_cumulative_difficulty_block().block_hash;
             read.get_block(&parent_hash)
                 .map(|b| b.vdf_limiter_info.next_seed)
                 .unwrap_or_default()
@@ -3740,7 +3741,7 @@ pub async fn solution_context(node_ctx: &IrysNodeCtx) -> Result<SolutionContext,
     // Get parent block directly from in-memory block tree
     let prev_block = {
         let read = node_ctx.block_tree_guard.read();
-        let parent_hash = read.get_max_cumulative_difficulty_block().1;
+        let parent_hash = read.get_max_cumulative_difficulty_block().block_hash;
         read.get_block(&parent_hash)
             .cloned()
             .ok_or_else(|| eyre!("Parent block header not found in block tree"))?

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -960,7 +960,7 @@ impl IrysNode {
                     let btrg = block_tree_guard.read();
                     debug!(
                         "Checking stakes & pledges at height {}, latest hash: {}",
-                        btrg.get_canonical_chain().0.last().unwrap().height(),
+                        btrg.get_canonical_chain().entries.last().unwrap().height(),
                         &latest_hash
                     );
                 };

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -960,7 +960,7 @@ impl IrysNode {
                     let btrg = block_tree_guard.read();
                     debug!(
                         "Checking stakes & pledges at height {}, latest hash: {}",
-                        btrg.get_canonical_chain().entries.last().unwrap().height(),
+                        btrg.get_latest_canonical_entry().height(),
                         &latest_hash
                     );
                 };

--- a/crates/domain/src/guards/block_tree_guard.rs
+++ b/crates/domain/src/guards/block_tree_guard.rs
@@ -28,8 +28,9 @@ impl BlockTreeReadGuard {
     /// Returns the height of the latest block on the canonical chain.
     pub fn latest_canonical_block_height(&self) -> Option<u64> {
         let tree = self.read();
-        let (canonical, _) = tree.get_canonical_chain();
+        let canonical = tree.get_canonical_chain();
         canonical
+            .entries
             .last()
             .map(super::super::models::block_tree::BlockTreeEntry::height)
     }
@@ -37,17 +38,18 @@ impl BlockTreeReadGuard {
     /// Gets the total number of chunks in a ledger at a given block height
     pub fn get_total_chunks(&self, block_height: u64, ledger_id: u32) -> Option<LedgerChunkOffset> {
         let tree = self.read();
-        let (canonical, _) = tree.get_canonical_chain();
+        let canonical = tree.get_canonical_chain();
 
         let depth = canonical
+            .entries
             .last()
             .unwrap()
             .height()
             .saturating_sub(block_height) as usize;
 
-        if canonical.len() > depth {
-            let idx = canonical.len() - 1 - depth;
-            let block_entry = &canonical[idx];
+        if canonical.entries.len() > depth {
+            let idx = canonical.entries.len() - 1 - depth;
+            let block_entry = &canonical.entries[idx];
 
             let block = tree
                 .get_block(&block_entry.block_hash())

--- a/crates/domain/src/models/block_tree.rs
+++ b/crates/domain/src/models/block_tree.rs
@@ -39,7 +39,7 @@ pub struct MaxDifficultyInfo {
 }
 
 /// Extended info about the max-difficulty block.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MaxBlockInfo {
     pub block_hash: BlockHash,
     pub height: u64,
@@ -677,22 +677,12 @@ impl BlockTree {
 
     /// Returns the canonical chain as a cached sequence of block entries.
     ///
-    /// The canonical chain represents the longest valid chain from the earliest cached block
-    /// to the current tip. The chain is maintained as a cached tuple containing:
-    /// - **Block entries**: Ordered sequence from oldest to newest block in cache
-    /// - **Non-onchain count**: Number of blocks not yet fully validated
+    /// Returns the canonical chain as a [`CanonicalChain`].
     ///
-    /// ## Canonical Chain Structure
-    /// * **First element**: Genesis block or the oldest block within `block_tree_depth`
-    /// * **Last element**: Current chain tip (highest cumulative difficulty)
-    /// * **Ordering**: Chronological from oldest to newest block
-    ///
-    /// ## Returns
-    /// `(Vec<BlockTreeEntry>, usize)` - Tuple of (block entries, count of non-onchain blocks)
-    ///
-    /// ## Note
-    /// This returns a cloned copy of the cached chain for thread-safe access. The cache
-    /// is updated whenever the canonical chain changes due to new blocks or reorganizations.
+    /// Entries are ordered chronologically from the oldest cached block (genesis or
+    /// earliest within `block_tree_depth`) to the current tip (highest cumulative
+    /// difficulty). Returns a cloned copy for thread-safe access; the cache is
+    /// updated on new blocks or reorganisations.
     #[must_use]
     pub fn get_canonical_chain(&self) -> CanonicalChain {
         self.longest_chain_cache.clone()

--- a/crates/domain/src/models/block_tree.rs
+++ b/crates/domain/src/models/block_tree.rs
@@ -17,6 +17,35 @@ use crate::{
     EpochSnapshot, create_ema_snapshot_from_chain_history,
 };
 
+/// The canonical chain: ordered block entries with chain-state metadata.
+#[derive(Debug, Clone)]
+pub struct CanonicalChain {
+    pub entries: Vec<BlockTreeEntry>,
+    pub not_onchain_count: usize,
+}
+
+/// Lightweight reference to a block by hash and height.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChainBlockRef {
+    pub block_hash: H256,
+    pub height: u64,
+}
+
+/// Tracks the block with the highest cumulative difficulty.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MaxDifficultyInfo {
+    pub cumulative_diff: U256,
+    pub block_hash: BlockHash,
+}
+
+/// Extended info about the max-difficulty block.
+#[derive(Debug, Clone, Copy)]
+pub struct MaxBlockInfo {
+    pub block_hash: BlockHash,
+    pub height: u64,
+    pub can_build_upon: bool,
+}
+
 #[derive(Debug)]
 pub struct BlockTreeEntry(pub Arc<SealedBlock>);
 
@@ -68,13 +97,13 @@ pub struct BlockTree {
     pub tip: BlockHash,
 
     // Track max cumulative difficulty
-    max_cumulative_difficulty: (U256, BlockHash), // (difficulty, block_hash)
+    max_cumulative_difficulty: MaxDifficultyInfo,
 
     // Height -> Hash mapping
     height_index: BTreeMap<u64, HashSet<BlockHash>>,
 
     // Cache of longest chain: (block/tx pairs, count of non-onchain blocks)
-    longest_chain_cache: (Vec<BlockTreeEntry>, usize),
+    longest_chain_cache: CanonicalChain,
 
     // Consensus configuration containing cache depth
     consensus_config: ConsensusConfig,
@@ -160,7 +189,10 @@ impl BlockTree {
 
         // Initialize longest chain cache to contain the genesis block
         let entry = make_block_tree_entry(Arc::clone(&sealed_genesis));
-        let longest_chain_cache = (vec![(entry)], 0);
+        let longest_chain_cache = CanonicalChain {
+            entries: vec![entry],
+            not_onchain_count: 0,
+        };
 
         // Create initial block entry for genesis block, marking it as confirmed
         // and part of the canonical chain
@@ -184,7 +216,10 @@ impl BlockTree {
             blocks,
             solutions,
             tip: block_hash,
-            max_cumulative_difficulty: (cumulative_diff, block_hash),
+            max_cumulative_difficulty: MaxDifficultyInfo {
+                cumulative_diff,
+                block_hash,
+            },
             height_index,
             longest_chain_cache,
             consensus_config,
@@ -297,9 +332,15 @@ impl BlockTree {
             blocks: HashMap::new(),
             solutions: HashMap::new(),
             tip: start_block_hash,
-            max_cumulative_difficulty: (start_block.cumulative_diff, start_block_hash),
+            max_cumulative_difficulty: MaxDifficultyInfo {
+                cumulative_diff: start_block.cumulative_diff,
+                block_hash: start_block_hash,
+            },
             height_index: BTreeMap::new(),
-            longest_chain_cache: (vec![entry], 0),
+            longest_chain_cache: CanonicalChain {
+                entries: vec![entry],
+                not_onchain_count: 0,
+            },
             consensus_config: consensus_config.clone(),
         };
 
@@ -475,7 +516,7 @@ impl BlockTree {
 
         debug!(
             "adding block: max_cumulative_difficulty: {} block.cumulative_diff: {} {}, commitment_snapshot_hash: {}, epoch_snapshot_hash: {}, ema_snapshot_hash: {}",
-            self.max_cumulative_difficulty.0,
+            self.max_cumulative_difficulty.cumulative_diff,
             block.header().cumulative_diff,
             block.header().block_hash,
             &commitment_snapshot.get_hash(),
@@ -483,14 +524,17 @@ impl BlockTree {
             &ema_snapshot.get_hash()
         );
 
-        if block.header().cumulative_diff > self.max_cumulative_difficulty.0 {
+        if block.header().cumulative_diff > self.max_cumulative_difficulty.cumulative_diff {
             debug!(
                 "setting max_cumulative_difficulty ({}, {}) for height: {}",
                 block.header().cumulative_diff,
                 hash,
                 block.header().height
             );
-            self.max_cumulative_difficulty = (block.header().cumulative_diff, hash);
+            self.max_cumulative_difficulty = MaxDifficultyInfo {
+                cumulative_diff: block.header().cumulative_diff,
+                block_hash: hash,
+            };
         }
 
         self.blocks.insert(
@@ -585,7 +629,7 @@ impl BlockTree {
         self.blocks.remove(block_hash);
 
         // Update max_cumulative_difficulty if necessary
-        if self.max_cumulative_difficulty.1 == *block_hash {
+        if self.max_cumulative_difficulty.block_hash == *block_hash {
             self.max_cumulative_difficulty = self.find_max_difficulty();
         }
 
@@ -617,12 +661,18 @@ impl BlockTree {
     }
 
     // Helper to find new max difficulty when current max is removed
-    fn find_max_difficulty(&self) -> (U256, BlockHash) {
+    fn find_max_difficulty(&self) -> MaxDifficultyInfo {
         self.blocks
             .iter()
-            .map(|(hash, entry)| (entry.block.header().cumulative_diff, *hash))
-            .max_by_key(|(diff, _)| *diff)
-            .unwrap_or((U256::zero(), BlockHash::default()))
+            .map(|(hash, entry)| MaxDifficultyInfo {
+                cumulative_diff: entry.block.header().cumulative_diff,
+                block_hash: *hash,
+            })
+            .max_by_key(|info| info.cumulative_diff)
+            .unwrap_or(MaxDifficultyInfo {
+                cumulative_diff: U256::zero(),
+                block_hash: BlockHash::default(),
+            })
     }
 
     /// Returns the canonical chain as a cached sequence of block entries.
@@ -644,26 +694,26 @@ impl BlockTree {
     /// This returns a cloned copy of the cached chain for thread-safe access. The cache
     /// is updated whenever the canonical chain changes due to new blocks or reorganizations.
     #[must_use]
-    pub fn get_canonical_chain(&self) -> (Vec<BlockTreeEntry>, usize) {
+    pub fn get_canonical_chain(&self) -> CanonicalChain {
         self.longest_chain_cache.clone()
     }
 
     #[must_use]
     pub fn get_latest_canonical_entry(&self) -> &BlockTreeEntry {
         self.longest_chain_cache
-            .0
+            .entries
             .last()
             .expect("canonical chain must always have an entry in it")
     }
 
     fn update_longest_chain_cache(&mut self) {
         let pairs = {
-            self.longest_chain_cache.0.clear();
-            &mut self.longest_chain_cache.0
+            self.longest_chain_cache.entries.clear();
+            &mut self.longest_chain_cache.entries
         };
         let mut not_onchain_count = 0;
 
-        let mut current = self.max_cumulative_difficulty.1;
+        let mut current = self.max_cumulative_difficulty.block_hash;
         let mut blocks_to_collect = self.consensus_config.block_tree_depth;
         debug!(
             "updating canonical chain cache latest_cache_tip: {}",
@@ -729,7 +779,7 @@ impl BlockTree {
         }
 
         pairs.reverse();
-        self.longest_chain_cache.1 = not_onchain_count;
+        self.longest_chain_cache.not_onchain_count = not_onchain_count;
     }
 
     /// Helper to mark off-chain blocks in a set
@@ -791,7 +841,8 @@ impl BlockTree {
         let block_header = block_entry.block.header().clone();
         let old_tip = self.tip;
 
-        let (canonical_diff, canonical_block_hash) = self.max_cumulative_difficulty;
+        let canonical_diff = self.max_cumulative_difficulty.cumulative_diff;
+        let canonical_block_hash = self.max_cumulative_difficulty.block_hash;
 
         if block_header.cumulative_diff == canonical_diff && canonical_block_hash != *block_hash {
             // "Cannot move tip away from canonical for another block with same cumulative_diff"
@@ -881,7 +932,7 @@ impl BlockTree {
     pub fn canonical_commitment_snapshot(&self) -> Arc<CommitmentSnapshot> {
         let head_entry = self
             .longest_chain_cache
-            .0
+            .entries
             .last()
             .expect("at least one block in the longest chain");
 
@@ -895,7 +946,7 @@ impl BlockTree {
     pub fn canonical_epoch_snapshot(&self) -> Arc<EpochSnapshot> {
         let head_entry = self
             .longest_chain_cache
-            .0
+            .entries
             .last()
             .expect("at least one block in the longest chain");
 
@@ -935,25 +986,25 @@ impl BlockTree {
     }
 
     /// Get the block with maximum cumulative difficulty
-    pub fn get_max_cumulative_difficulty_block(&self) -> (U256, BlockHash) {
+    pub fn get_max_cumulative_difficulty_block(&self) -> MaxDifficultyInfo {
         self.max_cumulative_difficulty
     }
 
-    /// Returns max-difficulty block info: (hash, height, can_build_upon)
+    /// Returns max-difficulty block info.
     ///
     /// # Panics
     /// Panics if the max difficulty block is not in the tree (invariant violation).
-    pub fn get_max_block_info(&self) -> (BlockHash, u64, bool) {
-        let (_, hash) = self.max_cumulative_difficulty;
+    pub fn get_max_block_info(&self) -> MaxBlockInfo {
+        let hash = self.max_cumulative_difficulty.block_hash;
         let entry = self
             .blocks
             .get(&hash)
             .expect("max difficulty block must exist in tree");
-        (
-            hash,
-            entry.block.header().height,
-            self.can_be_built_upon(&hash),
-        )
+        MaxBlockInfo {
+            block_hash: hash,
+            height: entry.block.header().height,
+            can_build_upon: self.can_be_built_upon(&hash),
+        }
     }
 
     /// Check if a block can be built upon
@@ -1091,14 +1142,14 @@ impl BlockTree {
         &self,
     ) -> Option<(&BlockMetadata, Vec<Arc<SealedBlock>>, SystemTime)> {
         // Get the block with max cumulative difficulty
-        let (_max_cdiff, max_diff_hash) = self.max_cumulative_difficulty;
+        let max_diff_hash = self.max_cumulative_difficulty.block_hash;
 
         // Get the tip's cumulative difficulty
         let tip_entry = self.blocks.get(&self.tip)?;
         let tip_cdiff = tip_entry.block.header().cumulative_diff;
 
         // Check if tip's difficulty exceeds max difficulty
-        if tip_cdiff >= self.max_cumulative_difficulty.0 {
+        if tip_cdiff >= self.max_cumulative_difficulty.cumulative_diff {
             return None;
         }
 
@@ -1297,7 +1348,7 @@ fn build_current_ema_snapshot_from_index(
         .expect("Failed to create EMA snapshot from chain history")
 }
 
-pub async fn get_optimistic_chain(tree: BlockTreeReadGuard) -> eyre::Result<Vec<(H256, u64)>> {
+pub async fn get_optimistic_chain(tree: BlockTreeReadGuard) -> eyre::Result<Vec<ChainBlockRef>> {
     let canonical_chain = tokio::task::spawn_blocking(move || {
         let cache = tree.read();
 
@@ -1307,11 +1358,14 @@ pub async fn get_optimistic_chain(tree: BlockTreeReadGuard) -> eyre::Result<Vec<
                 .try_into()
                 .expect("u64 must fit into usize"),
         );
-        let mut current = cache.max_cumulative_difficulty.1;
+        let mut current = cache.max_cumulative_difficulty.block_hash;
         debug!("get_optimistic_chain with latest_cache_tip: {}", current);
 
         while let Some(entry) = cache.blocks.get(&current) {
-            chain_cache.push((current, entry.block.header().height));
+            chain_cache.push(ChainBlockRef {
+                block_hash: current,
+                height: entry.block.header().height,
+            });
 
             if blocks_to_collect == 0 {
                 break;
@@ -1336,9 +1390,7 @@ pub async fn get_optimistic_chain(tree: BlockTreeReadGuard) -> eyre::Result<Vec<
 /// Uses spawn_blocking to prevent the read operation from blocking the async executor
 /// and locking other async tasks while traversing the block tree.
 /// Notably useful in single-threaded tokio based unittests.
-pub async fn get_canonical_chain(
-    tree: BlockTreeReadGuard,
-) -> eyre::Result<(Vec<BlockTreeEntry>, usize)> {
+pub async fn get_canonical_chain(tree: BlockTreeReadGuard) -> eyre::Result<CanonicalChain> {
     let canonical_chain =
         tokio::task::spawn_blocking(move || tree.read().get_canonical_chain()).await?;
     Ok(canonical_chain)
@@ -2617,8 +2669,9 @@ mod tests {
         expected_not_onchain: usize,
         cache: &BlockTree,
     ) -> eyre::Result<()> {
-        let (canonical_blocks, not_onchain_count) = cache.get_canonical_chain();
-        let actual_blocks: Vec<_> = canonical_blocks
+        let chain = cache.get_canonical_chain();
+        let actual_blocks: Vec<_> = chain
+            .entries
             .iter()
             .map(super::BlockTreeEntry::block_hash)
             .collect();
@@ -2639,10 +2692,10 @@ mod tests {
             "Canonical chain does not match expected blocks"
         );
         ensure!(
-            not_onchain_count == expected_not_onchain,
+            chain.not_onchain_count == expected_not_onchain,
             format!(
                 "Number of not-onchain blocks ({}) does not match expected ({})",
-                not_onchain_count, expected_not_onchain
+                chain.not_onchain_count, expected_not_onchain
             )
         );
         Ok(())

--- a/crates/domain/src/models/forkchoice_markers.rs
+++ b/crates/domain/src/models/forkchoice_markers.rs
@@ -49,13 +49,13 @@ impl ForkChoiceMarkers {
         migration_depth: usize,
         prune_depth: usize,
     ) -> Result<Self> {
-        let (canonical_chain, _) = block_tree.get_canonical_chain();
-        if canonical_chain.is_empty() {
+        let chain = block_tree.get_canonical_chain();
+        if chain.entries.is_empty() {
             bail!("canonical chain is empty while computing fork-choice markers");
         }
 
-        let head_height = tree_head_height(&canonical_chain)?;
-        let tree_safe_height = tree_safe_height(&canonical_chain, migration_depth)?;
+        let head_height = tree_head_height(&chain.entries)?;
+        let tree_safe_height = tree_safe_height(&chain.entries, migration_depth)?;
         let index_safe_height = block_index.latest_height();
         let migration_height =
             compute_migration_height(head_height, tree_safe_height, index_safe_height);
@@ -64,7 +64,7 @@ impl ForkChoiceMarkers {
 
         let head_block = block_at_height(
             head_height,
-            &canonical_chain,
+            &chain.entries,
             block_tree,
             block_index,
             database,
@@ -72,7 +72,7 @@ impl ForkChoiceMarkers {
 
         let migration_block = block_at_height(
             migration_height,
-            &canonical_chain,
+            &chain.entries,
             block_tree,
             block_index,
             database,
@@ -80,7 +80,7 @@ impl ForkChoiceMarkers {
 
         let prune_block = block_at_height(
             prune_height,
-            &canonical_chain,
+            &chain.entries,
             block_tree,
             block_index,
             database,
@@ -93,13 +93,13 @@ impl ForkChoiceMarkers {
         })
     }
 
-    /// Computes canonical fork-choice markers using only the block index—mirroring the values that
+    /// Computes canonical fork-choice markers using only the block index---mirroring the values that
     /// would have been in effect before shutdown (aside from the head, which is rolled back to the
     /// latest indexed block).
     ///
     /// During startup the block tree is empty, so:
     /// - `head` resolves to the latest block index entry (the prior canonical head).
-    /// - `migration_block` mirrors that same entry to match the “confirmed” head just before shutdown.
+    /// - `migration_block` mirrors that same entry to match the "confirmed" head just before shutdown.
     /// - `prune_block` is derived from the index at `block_tree_depth` behind the tip so the finalized
     ///   marker aligns with the state before shutdown.
     pub fn from_index(

--- a/crates/domain/src/models/node_info.rs
+++ b/crates/domain/src/models/node_info.rs
@@ -23,8 +23,9 @@ pub async fn get_node_info(
         )
     };
 
-    let (chain, blocks) = get_canonical_chain(block_tree.clone()).await?;
+    let chain = get_canonical_chain(block_tree.clone()).await?;
     let latest = chain
+        .entries
         .last()
         .ok_or_else(|| eyre::eyre!("canonical chain is empty"))?;
     let max_diff = block_tree.read().get_max_cumulative_difficulty_block();
@@ -37,11 +38,11 @@ pub async fn get_node_info(
         block_hash: latest.block_hash(),
         block_index_height,
         block_index_hash,
-        pending_blocks: u64::try_from(blocks)?,
+        pending_blocks: u64::try_from(chain.not_onchain_count)?,
         is_syncing: sync_state.is_syncing(),
         current_sync_height: u64::try_from(sync_state.sync_target_height())?,
         uptime_secs: started_at.elapsed().as_secs(),
-        cumulative_difficulty: max_diff.0,
+        cumulative_difficulty: max_diff.cumulative_diff,
         mining_address,
     })
 }


### PR DESCRIPTION
## Summary

**Before:**
Four `BlockTree` API methods returned raw tuples (`(Vec<BlockTreeEntry>, usize)`, `(U256, BlockHash)`, `(BlockHash, u64, bool)`, `Vec<(H256, u64)>`), forcing ~40 call sites to use positional `.0`/`.1` access or discard elements via `_`.

**After:**
Each tuple return is replaced by a named struct (`CanonicalChain`, `MaxDifficultyInfo`, `MaxBlockInfo`, `ChainBlockRef`), and all call sites use explicit field access (`.entries`, `.block_hash`, `.cumulative_diff`, etc.).

## Changes

### New types (`crates/domain/src/models/block_tree.rs`)
- `CanonicalChain { entries, not_onchain_count }` replaces `(Vec<BlockTreeEntry>, usize)`
- `ChainBlockRef { block_hash, height }` replaces `(H256, u64)` in `get_optimistic_chain`
- `MaxDifficultyInfo { cumulative_diff, block_hash }` replaces `(U256, BlockHash)`
- `MaxBlockInfo { block_hash, height, can_build_upon }` replaces `(BlockHash, u64, bool)`

### Internal fields updated
- `BlockTree::longest_chain_cache` changed from tuple to `CanonicalChain`
- `BlockTree::max_cumulative_difficulty` changed from tuple to `MaxDifficultyInfo`
- `find_max_difficulty()` return type updated to `MaxDifficultyInfo`

### Call sites updated (26 files)
- `crates/actors/` (10 files): block_tree_service, block_producer, validation_service, cache_service, chunk_orchestrator, mempool_service, tx_selector, anchor_validation
- `crates/api-server/` (5 files): block, mining, observability, price, supply routes
- `crates/domain/` (3 files): block_tree_guard, forkchoice_markers, node_info
- `crates/chain/` (1 file): chain.rs
- `crates/chain-tests/` (6 files): utils, fork_recovery, mempool_tests, block_production, startup, ema_pricing

## Technical Notes

- **Breaking changes**: All four method signatures changed. No external API impact (these are internal crate boundaries).
- **Behavioural changes**: None. Pure refactor validated by existing test suite.
- **Dead code**: `get_optimistic_chain()` has zero callers; its signature was updated for consistency but removal is a separate concern.

## Testing
- [x] Existing tests pass (121 domain tests, full workspace check)
- [x] `cargo xtask local-checks` passes (fmt, check, clippy, unused-deps, typos)
- [x] Grep verification confirms zero remaining `.0`/`.1` positional access on affected return types

## Related
- Closes #1185
- Requested in PR #1159 review (comment by @JesseTheRobot)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized internal canonical-chain and block-tracking data structures and updated related APIs for clearer, consistent handling across validation, sync, and RPC layers.
* **Tests**
  * Updated test suites and utilities to align with the internal data model changes.

Note: No user-facing behavior or visible features changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->