### PR TITLE
fix: ring recompilation

### DIFF
--- a/crates/tooling/multiversion-tests/src/binary.rs
+++ b/crates/tooling/multiversion-tests/src/binary.rs
@@ -381,6 +381,9 @@ impl BinaryResolver {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 
+        // TODO: once ring releases 0.17.15+ (current: 0.17.14), we should no
+        // longer need this workaround. See https://github.com/rust-lang/cargo/issues/16134
+        //
         // Strip env vars that ring's build.rs registers via
         // `cargo:rerun-if-env-changed`. When this inner `cargo build` is
         // spawned by a `cargo test` process, cargo sets CARGO_PKG_* etc. for


### PR DESCRIPTION
**Describe the changes**
This fixes `ring` recompilation caused by nested cargo env var inheritance when the multiversion test harness runs cargo build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build isolation by preventing unintended environment variable interference during multiversion testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->