### PR TITLE
perf(efficient-sampling): skip HashMap on validation reconstruct path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5307,6 +5307,7 @@ dependencies = [
 name = "irys-efficient-sampling"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "eyre",
  "irys-types",
  "openssl",

--- a/crates/efficient-sampling/Cargo.toml
+++ b/crates/efficient-sampling/Cargo.toml
@@ -14,6 +14,11 @@ tracing.workspace = true
 rstest.workspace = true
 proptest.workspace = true
 test-log.workspace = true
+criterion.workspace = true
+
+[[bench]]
+name = "recall_range"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/efficient-sampling/benches/recall_range.rs
+++ b/crates/efficient-sampling/benches/recall_range.rs
@@ -1,0 +1,21 @@
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use irys_efficient_sampling::get_recall_range;
+use irys_types::{H256, H256List};
+
+fn bench_get_recall_range(c: &mut Criterion) {
+    let mut group = c.benchmark_group("get_recall_range");
+    // mainnet today is 64_840 ranges per partition; cover a representative spread.
+    for &n in &[100_usize, 1_000, 10_000, 64_840] {
+        let partition_hash = H256::random();
+        let seeds = H256List((0..n).map(|_| H256::random()).collect());
+
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            b.iter(|| get_recall_range(n, &seeds, &partition_hash).unwrap());
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_get_recall_range);
+criterion_main!(benches);

--- a/crates/efficient-sampling/src/lib.rs
+++ b/crates/efficient-sampling/src/lib.rs
@@ -46,10 +46,6 @@ impl Ranges {
         Ok(range)
     }
 
-    pub fn get_last_recall_range(self) -> Option<usize> {
-        self.last_recall_ranges.get(&self.last_step_num).copied()
-    }
-
     /// Picks next random (using seed as entropy) range idx in [0..NUM_RECALL_RANGES_IN_PARTITION-1] interval
     pub fn next_recall_range(
         &mut self,
@@ -66,34 +62,40 @@ impl Ranges {
             ));
         }
 
-        let range = if self.last_range_pos == 0 {
-            let range = self.ranges[0];
-            self.reinitialize();
-            range
-        } else {
-            let mut hasher = sha::Sha256::new();
-            hasher.update(&seed.0);
-            hasher.update(&partition_hash.0);
-            let rng_seed: u32 = u32::from_be_bytes(
-                hasher.finish()[28..32]
-                    .try_into()
-                    .map_err(|_| eyre::eyre!("SHA256 slice [28..32] was not 4 bytes"))?,
-            );
-            let mut rng = SimpleRNG::new(rng_seed);
-
-            let last_range_pos_u32 = u32::try_from(self.last_range_pos).map_err(|_| {
-                eyre::eyre!("last_range_pos {} exceeds u32::MAX", self.last_range_pos)
-            })?;
-            let next_range_pos = usize::try_from(rng.next() % last_range_pos_u32)
-                .map_err(|_| eyre::eyre!("range position exceeds usize"))?;
-            let range = self.ranges[next_range_pos];
-            self.ranges[next_range_pos] = self.ranges[self.last_range_pos]; // overwrite returned range with last one
-            self.last_range_pos -= 1;
-            range
-        };
-
+        let range = self.pick_next(seed, partition_hash)?;
         self.last_recall_ranges.insert(step, range);
         self.last_step_num = step;
+        Ok(range)
+    }
+
+    /// Pure picking step: derives the next recall range from `(seed, partition_hash)` using
+    /// SHA-256 → `SimpleRNG` → Fisher–Yates swap on `self.ranges`. Does NOT touch
+    /// `last_recall_ranges` or `last_step_num`, so callers that only need the final value
+    /// (e.g. block validation) can skip the per-step HashMap insert.
+    fn pick_next(&mut self, seed: &H256, partition_hash: &H256) -> Result<usize> {
+        if self.last_range_pos == 0 {
+            let range = self.ranges[0];
+            self.reinitialize();
+            return Ok(range);
+        }
+
+        let mut hasher = sha::Sha256::new();
+        hasher.update(&seed.0);
+        hasher.update(&partition_hash.0);
+        let rng_seed: u32 = u32::from_be_bytes(
+            hasher.finish()[28..32]
+                .try_into()
+                .map_err(|_| eyre::eyre!("SHA256 slice [28..32] was not 4 bytes"))?,
+        );
+        let mut rng = SimpleRNG::new(rng_seed);
+
+        let last_range_pos_u32 = u32::try_from(self.last_range_pos)
+            .map_err(|_| eyre::eyre!("last_range_pos {} exceeds u32::MAX", self.last_range_pos))?;
+        let next_range_pos = usize::try_from(rng.next() % last_range_pos_u32)
+            .map_err(|_| eyre::eyre!("range position exceeds usize"))?;
+        let range = self.ranges[next_range_pos];
+        self.ranges[next_range_pos] = self.ranges[self.last_range_pos]; // overwrite returned range with last one
+        self.last_range_pos -= 1;
         Ok(range)
     }
 
@@ -173,19 +175,22 @@ pub fn recall_range_is_valid(
     }
 }
 
-/// Construct recall range index from given step seeds and partition hash
+/// Construct recall range index from given step seeds and partition hash.
+///
+/// Only the final pick is needed (e.g. block validation), so this skips the per-step
+/// `last_recall_ranges` HashMap inserts and `last_step_num` bookkeeping that
+/// `Ranges::reconstruct` does for the mining path.
 pub fn get_recall_range(
     num_recall_ranges_in_partition: usize,
     steps: &H256List,
     partition_hash: &H256,
 ) -> eyre::Result<usize> {
     let mut ranges = Ranges::new(num_recall_ranges_in_partition)?;
-    ranges.reconstruct(steps, partition_hash)?;
-    if let Some(reconstructed_range) = ranges.get_last_recall_range() {
-        Ok(reconstructed_range)
-    } else {
-        Err(eyre::eyre!("No recall range index found"))
+    let mut last = None;
+    for seed in &steps.0 {
+        last = Some(ranges.pick_next(seed, partition_hash)?);
     }
+    last.ok_or_else(|| eyre::eyre!("No recall range index found"))
 }
 
 /// Get last step number where ranges were reinitialized


### PR DESCRIPTION
Block validation only needs the final recall range, but the freestanding get_recall_range was driving Ranges::reconstruct which inserts each intermediate pick into last_recall_ranges and updates last_step_num. On mainnet (64_840 ranges per partition) that's ~64k wasted HashMap inserts per recall_range_is_valid call.

Extract the pure swap-pick into Ranges::pick_next (no HashMap, no last_step_num) and have the freestanding get_recall_range loop on it directly, keeping only the final value. The mining path (Ranges::next_recall_range, used by partition_mining_service) is unchanged - it still goes through pick_next and then updates its bookkeeping. get_last_recall_range was orphaned by the change and is removed.

Bench (crates/efficient-sampling/benches/recall_range.rs, criterion, p < 0.05 at every size):

  steps      before      after       delta
  100        12.77 us    10.23 us    -20.9%
  1000       132.5 us    102.9 us    -23.0%
  10000      1.327 ms    1.048 ms    -20.4%
  64840      9.30 ms     6.82 ms     -26.6%

The win scales with N as expected (HashMap rehash cost dominates the tail). Existing determinism/uniqueness proptests confirm behavior is unchanged.

**Describe the changes**
A clear and concise description of what the bug fix, feature, or improvement is.

**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Introduced comprehensive benchmarking suite to measure and validate sampling performance.

* **Refactor**
  * Streamlined core sampling logic for improved implementation efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Irys-xyz/irys/pull/1418)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->