### PR TITLE
fix(storage): map OneYear/ThirtyDay ledgers to storage modules

### DIFF
--- a/crates/actors/src/chunk_migration_service.rs
+++ b/crates/actors/src/chunk_migration_service.rs
@@ -164,35 +164,19 @@ impl ChunkMigrationServiceInner {
         let db = Arc::new(self.db.clone());
         let service_senders = self.service_senders.clone();
 
-        // Extract transactions for each ledger
-        let submit_txs = all_txs.get(&DataLedger::Submit);
-        let publish_txs = all_txs.get(&DataLedger::Publish);
         let block_height = block.height;
 
-        // Process Submit ledger transactions
-        if let Some(submit_txs) = submit_txs {
+        // Process transactions for all data ledgers present in the block
+        for (ledger, txs) in all_txs.iter() {
             process_ledger_transactions(
                 &block,
-                DataLedger::Submit,
-                submit_txs,
+                *ledger,
+                txs,
                 &block_index,
                 chunk_size,
                 &storage_modules,
                 &db,
-            )?
-        }
-
-        // Process Publish ledger transactions
-        if let Some(publish_txs) = publish_txs {
-            process_ledger_transactions(
-                &block,
-                DataLedger::Publish,
-                publish_txs,
-                &block_index,
-                chunk_size,
-                &storage_modules,
-                &db,
-            )?
+            )?;
         }
 
         // forward the finalization message to the cache service for cleanup

--- a/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
+++ b/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
@@ -1207,7 +1207,27 @@ impl EpochSnapshot {
             num_chunks,
         );
 
-        // STEP 3: Capacity (with remaining slots limit)
+        // STEP 3: OneYear ledger
+        self.process_storage_module_assignments(
+            &assignments,
+            &mut sm_packing_info,
+            &mut module_infos,
+            Some(DataLedger::OneYear as u32),
+            miner,
+            num_chunks,
+        );
+
+        // STEP 4: ThirtyDay ledger
+        self.process_storage_module_assignments(
+            &assignments,
+            &mut sm_packing_info,
+            &mut module_infos,
+            Some(DataLedger::ThirtyDay as u32),
+            miner,
+            num_chunks,
+        );
+
+        // STEP 5: Capacity (with remaining slots limit)
         self.process_storage_module_assignments(
             &assignments,
             &mut sm_packing_info,


### PR DESCRIPTION
## Summary

- `map_storage_modules_to_partition_assignments()` only processed Publish, Submit, and Capacity partitions — OneYear and ThirtyDay assignments existed in the epoch snapshot but were never forwarded to the StorageModuleService
- `on_block_migrated()` only extracted Submit and Publish ledger transactions during chunk migration, so OneYear and ThirtyDay chunks were never written to storage modules

## Test plan

- [x] `cargo nextest run -p irys-chain-tests heavy4_network_partition_recovery` verifies OneYear/ThirtyDay data is correctly migrated to storage modules (though this test is in another branch -dmac/network-partition-recovery)
- [x] `cargo fmt` and `cargo clippy` clean