### PR TITLE
fix: block pool race

### DIFF
--- a/crates/api-client/proptest-regressions/lib.txt
+++ b/crates/api-client/proptest-regressions/lib.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 6dfbc142764900be009057dbe82cbcf7d7630af9a8022227e5576661ac8d7421

--- a/crates/api-client/src/lib.rs
+++ b/crates/api-client/src/lib.rs
@@ -650,7 +650,9 @@ mod tests {
             let addr: SocketAddr = addr_str.parse().unwrap();
             let url = peer_base_url(addr).unwrap();
             prop_assert_eq!(url.scheme(), "http");
-            prop_assert_eq!(url.port(), Some(port));
+            // `Url::port()` returns `None` for scheme-default ports (80 for http),
+            // so use `port_or_known_default()` which reflects the effective port.
+            prop_assert_eq!(url.port_or_known_default(), Some(port));
             prop_assert_eq!(url.path(), "/v1");
         }
 

--- a/crates/chain-tests/Cargo.toml
+++ b/crates/chain-tests/Cargo.toml
@@ -24,7 +24,7 @@ irys-api-server.workspace = true
 irys-chain.workspace = true
 irys-config.workspace = true
 irys-database.workspace = true
-irys-domain.workspace = true
+irys-domain = { workspace = true, features = ["test-utils"] }
 irys-macros-diag-slow.workspace = true
 irys-p2p.workspace = true
 irys-packing.workspace = true

--- a/crates/chain-tests/src/multi_node/vdf_validation_progress.rs
+++ b/crates/chain-tests/src/multi_node/vdf_validation_progress.rs
@@ -224,6 +224,7 @@ async fn heavy_test_vdf_progress_check_fails_stalled_peer() -> eyre::Result<()> 
     genesis
         .send_full_block(&peer, &head_header, head_payload, head_txs)
         .await?;
+    let delivery_instant = Instant::now();
     tracing::info!(block.hash = %head_hash, "head delivered to peer via send_full_block");
 
     // -- Wait for peer's validation_service to die from the Stalled panic.
@@ -295,18 +296,43 @@ async fn heavy_test_vdf_progress_check_fails_stalled_peer() -> eyre::Result<()> 
             }
         }
 
-        // Only treat a closed validation_service as success once the head
-        // has reached peer's block_tree (i.e. prevalidation completed and
-        // the validation message was scheduled). This rules out the
-        // false-positive where an unrelated panic in validation_service
-        // closes the sender before our scenario plays out.
-        let head_reached_tree = peer
+        // Only treat a closed validation_service as success when:
+        //   1. The head has reached peer's block_tree (prevalidation
+        //      completed → validation message was scheduled), AND
+        //   2. At least `SHORT_PROGRESS_TIMEOUT_SECS` has elapsed since
+        //      delivery (the Stalled panic cannot fire before the
+        //      progress timer expires), AND
+        //   3. The head's chain state is still pre-validation
+        //      (NotOnchain(Unknown|ValidationScheduled) or
+        //      Validated(Unknown|ValidationScheduled)) — a Stalled panic
+        //      kills the task before `on_block_validation_finished`
+        //      runs, so the head must not have transitioned past
+        //      `ValidationScheduled`.
+        //
+        // These three gates together rule out an unrelated panic in
+        // validation_service satisfying the success condition for the
+        // wrong reason.
+        let head_state = peer
             .node_ctx
             .block_tree_guard
             .read()
-            .get_block(&head_hash)
-            .is_some();
-        if peer.node_ctx.service_senders.validation_service.is_closed() && head_reached_tree {
+            .get_block_and_status(&head_hash)
+            .map(|(_, state)| *state);
+        let head_reached_tree = head_state.is_some();
+        let head_still_pending = matches!(
+            head_state,
+            Some(
+                ChainState::NotOnchain(BlockState::Unknown | BlockState::ValidationScheduled)
+                    | ChainState::Validated(BlockState::Unknown | BlockState::ValidationScheduled)
+            )
+        );
+        let stall_window_elapsed =
+            delivery_instant.elapsed() >= Duration::from_secs(SHORT_PROGRESS_TIMEOUT_SECS);
+        if peer.node_ctx.service_senders.validation_service.is_closed()
+            && head_reached_tree
+            && stall_window_elapsed
+            && head_still_pending
+        {
             peer_validation_dead = true;
             break;
         }

--- a/crates/chain-tests/src/multi_node/vdf_validation_progress.rs
+++ b/crates/chain-tests/src/multi_node/vdf_validation_progress.rs
@@ -12,15 +12,16 @@
 //! peer's `global_step` has caught up and the progress check correctly
 //! does not fire.
 //!
-//! The `BlockStatus::InTreePendingValidation` branch is necessary for
-//! this test to be expressible, but on its own it isn't sufficient —
-//! even with that branch in place, a head whose parent is
-//! `NotProcessed` still triggers the cascade. We also need a way to
-//! deliver the head whose parent is in peer's tree *but whose validated
-//! steps were never fast-forwarded into peer's VDF state*. The cleanest
-//! way to do that in an integration test is to inject the parent block
-//! into peer's `block_tree` directly via the `test-utils`-gated write
-//! guard, marking it as `Validated`. The head is then delivered via
+//! Gating the orphan re-pull on `!is_in_tree()` (so a parent that's in
+//! the tree but pending validation doesn't trigger the cascade) is part
+//! of what makes this test expressible, but it isn't sufficient on its
+//! own — a head whose parent is `NotProcessed` still triggers the
+//! cascade. We also need a way to deliver the head whose parent is in
+//! peer's tree *but whose validated steps were never fast-forwarded
+//! into peer's VDF state*. The cleanest way to do that in an
+//! integration test is to inject the parent block into peer's
+//! `block_tree` directly via the `test-utils`-gated write guard,
+//! marking it as `Validated`. The head is then delivered via
 //! `send_full_block`, which calls `block_discovery.handle_block`
 //! directly and goes through normal prevalidation + validation_service
 //! — without going through `block_pool` and without re-validating the
@@ -102,10 +103,9 @@ async fn heavy_test_vdf_progress_check_fails_stalled_peer() -> eyre::Result<()> 
     // `on_block_prevalidated` to derive snapshots from it. The parent's
     // chain state is then promoted Unknown → ValidationScheduled →
     // ValidBlock so it is observable as `ProcessedButCanBeReorganized`
-    // by `block_status`, and `block_pool` would not enter the
-    // `InTreePendingValidation` wait-for-parent path (this test still
-    // delivers the child via `send_full_block`, which bypasses
-    // `block_pool`).
+    // by `block_status`. This test bypasses `block_pool` anyway by
+    // delivering the child via `send_full_block`, so the orphan/in-tree
+    // gating is not on the path under test.
     {
         // Build a SealedBlock with an empty body; the body isn't read
         // along the failure path we want to exercise.
@@ -154,10 +154,8 @@ async fn heavy_test_vdf_progress_check_fails_stalled_peer() -> eyre::Result<()> 
         // `mark_block_as_valid` from `NotOnchain(Unknown)` →
         // `NotOnchain(ValidationScheduled)` → `NotOnchain(ValidBlock)` (not
         // `Validated(...)`, which is reached via `mark_tip` walking back
-        // through `mark_on_chain`). Either way, the block is "validated" as
-        // far as `block_status` and `wait_for_parent_validation` are
-        // concerned (both bucket `NotOnchain(ValidBlock)` into
-        // `ProcessedButCanBeReorganized`).
+        // through `mark_on_chain`). Either way, `block_status` buckets
+        // `NotOnchain(ValidBlock)` into `ProcessedButCanBeReorganized`.
         let (_h, state) = tree
             .get_block_and_status(&parent_hash)
             .expect("parent must be in peer's tree after injection");

--- a/crates/chain-tests/src/multi_node/vdf_validation_progress.rs
+++ b/crates/chain-tests/src/multi_node/vdf_validation_progress.rs
@@ -246,6 +246,12 @@ async fn heavy_test_vdf_progress_check_fails_stalled_peer() -> eyre::Result<()> 
     // regression of the very scenario this test is meant to lock in.
     let deadline = Instant::now() + Duration::from_secs(FAILURE_DEADLINE_SECS);
     let mut peer_validation_dead = false;
+    // Only treat a closed validation_service as success after we've
+    // observed at least one block-state event for `head_hash`. Otherwise
+    // an unrelated panic elsewhere in validation_service (which also
+    // closes the sender) could make this test pass without exercising
+    // the Stage A progress check at all.
+    let mut saw_head_update = false;
     while Instant::now() < deadline {
         // Drain any pending state events with a small timeout so we
         // don't sleep through the whole wait. A `Valid` event for the
@@ -254,6 +260,7 @@ async fn heavy_test_vdf_progress_check_fails_stalled_peer() -> eyre::Result<()> 
             tokio::time::timeout(Duration::from_millis(100), event_rx.recv()).await
             && event.block_hash == head_hash
         {
+            saw_head_update = true;
             tracing::info!(
                 block.hash = ?event.block_hash,
                 state = ?event.state,
@@ -286,7 +293,7 @@ async fn heavy_test_vdf_progress_check_fails_stalled_peer() -> eyre::Result<()> 
             }
         }
 
-        if peer.node_ctx.service_senders.validation_service.is_closed() {
+        if peer.node_ctx.service_senders.validation_service.is_closed() && saw_head_update {
             peer_validation_dead = true;
             break;
         }

--- a/crates/chain-tests/src/multi_node/vdf_validation_progress.rs
+++ b/crates/chain-tests/src/multi_node/vdf_validation_progress.rs
@@ -246,21 +246,23 @@ async fn heavy_test_vdf_progress_check_fails_stalled_peer() -> eyre::Result<()> 
     // regression of the very scenario this test is meant to lock in.
     let deadline = Instant::now() + Duration::from_secs(FAILURE_DEADLINE_SECS);
     let mut peer_validation_dead = false;
-    // Only treat a closed validation_service as success after we've
-    // observed at least one block-state event for `head_hash`. Otherwise
-    // an unrelated panic elsewhere in validation_service (which also
-    // closes the sender) could make this test pass without exercising
-    // the Stage A progress check at all.
-    let mut saw_head_update = false;
     while Instant::now() < deadline {
         // Drain any pending state events with a small timeout so we
         // don't sleep through the whole wait. A `Valid` event for the
         // head would mean fast-forward bridged the gap — fail loudly.
+        //
+        // Note: in the expected Stalled-panic path no `BlockStateUpdated`
+        // event for `head_hash` is ever emitted — `BlockStateUpdated` is
+        // broadcast from `on_block_validation_finished`, but the panic in
+        // `active_validations.rs` re-unwinds through the validation_service
+        // select loop (`std::panic::resume_unwind`), so validation never
+        // "finishes" with a result. We still subscribe here as a regression
+        // detector for the `Valid` and (legacy) `Invalid(VdfValidationFailed)`
+        // paths that would emit an event.
         if let Ok(Ok(event)) =
             tokio::time::timeout(Duration::from_millis(100), event_rx.recv()).await
             && event.block_hash == head_hash
         {
-            saw_head_update = true;
             tracing::info!(
                 block.hash = ?event.block_hash,
                 state = ?event.state,
@@ -293,7 +295,18 @@ async fn heavy_test_vdf_progress_check_fails_stalled_peer() -> eyre::Result<()> 
             }
         }
 
-        if peer.node_ctx.service_senders.validation_service.is_closed() && saw_head_update {
+        // Only treat a closed validation_service as success once the head
+        // has reached peer's block_tree (i.e. prevalidation completed and
+        // the validation message was scheduled). This rules out the
+        // false-positive where an unrelated panic in validation_service
+        // closes the sender before our scenario plays out.
+        let head_reached_tree = peer
+            .node_ctx
+            .block_tree_guard
+            .read()
+            .get_block(&head_hash)
+            .is_some();
+        if peer.node_ctx.service_senders.validation_service.is_closed() && head_reached_tree {
             peer_validation_dead = true;
             break;
         }

--- a/crates/chain-tests/src/multi_node/vdf_validation_progress.rs
+++ b/crates/chain-tests/src/multi_node/vdf_validation_progress.rs
@@ -12,18 +12,19 @@
 //! peer's `global_step` has caught up and the progress check correctly
 //! does not fire.
 //!
-//! Fix 2 (`BlockStatus::InTreePendingValidation`) is necessary for this
-//! test to be expressible, but on its own it isn't sufficient — even
-//! with Fix 2, a head whose parent is `NotProcessed` still triggers the
-//! cascade. We also need a way to deliver the head whose parent is in
-//! peer's tree *but whose validated steps were never fast-forwarded into
-//! peer's VDF state*. The cleanest way to do that in an integration test
-//! is to inject the parent block into peer's `block_tree` directly via
-//! the `test-utils`-gated write guard, marking it as `Validated`. The
-//! head is then delivered via `send_full_block`, which calls
-//! `block_discovery.handle_block` directly and goes through normal
-//! prevalidation + validation_service — without going through
-//! `block_pool` and without re-validating the parent.
+//! The `BlockStatus::InTreePendingValidation` branch is necessary for
+//! this test to be expressible, but on its own it isn't sufficient —
+//! even with that branch in place, a head whose parent is
+//! `NotProcessed` still triggers the cascade. We also need a way to
+//! deliver the head whose parent is in peer's tree *but whose validated
+//! steps were never fast-forwarded into peer's VDF state*. The cleanest
+//! way to do that in an integration test is to inject the parent block
+//! into peer's `block_tree` directly via the `test-utils`-gated write
+//! guard, marking it as `Validated`. The head is then delivered via
+//! `send_full_block`, which calls `block_discovery.handle_block`
+//! directly and goes through normal prevalidation + validation_service
+//! — without going through `block_pool` and without re-validating the
+//! parent.
 //!
 //! Peer's `run_vdf` thread is left running so the fast-forward channel
 //! is still drained (otherwise validation would panic on a closed/full
@@ -101,9 +102,10 @@ async fn heavy_test_vdf_progress_check_fails_stalled_peer() -> eyre::Result<()> 
     // `on_block_prevalidated` to derive snapshots from it. The parent's
     // chain state is then promoted Unknown → ValidationScheduled →
     // ValidBlock so it is observable as `ProcessedButCanBeReorganized`
-    // by `block_status`, and `block_pool` would not enter Fix 2's
-    // wait-for-parent-validation path (this test still delivers the
-    // child via `send_full_block`, which bypasses `block_pool`).
+    // by `block_status`, and `block_pool` would not enter the
+    // `InTreePendingValidation` wait-for-parent path (this test still
+    // delivers the child via `send_full_block`, which bypasses
+    // `block_pool`).
     {
         // Build a SealedBlock with an empty body; the body isn't read
         // along the failure path we want to exercise.

--- a/crates/chain-tests/src/multi_node/vdf_validation_progress.rs
+++ b/crates/chain-tests/src/multi_node/vdf_validation_progress.rs
@@ -1,87 +1,57 @@
-//! Integration test (currently `#[ignore]`d — see "Why ignored" below).
+//! Integration test verifying that a peer whose local VDF state cannot
+//! reach a block's required `prev_output_step_number` surfaces a
+//! `WaitForStepError::Stalled` (turned into `Invalid(VdfValidationFailed)`
+//! at the validation-service boundary) within `progress_timeout_secs`,
+//! rather than hanging the validation pipeline indefinitely.
 //!
-//! Goal: verify end-to-end that a peer whose local VDF state cannot reach a
-//! block's required `global_step_number` surfaces a `WaitForStepError::Stalled`
-//! within `progress_timeout_secs` rather than hanging the validation
-//! pipeline.
+//! Why a normal "gossip the head only" setup doesn't exercise this:
+//! when peer receives a head whose parent isn't in its tree,
+//! `block_pool` runs the orphan-fetch cascade — each fetched ancestor is
+//! validated and `fast_forward_vdf_steps_from_block` bridges the peer's
+//! VDF state over the gap. By the time the head reaches VDF validation,
+//! peer's `global_step` has caught up and the progress check correctly
+//! does not fire.
 //!
-//! Setup:
-//! - Genesis (Peer A) and Peer B reach a common baseline height via gossip.
-//! - Peer B stops mining (its `run_vdf` thread halts; `is_mining_enabled = false`).
-//! - Peer A privately mines a divergent chain (no gossip), advancing its
-//!   global_step well beyond Peer B's.
-//! - Peer A gossips only the head block to Peer B and is then stopped.
-//! - Expectation: Peer B cannot reach the head's `prev_output_step_number`,
-//!   `wait_for_step` bails on the progress check with `Stalled`, and Peer B
-//!   panics (the "never mislabel" rule: a local liveness failure must not
-//!   be reported as block-Invalid to the block tree). The test body still
-//!   asserts on the legacy `Invalid(VdfValidationFailed)` path and will need
-//!   to be reworked to observe a process exit instead — out of scope for
-//!   this branch.
+//! Fix 2 (`BlockStatus::InTreePendingValidation`) is necessary for this
+//! test to be expressible, but on its own it isn't sufficient — even
+//! with Fix 2, a head whose parent is `NotProcessed` still triggers the
+//! cascade. We also need a way to deliver the head whose parent is in
+//! peer's tree *but whose validated steps were never fast-forwarded into
+//! peer's VDF state*. The cleanest way to do that in an integration test
+//! is to inject the parent block into peer's `block_tree` directly via
+//! the `test-utils`-gated write guard, marking it as `Validated`. The
+//! head is then delivered via `send_full_block`, which calls
+//! `block_discovery.handle_block` directly and goes through normal
+//! prevalidation + validation_service — without going through
+//! `block_pool` and without re-validating the parent.
 //!
-//! Why ignored: the assumption that Peer B "cannot reach `prev_output_step`"
-//! does not hold under the current `block_pool`. When Peer B receives the
-//! head block whose parent is unknown, it walks the orphan-fetch cascade:
-//! `AttemptReprocessingBlock` + `RequestBlockFromTheNetwork` pull each
-//! intermediate block from genesis (or from any other peer that still has
-//! them). Each fetched block carries its own `vdf_info.steps`, and
-//! `ensure_vdf_is_valid` calls `fast_forward_vdf_steps_from_block` for
-//! every block it validates. By the time the head block reaches VDF
-//! validation, Peer B's `global_step` has already been bridged across the
-//! gap and the progress check correctly does not fire. The test still
-//! observes a hang in shadow_tx_validation's EVM-payload fetch, which is
-//! an out-of-scope path.
-//!
-//! For this test to actually exercise the VDF progress check, we need
-//! either:
-//! 1. The orphan-storm fix (Defect 2 in `claude/issue.md`) plus a way to
-//!    deliver only the head without triggering the cascade — i.e. a block
-//!    whose parent is in the tree but unvalidated, so the new
-//!    `InTreePendingValidation` path applies and no parent fetch is
-//!    triggered; OR
-//! 2. A direct injection helper that posts a `ValidateBlock` message to a
-//!    peer's `validation_service` without going through `block_pool`,
-//!    paired with a synthetic block builder that produces a properly
-//!    signed block with malicious `vdf_info`.
-//!
-//! Both prerequisites are out of scope for this branch (see
-//! `design/docs/vdf-validation-stall-detection.md`). The unit tests in
-//! `crates/vdf/src/state.rs`
-//! (`wait_for_step_bails_when_no_progress`,
-//! `wait_for_step_bails_on_cancel`,
-//! `wait_for_step_completes_when_state_advances`) are the canonical
-//! coverage of the progress-check semantics until one of those
-//! prerequisites lands.
-//!
-//! Status: this test is kept in-tree intentionally — the scenario it
-//! describes is the one we ultimately want covered end-to-end. It will be
-//! re-activated in a follow-up PR once the orphan-storm fix (Defect 2) or
-//! the direct `ValidateBlock` injection helper lands; the test body itself
-//! is otherwise correct against the design.
+//! Peer's `run_vdf` thread is left running so the fast-forward channel
+//! is still drained (otherwise validation would panic on a closed/full
+//! channel, masking the progress-check failure), but local mining is
+//! stopped via `stop_mining` so the peer cannot advance the step itself.
+//! The injected parent is *not* sent through validation, so the
+//! parent's VDF steps never enter peer's `vdf_state` buffer — the head's
+//! `prev_output_step_number` is therefore beyond peer's `global_step`,
+//! and the wait stalls.
 
 use crate::utils::IrysNodeTest;
 use irys_actors::{block_tree_service::ValidationResult, block_validation::ValidationError};
+use irys_domain::{BlockState, ChainState};
 use irys_types::NodeConfig;
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-/// Aggressively short progress timeout so the test runs quickly.
-/// Must be > 1s so Stage A doesn't false-positive while the peer is
-/// receiving the gossiped block header.
+/// Aggressively short progress timeout so the test runs quickly. Must be
+/// > 1s so the wait doesn't false-positive while the peer is receiving
+/// the gossiped block header / payload.
 const SHORT_PROGRESS_TIMEOUT_SECS: u64 = 3;
 
-/// Slack for event-channel + scheduling latency on top of the progress
-/// timeout. The full deadline must comfortably exceed
-/// `SHORT_PROGRESS_TIMEOUT_SECS`.
-const FAILURE_DEADLINE_SECS: u64 = SHORT_PROGRESS_TIMEOUT_SECS + 30;
+/// Slack on top of the progress timeout for event-channel + scheduling latency.
+const FAILURE_DEADLINE_SECS: u64 = SHORT_PROGRESS_TIMEOUT_SECS + 20;
 
-#[ignore = "see file-level docs: orphan-fetch cascade fast-forwards the peer's VDF state, so the progress check correctly does not fire under the current block_pool semantics; re-enable once Defect 2 lands or direct ValidateBlock injection helpers exist"]
 #[test_log::test(tokio::test)]
 async fn heavy_test_vdf_progress_check_fails_stalled_peer() -> eyre::Result<()> {
     // -- Genesis (Peer A) ------------------------------------------------
     let mut genesis_cfg = NodeConfig::testing();
-    // Both nodes share the short progress timeout. The peer is the one
-    // we expect to bail; setting the genesis to the same value is harmless.
     genesis_cfg.vdf.progress_timeout_secs = SHORT_PROGRESS_TIMEOUT_SECS;
     let genesis = IrysNodeTest::new_genesis(genesis_cfg.clone())
         .start_and_wait_for_packing("GENESIS", 30)
@@ -98,91 +68,252 @@ async fn heavy_test_vdf_progress_check_fails_stalled_peer() -> eyre::Result<()> 
     genesis.mine_block().await?;
     peer.wait_until_height(2, 30).await?;
 
-    // -- Freeze the peer's VDF ------------------------------------------
-    // After this point, peer.global_step is pinned at whatever was last
-    // fast-forwarded from genesis. NB: we must not call `wait_until_height`
-    // on the peer after this point, since that helper auto-restarts the
-    // peer's VDF for sync purposes.
+    // Capture peer's "frozen" baseline VDF step. After this point the
+    // peer is not allowed to mine new steps locally, so anything past
+    // this value would have to arrive via fast-forward — and the
+    // injected parent below is never sent through validation, so its
+    // steps will never reach the fast-forward channel.
     peer.stop_mining();
+    let peer_frozen_step = peer.node_ctx.vdf_steps_guard.read().global_step;
+    tracing::info!(
+        peer.frozen_global_step = peer_frozen_step,
+        "peer mining stopped"
+    );
+
+    // -- Mine the parent privately on genesis ----------------------------
+    // This block (height 3) will be injected directly into peer's tree
+    // as `Validated(ValidBlock)`, bypassing block_discovery /
+    // block_tree_service / validation_service entirely. Its VDF steps
+    // are therefore NEVER fast-forwarded into peer's `vdf_state`.
+    let (parent_header, _parent_payload, _parent_txs) = genesis.mine_block_without_gossip().await?;
+    let parent_hash = parent_header.block_hash;
+    let parent_height = parent_header.height;
+    tracing::info!(
+        block.hash = %parent_hash,
+        block.height = parent_height,
+        vdf.global_step_number = parent_header.vdf_limiter_info.global_step_number,
+        "private parent block mined on genesis"
+    );
+
+    // Inject the parent into peer's block_tree. We reuse the parent's
+    // own parent's snapshots (a no-commitment, non-epoch block inherits
+    // them) so the entry is coherent enough for the child's
+    // `on_block_prevalidated` to derive snapshots from it. The parent's
+    // chain state is then promoted Unknown → ValidationScheduled →
+    // ValidBlock so it is observable as `ProcessedButCanBeReorganized`
+    // by `block_status`, and `block_pool` would not enter Fix 2's
+    // wait-for-parent-validation path (this test still delivers the
+    // child via `send_full_block`, which bypasses `block_pool`).
+    {
+        // Build a SealedBlock with an empty body; the body isn't read
+        // along the failure path we want to exercise.
+        let sealed_parent = std::sync::Arc::new(irys_types::SealedBlock::new(
+            parent_header.as_ref().clone(),
+            irys_types::BlockBody {
+                block_hash: parent_hash,
+                ..Default::default()
+            },
+        )?);
+
+        // Pull cloned snapshots from the parent's parent (height 2 in
+        // peer's tree). For a non-epoch, no-commitment block these are
+        // identical to what `on_block_prevalidated` would derive itself.
+        let (grandparent_commitment, grandparent_epoch, grandparent_ema, grandparent_header) = {
+            let tree = peer.node_ctx.block_tree_guard.read();
+            let grandparent_hash = parent_header.previous_block_hash;
+            (
+                tree.get_commitment_snapshot(&grandparent_hash)
+                    .map_err(|e| eyre::eyre!("grandparent commitment snapshot missing: {e}"))?,
+                tree.get_epoch_snapshot(&grandparent_hash)
+                    .ok_or_else(|| eyre::eyre!("grandparent epoch snapshot missing"))?,
+                tree.get_ema_snapshot(&grandparent_hash)
+                    .ok_or_else(|| eyre::eyre!("grandparent ema snapshot missing"))?,
+                tree.get_block(&grandparent_hash)
+                    .ok_or_else(|| eyre::eyre!("grandparent header missing"))?
+                    .clone(),
+            )
+        };
+        let next_ema = grandparent_ema.next_snapshot(
+            &parent_header,
+            &grandparent_header,
+            &peer.node_ctx.config.consensus,
+        )?;
+
+        let mut tree = peer.node_ctx.block_tree_guard.write();
+        tree.add_block(
+            &sealed_parent,
+            grandparent_commitment,
+            grandparent_epoch,
+            next_ema,
+        )?;
+        tree.mark_block_as_validation_scheduled(&parent_hash)?;
+        tree.mark_block_as_valid(&parent_hash)?;
+        // Sanity: the injected parent is now in a validated state.
+        // `mark_block_as_valid` from `NotOnchain(Unknown)` →
+        // `NotOnchain(ValidationScheduled)` → `NotOnchain(ValidBlock)` (not
+        // `Validated(...)`, which is reached via `mark_tip` walking back
+        // through `mark_on_chain`). Either way, the block is "validated" as
+        // far as `block_status` and `wait_for_parent_validation` are
+        // concerned (both bucket `NotOnchain(ValidBlock)` into
+        // `ProcessedButCanBeReorganized`).
+        let (_h, state) = tree
+            .get_block_and_status(&parent_hash)
+            .expect("parent must be in peer's tree after injection");
+        assert!(
+            matches!(
+                state,
+                ChainState::Validated(BlockState::ValidBlock)
+                    | ChainState::NotOnchain(BlockState::ValidBlock)
+                    | ChainState::Onchain
+            ),
+            "injected parent must be in a validated state, got {state:?}"
+        );
+    }
+    tracing::info!(
+        block.hash = %parent_hash,
+        block.height = parent_height,
+        "parent injected into peer's tree as Validated(ValidBlock)"
+    );
+
+    // -- Mine the head privately on genesis ------------------------------
+    // Height 4. Its `prev_output_step_number` equals the parent's last
+    // VDF step, which is strictly greater than peer's frozen step. Its
+    // own steps are in `vdf_info.steps`, so once validation reaches
+    // Stage D it would fast-forward — but we never get past Stage A
+    // (`wait_for_step(prev_output_step_number)`), because peer cannot
+    // reach the parent's last step without local mining and the
+    // parent's steps were never fast-forwarded into peer's state.
+    let (head_header, head_payload, head_txs) = genesis.mine_block_without_gossip().await?;
+    let head_hash = head_header.block_hash;
+    tracing::info!(
+        block.hash = %head_hash,
+        block.height = head_header.height,
+        vdf.prev_output_step = head_header.vdf_limiter_info.first_step_number().saturating_sub(1),
+        vdf.global_step_number = head_header.vdf_limiter_info.global_step_number,
+        peer.frozen_step = peer_frozen_step,
+        "head block mined; expect peer Stage A to stall"
+    );
+    let head_prev_output_step = head_header
+        .vdf_limiter_info
+        .first_step_number()
+        .saturating_sub(1);
+    assert!(
+        head_prev_output_step > peer_frozen_step,
+        "test invariant: head's prev_output_step ({head_prev_output_step}) must exceed peer's frozen step ({peer_frozen_step})"
+    );
 
     // -- Subscribe to the peer's block-state events *before* delivering
-    //    the block, so we don't miss the failure event.
+    //    the head, so we'd catch a spurious Valid event if the gap
+    //    somehow got bridged (regression detector).
     let mut event_rx = peer
         .node_ctx
         .service_senders
         .subscribe_block_state_updates();
 
-    // -- Genesis privately advances --------------------------------------
-    // Mining without gossip: blocks land on genesis only. Genesis's VDF
-    // jumps several steps; the peer's `global_step` does not budge.
-    genesis.mine_blocks_without_gossip(5).await?;
-    let private_tip_height = genesis.get_canonical_chain_height().await;
-    assert!(
-        private_tip_height >= 7,
-        "genesis should have advanced privately, got height {private_tip_height}"
-    );
-    let private_tip = genesis.get_block_by_height(private_tip_height).await?;
-    let target_hash = private_tip.block_hash;
-    let head = Arc::new(private_tip);
+    // Snapshot peer's vdf step *before* delivery; we'll assert it
+    // doesn't advance during the wait (peer is supposed to be unable
+    // to reach the parent's last step).
+    let pre_delivery_step = peer.node_ctx.vdf_steps_guard.read().global_step;
 
-    // -- Deliver only the head, then take genesis offline ----------------
-    // The gossip is fire-and-forget; the peer's gossip task picks up the
-    // header and routes it through block_pool -> block_discovery ->
-    // block_tree_service -> validation_service. We must take genesis
-    // offline *after* the gossip has had a chance to enqueue, otherwise
-    // the broadcast itself can race the shutdown.
-    genesis.gossip_block_to_peers(&head)?;
-    // Give the gossip a moment to be received before we kill genesis,
-    // so the peer can't fetch missing parents from the now-dead trusted
-    // peer. Without this, the peer's block_pool would walk the parent
-    // cascade (each parent block carries its own VDF checkpoints, so
-    // fast-forward would let the peer reach `global_step_number`
-    // legitimately, and the progress guard would never fire).
-    tokio::time::sleep(Duration::from_millis(500)).await;
-    genesis.stop().await;
+    // -- Deliver the head via direct block_discovery + payload injection.
+    //    This bypasses block_pool entirely, so the orphan-fetch cascade
+    //    cannot trigger. block_discovery.handle_block runs prevalidation
+    //    on the head, on_block_prevalidated adds it to the tree as
+    //    NotOnchain(ValidationScheduled), and validation_service then
+    //    picks it up and runs ensure_vdf_is_valid.
+    genesis
+        .send_full_block(&peer, &head_header, head_payload, head_txs)
+        .await?;
+    tracing::info!(block.hash = %head_hash, "head delivered to peer via send_full_block");
 
-    // -- Wait for the failure event --------------------------------------
+    // -- Wait for peer's validation_service to die from the Stalled panic.
+    //
+    // `ensure_vdf_is_valid` Stage A polls `vdf_state.global_step` and
+    // returns `WaitForStepError::Stalled` once `progress_timeout_secs`
+    // elapses without local progress. `PreemptibleVdfTask::execute` then
+    // panics with "VDF wait stalled" (see
+    // `active_validations.rs` ~line 150 and
+    // `design/docs/vdf-validation-stall-detection.md` — never-mislabel
+    // rule: a local liveness failure must not be reported as block-Invalid
+    // to the block tree). The validation_service task ends, which drops
+    // its `mpsc` receiver and flips
+    // `service_senders.validation_service.is_closed()` to true.
+    //
+    // That sender-closed transition is the cleanest in-test signal that
+    // the progress check fired. We also assert (separately) that no
+    // `Valid` event was emitted for the head — that would mean peer's
+    // VDF state somehow got bridged across the gap, which would be a
+    // regression of the very scenario this test is meant to lock in.
     let deadline = Instant::now() + Duration::from_secs(FAILURE_DEADLINE_SECS);
-    let mut saw_failure = false;
+    let mut peer_validation_dead = false;
     while Instant::now() < deadline {
-        let remaining = deadline.saturating_duration_since(Instant::now());
-        match tokio::time::timeout(remaining, event_rx.recv()).await {
-            Ok(Ok(event)) => {
-                if event.block_hash != target_hash {
-                    continue;
-                }
-                tracing::info!(
-                    block.hash = ?event.block_hash,
-                    block.height = event.height,
-                    discarded = event.discarded,
-                    state = ?event.state,
-                    result = ?event.validation_result,
-                    "peer block-state event for target block",
+        // Drain any pending state events with a small timeout so we
+        // don't sleep through the whole wait. A `Valid` event for the
+        // head would mean fast-forward bridged the gap — fail loudly.
+        if let Ok(Ok(event)) =
+            tokio::time::timeout(Duration::from_millis(100), event_rx.recv()).await
+            && event.block_hash == head_hash
+        {
+            tracing::info!(
+                block.hash = ?event.block_hash,
+                state = ?event.state,
+                discarded = event.discarded,
+                result = ?event.validation_result,
+                "peer block-state event for head"
+            );
+            if matches!(event.validation_result, ValidationResult::Valid) {
+                panic!(
+                    "head was unexpectedly validated as Valid — peer's VDF must \
+                     have caught up across the gap (regression of the stalled-peer \
+                     scenario)"
                 );
-                if let ValidationResult::Invalid(err) = &event.validation_result {
-                    let reason = err.to_string();
-                    let is_progress_check = matches!(err, ValidationError::VdfValidationFailed(_))
-                        || reason.contains("did not advance")
-                        || reason.contains("VDF validation failed");
-                    assert!(
-                        is_progress_check,
-                        "validation failed for unexpected reason: {reason}"
-                    );
-                    saw_failure = true;
-                    break;
-                }
             }
-            // Channel closed or recv error: the peer has shut down before us;
-            // treat as missed event and exit the loop so the assert below
-            // produces a clear diagnostic.
-            Ok(Err(_)) | Err(_) => break,
+            if let ValidationResult::Invalid(err) = &event.validation_result {
+                // Defensive: if the wait stage ever gets converted into
+                // an Invalid result via a different code path (rather
+                // than the current "panic on Stalled" behaviour), still
+                // accept it — but require the reason to mention VDF.
+                let reason = err.to_string();
+                assert!(
+                    matches!(err, ValidationError::VdfValidationFailed(_))
+                        || reason.contains("VDF")
+                        || reason.contains("Stalled")
+                        || reason.contains("did not advance"),
+                    "head failed validation for an unexpected non-VDF reason: {reason}"
+                );
+                peer_validation_dead = true;
+                break;
+            }
+        }
+
+        if peer.node_ctx.service_senders.validation_service.is_closed() {
+            peer_validation_dead = true;
+            break;
         }
     }
     assert!(
-        saw_failure,
-        "expected VdfValidationFailed for {target_hash} within {FAILURE_DEADLINE_SECS}s"
+        peer_validation_dead,
+        "expected peer's validation_service to die within {FAILURE_DEADLINE_SECS}s \
+         (either via Stalled panic or Invalid(VdfValidationFailed) on the legacy \
+         path) — Stage A's progress check did not fire"
     );
 
-    peer.stop().await;
+    // Peer's local VDF must not have advanced (mining is stopped, no
+    // fast-forward arrived). Any advancement would mean a different
+    // code path bridged the gap.
+    let post_step = peer.node_ctx.vdf_steps_guard.read().global_step;
+    assert_eq!(
+        post_step, pre_delivery_step,
+        "peer's local global_step changed during the wait \
+         (pre={pre_delivery_step}, post={post_step}) — fast-forward must not run \
+         on the stalled path"
+    );
+
+    // Cluster teardown. Peer's validation_service has already panicked,
+    // and the panic hook in testing-utils raised SIGINT — peer is
+    // already mid-shutdown. We swallow any teardown errors here; the
+    // important assertions above have already passed.
+    let _ = peer.stop().await;
+    let _ = genesis.stop().await;
     Ok(())
 }

--- a/crates/p2p/src/block_pool.rs
+++ b/crates/p2p/src/block_pool.rs
@@ -28,7 +28,7 @@ use std::fmt::{Display, Formatter};
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use thiserror::Error;
-use tokio::sync::{RwLock, mpsc, oneshot};
+use tokio::sync::{RwLock, broadcast, mpsc, oneshot};
 use tracing::{debug, error, info, instrument, warn};
 
 const BLOCK_POOL_CACHE_SIZE: usize = 250;
@@ -125,6 +125,17 @@ pub(crate) enum ProcessBlockResult {
     ParentTooFarAhead,
 }
 
+/// Outcome of waiting for a `InTreePendingValidation` parent to leave the
+/// pending-validation state.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum ParentValidationOutcome {
+    /// Parent transitioned to a validated state.
+    Valid,
+    /// Parent was removed from the tree (validation failed, reorg, or prune),
+    /// or the event channel disappeared. The child should be discarded.
+    Invalid,
+}
+
 #[derive(Debug, Clone)]
 pub struct BlockPool<B, M>
 where
@@ -196,6 +207,10 @@ impl Display for BlockRemovalReason {
 #[derive(Clone, Debug)]
 pub(crate) enum FailureReason {
     ParentIsAPartOfAPrunedFork,
+    /// The parent block was in the tree pending validation when this block
+    /// arrived; the parent's validation then failed (block was removed from
+    /// the tree). The child is unreachable on any valid chain.
+    ParentValidationFailed,
     WasNotAbleToFetchRethPayload,
     BlockPrevalidationFailed,
     FailedToPull(GossipError),
@@ -206,6 +221,9 @@ impl Display for FailureReason {
         match self {
             Self::ParentIsAPartOfAPrunedFork => {
                 write!(f, "Parent block is a part of a pruned fork")
+            }
+            Self::ParentValidationFailed => {
+                write!(f, "Parent block failed validation")
             }
             Self::WasNotAbleToFetchRethPayload => {
                 write!(f, "Was not able to fetch Reth execution payload")
@@ -713,7 +731,7 @@ where
             return Err(err.into());
         }
 
-        if !previous_block_status.is_processed() {
+        if !previous_block_status.is_in_tree() {
             // For orphan blocks, we already have ordered transactions from SealedBlock
             let block_transactions = block.transactions();
 
@@ -816,6 +834,51 @@ where
                     prev_block_hash, current_block_hash
                 );
                 return Ok(ProcessBlockResult::ParentRequested);
+            }
+        }
+
+        // If the parent is in the tree but its validation has not completed yet,
+        // pause this block before adding it to the tree. Adding the child eagerly
+        // and letting validation_service handle the parent-wait is what caused
+        // the storm: when the parent later turned out to be invalid and was
+        // removed, every descendant we already added cascade-failed with
+        // `Parent block not found` and got re-pulled from the network.
+        if matches!(previous_block_status, BlockStatus::InTreePendingValidation) {
+            debug!(
+                "Block pool: Parent block {:?} for block {:?} is in tree pending validation; waiting for parent's validation to complete",
+                prev_block_hash, current_block_hash
+            );
+            match self
+                .wait_for_parent_validation(prev_block_hash, block_height.saturating_sub(1))
+                .await
+            {
+                ParentValidationOutcome::Valid => {
+                    debug!(
+                        "Block pool: Parent block {:?} for block {:?} validated; resuming processing",
+                        prev_block_hash, current_block_hash
+                    );
+                }
+                ParentValidationOutcome::Invalid => {
+                    warn!(
+                        "Block pool: Parent block {:?} for block {:?} failed validation; dropping child",
+                        prev_block_hash, current_block_hash
+                    );
+                    self.blocks_cache
+                        .remove_block(
+                            &block_hash,
+                            BlockRemovalReason::FailedToProcess(
+                                FailureReason::ParentValidationFailed,
+                            ),
+                        )
+                        .await;
+                    let err = CriticalBlockPoolError::BlockError(format!(
+                        "parent {:?} of block {:?} failed validation",
+                        prev_block_hash, current_block_hash
+                    ));
+                    self.sync_state
+                        .record_block_processing_error(err.to_string());
+                    return Err(err.into());
+                }
             }
         }
 
@@ -1175,11 +1238,70 @@ where
         block_hash: &BlockHash,
         block_height: u64,
     ) -> bool {
-        self.blocks_cache.is_block_processing(block_hash).await
-            || self
+        if self.blocks_cache.is_block_processing(block_hash).await {
+            return true;
+        }
+        let status = self
+            .block_status_provider
+            .block_status(block_height, block_hash);
+        // A block that is in the tree pending validation has also been observed
+        // already; we do not want gossip handlers to re-enter `process_block`
+        // for it.
+        status.is_processed() || status.is_in_tree()
+    }
+
+    /// Wait until the parent's `ChainState` leaves the pending-validation set
+    /// (either it transitions to a validated state, or it is removed from the
+    /// tree because validation failed).
+    ///
+    /// Subscribes to `block_state_events` *before* re-reading the parent state,
+    /// so a transition that fires between the initial check and the subscription
+    /// is not lost. Lagged events are tolerated — the loop re-reads parent state
+    /// from the block tree on every iteration, so a missed update only delays
+    /// the next exit check by one event.
+    async fn wait_for_parent_validation(
+        &self,
+        parent_hash: BlockHash,
+        parent_height: u64,
+    ) -> ParentValidationOutcome {
+        let mut rx = self.service_senders.subscribe_block_state_updates();
+        loop {
+            match self
                 .block_status_provider
-                .block_status(block_height, block_hash)
-                .is_processed()
+                .block_status(parent_height, &parent_hash)
+            {
+                BlockStatus::InTreePendingValidation => {
+                    // still pending — fall through to await the next event
+                }
+                BlockStatus::ProcessedButCanBeReorganized | BlockStatus::Finalized => {
+                    return ParentValidationOutcome::Valid;
+                }
+                BlockStatus::NotProcessed | BlockStatus::PartOfAPrunedFork => {
+                    return ParentValidationOutcome::Invalid;
+                }
+            }
+
+            match rx.recv().await {
+                Ok(_event) => {
+                    // Re-read parent state on every event, regardless of which
+                    // block the event was for. Cheap, and avoids races against
+                    // out-of-order state transitions on a busy node.
+                }
+                Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                    warn!(
+                        "BlockPool: block_state_events lagged by {} while waiting for parent {:?}; re-checking state",
+                        skipped, parent_hash
+                    );
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    error!(
+                        "BlockPool: block_state_events channel closed while waiting for parent {:?}",
+                        parent_hash
+                    );
+                    return ParentValidationOutcome::Invalid;
+                }
+            }
+        }
     }
 
     /// Inserts an execution payload into the internal cache so that it can be
@@ -1308,6 +1430,15 @@ fn check_block_status(
 
     match block_status {
         BlockStatus::NotProcessed => Ok(()),
+        BlockStatus::InTreePendingValidation => {
+            debug!(
+                "Block pool: Block {:?} (height {}) is already in tree pending validation",
+                block_hash, block_height,
+            );
+            Err(BlockPoolError::Advisory(
+                AdvisoryBlockPoolError::AlreadyProcessed(block_hash),
+            ))
+        }
         BlockStatus::ProcessedButCanBeReorganized => {
             debug!(
                 "Block pool: Block {:?} (height {}) is already processed",

--- a/crates/p2p/src/block_pool.rs
+++ b/crates/p2p/src/block_pool.rs
@@ -27,18 +27,13 @@ use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
 use std::num::NonZeroUsize;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
 use thiserror::Error;
-use tokio::sync::{RwLock, broadcast, mpsc, oneshot};
+use tokio::sync::{RwLock, mpsc, oneshot};
 use tracing::{debug, error, info, instrument, warn};
 
 const BLOCK_POOL_CACHE_SIZE: usize = 250;
 const RECENTLY_PROCESSED_CACHE_SIZE: usize = 20;
 const BACKFILL_DEPTH: u64 = 100;
-/// Interval at which `wait_for_parent_validation` emits a "still waiting"
-/// warn log while the parent remains `InTreePendingValidation`. Not a hard
-/// timeout — see the function's docstring.
-const PARENT_WAIT_WARN_INTERVAL: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Clone, PartialEq, Error)]
 pub enum CriticalBlockPoolError {
@@ -130,17 +125,6 @@ pub(crate) enum ProcessBlockResult {
     ParentTooFarAhead,
 }
 
-/// Outcome of waiting for a `InTreePendingValidation` parent to leave the
-/// pending-validation state.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-enum ParentValidationOutcome {
-    /// Parent transitioned to a validated state.
-    Valid,
-    /// Parent was removed from the tree (validation failed, reorg, or prune),
-    /// or the event channel disappeared. The child should be discarded.
-    Invalid,
-}
-
 #[derive(Debug, Clone)]
 pub struct BlockPool<B, M>
 where
@@ -212,10 +196,6 @@ impl Display for BlockRemovalReason {
 #[derive(Clone, Debug)]
 pub(crate) enum FailureReason {
     ParentIsAPartOfAPrunedFork,
-    /// The parent block was in the tree pending validation when this block
-    /// arrived; the parent's validation then failed (block was removed from
-    /// the tree). The child is unreachable on any valid chain.
-    ParentValidationFailed,
     WasNotAbleToFetchRethPayload,
     BlockPrevalidationFailed,
     FailedToPull(GossipError),
@@ -226,9 +206,6 @@ impl Display for FailureReason {
         match self {
             Self::ParentIsAPartOfAPrunedFork => {
                 write!(f, "Parent block is a part of a pruned fork")
-            }
-            Self::ParentValidationFailed => {
-                write!(f, "Parent block failed validation")
             }
             Self::WasNotAbleToFetchRethPayload => {
                 write!(f, "Was not able to fetch Reth execution payload")
@@ -842,51 +819,6 @@ where
             }
         }
 
-        // If the parent is in the tree but its validation has not completed yet,
-        // pause this block before adding it to the tree. Adding the child eagerly
-        // and letting validation_service handle the parent-wait is what caused
-        // the storm: when the parent later turned out to be invalid and was
-        // removed, every descendant we already added cascade-failed with
-        // `Parent block not found` and got re-pulled from the network.
-        if matches!(previous_block_status, BlockStatus::InTreePendingValidation) {
-            debug!(
-                "Block pool: Parent block {:?} for block {:?} is in tree pending validation; waiting for parent's validation to complete",
-                prev_block_hash, current_block_hash
-            );
-            match self
-                .wait_for_parent_validation(prev_block_hash, block_height.saturating_sub(1))
-                .await
-            {
-                ParentValidationOutcome::Valid => {
-                    debug!(
-                        "Block pool: Parent block {:?} for block {:?} validated; resuming processing",
-                        prev_block_hash, current_block_hash
-                    );
-                }
-                ParentValidationOutcome::Invalid => {
-                    warn!(
-                        "Block pool: Parent block {:?} for block {:?} failed validation; dropping child",
-                        prev_block_hash, current_block_hash
-                    );
-                    self.blocks_cache
-                        .remove_block(
-                            &block_hash,
-                            BlockRemovalReason::FailedToProcess(
-                                FailureReason::ParentValidationFailed,
-                            ),
-                        )
-                        .await;
-                    let err = CriticalBlockPoolError::BlockError(format!(
-                        "parent {:?} of block {:?} failed validation",
-                        prev_block_hash, current_block_hash
-                    ));
-                    self.sync_state
-                        .record_block_processing_error(err.to_string());
-                    return Err(err.into());
-                }
-            }
-        }
-
         if skip_validation_for_fast_track {
             // Preemptively handle reth payload for the trusted sync path
             if let Err(err) = Self::pull_and_seal_execution_payload(
@@ -1253,93 +1185,6 @@ where
         // already; we do not want gossip handlers to re-enter `process_block`
         // for it.
         status.is_processed() || status.is_in_tree()
-    }
-
-    /// Wait until the parent's `ChainState` leaves the pending-validation set
-    /// (either it transitions to a validated state, or it is removed from the
-    /// tree because validation failed).
-    ///
-    /// Subscribes to `block_state_events` *before* re-reading the parent state,
-    /// so a transition that fires between the initial check and the subscription
-    /// is not lost. Lagged events are tolerated — the loop re-reads parent state
-    /// from the block tree on every iteration, so a missed update only delays
-    /// the next exit check by one event.
-    ///
-    /// **No hard timeout.** Block validation is unbounded by design (PoA + EVM
-    /// state + VDF steps), and stuck-validation detection is the upstream VDF
-    /// watchdog's job (see `record_validation_task_force_aborted` in
-    /// `validation_service`). A timeout here would either force-drop a child
-    /// whose parent is legitimately still validating — re-triggering the
-    /// network re-pull cascade this orphan-cascade fix was built to prevent —
-    /// or be a pure no-op continue. The terminal "validation system is dead"
-    /// case is already covered by `broadcast::error::RecvError::Closed`. We
-    /// instead emit a periodic warn log every [`PARENT_WAIT_WARN_INTERVAL`]
-    /// and record total wait duration to a histogram for observability.
-    async fn wait_for_parent_validation(
-        &self,
-        parent_hash: BlockHash,
-        parent_height: u64,
-    ) -> ParentValidationOutcome {
-        let mut rx = self.service_senders.subscribe_block_state_updates();
-        let started = Instant::now();
-        let outcome = loop {
-            match self
-                .block_status_provider
-                .block_status(parent_height, &parent_hash)
-            {
-                BlockStatus::InTreePendingValidation => {
-                    // still pending — fall through to await the next event
-                }
-                BlockStatus::ProcessedButCanBeReorganized | BlockStatus::Finalized => {
-                    break ParentValidationOutcome::Valid;
-                }
-                BlockStatus::NotProcessed | BlockStatus::PartOfAPrunedFork => {
-                    break ParentValidationOutcome::Invalid;
-                }
-            }
-
-            match tokio::time::timeout(PARENT_WAIT_WARN_INTERVAL, rx.recv()).await {
-                Ok(Ok(_event)) => {
-                    // Re-read parent state on every event, regardless of which
-                    // block the event was for. Cheap, and avoids races against
-                    // out-of-order state transitions on a busy node.
-                }
-                Ok(Err(broadcast::error::RecvError::Lagged(skipped))) => {
-                    warn!(
-                        "BlockPool: block_state_events lagged by {} while waiting for parent {:?}; re-checking state",
-                        skipped, parent_hash
-                    );
-                }
-                Ok(Err(broadcast::error::RecvError::Closed)) => {
-                    error!(
-                        "BlockPool: block_state_events channel closed while waiting for parent {:?}",
-                        parent_hash
-                    );
-                    break ParentValidationOutcome::Invalid;
-                }
-                Err(_elapsed) => {
-                    // Observability only — not a timeout. Loop re-reads state
-                    // and continues waiting. The VDF watchdog upstream is
-                    // responsible for breaking truly stuck validations.
-                    warn!(
-                        parent.hash = %parent_hash,
-                        parent.height = parent_height,
-                        waited_ms = started.elapsed().as_millis() as u64,
-                        "BlockPool: still waiting for parent validation"
-                    );
-                }
-            }
-        };
-
-        let label = match outcome {
-            ParentValidationOutcome::Valid => "valid",
-            ParentValidationOutcome::Invalid => "invalid",
-        };
-        crate::metrics::record_block_pool_parent_wait_duration_ms(
-            label,
-            started.elapsed().as_secs_f64() * 1000.0,
-        );
-        outcome
     }
 
     /// Inserts an execution payload into the internal cache so that it can be

--- a/crates/p2p/src/block_pool.rs
+++ b/crates/p2p/src/block_pool.rs
@@ -27,6 +27,7 @@ use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
 use std::num::NonZeroUsize;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use thiserror::Error;
 use tokio::sync::{RwLock, broadcast, mpsc, oneshot};
 use tracing::{debug, error, info, instrument, warn};
@@ -34,6 +35,10 @@ use tracing::{debug, error, info, instrument, warn};
 const BLOCK_POOL_CACHE_SIZE: usize = 250;
 const RECENTLY_PROCESSED_CACHE_SIZE: usize = 20;
 const BACKFILL_DEPTH: u64 = 100;
+/// Interval at which `wait_for_parent_validation` emits a "still waiting"
+/// warn log while the parent remains `InTreePendingValidation`. Not a hard
+/// timeout — see the function's docstring.
+const PARENT_WAIT_WARN_INTERVAL: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Clone, PartialEq, Error)]
 pub enum CriticalBlockPoolError {
@@ -1259,13 +1264,25 @@ where
     /// is not lost. Lagged events are tolerated — the loop re-reads parent state
     /// from the block tree on every iteration, so a missed update only delays
     /// the next exit check by one event.
+    ///
+    /// **No hard timeout.** Block validation is unbounded by design (PoA + EVM
+    /// state + VDF steps), and stuck-validation detection is the upstream VDF
+    /// watchdog's job (see `record_validation_task_force_aborted` in
+    /// `validation_service`). A timeout here would either force-drop a child
+    /// whose parent is legitimately still validating — triggering the network
+    /// re-pull storm that the surrounding fix (commit b0b8db85c) was built to
+    /// prevent — or be a pure no-op continue. The terminal "validation system
+    /// is dead" case is already covered by `broadcast::error::RecvError::Closed`.
+    /// We instead emit a periodic warn log every [`PARENT_WAIT_WARN_INTERVAL`]
+    /// and record total wait duration to a histogram for observability.
     async fn wait_for_parent_validation(
         &self,
         parent_hash: BlockHash,
         parent_height: u64,
     ) -> ParentValidationOutcome {
         let mut rx = self.service_senders.subscribe_block_state_updates();
-        loop {
+        let started = Instant::now();
+        let outcome = loop {
             match self
                 .block_status_provider
                 .block_status(parent_height, &parent_hash)
@@ -1274,34 +1291,55 @@ where
                     // still pending — fall through to await the next event
                 }
                 BlockStatus::ProcessedButCanBeReorganized | BlockStatus::Finalized => {
-                    return ParentValidationOutcome::Valid;
+                    break ParentValidationOutcome::Valid;
                 }
                 BlockStatus::NotProcessed | BlockStatus::PartOfAPrunedFork => {
-                    return ParentValidationOutcome::Invalid;
+                    break ParentValidationOutcome::Invalid;
                 }
             }
 
-            match rx.recv().await {
-                Ok(_event) => {
+            match tokio::time::timeout(PARENT_WAIT_WARN_INTERVAL, rx.recv()).await {
+                Ok(Ok(_event)) => {
                     // Re-read parent state on every event, regardless of which
                     // block the event was for. Cheap, and avoids races against
                     // out-of-order state transitions on a busy node.
                 }
-                Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                Ok(Err(broadcast::error::RecvError::Lagged(skipped))) => {
                     warn!(
                         "BlockPool: block_state_events lagged by {} while waiting for parent {:?}; re-checking state",
                         skipped, parent_hash
                     );
                 }
-                Err(broadcast::error::RecvError::Closed) => {
+                Ok(Err(broadcast::error::RecvError::Closed)) => {
                     error!(
                         "BlockPool: block_state_events channel closed while waiting for parent {:?}",
                         parent_hash
                     );
-                    return ParentValidationOutcome::Invalid;
+                    break ParentValidationOutcome::Invalid;
+                }
+                Err(_elapsed) => {
+                    // Observability only — not a timeout. Loop re-reads state
+                    // and continues waiting. The VDF watchdog upstream is
+                    // responsible for breaking truly stuck validations.
+                    warn!(
+                        parent.hash = %parent_hash,
+                        parent.height = parent_height,
+                        waited_ms = started.elapsed().as_millis() as u64,
+                        "BlockPool: still waiting for parent validation"
+                    );
                 }
             }
-        }
+        };
+
+        let label = match outcome {
+            ParentValidationOutcome::Valid => "valid",
+            ParentValidationOutcome::Invalid => "invalid",
+        };
+        crate::metrics::record_block_pool_parent_wait_duration_ms(
+            label,
+            started.elapsed().as_secs_f64() * 1000.0,
+        );
+        outcome
     }
 
     /// Inserts an execution payload into the internal cache so that it can be

--- a/crates/p2p/src/block_pool.rs
+++ b/crates/p2p/src/block_pool.rs
@@ -1269,11 +1269,11 @@ where
     /// state + VDF steps), and stuck-validation detection is the upstream VDF
     /// watchdog's job (see `record_validation_task_force_aborted` in
     /// `validation_service`). A timeout here would either force-drop a child
-    /// whose parent is legitimately still validating — triggering the network
-    /// re-pull storm that the surrounding fix (commit b0b8db85c) was built to
-    /// prevent — or be a pure no-op continue. The terminal "validation system
-    /// is dead" case is already covered by `broadcast::error::RecvError::Closed`.
-    /// We instead emit a periodic warn log every [`PARENT_WAIT_WARN_INTERVAL`]
+    /// whose parent is legitimately still validating — re-triggering the
+    /// network re-pull cascade this orphan-cascade fix was built to prevent —
+    /// or be a pure no-op continue. The terminal "validation system is dead"
+    /// case is already covered by `broadcast::error::RecvError::Closed`. We
+    /// instead emit a periodic warn log every [`PARENT_WAIT_WARN_INTERVAL`]
     /// and record total wait duration to a histogram for observability.
     async fn wait_for_parent_validation(
         &self,

--- a/crates/p2p/src/block_status_provider.rs
+++ b/crates/p2p/src/block_status_provider.rs
@@ -17,10 +17,12 @@ pub enum BlockStatus {
     NotProcessed,
     /// The block exists in the in-memory tree but its validation has not
     /// completed (`ChainState::NotOnchain(Unknown|ValidationScheduled)` or
-    /// `Validated(Unknown|ValidationScheduled)`). Children of a block in this
-    /// state must not be added to the tree yet — if the parent's validation
-    /// fails it will be removed, and any descendants we already added would
-    /// cascade-fail with `Parent block not found`.
+    /// `Validated(Unknown|ValidationScheduled)`). Distinguished from
+    /// `NotProcessed` so the orphan re-pull branch in
+    /// `block_pool::process_block` recognises the parent as locally known
+    /// and does not re-pull from the network; distinguished from
+    /// `ProcessedButCanBeReorganized` so `is_processed()` still reflects
+    /// that validation hasn't finished.
     InTreePendingValidation,
     /// The block is in the in-memory tree and has been validated (either
     /// canonical `Onchain` or a `Validated`/`NotOnchain(ValidBlock)` fork).
@@ -41,8 +43,8 @@ impl BlockStatus {
 
     /// True iff the block is observable in the in-memory tree or has been
     /// finalized into the block index. Used to distinguish "parent genuinely
-    /// missing" (orphan re-pull is appropriate) from "parent in tree but not
-    /// yet validated" (waiting for the parent's validation event is appropriate).
+    /// missing" (orphan re-pull is appropriate) from "parent locally known"
+    /// (no re-pull needed — the child can proceed through prevalidation).
     pub fn is_in_tree(&self) -> bool {
         matches!(
             self,
@@ -114,10 +116,10 @@ impl BlockStatusProvider {
             }
         }
 
-        // Index has nothing at this height. Distinguish "block missing from tree" from
-        // "block in tree pending validation" so children of a not-yet-validated parent
-        // don't trigger the orphan re-pull path (and don't get added to the tree where
-        // they would cascade-fail if the parent later turns out to be invalid).
+        // Index has nothing at this height. Distinguish "block missing from tree"
+        // (orphan — re-pull from network) from "block in tree, validation pending"
+        // (parent is locally known — children of such a parent must not trigger
+        // the orphan re-pull path).
         match self
             .block_tree_read_guard
             .read()

--- a/crates/p2p/src/block_status_provider.rs
+++ b/crates/p2p/src/block_status_provider.rs
@@ -403,6 +403,32 @@ impl BlockStatusProvider {
             .expect("to add block to the tree");
     }
 
+    /// Like `add_block_mock_to_the_tree` but inserts the block in an arbitrary
+    /// `ChainState` via `add_common` directly — used to exercise the
+    /// `Validated(Unknown|ValidationScheduled)` branches of `block_status`.
+    #[cfg(test)]
+    pub fn add_block_mock_with_state(&self, block: &IrysBlockHeader, chain_state: ChainState) {
+        use irys_domain::{CommitmentSnapshot, EmaSnapshot, EpochSnapshot};
+        use irys_types::{BlockTransactions, SealedBlock};
+
+        let sealed = Arc::new(SealedBlock::new_unchecked(
+            Arc::new(block.clone()),
+            BlockTransactions::default(),
+        ));
+
+        self.block_tree_read_guard
+            .write()
+            .add_common(
+                block.block_hash,
+                &sealed,
+                Arc::new(CommitmentSnapshot::default()),
+                Arc::new(EpochSnapshot::default()),
+                Arc::new(EmaSnapshot::default()),
+                chain_state,
+            )
+            .expect("to add block to the tree with chain_state");
+    }
+
     #[cfg(test)]
     pub fn set_tip_for_testing(&self, block_hash: &BlockHash) {
         self.block_tree_read_guard.write().tip = *block_hash;
@@ -521,6 +547,50 @@ mod tests {
         let status = provider.block_status(7, &unknown_hash);
         assert_eq!(status, BlockStatus::NotProcessed);
         assert!(!status.is_in_tree());
+        assert!(!status.is_processed());
+    }
+
+    /// Locally-produced blocks are inserted directly as
+    /// `ChainState::Validated(BlockState::Unknown)` (see `BlockTree::add_common`
+    /// call sites) — `block_status` must still treat this as
+    /// `InTreePendingValidation` so children of a not-yet-fully-validated local
+    /// block don't enter the orphan re-pull path.
+    #[test]
+    fn block_status_returns_in_tree_pending_validation_for_validated_unknown_state() {
+        let (provider, genesis, _tmp) = mock_provider();
+        let consensus = NodeConfig::testing().consensus_config();
+        let chain = BlockStatusProvider::produce_mock_chain(1, Some(&genesis), &consensus);
+        let pending = &chain[0];
+
+        provider.add_block_mock_with_state(
+            pending,
+            ChainState::Validated(irys_domain::BlockState::Unknown),
+        );
+
+        let status = provider.block_status(pending.height, &pending.block_hash);
+        assert_eq!(status, BlockStatus::InTreePendingValidation);
+        assert!(status.is_in_tree());
+        assert!(!status.is_processed());
+    }
+
+    /// Same as above for `Validated(ValidationScheduled)` — the state a locally
+    /// produced block transitions to once `mark_block_as_validation_scheduled`
+    /// fires but before validation completes.
+    #[test]
+    fn block_status_returns_in_tree_pending_validation_for_validated_validation_scheduled_state() {
+        let (provider, genesis, _tmp) = mock_provider();
+        let consensus = NodeConfig::testing().consensus_config();
+        let chain = BlockStatusProvider::produce_mock_chain(1, Some(&genesis), &consensus);
+        let pending = &chain[0];
+
+        provider.add_block_mock_with_state(
+            pending,
+            ChainState::Validated(irys_domain::BlockState::ValidationScheduled),
+        );
+
+        let status = provider.block_status(pending.height, &pending.block_hash);
+        assert_eq!(status, BlockStatus::InTreePendingValidation);
+        assert!(status.is_in_tree());
         assert!(!status.is_processed());
     }
 }

--- a/crates/p2p/src/block_status_provider.rs
+++ b/crates/p2p/src/block_status_provider.rs
@@ -1,4 +1,4 @@
-use irys_domain::{BlockIndexReadGuard, BlockTreeReadGuard};
+use irys_domain::{BlockIndexReadGuard, BlockState, BlockTreeReadGuard, ChainState};
 use irys_types::{BlockHash, BlockIndexItem, H256, VDFLimiterInfo, block_provider::BlockProvider};
 use tracing::debug;
 #[cfg(test)]
@@ -12,12 +12,18 @@ use {
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-// TODO: expand these enum variants to account for all the actual states
 pub enum BlockStatus {
     /// The block is not in the index or tree.
     NotProcessed,
-    /// The block is still in the tree. It might or might not
-    /// be in the block index.
+    /// The block exists in the in-memory tree but its validation has not
+    /// completed (`ChainState::NotOnchain(Unknown|ValidationScheduled)` or
+    /// `Validated(Unknown|ValidationScheduled)`). Children of a block in this
+    /// state must not be added to the tree yet — if the parent's validation
+    /// fails it will be removed, and any descendants we already added would
+    /// cascade-fail with `Parent block not found`.
+    InTreePendingValidation,
+    /// The block is in the in-memory tree and has been validated (either
+    /// canonical `Onchain` or a `Validated`/`NotOnchain(ValidBlock)` fork).
     ProcessedButCanBeReorganized,
     /// The block is in the index, but the tree has already pruned it.
     Finalized,
@@ -30,6 +36,17 @@ impl BlockStatus {
         matches!(
             self,
             Self::Finalized | Self::ProcessedButCanBeReorganized | Self::PartOfAPrunedFork
+        )
+    }
+
+    /// True iff the block is observable in the in-memory tree or has been
+    /// finalized into the block index. Used to distinguish "parent genuinely
+    /// missing" (orphan re-pull is appropriate) from "parent in tree but not
+    /// yet validated" (waiting for the parent's validation event is appropriate).
+    pub fn is_in_tree(&self) -> bool {
+        matches!(
+            self,
+            Self::InTreePendingValidation | Self::ProcessedButCanBeReorganized | Self::Finalized
         )
     }
 
@@ -72,13 +89,15 @@ impl BlockStatusProvider {
     /// Returns the status of a block based on its height and hash.
     /// Possible statuses:
     /// - `NotProcessed`: The block is not in the index or tree.
-    /// - `ProcessedButCanBeReorganized`: The block is still in the tree. It might or might not
-    ///   be in the block index.
+    /// - `InTreePendingValidation`: The block is in the tree but validation has not completed.
+    /// - `ProcessedButCanBeReorganized`: The block is in the tree and has been validated; it
+    ///   may or may not be in the block index.
     /// - `Finalized`: The block is in the index, but the tree has already pruned it.
+    /// - `PartOfAPrunedFork`: A different block has been migrated at this height.
+    ///
     /// TODO: this needs to handle migrated block reorgs, it does not currently :)
     /// NOTE: block height is UNTRUSTED here, we haven't validated it yet
     pub fn block_status(&self, block_height: u64, block_hash: &BlockHash) -> BlockStatus {
-        let block_is_anywhere_in_the_tree = self.is_block_in_the_tree(block_hash);
         let binding = self.block_index_read_guard.read();
         let index_item = binding.get_item(block_height);
         let height_is_in_the_index = index_item.is_some();
@@ -95,14 +114,26 @@ impl BlockStatusProvider {
             }
         }
 
-        if !height_is_in_the_index && block_is_anywhere_in_the_tree {
-            // All blocks in the tree are a subject of reorganization
-            BlockStatus::ProcessedButCanBeReorganized
-        } else
-        /* !height_is_in_the_index && !block_is_anywhere_in_the_tree */
+        // Index has nothing at this height. Distinguish "block missing from tree" from
+        // "block in tree pending validation" so children of a not-yet-validated parent
+        // don't trigger the orphan re-pull path (and don't get added to the tree where
+        // they would cascade-fail if the parent later turns out to be invalid).
+        match self
+            .block_tree_read_guard
+            .read()
+            .get_block_and_status(block_hash)
+            .map(|(_, state)| *state)
         {
-            // No information about the block in the index or tree
-            BlockStatus::NotProcessed
+            None => BlockStatus::NotProcessed,
+            Some(
+                ChainState::NotOnchain(BlockState::Unknown | BlockState::ValidationScheduled)
+                | ChainState::Validated(BlockState::Unknown | BlockState::ValidationScheduled),
+            ) => BlockStatus::InTreePendingValidation,
+            Some(
+                ChainState::Onchain
+                | ChainState::Validated(BlockState::ValidBlock)
+                | ChainState::NotOnchain(BlockState::ValidBlock),
+            ) => BlockStatus::ProcessedButCanBeReorganized,
         }
     }
 
@@ -415,5 +446,81 @@ impl BlockProvider for BlockStatusProvider {
         binding
             .get_block(&latest_canonical_hash)
             .map(|block| block.vdf_limiter_info.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use irys_storage::irys_consensus_data_db::open_or_create_irys_consensus_data_db;
+    use irys_testing_utils::utils::TempDirBuilder;
+    use irys_types::{DatabaseProvider, DbSyncMode, NodeConfig};
+    use std::sync::Arc;
+
+    fn mock_provider() -> (BlockStatusProvider, IrysBlockHeader, tempfile::TempDir) {
+        let tmp_dir = TempDirBuilder::new()
+            .prefix("block-status-provider-test-")
+            .build();
+        let db_env =
+            open_or_create_irys_consensus_data_db(tmp_dir.path(), DbSyncMode::UtterlyNoSync)
+                .expect("to open consensus db");
+        let db = DatabaseProvider(Arc::new(db_env));
+        let node_config = NodeConfig::testing();
+        let provider = BlockStatusProvider::mock(&node_config, db);
+        let genesis = provider.genesis_header();
+        (provider, genesis, tmp_dir)
+    }
+
+    #[test]
+    fn block_status_returns_in_tree_pending_validation_for_unvalidated_block() {
+        let (provider, genesis, _tmp) = mock_provider();
+        let consensus = NodeConfig::testing().consensus_config();
+        let chain = BlockStatusProvider::produce_mock_chain(1, Some(&genesis), &consensus);
+        let pending = &chain[0];
+
+        // Add to tree only. Default chain_state after `BlockTree::add_block`
+        // is `NotOnchain(Unknown)` — the "in tree pending validation" state.
+        provider.add_block_mock_to_the_tree(pending);
+
+        let status = provider.block_status(pending.height, &pending.block_hash);
+        assert_eq!(status, BlockStatus::InTreePendingValidation);
+        assert!(status.is_in_tree());
+        assert!(!status.is_processed());
+    }
+
+    #[test]
+    fn block_status_returns_processed_for_validated_block() {
+        let (provider, genesis, _tmp) = mock_provider();
+        let consensus = NodeConfig::testing().consensus_config();
+        let chain = BlockStatusProvider::produce_mock_chain(1, Some(&genesis), &consensus);
+        let validated = &chain[0];
+
+        provider.add_block_mock_to_the_tree(validated);
+        // Mark validation scheduled, then valid.
+        provider
+            .block_tree_read_guard
+            .write()
+            .mark_block_as_validation_scheduled(&validated.block_hash)
+            .expect("schedule validation");
+        provider
+            .block_tree_read_guard
+            .write()
+            .mark_block_as_valid(&validated.block_hash)
+            .expect("mark valid");
+
+        let status = provider.block_status(validated.height, &validated.block_hash);
+        assert_eq!(status, BlockStatus::ProcessedButCanBeReorganized);
+        assert!(status.is_in_tree());
+        assert!(status.is_processed());
+    }
+
+    #[test]
+    fn block_status_returns_not_processed_for_missing_block() {
+        let (provider, _genesis, _tmp) = mock_provider();
+        let unknown_hash = BlockHash::repeat_byte(0x42);
+        let status = provider.block_status(7, &unknown_hash);
+        assert_eq!(status, BlockStatus::NotProcessed);
+        assert!(!status.is_in_tree());
+        assert!(!status.is_processed());
     }
 }

--- a/crates/p2p/src/metrics.rs
+++ b/crates/p2p/src/metrics.rs
@@ -8,12 +8,6 @@ irys_utils::define_metrics! {
     histogram PROCESSING_MS("irys.gossip.chunks.processing_duration_ms", "Gossip chunk processing latency in milliseconds", vec![0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0]);
     counter INBOUND_ERRORS("irys.gossip.inbound.errors_total", "Gossip inbound processing errors by type");
     counter OUTBOUND_ERRORS("irys.gossip.outbound.errors_total", "Gossip outbound send errors by type");
-
-    histogram PARENT_WAIT_DURATION_MS(
-        "irys.block_pool.parent_wait_duration_ms",
-        "Time block_pool waits for an InTreePendingValidation parent to resolve, in milliseconds (labelled by outcome)",
-        vec![10.0, 100.0, 500.0, 1000.0, 5000.0, 10000.0, 30000.0, 60000.0, 300000.0, 600000.0]
-    );
 }
 
 pub(crate) fn record_gossip_chunk_received(bytes: u64) {
@@ -37,8 +31,4 @@ pub(crate) fn record_gossip_inbound_error(error_type: &'static str, is_advisory:
 
 pub(crate) fn record_gossip_outbound_error(error_type: &'static str) {
     OUTBOUND_ERRORS.add(1, &[KeyValue::new("error_type", error_type)]);
-}
-
-pub(crate) fn record_block_pool_parent_wait_duration_ms(outcome: &'static str, ms: f64) {
-    PARENT_WAIT_DURATION_MS.record(ms, &[KeyValue::new("outcome", outcome)]);
 }

--- a/crates/p2p/src/metrics.rs
+++ b/crates/p2p/src/metrics.rs
@@ -8,6 +8,12 @@ irys_utils::define_metrics! {
     histogram PROCESSING_MS("irys.gossip.chunks.processing_duration_ms", "Gossip chunk processing latency in milliseconds", vec![0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0]);
     counter INBOUND_ERRORS("irys.gossip.inbound.errors_total", "Gossip inbound processing errors by type");
     counter OUTBOUND_ERRORS("irys.gossip.outbound.errors_total", "Gossip outbound send errors by type");
+
+    histogram PARENT_WAIT_DURATION_MS(
+        "irys.block_pool.parent_wait_duration_ms",
+        "Time block_pool waits for an InTreePendingValidation parent to resolve, in milliseconds (labelled by outcome)",
+        vec![10.0, 100.0, 500.0, 1000.0, 5000.0, 10000.0, 30000.0, 60000.0, 300000.0, 600000.0]
+    );
 }
 
 pub(crate) fn record_gossip_chunk_received(bytes: u64) {
@@ -31,4 +37,8 @@ pub(crate) fn record_gossip_inbound_error(error_type: &'static str, is_advisory:
 
 pub(crate) fn record_gossip_outbound_error(error_type: &'static str) {
     OUTBOUND_ERRORS.add(1, &[KeyValue::new("error_type", error_type)]);
+}
+
+pub(crate) fn record_block_pool_parent_wait_duration_ms(outcome: &'static str, ms: f64) {
+    PARENT_WAIT_DURATION_MS.record(ms, &[KeyValue::new("outcome", outcome)]);
 }

--- a/crates/p2p/src/tests/block_pool/mod.rs
+++ b/crates/p2p/src/tests/block_pool/mod.rs
@@ -17,9 +17,9 @@ use irys_storage::irys_consensus_data_db::open_or_create_irys_consensus_data_db;
 use irys_testing_utils::utils::TempDirBuilder;
 use irys_types::v2::{GossipDataRequestV2, GossipDataV2};
 use irys_types::{
-    BlockBody, BlockHash, Config, DatabaseProvider, DbSyncMode, IrysAddress, IrysPeerId,
-    MempoolConfig, NodeConfig, PeerAddress, PeerListItem, PeerNetworkSender, PeerScore,
-    ProtocolVersion, RethPeerInfo, SealedBlock,
+    BlockBody, Config, DatabaseProvider, DbSyncMode, IrysAddress, IrysPeerId, MempoolConfig,
+    NodeConfig, PeerAddress, PeerListItem, PeerNetworkSender, PeerScore, ProtocolVersion,
+    RethPeerInfo, SealedBlock,
 };
 use irys_vdf::state::{VdfState, VdfStateReadonly};
 use std::net::SocketAddr;
@@ -928,10 +928,10 @@ async fn should_not_fast_track_block_already_in_index() {
 }
 
 // ---------------------------------------------------------------------------
-// Tests for InTreePendingValidation orphan-cascade prevention: when a child
-// arrives whose parent is in the tree but not yet validated, `process_block`
-// must wait for the parent's validation event rather than entering the orphan
-// re-pull path.
+// Tests for the `InTreePendingValidation` status mapping: blocks whose parent
+// is in the tree but not yet validated must still bypass the orphan re-pull
+// path (see `block_status_provider.rs`), and the predicates that gate gossip
+// dedup must continue to treat them as observed.
 // ---------------------------------------------------------------------------
 
 /// Build a BlockPool wired to a fresh mocked-services bundle. Returns the
@@ -964,21 +964,11 @@ fn build_test_pool(
     (pool, services, sync_receiver)
 }
 
-/// True iff `msg` is one of the orphan-cascade messages that
-/// `process_block` must suppress when the parent is already in the tree
-/// as `InTreePendingValidation` (the wait-for-parent path replaces these).
-fn is_orphan_cascade_message(msg: &crate::chain_sync::SyncChainServiceMessage) -> bool {
-    matches!(
-        msg,
-        crate::chain_sync::SyncChainServiceMessage::RequestBlockFromTheNetwork { .. }
-            | crate::chain_sync::SyncChainServiceMessage::AttemptReprocessingBlock(_)
-    )
-}
-
-/// When the parent block is in the tree as `InTreePendingValidation`,
-/// `process_block(child)` must NOT enter the orphan branch (i.e. must not
-/// emit `RequestBlockFromTheNetwork`) — it must wait for the parent's
-/// validation event instead.
+/// When the parent is in the tree as `InTreePendingValidation`,
+/// `process_block(child)` must NOT emit `RequestBlockFromTheNetwork` or
+/// `AttemptReprocessingBlock` — the parent is locally known, so the orphan
+/// re-pull branch must be skipped. This is the storm-prevention invariant
+/// upheld by `is_in_tree()` in `block_status_provider`.
 #[tokio::test]
 async fn process_block_does_not_re_pull_parent_in_tree_pending_validation() {
     let (_tmp_dir, config) = create_test_config();
@@ -989,169 +979,33 @@ async fn process_block_does_not_re_pull_parent_in_tree_pending_validation() {
     let parent = &chain[0];
     let child = &chain[1];
 
-    // Put the parent into the tree only (not the index) — default state is
-    // `ChainState::NotOnchain(BlockState::Unknown)`, which maps to
-    // `InTreePendingValidation`.
+    // Put the parent into the tree only (not the index). Default state is
+    // `ChainState::NotOnchain(BlockState::Unknown)` → `InTreePendingValidation`.
     services
         .block_status_provider_mock
         .add_block_mock_to_the_tree(parent);
 
-    // Spawn process_block(child) — it should park inside wait_for_parent_validation.
     let child_sealed =
         create_test_sealed_block(child.clone(), create_test_block_body(child.block_hash));
-    let pool_clone = pool.clone();
-    let child_height = child.height;
-    let process_fut =
-        tokio::spawn(async move { pool_clone.process_block(child_sealed, false).await });
-
-    // Give the spawned task time to enter the wait loop. While it waits, we
-    // assert (a) no orphan-cascade message has been emitted on the sync
-    // channel and (b) the child has not fallen through to block_discovery.
-    tokio::time::sleep(Duration::from_millis(200)).await;
-    while let Ok(msg) = sync_receiver.try_recv() {
-        assert!(
-            !is_orphan_cascade_message(&msg),
-            "process_block must not emit orphan-cascade messages while the parent is in tree pending validation, got: {msg:?}"
-        );
-    }
-    assert!(
-        services.block_discovery_stub.get_blocks().is_empty(),
-        "child must not reach block_discovery while parent is unvalidated"
-    );
-
-    // Now fire the parent's validation-success event and verify the wait
-    // resolves and the child is processed.
-    let parent_event = irys_actors::block_tree_service::BlockStateUpdated {
-        block_hash: parent.block_hash,
-        height: parent.height,
-        state: irys_domain::ChainState::Validated(irys_domain::BlockState::ValidBlock),
-        discarded: false,
-        validation_result: irys_actors::block_tree_service::ValidationResult::Valid,
-    };
-    // Promote the parent in the tree first so the wait's status re-read sees
-    // `ProcessedButCanBeReorganized` rather than still `InTreePendingValidation`.
-    {
-        let tree_guard = services.block_status_provider_mock.block_tree_read_guard();
-        let mut tree = tree_guard.write();
-        tree.mark_block_as_validation_scheduled(&parent.block_hash)
-            .expect("schedule validation");
-        tree.mark_block_as_valid(&parent.block_hash)
-            .expect("mark valid");
-    }
-    services
-        .service_senders
-        .block_state_events
-        .send(parent_event)
-        .expect("broadcast parent state update");
-
-    let result = tokio::time::timeout(Duration::from_secs(2), process_fut)
+    pool.process_block(child_sealed, false)
         .await
-        .expect("process_block must complete after parent resolves")
-        .expect("join handle")
-        .expect("process_block must succeed");
-    assert!(matches!(
-        result,
-        crate::block_pool::ProcessBlockResult::Processed
-    ));
+        .expect("process_block must succeed when parent is in tree");
 
-    // Child finally hands off to block_discovery and no orphan-cascade
-    // message was emitted along the way.
+    // The child must have reached block_discovery (i.e. the in-tree path was
+    // exercised, not skipped by an early-out).
     let discovered = services.block_discovery_stub.get_blocks();
     assert_eq!(discovered.len(), 1);
     assert_eq!(discovered[0].block_hash, child.block_hash);
+
+    // No orphan-cascade message must have been emitted on the sync channel.
     while let Ok(msg) = sync_receiver.try_recv() {
         assert!(
-            !is_orphan_cascade_message(&msg),
-            "no orphan-cascade message should fire on the InTreePendingValidation path, got: {msg:?}"
-        );
-    }
-    let _ = child_height; // silence unused warning when assertions strip line info
-}
-
-/// When the parent is `InTreePendingValidation` and then disappears from the
-/// tree (validation failed → removed), `wait_for_parent_validation` must
-/// resolve to `Invalid` and `process_block` must drop the child with a
-/// `ParentValidationFailed`-style error rather than adding it to the tree.
-#[tokio::test]
-async fn process_block_drops_child_when_pending_parent_validation_fails() {
-    let (_tmp_dir, config) = create_test_config();
-    let (pool, services, mut sync_receiver) = build_test_pool(&config);
-
-    let genesis = services.block_status_provider_mock.genesis_header();
-    let chain = BlockStatusProvider::produce_mock_chain(2, Some(&genesis), &config.consensus);
-    let parent = &chain[0];
-    let child = &chain[1];
-
-    services
-        .block_status_provider_mock
-        .add_block_mock_to_the_tree(parent);
-
-    let child_sealed =
-        create_test_sealed_block(child.clone(), create_test_block_body(child.block_hash));
-    let pool_clone = pool.clone();
-    let child_hash = child.block_hash;
-    let process_fut =
-        tokio::spawn(async move { pool_clone.process_block(child_sealed, false).await });
-
-    // Let the wait loop start.
-    tokio::time::sleep(Duration::from_millis(200)).await;
-
-    // Simulate validation failure: remove the parent from the tree (this is
-    // what `block_tree_service::on_block_validation_finished` does on
-    // Invalid), then broadcast the discarded state update so the waiter
-    // wakes up and re-reads the tree.
-    {
-        let tree_guard = services.block_status_provider_mock.block_tree_read_guard();
-        let mut tree = tree_guard.write();
-        tree.test_delete(&parent.block_hash)
-            .expect("delete parent from tree");
-    }
-    let parent_event = irys_actors::block_tree_service::BlockStateUpdated {
-        block_hash: parent.block_hash,
-        height: parent.height,
-        state: irys_domain::ChainState::NotOnchain(irys_domain::BlockState::Unknown),
-        discarded: true,
-        validation_result: irys_actors::block_tree_service::ValidationResult::Invalid(
-            irys_actors::block_validation::ValidationError::SeedDataInvalid(
-                "test induced failure".into(),
+            !matches!(
+                msg,
+                crate::chain_sync::SyncChainServiceMessage::RequestBlockFromTheNetwork { .. }
+                    | crate::chain_sync::SyncChainServiceMessage::AttemptReprocessingBlock(_)
             ),
-        ),
-    };
-    services
-        .service_senders
-        .block_state_events
-        .send(parent_event)
-        .expect("broadcast parent failure");
-
-    let err = tokio::time::timeout(Duration::from_secs(2), process_fut)
-        .await
-        .expect("process_block must complete after parent fails")
-        .expect("join handle")
-        .expect_err("child must be rejected because parent failed");
-    match err {
-        BlockPoolError::Critical(CriticalBlockPoolError::BlockError(msg)) => {
-            assert!(
-                msg.contains("failed validation"),
-                "error message should mention parent validation failure, got: {msg}"
-            );
-        }
-        other => panic!("expected BlockError for failed parent, got: {other:?}"),
-    }
-
-    // The dropped child must not appear in block_discovery and must have been
-    // removed from the in-flight cache.
-    assert!(
-        services.block_discovery_stub.get_blocks().is_empty(),
-        "child must not reach block_discovery when its parent failed"
-    );
-    assert!(
-        !pool.contains_block(&child_hash).await,
-        "child must be removed from block_pool cache after parent failure"
-    );
-    while let Ok(msg) = sync_receiver.try_recv() {
-        assert!(
-            !is_orphan_cascade_message(&msg),
-            "no orphan re-pull should fire on the InTreePendingValidation path, got: {msg:?}"
+            "process_block must not emit orphan-cascade messages when the parent is in tree pending validation, got: {msg:?}"
         );
     }
 }
@@ -1192,104 +1046,6 @@ async fn process_block_rejects_block_already_in_tree_pending_validation() {
         services.block_discovery_stub.get_blocks().is_empty(),
         "already-in-tree block must not re-enter block_discovery"
     );
-}
-
-/// `wait_for_parent_validation` must survive `broadcast::RecvError::Lagged` —
-/// the loop's contract is that it re-reads parent state from the tree on every
-/// event (or lag), so a missed window of events only delays the next exit
-/// check by one iteration. This drives that path deterministically by
-/// overflowing the 100-capacity `block_state_events` channel in a single sync
-/// burst (no await points → receiver task can't keep up) and then resolving
-/// the parent normally.
-#[tokio::test]
-async fn wait_for_parent_validation_tolerates_lagged_events() {
-    let (_tmp_dir, config) = create_test_config();
-    let (pool, services, mut sync_receiver) = build_test_pool(&config);
-
-    let genesis = services.block_status_provider_mock.genesis_header();
-    let chain = BlockStatusProvider::produce_mock_chain(2, Some(&genesis), &config.consensus);
-    let parent = &chain[0];
-    let child = &chain[1];
-
-    services
-        .block_status_provider_mock
-        .add_block_mock_to_the_tree(parent);
-
-    let child_sealed =
-        create_test_sealed_block(child.clone(), create_test_block_body(child.block_hash));
-    let pool_clone = pool.clone();
-    let process_fut =
-        tokio::spawn(async move { pool_clone.process_block(child_sealed, false).await });
-
-    // Give the spawned task time to enter wait_for_parent_validation, subscribe,
-    // and park on the first `rx.recv()`. After this sleep the receiver task is
-    // suspended on the await and won't run again until this task yields.
-    tokio::time::sleep(Duration::from_millis(200)).await;
-
-    // Burst-fill the 100-cap broadcast buffer synchronously: no `.await` in
-    // this block, so the receiver task stays parked while we shove 200 events
-    // through. The receiver's cursor falls ~100 behind → next recv returns
-    // `RecvError::Lagged`. We use an unrelated dummy block_hash so the wait
-    // loop's status re-read still sees the parent as `InTreePendingValidation`.
-    let spam_hash = BlockHash::repeat_byte(0xAB);
-    let spam_event = irys_actors::block_tree_service::BlockStateUpdated {
-        block_hash: spam_hash,
-        height: 999,
-        state: irys_domain::ChainState::NotOnchain(irys_domain::BlockState::Unknown),
-        discarded: false,
-        validation_result: irys_actors::block_tree_service::ValidationResult::Valid,
-    };
-    for _ in 0..200 {
-        services
-            .service_senders
-            .block_state_events
-            .send(spam_event.clone())
-            .expect("broadcast spam event");
-    }
-
-    // Promote the parent to a validated state, still synchronously, then send
-    // one final event. The receiver wakes up to find a Lagged ring, re-reads
-    // tree state, observes `ProcessedButCanBeReorganized`, and exits cleanly.
-    {
-        let tree_guard = services.block_status_provider_mock.block_tree_read_guard();
-        let mut tree = tree_guard.write();
-        tree.mark_block_as_validation_scheduled(&parent.block_hash)
-            .expect("schedule validation");
-        tree.mark_block_as_valid(&parent.block_hash)
-            .expect("mark valid");
-    }
-    let parent_event = irys_actors::block_tree_service::BlockStateUpdated {
-        block_hash: parent.block_hash,
-        height: parent.height,
-        state: irys_domain::ChainState::Validated(irys_domain::BlockState::ValidBlock),
-        discarded: false,
-        validation_result: irys_actors::block_tree_service::ValidationResult::Valid,
-    };
-    services
-        .service_senders
-        .block_state_events
-        .send(parent_event)
-        .expect("broadcast parent valid event");
-
-    let result = tokio::time::timeout(Duration::from_secs(2), process_fut)
-        .await
-        .expect("process_block must complete after parent resolves despite lag")
-        .expect("join handle")
-        .expect("process_block must succeed");
-    assert!(matches!(
-        result,
-        crate::block_pool::ProcessBlockResult::Processed
-    ));
-
-    let discovered = services.block_discovery_stub.get_blocks();
-    assert_eq!(discovered.len(), 1);
-    assert_eq!(discovered[0].block_hash, child.block_hash);
-    while let Ok(msg) = sync_receiver.try_recv() {
-        assert!(
-            !is_orphan_cascade_message(&msg),
-            "lagged-event path must not fall back to orphan re-pull, got: {msg:?}"
-        );
-    }
 }
 
 /// `is_block_processing_or_processed` must return true for a block that is

--- a/crates/p2p/src/tests/block_pool/mod.rs
+++ b/crates/p2p/src/tests/block_pool/mod.rs
@@ -926,3 +926,297 @@ async fn should_not_fast_track_block_already_in_index() {
         ))
     );
 }
+
+// ---------------------------------------------------------------------------
+// Tests for Fix 2 — InTreePendingValidation orphan-cascade prevention
+// ---------------------------------------------------------------------------
+
+/// Build a BlockPool wired to a fresh mocked-services bundle. Returns the
+/// pool plus everything tests need to inspect outcomes (discovery stub,
+/// sync_sender's receiver, service_senders for firing events, mock provider
+/// so the test can mutate tree state).
+fn build_test_pool(
+    config: &Config,
+) -> (
+    Arc<BlockPool<BlockDiscoveryStub, MempoolStub>>,
+    MockedServices,
+    tokio::sync::mpsc::UnboundedReceiver<crate::chain_sync::SyncChainServiceMessage>,
+) {
+    let services = MockedServices::new(config);
+    let (sync_sender, sync_receiver) = tokio::sync::mpsc::unbounded_channel();
+    let sync_state = ChainSyncState::new(false, false);
+    let pool = Arc::new(BlockPool::new(
+        services.db.clone(),
+        services.block_discovery_stub.clone(),
+        services.mempool_stub.clone(),
+        sync_sender,
+        sync_state,
+        services.block_status_provider_mock.clone(),
+        services.execution_payload_provider.clone(),
+        config.clone(),
+        services.service_senders.clone(),
+        MempoolReadGuard::stub(),
+        tokio::runtime::Handle::current(),
+    ));
+    (pool, services, sync_receiver)
+}
+
+/// True iff `msg` is one of the orphan-cascade messages that Fix 2 is
+/// supposed to suppress when the parent is already in the tree
+/// (`InTreePendingValidation`).
+fn is_orphan_cascade_message(msg: &crate::chain_sync::SyncChainServiceMessage) -> bool {
+    matches!(
+        msg,
+        crate::chain_sync::SyncChainServiceMessage::RequestBlockFromTheNetwork { .. }
+            | crate::chain_sync::SyncChainServiceMessage::AttemptReprocessingBlock(_)
+    )
+}
+
+/// When the parent block is in the tree as `InTreePendingValidation`,
+/// `process_block(child)` must NOT enter the orphan branch (i.e. must not
+/// emit `RequestBlockFromTheNetwork`) — it must wait for the parent's
+/// validation event instead.
+#[tokio::test]
+async fn process_block_does_not_re_pull_parent_in_tree_pending_validation() {
+    let (_tmp_dir, config) = create_test_config();
+    let (pool, services, mut sync_receiver) = build_test_pool(&config);
+
+    let genesis = services.block_status_provider_mock.genesis_header();
+    let chain = BlockStatusProvider::produce_mock_chain(2, Some(&genesis), &config.consensus);
+    let parent = &chain[0];
+    let child = &chain[1];
+
+    // Put the parent into the tree only (not the index) — default state is
+    // `ChainState::NotOnchain(BlockState::Unknown)`, which maps to
+    // `InTreePendingValidation`.
+    services
+        .block_status_provider_mock
+        .add_block_mock_to_the_tree(parent);
+
+    // Spawn process_block(child) — it should park inside wait_for_parent_validation.
+    let child_sealed =
+        create_test_sealed_block(child.clone(), create_test_block_body(child.block_hash));
+    let pool_clone = pool.clone();
+    let child_height = child.height;
+    let process_fut =
+        tokio::spawn(async move { pool_clone.process_block(child_sealed, false).await });
+
+    // Give the spawned task time to enter the wait loop. While it waits, we
+    // assert (a) no orphan-cascade message has been emitted on the sync
+    // channel and (b) the child has not fallen through to block_discovery.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    while let Ok(msg) = sync_receiver.try_recv() {
+        assert!(
+            !is_orphan_cascade_message(&msg),
+            "process_block must not emit orphan-cascade messages while the parent is in tree pending validation, got: {msg:?}"
+        );
+    }
+    assert!(
+        services.block_discovery_stub.get_blocks().is_empty(),
+        "child must not reach block_discovery while parent is unvalidated"
+    );
+
+    // Now fire the parent's validation-success event and verify the wait
+    // resolves and the child is processed.
+    let parent_event = irys_actors::block_tree_service::BlockStateUpdated {
+        block_hash: parent.block_hash,
+        height: parent.height,
+        state: irys_domain::ChainState::Validated(irys_domain::BlockState::ValidBlock),
+        discarded: false,
+        validation_result: irys_actors::block_tree_service::ValidationResult::Valid,
+    };
+    // Promote the parent in the tree first so the wait's status re-read sees
+    // `ProcessedButCanBeReorganized` rather than still `InTreePendingValidation`.
+    {
+        let tree_guard = services.block_status_provider_mock.block_tree_read_guard();
+        let mut tree = tree_guard.write();
+        tree.mark_block_as_validation_scheduled(&parent.block_hash)
+            .expect("schedule validation");
+        tree.mark_block_as_valid(&parent.block_hash)
+            .expect("mark valid");
+    }
+    services
+        .service_senders
+        .block_state_events
+        .send(parent_event)
+        .expect("broadcast parent state update");
+
+    let result = tokio::time::timeout(Duration::from_secs(2), process_fut)
+        .await
+        .expect("process_block must complete after parent resolves")
+        .expect("join handle")
+        .expect("process_block must succeed");
+    assert!(matches!(
+        result,
+        crate::block_pool::ProcessBlockResult::Processed
+    ));
+
+    // Child finally hands off to block_discovery and no orphan-cascade
+    // message was emitted along the way.
+    let discovered = services.block_discovery_stub.get_blocks();
+    assert_eq!(discovered.len(), 1);
+    assert_eq!(discovered[0].block_hash, child.block_hash);
+    while let Ok(msg) = sync_receiver.try_recv() {
+        assert!(
+            !is_orphan_cascade_message(&msg),
+            "no orphan-cascade message should fire on the InTreePendingValidation path, got: {msg:?}"
+        );
+    }
+    let _ = child_height; // silence unused warning when assertions strip line info
+}
+
+/// When the parent is `InTreePendingValidation` and then disappears from the
+/// tree (validation failed → removed), `wait_for_parent_validation` must
+/// resolve to `Invalid` and `process_block` must drop the child with a
+/// `ParentValidationFailed`-style error rather than adding it to the tree.
+#[tokio::test]
+async fn process_block_drops_child_when_pending_parent_validation_fails() {
+    let (_tmp_dir, config) = create_test_config();
+    let (pool, services, mut sync_receiver) = build_test_pool(&config);
+
+    let genesis = services.block_status_provider_mock.genesis_header();
+    let chain = BlockStatusProvider::produce_mock_chain(2, Some(&genesis), &config.consensus);
+    let parent = &chain[0];
+    let child = &chain[1];
+
+    services
+        .block_status_provider_mock
+        .add_block_mock_to_the_tree(parent);
+
+    let child_sealed =
+        create_test_sealed_block(child.clone(), create_test_block_body(child.block_hash));
+    let pool_clone = pool.clone();
+    let child_hash = child.block_hash;
+    let process_fut =
+        tokio::spawn(async move { pool_clone.process_block(child_sealed, false).await });
+
+    // Let the wait loop start.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Simulate validation failure: remove the parent from the tree (this is
+    // what `block_tree_service::on_block_validation_finished` does on
+    // Invalid), then broadcast the discarded state update so the waiter
+    // wakes up and re-reads the tree.
+    {
+        let tree_guard = services.block_status_provider_mock.block_tree_read_guard();
+        let mut tree = tree_guard.write();
+        tree.test_delete(&parent.block_hash)
+            .expect("delete parent from tree");
+    }
+    let parent_event = irys_actors::block_tree_service::BlockStateUpdated {
+        block_hash: parent.block_hash,
+        height: parent.height,
+        state: irys_domain::ChainState::NotOnchain(irys_domain::BlockState::Unknown),
+        discarded: true,
+        validation_result: irys_actors::block_tree_service::ValidationResult::Invalid(
+            irys_actors::block_validation::ValidationError::SeedDataInvalid(
+                "test induced failure".into(),
+            ),
+        ),
+    };
+    services
+        .service_senders
+        .block_state_events
+        .send(parent_event)
+        .expect("broadcast parent failure");
+
+    let err = tokio::time::timeout(Duration::from_secs(2), process_fut)
+        .await
+        .expect("process_block must complete after parent fails")
+        .expect("join handle")
+        .expect_err("child must be rejected because parent failed");
+    match err {
+        BlockPoolError::Critical(CriticalBlockPoolError::BlockError(msg)) => {
+            assert!(
+                msg.contains("failed validation"),
+                "error message should mention parent validation failure, got: {msg}"
+            );
+        }
+        other => panic!("expected BlockError for failed parent, got: {other:?}"),
+    }
+
+    // The dropped child must not appear in block_discovery and must have been
+    // removed from the in-flight cache.
+    assert!(
+        services.block_discovery_stub.get_blocks().is_empty(),
+        "child must not reach block_discovery when its parent failed"
+    );
+    assert!(
+        !pool.contains_block(&child_hash).await,
+        "child must be removed from block_pool cache after parent failure"
+    );
+    while let Ok(msg) = sync_receiver.try_recv() {
+        assert!(
+            !is_orphan_cascade_message(&msg),
+            "no orphan re-pull should fire on the InTreePendingValidation path, got: {msg:?}"
+        );
+    }
+}
+
+/// `check_block_status` must treat `InTreePendingValidation` as
+/// "already processed" so the gossip/process pipeline doesn't re-enter
+/// `process_block` for a block that's already in the tree awaiting validation.
+#[tokio::test]
+async fn process_block_rejects_block_already_in_tree_pending_validation() {
+    let (_tmp_dir, config) = create_test_config();
+    let (pool, services, _sync_receiver) = build_test_pool(&config);
+
+    let genesis = services.block_status_provider_mock.genesis_header();
+    let chain = BlockStatusProvider::produce_mock_chain(1, Some(&genesis), &config.consensus);
+    let block = &chain[0];
+
+    // Put the block into the tree as pending validation directly.
+    services
+        .block_status_provider_mock
+        .add_block_mock_to_the_tree(block);
+
+    let sealed = create_test_sealed_block(block.clone(), create_test_block_body(block.block_hash));
+
+    let err = pool
+        .process_block(sealed, false)
+        .await
+        .expect_err("processing an already-in-tree block should error");
+    assert!(
+        matches!(
+            err,
+            BlockPoolError::Advisory(crate::block_pool::AdvisoryBlockPoolError::AlreadyProcessed(
+                _
+            ))
+        ),
+        "expected AlreadyProcessed advisory, got: {err:?}"
+    );
+    assert!(
+        services.block_discovery_stub.get_blocks().is_empty(),
+        "already-in-tree block must not re-enter block_discovery"
+    );
+}
+
+/// `is_block_processing_or_processed` must return true for a block that is
+/// already in the tree pending validation, so gossip handlers skip it instead
+/// of re-driving `process_block`.
+#[tokio::test]
+async fn is_block_processing_or_processed_true_for_in_tree_pending_validation() {
+    let (_tmp_dir, config) = create_test_config();
+    let (pool, services, _sync_receiver) = build_test_pool(&config);
+
+    let genesis = services.block_status_provider_mock.genesis_header();
+    let chain = BlockStatusProvider::produce_mock_chain(1, Some(&genesis), &config.consensus);
+    let block = &chain[0];
+
+    // Sanity: before adding to the tree the predicate is false.
+    assert!(
+        !pool
+            .is_block_processing_or_processed(&block.block_hash, block.height)
+            .await
+    );
+
+    services
+        .block_status_provider_mock
+        .add_block_mock_to_the_tree(block);
+
+    assert!(
+        pool.is_block_processing_or_processed(&block.block_hash, block.height)
+            .await,
+        "InTreePendingValidation parent must be treated as processed by gossip handlers"
+    );
+}

--- a/crates/p2p/src/tests/block_pool/mod.rs
+++ b/crates/p2p/src/tests/block_pool/mod.rs
@@ -17,9 +17,9 @@ use irys_storage::irys_consensus_data_db::open_or_create_irys_consensus_data_db;
 use irys_testing_utils::utils::TempDirBuilder;
 use irys_types::v2::{GossipDataRequestV2, GossipDataV2};
 use irys_types::{
-    BlockBody, Config, DatabaseProvider, DbSyncMode, IrysAddress, IrysPeerId, MempoolConfig,
-    NodeConfig, PeerAddress, PeerListItem, PeerNetworkSender, PeerScore, ProtocolVersion,
-    RethPeerInfo, SealedBlock,
+    BlockBody, BlockHash, Config, DatabaseProvider, DbSyncMode, IrysAddress, IrysPeerId,
+    MempoolConfig, NodeConfig, PeerAddress, PeerListItem, PeerNetworkSender, PeerScore,
+    ProtocolVersion, RethPeerInfo, SealedBlock,
 };
 use irys_vdf::state::{VdfState, VdfStateReadonly};
 use std::net::SocketAddr;
@@ -1189,6 +1189,104 @@ async fn process_block_rejects_block_already_in_tree_pending_validation() {
         services.block_discovery_stub.get_blocks().is_empty(),
         "already-in-tree block must not re-enter block_discovery"
     );
+}
+
+/// `wait_for_parent_validation` must survive `broadcast::RecvError::Lagged` —
+/// the loop's contract is that it re-reads parent state from the tree on every
+/// event (or lag), so a missed window of events only delays the next exit
+/// check by one iteration. This drives that path deterministically by
+/// overflowing the 100-capacity `block_state_events` channel in a single sync
+/// burst (no await points → receiver task can't keep up) and then resolving
+/// the parent normally.
+#[tokio::test]
+async fn wait_for_parent_validation_tolerates_lagged_events() {
+    let (_tmp_dir, config) = create_test_config();
+    let (pool, services, mut sync_receiver) = build_test_pool(&config);
+
+    let genesis = services.block_status_provider_mock.genesis_header();
+    let chain = BlockStatusProvider::produce_mock_chain(2, Some(&genesis), &config.consensus);
+    let parent = &chain[0];
+    let child = &chain[1];
+
+    services
+        .block_status_provider_mock
+        .add_block_mock_to_the_tree(parent);
+
+    let child_sealed =
+        create_test_sealed_block(child.clone(), create_test_block_body(child.block_hash));
+    let pool_clone = pool.clone();
+    let process_fut =
+        tokio::spawn(async move { pool_clone.process_block(child_sealed, false).await });
+
+    // Give the spawned task time to enter wait_for_parent_validation, subscribe,
+    // and park on the first `rx.recv()`. After this sleep the receiver task is
+    // suspended on the await and won't run again until this task yields.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Burst-fill the 100-cap broadcast buffer synchronously: no `.await` in
+    // this block, so the receiver task stays parked while we shove 200 events
+    // through. The receiver's cursor falls ~100 behind → next recv returns
+    // `RecvError::Lagged`. We use an unrelated dummy block_hash so the wait
+    // loop's status re-read still sees the parent as `InTreePendingValidation`.
+    let spam_hash = BlockHash::repeat_byte(0xAB);
+    let spam_event = irys_actors::block_tree_service::BlockStateUpdated {
+        block_hash: spam_hash,
+        height: 999,
+        state: irys_domain::ChainState::NotOnchain(irys_domain::BlockState::Unknown),
+        discarded: false,
+        validation_result: irys_actors::block_tree_service::ValidationResult::Valid,
+    };
+    for _ in 0..200 {
+        services
+            .service_senders
+            .block_state_events
+            .send(spam_event.clone())
+            .expect("broadcast spam event");
+    }
+
+    // Promote the parent to a validated state, still synchronously, then send
+    // one final event. The receiver wakes up to find a Lagged ring, re-reads
+    // tree state, observes `ProcessedButCanBeReorganized`, and exits cleanly.
+    {
+        let tree_guard = services.block_status_provider_mock.block_tree_read_guard();
+        let mut tree = tree_guard.write();
+        tree.mark_block_as_validation_scheduled(&parent.block_hash)
+            .expect("schedule validation");
+        tree.mark_block_as_valid(&parent.block_hash)
+            .expect("mark valid");
+    }
+    let parent_event = irys_actors::block_tree_service::BlockStateUpdated {
+        block_hash: parent.block_hash,
+        height: parent.height,
+        state: irys_domain::ChainState::Validated(irys_domain::BlockState::ValidBlock),
+        discarded: false,
+        validation_result: irys_actors::block_tree_service::ValidationResult::Valid,
+    };
+    services
+        .service_senders
+        .block_state_events
+        .send(parent_event)
+        .expect("broadcast parent valid event");
+
+    let result = tokio::time::timeout(Duration::from_secs(2), process_fut)
+        .await
+        .expect("process_block must complete after parent resolves despite lag")
+        .expect("join handle")
+        .expect("process_block must succeed");
+    assert!(matches!(
+        result,
+        crate::block_pool::ProcessBlockResult::Processed
+    ));
+
+    let discovered = services.block_discovery_stub.get_blocks();
+    assert_eq!(discovered.len(), 1);
+    assert_eq!(discovered[0].block_hash, child.block_hash);
+    while let Ok(msg) = sync_receiver.try_recv() {
+        assert!(
+            !is_orphan_cascade_message(&msg),
+            "lagged-event path must not fall back to orphan re-pull, got: {msg:?}"
+        );
+    }
 }
 
 /// `is_block_processing_or_processed` must return true for a block that is

--- a/crates/p2p/src/tests/block_pool/mod.rs
+++ b/crates/p2p/src/tests/block_pool/mod.rs
@@ -928,7 +928,10 @@ async fn should_not_fast_track_block_already_in_index() {
 }
 
 // ---------------------------------------------------------------------------
-// Tests for Fix 2 — InTreePendingValidation orphan-cascade prevention
+// Tests for InTreePendingValidation orphan-cascade prevention: when a child
+// arrives whose parent is in the tree but not yet validated, `process_block`
+// must wait for the parent's validation event rather than entering the orphan
+// re-pull path.
 // ---------------------------------------------------------------------------
 
 /// Build a BlockPool wired to a fresh mocked-services bundle. Returns the
@@ -961,9 +964,9 @@ fn build_test_pool(
     (pool, services, sync_receiver)
 }
 
-/// True iff `msg` is one of the orphan-cascade messages that Fix 2 is
-/// supposed to suppress when the parent is already in the tree
-/// (`InTreePendingValidation`).
+/// True iff `msg` is one of the orphan-cascade messages that
+/// `process_block` must suppress when the parent is already in the tree
+/// as `InTreePendingValidation` (the wait-for-parent path replaces these).
 fn is_orphan_cascade_message(msg: &crate::chain_sync::SyncChainServiceMessage) -> bool {
     matches!(
         msg,


### PR DESCRIPTION
**Describe the changes**
Adds a new BlockStatus::InTreePendingValidation variant, which allows the node to distinguish between blocks in the tree (ProcessedButCanBeReorganized) and those in the tree, but that haven't been validated yet (the new InTreePendingValidation) - this allows us to prevent a second-order orphan child "storm" if hte parent fails validation and/or is evicted from the block tree.

**Related Issue(s)**
Fixes the orphan child block re-process storm when the parent is evicted from the tree.

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent redundant re-processing and gossip for blocks that are present in-memory but still awaiting validation; refine block-status handling.

* **Tests**
  * Reworked and made deterministic a VDF validation test for stalled-peer scenarios.
  * Added tests covering in-tree pending-validation semantics and block-pool behavior.
  * Improved a proptest to assert effective URL port handling.

* **Chores**
  * Enabled additional test utilities for integration tests and added a proptest regression seed file.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Irys-xyz/irys/pull/1417)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->