### PR TITLE
fix(build): pass git metadata via env vars for Docker builds

### DIFF
--- a/crates/chain/build.rs
+++ b/crates/chain/build.rs
@@ -1,6 +1,19 @@
 use std::process::Command;
 
 fn main() {
+    // When building outside a git repo (e.g. Docker), accept git metadata via env
+    // vars and skip all git detection. build_image.sh captures these from the host.
+    if let (Ok(sha), Ok(has_tag), Ok(dirty)) = (
+        std::env::var("GIT_SHA"),
+        std::env::var("GIT_HAS_TAG"),
+        std::env::var("GIT_DIRTY"),
+    ) {
+        println!("cargo:rustc-env=GIT_SHA={sha}");
+        println!("cargo:rustc-env=GIT_HAS_TAG={has_tag}");
+        println!("cargo:rustc-env=GIT_DIRTY={dirty}");
+        return;
+    }
+
     // In worktrees, HEAD lives in the worktree's own git dir, but refs/tags and
     // packed-refs live in the common (main repo) git dir. Track both.
 

--- a/crates/chain/build.rs
+++ b/crates/chain/build.rs
@@ -12,6 +12,10 @@ fn main() {
         std::env::var("GIT_HAS_TAG"),
         std::env::var("GIT_DIRTY"),
     ) {
+        let has_tag: bool = has_tag
+            .parse()
+            .expect("GIT_HAS_TAG must be 'true' or 'false'");
+        let dirty: bool = dirty.parse().expect("GIT_DIRTY must be 'true' or 'false'");
         println!("cargo:rustc-env=GIT_SHA={sha}");
         println!("cargo:rustc-env=GIT_HAS_TAG={has_tag}");
         println!("cargo:rustc-env=GIT_DIRTY={dirty}");

--- a/crates/chain/build.rs
+++ b/crates/chain/build.rs
@@ -20,6 +20,14 @@ fn main() {
         println!("cargo:rustc-env=GIT_HAS_TAG={has_tag}");
         println!("cargo:rustc-env=GIT_DIRTY={dirty}");
         return;
+    } else if std::env::var("GIT_SHA").is_ok()
+        || std::env::var("GIT_HAS_TAG").is_ok()
+        || std::env::var("GIT_DIRTY").is_ok()
+    {
+        panic!(
+            "GIT_SHA, GIT_HAS_TAG, and GIT_DIRTY must all be set together; \
+             found only a subset — check your Docker build args"
+        );
     }
 
     // In worktrees, HEAD lives in the worktree's own git dir, but refs/tags and

--- a/crates/chain/build.rs
+++ b/crates/chain/build.rs
@@ -1,6 +1,10 @@
 use std::process::Command;
 
 fn main() {
+    println!("cargo:rerun-if-env-changed=GIT_SHA");
+    println!("cargo:rerun-if-env-changed=GIT_HAS_TAG");
+    println!("cargo:rerun-if-env-changed=GIT_DIRTY");
+
     // When building outside a git repo (e.g. Docker), accept git metadata via env
     // vars and skip all git detection. build_image.sh captures these from the host.
     if let (Ok(sha), Ok(has_tag), Ok(dirty)) = (

--- a/crates/chain/build.rs
+++ b/crates/chain/build.rs
@@ -16,6 +16,10 @@ fn main() {
             .parse()
             .expect("GIT_HAS_TAG must be 'true' or 'false'");
         let dirty: bool = dirty.parse().expect("GIT_DIRTY must be 'true' or 'false'");
+        let sha = sha.trim();
+        if !has_tag && sha.is_empty() {
+            panic!("GIT_SHA must be non-empty when GIT_HAS_TAG is false");
+        }
         println!("cargo:rustc-env=GIT_SHA={sha}");
         println!("cargo:rustc-env=GIT_HAS_TAG={has_tag}");
         println!("cargo:rustc-env=GIT_DIRTY={dirty}");

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Copy the full workspace (simpler and more robust than fine-grained caching here)
 COPY . .
 
+# Git metadata — .git is excluded from context, so pass via build args
+ARG GIT_SHA=unknown
+ARG GIT_HAS_TAG=false
+ARG GIT_DIRTY=false
+ENV GIT_SHA=${GIT_SHA}
+ENV GIT_HAS_TAG=${GIT_HAS_TAG}
+ENV GIT_DIRTY=${GIT_DIRTY}
+
 # Build the binary defined in crates/chain [[bin]] name = "irys"
 # Use the existing debug-release profile to match compose expectations
 # Reduce memory usage: single job, no incremental, minimal debuginfo, fewer codegen units

--- a/docker/Dockerfile.debug
+++ b/docker/Dockerfile.debug
@@ -32,6 +32,12 @@ COPY . .
 
 # Build the release binary with portable CPU target
 ARG CARGO_FEATURES=""
+ARG GIT_SHA=unknown
+ARG GIT_HAS_TAG=false
+ARG GIT_DIRTY=false
+ENV GIT_SHA=${GIT_SHA}
+ENV GIT_HAS_TAG=${GIT_HAS_TAG}
+ENV GIT_DIRTY=${GIT_DIRTY}
 ENV RUSTFLAGS="-C target-cpu=x86-64 -C link-arg=-fuse-ld=mold"
 RUN if [ -n "$CARGO_FEATURES" ]; then \
       cargo build --release --bin irys -p irys-chain --locked --features "$CARGO_FEATURES"; \

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -28,6 +28,14 @@ WORKDIR /workspace
 
 COPY . .
 
+# Git metadata — .git is excluded from context, so pass via build args
+ARG GIT_SHA=unknown
+ARG GIT_HAS_TAG=false
+ARG GIT_DIRTY=false
+ENV GIT_SHA=${GIT_SHA}
+ENV GIT_HAS_TAG=${GIT_HAS_TAG}
+ENV GIT_DIRTY=${GIT_DIRTY}
+
 # Reproducible build: deterministic timestamps, no incremental, mold linker
 ENV SOURCE_DATE_EPOCH=0 \
     CARGO_INCREMENTAL=0 \

--- a/docker/tests/data-sync/build_image.sh
+++ b/docker/tests/data-sync/build_image.sh
@@ -19,7 +19,7 @@ cd "$REPO_ROOT"
 
 # Capture git metadata from the host — .git is excluded from Docker context
 GIT_SHA="$(git rev-parse --short=7 HEAD 2>/dev/null || echo unknown)"
-GIT_HAS_TAG="$(git describe --exact-match --tags HEAD 2>/dev/null && echo true || echo false)"
+GIT_HAS_TAG="$(git describe --exact-match --tags HEAD >/dev/null 2>&1 && echo true || echo false)"
 GIT_DIRTY="$(git diff-index --quiet HEAD -- 2>/dev/null && echo false || echo true)"
 GIT_COMMIT="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
 

--- a/docker/tests/data-sync/build_image.sh
+++ b/docker/tests/data-sync/build_image.sh
@@ -17,7 +17,20 @@ echo ""
 
 cd "$REPO_ROOT"
 
-BUILD_ARGS=()
+# Capture git metadata from the host — .git is excluded from Docker context
+GIT_SHA="$(git rev-parse --short=7 HEAD 2>/dev/null || echo unknown)"
+GIT_HAS_TAG="$(git describe --exact-match --tags HEAD 2>/dev/null && echo true || echo false)"
+GIT_DIRTY="$(git diff-index --quiet HEAD -- 2>/dev/null && echo false || echo true)"
+GIT_COMMIT="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+
+echo "Git SHA: $GIT_SHA (dirty=$GIT_DIRTY, tagged=$GIT_HAS_TAG)"
+
+BUILD_ARGS=(
+    --build-arg "GIT_SHA=$GIT_SHA"
+    --build-arg "GIT_HAS_TAG=$GIT_HAS_TAG"
+    --build-arg "GIT_DIRTY=$GIT_DIRTY"
+    --build-arg "GIT_COMMIT=$GIT_COMMIT"
+)
 if [ "$ENABLE_TELEMETRY" = "true" ] || [ "$ENABLE_TELEMETRY" = "1" ]; then
     BUILD_ARGS+=(--build-arg CARGO_FEATURES=telemetry)
     echo "Building with telemetry support..."

--- a/docker/tests/data-sync/docker-compose.yaml
+++ b/docker/tests/data-sync/docker-compose.yaml
@@ -2,7 +2,7 @@
 #
 # Uses the image built by build_image.sh (localhost/irys-test:latest by default).
 # Override with IMAGE_NAME env var if needed.
-# Sends telemetry to remote observability stack.
+# Sends telemetry to local observability stack by default.
 #
 # OTEL_HOST: defaults to host.docker.internal (local observation stack).
 # Override for remote environments:
@@ -110,6 +110,8 @@ services:
     image: otel/opentelemetry-collector-contrib:0.96.0
     container_name: otel-sidecar-1
     restart: unless-stopped
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       test-irys-1:
         condition: service_started
@@ -127,6 +129,8 @@ services:
     image: otel/opentelemetry-collector-contrib:0.96.0
     container_name: otel-sidecar-2
     restart: unless-stopped
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       test-irys-2:
         condition: service_started
@@ -144,6 +148,8 @@ services:
     image: otel/opentelemetry-collector-contrib:0.96.0
     container_name: otel-sidecar-3
     restart: unless-stopped
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       test-irys-3:
         condition: service_started

--- a/docker/tests/data-sync/docker-compose.yaml
+++ b/docker/tests/data-sync/docker-compose.yaml
@@ -4,9 +4,9 @@
 # Override with IMAGE_NAME env var if needed.
 # Sends telemetry to remote observability stack.
 #
-# OTEL_REMOTE_HOST: defaults to 51.38.53.126 (external OVH collector).
-# Override for local/isolated environments:
-#   OTEL_REMOTE_HOST=host.docker.internal docker compose up
+# OTEL_HOST: defaults to host.docker.internal (local observation stack).
+# Override for remote environments:
+#   OTEL_HOST=51.38.53.126 docker compose up
 
 services:
   # ==========================================================================
@@ -26,8 +26,8 @@ services:
       - RUST_LOG=debug
       - ENABLE_TELEMETRY=true
       - OTEL_SERVICE_NAME=irys-node-1
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://${OTEL_REMOTE_HOST:-51.38.53.126}:4317
-      - OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://${OTEL_REMOTE_HOST:-51.38.53.126}:4318/v1/logs
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://${OTEL_HOST:-host.docker.internal}:4317
+      - OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://${OTEL_HOST:-host.docker.internal}:4318/v1/logs
     volumes:
       - ./configs/irys-1.toml:/app/config.toml:ro
       - ./configs/.irys_submodules.toml:/app/staged/.irys_submodules.toml:ro
@@ -56,8 +56,8 @@ services:
       - GENESIS_URL=http://test-irys-1:8080
       - ENABLE_TELEMETRY=true
       - OTEL_SERVICE_NAME=irys-node-2
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://${OTEL_REMOTE_HOST:-51.38.53.126}:4317
-      - OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://${OTEL_REMOTE_HOST:-51.38.53.126}:4318/v1/logs
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://${OTEL_HOST:-host.docker.internal}:4317
+      - OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://${OTEL_HOST:-host.docker.internal}:4318/v1/logs
     volumes:
       - ./configs/irys-2.toml:/app/config.toml:ro
       - ./configs/.irys_submodules.toml:/app/staged/.irys_submodules.toml:ro
@@ -88,8 +88,8 @@ services:
       - GENESIS_URL=http://test-irys-1:8080
       - ENABLE_TELEMETRY=true
       - OTEL_SERVICE_NAME=irys-node-3
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://${OTEL_REMOTE_HOST:-51.38.53.126}:4317
-      - OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://${OTEL_REMOTE_HOST:-51.38.53.126}:4318/v1/logs
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://${OTEL_HOST:-host.docker.internal}:4317
+      - OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://${OTEL_HOST:-host.docker.internal}:4318/v1/logs
     volumes:
       - ./configs/irys-3.toml:/app/config.toml:ro
       - ./configs/.irys_submodules.toml:/app/staged/.irys_submodules.toml:ro
@@ -116,7 +116,7 @@ services:
     environment:
       - OTEL_SERVICE_NAME=irys-node-1
       - RETH_METRICS_HOST=172.24.0.2
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://${OTEL_REMOTE_HOST:-51.38.53.126}:4317
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://${OTEL_HOST:-host.docker.internal}:4317
     volumes:
       - ./configs/otel-sidecar.yaml:/etc/otelcol-contrib/config.yaml:ro
     networks:
@@ -133,7 +133,7 @@ services:
     environment:
       - OTEL_SERVICE_NAME=irys-node-2
       - RETH_METRICS_HOST=172.24.0.3
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://${OTEL_REMOTE_HOST:-51.38.53.126}:4317
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://${OTEL_HOST:-host.docker.internal}:4317
     volumes:
       - ./configs/otel-sidecar.yaml:/etc/otelcol-contrib/config.yaml:ro
     networks:
@@ -150,7 +150,7 @@ services:
     environment:
       - OTEL_SERVICE_NAME=irys-node-3
       - RETH_METRICS_HOST=172.24.0.4
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://${OTEL_REMOTE_HOST:-51.38.53.126}:4317
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://${OTEL_HOST:-host.docker.internal}:4317
     volumes:
       - ./configs/otel-sidecar.yaml:/etc/otelcol-contrib/config.yaml:ro
     networks:

--- a/docker/tests/data-sync/docker-compose.yaml
+++ b/docker/tests/data-sync/docker-compose.yaml
@@ -4,7 +4,7 @@
 # Override with IMAGE_NAME env var if needed.
 # Sends telemetry to local observability stack by default.
 #
-# OTEL_HOST: defaults to host.docker.internal (local observation stack).
+# OTEL_HOST: defaults to host.docker.internal (local observability stack).
 # Override for remote environments:
 #   OTEL_HOST=51.38.53.126 docker compose up
 


### PR DESCRIPTION
**Describe the changes**
A clear and concise description of what the bug fix, feature, or improvement is.

**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build now accepts and forwards Git metadata (commit SHA, tag presence, dirty state) into the build environment; these can be supplied externally to bypass repo probing.
  * Container builds accept those metadata inputs as build args and expose them as runtime environment variables.
  * Build scripts populate and log the Git metadata used for image builds for reproducibility.
  * Test compose configs use a unified OTEL host variable for exporters and add host.docker.internal mapping to sidecar services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->