### PR TITLE
fix: clock drift/monotonic timers

### DIFF
--- a/.claude/skills/monotonic-time/SKILL.md
+++ b/.claude/skills/monotonic-time/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: monotonic-time
+description: Use when writing or reviewing code that involves time — sleeps, timeouts, retry/backoff, deduplication windows, rate limits, cache TTLs, "wait until X", timing assertions, or any arithmetic over `SystemTime::now()` / `UnixTimestamp::now()` / `Instant::now()` / `tokio::time::sleep`. Decides whether to use monotonic (`Instant`) or wall-clock (`SystemTime`) and how to mix them safely.
+---
+
+# Use monotonic time for internal timing
+
+## Default: `Instant` / `Duration`
+
+For any internal duration measurement, deduplication window, rate limit, retry/backoff, timeout, sleep, or cache TTL, default to `std::time::Instant` (or `tokio::time::Instant`) and `Duration`.
+
+`SystemTime::now()` / `UnixTimestamp::now()` is wall-clock. It can:
+
+- Step backward (NTP correction, manual change, VM host resync).
+- Jump forward arbitrarily.
+- Be inconsistent with `tokio::time::sleep`, which is monotonic.
+
+WSL2 in particular regularly skews `CLOCK_REALTIME` against `CLOCK_MONOTONIC` by hundreds of milliseconds, occasionally seconds (the Hyper-V host clock periodically rewrites the VM's realtime). Mixing tokio sleeps with realtime arithmetic produces hard-to-reproduce flakiness — and in production code, real correctness bugs (a backward jump can violate "child timestamp > parent timestamp" invariants, defeat dedup windows, or expire caches early).
+
+## When wall-clock IS correct
+
+Use `SystemTime` / `UnixTimestamp` *only* when the value crosses a trust boundary that requires it:
+
+- **Block timestamps** — consensus uses real-time for hardfork activation and EVM block headers.
+- **Persisted records** — values written to disk/DB that other processes or future invocations will read.
+- **Log lines** — human-readable wall-clock context.
+- **Anything compared against another node's clock** — peer protocols, signed timestamps.
+
+## If you must use wall-clock + sleep together
+
+Never assume `tokio::time::sleep(N)` advances `SystemTime::now()` by `N`. They use different clocks. After the sleep, re-check the wall clock and loop or retry if the post-condition isn't met.
+
+Two patterns in the tree to copy:
+
+- **`current_timestamp` in `crates/actors/src/block_producer.rs`** — block production needs a wall-clock timestamp strictly greater than the parent's. The function loops until `now().to_secs()` has actually crossed the boundary, instead of trusting one tokio sleep.
+
+- **`wait_for_wallclock` in `crates/chain-tests/src/api/hardfork_tests.rs`** — waits past activation, then *holds on monotonic time* and re-reads realtime. If realtime dips back below activation during the hold (e.g. a backwards lurch), the wait restarts. Adaptive on flaky hosts, fast on stable ones.
+
+## Refactor signal
+
+If you see `SystemTime::now()` / `UnixTimestamp::now()` used for any of:
+
+- A duration measurement (`later - earlier` math).
+- A timeout / sleep target.
+- A "has window expired" check.
+- A "last seen / last request" timestamp for in-process bookkeeping.
+
+…it should almost certainly be `Instant` instead. See `crates/p2p/src/rate_limiting.rs` for a clean example: the rate limiter uses `Instant`/`Duration` because there's no externally-observable reason to expose realtime — switching from `SystemTime` epoch math eliminated a class of WSL2 flakes there.
+
+## Background reading
+
+If a contributor is hitting WSL2 clock issues directly (test flakes, `block timestamp ... is in the past compared to parent timestamp` panics, etc.), see the "WSL2 clock instability" section in the repo `README.md` for the Windows-side `.wslconfig` fix.

--- a/.github/workflows/multiversion.yml
+++ b/.github/workflows/multiversion.yml
@@ -49,7 +49,7 @@ jobs:
         uses: ./.github/actions/setup-repo
 
       - name: Run multiversion tests
-        run: cargo xtask multiversion-test --profile dev --old-ref ${{ steps.refs.outputs.old_ref }} --new-ref HEAD --clean
+        run: cargo xtask multiversion-test --profile dev --old-ref ${{ steps.refs.outputs.old_ref }} --new-ref HEAD --clean -- --no-fail-fast
 
       - name: sccache stats
         if: always()

--- a/.github/workflows/multiversion.yml
+++ b/.github/workflows/multiversion.yml
@@ -49,7 +49,9 @@ jobs:
         uses: ./.github/actions/setup-repo
 
       - name: Run multiversion tests
-        run: cargo xtask multiversion-test --profile dev --old-ref ${{ steps.refs.outputs.old_ref }} --new-ref HEAD --clean -- --no-fail-fast
+        env:
+          OLD_REF: ${{ steps.refs.outputs.old_ref }}
+        run: cargo xtask multiversion-test --profile dev --old-ref "$OLD_REF" --new-ref HEAD --clean -- --no-fail-fast
 
       - name: sccache stats
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,8 @@ HTTP-based gossip protocol. Routes: `/gossip/block`, `/gossip/tx`, `/gossip/chun
 
 When refactoring or simplifying code, preserve existing comments that explain *why* something is done or map code to external concepts (CLI flags, config fields, protocol steps, etc.). Only remove comments that are genuinely redundant or stale.
 
+For guidance on choosing between monotonic (`Instant`) and wall-clock (`SystemTime` / `UnixTimestamp`) time when writing or reviewing timing code, see the `monotonic-time` skill.
+
 ## Git Conventions
 
 Never add "Co-Authored-By" lines to commit messages.

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ sudo chmod 644 /Library/LaunchDaemons/limit.maxfiles.plist
 
 sudo launchctl load -w /Library/LaunchDaemons/limit.maxfiles.plist
 ```
+
 ## WSL2 clock instability
 
 If you're running tests under WSL2, you may see intermittent failures around

--- a/README.md
+++ b/README.md
@@ -128,5 +128,27 @@ sudo chmod 644 /Library/LaunchDaemons/limit.maxfiles.plist
 
 sudo launchctl load -w /Library/LaunchDaemons/limit.maxfiles.plist
 ```
+## WSL2 clock instability
+
+If you're running tests under WSL2, you may see intermittent failures around
+block production, hardfork activation, or any test that mixes
+`tokio::time::sleep` (monotonic) with `SystemTime::now()` /
+`UnixTimestamp::now()` (realtime). This is WSL2's Hyper-V
+time-sync integration component periodically jamming the Windows host clock
+into the VM, which makes `CLOCK_REALTIME` lurch backwards (we've measured
+backward jumps of up to ~12s on this codebase) while `CLOCK_MONOTONIC` keeps
+ticking smoothly.
+
+### Fix (Windows-side, persistent)
+
+Edit `%UserProfile%\.wslconfig`:
+
+```ini
+[wsl2]
+kernelCommandLine = hv_utils.timesync_implicit=0
+```
+
+Then `wsl --shutdown` once. 
+
 ## Misc
 use the `IRYS_CUSTOM_TMP_DIR` env var to change the temporary directory used for tests from ./.tmp to whatever path you like. it can also be set to another env var to lookup and resolve as a path at runtime.

--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -1887,24 +1887,28 @@ impl BlockProdStrategy for ProductionStrategy {
 
 #[tracing::instrument(level = "trace", skip_all)]
 pub async fn current_timestamp(prev_block_header: &IrysBlockHeader) -> UnixTimestampMs {
-    let now_ms = UnixTimestampMs::now().unwrap();
     let prev_secs = prev_block_header.timestamp.to_secs();
 
-    // If we're in the same second as the previous block, wait until the next second.
-    // This prevents EVM timestamp collisions (EVM uses second-precision).
-    // Dev configs can easily trigger this behaviour due to fast block times.
-    if now_ms.to_secs() == prev_secs {
+    // EVM block timestamps are seconds-precision and must be strictly greater
+    // than the parent's. Loop until wall-clock time has actually advanced past
+    // the parent's second. We re-check after each sleep because tokio's sleep
+    // is monotonic-clock based, while the timestamp comes from the realtime
+    // clock — the two can drift (notably under WSL2, which periodically
+    // resyncs CLOCK_REALTIME against the Windows host and can lurch by
+    // hundreds of ms or seconds), so a one-shot computed wait is unsafe.
+    loop {
+        let now_ms = UnixTimestampMs::now().unwrap();
+        if now_ms.to_secs() > prev_secs {
+            return now_ms;
+        }
         let ms_into_sec = (now_ms.as_millis() % 1000) as u64;
-        let wait_duration = Duration::from_millis(1000 - ms_into_sec);
+        let wait_duration = Duration::from_millis(1001 - ms_into_sec);
         info!(
             "Waiting {:.2?} to prevent timestamp overlap",
             &wait_duration
         );
         tokio::time::sleep(wait_duration).await;
-        return UnixTimestampMs::now().unwrap();
     }
-
-    now_ms
 }
 
 /// Calculates the total number of full chunks needed to store a list of transactions,

--- a/crates/chain-tests/src/api/hardfork_tests.rs
+++ b/crates/chain-tests/src/api/hardfork_tests.rs
@@ -194,20 +194,47 @@ async fn wait_until_activation(node: &IrysNodeTest<IrysNodeCtx>, activation_time
 
 async fn wait_for_wallclock(activation_timestamp: u64) {
     const MAX_WAIT_SECS: u64 = 60;
-    const POST_ACTIVATION_BUFFER_MS: u64 = 500;
-    let deadline = now_secs().saturating_add(MAX_WAIT_SECS);
+    // After realtime crosses `activation_timestamp` we hold on monotonic time
+    // and keep re-checking realtime: if it ever dips back below activation
+    // during the hold (Hyper-V time-sync lurch on WSL2, NTP correction, etc.),
+    // we restart the wait. This converts the previous static buffer into an
+    // adaptive check — fast on stable hosts, self-correcting on flaky ones.
+    const HOLD_DURATION: std::time::Duration = std::time::Duration::from_secs(2);
+    let poll_interval = std::time::Duration::from_millis(POLL_INTERVAL_MS);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(MAX_WAIT_SECS);
+
     loop {
-        let current = now_secs();
-        if current >= activation_timestamp {
-            break;
+        // Phase 1: wait until realtime first crosses the activation timestamp.
+        loop {
+            if now_secs() >= activation_timestamp {
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                panic!("Timed out waiting for wallclock to reach activation timestamp");
+            }
+            tokio::time::sleep(poll_interval).await;
         }
-        if current >= deadline {
-            panic!("Timed out waiting for wallclock to reach activation timestamp");
+
+        // Phase 2: hold for `HOLD_DURATION` of monotonic time, watching for a
+        // backward realtime lurch. If realtime stays >= activation throughout,
+        // we're past the boundary stably enough to return.
+        let hold_end = std::time::Instant::now() + HOLD_DURATION;
+        let mut lurched = false;
+        while std::time::Instant::now() < hold_end {
+            if now_secs() < activation_timestamp {
+                lurched = true;
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                panic!("Timed out waiting for stable post-activation wallclock");
+            }
+            tokio::time::sleep(poll_interval).await;
         }
-        tokio::time::sleep(std::time::Duration::from_millis(POLL_INTERVAL_MS)).await;
+        if !lurched {
+            return;
+        }
+        // Realtime dipped below activation mid-hold; loop and re-wait.
     }
-    // Buffer to ensure node's internal state has caught up with wall clock
-    tokio::time::sleep(std::time::Duration::from_millis(POST_ACTIVATION_BUFFER_MS)).await;
 }
 
 #[cfg(test)]
@@ -329,7 +356,7 @@ mod boundary_crossing {
     use super::*;
 
     #[test_log::test(tokio::test)]
-    async fn test_boundary_crossing_v1_behavior() -> eyre::Result<()> {
+    async fn slow_test_boundary_crossing_v1_behavior() -> eyre::Result<()> {
         initialize_tracing();
 
         let aurora_activation = now_secs().saturating_add(PRE_ACTIVATION_WINDOW_SECS);
@@ -353,6 +380,7 @@ mod boundary_crossing {
             "V1 submitted before activation should be mined in a pre-activation block"
         );
 
+        wait_for_wallclock(aurora_activation).await;
         let v1_after = create_stake_tx(&node, &signer2, TxVersion::V1).await;
         let result_after = node.post_commitment_tx(&v1_after).await;
         assert!(result_after.is_err(), "V1 should be rejected after Aurora");
@@ -414,7 +442,7 @@ mod edge_cases {
     /// and validators must reject blocks containing V1 transactions post-activation.
     /// This ensures consensus - all nodes agree on block validity.
     #[test_log::test(tokio::test)]
-    async fn test_v1_in_mempool_before_activation_filtered_after() -> eyre::Result<()> {
+    async fn slow_test_v1_in_mempool_before_activation_filtered_after() -> eyre::Result<()> {
         initialize_tracing();
 
         let aurora_activation = now_secs().saturating_add(PRE_ACTIVATION_WINDOW_SECS);
@@ -450,7 +478,7 @@ mod edge_cases {
     }
 
     #[test_log::test(tokio::test)]
-    async fn test_v2_accepted_at_exact_activation_boundary() -> eyre::Result<()> {
+    async fn slow_test_v2_accepted_at_exact_activation_boundary() -> eyre::Result<()> {
         initialize_tracing();
 
         let aurora_activation = now_secs().saturating_add(ACTIVATION_DELAY_SECS);
@@ -481,7 +509,7 @@ mod edge_cases {
     }
 
     #[test_log::test(tokio::test)]
-    async fn test_v1_rejected_at_exact_activation_boundary() -> eyre::Result<()> {
+    async fn slow_test_v1_rejected_at_exact_activation_boundary() -> eyre::Result<()> {
         initialize_tracing();
 
         let aurora_activation = now_secs().saturating_add(ACTIVATION_DELAY_SECS);
@@ -632,7 +660,7 @@ mod epoch_block_filtering {
     /// Epoch block at hardfork boundary: V1 commitments accepted pre-activation
     /// should NOT be filtered out when the epoch block falls post-activation.
     #[test_log::test(tokio::test)]
-    async fn test_epoch_at_hardfork_boundary_doesnt_filter_v1() -> eyre::Result<()> {
+    async fn slow_test_epoch_at_hardfork_boundary_doesnt_filter_v1() -> eyre::Result<()> {
         initialize_tracing();
 
         let aurora_activation = now_secs().saturating_add(ACTIVATION_DELAY_SECS);

--- a/crates/chain-tests/src/api/hardfork_tests.rs
+++ b/crates/chain-tests/src/api/hardfork_tests.rs
@@ -193,7 +193,7 @@ async fn wait_until_activation(node: &IrysNodeTest<IrysNodeCtx>, activation_time
 }
 
 async fn wait_for_wallclock(activation_timestamp: u64) {
-    const MAX_WAIT_SECS: u64 = 60;
+    const MAX_WAIT_SECS: u64 = 120;
     // After realtime crosses `activation_timestamp` we hold on monotonic time
     // and keep re-checking realtime: if it ever dips back below activation
     // during the hold (Hyper-V time-sync lurch on WSL2, NTP correction, etc.),
@@ -231,6 +231,12 @@ async fn wait_for_wallclock(activation_timestamp: u64) {
             tokio::time::sleep(poll_interval).await;
         }
         if !lurched {
+            // The final poll-interval sleep in the hold loop above is otherwise
+            // unguarded: re-check once more so a lurch landing in that last
+            // window restarts the wait instead of returning a false success.
+            if now_secs() < activation_timestamp {
+                continue;
+            }
             return;
         }
         // Realtime dipped below activation mid-hold; loop and re-wait.

--- a/crates/chain-tests/src/block_production/reset_seed.rs
+++ b/crates/chain-tests/src/block_production/reset_seed.rs
@@ -20,12 +20,12 @@ use tracing::{debug, warn};
 /// 3. Verifies non-reset blocks maintain seed continuity
 /// 4. Spins up a peer node to verify reset seeds propagate correctly during sync
 #[test_log::test(tokio::test)]
-async fn slow_heavy_reset_seeds_should_be_correctly_applied_by_the_miner_and_verified_by_the_peer()
+async fn spiky_slow_heavy_reset_seeds_should_be_correctly_applied_by_the_miner_and_verified_by_the_peer()
 -> eyre::Result<()> {
     // SAFETY: test code; env var set before other threads spawn.
     unsafe { std::env::set_var("RUST_LOG", "debug") };
     initialize_tracing();
-    let max_seconds = 20;
+    let max_seconds = 60;
     let reset_frequency = 48; // Reset every 48 VDF steps
     let min_resets_required = 3; // Need at least 3 resets to verify seed rotation behavior
     let block_migration_depth = 1;

--- a/crates/chain-tests/src/multi_node/ema_forks.rs
+++ b/crates/chain-tests/src/multi_node/ema_forks.rs
@@ -15,7 +15,7 @@ use tracing::warn;
 // Assert: EMA snapshots differ after the price adjustment interval during the fork.
 // Assert: After convergence, both nodes have identical chains with matching EMA snapshots.
 #[test_log::test(tokio::test)]
-async fn heavy4_ema_intervals_roll_over_in_forks() -> eyre::Result<()> {
+async fn spiky_slow_heavy4_ema_intervals_roll_over_in_forks() -> eyre::Result<()> {
     // setup
     const PRICE_ADJUSTMENT_INTERVAL: u64 = 2;
     let num_blocks_in_epoch = 13;

--- a/crates/chain-tests/src/promotion/data_promotion_double.rs
+++ b/crates/chain-tests/src/promotion/data_promotion_double.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 use tracing::debug;
 
 #[test_log::test(tokio::test)]
-async fn spiky_heavy_double_root_data_promotion_test() -> eyre::Result<()> {
+async fn spiky_slow_heavy_double_root_data_promotion_test() -> eyre::Result<()> {
     let mut config = NodeConfig::testing();
     let chunk_size = 32; // 32 byte chunks
     config.consensus.get_mut().chunk_size = chunk_size;

--- a/crates/chain-tests/src/promotion/promotion_with_multiple_proofs.rs
+++ b/crates/chain-tests/src/promotion/promotion_with_multiple_proofs.rs
@@ -5,7 +5,7 @@ use irys_testing_utils::initialize_tracing;
 use irys_types::{CommitmentTransaction, NodeConfig, irys::IrysSigner};
 
 #[tokio::test]
-async fn spiky_heavy4_promotion_with_multiple_proofs_test() -> eyre::Result<()> {
+async fn spiky_slow_heavy4_promotion_with_multiple_proofs_test() -> eyre::Result<()> {
     // SAFETY: test code; env var set before other threads spawn.
     unsafe {
         std::env::set_var(
@@ -15,7 +15,7 @@ async fn spiky_heavy4_promotion_with_multiple_proofs_test() -> eyre::Result<()> 
     }
     initialize_tracing();
 
-    let seconds_to_wait = 30;
+    let seconds_to_wait = 50;
 
     // Set up consensus to require 3 ingress proofs to promote
     let mut config = NodeConfig::testing()

--- a/crates/chain-tests/src/promotion/stale_txid_in_cached_data_root.rs
+++ b/crates/chain-tests/src/promotion/stale_txid_in_cached_data_root.rs
@@ -183,7 +183,7 @@ async fn stale_txid_in_cached_data_root_blocks_block_production() -> eyre::Resul
 /// chunks → wait for ingress proof → mine blocks until anchor expires →
 /// verify txid_set was cleaned → mine a block successfully.
 #[tokio::test]
-async fn stale_txid_in_cached_data_root_does_not_block_after_fix() -> eyre::Result<()> {
+async fn slow_heavy_stale_txid_in_cached_data_root_does_not_block_after_fix() -> eyre::Result<()> {
     let seconds_to_wait = 30;
 
     let config = NodeConfig::testing()

--- a/crates/p2p/src/gossip_data_handler.rs
+++ b/crates/p2p/src/gossip_data_handler.rs
@@ -33,7 +33,7 @@ use reth::builder::Block as _;
 use reth_ethereum_primitives::Block;
 use std::collections::HashSet;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tracing::{Instrument as _, debug, error, warn};
 
 const HEADER_AND_BODY_RETRIES: usize = 3;
@@ -838,12 +838,12 @@ where
         &self,
         peer_info: &PeerListItem,
         request: GossipRequestV2<GossipDataRequestV2>,
-        duplicate_request_milliseconds: u128,
+        duplicate_request_window: Duration,
     ) -> GossipResult<bool> {
         // Check rate limiting and score cap
         let check_result = self
             .data_request_tracker
-            .check_request(&request.peer_id, duplicate_request_milliseconds);
+            .check_request(&request.peer_id, duplicate_request_window);
 
         // If rate limited, don't serve data
         if !check_result.should_serve() {
@@ -875,11 +875,11 @@ where
     pub(crate) async fn handle_get_data_sync(
         &self,
         request: GossipRequestV2<GossipDataRequestV2>,
-        duplicate_request_milliseconds: u128,
+        duplicate_request_window: Duration,
     ) -> GossipResult<Option<GossipDataV2>> {
         let check_result = self
             .data_request_tracker
-            .check_request(&request.peer_id, duplicate_request_milliseconds);
+            .check_request(&request.peer_id, duplicate_request_window);
         if !check_result.should_serve() {
             debug!(
                 "Node {}: Rate limiting peer {:?} for pull-data request",

--- a/crates/p2p/src/rate_limiting.rs
+++ b/crates/p2p/src/rate_limiting.rs
@@ -124,7 +124,10 @@ impl DataRequestTracker {
         // Perform cleanup if needed
         self.cleanup_if_needed();
 
-        let duplicate_request_window = Duration::from_millis(duplicate_request_milliseconds as u64);
+        let duplicate_request_window = Duration::from_millis(
+            u64::try_from(duplicate_request_milliseconds)
+                .expect("duplicate_request_milliseconds out of range for u64"),
+        );
 
         // Get or create record for this peer
         let mut entry = self

--- a/crates/p2p/src/rate_limiting.rs
+++ b/crates/p2p/src/rate_limiting.rs
@@ -119,15 +119,10 @@ impl DataRequestTracker {
     pub fn check_request(
         &self,
         peer_id: &IrysPeerId,
-        duplicate_request_milliseconds: u128,
+        duplicate_request_window: Duration,
     ) -> RequestCheckResult {
         // Perform cleanup if needed
         self.cleanup_if_needed();
-
-        let duplicate_request_window = Duration::from_millis(
-            u64::try_from(duplicate_request_milliseconds)
-                .expect("duplicate_request_milliseconds out of range for u64"),
-        );
 
         // Get or create record for this peer
         let mut entry = self
@@ -260,7 +255,7 @@ mod tests {
     use irys_types::{IrysAddress, IrysPeerId};
     use rstest::rstest;
 
-    const TEST_DEDUP_WINDOW_MS: u128 = 10_000;
+    const TEST_DEDUP_WINDOW: Duration = Duration::from_millis(10_000);
     const TEST_SLEEP_MS: u64 = 11_000;
     #[tokio::test]
     async fn slow_test_data_request_tracker_score_limiting() {
@@ -271,7 +266,7 @@ mod tests {
         for i in 1..=5 {
             // Wait a bit to avoid deduplication window
             tokio::time::sleep(Duration::from_millis(TEST_SLEEP_MS)).await;
-            let result = tracker.check_request(&peer_id, TEST_DEDUP_WINDOW_MS);
+            let result = tracker.check_request(&peer_id, TEST_DEDUP_WINDOW);
             assert!(result.should_serve(), "Should serve data for request {}", i);
             if i == 1 {
                 // First request always updates score
@@ -290,7 +285,7 @@ mod tests {
 
         // Nth request should not update score but still serve
         tokio::time::sleep(Duration::from_millis(TEST_SLEEP_MS)).await;
-        let result = tracker.check_request(&peer_id, TEST_DEDUP_WINDOW_MS);
+        let result = tracker.check_request(&peer_id, TEST_DEDUP_WINDOW);
         assert!(
             !result.should_update_score(),
             "Should not update score after cap"
@@ -312,12 +307,12 @@ mod tests {
         let peer_id = IrysPeerId::from(IrysAddress::from([2_u8; 20]));
 
         // First request
-        let result1 = tracker.check_request(&peer_id, TEST_DEDUP_WINDOW_MS);
+        let result1 = tracker.check_request(&peer_id, TEST_DEDUP_WINDOW);
         assert!(result1.should_update_score());
         assert!(result1.should_serve());
 
         // Immediate second request should be deduplicated
-        let result2 = tracker.check_request(&peer_id, TEST_DEDUP_WINDOW_MS);
+        let result2 = tracker.check_request(&peer_id, TEST_DEDUP_WINDOW);
         assert!(
             !result2.should_update_score(),
             "Should not update score for duplicate"
@@ -329,7 +324,7 @@ mod tests {
 
         // After deduplication window, should allow score update
         tokio::time::sleep(Duration::from_millis(TEST_SLEEP_MS)).await;
-        let result3 = tracker.check_request(&peer_id, TEST_DEDUP_WINDOW_MS);
+        let result3 = tracker.check_request(&peer_id, TEST_DEDUP_WINDOW);
         assert!(
             result3.should_update_score(),
             "Should update score after dedup window"
@@ -339,7 +334,7 @@ mod tests {
 
     #[test]
     fn test_data_request_record_expiry() {
-        let mut record = DataRequestRecord::new(Duration::from_millis(TEST_DEDUP_WINDOW_MS as u64));
+        let mut record = DataRequestRecord::new(TEST_DEDUP_WINDOW);
 
         // Fresh record should not be expired
         assert!(!record.is_window_expired());
@@ -387,7 +382,7 @@ mod tests {
 
     #[test]
     fn record_checks_do_not_panic_when_timestamps_are_in_the_future() {
-        let mut record = DataRequestRecord::new(Duration::from_millis(TEST_DEDUP_WINDOW_MS as u64));
+        let mut record = DataRequestRecord::new(TEST_DEDUP_WINDOW);
         let future = Instant::now()
             .checked_add(Duration::from_secs(5))
             .expect("instant + 5s must not overflow");
@@ -423,9 +418,9 @@ mod tests {
         let tracker = DataRequestTracker::new();
         let peer_id = IrysPeerId::from(IrysAddress::from([3_u8; 20]));
 
-        let mut last_result = tracker.check_request(&peer_id, 0);
+        let mut last_result = tracker.check_request(&peer_id, Duration::ZERO);
         for _ in 1..total_requests {
-            last_result = tracker.check_request(&peer_id, 0);
+            last_result = tracker.check_request(&peer_id, Duration::ZERO);
         }
 
         assert_eq!(

--- a/crates/p2p/src/rate_limiting.rs
+++ b/crates/p2p/src/rate_limiting.rs
@@ -235,7 +235,7 @@ impl DataRequestTracker {
         let Ok(mut last) = self.last_cleanup.lock() else {
             return;
         };
-        if now.duration_since(*last) > self.cleanup_interval {
+        if now.saturating_duration_since(*last) > self.cleanup_interval {
             *last = now;
             drop(last);
             self.cleanup_expired_entries();

--- a/crates/p2p/src/rate_limiting.rs
+++ b/crates/p2p/src/rate_limiting.rs
@@ -1,24 +1,15 @@
 use dashmap::DashMap;
 use irys_types::IrysPeerId;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 use tracing::{debug, trace};
 
 // Constants for rate limiting configuration
-const WINDOW_DURATION_MS: u128 = 60_000; // 1 minute in milliseconds
+const WINDOW_DURATION: Duration = Duration::from_secs(60); // 1 minute window
 const MAX_SCORE_PER_MINUTE: u32 = 5; // Max score points per minute
 const MAX_REQUESTS_PER_MINUTE: u32 = 100; // Max requests per minute
-const CLEANUP_INTERVAL_SECS: u64 = 60; // Cleanup every minute
-const ENTRY_EXPIRY_MS: u128 = 120_000; // 2 minutes in milliseconds
-
-/// Get current time as milliseconds since Unix epoch
-fn now_as_millis() -> u128 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis()
-}
+const CLEANUP_INTERVAL: Duration = Duration::from_secs(60); // Cleanup every minute
+const ENTRY_EXPIRY: Duration = Duration::from_secs(120); // 2 minutes
 
 /// Result of checking a data request for rate limiting and scoring
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -46,47 +37,44 @@ impl RequestCheckResult {
 /// Record of data requests from a peer
 #[derive(Debug, Clone)]
 pub struct DataRequestRecord {
-    /// Timestamp when the tracking window started (Unix timestamp in milliseconds)
-    pub window_start: u128,
+    /// When the tracking window started (monotonic clock).
+    pub window_start: Instant,
     /// Total number of requests in current window
     pub request_count: u32,
     /// Score points given in current window
     pub score_given: u32,
     /// Last request timestamp for deduplication
-    pub last_request: u128,
-    /// Consider a duplicate if within (milliseconds)
-    pub duplicate_request_milliseconds: u128,
+    pub last_request: Instant,
+    /// Consider a duplicate if within this duration
+    pub duplicate_request_window: Duration,
 }
 
 impl DataRequestRecord {
-    pub fn new(duplicate_request_milliseconds: u128) -> Self {
-        let now = now_as_millis();
+    pub fn new(duplicate_request_window: Duration) -> Self {
+        let now = Instant::now();
 
         Self {
             window_start: now,
             request_count: 1,
             score_given: 0,
             last_request: now,
-            duplicate_request_milliseconds,
+            duplicate_request_window,
         }
     }
 
     /// Check if the tracking window has expired
     pub fn is_window_expired(&self) -> bool {
-        let now = now_as_millis();
-        now.saturating_sub(self.window_start) > WINDOW_DURATION_MS
+        self.window_start.elapsed() > WINDOW_DURATION
     }
 
     /// Check if enough time has passed since last request (deduplication window)
     pub fn is_duplicate_request(&self) -> bool {
-        let now = now_as_millis();
-        // Consider duplicate if within the configured milliseconds
-        now.saturating_sub(self.last_request) < self.duplicate_request_milliseconds
+        self.last_request.elapsed() < self.duplicate_request_window
     }
 
     /// Reset for new tracking window
     pub fn reset_window(&mut self) {
-        let now = now_as_millis();
+        let now = Instant::now();
 
         self.window_start = now;
         self.request_count = 1;
@@ -96,10 +84,8 @@ impl DataRequestRecord {
 
     /// Update for new request
     pub fn update_request(&mut self) {
-        let now = now_as_millis();
-
         self.request_count += 1;
-        self.last_request = now;
+        self.last_request = Instant::now();
     }
 }
 
@@ -114,20 +100,18 @@ pub struct DataRequestTracker {
     max_requests_per_minute: u32,
     /// Interval for cleaning up old entries
     cleanup_interval: Duration,
-    /// Last cleanup timestamp (Unix timestamp in milliseconds, truncated from u128)
-    last_cleanup: Arc<AtomicU64>,
+    /// Last cleanup time (monotonic)
+    last_cleanup: Arc<Mutex<Instant>>,
 }
 
 impl DataRequestTracker {
     pub fn new() -> Self {
-        let now = now_as_millis();
-
         Self {
             request_history: Arc::new(DashMap::new()),
             max_score_per_minute: MAX_SCORE_PER_MINUTE,
             max_requests_per_minute: MAX_REQUESTS_PER_MINUTE,
-            cleanup_interval: Duration::from_secs(CLEANUP_INTERVAL_SECS),
-            last_cleanup: Arc::new(AtomicU64::new(now as u64)),
+            cleanup_interval: CLEANUP_INTERVAL,
+            last_cleanup: Arc::new(Mutex::new(Instant::now())),
         }
     }
 
@@ -140,11 +124,13 @@ impl DataRequestTracker {
         // Perform cleanup if needed
         self.cleanup_if_needed();
 
+        let duplicate_request_window = Duration::from_millis(duplicate_request_milliseconds as u64);
+
         // Get or create record for this peer
         let mut entry = self
             .request_history
             .entry(*peer_id)
-            .or_insert_with(|| DataRequestRecord::new(duplicate_request_milliseconds));
+            .or_insert_with(|| DataRequestRecord::new(duplicate_request_window));
 
         // If this is the first request ever for this peer, allow score update immediately
         let is_first_request = entry.request_count == 1 && entry.score_given == 0;
@@ -221,16 +207,13 @@ impl DataRequestTracker {
 
     /// Cleanup expired entries to prevent memory growth
     fn cleanup_expired_entries(&self) {
-        let now = now_as_millis();
-
         let _before = self.request_history.len();
         let mut removed_count = 0;
 
         // Collect keys to remove (can't remove while iterating)
         let mut keys_to_remove = Vec::new();
         for entry in self.request_history.iter() {
-            let age = now.saturating_sub(entry.window_start);
-            if age > ENTRY_EXPIRY_MS {
+            if entry.window_start.elapsed() > ENTRY_EXPIRY {
                 keys_to_remove.push(*entry.key());
             }
         }
@@ -250,25 +233,14 @@ impl DataRequestTracker {
 
     /// Check if cleanup is needed and perform it
     fn cleanup_if_needed(&self) {
-        let now = now_as_millis();
-
-        let last_cleanup = self.last_cleanup.load(Ordering::Relaxed) as u128;
-        let cleanup_interval_ms = self.cleanup_interval.as_millis();
-
-        if now.saturating_sub(last_cleanup) > cleanup_interval_ms {
-            // Use compare_exchange to ensure only one thread does cleanup
-            if self
-                .last_cleanup
-                .compare_exchange(
-                    last_cleanup as u64,
-                    now as u64,
-                    Ordering::Relaxed,
-                    Ordering::Relaxed,
-                )
-                .is_ok()
-            {
-                self.cleanup_expired_entries();
-            }
+        let now = Instant::now();
+        let Ok(mut last) = self.last_cleanup.lock() else {
+            return;
+        };
+        if now.duration_since(*last) > self.cleanup_interval {
+            *last = now;
+            drop(last);
+            self.cleanup_expired_entries();
         }
     }
 }
@@ -364,13 +336,15 @@ mod tests {
 
     #[test]
     fn test_data_request_record_expiry() {
-        let mut record = DataRequestRecord::new(TEST_DEDUP_WINDOW_MS);
+        let mut record = DataRequestRecord::new(Duration::from_millis(TEST_DEDUP_WINDOW_MS as u64));
 
         // Fresh record should not be expired
         assert!(!record.is_window_expired());
 
-        // Simulate old record
-        record.window_start = now_as_millis().saturating_sub(WINDOW_DURATION_MS + 10_000); // Over 1 minute ago
+        // Simulate old record (back-date past the window)
+        record.window_start = Instant::now()
+            .checked_sub(WINDOW_DURATION + Duration::from_secs(10))
+            .expect("monotonic clock must be at least WINDOW_DURATION+10s past zero in tests");
 
         assert!(record.is_window_expired());
 
@@ -385,8 +359,11 @@ mod tests {
         let peer_id = IrysPeerId::from(IrysAddress::from([4_u8; 20]));
 
         // Simulate the race / backward-clock case: an entry whose window_start is
-        // slightly ahead of the wall clock that cleanup will read.
-        let future = now_as_millis() + 5_000;
+        // slightly ahead of the "now" cleanup reads. Monotonic Instant math must
+        // saturate to elapsed 0, never panic or evict a fresh entry.
+        let future = Instant::now()
+            .checked_add(Duration::from_secs(5))
+            .expect("instant + 5s must not overflow");
         tracker.request_history.insert(
             peer_id,
             DataRequestRecord {
@@ -394,7 +371,7 @@ mod tests {
                 request_count: 1,
                 score_given: 0,
                 last_request: future,
-                duplicate_request_milliseconds: 0,
+                duplicate_request_window: Duration::ZERO,
             },
         );
 
@@ -407,8 +384,10 @@ mod tests {
 
     #[test]
     fn record_checks_do_not_panic_when_timestamps_are_in_the_future() {
-        let mut record = DataRequestRecord::new(TEST_DEDUP_WINDOW_MS);
-        let future = now_as_millis() + 5_000;
+        let mut record = DataRequestRecord::new(Duration::from_millis(TEST_DEDUP_WINDOW_MS as u64));
+        let future = Instant::now()
+            .checked_add(Duration::from_secs(5))
+            .expect("instant + 5s must not overflow");
         record.window_start = future;
         record.last_request = future;
 
@@ -419,8 +398,13 @@ mod tests {
     #[test]
     fn cleanup_if_needed_does_not_panic_when_last_cleanup_is_in_the_future() {
         let tracker = DataRequestTracker::new();
-        let future = (now_as_millis() + 5_000) as u64;
-        tracker.last_cleanup.store(future, Ordering::Relaxed);
+        let future = Instant::now()
+            .checked_add(Duration::from_secs(5))
+            .expect("instant + 5s must not overflow");
+        *tracker
+            .last_cleanup
+            .lock()
+            .expect("last_cleanup mutex poisoned") = future;
 
         tracker.cleanup_if_needed();
     }

--- a/crates/p2p/src/server.rs
+++ b/crates/p2p/src/server.rs
@@ -32,14 +32,14 @@ use reth::builder::Block as _;
 use reth_ethereum_primitives::Block;
 use std::net::{IpAddr, TcpListener};
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument as _, debug, error, info, warn};
 use tracing_actix_web::TracingLogger;
 
-/// Default deduplication window in milliseconds for data requests
-/// Prevents rapid duplicate requests within this time window
-const DEFAULT_DUPLICATE_REQUEST_MILLISECONDS: u128 = 10_000; // 10 seconds
+/// Default deduplication window for data requests.
+/// Prevents rapid duplicate requests within this time window.
+const DEFAULT_DUPLICATE_REQUEST_WINDOW: Duration = Duration::from_secs(10);
 
 #[derive(Debug)]
 pub struct GossipServer<M, B>
@@ -1652,7 +1652,7 @@ where
 
         match server
             .data_handler
-            .handle_get_data_sync(v2_request, DEFAULT_DUPLICATE_REQUEST_MILLISECONDS)
+            .handle_get_data_sync(v2_request, DEFAULT_DUPLICATE_REQUEST_WINDOW)
             .in_current_span()
             .await
         {
@@ -1748,7 +1748,7 @@ where
 
         match server
             .data_handler
-            .handle_get_data(&peer, v2_request, DEFAULT_DUPLICATE_REQUEST_MILLISECONDS)
+            .handle_get_data(&peer, v2_request, DEFAULT_DUPLICATE_REQUEST_WINDOW)
             .await
         {
             Ok(has_data) => HttpResponse::Ok().json(GossipResponse::Accepted(has_data)),
@@ -1785,7 +1785,7 @@ where
 
         match server
             .data_handler
-            .handle_get_data_sync(v2_request, DEFAULT_DUPLICATE_REQUEST_MILLISECONDS)
+            .handle_get_data_sync(v2_request, DEFAULT_DUPLICATE_REQUEST_WINDOW)
             .in_current_span()
             .await
         {


### PR DESCRIPTION
**Describe the changes**
 harden logic against clock drift
In certain conditions, i.e WSL2, wallclock time can notably drift - this causes test failures.
This commit hardens relevant logic so that we use monotonic clocks where possible.

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp progression to prevent stalling during realtime drift.
  * Made hardfork wall-clock waits more resilient by using a safer monotonic/realtime approach.
  * Updated gossip request deduplication/rate-limiting windows to use monotonic timing for more reliable behavior and cleanup.
* **Documentation**
  * Added contributor guidance on when to use monotonic time vs wall-clock time.
  * Added a README troubleshooting section for WSL2 clock instability with a Windows-side mitigation.
* **Tests**
  * Renamed timing-sensitive tests to “slow/spiky” variants and extended relevant waits/timeouts.
* **Chores**
  * Multiversion test runs now pass through prior ref handling and continue after failures (no fail-fast).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->