### PR TITLE
refactor(telemetry): remove Axiom log broadcasting

### DIFF
--- a/MAINNET_BETA.md
+++ b/MAINNET_BETA.md
@@ -39,7 +39,6 @@ Once you’ve installed the dependencies you can compile the build with
 ## Compile feature flags
 `telemetry` - enables exporting of opentelemetry log & span collection.
 *  Use the canonical `OTEL_EXPORTER_OTLP_ENDPOINT` env var to configure the opentelemetry endpoint to send both spans and logs to.
-* Optionally, specify the `AXIOM_API_TOKEN` and `AXIOM_DATASET` env vars to configure support for Axiom. \
 
 `nvidia` - enables CUDA accelerated packing. 
 

--- a/crates/utils/utils/src/telemetry.rs
+++ b/crates/utils/utils/src/telemetry.rs
@@ -40,7 +40,6 @@ struct TelemetryConfig {
     service_name: String,
     traces_endpoint: String,
     logs_endpoint: String,
-    axiom_logs_endpoint: Option<String>,
     metrics_endpoint: String,
 }
 
@@ -64,7 +63,6 @@ impl TelemetryConfig {
                 .unwrap_or_else(|_| otlp_endpoint.clone()),
             logs_endpoint: std::env::var("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT")
                 .unwrap_or(default_logs_endpoint),
-            axiom_logs_endpoint: std::env::var("AXIOM_LOGS_ENDPOINT").ok(),
             metrics_endpoint: std::env::var("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT")
                 .unwrap_or(otlp_endpoint),
         }
@@ -285,8 +283,6 @@ fn install_panic_hook() {
 /// - `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`: Override endpoint for traces (optional)
 /// - `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`: Override endpoint for logs (optional)
 /// - `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`: Override endpoint for metrics (optional)
-/// - `AXIOM_LOGS_ENDPOINT`: Additional Axiom OTLP endpoint for logs (optional)
-///   When set, logs are sent to BOTH the primary logs endpoint AND Axiom
 ///
 /// # Errors
 ///
@@ -306,20 +302,7 @@ pub fn init_telemetry() -> Result<()> {
     let trace_exporter = build_trace_exporter(&config.traces_endpoint)?;
     let metrics_exporter = build_metrics_exporter(&config.metrics_endpoint)?;
 
-    let mut log_exporters = vec![build_log_exporter(&config.logs_endpoint)?];
-    let mut log_endpoints = vec![config.logs_endpoint.clone()];
-
-    if let Some(ref axiom_endpoint) = config.axiom_logs_endpoint {
-        match build_log_exporter(axiom_endpoint) {
-            Ok(exporter) => {
-                log_exporters.push(exporter);
-                log_endpoints.push(axiom_endpoint.clone());
-            }
-            Err(e) => {
-                eprintln!("Failed to build Axiom log exporter (continuing with primary): {e:?}");
-            }
-        }
-    }
+    let log_exporters = vec![build_log_exporter(&config.logs_endpoint)?];
 
     let tracer_provider = build_tracer_provider(trace_exporter, resource.clone());
     let logger_provider = build_logger_provider(log_exporters, resource.clone());
@@ -335,11 +318,10 @@ pub fn init_telemetry() -> Result<()> {
     setup_tracing_subscriber(&tracer_provider, &logger_provider, &config.service_name);
     install_panic_hook();
 
-    let endpoints_str = log_endpoints.join(", ");
     tracing::info!(
         telemetry.service_name = %config.service_name,
         telemetry.traces_endpoint = %config.traces_endpoint,
-        telemetry.logs_endpoints = %endpoints_str,
+        telemetry.logs_endpoints = %config.logs_endpoint,
         telemetry.metrics_endpoint = %config.metrics_endpoint,
         "OpenTelemetry telemetry initialized - logs, traces, metrics, and Reth metrics will be exported"
     );


### PR DESCRIPTION
**Describe the changes**

**Before**: init_telemetry fanned logs out to a second Axiom OTLP exporter when AXIOM_LOGS_ENDPOINT was set; MAINNET_BETA.md referenced stale AXIOM_API_TOKEN / AXIOM_DATASET env vars the code never read.

**After**: Logs are exported only to the primary OTLP endpoint. The Axiom field, env read, fan-out block, and stale doc bullet are removed.


**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed Axiom logs endpoint configuration support. Telemetry now uses only the standard OpenTelemetry endpoint (`OTEL_EXPORTER_OTLP_ENDPOINT`) for log exports.
  * Updated documentation to reflect telemetry configuration changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Irys-xyz/irys/pull/1420)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->