### PR TITLE
fix: cached data roots block set

### DIFF
--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -360,3 +360,318 @@ impl BlockMigrationService {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! Focused unit tests for `BlockMigrationService::persist_metadata` —
+    //! the authoritative-writer entry point for
+    //! `CachedDataRoot.block_set` and `IrysDataTxMetadata.included_height`.
+    //!
+    //! The function only touches `self.db`; the other service fields
+    //! (block_index_guard, cache, chunk_migration_sender, supply_state) are
+    //! satisfied with cheap placeholders.
+    use super::*;
+    use irys_database::{
+        IrysDatabaseArgs as _, cache_data_root, open_or_create_db,
+        tables::{CachedDataRoots, IrysTables},
+    };
+    use irys_domain::BlockTree;
+    use irys_testing_utils::IrysBlockHeaderTestExt as _;
+    use irys_types::{
+        BlockTransactions, ConsensusConfig, DataTransactionHeader, DataTransactionHeaderV1,
+        DataTransactionHeaderV1WithMetadata, DataTransactionMetadata, H256, H256List,
+        IrysBlockHeader, U256,
+    };
+    use reth_db::Database as _;
+    use reth_db::mdbx::DatabaseArguments;
+    use reth_db::transaction::{DbTx as _, DbTxMut as _};
+
+    /// Build a `BlockMigrationService` whose only meaningful field is `db`.
+    /// All other dependencies are placeholders sufficient to construct but
+    /// not exercised by `persist_metadata`.
+    fn make_service(
+        db: DatabaseProvider,
+    ) -> (
+        BlockMigrationService,
+        irys_testing_utils::utils::tempfile::TempDir,
+    ) {
+        // BlockIndex needs a writable DB; reuse the test DB.
+        let block_index = BlockIndex::new_for_testing(db.clone());
+        let block_index_guard = BlockIndexReadGuard::new(block_index);
+
+        // BlockTree needs a genesis to seal; consensus testing config.
+        let mut genesis = IrysBlockHeader::new_mock_header();
+        genesis.height = 0;
+        genesis.previous_block_hash = H256::zero();
+        genesis.cumulative_diff = U256::from(0);
+        genesis.test_sign();
+        let tree = BlockTree::new(&genesis, ConsensusConfig::testing());
+        let cache = Arc::new(RwLock::new(tree));
+
+        let (chunk_migration_sender, _rx) = tokio::sync::mpsc::unbounded_channel();
+
+        // Return a dummy tempdir alongside so callers can keep it alive if
+        // they want; in practice the test owns its own tempdir for the DB.
+        let tmp = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let svc = BlockMigrationService::new(
+            db,
+            block_index_guard,
+            None, // supply_state — unused by persist_metadata
+            ConsensusConfig::testing().chunk_size,
+            cache,
+            chunk_migration_sender,
+        );
+        (svc, tmp)
+    }
+
+    fn open_db() -> eyre::Result<(
+        DatabaseProvider,
+        irys_testing_utils::utils::tempfile::TempDir,
+    )> {
+        let tmp = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let env = open_or_create_db(
+            tmp.path(),
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        Ok((DatabaseProvider(Arc::new(env)), tmp))
+    }
+
+    /// Build a signed block header with the given Submit-ledger `tx_ids`
+    /// and `total_chunks`.
+    fn make_block_header(
+        height: u64,
+        previous_block_hash: H256,
+        submit_total_chunks: u64,
+        submit_tx_ids: Vec<H256>,
+    ) -> IrysBlockHeader {
+        let mut header = IrysBlockHeader::new_mock_header();
+        header.height = height;
+        header.previous_block_hash = previous_block_hash;
+        header.cumulative_diff = U256::from(height);
+        let submit = &mut header.data_ledgers[DataLedger::Submit as usize];
+        submit.total_chunks = submit_total_chunks;
+        submit.tx_ids = H256List(submit_tx_ids);
+        header.test_sign();
+        header
+    }
+
+    /// Wrap a header in a `SealedBlock` whose body carries matching
+    /// `DataTransactionHeader` entries for each Submit tx_id (so
+    /// `block.transactions().get_ledger_txs(Submit)` returns non-empty).
+    fn make_sealed_with_submit_txs(
+        header: IrysBlockHeader,
+        submit_data_roots: &[(H256, H256)], // (tx_id, data_root)
+    ) -> Arc<SealedBlock> {
+        let data_txs: Vec<DataTransactionHeader> = submit_data_roots
+            .iter()
+            .map(|(tx_id, data_root)| {
+                DataTransactionHeader::V1(DataTransactionHeaderV1WithMetadata {
+                    tx: DataTransactionHeaderV1 {
+                        id: *tx_id,
+                        data_root: *data_root,
+                        ledger_id: DataLedger::Submit as u32,
+                        ..Default::default()
+                    },
+                    metadata: DataTransactionMetadata::new(),
+                })
+            })
+            .collect();
+        let mut data_txs_map = HashMap::new();
+        data_txs_map.insert(DataLedger::Submit, data_txs);
+        let body = BlockTransactions {
+            data_txs: data_txs_map,
+            ..Default::default()
+        };
+        Arc::new(SealedBlock::new_unchecked(Arc::new(header), body))
+    }
+
+    /// Seed a CachedDataRoot via the normal `cache_data_root` path, then
+    /// stamp specific `block_set` / `expiry_height` values.
+    fn seed_cdr(
+        db: &DatabaseProvider,
+        data_root: H256,
+        tx_id: H256,
+        block_set: Vec<H256>,
+        expiry: Option<u64>,
+    ) {
+        let tx_header = DataTransactionHeader::V1(DataTransactionHeaderV1WithMetadata {
+            tx: DataTransactionHeaderV1 {
+                id: tx_id,
+                data_root,
+                ledger_id: DataLedger::Submit as u32,
+                ..Default::default()
+            },
+            metadata: DataTransactionMetadata::new(),
+        });
+        db.update(|tx| -> eyre::Result<()> {
+            cache_data_root(tx, &tx_header, None)?;
+            let mut cdr = tx
+                .get::<CachedDataRoots>(data_root)?
+                .expect("seed_cdr: cache_data_root must produce an entry");
+            cdr.block_set = block_set;
+            cdr.expiry_height = expiry;
+            tx.put::<CachedDataRoots>(data_root, cdr)?;
+            Ok(())
+        })
+        .unwrap()
+        .unwrap();
+    }
+
+    fn read_cdr(
+        db: &DatabaseProvider,
+        data_root: H256,
+    ) -> Option<irys_database::db_cache::CachedDataRoot> {
+        db.view(|tx| tx.get::<CachedDataRoots>(data_root))
+            .unwrap()
+            .unwrap()
+    }
+
+    /// Phase 3 normal advance: an existing CDR for a Submit tx in
+    /// `blocks_to_confirm` gets the new tip's `block_hash` appended and
+    /// `expiry_height` cleared.
+    #[tokio::test]
+    async fn phase3_appends_tip_hash_and_clears_expiry_on_existing_cdr() -> eyre::Result<()> {
+        let (db, _db_tmp) = open_db()?;
+        let (svc, _svc_tmp) = make_service(db.clone());
+
+        let tx_id = H256::random();
+        let data_root = H256::random();
+        // Pre-confirmation state: expiry set, block_set empty.
+        seed_cdr(&db, data_root, tx_id, vec![], Some(99));
+
+        let tip = make_block_header(1, H256::random(), 50, vec![tx_id]);
+        let tip_hash = tip.block_hash;
+        let tip_sealed = make_sealed_with_submit_txs(tip, &[(tx_id, data_root)]);
+
+        svc.persist_metadata(&[], std::slice::from_ref(&tip_sealed))?;
+
+        let cdr = read_cdr(&db, data_root).expect("CDR present");
+        assert_eq!(
+            cdr.block_set,
+            vec![tip_hash],
+            "tip hash appended to block_set"
+        );
+        assert!(
+            cdr.expiry_height.is_none(),
+            "expiry cleared by Phase 3 update_data_root_block_set"
+        );
+        Ok(())
+    }
+
+    /// Phase 3 update-only contract: a Submit tx in `blocks_to_confirm`
+    /// with no corresponding CDR row produces no CDR write.  Mirrors
+    /// `update_data_root_block_set`'s "must not fabricate" doc.
+    #[tokio::test]
+    async fn phase3_does_not_fabricate_cdr_when_missing() -> eyre::Result<()> {
+        let (db, _db_tmp) = open_db()?;
+        let (svc, _svc_tmp) = make_service(db.clone());
+
+        let tx_id = H256::random();
+        let data_root = H256::random();
+        // No seed_cdr call — no CDR for this data_root.
+
+        let tip = make_block_header(1, H256::random(), 50, vec![tx_id]);
+        let tip_sealed = make_sealed_with_submit_txs(tip, &[(tx_id, data_root)]);
+
+        svc.persist_metadata(&[], std::slice::from_ref(&tip_sealed))?;
+
+        assert!(
+            read_cdr(&db, data_root).is_none(),
+            "Phase 3 must not create a CDR for a data_root the node never tracked"
+        );
+        Ok(())
+    }
+
+    /// Phase 1 scrub on reorg: an existing CDR carrying the orphaned
+    /// block's hash has that hash removed.  `expiry_height` is left
+    /// untouched per the helper's docblock — mempool re-anchor restores it.
+    #[tokio::test]
+    async fn phase1_scrubs_orphan_block_hash_from_cdr() -> eyre::Result<()> {
+        let (db, _db_tmp) = open_db()?;
+        let (svc, _svc_tmp) = make_service(db.clone());
+
+        let tx_id = H256::random();
+        let data_root = H256::random();
+        let other_canonical_hash = H256::random();
+        let orphan_tip = make_block_header(1, H256::random(), 50, vec![tx_id]);
+        let orphan_hash = orphan_tip.block_hash;
+
+        // CDR currently records the orphaned tip alongside another canonical
+        // hash; expiry already cleared (post-confirmation).
+        seed_cdr(
+            &db,
+            data_root,
+            tx_id,
+            vec![orphan_hash, other_canonical_hash],
+            None,
+        );
+
+        let orphan_sealed = make_sealed_with_submit_txs(orphan_tip, &[(tx_id, data_root)]);
+
+        svc.persist_metadata(std::slice::from_ref(&orphan_sealed), &[])?;
+
+        let cdr = read_cdr(&db, data_root).expect("CDR present");
+        assert_eq!(
+            cdr.block_set,
+            vec![other_canonical_hash],
+            "orphan hash scrubbed; non-orphan hash retained"
+        );
+        assert!(
+            cdr.expiry_height.is_none(),
+            "expiry_height intentionally left untouched per helper docblock"
+        );
+        Ok(())
+    }
+
+    /// Phase 1 + Phase 3 ordering: a Submit tx appears in both the orphaned
+    /// block (`blocks_to_clear`) and the new canonical block
+    /// (`blocks_to_confirm`).  Phase 1 must run before Phase 3 so the
+    /// orphan hash is scrubbed first and the new canonical hash appended
+    /// second — final state has only the new canonical hash.
+    ///
+    /// Guards the ordering invariant: if the phases were swapped, the
+    /// new canonical hash would be appended, then the orphan hash
+    /// scrubbed (no effect), leaving both hashes present.  Worse, if
+    /// they referenced the same hash by accident the final state could
+    /// be empty.
+    #[tokio::test]
+    async fn phase1_before_phase3_for_overlapping_tx() -> eyre::Result<()> {
+        let (db, _db_tmp) = open_db()?;
+        let (svc, _svc_tmp) = make_service(db.clone());
+
+        let tx_id = H256::random();
+        let data_root = H256::random();
+        let orphan = make_block_header(1, H256::random(), 50, vec![tx_id]);
+        let orphan_hash = orphan.block_hash;
+        let new_canonical = make_block_header(1, H256::random(), 50, vec![tx_id]);
+        let new_canonical_hash = new_canonical.block_hash;
+        // Distinct hashes — they're constructed with different parents so
+        // even with otherwise identical contents the headers diverge.
+        assert_ne!(orphan_hash, new_canonical_hash);
+
+        // CDR currently records only the orphaned hash.
+        seed_cdr(&db, data_root, tx_id, vec![orphan_hash], None);
+
+        let orphan_sealed = make_sealed_with_submit_txs(orphan, &[(tx_id, data_root)]);
+        let new_canonical_sealed =
+            make_sealed_with_submit_txs(new_canonical, &[(tx_id, data_root)]);
+
+        svc.persist_metadata(
+            std::slice::from_ref(&orphan_sealed),
+            std::slice::from_ref(&new_canonical_sealed),
+        )?;
+
+        let cdr = read_cdr(&db, data_root).expect("CDR present");
+        assert_eq!(
+            cdr.block_set,
+            vec![new_canonical_hash],
+            "orphan scrubbed then new canonical appended; final state has only the new hash"
+        );
+        assert!(
+            cdr.expiry_height.is_none(),
+            "expiry remains cleared post-Phase 3"
+        );
+        Ok(())
+    }
+}

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -92,15 +92,28 @@ impl BlockMigrationService {
     /// `block_set` that retained them so the hint stays meaningful across
     /// reorgs.
     ///
-    /// Phase 3 is the migration-time backstop for cases where the
-    /// `BlockConfirmed`-driven fast path in mempool did not run or failed —
-    /// but it is **update-only**: `update_data_root_block_set` is a no-op for
-    /// data_roots with no existing [`CachedDataRoot`] row.  In practice this
-    /// is the right scope: a node only holds a `CachedDataRoot` for a tx if
-    /// it has the chunks (`cache_chunk` rejects writes without one), so a
-    /// missing CDR ⇒ no chunks ⇒ nothing to ingress-proof, and the absent
-    /// `block_set` entry has no observable effect.  Missed-`BlockConfirmed` +
-    /// missing-CDR remains an unrecovered combination but is unobservable.
+    /// **`block_set` writer model.**  `block_set` is a hint, not consensus
+    /// state — canonical truth lives in `IrysDataTxMetadata` +
+    /// `MigratedBlockHashes`.  Two writers maintain the hint:
+    ///   - The mempool `BlockConfirmed` path (`cache_data_root(_, Some(block))`)
+    ///     fires *before* migration and serves as a forward-fill: it records
+    ///     the confirming `block_hash` so when chunks arrive *after* block
+    ///     confirmation, [`try_generate_ingress_proof_for_root`] finds a
+    ///     populated `block_set` and proceeds.  It may fabricate a CDR row
+    ///     for a data_root the node has no chunks for yet; the entry is
+    ///     harmless until either chunks arrive or the prune pass evicts it.
+    ///   - `persist_metadata` (this function) runs at migration time and is
+    ///     the authoritative writer for canonical state changes: Phase 1
+    ///     scrubs orphan block_hashes from any retained `block_set`, and
+    ///     Phase 3's `update_data_root_block_set` is update-only — it never
+    ///     fabricates, because by migration time any data_root the node
+    ///     cares about already has a CDR (either chunks have arrived, or
+    ///     the mempool BlockConfirmed path put one there).
+    ///
+    /// A stale `BlockConfirmed` arriving after a reorg can re-add an orphan
+    /// block_hash to `block_set`; that is tolerated because consumers treat
+    /// `block_set` as a hint and re-verify canonicality through
+    /// `find_canonical_ledger_range` before acting.
     ///
     /// Reorg invariant: if a Publish-promotion remains canonical, the
     /// underlying Submit inclusion must also be present in `blocks_to_confirm`
@@ -122,9 +135,10 @@ impl BlockMigrationService {
         // returns `&[]` for a SealedBlock whose body has been stripped, even
         // if `header.data_ledgers[Submit].tx_ids` is populated — silently
         // skipping every `block_set` mutation.  The in-memory block-tree path
-        // always carries full transactions, but future code paths (e.g. blocks
-        // hydrated from disk without their body) could regress this without
-        // any error.  Catch the divergence in debug builds.
+        // always carries full transactions, but future code paths (e.g.
+        // blocks hydrated from disk without their body) could regress this
+        // without any error.  Surface the divergence in every build so the
+        // caller fails loudly rather than committing partial state.
         for block in blocks_to_clear.iter().chain(blocks_to_confirm.iter()) {
             let header_submit_count = block
                 .header()
@@ -136,9 +150,8 @@ impl BlockMigrationService {
                 .transactions()
                 .get_ledger_txs(DataLedger::Submit)
                 .len();
-            debug_assert_eq!(
-                header_submit_count,
-                body_submit_count,
+            ensure!(
+                header_submit_count == body_submit_count,
                 "SealedBlock {} has header/body Submit-tx count mismatch ({} vs {}); transactions appear stripped — block_set mutations would silently no-op",
                 block.header().block_hash,
                 header_submit_count,

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -43,21 +43,33 @@ impl BlockMigrationService {
         }
     }
 
-    /// Atomically persists tx metadata (included_height, promoted_height) to the DB.
+    /// Atomically persists tx metadata (included_height, promoted_height) and
+    /// keeps the `CachedDataRoots.block_set` hint consistent with the canonical
+    /// chain.
     ///
     /// For normal blocks: `blocks_to_clear` is empty, `blocks_to_confirm` contains just the tip.
     /// For reorgs: `blocks_to_clear` contains orphaned fork blocks, `blocks_to_confirm` contains
     /// the new canonical fork blocks. Both operations happen in a single DB transaction to
     /// prevent inconsistent metadata state.
+    ///
+    /// Invariant established at every commit boundary: if a Submit-ledger tx
+    /// in `blocks_to_confirm` has a [`CachedDataRoot`] entry, its `block_set`
+    /// contains the confirming block hash and `expiry_height` is `None`.
+    /// Orphan block hashes from `blocks_to_clear` are scrubbed from any
+    /// `block_set` that retained them so the hint stays meaningful across
+    /// reorgs.  This is the migration-time backstop for cases where the
+    /// `BlockConfirmed`-driven fast path in mempool did not run or failed.
     pub fn persist_metadata(
         &self,
         blocks_to_clear: &[Arc<SealedBlock>],
         blocks_to_confirm: &[Arc<SealedBlock>],
     ) -> eyre::Result<()> {
         self.db.update_eyre(|tx| {
-            // Phase 1: Clear orphaned metadata
+            // Phase 1: Clear orphaned tx metadata, and scrub the orphaned
+            // block_hash from any CachedDataRoot.block_set that retained it.
             for block in blocks_to_clear {
                 let header = block.header();
+                let orphan_block_hash = header.block_hash;
                 let all_data_tx_ids: Vec<_> = header
                     .data_ledgers
                     .iter()
@@ -72,6 +84,15 @@ impl BlockMigrationService {
                 if !commitment_ids.is_empty() {
                     irys_database::batch_clear_commitment_tx_metadata(tx, commitment_ids)
                         .map_err(|e| eyre::eyre!("{:?}", e))?;
+                }
+
+                for submit_tx in block.transactions().get_ledger_txs(DataLedger::Submit) {
+                    irys_database::remove_data_root_block_set_entry(
+                        tx,
+                        submit_tx.data_root,
+                        orphan_block_hash,
+                    )
+                    .map_err(|e| eyre::eyre!("{:?}", e))?;
                 }
             }
             // Phase 2: Write confirmed metadata
@@ -101,6 +122,17 @@ impl BlockMigrationService {
                         height,
                     )
                     .map_err(|e| eyre::eyre!("{:?}", e))?;
+                }
+            }
+            // Phase 3: Backstop the CachedDataRoot.block_set invariant for the
+            // canonical Submit-ledger txs we just confirmed.  Update-only —
+            // does not create cache entries for data_roots the node never
+            // tracked chunks for.
+            for block in blocks_to_confirm {
+                let block_hash = block.header().block_hash;
+                for submit_tx in block.transactions().get_ledger_txs(DataLedger::Submit) {
+                    irys_database::update_data_root_block_set(tx, submit_tx.data_root, block_hash)
+                        .map_err(|e| eyre::eyre!("{:?}", e))?;
                 }
             }
             Ok(())

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -102,19 +102,16 @@ impl BlockMigrationService {
     /// `block_set` entry has no observable effect.  Missed-`BlockConfirmed` +
     /// missing-CDR remains an unrecovered combination but is unobservable.
     ///
-    /// **Transient state between Phase 1 and Phase 2 (within the same DB
-    /// transaction):**  Phase 1 may clear `included_height` from a row whose
-    /// `promoted_height` is still set, leaving the row in a `{included:
-    /// None, promoted: Some}` state, stored directly via `tx.put` (bypassing
-    /// `put_data_tx_metadata`'s `is_included` guard).
-    /// This state is allowed *only* because Phase 2 runs in the same
-    /// transaction and restores `included_height` for any tx whose
-    /// Submit-block was re-included in the new canonical chain.  External
-    /// readers never observe this gap — the transaction commits atomically.
-    /// The reorg invariant assumed here is: if a Publish-promotion remains
-    /// canonical, the underlying Submit inclusion must also be present in
-    /// `blocks_to_confirm` (otherwise the Publish block itself would be in
-    /// `blocks_to_clear`).
+    /// Reorg invariant: if a Publish-promotion remains canonical, the
+    /// underlying Submit inclusion must also be present in `blocks_to_confirm`
+    /// — otherwise the Publish block itself would be in `blocks_to_clear`.
+    /// Therefore Phase 1 always deletes orphaned term-ledger metadata rows
+    /// outright (the `{None, Some}` state is semantically illegal:
+    /// `promoted_height` requires a prior `included_height`).  Any matching
+    /// Publish `clear_data_tx_promoted_height` becomes a no-op on the
+    /// already-deleted row.  Phase 2 then recreates rows for txs that are
+    /// re-canonical on the new fork, restoring `promoted_height` in the same
+    /// transaction when the Publish block is also re-included.
     pub fn persist_metadata(
         &self,
         blocks_to_clear: &[Arc<SealedBlock>],
@@ -154,13 +151,14 @@ impl BlockMigrationService {
             // block_hash from any CachedDataRoot.block_set that retained it.
             //
             // Per-ledger semantics:
-            //   - Term-ledger (Submit, OneYear, ThirtyDay): clear `included_height` only.
-            //     If `promoted_height` is also set (Submit tx later promoted to Publish),
-            //     the row is retained with `included_height = None` so the Publish
-            //     confirmation survives the reorg.  If neither field remains the row
-            //     is deleted.
+            //   - Term-ledger (Submit, OneYear, ThirtyDay): delete the row.
+            //     The reorg invariant guarantees the matching Publish block is
+            //     also in `blocks_to_clear` (if the tx was promoted at all),
+            //     so either iteration order ends with the row deleted.
             //   - Publish ledger: clear `promoted_height` only.  A Submit-confirmed
-            //     `included_height` on the same tx must not be disturbed.
+            //     `included_height` on the same tx must not be disturbed
+            //     (Publish-only orphan: Submit stays canonical, row kept as
+            //     `{Some, None}`).
             for block in blocks_to_clear {
                 let header = block.header();
                 let orphan_block_hash = header.block_hash;

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -3,11 +3,11 @@ use eyre::{OptionExt as _, ensure};
 use irys_database::{db::IrysDatabaseExt as _, insert_commitment_tx, insert_tx_header};
 use irys_domain::{BlockIndex, BlockTree, SupplyState, block_index_guard::BlockIndexReadGuard};
 use irys_types::{
-    DataLedger, DataTransactionHeader, IrysBlockHeader, SealedBlock, SendTraced as _, SystemLedger,
-    Traced, app_state::DatabaseProvider,
+    DataLedger, DataTransactionHeader, H256, IrysBlockHeader, SealedBlock, SendTraced as _,
+    SystemLedger, Traced, app_state::DatabaseProvider,
 };
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{Arc, RwLock},
 };
 use tokio::sync::mpsc::UnboundedSender;
@@ -157,6 +157,45 @@ impl BlockMigrationService {
                 header_submit_count,
                 body_submit_count,
             );
+        }
+
+        // Defense-in-depth structural check on the reorg invariant documented
+        // above: a Publish-ledger tx_id appearing in `blocks_to_confirm` while
+        // its Submit row is being orphaned by `blocks_to_clear` (and NOT
+        // re-confirmed in this same batch) would leave the DB in the illegal
+        // `{None, Some}` state — promoted_height set, included_height
+        // missing.  `batch_set_data_tx_promoted_height` already errs on this,
+        // so production behavior is to fail the transaction; this assert
+        // surfaces the caller-side construction bug earlier and more loudly
+        // in debug builds, before any DB I/O.
+        #[cfg(debug_assertions)]
+        {
+            let confirmed_submit: HashSet<H256> = blocks_to_confirm
+                .iter()
+                .flat_map(|b| b.transactions().get_ledger_txs(DataLedger::Submit))
+                .map(|tx| tx.id)
+                .collect();
+            let cleared_submit: HashSet<H256> = blocks_to_clear
+                .iter()
+                .flat_map(|b| b.transactions().get_ledger_txs(DataLedger::Submit))
+                .map(|tx| tx.id)
+                .collect();
+            for block in blocks_to_confirm {
+                for dl in &block.header().data_ledgers {
+                    if dl.ledger_id != DataLedger::Publish as u32 {
+                        continue;
+                    }
+                    for tx_id in &dl.tx_ids.0 {
+                        debug_assert!(
+                            !cleared_submit.contains(tx_id) || confirmed_submit.contains(tx_id),
+                            "Publish-ledger tx {tx_id} in blocks_to_confirm has its Submit \
+                             orphaned in blocks_to_clear with no re-confirmation in the same \
+                             batch — caller would promote a tx whose included_height is about \
+                             to be deleted",
+                        );
+                    }
+                }
+            }
         }
 
         self.db.update_eyre(|tx| {

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -1,10 +1,10 @@
 use crate::chunk_migration_service::ChunkMigrationServiceMessage;
-use eyre::{ensure, OptionExt as _};
+use eyre::{OptionExt as _, ensure};
 use irys_database::{db::IrysDatabaseExt as _, insert_commitment_tx, insert_tx_header};
-use irys_domain::{block_index_guard::BlockIndexReadGuard, BlockIndex, BlockTree, SupplyState};
+use irys_domain::{BlockIndex, BlockTree, SupplyState, block_index_guard::BlockIndexReadGuard};
 use irys_types::{
-    app_state::DatabaseProvider, DataLedger, DataTransactionHeader, IrysBlockHeader, SealedBlock,
-    SendTraced as _, SystemLedger, Traced,
+    DataLedger, DataTransactionHeader, IrysBlockHeader, SealedBlock, SendTraced as _, SystemLedger,
+    Traced, app_state::DatabaseProvider,
 };
 use std::{
     collections::HashMap,
@@ -441,20 +441,19 @@ mod tests {
     //! satisfied with cheap placeholders.
     use super::*;
     use irys_database::{
-        cache_data_root, open_or_create_db,
+        IrysDatabaseArgs as _, cache_data_root, open_or_create_db,
         tables::{CachedDataRoots, IrysTables},
-        IrysDatabaseArgs as _,
     };
     use irys_domain::BlockTree;
     use irys_testing_utils::IrysBlockHeaderTestExt as _;
     use irys_types::{
         BlockTransactions, ConsensusConfig, DataTransactionHeader, DataTransactionHeaderV1,
-        DataTransactionHeaderV1WithMetadata, DataTransactionMetadata, H256List, IrysBlockHeader,
-        H256, U256,
+        DataTransactionHeaderV1WithMetadata, DataTransactionMetadata, H256, H256List,
+        IrysBlockHeader, U256,
     };
+    use reth_db::Database as _;
     use reth_db::mdbx::DatabaseArguments;
     use reth_db::transaction::{DbTx as _, DbTxMut as _};
-    use reth_db::Database as _;
 
     /// Build a `BlockMigrationService` whose only meaningful field is `db`.
     /// All other dependencies are placeholders sufficient to construct but
@@ -871,8 +870,8 @@ mod tests {
     /// so same-block promotions must also write `included_height` before
     /// `promoted_height` during migration.
     #[tokio::test]
-    async fn persist_block_same_block_submit_publish_promotion_sets_both_heights(
-    ) -> eyre::Result<()> {
+    async fn persist_block_same_block_submit_publish_promotion_sets_both_heights()
+    -> eyre::Result<()> {
         let (db, _db_tmp) = open_db()?;
         let (svc, _svc_tmp) = make_service(db.clone());
 

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -56,8 +56,17 @@ impl BlockMigrationService {
     /// contains the confirming block hash and `expiry_height` is `None`.
     /// Orphan block hashes from `blocks_to_clear` are scrubbed from any
     /// `block_set` that retained them so the hint stays meaningful across
-    /// reorgs.  This is the migration-time backstop for cases where the
-    /// `BlockConfirmed`-driven fast path in mempool did not run or failed.
+    /// reorgs.
+    ///
+    /// Phase 3 is the migration-time backstop for cases where the
+    /// `BlockConfirmed`-driven fast path in mempool did not run or failed —
+    /// but it is **update-only**: `update_data_root_block_set` is a no-op for
+    /// data_roots with no existing [`CachedDataRoot`] row.  In practice this
+    /// is the right scope: a node only holds a `CachedDataRoot` for a tx if
+    /// it has the chunks (`cache_chunk` rejects writes without one), so a
+    /// missing CDR ⇒ no chunks ⇒ nothing to ingress-proof, and the absent
+    /// `block_set` entry has no observable effect.  Missed-`BlockConfirmed` +
+    /// missing-CDR remains an unrecovered combination but is unobservable.
     ///
     /// **Transient state between Phase 1 and Phase 2 (within the same DB
     /// transaction):**  Phase 1 may clear `included_height` from a row whose
@@ -76,6 +85,32 @@ impl BlockMigrationService {
         blocks_to_clear: &[Arc<SealedBlock>],
         blocks_to_confirm: &[Arc<SealedBlock>],
     ) -> eyre::Result<()> {
+        // Phase 1 scrub and Phase 3 append both iterate
+        // `block.transactions().get_ledger_txs(DataLedger::Submit)`. That call
+        // returns `&[]` for a SealedBlock whose body has been stripped, even
+        // if `header.data_ledgers[Submit].tx_ids` is populated — silently
+        // skipping every `block_set` mutation.  The in-memory block-tree path
+        // always carries full transactions, but future code paths (e.g. blocks
+        // hydrated from disk without their body) could regress this without
+        // any error.  Catch the divergence in debug builds.
+        for block in blocks_to_clear.iter().chain(blocks_to_confirm.iter()) {
+            let header_submit_count = block
+                .header()
+                .data_ledgers
+                .iter()
+                .find(|dl| dl.ledger_id == DataLedger::Submit as u32)
+                .map_or(0, |dl| dl.tx_ids.0.len());
+            let body_submit_count = block.transactions().get_ledger_txs(DataLedger::Submit).len();
+            debug_assert_eq!(
+                header_submit_count,
+                body_submit_count,
+                "SealedBlock {} has header/body Submit-tx count mismatch ({} vs {}); transactions appear stripped — block_set mutations would silently no-op",
+                block.header().block_hash,
+                header_submit_count,
+                body_submit_count,
+            );
+        }
+
         self.db.update_eyre(|tx| {
             // Phase 1: Clear orphaned tx metadata, and scrub the orphaned
             // block_hash from any CachedDataRoot.block_set that retained it.

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -42,7 +42,6 @@ impl BlockMigrationService {
             chunk_migration_sender,
         }
     }
-
     /// Atomically persists tx metadata (included_height, promoted_height) and
     /// keeps the `CachedDataRoots.block_set` hint consistent with the canonical
     /// chain.

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -100,7 +100,10 @@ impl BlockMigrationService {
                 .iter()
                 .find(|dl| dl.ledger_id == DataLedger::Submit as u32)
                 .map_or(0, |dl| dl.tx_ids.0.len());
-            let body_submit_count = block.transactions().get_ledger_txs(DataLedger::Submit).len();
+            let body_submit_count = block
+                .transactions()
+                .get_ledger_txs(DataLedger::Submit)
+                .len();
             debug_assert_eq!(
                 header_submit_count,
                 body_submit_count,
@@ -134,17 +137,14 @@ impl BlockMigrationService {
                         continue;
                     }
                     if dl.ledger_id == DataLedger::Publish as u32 {
-                        irys_database::batch_clear_data_tx_promoted_height(tx, tx_ids)
-                            .map_err(|e| eyre::eyre!("{:?}", e))?;
+                        irys_database::batch_clear_data_tx_promoted_height(tx, tx_ids)?;
                     } else {
                         // Term ledger (Submit / OneYear / ThirtyDay)
-                        irys_database::batch_clear_data_tx_included_height(tx, tx_ids)
-                            .map_err(|e| eyre::eyre!("{:?}", e))?;
+                        irys_database::batch_clear_data_tx_included_height(tx, tx_ids)?;
                     }
                 }
                 if !commitment_ids.is_empty() {
-                    irys_database::batch_clear_commitment_tx_metadata(tx, commitment_ids)
-                        .map_err(|e| eyre::eyre!("{:?}", e))?;
+                    irys_database::batch_clear_commitment_tx_metadata(tx, commitment_ids)?;
                 }
 
                 for submit_tx in block.transactions().get_ledger_txs(DataLedger::Submit) {
@@ -152,21 +152,28 @@ impl BlockMigrationService {
                         tx,
                         submit_tx.data_root,
                         orphan_block_hash,
-                    )
-                    .map_err(|e| eyre::eyre!("{:?}", e))?;
+                    )?;
                 }
             }
-            // Phase 2: Write confirmed metadata
+            // Phase 2: Write confirmed metadata.
+            // Phase 3: Backstop the CachedDataRoot.block_set invariant for the
+            //          canonical Submit-ledger txs we just confirmed (update-only,
+            //          does not create cache entries for data_roots the node
+            //          never tracked chunks for).
             //
             // `included_height` ↔ term ledgers (Submit, OneYear, ThirtyDay) only.
             // `promoted_height` ↔ Publish ledger only.
             // Writing `included_height` for Publish txs would overwrite the
             // Submit-block height that was set when the tx first entered the
             // Submit ledger, violating the "first included in Submit" invariant.
+            // Phase 3 reads tx bodies (not the metadata written in Phase 2), so
+            // it has no ordering dependency on Phase 2 writes and is folded into
+            // the same outer loop.
             for block in blocks_to_confirm {
                 let header = block.header();
                 let commitment_ids = header.commitment_tx_ids();
                 let height = header.height;
+                let block_hash = header.block_hash;
 
                 // NOTE: same-block Submit→Publish promotions are valid. Keep
                 // the term-ledger pass first so `included_height` is written
@@ -183,8 +190,7 @@ impl BlockMigrationService {
                         continue;
                     }
                     // Term ledger (Submit / OneYear / ThirtyDay): set included_height.
-                    irys_database::batch_set_data_tx_included_height(tx, tx_ids, height)
-                        .map_err(|e| eyre::eyre!("{:?}", e))?;
+                    irys_database::batch_set_data_tx_included_height(tx, tx_ids, height)?;
                 }
                 for dl in header
                     .data_ledgers
@@ -196,27 +202,19 @@ impl BlockMigrationService {
                         continue;
                     }
                     // Publish: only set promoted_height, never touch included_height.
-                    irys_database::batch_set_data_tx_promoted_height(tx, tx_ids, height)
-                        .map_err(|e| eyre::eyre!("{:?}", e))?;
+                    irys_database::batch_set_data_tx_promoted_height(tx, tx_ids, height)?;
                 }
                 if !commitment_ids.is_empty() {
                     irys_database::batch_set_commitment_tx_included_height(
                         tx,
                         commitment_ids,
                         height,
-                    )
-                    .map_err(|e| eyre::eyre!("{:?}", e))?;
+                    )?;
                 }
-            }
-            // Phase 3: Backstop the CachedDataRoot.block_set invariant for the
-            // canonical Submit-ledger txs we just confirmed.  Update-only —
-            // does not create cache entries for data_roots the node never
-            // tracked chunks for.
-            for block in blocks_to_confirm {
-                let block_hash = block.header().block_hash;
+
+                // Phase 3: append `block_hash` to each Submit-tx's CDR.block_set.
                 for submit_tx in block.transactions().get_ledger_txs(DataLedger::Submit) {
-                    irys_database::update_data_root_block_set(tx, submit_tx.data_root, block_hash)
-                        .map_err(|e| eyre::eyre!("{:?}", e))?;
+                    irys_database::update_data_root_block_set(tx, submit_tx.data_root, block_hash)?;
                 }
             }
             Ok(())
@@ -406,8 +404,7 @@ impl BlockMigrationService {
                     continue;
                 }
                 // `included_height` ↔ term ledgers only; never overwrite for Publish.
-                irys_database::batch_set_data_tx_included_height(tx, tx_ids, block_height)
-                    .map_err(|e| eyre::eyre!("{:?}", e))?;
+                irys_database::batch_set_data_tx_included_height(tx, tx_ids, block_height)?;
             }
             for dl in header
                 .data_ledgers
@@ -419,8 +416,7 @@ impl BlockMigrationService {
                     continue;
                 }
                 // `promoted_height` ↔ Publish ledger only.
-                irys_database::batch_set_data_tx_promoted_height(tx, tx_ids, block_height)
-                    .map_err(|e| eyre::eyre!("{:?}", e))?;
+                irys_database::batch_set_data_tx_promoted_height(tx, tx_ids, block_height)?;
             }
 
             if !commitment_tx_ids.is_empty() {
@@ -428,8 +424,7 @@ impl BlockMigrationService {
                     tx,
                     commitment_tx_ids,
                     block_height,
-                )
-                .map_err(|e| eyre::eyre!("{:?}", e))?;
+                )?;
             }
 
             irys_database::insert_block_header(tx, &migrated_block)?;

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -24,36 +24,51 @@ pub struct BlockMigrationService {
     chunk_migration_sender: UnboundedSender<Traced<ChunkMigrationServiceMessage>>,
 }
 
-/// Asserts the block's body carries exactly the Submit-ledger tx_ids its
-/// header advertises.  `transactions().get_ledger_txs(DataLedger::Submit)`
-/// returns `&[]` for a SealedBlock whose body has been stripped, even if
-/// `header.data_ledgers[Submit].tx_ids` is populated — every downstream loop
-/// that iterates body txs (block_set mutation, tx-header insertion, etc.)
-/// would silently no-op.  Compare as sorted lists — same-length-different-ids
-/// must also fail loudly.
-fn ensure_submit_header_body_consistent(block: &SealedBlock) -> eyre::Result<()> {
-    let mut header_ids: Vec<H256> = block
-        .header()
-        .data_ledgers
-        .iter()
-        .find(|dl| dl.ledger_id == DataLedger::Submit as u32)
-        .map(|dl| dl.tx_ids.0.clone())
-        .unwrap_or_default();
-    let mut body_ids: Vec<H256> = block
-        .transactions()
-        .get_ledger_txs(DataLedger::Submit)
-        .iter()
-        .map(|tx| tx.id)
-        .collect();
-    header_ids.sort();
-    body_ids.sort();
-    ensure!(
-        header_ids == body_ids,
-        "SealedBlock {} has header/body Submit-tx mismatch; transactions appear stripped or diverged — header={:?} body={:?}",
-        block.header().block_hash,
-        header_ids,
-        body_ids,
-    );
+/// Asserts the block's body carries exactly the tx_ids its header advertises,
+/// for every data ledger (Submit / Publish / OneYear / ThirtyDay).
+///
+/// `transactions().get_ledger_txs(ledger)` returns `&[]` for a SealedBlock
+/// whose body has been stripped, even if `header.data_ledgers[ledger].tx_ids`
+/// is populated — every downstream loop that iterates body txs (block_set
+/// mutation, `insert_tx_header`, etc.) silently no-ops, while
+/// `write_data_ledger_metadata` reads from `header.data_ledgers` and writes
+/// `included_height` / `promoted_height` anyway.  The result is metadata rows
+/// for tx_ids that `IrysDataTxHeaders` has no entry for —
+/// `tx_header_by_txid_canonical` then returns `Ok(None)` for those tx_ids
+/// (see `database.rs:207-209`), silently masking the divergence.
+///
+/// Compare as sorted lists — same-length-different-ids must also fail loudly.
+fn ensure_header_body_consistent(block: &SealedBlock) -> eyre::Result<()> {
+    for ledger in [
+        DataLedger::Submit,
+        DataLedger::Publish,
+        DataLedger::OneYear,
+        DataLedger::ThirtyDay,
+    ] {
+        let mut header_ids: Vec<H256> = block
+            .header()
+            .data_ledgers
+            .iter()
+            .find(|dl| dl.ledger_id == ledger as u32)
+            .map(|dl| dl.tx_ids.0.clone())
+            .unwrap_or_default();
+        let mut body_ids: Vec<H256> = block
+            .transactions()
+            .get_ledger_txs(ledger)
+            .iter()
+            .map(|tx| tx.id)
+            .collect();
+        header_ids.sort();
+        body_ids.sort();
+        ensure!(
+            header_ids == body_ids,
+            "SealedBlock {} has header/body {:?} tx mismatch; transactions appear stripped or diverged — header={:?} body={:?}",
+            block.header().block_hash,
+            ledger,
+            header_ids,
+            body_ids,
+        );
+    }
     Ok(())
 }
 
@@ -164,14 +179,16 @@ impl BlockMigrationService {
         blocks_to_confirm: &[Arc<SealedBlock>],
     ) -> eyre::Result<()> {
         // Phase 1 scrub and Phase 3 append both iterate
-        // `block.transactions().get_ledger_txs(DataLedger::Submit)`.  The
-        // in-memory block-tree path always carries full transactions, but
-        // future code paths (e.g. blocks hydrated from disk without their
-        // body) could regress this without any error.  Surface the divergence
-        // in every build so the caller fails loudly rather than committing
-        // partial state.
+        // `block.transactions().get_ledger_txs(...)`.  The in-memory
+        // block-tree path always carries full transactions, but future code
+        // paths (e.g. blocks hydrated from disk without their body) could
+        // regress this without any error.  Surface the divergence in every
+        // build so the caller fails loudly rather than committing partial
+        // state.  Checked across all data ledgers because Phase 2's
+        // `write_data_ledger_metadata` writes from `header.data_ledgers` for
+        // every ledger, not just Submit.
         for block in blocks_to_clear.iter().chain(blocks_to_confirm.iter()) {
-            ensure_submit_header_body_consistent(block)?;
+            ensure_header_body_consistent(block)?;
         }
 
         // Defense-in-depth structural check on the reorg invariant documented
@@ -433,8 +450,10 @@ impl BlockMigrationService {
         // inserting zero tx-header rows from `transactions().get_ledger_txs`,
         // leaving canonical metadata pointing at txs `IrysDataTxHeaders` has
         // no entry for.  `tx_inclusion::find_canonical_ledger_range` and the
-        // prior-Submit fallback both depend on those rows existing.
-        ensure_submit_header_body_consistent(sealed_block)?;
+        // prior-Submit fallback both depend on those rows existing.  Checked
+        // for every data ledger since `write_data_ledger_metadata` below
+        // touches all of them.
+        ensure_header_body_consistent(sealed_block)?;
 
         let header = sealed_block.header();
         let transactions = sealed_block.transactions();
@@ -1353,6 +1372,56 @@ mod tests {
             Some(20),
             "CDR B expiry_height must remain untouched — Phase 3 doesn't run \
              when the tx is absent from `blocks_to_confirm`"
+        );
+
+        Ok(())
+    }
+
+    /// Regression for the broadened `ensure_header_body_consistent` check:
+    /// every data ledger (Submit / Publish / OneYear / ThirtyDay) must
+    /// trigger the guard when its header advertises a tx_id its body lacks.
+    /// Prior to broadening, only Submit was checked, so a stripped
+    /// OneYear/ThirtyDay/Publish body would silently write `included_height` /
+    /// `promoted_height` rows for tx_ids `IrysDataTxHeaders` has no entry
+    /// for — `tx_header_by_txid_canonical` then returns `Ok(None)` for them.
+    #[rstest::rstest]
+    #[case::submit(DataLedger::Submit)]
+    #[case::publish(DataLedger::Publish)]
+    #[case::oneyear(DataLedger::OneYear)]
+    #[case::thirtyday(DataLedger::ThirtyDay)]
+    #[tokio::test]
+    async fn persist_metadata_rejects_stripped_body_for_any_ledger(
+        #[case] ledger: DataLedger,
+    ) -> eyre::Result<()> {
+        let (db, _db_tmp) = open_db()?;
+        let (svc, _svc_tmp) = make_service(db);
+
+        let tx_id = H256::random();
+        let header = make_block_header_with_ledger(1, H256::random(), ledger, tx_id);
+        // Stripped body: header advertises `tx_id` in `ledger`, but the
+        // BlockTransactions map has no entry for that ledger at all.
+        let stripped = Arc::new(SealedBlock::new_unchecked(
+            Arc::new(header),
+            BlockTransactions::default(),
+        ));
+
+        let err = svc
+            .persist_metadata(&[], std::slice::from_ref(&stripped))
+            .expect_err("stripped body must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("header/body") && msg.contains(&format!("{ledger:?}")),
+            "error must call out the offending ledger; got: {msg}"
+        );
+
+        // And the same for `persist_block`, which mirrors the guard.
+        let err = svc
+            .persist_block(&stripped)
+            .expect_err("persist_block stripped body must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("header/body") && msg.contains(&format!("{ledger:?}")),
+            "persist_block error must call out the offending ledger; got: {msg}"
         );
 
         Ok(())

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -24,6 +24,39 @@ pub struct BlockMigrationService {
     chunk_migration_sender: UnboundedSender<Traced<ChunkMigrationServiceMessage>>,
 }
 
+/// Asserts the block's body carries exactly the Submit-ledger tx_ids its
+/// header advertises.  `transactions().get_ledger_txs(DataLedger::Submit)`
+/// returns `&[]` for a SealedBlock whose body has been stripped, even if
+/// `header.data_ledgers[Submit].tx_ids` is populated — every downstream loop
+/// that iterates body txs (block_set mutation, tx-header insertion, etc.)
+/// would silently no-op.  Compare as sorted lists — same-length-different-ids
+/// must also fail loudly.
+fn ensure_submit_header_body_consistent(block: &SealedBlock) -> eyre::Result<()> {
+    let mut header_ids: Vec<H256> = block
+        .header()
+        .data_ledgers
+        .iter()
+        .find(|dl| dl.ledger_id == DataLedger::Submit as u32)
+        .map(|dl| dl.tx_ids.0.clone())
+        .unwrap_or_default();
+    let mut body_ids: Vec<H256> = block
+        .transactions()
+        .get_ledger_txs(DataLedger::Submit)
+        .iter()
+        .map(|tx| tx.id)
+        .collect();
+    header_ids.sort();
+    body_ids.sort();
+    ensure!(
+        header_ids == body_ids,
+        "SealedBlock {} has header/body Submit-tx mismatch; transactions appear stripped or diverged — header={:?} body={:?}",
+        block.header().block_hash,
+        header_ids,
+        body_ids,
+    );
+    Ok(())
+}
+
 /// Write `included_height` for term ledgers and `promoted_height` for the
 /// Publish ledger from a single block's `data_ledgers` slice.
 ///
@@ -131,32 +164,14 @@ impl BlockMigrationService {
         blocks_to_confirm: &[Arc<SealedBlock>],
     ) -> eyre::Result<()> {
         // Phase 1 scrub and Phase 3 append both iterate
-        // `block.transactions().get_ledger_txs(DataLedger::Submit)`. That call
-        // returns `&[]` for a SealedBlock whose body has been stripped, even
-        // if `header.data_ledgers[Submit].tx_ids` is populated — silently
-        // skipping every `block_set` mutation.  The in-memory block-tree path
-        // always carries full transactions, but future code paths (e.g.
-        // blocks hydrated from disk without their body) could regress this
-        // without any error.  Surface the divergence in every build so the
-        // caller fails loudly rather than committing partial state.
+        // `block.transactions().get_ledger_txs(DataLedger::Submit)`.  The
+        // in-memory block-tree path always carries full transactions, but
+        // future code paths (e.g. blocks hydrated from disk without their
+        // body) could regress this without any error.  Surface the divergence
+        // in every build so the caller fails loudly rather than committing
+        // partial state.
         for block in blocks_to_clear.iter().chain(blocks_to_confirm.iter()) {
-            let header_submit_count = block
-                .header()
-                .data_ledgers
-                .iter()
-                .find(|dl| dl.ledger_id == DataLedger::Submit as u32)
-                .map_or(0, |dl| dl.tx_ids.0.len());
-            let body_submit_count = block
-                .transactions()
-                .get_ledger_txs(DataLedger::Submit)
-                .len();
-            ensure!(
-                header_submit_count == body_submit_count,
-                "SealedBlock {} has header/body Submit-tx count mismatch ({} vs {}); transactions appear stripped — block_set mutations would silently no-op",
-                block.header().block_hash,
-                header_submit_count,
-                body_submit_count,
-            );
+            ensure_submit_header_body_consistent(block)?;
         }
 
         // Defense-in-depth structural check on the reorg invariant documented
@@ -413,6 +428,14 @@ impl BlockMigrationService {
     /// Persists block data and block index in a single atomic DB transaction.
     #[tracing::instrument(level = "trace", skip_all, fields(block.hash = %sealed_block.header().block_hash, block.height = sealed_block.header().height))]
     fn persist_block(&self, sealed_block: &SealedBlock) -> eyre::Result<()> {
+        // Mirror of the `persist_metadata` guard: a stripped body would write
+        // ledger metadata + block index from `header.data_ledgers` while
+        // inserting zero tx-header rows from `transactions().get_ledger_txs`,
+        // leaving canonical metadata pointing at txs `IrysDataTxHeaders` has
+        // no entry for.  `tx_inclusion::find_canonical_ledger_range` and the
+        // prior-Submit fallback both depend on those rows existing.
+        ensure_submit_header_body_consistent(sealed_block)?;
+
         let header = sealed_block.header();
         let transactions = sealed_block.transactions();
 

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -778,39 +778,23 @@ mod tests {
         Ok(())
     }
 
-    /// OneYear direct inclusion (no prior Submit): `included_height` set, `promoted_height` None.
+    /// Direct inclusion in a term ledger (no prior Submit):
+    /// `included_height` is set, `promoted_height` stays `None`.
+    #[rstest::rstest]
+    #[case::oneyear(DataLedger::OneYear, 3_u64)]
+    #[case::thirtyday(DataLedger::ThirtyDay, 7_u64)]
     #[tokio::test]
-    async fn oneyear_direct_inclusion_sets_included_height() -> eyre::Result<()> {
+    async fn direct_inclusion_sets_included_height(
+        #[case] ledger: DataLedger,
+        #[case] height: u64,
+    ) -> eyre::Result<()> {
         let (db, _db_tmp) = open_db()?;
         let (svc, _svc_tmp) = make_service(db.clone());
 
         let tx_id = H256::random();
-        let height = 3_u64;
 
-        let header =
-            make_block_header_with_ledger(height, H256::random(), DataLedger::OneYear, tx_id);
-        let sealed = make_sealed_single_ledger_tx(header, DataLedger::OneYear, tx_id);
-        svc.persist_metadata(&[], std::slice::from_ref(&sealed))?;
-
-        let meta =
-            read_data_tx_metadata(&db, &tx_id).expect("metadata must exist after confirmation");
-        assert_eq!(meta.included_height, Some(height));
-        assert_eq!(meta.promoted_height, None);
-        Ok(())
-    }
-
-    /// ThirtyDay direct inclusion: analogous to OneYear.
-    #[tokio::test]
-    async fn thirtyday_direct_inclusion_sets_included_height() -> eyre::Result<()> {
-        let (db, _db_tmp) = open_db()?;
-        let (svc, _svc_tmp) = make_service(db.clone());
-
-        let tx_id = H256::random();
-        let height = 7_u64;
-
-        let header =
-            make_block_header_with_ledger(height, H256::random(), DataLedger::ThirtyDay, tx_id);
-        let sealed = make_sealed_single_ledger_tx(header, DataLedger::ThirtyDay, tx_id);
+        let header = make_block_header_with_ledger(height, H256::random(), ledger, tx_id);
+        let sealed = make_sealed_single_ledger_tx(header, ledger, tx_id);
         svc.persist_metadata(&[], std::slice::from_ref(&sealed))?;
 
         let meta =
@@ -899,19 +883,23 @@ mod tests {
         Ok(())
     }
 
-    /// Phase 1 orphan of OneYear confirmation: tx in OneYear at H.
-    /// Orphan. `included_height` cleared.
+    /// Phase 1 orphan of a term-ledger confirmation: tx in `ledger` at H.
+    /// Orphan. `included_height` cleared and the row is deleted.
+    #[rstest::rstest]
+    #[case::oneyear(DataLedger::OneYear, 6_u64)]
+    #[case::thirtyday(DataLedger::ThirtyDay, 9_u64)]
     #[tokio::test]
-    async fn phase1_orphan_oneyear_clears_included_height() -> eyre::Result<()> {
+    async fn phase1_orphan_term_ledger_clears_included_height(
+        #[case] ledger: DataLedger,
+        #[case] height: u64,
+    ) -> eyre::Result<()> {
         let (db, _db_tmp) = open_db()?;
         let (svc, _svc_tmp) = make_service(db.clone());
 
         let tx_id = H256::random();
-        let height = 6_u64;
 
-        let header =
-            make_block_header_with_ledger(height, H256::random(), DataLedger::OneYear, tx_id);
-        let sealed = make_sealed_single_ledger_tx(header, DataLedger::OneYear, tx_id);
+        let header = make_block_header_with_ledger(height, H256::random(), ledger, tx_id);
+        let sealed = make_sealed_single_ledger_tx(header, ledger, tx_id);
         svc.persist_metadata(&[], std::slice::from_ref(&sealed))?;
 
         assert!(read_data_tx_metadata(&db, &tx_id).is_some());
@@ -920,33 +908,7 @@ mod tests {
 
         assert!(
             read_data_tx_metadata(&db, &tx_id).is_none(),
-            "row must be deleted when OneYear-block is orphaned"
-        );
-        Ok(())
-    }
-
-    /// Phase 1 orphan of ThirtyDay confirmation: tx in ThirtyDay at H.
-    /// Orphan. `included_height` cleared.
-    #[tokio::test]
-    async fn phase1_orphan_thirtyday_clears_included_height() -> eyre::Result<()> {
-        let (db, _db_tmp) = open_db()?;
-        let (svc, _svc_tmp) = make_service(db.clone());
-
-        let tx_id = H256::random();
-        let height = 9_u64;
-
-        let header =
-            make_block_header_with_ledger(height, H256::random(), DataLedger::ThirtyDay, tx_id);
-        let sealed = make_sealed_single_ledger_tx(header, DataLedger::ThirtyDay, tx_id);
-        svc.persist_metadata(&[], std::slice::from_ref(&sealed))?;
-
-        assert!(read_data_tx_metadata(&db, &tx_id).is_some());
-
-        svc.persist_metadata(std::slice::from_ref(&sealed), &[])?;
-
-        assert!(
-            read_data_tx_metadata(&db, &tx_id).is_none(),
-            "row must be deleted when ThirtyDay-block is orphaned"
+            "row must be deleted when {ledger:?}-block is orphaned"
         );
         Ok(())
     }

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -1,10 +1,10 @@
 use crate::chunk_migration_service::ChunkMigrationServiceMessage;
-use eyre::{OptionExt as _, ensure};
+use eyre::{ensure, OptionExt as _};
 use irys_database::{db::IrysDatabaseExt as _, insert_commitment_tx, insert_tx_header};
-use irys_domain::{BlockIndex, BlockTree, SupplyState, block_index_guard::BlockIndexReadGuard};
+use irys_domain::{block_index_guard::BlockIndexReadGuard, BlockIndex, BlockTree, SupplyState};
 use irys_types::{
-    DataLedger, DataTransactionHeader, IrysBlockHeader, SealedBlock, SendTraced as _, SystemLedger,
-    Traced, app_state::DatabaseProvider,
+    app_state::DatabaseProvider, DataLedger, DataTransactionHeader, IrysBlockHeader, SealedBlock,
+    SendTraced as _, SystemLedger, Traced,
 };
 use std::{
     collections::HashMap,
@@ -133,21 +133,36 @@ impl BlockMigrationService {
                 let commitment_ids = header.commitment_tx_ids();
                 let height = header.height;
 
-                for dl in &header.data_ledgers {
+                // NOTE: same-block Submit→Publish promotions are valid. Keep
+                // the term-ledger pass first so `included_height` is written
+                // before any Publish-ledger `promoted_height` write for the
+                // same tx_id; `set_data_tx_promoted_height` requires
+                // `included_height` to already exist.
+                for dl in header
+                    .data_ledgers
+                    .iter()
+                    .filter(|dl| dl.ledger_id != DataLedger::Publish as u32)
+                {
                     let tx_ids = &dl.tx_ids.0;
                     if tx_ids.is_empty() {
                         continue;
                     }
-
-                    if dl.ledger_id == DataLedger::Publish as u32 {
-                        // Publish: only set promoted_height, never touch included_height.
-                        irys_database::batch_set_data_tx_promoted_height(tx, tx_ids, height)
-                            .map_err(|e| eyre::eyre!("{:?}", e))?;
-                    } else {
-                        // Term ledger (Submit / OneYear / ThirtyDay): set included_height.
-                        irys_database::batch_set_data_tx_included_height(tx, tx_ids, height)
-                            .map_err(|e| eyre::eyre!("{:?}", e))?;
+                    // Term ledger (Submit / OneYear / ThirtyDay): set included_height.
+                    irys_database::batch_set_data_tx_included_height(tx, tx_ids, height)
+                        .map_err(|e| eyre::eyre!("{:?}", e))?;
+                }
+                for dl in header
+                    .data_ledgers
+                    .iter()
+                    .filter(|dl| dl.ledger_id == DataLedger::Publish as u32)
+                {
+                    let tx_ids = &dl.tx_ids.0;
+                    if tx_ids.is_empty() {
+                        continue;
                     }
+                    // Publish: only set promoted_height, never touch included_height.
+                    irys_database::batch_set_data_tx_promoted_height(tx, tx_ids, height)
+                        .map_err(|e| eyre::eyre!("{:?}", e))?;
                 }
                 if !commitment_ids.is_empty() {
                     irys_database::batch_set_commitment_tx_included_height(
@@ -328,7 +343,6 @@ impl BlockMigrationService {
                 let ledger = DataLedger::try_from(dl.ledger_id)
                     .map_err(|_| eyre::eyre!("Unknown ledger_id {}", dl.ledger_id))?;
                 let mut ledger_txs = transactions.get_ledger_txs(ledger).to_vec();
-                let tx_ids = &dl.tx_ids.0;
 
                 // Publish txs get promoted_height set on their headers
                 if ledger == DataLedger::Publish {
@@ -342,18 +356,36 @@ impl BlockMigrationService {
                 for data_tx in &ledger_txs {
                     insert_tx_header(tx, data_tx)?;
                 }
+            }
 
-                if !tx_ids.is_empty() {
-                    // `included_height` ↔ term ledgers only; never overwrite for Publish.
-                    // `promoted_height` ↔ Publish ledger only.
-                    if ledger == DataLedger::Publish {
-                        irys_database::batch_set_data_tx_promoted_height(tx, tx_ids, block_height)
-                            .map_err(|e| eyre::eyre!("{:?}", e))?;
-                    } else {
-                        irys_database::batch_set_data_tx_included_height(tx, tx_ids, block_height)
-                            .map_err(|e| eyre::eyre!("{:?}", e))?;
-                    }
+            // NOTE: same-block Submit→Publish promotions are valid. Keep the
+            // term-ledger pass first so `included_height` exists before the
+            // Publish-ledger pass writes `promoted_height` for the same tx_id.
+            for dl in header
+                .data_ledgers
+                .iter()
+                .filter(|dl| dl.ledger_id != DataLedger::Publish as u32)
+            {
+                let tx_ids = &dl.tx_ids.0;
+                if tx_ids.is_empty() {
+                    continue;
                 }
+                // `included_height` ↔ term ledgers only; never overwrite for Publish.
+                irys_database::batch_set_data_tx_included_height(tx, tx_ids, block_height)
+                    .map_err(|e| eyre::eyre!("{:?}", e))?;
+            }
+            for dl in header
+                .data_ledgers
+                .iter()
+                .filter(|dl| dl.ledger_id == DataLedger::Publish as u32)
+            {
+                let tx_ids = &dl.tx_ids.0;
+                if tx_ids.is_empty() {
+                    continue;
+                }
+                // `promoted_height` ↔ Publish ledger only.
+                irys_database::batch_set_data_tx_promoted_height(tx, tx_ids, block_height)
+                    .map_err(|e| eyre::eyre!("{:?}", e))?;
             }
 
             if !commitment_tx_ids.is_empty() {
@@ -409,19 +441,20 @@ mod tests {
     //! satisfied with cheap placeholders.
     use super::*;
     use irys_database::{
-        IrysDatabaseArgs as _, cache_data_root, open_or_create_db,
+        cache_data_root, open_or_create_db,
         tables::{CachedDataRoots, IrysTables},
+        IrysDatabaseArgs as _,
     };
     use irys_domain::BlockTree;
     use irys_testing_utils::IrysBlockHeaderTestExt as _;
     use irys_types::{
         BlockTransactions, ConsensusConfig, DataTransactionHeader, DataTransactionHeaderV1,
-        DataTransactionHeaderV1WithMetadata, DataTransactionMetadata, H256, H256List,
-        IrysBlockHeader, U256,
+        DataTransactionHeaderV1WithMetadata, DataTransactionMetadata, H256List, IrysBlockHeader,
+        H256, U256,
     };
-    use reth_db::Database as _;
     use reth_db::mdbx::DatabaseArguments;
     use reth_db::transaction::{DbTx as _, DbTxMut as _};
+    use reth_db::Database as _;
 
     /// Build a `BlockMigrationService` whose only meaningful field is `db`.
     /// All other dependencies are placeholders sufficient to construct but
@@ -723,6 +756,38 @@ mod tests {
         Arc::new(SealedBlock::new_unchecked(Arc::new(header), body))
     }
 
+    /// Wrap a header in a `SealedBlock` whose body carries the same tx_id in
+    /// both Submit and Publish. This models a same-block promotion.
+    fn make_sealed_same_block_submit_publish_promotion(
+        mut header: IrysBlockHeader,
+        tx_id: H256,
+        data_root: H256,
+    ) -> Arc<SealedBlock> {
+        header.data_ledgers[DataLedger::Publish].tx_ids = H256List(vec![tx_id]);
+        header.data_ledgers[DataLedger::Submit].tx_ids = H256List(vec![tx_id]);
+
+        let tx_header = DataTransactionHeader::V1(DataTransactionHeaderV1WithMetadata {
+            tx: DataTransactionHeaderV1 {
+                id: tx_id,
+                data_root,
+                // Submit-ledger entries already carry Publish-targeting txs.
+                ledger_id: DataLedger::Publish as u32,
+                ..Default::default()
+            },
+            metadata: DataTransactionMetadata::new(),
+        });
+
+        let mut data_txs_map = HashMap::new();
+        data_txs_map.insert(DataLedger::Publish, vec![tx_header.clone()]);
+        data_txs_map.insert(DataLedger::Submit, vec![tx_header]);
+
+        let body = BlockTransactions {
+            data_txs: data_txs_map,
+            ..Default::default()
+        };
+        Arc::new(SealedBlock::new_unchecked(Arc::new(header), body))
+    }
+
     fn read_data_tx_metadata(
         db: &DatabaseProvider,
         tx_id: &H256,
@@ -775,6 +840,55 @@ mod tests {
             Some(publish_height),
             "promoted_height must be set to Publish-block height"
         );
+        Ok(())
+    }
+
+    /// Same-block Submit→Publish promotion: the term-ledger metadata write
+    /// must happen before the Publish write so `promoted_height` can be set in
+    /// the same transaction.
+    #[tokio::test]
+    async fn same_block_submit_publish_promotion_sets_both_heights() -> eyre::Result<()> {
+        let (db, _db_tmp) = open_db()?;
+        let (svc, _svc_tmp) = make_service(db.clone());
+
+        let tx_id = H256::random();
+        let data_root = H256::random();
+        let height = 11_u64;
+
+        let header = make_block_header(height, H256::random(), 50, vec![tx_id]);
+        let sealed = make_sealed_same_block_submit_publish_promotion(header, tx_id, data_root);
+
+        svc.persist_metadata(&[], std::slice::from_ref(&sealed))?;
+
+        let meta =
+            read_data_tx_metadata(&db, &tx_id).expect("metadata must exist after confirmation");
+        assert_eq!(meta.included_height, Some(height));
+        assert_eq!(meta.promoted_height, Some(height));
+        Ok(())
+    }
+
+    /// `persist_block` uses the same metadata helpers as `persist_metadata`,
+    /// so same-block promotions must also write `included_height` before
+    /// `promoted_height` during migration.
+    #[tokio::test]
+    async fn persist_block_same_block_submit_publish_promotion_sets_both_heights(
+    ) -> eyre::Result<()> {
+        let (db, _db_tmp) = open_db()?;
+        let (svc, _svc_tmp) = make_service(db.clone());
+
+        let tx_id = H256::random();
+        let data_root = H256::random();
+
+        // Height 0 avoids block-index continuity requirements in this focused
+        // unit test while still exercising the metadata write ordering.
+        let header = make_block_header(0, H256::zero(), 50, vec![tx_id]);
+        let sealed = make_sealed_same_block_submit_publish_promotion(header, tx_id, data_root);
+
+        svc.persist_block(sealed.as_ref())?;
+
+        let meta = read_data_tx_metadata(&db, &tx_id).expect("metadata must exist after migration");
+        assert_eq!(meta.included_height, Some(0));
+        assert_eq!(meta.promoted_height, Some(0));
         Ok(())
     }
 

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -1236,4 +1236,102 @@ mod tests {
 
         Ok(())
     }
+
+    /// Multi-block reorg where one cleared tx is permanently orphaned —
+    /// present in `blocks_to_clear` but NOT re-confirmed in
+    /// `blocks_to_confirm`.  Companion to
+    /// `persist_metadata_multi_block_reorg_handles_both_slices`, which only
+    /// asserts the re-confirmation case.
+    ///
+    /// Expected post-state for the permanently-orphaned tx:
+    ///   - Metadata row fully deleted (Phase 1 term-ledger unconditional
+    ///     delete; no Phase 2 recreation).
+    ///   - CDR has the orphan block hash scrubbed (Phase 1) but no new hash
+    ///     appended (Phase 3 only touches CDRs whose tx is in
+    ///     `blocks_to_confirm`).
+    ///   - CDR `expiry_height` is left untouched — the mempool reorg
+    ///     re-anchor path (`handle_confirmed_data_tx_reorg`) is responsible
+    ///     for refreshing it once the orphaned tx is re-ingested.
+    #[tokio::test]
+    async fn persist_metadata_multi_block_reorg_permanent_orphan() -> eyre::Result<()> {
+        let (db, _db_tmp) = open_db()?;
+        let (svc, _svc_tmp) = make_service(db.clone());
+
+        let tx_id_a = H256::random();
+        let data_root_a = H256::random();
+        let tx_id_b = H256::random();
+        let data_root_b = H256::random();
+
+        // Orphan fork: orphan1 carries tx_a, orphan2 carries tx_b.
+        let orphan1 = make_block_header(1, H256::random(), 50, vec![tx_id_a]);
+        let orphan1_hash = orphan1.block_hash;
+        let orphan2 = make_block_header(2, orphan1.block_hash, 50, vec![tx_id_b]);
+        let orphan2_hash = orphan2.block_hash;
+
+        // Seed CDRs and pre-write included_height as if both txs were once
+        // confirmed on the orphan fork.
+        seed_cdr(&db, data_root_a, tx_id_a, vec![orphan1_hash], Some(10));
+        seed_cdr(&db, data_root_b, tx_id_b, vec![orphan2_hash], Some(20));
+        db.update_eyre(|tx| {
+            irys_database::batch_set_data_tx_included_height(tx, &[tx_id_a], 1)?;
+            irys_database::batch_set_data_tx_included_height(tx, &[tx_id_b], 2)?;
+            Ok(())
+        })?;
+
+        // New canonical fork re-confirms ONLY tx_a.  tx_b is permanently orphaned.
+        let new1 = make_block_header(10, H256::random(), 50, vec![tx_id_a]);
+        let new1_hash = new1.block_hash;
+
+        let orphan1_sealed = make_sealed_with_submit_txs(orphan1, &[(tx_id_a, data_root_a)]);
+        let orphan2_sealed = make_sealed_with_submit_txs(orphan2, &[(tx_id_b, data_root_b)]);
+        let new1_sealed = make_sealed_with_submit_txs(new1, &[(tx_id_a, data_root_a)]);
+
+        svc.persist_metadata(&[orphan1_sealed, orphan2_sealed], &[new1_sealed])?;
+
+        // tx_a: re-confirmed on the new fork.
+        let meta_a = read_data_tx_metadata(&db, &tx_id_a)
+            .expect("tx_a metadata must exist after re-confirmation");
+        assert_eq!(
+            meta_a.included_height,
+            Some(10),
+            "tx_a included_height updated to new canonical height"
+        );
+
+        // tx_b: row fully deleted — term-ledger Phase 1 unconditional delete,
+        // no Phase 2 recreation because tx_b is not in `blocks_to_confirm`.
+        assert!(
+            read_data_tx_metadata(&db, &tx_id_b).is_none(),
+            "permanently-orphaned tx_b metadata row must be fully deleted"
+        );
+
+        // CDR A: re-confirmation path — orphan scrubbed, new canonical hash
+        // appended, expiry cleared by Phase 3.
+        let cdr_a = read_cdr(&db, data_root_a).expect("CDR A present");
+        assert!(!cdr_a.block_set.contains(&orphan1_hash));
+        assert!(cdr_a.block_set.contains(&new1_hash));
+        assert!(cdr_a.expiry_height.is_none());
+
+        // CDR B: permanent-orphan path — orphan hash scrubbed, no new hash
+        // appended (Phase 3 doesn't run for un-re-confirmed txs).  Block_set
+        // is now empty, but expiry_height stays at the pre-reorg value
+        // because Phase 3 never executed for this CDR.
+        let cdr_b = read_cdr(&db, data_root_b).expect("CDR B present");
+        assert!(
+            !cdr_b.block_set.contains(&orphan2_hash),
+            "orphan2 hash must be scrubbed from CDR B"
+        );
+        assert!(
+            cdr_b.block_set.is_empty(),
+            "CDR B block_set must be empty after permanent-orphan scrub \
+             (no Phase 3 append for un-re-confirmed tx)"
+        );
+        assert_eq!(
+            cdr_b.expiry_height,
+            Some(20),
+            "CDR B expiry_height must remain untouched — Phase 3 doesn't run \
+             when the tx is absent from `blocks_to_confirm`"
+        );
+
+        Ok(())
+    }
 }

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -58,6 +58,19 @@ impl BlockMigrationService {
     /// `block_set` that retained them so the hint stays meaningful across
     /// reorgs.  This is the migration-time backstop for cases where the
     /// `BlockConfirmed`-driven fast path in mempool did not run or failed.
+    ///
+    /// **Transient state between Phase 1 and Phase 2 (within the same DB
+    /// transaction):**  Phase 1 may clear `included_height` from a row whose
+    /// `promoted_height` is still set, leaving the row in a `{included:
+    /// None, promoted: Some}` state that `put_data_tx_metadata` would reject.
+    /// This state is allowed *only* because Phase 2 runs in the same
+    /// transaction and restores `included_height` for any tx whose
+    /// Submit-block was re-included in the new canonical chain.  External
+    /// readers never observe this gap — the transaction commits atomically.
+    /// The reorg invariant assumed here is: if a Publish-promotion remains
+    /// canonical, the underlying Submit inclusion must also be present in
+    /// `blocks_to_confirm` (otherwise the Publish block itself would be in
+    /// `blocks_to_clear`).
     pub fn persist_metadata(
         &self,
         blocks_to_clear: &[Arc<SealedBlock>],
@@ -66,19 +79,33 @@ impl BlockMigrationService {
         self.db.update_eyre(|tx| {
             // Phase 1: Clear orphaned tx metadata, and scrub the orphaned
             // block_hash from any CachedDataRoot.block_set that retained it.
+            //
+            // Per-ledger semantics:
+            //   - Term-ledger (Submit, OneYear, ThirtyDay): clear `included_height` only.
+            //     If `promoted_height` is also set (Submit tx later promoted to Publish),
+            //     the row is retained with `included_height = None` so the Publish
+            //     confirmation survives the reorg.  If neither field remains the row
+            //     is deleted.
+            //   - Publish ledger: clear `promoted_height` only.  A Submit-confirmed
+            //     `included_height` on the same tx must not be disturbed.
             for block in blocks_to_clear {
                 let header = block.header();
                 let orphan_block_hash = header.block_hash;
-                let all_data_tx_ids: Vec<_> = header
-                    .data_ledgers
-                    .iter()
-                    .flat_map(|dl| dl.tx_ids.0.iter())
-                    .collect();
                 let commitment_ids = header.commitment_tx_ids();
 
-                if !all_data_tx_ids.is_empty() {
-                    irys_database::batch_clear_data_tx_metadata(tx, all_data_tx_ids.into_iter())
-                        .map_err(|e| eyre::eyre!("{:?}", e))?;
+                for dl in &header.data_ledgers {
+                    let tx_ids = &dl.tx_ids.0;
+                    if tx_ids.is_empty() {
+                        continue;
+                    }
+                    if dl.ledger_id == DataLedger::Publish as u32 {
+                        irys_database::batch_clear_data_tx_promoted_height(tx, tx_ids)
+                            .map_err(|e| eyre::eyre!("{:?}", e))?;
+                    } else {
+                        // Term ledger (Submit / OneYear / ThirtyDay)
+                        irys_database::batch_clear_data_tx_included_height(tx, tx_ids)
+                            .map_err(|e| eyre::eyre!("{:?}", e))?;
+                    }
                 }
                 if !commitment_ids.is_empty() {
                     irys_database::batch_clear_commitment_tx_metadata(tx, commitment_ids)
@@ -95,6 +122,12 @@ impl BlockMigrationService {
                 }
             }
             // Phase 2: Write confirmed metadata
+            //
+            // `included_height` ↔ term ledgers (Submit, OneYear, ThirtyDay) only.
+            // `promoted_height` ↔ Publish ledger only.
+            // Writing `included_height` for Publish txs would overwrite the
+            // Submit-block height that was set when the tx first entered the
+            // Submit ledger, violating the "first included in Submit" invariant.
             for block in blocks_to_confirm {
                 let header = block.header();
                 let commitment_ids = header.commitment_tx_ids();
@@ -105,12 +138,14 @@ impl BlockMigrationService {
                     if tx_ids.is_empty() {
                         continue;
                     }
-                    irys_database::batch_set_data_tx_included_height(tx, tx_ids, height)
-                        .map_err(|e| eyre::eyre!("{:?}", e))?;
 
-                    // Publish ledger txs also get promoted_height
                     if dl.ledger_id == DataLedger::Publish as u32 {
+                        // Publish: only set promoted_height, never touch included_height.
                         irys_database::batch_set_data_tx_promoted_height(tx, tx_ids, height)
+                            .map_err(|e| eyre::eyre!("{:?}", e))?;
+                    } else {
+                        // Term ledger (Submit / OneYear / ThirtyDay): set included_height.
+                        irys_database::batch_set_data_tx_included_height(tx, tx_ids, height)
                             .map_err(|e| eyre::eyre!("{:?}", e))?;
                     }
                 }
@@ -309,11 +344,13 @@ impl BlockMigrationService {
                 }
 
                 if !tx_ids.is_empty() {
-                    irys_database::batch_set_data_tx_included_height(tx, tx_ids, block_height)
-                        .map_err(|e| eyre::eyre!("{:?}", e))?;
-
+                    // `included_height` ↔ term ledgers only; never overwrite for Publish.
+                    // `promoted_height` ↔ Publish ledger only.
                     if ledger == DataLedger::Publish {
                         irys_database::batch_set_data_tx_promoted_height(tx, tx_ids, block_height)
+                            .map_err(|e| eyre::eyre!("{:?}", e))?;
+                    } else {
+                        irys_database::batch_set_data_tx_included_height(tx, tx_ids, block_height)
                             .map_err(|e| eyre::eyre!("{:?}", e))?;
                     }
                 }
@@ -620,6 +657,296 @@ mod tests {
         assert!(
             cdr.expiry_height.is_none(),
             "expiry_height intentionally left untouched per helper docblock"
+        );
+        Ok(())
+    }
+
+    /// Build a block header that carries a single tx_id in the given ledger.
+    /// For ledgers not present in `new_mock_header()` (OneYear, ThirtyDay),
+    /// appends the appropriate `DataTransactionLedger` entry.
+    fn make_block_header_with_ledger(
+        height: u64,
+        previous_block_hash: H256,
+        ledger: DataLedger,
+        tx_id: H256,
+    ) -> IrysBlockHeader {
+        use irys_types::DataTransactionLedger;
+        let mut header = IrysBlockHeader::new_mock_header();
+        header.height = height;
+        header.previous_block_hash = previous_block_hash;
+        header.cumulative_diff = U256::from(height);
+
+        match ledger {
+            DataLedger::Publish | DataLedger::Submit => {
+                // These ledgers are already present in new_mock_header; just set tx_ids.
+                let entry = &mut header.data_ledgers[ledger as usize];
+                entry.tx_ids = H256List(vec![tx_id]);
+            }
+            DataLedger::OneYear | DataLedger::ThirtyDay => {
+                header.data_ledgers.push(DataTransactionLedger {
+                    ledger_id: ledger.into(),
+                    tx_root: H256::zero(),
+                    tx_ids: H256List(vec![tx_id]),
+                    total_chunks: 0,
+                    expires: Some(10),
+                    proofs: None,
+                    required_proof_count: None,
+                });
+            }
+        }
+        header.test_sign();
+        header
+    }
+
+    /// Wrap a header in a `SealedBlock` whose body carries a single
+    /// `DataTransactionHeader` for `tx_id` in `ledger`.
+    fn make_sealed_single_ledger_tx(
+        header: IrysBlockHeader,
+        ledger: DataLedger,
+        tx_id: H256,
+    ) -> Arc<SealedBlock> {
+        let tx_header = DataTransactionHeader::V1(DataTransactionHeaderV1WithMetadata {
+            tx: DataTransactionHeaderV1 {
+                id: tx_id,
+                data_root: H256::random(),
+                ledger_id: ledger as u32,
+                ..Default::default()
+            },
+            metadata: DataTransactionMetadata::new(),
+        });
+        let mut data_txs_map = HashMap::new();
+        data_txs_map.insert(ledger, vec![tx_header]);
+        let body = BlockTransactions {
+            data_txs: data_txs_map,
+            ..Default::default()
+        };
+        Arc::new(SealedBlock::new_unchecked(Arc::new(header), body))
+    }
+
+    fn read_data_tx_metadata(
+        db: &DatabaseProvider,
+        tx_id: &H256,
+    ) -> Option<DataTransactionMetadata> {
+        db.view(|tx| irys_database::get_data_tx_metadata(tx, tx_id))
+            .unwrap()
+            .unwrap()
+    }
+
+    // ---- included_height / promoted_height correctness tests ----
+
+    /// Submit→Publish promotion: after confirming in a Submit block at height H,
+    /// then a Publish block at height H+N, `included_height` must still be H
+    /// and `promoted_height` must be H+N.
+    #[tokio::test]
+    async fn submit_to_publish_promotion_preserves_included_height() -> eyre::Result<()> {
+        let (db, _db_tmp) = open_db()?;
+        let (svc, _svc_tmp) = make_service(db.clone());
+
+        let tx_id = H256::random();
+        let submit_height = 1_u64;
+        let publish_height = 5_u64;
+
+        // Confirm in Submit ledger at height 1
+        let submit_header =
+            make_block_header_with_ledger(submit_height, H256::random(), DataLedger::Submit, tx_id);
+        let submit_sealed = make_sealed_single_ledger_tx(submit_header, DataLedger::Submit, tx_id);
+        svc.persist_metadata(&[], std::slice::from_ref(&submit_sealed))?;
+
+        // Confirm same tx in Publish ledger at height 5
+        let publish_header = make_block_header_with_ledger(
+            publish_height,
+            H256::random(),
+            DataLedger::Publish,
+            tx_id,
+        );
+        let publish_sealed =
+            make_sealed_single_ledger_tx(publish_header, DataLedger::Publish, tx_id);
+        svc.persist_metadata(&[], std::slice::from_ref(&publish_sealed))?;
+
+        let meta =
+            read_data_tx_metadata(&db, &tx_id).expect("metadata must exist after confirmation");
+        assert_eq!(
+            meta.included_height,
+            Some(submit_height),
+            "included_height must stay at Submit-block height, not be overwritten by Publish"
+        );
+        assert_eq!(
+            meta.promoted_height,
+            Some(publish_height),
+            "promoted_height must be set to Publish-block height"
+        );
+        Ok(())
+    }
+
+    /// OneYear direct inclusion (no prior Submit): `included_height` set, `promoted_height` None.
+    #[tokio::test]
+    async fn oneyear_direct_inclusion_sets_included_height() -> eyre::Result<()> {
+        let (db, _db_tmp) = open_db()?;
+        let (svc, _svc_tmp) = make_service(db.clone());
+
+        let tx_id = H256::random();
+        let height = 3_u64;
+
+        let header =
+            make_block_header_with_ledger(height, H256::random(), DataLedger::OneYear, tx_id);
+        let sealed = make_sealed_single_ledger_tx(header, DataLedger::OneYear, tx_id);
+        svc.persist_metadata(&[], std::slice::from_ref(&sealed))?;
+
+        let meta =
+            read_data_tx_metadata(&db, &tx_id).expect("metadata must exist after confirmation");
+        assert_eq!(meta.included_height, Some(height));
+        assert_eq!(meta.promoted_height, None);
+        Ok(())
+    }
+
+    /// ThirtyDay direct inclusion: analogous to OneYear.
+    #[tokio::test]
+    async fn thirtyday_direct_inclusion_sets_included_height() -> eyre::Result<()> {
+        let (db, _db_tmp) = open_db()?;
+        let (svc, _svc_tmp) = make_service(db.clone());
+
+        let tx_id = H256::random();
+        let height = 7_u64;
+
+        let header =
+            make_block_header_with_ledger(height, H256::random(), DataLedger::ThirtyDay, tx_id);
+        let sealed = make_sealed_single_ledger_tx(header, DataLedger::ThirtyDay, tx_id);
+        svc.persist_metadata(&[], std::slice::from_ref(&sealed))?;
+
+        let meta =
+            read_data_tx_metadata(&db, &tx_id).expect("metadata must exist after confirmation");
+        assert_eq!(meta.included_height, Some(height));
+        assert_eq!(meta.promoted_height, None);
+        Ok(())
+    }
+
+    /// Phase 1 orphan of Publish promotion only:
+    /// tx confirmed in Submit at H, promoted in Publish at H+N.
+    /// Orphan the Publish block. `included_height` must stay at H; `promoted_height` cleared.
+    #[tokio::test]
+    async fn phase1_orphan_publish_only_preserves_submit_included_height() -> eyre::Result<()> {
+        let (db, _db_tmp) = open_db()?;
+        let (svc, _svc_tmp) = make_service(db.clone());
+
+        let tx_id = H256::random();
+        let submit_height = 2_u64;
+        let publish_height = 8_u64;
+
+        // Confirm in Submit at height 2
+        let submit_header =
+            make_block_header_with_ledger(submit_height, H256::random(), DataLedger::Submit, tx_id);
+        let submit_sealed = make_sealed_single_ledger_tx(submit_header, DataLedger::Submit, tx_id);
+        svc.persist_metadata(&[], std::slice::from_ref(&submit_sealed))?;
+
+        // Promote in Publish at height 8
+        let publish_header = make_block_header_with_ledger(
+            publish_height,
+            H256::random(),
+            DataLedger::Publish,
+            tx_id,
+        );
+        let publish_sealed =
+            make_sealed_single_ledger_tx(publish_header, DataLedger::Publish, tx_id);
+        svc.persist_metadata(&[], std::slice::from_ref(&publish_sealed))?;
+
+        // Verify both are set
+        let meta = read_data_tx_metadata(&db, &tx_id).unwrap();
+        assert_eq!(meta.included_height, Some(submit_height));
+        assert_eq!(meta.promoted_height, Some(publish_height));
+
+        // Orphan the Publish block only
+        svc.persist_metadata(std::slice::from_ref(&publish_sealed), &[])?;
+
+        let meta = read_data_tx_metadata(&db, &tx_id)
+            .expect("row must still exist: included_height is preserved");
+        assert_eq!(
+            meta.included_height,
+            Some(submit_height),
+            "Submit-block included_height must survive Publish-block orphan"
+        );
+        assert_eq!(
+            meta.promoted_height, None,
+            "promoted_height must be cleared by Phase 1"
+        );
+        Ok(())
+    }
+
+    /// Phase 1 orphan of Submit confirmation: tx in Submit at H.
+    /// Orphan that block. `included_height` cleared, row deleted.
+    #[tokio::test]
+    async fn phase1_orphan_submit_clears_included_height_and_deletes_row() -> eyre::Result<()> {
+        let (db, _db_tmp) = open_db()?;
+        let (svc, _svc_tmp) = make_service(db.clone());
+
+        let tx_id = H256::random();
+        let height = 4_u64;
+
+        let header =
+            make_block_header_with_ledger(height, H256::random(), DataLedger::Submit, tx_id);
+        let sealed = make_sealed_single_ledger_tx(header, DataLedger::Submit, tx_id);
+        svc.persist_metadata(&[], std::slice::from_ref(&sealed))?;
+
+        // Verify it exists
+        assert!(read_data_tx_metadata(&db, &tx_id).is_some());
+
+        // Orphan it
+        svc.persist_metadata(std::slice::from_ref(&sealed), &[])?;
+
+        assert!(
+            read_data_tx_metadata(&db, &tx_id).is_none(),
+            "row must be deleted when Submit-block is orphaned"
+        );
+        Ok(())
+    }
+
+    /// Phase 1 orphan of OneYear confirmation: tx in OneYear at H.
+    /// Orphan. `included_height` cleared.
+    #[tokio::test]
+    async fn phase1_orphan_oneyear_clears_included_height() -> eyre::Result<()> {
+        let (db, _db_tmp) = open_db()?;
+        let (svc, _svc_tmp) = make_service(db.clone());
+
+        let tx_id = H256::random();
+        let height = 6_u64;
+
+        let header =
+            make_block_header_with_ledger(height, H256::random(), DataLedger::OneYear, tx_id);
+        let sealed = make_sealed_single_ledger_tx(header, DataLedger::OneYear, tx_id);
+        svc.persist_metadata(&[], std::slice::from_ref(&sealed))?;
+
+        assert!(read_data_tx_metadata(&db, &tx_id).is_some());
+
+        svc.persist_metadata(std::slice::from_ref(&sealed), &[])?;
+
+        assert!(
+            read_data_tx_metadata(&db, &tx_id).is_none(),
+            "row must be deleted when OneYear-block is orphaned"
+        );
+        Ok(())
+    }
+
+    /// Phase 1 orphan of ThirtyDay confirmation: tx in ThirtyDay at H.
+    /// Orphan. `included_height` cleared.
+    #[tokio::test]
+    async fn phase1_orphan_thirtyday_clears_included_height() -> eyre::Result<()> {
+        let (db, _db_tmp) = open_db()?;
+        let (svc, _svc_tmp) = make_service(db.clone());
+
+        let tx_id = H256::random();
+        let height = 9_u64;
+
+        let header =
+            make_block_header_with_ledger(height, H256::random(), DataLedger::ThirtyDay, tx_id);
+        let sealed = make_sealed_single_ledger_tx(header, DataLedger::ThirtyDay, tx_id);
+        svc.persist_metadata(&[], std::slice::from_ref(&sealed))?;
+
+        assert!(read_data_tx_metadata(&db, &tx_id).is_some());
+
+        svc.persist_metadata(std::slice::from_ref(&sealed), &[])?;
+
+        assert!(
+            read_data_tx_metadata(&db, &tx_id).is_none(),
+            "row must be deleted when ThirtyDay-block is orphaned"
         );
         Ok(())
     }

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -24,6 +24,40 @@ pub struct BlockMigrationService {
     chunk_migration_sender: UnboundedSender<Traced<ChunkMigrationServiceMessage>>,
 }
 
+/// Write `included_height` for term ledgers and `promoted_height` for the
+/// Publish ledger from a single block's `data_ledgers` slice.
+///
+/// NOTE: Keep the term-ledger pass first — same-block Submit→Publish
+/// promotions require `included_height` to exist before
+/// `set_data_tx_promoted_height` runs for the same tx_id.
+fn write_data_ledger_metadata(
+    tx: &(impl reth_db::transaction::DbTxMut + reth_db::transaction::DbTx),
+    data_ledgers: &[irys_types::DataTransactionLedger],
+    height: u64,
+) -> Result<(), reth_db::DatabaseError> {
+    // Term ledgers (Submit / OneYear / ThirtyDay): set included_height.
+    for dl in data_ledgers
+        .iter()
+        .filter(|dl| dl.ledger_id != DataLedger::Publish as u32)
+    {
+        let tx_ids = &dl.tx_ids.0;
+        if !tx_ids.is_empty() {
+            irys_database::batch_set_data_tx_included_height(tx, tx_ids, height)?;
+        }
+    }
+    // Publish ledger: set promoted_height only — never touch included_height.
+    for dl in data_ledgers
+        .iter()
+        .filter(|dl| dl.ledger_id == DataLedger::Publish as u32)
+    {
+        let tx_ids = &dl.tx_ids.0;
+        if !tx_ids.is_empty() {
+            irys_database::batch_set_data_tx_promoted_height(tx, tx_ids, height)?;
+        }
+    }
+    Ok(())
+}
+
 impl BlockMigrationService {
     pub fn new(
         db: DatabaseProvider,
@@ -71,7 +105,8 @@ impl BlockMigrationService {
     /// **Transient state between Phase 1 and Phase 2 (within the same DB
     /// transaction):**  Phase 1 may clear `included_height` from a row whose
     /// `promoted_height` is still set, leaving the row in a `{included:
-    /// None, promoted: Some}` state that `put_data_tx_metadata` would reject.
+    /// None, promoted: Some}` state, stored directly via `tx.put` (bypassing
+    /// `put_data_tx_metadata`'s `is_included` guard).
     /// This state is allowed *only* because Phase 2 runs in the same
     /// transaction and restores `included_height` for any tx whose
     /// Submit-block was re-included in the new canonical chain.  External
@@ -175,35 +210,7 @@ impl BlockMigrationService {
                 let height = header.height;
                 let block_hash = header.block_hash;
 
-                // NOTE: same-block Submit→Publish promotions are valid. Keep
-                // the term-ledger pass first so `included_height` is written
-                // before any Publish-ledger `promoted_height` write for the
-                // same tx_id; `set_data_tx_promoted_height` requires
-                // `included_height` to already exist.
-                for dl in header
-                    .data_ledgers
-                    .iter()
-                    .filter(|dl| dl.ledger_id != DataLedger::Publish as u32)
-                {
-                    let tx_ids = &dl.tx_ids.0;
-                    if tx_ids.is_empty() {
-                        continue;
-                    }
-                    // Term ledger (Submit / OneYear / ThirtyDay): set included_height.
-                    irys_database::batch_set_data_tx_included_height(tx, tx_ids, height)?;
-                }
-                for dl in header
-                    .data_ledgers
-                    .iter()
-                    .filter(|dl| dl.ledger_id == DataLedger::Publish as u32)
-                {
-                    let tx_ids = &dl.tx_ids.0;
-                    if tx_ids.is_empty() {
-                        continue;
-                    }
-                    // Publish: only set promoted_height, never touch included_height.
-                    irys_database::batch_set_data_tx_promoted_height(tx, tx_ids, height)?;
-                }
+                write_data_ledger_metadata(tx, &header.data_ledgers, height)?;
                 if !commitment_ids.is_empty() {
                     irys_database::batch_set_commitment_tx_included_height(
                         tx,
@@ -391,33 +398,7 @@ impl BlockMigrationService {
                 }
             }
 
-            // NOTE: same-block Submit→Publish promotions are valid. Keep the
-            // term-ledger pass first so `included_height` exists before the
-            // Publish-ledger pass writes `promoted_height` for the same tx_id.
-            for dl in header
-                .data_ledgers
-                .iter()
-                .filter(|dl| dl.ledger_id != DataLedger::Publish as u32)
-            {
-                let tx_ids = &dl.tx_ids.0;
-                if tx_ids.is_empty() {
-                    continue;
-                }
-                // `included_height` ↔ term ledgers only; never overwrite for Publish.
-                irys_database::batch_set_data_tx_included_height(tx, tx_ids, block_height)?;
-            }
-            for dl in header
-                .data_ledgers
-                .iter()
-                .filter(|dl| dl.ledger_id == DataLedger::Publish as u32)
-            {
-                let tx_ids = &dl.tx_ids.0;
-                if tx_ids.is_empty() {
-                    continue;
-                }
-                // `promoted_height` ↔ Publish ledger only.
-                irys_database::batch_set_data_tx_promoted_height(tx, tx_ids, block_height)?;
-            }
+            write_data_ledger_metadata(tx, &header.data_ledgers, block_height)?;
 
             if !commitment_tx_ids.is_empty() {
                 irys_database::batch_set_commitment_tx_included_height(
@@ -1104,6 +1085,105 @@ mod tests {
             cdr.expiry_height.is_none(),
             "expiry remains cleared post-Phase 3"
         );
+        Ok(())
+    }
+
+    /// Multi-block reorg: both `blocks_to_clear` and `blocks_to_confirm` have
+    /// length 2 in a single `persist_metadata` call.
+    ///
+    /// Guards atomicity across the loop: an early `?` exit, off-by-one, or
+    /// phase ordering bug would leave one of the two txs in a stale state.
+    #[tokio::test]
+    async fn persist_metadata_multi_block_reorg_handles_both_slices() -> eyre::Result<()> {
+        let (db, _db_tmp) = open_db()?;
+        let (svc, _svc_tmp) = make_service(db.clone());
+
+        // Two distinct tx_id / data_root pairs.
+        let tx_id_a = H256::random();
+        let data_root_a = H256::random();
+        let tx_id_b = H256::random();
+        let data_root_b = H256::random();
+
+        // Build orphan blocks (different hashes via different previous_block_hash).
+        let orphan1 = make_block_header(1, H256::random(), 50, vec![tx_id_a]);
+        let orphan1_hash = orphan1.block_hash;
+        let orphan2 = make_block_header(2, orphan1.block_hash, 50, vec![tx_id_b]);
+        let orphan2_hash = orphan2.block_hash;
+
+        // Seed CDRs with orphan hashes in block_set and a non-None expiry_height.
+        seed_cdr(&db, data_root_a, tx_id_a, vec![orphan1_hash], Some(10));
+        seed_cdr(&db, data_root_b, tx_id_b, vec![orphan2_hash], Some(20));
+
+        // Pre-write IrysDataTxMetadata rows with included_height = Some(orphan_height).
+        db.update_eyre(|tx| {
+            irys_database::batch_set_data_tx_included_height(tx, &[tx_id_a], 1)?;
+            irys_database::batch_set_data_tx_included_height(tx, &[tx_id_b], 2)?;
+            Ok(())
+        })?;
+
+        // Build canonical blocks on the new fork.
+        let new1 = make_block_header(10, H256::random(), 50, vec![tx_id_a]);
+        let new1_hash = new1.block_hash;
+        let new2 = make_block_header(11, new1.block_hash, 50, vec![tx_id_b]);
+        let new2_hash = new2.block_hash;
+
+        let orphan1_sealed = make_sealed_with_submit_txs(orphan1, &[(tx_id_a, data_root_a)]);
+        let orphan2_sealed = make_sealed_with_submit_txs(orphan2, &[(tx_id_b, data_root_b)]);
+        let new1_sealed = make_sealed_with_submit_txs(new1, &[(tx_id_a, data_root_a)]);
+        let new2_sealed = make_sealed_with_submit_txs(new2, &[(tx_id_b, data_root_b)]);
+
+        // Single call with both slices of length 2.
+        svc.persist_metadata(
+            &[orphan1_sealed, orphan2_sealed],
+            &[new1_sealed, new2_sealed],
+        )?;
+
+        // Phase 1 cleared → Phase 2 restored: included_height == new block heights.
+        let meta_a = read_data_tx_metadata(&db, &tx_id_a)
+            .expect("tx_a metadata must exist after re-confirmation");
+        assert_eq!(
+            meta_a.included_height,
+            Some(10),
+            "tx_a included_height must be updated to new canonical height"
+        );
+
+        let meta_b = read_data_tx_metadata(&db, &tx_id_b)
+            .expect("tx_b metadata must exist after re-confirmation");
+        assert_eq!(
+            meta_b.included_height,
+            Some(11),
+            "tx_b included_height must be updated to new canonical height"
+        );
+
+        // Phase 1 scrubbed orphan hashes; Phase 3 appended new canonical hashes.
+        let cdr_a = read_cdr(&db, data_root_a).expect("CDR A present");
+        assert!(
+            !cdr_a.block_set.contains(&orphan1_hash),
+            "orphan1 hash must be scrubbed from CDR A"
+        );
+        assert!(
+            cdr_a.block_set.contains(&new1_hash),
+            "new1 hash must be appended to CDR A"
+        );
+        assert!(
+            cdr_a.expiry_height.is_none(),
+            "CDR A expiry cleared by Phase 3"
+        );
+
+        let cdr_b = read_cdr(&db, data_root_b).expect("CDR B present");
+        assert!(
+            !cdr_b.block_set.contains(&orphan2_hash),
+            "orphan2 hash must be scrubbed from CDR B"
+        );
+        assert!(
+            cdr_b.block_set.contains(&new2_hash),
+            "new2 hash must be appended to CDR B"
+        );
+        assert!(
+            cdr_b.expiry_height.is_none(),
+            "CDR B expiry cleared by Phase 3"
+        );
+
         Ok(())
     }
 }

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -414,11 +414,16 @@ impl BlockTreeServiceInner {
 
         // Handle a failed validation first
         if let ValidationResult::Invalid(validation_error) = &validation_result {
+            let reason = validation_error.metric_reason();
             error!(
                 block.hash = %block_hash,
+                %reason,
                 error = %validation_error,
                 "block validation failed"
             );
+            if validation_error.is_pre_validation() {
+                crate::metrics::record_block_pre_validation_failed(reason);
+            }
 
             // Record validation error for diagnostics
             let error_message = format!("block={} error={}", block_hash, validation_error);
@@ -440,9 +445,19 @@ impl BlockTreeServiceInner {
 
             // The block may already be gone if an invalid ancestor was removed recursively.
             if maybe_height.is_some() {
+                debug!(
+                    block.hash = %block_hash,
+                    block.height = height,
+                    prev_state = ?state,
+                    %reason,
+                    "block_tree.transition: remove_block (validation invalid)"
+                );
                 if let Err(err) = cache.remove_block(&block_hash) {
                     tracing::error!(
                         block.hash = %block_hash,
+                        block.height = height,
+                        prev_state = ?state,
+                        %reason,
                         ?err,
                         "Failed to remove block from cache"
                     );
@@ -605,6 +620,8 @@ impl BlockTreeServiceInner {
                 let old_tip_block = cache
                     .get_block(&cache.tip)
                     .ok_or_eyre("tip block must always be present")?;
+                let old_tip_hash = old_tip_block.block_hash;
+                let old_tip_height = old_tip_block.height;
 
                 // only mark the tip if the new tip has higher cumulative difficulty than the old one
                 if old_tip_block.cumulative_diff >= arc_block.cumulative_diff {
@@ -612,9 +629,25 @@ impl BlockTreeServiceInner {
                     // the canonical one (aka which the self.max_cumulative_difficulty is pointing at).
                     // That is valid because the blocks below self.max_cumulative_difficulty
                     // could still be undergoing validation, which is not guaranteed to succeed
+                    debug!(
+                        block.hash = %block_hash,
+                        block.height = arc_block.height,
+                        old_tip.hash = %old_tip_hash,
+                        old_tip.height = old_tip_height,
+                        "block_tree.transition: validated as Fork (kept current tip)"
+                    );
                     false
                 } else {
-                    cache.mark_tip(&block_hash)?
+                    let changed = cache.mark_tip(&block_hash)?;
+                    debug!(
+                        block.hash = %block_hash,
+                        block.height = arc_block.height,
+                        old_tip.hash = %old_tip_hash,
+                        old_tip.height = old_tip_height,
+                        tip_changed = changed,
+                        "block_tree.transition: mark_tip"
+                    );
+                    changed
                 }
             };
 

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -421,8 +421,16 @@ impl BlockTreeServiceInner {
                 error = %validation_error,
                 "block validation failed"
             );
+            // Symmetric counters: every ValidationError increments exactly
+            // one — pre-validation failures go to
+            // `irys.block.pre_validation_failed_total`, full-validation
+            // failures (VDF / EL / shadow tx / commitment) go to
+            // `irys.block.validation_failed_total`.  Reason tags share the
+            // same enum-driven `metric_reason()` taxonomy.
             if validation_error.is_pre_validation() {
                 crate::metrics::record_block_pre_validation_failed(reason);
+            } else {
+                crate::metrics::record_block_validation_failed(reason);
             }
 
             // Record validation error for diagnostics

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -47,7 +47,7 @@ use reth::rpc::types::engine::ExecutionPayload;
 use reth_db::Database as _;
 use reth_ethereum_primitives::Block;
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -3570,8 +3570,18 @@ pub fn get_assigned_ingress_proofs(
         //  c) Get the slots the proof address is assigned to store
         let slot_indexes = get_submit_ledger_slot_assignments(&proof_address, epoch_snapshot);
 
-        // d) Get the ledger ranges of the slot indexes
-        let slot_ranges: HashMap<usize, LedgerChunkRange> = slot_indexes
+        // d) Get the ledger ranges of the slot indexes.
+        //
+        // `BTreeMap` (not `HashMap`) so iteration order in (f) is deterministic
+        // across nodes.  When `block_range` intersects multiple Submit slots,
+        // the `break`-on-first-intersection picks `assigned_miners` from
+        // whichever slot iterates first; HashMap order would let two honest
+        // nodes pick different `assigned_miners` and produce divergent
+        // ingress-proof acceptance decisions.  Currently vacuous because
+        // `Config::validate` pins `number_of_ingress_proofs_from_assignees == 0`
+        // (see `crates/types/src/config/mod.rs`), but switching the container
+        // here removes the fork landmine the guard masks.
+        let slot_ranges: BTreeMap<usize, LedgerChunkRange> = slot_indexes
             .iter()
             .map(|index| {
                 let num_chunks_in_partition = config.consensus.num_chunks_in_partition;

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -354,12 +354,21 @@ impl PreValidationError {
     }
 
     /// Returns true for variants representing local/runtime failures (verifier
-    /// panics, transient task-join errors, etc.) that must NEVER be attributed
+    /// panics, transient task-join errors, local DB inconsistencies surfaced
+    /// by `find_canonical_ledger_range`, etc.) that must NEVER be attributed
     /// to the peer or used to mark a block as consensus-invalid. See the enum
     /// safety-critical doc for the full invariant. Grow this method as new
     /// non-consensus variants are added.
+    ///
+    /// `BlockBoundsLookupError` is included because it now also surfaces
+    /// local DB/header inconsistencies (e.g. `MigratedBlockHashes[H]` exists
+    /// but `IrysBlockHeaders[hash]` is missing) — a missing local row must
+    /// not cause us to reject a valid peer-provided block.
     pub fn is_internal_failure(&self) -> bool {
-        matches!(self, Self::InternalTaskJoin(_))
+        matches!(
+            self,
+            Self::InternalTaskJoin(_) | Self::BlockBoundsLookupError(_)
+        )
     }
 
     /// Stable, bounded-cardinality label for the
@@ -1374,6 +1383,20 @@ mod prevalidation_error_classification_tests {
         assert!(
             !PreValidationError::VDFCheckpointsInvalid("bad".to_string()).is_internal_failure()
         );
+    }
+
+    /// `BlockBoundsLookupError` is produced by `find_canonical_ledger_range`
+    /// when local DB/header storage is inconsistent (e.g. orphan
+    /// `MigratedBlockHashes` row with no `IrysBlockHeaders` entry). A local
+    /// corruption must not be attributed to the peer that delivered an
+    /// otherwise-valid block; classify as internal so the block pool keeps
+    /// the block in cache for retry rather than removing it as
+    /// consensus-invalid.
+    #[test]
+    fn block_bounds_lookup_error_is_internal_failure() {
+        let err = PreValidationError::BlockBoundsLookupError("local DB row missing".to_string());
+        assert!(err.is_internal_failure());
+        assert!(!err.is_fatal_corruption());
     }
 }
 

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -4555,14 +4555,14 @@ mod tests {
     /// the function looks up the Submit-ledger range via
     /// `tx_inclusion::find_canonical_ledger_range` and returns successfully.
     ///
-    /// Regression coverage for the 2026-05-15 self-fork: the previous
-    /// implementation walked `CachedDataRoots.block_set`, which retained
-    /// orphaned hashes after reorgs and caused `BlockBoundsLookupError`
-    /// once those blocks were purged.  Validation now consults
-    /// `tx_inclusion::find_canonical_ledger_range` directly; `block_set`
-    /// remains on `CachedDataRoot` as a cheap "ever-confirmed?" hint kept
-    /// in sync atomically with tip changes by
-    /// `BlockMigrationService::persist_metadata`.
+    /// Locks in the canonical-trust-root lookup: validation must derive
+    /// Submit ranges from `IrysDataTxMetadata` + `MigratedBlockHashes` (which
+    /// only retain canonical state) rather than from
+    /// `CachedDataRoots.block_set` (which historically retained orphaned
+    /// hashes across reorgs and could surface a stale `BlockBoundsLookupError`
+    /// once the block_tree purged those blocks).  `block_set` is now only a
+    /// cheap "ever-confirmed?" hint maintained atomically with tip changes
+    /// by `BlockMigrationService::persist_metadata`.
     #[test_log::test(tokio::test)]
     async fn assigned_ingress_proofs_uses_canonical_tx_metadata() -> eyre::Result<()> {
         use crate::tx_inclusion;

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -363,9 +363,10 @@ impl PreValidationError {
     }
 
     /// Stable, bounded-cardinality label for the
-    /// `irys.block.pre_validation_failed_total{reason}` counter.  Each variant
-    /// maps to a short snake_case tag so prometheus cardinality is capped at
-    /// the enum size.
+    /// `irys.block.pre_validation_failed_total{reason}` counter (and used by
+    /// [`ValidationError::metric_reason`] when delegating from the
+    /// pre-validation variant).  Each variant maps to a short snake_case tag
+    /// so prometheus cardinality is capped at the enum size.
     pub fn metric_reason(&self) -> &'static str {
         match self {
             Self::BlockBoundsLookupError(_) => "block_bounds_lookup",
@@ -578,10 +579,13 @@ pub enum ValidationError {
 
 impl ValidationError {
     /// Stable, bounded-cardinality label for the
-    /// `irys.block.pre_validation_failed_total{reason}` counter.  Delegates to
-    /// [`PreValidationError::metric_reason`] for the pre-validation variant
-    /// (the case the counter is named for); other variants get a coarse tag
-    /// matching the variant name.
+    /// `irys.block.pre_validation_failed_total{reason}` /
+    /// `irys.block.validation_failed_total{reason}` counters.  The caller
+    /// chooses which counter to increment based on
+    /// [`ValidationError::is_pre_validation`]; this method only returns the
+    /// tag.  Delegates to [`PreValidationError::metric_reason`] for the
+    /// pre-validation variant; other variants get a coarse tag matching the
+    /// variant name.
     pub fn metric_reason(&self) -> &'static str {
         match self {
             Self::PreValidation(inner) => inner.metric_reason(),
@@ -611,7 +615,8 @@ impl ValidationError {
     }
 
     /// Returns true for the pre-validation variant so callers can route to
-    /// the pre-validation-specific counter without re-matching.
+    /// `irys.block.pre_validation_failed_total` vs.
+    /// `irys.block.validation_failed_total` without re-matching the enum.
     pub fn is_pre_validation(&self) -> bool {
         matches!(self, Self::PreValidation(_))
     }

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -219,8 +219,6 @@ pub enum PreValidationError {
     ParentEpochSnapshotNotFound { block_hash: BlockHash },
     #[error("Failed to extract data ledgers: {0}")]
     DataLedgerExtractionFailed(String),
-    #[error("Failed to fetch transactions: {0}")]
-    TransactionFetchFailed(String),
     #[error("Failed to get previous transaction inclusions: {0}")]
     PreviousTxInclusionsFailed(String),
     #[error("Transaction {tx_id} has invalid ledger_id. Expected: {expected}, Actual: {actual}")]
@@ -429,7 +427,6 @@ impl PreValidationError {
             Self::BlockEmaSnapshotNotFound { .. } => "block_ema_snapshot_not_found",
             Self::ParentEpochSnapshotNotFound { .. } => "parent_epoch_snapshot_not_found",
             Self::DataLedgerExtractionFailed(_) => "data_ledger_extraction_failed",
-            Self::TransactionFetchFailed(_) => "tx_fetch_failed",
             Self::PreviousTxInclusionsFailed(_) => "prev_tx_inclusions_failed",
             Self::InvalidLedgerIdForTx { .. } => "invalid_ledger_id_for_tx",
             Self::InvalidLedgerId { .. } => "invalid_ledger_id",

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -1398,6 +1398,21 @@ mod prevalidation_error_classification_tests {
         assert!(err.is_internal_failure());
         assert!(!err.is_fatal_corruption());
     }
+
+    /// `PublishTxMissingPriorSubmit` is a consensus-invalidity verdict: a peer
+    /// gave us a block whose Publish-ledger txs lack a prior Submit confirmation.
+    /// It must classify as a peer-attributable failure so the block-pool removes
+    /// the offending block.  This is the counterpart of
+    /// `BlockBoundsLookupError`: the two arms of the Publish prior-Submit fallback
+    /// in `data_txs_are_valid` (`Ok(None)` and `Err(_)` respectively) must remain
+    /// on opposite sides of `is_internal_failure()` so a local DB inconsistency is
+    /// never confused with a peer-supplied invalid block.
+    #[test]
+    fn publish_tx_missing_prior_submit_is_peer_attributable() {
+        let err = PreValidationError::PublishTxMissingPriorSubmit { tx_id: H256::zero() };
+        assert!(!err.is_internal_failure());
+        assert!(!err.is_fatal_corruption());
+    }
 }
 
 #[cfg(test)]
@@ -2710,20 +2725,37 @@ pub async fn data_txs_are_valid(
             TxInclusionState::Searching { ledger_current } => {
                 match ledger_current {
                     DataLedger::Publish => {
-                        // check the db — constrained to canonical chain at or before the parent
+                        // Past Submit inclusion was not in the historical scan
+                        // window — fall back to the canonical DB index.  A
+                        // `Some` here is sufficient evidence of prior Submit:
+                        // the structural pre-pass guarantees `tx.ledger_id ==
+                        // Publish`, and term ledgers reject `ledger_id ==
+                        // Publish`, so the only term ledger that could have
+                        // produced this `included_height` is Submit.  An
+                        // `Err` is a local DB/header inconsistency and must
+                        // be classified as internal, matching the
+                        // `BlockBoundsLookupError` treatment elsewhere — not
+                        // peer-attributed as `PublishTxMissingPriorSubmit`.
                         let parent_height = block.height.saturating_sub(1);
-                        if let Ok(Some(_header)) =
-                            tx_header_by_txid_canonical(&ro_tx, &tx.id, parent_height)
-                        {
-                            warn!(
-                                "had to fetch header {:#?} from DB for {}, (exp: {:#?}) as submit inclusion wasn't within anchor depth",
-                                &_header, &tx.id, &tx
-                            );
-                        } else {
-                            // Publish tx with no past inclusion - INVALID
-                            return Err(PreValidationError::PublishTxMissingPriorSubmit {
-                                tx_id: tx.id,
-                            });
+                        match tx_header_by_txid_canonical(&ro_tx, &tx.id, parent_height) {
+                            Ok(Some(_header)) => {
+                                warn!(
+                                    tx.id = %tx.id,
+                                    parent_height,
+                                    "submit inclusion not in anchor window; resolved via canonical DB index"
+                                );
+                            }
+                            Ok(None) => {
+                                return Err(PreValidationError::PublishTxMissingPriorSubmit {
+                                    tx_id: tx.id,
+                                });
+                            }
+                            Err(e) => {
+                                return Err(PreValidationError::BlockBoundsLookupError(format!(
+                                    "tx_header_by_txid_canonical failed for tx {} during prior-Submit check: {}",
+                                    tx.id, e
+                                )));
+                            }
                         }
                     }
                     DataLedger::Submit => {

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -362,10 +362,19 @@ impl PreValidationError {
     /// local DB/header inconsistencies (e.g. `MigratedBlockHashes[H]` exists
     /// but `IrysBlockHeaders[hash]` is missing) — a missing local row must
     /// not cause us to reject a valid peer-provided block.
+    ///
+    /// `ValidationServiceUnreachable` and `DatabaseError` are transient
+    /// local-only failures called out explicitly in the enum safety doc as
+    /// the kind of error that MUST NEVER be mapped to a consensus-level
+    /// rejection — a momentary local DB I/O blip or service-unavailability
+    /// would otherwise cause a valid peer block to be attributed as invalid.
     pub fn is_internal_failure(&self) -> bool {
         matches!(
             self,
-            Self::InternalTaskJoin(_) | Self::BlockBoundsLookupError(_)
+            Self::InternalTaskJoin(_)
+                | Self::BlockBoundsLookupError(_)
+                | Self::ValidationServiceUnreachable
+                | Self::DatabaseError { .. }
         )
     }
 
@@ -1392,6 +1401,28 @@ mod prevalidation_error_classification_tests {
     #[test]
     fn block_bounds_lookup_error_is_internal_failure() {
         let err = PreValidationError::BlockBoundsLookupError("local DB row missing".to_string());
+        assert!(err.is_internal_failure());
+        assert!(!err.is_fatal_corruption());
+    }
+
+    /// `ValidationServiceUnreachable` surfaces transient local service
+    /// unavailability — exactly the case the enum's safety doc calls out as
+    /// MUST NEVER be mapped to a consensus-level rejection.
+    #[test]
+    fn validation_service_unreachable_is_internal_failure() {
+        let err = PreValidationError::ValidationServiceUnreachable;
+        assert!(err.is_internal_failure());
+        assert!(!err.is_fatal_corruption());
+    }
+
+    /// `DatabaseError` surfaces local DB I/O failures. Attributing a transient
+    /// MDBX hiccup to the peer would mark a valid block invalid; classify as
+    /// internal so the caller keeps the block for retry.
+    #[test]
+    fn database_error_is_internal_failure() {
+        let err = PreValidationError::DatabaseError {
+            error: "mdbx io".to_string(),
+        };
         assert!(err.is_internal_failure());
         assert!(!err.is_fatal_corruption());
     }

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -3609,7 +3609,7 @@ fn get_submit_ledger_slot_assignments(
     partition_assignments.retain(|pa| pa.ledger_id == Some(DataLedger::Submit.into()));
     partition_assignments
         .iter()
-        .map(|pa| pa.slot_index.unwrap())
+        .map(|pa| pa.slot_index.expect("Submit-ledger partition assignment must have slot_index — invariant from epoch_snapshot"))
         .collect()
 }
 

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -353,27 +353,35 @@ impl PreValidationError {
     }
 
     /// Returns true for variants representing local/runtime failures (verifier
-    /// panics, transient task-join errors, local DB inconsistencies surfaced
-    /// by `find_canonical_ledger_range`, etc.) that must NEVER be attributed
+    /// panics, transient task-join errors, etc.) that must NEVER be attributed
     /// to the peer or used to mark a block as consensus-invalid. See the enum
     /// safety-critical doc for the full invariant. Grow this method as new
     /// non-consensus variants are added.
-    ///
-    /// `BlockBoundsLookupError` is included because it now also surfaces
-    /// local DB/header inconsistencies (e.g. `MigratedBlockHashes[H]` exists
-    /// but `IrysBlockHeaders[hash]` is missing) — a missing local row must
-    /// not cause us to reject a valid peer-provided block.
     ///
     /// `ValidationServiceUnreachable` and `DatabaseError` are transient
     /// local-only failures called out explicitly in the enum safety doc as
     /// the kind of error that MUST NEVER be mapped to a consensus-level
     /// rejection — a momentary local DB I/O blip or service-unavailability
     /// would otherwise cause a valid peer block to be attributed as invalid.
+    ///
+    /// **`BlockBoundsLookupError` is intentionally NOT in this set on this
+    /// branch.**  Its producer at `poa_is_valid` (`block_validation.rs`
+    /// `get_block_bounds` call) still funnels peer-attributable bad-offset
+    /// cases through the same variant — classifying the variant as internal
+    /// would misroute an invalid PoA block to the parking/retry bucket.
+    /// `fix/validation-error-disamb` pre-filters the peer cases at the PoA
+    /// source (`PoAChunkOffsetOutOfBlockBounds`, `PoALedgerInactive`) and
+    /// then promotes `BlockBoundsLookupError` to `NodeFault` by
+    /// construction.  After that branch merges, the canonical-lookup paths
+    /// added here (Publish-fallback at L2798/2804/2826,
+    /// `find_canonical_ledger_range` at L3586) inherit the correct
+    /// classification automatically.  Until then a local DB blip on those
+    /// paths is peer-attributed — the same gap the pre-this-branch code
+    /// carried via `PublishTxMissingPriorSubmit`.
     pub fn is_internal_failure(&self) -> bool {
         matches!(
             self,
             Self::InternalTaskJoin(_)
-                | Self::BlockBoundsLookupError(_)
                 | Self::ValidationServiceUnreachable
                 | Self::DatabaseError { .. }
         )
@@ -1392,20 +1400,6 @@ mod prevalidation_error_classification_tests {
         );
     }
 
-    /// `BlockBoundsLookupError` is produced by `find_canonical_ledger_range`
-    /// when local DB/header storage is inconsistent (e.g. orphan
-    /// `MigratedBlockHashes` row with no `IrysBlockHeaders` entry). A local
-    /// corruption must not be attributed to the peer that delivered an
-    /// otherwise-valid block; classify as internal so the block pool keeps
-    /// the block in cache for retry rather than removing it as
-    /// consensus-invalid.
-    #[test]
-    fn block_bounds_lookup_error_is_internal_failure() {
-        let err = PreValidationError::BlockBoundsLookupError("local DB row missing".to_string());
-        assert!(err.is_internal_failure());
-        assert!(!err.is_fatal_corruption());
-    }
-
     /// `ValidationServiceUnreachable` surfaces transient local service
     /// unavailability — exactly the case the enum's safety doc calls out as
     /// MUST NEVER be mapped to a consensus-level rejection.
@@ -1431,11 +1425,16 @@ mod prevalidation_error_classification_tests {
     /// `PublishTxMissingPriorSubmit` is a consensus-invalidity verdict: a peer
     /// gave us a block whose Publish-ledger txs lack a prior Submit confirmation.
     /// It must classify as a peer-attributable failure so the block-pool removes
-    /// the offending block.  This is the counterpart of
-    /// `BlockBoundsLookupError`: the two arms of the Publish prior-Submit fallback
-    /// in `data_txs_are_valid` (`Ok(None)` and `Err(_)` respectively) must remain
-    /// on opposite sides of `is_internal_failure()` so a local DB inconsistency is
-    /// never confused with a peer-supplied invalid block.
+    /// the offending block.
+    ///
+    /// Companion to the `Err(_)` arm of the same `tx_header_by_txid_canonical`
+    /// fallback in `data_txs_are_valid`: that arm currently surfaces as
+    /// `BlockBoundsLookupError` (peer-attributable by default on this
+    /// branch, see the doc on `is_internal_failure`).  Both arms therefore
+    /// classify as peer-attributable today.  The asymmetry — making the
+    /// `Err(_)` arm internal — lands on `fix/validation-error-disamb` once
+    /// its PoA source-disambiguation prevents `BlockBoundsLookupError` from
+    /// carrying peer-attributable cases.
     #[test]
     fn publish_tx_missing_prior_submit_is_peer_attributable() {
         let err = PreValidationError::PublishTxMissingPriorSubmit {
@@ -2763,10 +2762,18 @@ pub async fn data_txs_are_valid(
                         // Publish`, and term ledgers reject `ledger_id ==
                         // Publish`, so the only term ledger that could have
                         // produced this `included_height` is Submit.  An
-                        // `Err` is a local DB/header inconsistency and must
-                        // be classified as internal, matching the
-                        // `BlockBoundsLookupError` treatment elsewhere — not
-                        // peer-attributed as `PublishTxMissingPriorSubmit`.
+                        // `Err` is a local DB/header inconsistency that we
+                        // surface as `BlockBoundsLookupError` for diagnostic
+                        // accuracy.  Classification follow-up:
+                        // `BlockBoundsLookupError` is intentionally NOT in
+                        // `is_internal_failure` on this branch (its PoA-side
+                        // producer still funnels peer cases through the same
+                        // variant); the disamb branch promotes it to
+                        // NodeFault after pre-filtering the peer cases.
+                        // Until then the `Err(_)` arm here remains
+                        // peer-attributable, the same effective behavior as
+                        // the pre-this-branch `PublishTxMissingPriorSubmit`
+                        // collapse.
                         //
                         // We must *also* reject when this tx has already been
                         // canonically promoted past the in-window walk: the
@@ -3575,6 +3582,13 @@ pub fn get_assigned_ingress_proofs(
     //     before `parent_height`.  This replaces the historical
     //     CachedDataRoots.block_set lookup, which retained reorg'd-out hashes
     //     and could produce stale BlockBoundsLookupError.
+    //
+    //     Classification follow-up: an `Err` here is a genuine local
+    //     canonical-metadata inconsistency, but we surface it via
+    //     `BlockBoundsLookupError` which is peer-attributable on this
+    //     branch in isolation (see `is_internal_failure` doc).  The
+    //     disamb branch's PoA source-disambiguation closes this gap by
+    //     promoting `BlockBoundsLookupError` to NodeFault by construction.
     let block_range = crate::tx_inclusion::find_canonical_ledger_range(
         &tx_header.id,
         parent_height,

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -4366,8 +4366,11 @@ mod tests {
     /// Regression coverage for the 2026-05-15 self-fork: the previous
     /// implementation walked `CachedDataRoots.block_set`, which retained
     /// orphaned hashes after reorgs and caused `BlockBoundsLookupError`
-    /// once those blocks were purged.  `block_set` has since been removed
-    /// from `CachedDataRoot` entirely.
+    /// once those blocks were purged.  Validation now consults
+    /// `tx_inclusion::find_canonical_ledger_range` directly; `block_set`
+    /// remains on `CachedDataRoot` as a cheap "ever-confirmed?" hint kept
+    /// in sync atomically with tip changes by
+    /// `BlockMigrationService::persist_metadata`.
     #[test_log::test(tokio::test)]
     async fn assigned_ingress_proofs_uses_canonical_tx_metadata() -> eyre::Result<()> {
         use crate::tx_inclusion;

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -8,7 +8,7 @@ use crate::{
 use alloy_eips::eip7685::{Requests, RequestsOrHash};
 use alloy_rpc_types_engine::ExecutionData;
 use eyre::{OptionExt as _, ensure, eyre};
-use irys_database::tx_header_by_txid_canonical;
+use irys_database::{tables::MigratedBlockHashes, tx_header_by_txid_canonical};
 use irys_domain::{
     BlockIndex, BlockIndexReadGuard, BlockTreeReadGuard, CommitmentSnapshot,
     CommitmentSnapshotStatus, EmaSnapshot, EpochSnapshot, ExecutionPayloadCache,
@@ -45,6 +45,7 @@ use reth::revm::primitives::{Address, FixedBytes};
 use reth::rpc::api::EngineApiClient as _;
 use reth::rpc::types::engine::ExecutionPayload;
 use reth_db::Database as _;
+use reth_db::transaction::DbTx as _;
 use reth_ethereum_primitives::Block;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
@@ -2766,9 +2767,50 @@ pub async fn data_txs_are_valid(
                         // be classified as internal, matching the
                         // `BlockBoundsLookupError` treatment elsewhere — not
                         // peer-attributed as `PublishTxMissingPriorSubmit`.
+                        //
+                        // We must *also* reject when this tx has already been
+                        // canonically promoted past the in-window walk: the
+                        // walk's `Found { historical: Publish, current:
+                        // Publish }` arm correctly emits
+                        // `PublishTxAlreadyIncluded`, but that arm is
+                        // unreachable when the prior Publish block sits
+                        // outside `anchor_expiry_depth`.  Without a
+                        // `promoted_height` check here a peer can re-publish
+                        // a tx at `h_publish + anchor_expiry_depth + N` and
+                        // get a `warn!`+accept instead of the consensus-level
+                        // double-include rejection.
                         let parent_height = block.height.saturating_sub(1);
                         match tx_header_by_txid_canonical(&ro_tx, &tx.id, parent_height) {
-                            Ok(Some(_header)) => {
+                            Ok(Some(header)) => {
+                                if let Some(promoted_height) = header.metadata().promoted_height
+                                    && promoted_height <= parent_height
+                                {
+                                    // `promoted_height` is written by
+                                    // `persist_metadata` Phase 2 atomically
+                                    // with `MigratedBlockHashes[h]`, so a
+                                    // missing row here is cross-table
+                                    // corruption — surface as internal,
+                                    // matching the IrysBlockHeaders /
+                                    // prev-header arms.
+                                    let promoted_block_hash = ro_tx
+                                        .get::<MigratedBlockHashes>(promoted_height)
+                                        .map_err(|e| {
+                                            PreValidationError::BlockBoundsLookupError(format!(
+                                                "MigratedBlockHashes read failed for promoted_height {} of tx {}: {}",
+                                                promoted_height, tx.id, e
+                                            ))
+                                        })?
+                                        .ok_or_else(|| {
+                                            PreValidationError::BlockBoundsLookupError(format!(
+                                                "canonical metadata inconsistent: tx {} has promoted_height {} but MigratedBlockHashes has no row at that height",
+                                                tx.id, promoted_height
+                                            ))
+                                        })?;
+                                    return Err(PreValidationError::PublishTxAlreadyIncluded {
+                                        tx_id: tx.id,
+                                        block_hash: promoted_block_hash,
+                                    });
+                                }
                                 warn!(
                                     tx.id = %tx.id,
                                     parent_height,

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -361,6 +361,97 @@ impl PreValidationError {
     pub fn is_internal_failure(&self) -> bool {
         matches!(self, Self::InternalTaskJoin(_))
     }
+
+    /// Stable, bounded-cardinality label for the
+    /// `irys.block.pre_validation_failed_total{reason}` counter.  Each variant
+    /// maps to a short snake_case tag so prometheus cardinality is capped at
+    /// the enum size.
+    pub fn metric_reason(&self) -> &'static str {
+        match self {
+            Self::BlockBoundsLookupError(_) => "block_bounds_lookup",
+            Self::BlockSignatureInvalid => "block_signature_invalid",
+            Self::CascadeNotConfigured { .. } => "cascade_not_configured",
+            Self::CumulativeDifficultyMismatch { .. } => "cumulative_difficulty_mismatch",
+            Self::DifficultyMismatch { .. } => "difficulty_mismatch",
+            Self::EmaMismatch => "ema_mismatch",
+            Self::EmaSnapshotError(_) => "ema_snapshot_error",
+            Self::IngressProofsMissing => "ingress_proofs_missing",
+            Self::IngressProofSignatureInvalid(_) => "ingress_proof_signature_invalid",
+            Self::InvalidPromotionDataSizeMismatch { .. } => "promotion_data_size_mismatch",
+            Self::LastDiffTimestampMismatch { .. } => "last_diff_timestamp_mismatch",
+            Self::LedgerIdInvalid { .. } => "ledger_id_invalid",
+            Self::MerkleProofInvalid(_) => "merkle_proof_invalid",
+            Self::OraclePriceInvalid => "oracle_price_invalid",
+            Self::UpdateCacheForScheduledValidationError(_) => "update_cache_scheduled_validation",
+            Self::PoACapacityChunkMismatch { .. } => "poa_capacity_chunk_mismatch",
+            Self::PoAChunkHashMismatch { .. } => "poa_chunk_hash_mismatch",
+            Self::PoAChunkMissing => "poa_chunk_missing",
+            Self::PoAChunkOffsetOutOfDataChunksBounds => "poa_chunk_offset_out_of_data_bounds",
+            Self::PoAChunkOffsetOutOfBlockBounds => "poa_chunk_offset_out_of_block_bounds",
+            Self::PoAChunkOffsetOutOfTxBounds => "poa_chunk_offset_out_of_tx_bounds",
+            Self::PartitionAssignmentMissing { .. } => "partition_assignment_missing",
+            Self::PartitionAssignmentSlotIndexMissing { .. } => "partition_slot_index_missing",
+            Self::PartitionAssignmentSlotIndexTooLarge { .. } => "partition_slot_index_too_large",
+            Self::PoADataPartitionExpired { .. } => "poa_data_partition_expired",
+            Self::PreviousCumulativeDifficultyMismatch { .. } => "prev_cumulative_diff_mismatch",
+            Self::PreviousSolutionHashMismatch { .. } => "prev_solution_hash_mismatch",
+            Self::RewardCurveError(_) => "reward_curve_error",
+            Self::RewardMismatch { .. } => "reward_mismatch",
+            Self::SolutionHashBelowDifficulty { .. } => "solution_hash_below_difficulty",
+            Self::SolutionHashLinkInvalid { .. } => "solution_hash_link_invalid",
+            Self::SystemTimeError(_) => "system_time_error",
+            Self::TermLedgerExpiryMismatch { .. } => "term_ledger_expiry_mismatch",
+            Self::TimestampOlderThanParent { .. } => "timestamp_older_than_parent",
+            Self::TimestampTooFarInFuture { .. } => "timestamp_too_far_in_future",
+            Self::ValidationServiceUnreachable => "validation_service_unreachable",
+            Self::InternalTaskJoin(_) => "internal_task_join",
+            Self::VDFCheckpointsInvalid(_) => "vdf_checkpoints_invalid",
+            Self::VDFPreviousOutputMismatch { .. } => "vdf_prev_output_mismatch",
+            Self::HeightInvalid { .. } => "height_invalid",
+            Self::LastEpochHashMismatch { .. } => "last_epoch_hash_mismatch",
+            Self::PublishTxMissingPriorSubmit { .. } => "publish_tx_missing_prior_submit",
+            Self::PublishTxAlreadyIncluded { .. } => "publish_tx_already_included",
+            Self::InvalidPromotionPath { .. } => "invalid_promotion_path",
+            Self::SubmitTxAlreadyIncluded { .. } => "submit_tx_already_included",
+            Self::TxFoundInMultipleBlocks { .. } => "tx_in_multiple_blocks",
+            Self::TxInMultipleLedgers { .. } => "tx_in_multiple_ledgers",
+            Self::PublishTxProofLengthMismatch => "publish_tx_proof_length_mismatch",
+            Self::BlockEmaSnapshotNotFound { .. } => "block_ema_snapshot_not_found",
+            Self::ParentEpochSnapshotNotFound { .. } => "parent_epoch_snapshot_not_found",
+            Self::DataLedgerExtractionFailed(_) => "data_ledger_extraction_failed",
+            Self::TransactionFetchFailed(_) => "tx_fetch_failed",
+            Self::PreviousTxInclusionsFailed(_) => "prev_tx_inclusions_failed",
+            Self::InvalidLedgerIdForTx { .. } => "invalid_ledger_id_for_tx",
+            Self::InvalidLedgerId { .. } => "invalid_ledger_id",
+            Self::FeeCalculationFailed(_) => "fee_calculation_failed",
+            Self::InsufficientPermFee { .. } => "insufficient_perm_fee",
+            Self::InsufficientTermFee { .. } => "insufficient_term_fee",
+            Self::InvalidTermFeeStructure { .. } => "invalid_term_fee_structure",
+            Self::InvalidPermFeeStructure { .. } => "invalid_perm_fee_structure",
+            Self::SubmitTxHasPromotedHeight { .. } => "submit_tx_has_promoted_height",
+            Self::TermLedgerTxHasPermFee { .. } => "term_ledger_tx_has_perm_fee",
+            Self::PublishLedgerProofCountMismatch { .. } => "publish_ledger_proof_count_mismatch",
+            Self::IngressProofCountMismatch { .. } => "ingress_proof_count_mismatch",
+            Self::AssignedProofCountMismatch { .. } => "assigned_proof_count_mismatch",
+            Self::InvalidIngressProof { .. } => "invalid_ingress_proof",
+            Self::IngressProofMismatch { .. } => "ingress_proof_mismatch",
+            Self::DuplicateIngressProofSigner { .. } => "duplicate_ingress_proof_signer",
+            Self::UnstakedIngressProofSigner { .. } => "unstaked_ingress_proof_signer",
+            Self::DatabaseError { .. } => "database_error",
+            Self::InvalidEpochSnapshot { .. } => "invalid_epoch_snapshot",
+            Self::TooManyDataTxs { .. } => "too_many_data_txs",
+            Self::TooManyCommitmentTxs { .. } => "too_many_commitment_txs",
+            Self::MissingTransactions(_) => "missing_transactions",
+            Self::TransactionIdMismatch { .. } => "tx_id_mismatch",
+            Self::InvalidTransactionSignature(_) => "invalid_tx_signature",
+            Self::CommitmentVersionInvalid { .. } => "commitment_version_invalid",
+            Self::UnexpectedCommitmentTransactions => "unexpected_commitment_txs",
+            Self::InvalidDataLedgersLength { .. } => "invalid_data_ledgers_length",
+            Self::AddBlockFailed { .. } => "add_block_failed",
+            Self::CachePoisoned { .. } => "cache_poisoned",
+            Self::ParentNotInCache { .. } => "parent_not_in_cache",
+        }
+    }
 }
 
 /// Validation error type that covers all block validation failures.
@@ -483,6 +574,47 @@ pub enum ValidationError {
     /// Generic validation error for edge cases
     #[error("Validation failed: {0}")]
     Other(String),
+}
+
+impl ValidationError {
+    /// Stable, bounded-cardinality label for the
+    /// `irys.block.pre_validation_failed_total{reason}` counter.  Delegates to
+    /// [`PreValidationError::metric_reason`] for the pre-validation variant
+    /// (the case the counter is named for); other variants get a coarse tag
+    /// matching the variant name.
+    pub fn metric_reason(&self) -> &'static str {
+        match self {
+            Self::PreValidation(inner) => inner.metric_reason(),
+            Self::ValidationCancelled { .. } => "validation_cancelled",
+            Self::TaskPanicked { .. } => "task_panicked",
+            Self::VdfValidationFailed(_) => "vdf_validation_failed",
+            Self::SeedDataInvalid(_) => "seed_data_invalid",
+            Self::ExecutionLayerFailed(_) => "execution_layer_failed",
+            Self::RecallRangeInvalid(_) => "recall_range_invalid",
+            Self::ShadowTransactionInvalid(_) => "shadow_tx_invalid",
+            Self::CommitmentTransactionFetchFailed(_) => "commitment_tx_fetch_failed",
+            Self::CommitmentValueInvalid { .. } => "commitment_value_invalid",
+            Self::CommitmentVersionInvalid { .. } => "commitment_version_invalid",
+            Self::CommitmentTypeNotAllowed { .. } => "commitment_type_not_allowed",
+            Self::CommitmentOrderingFailed(_) => "commitment_ordering_failed",
+            Self::CommitmentSnapshotRejected { .. } => "commitment_snapshot_rejected",
+            Self::UnpledgePartitionNotOwned { .. } => "unpledge_partition_not_owned",
+            Self::ParentCommitmentSnapshotMissing { .. } => "parent_commitment_snapshot_missing",
+            Self::ParentEpochSnapshotMissing { .. } => "parent_epoch_snapshot_missing",
+            Self::ParentBlockMissing { .. } => "parent_block_missing",
+            Self::EpochCommitmentMismatch { .. } => "epoch_commitment_mismatch",
+            Self::EpochExtraCommitment { .. } => "epoch_extra_commitment",
+            Self::EpochMissingCommitment { .. } => "epoch_missing_commitment",
+            Self::CommitmentWrongOrder { .. } => "commitment_wrong_order",
+            Self::Other(_) => "other",
+        }
+    }
+
+    /// Returns true for the pre-validation variant so callers can route to
+    /// the pre-validation-specific counter without re-matching.
+    pub fn is_pre_validation(&self) -> bool {
+        matches!(self, Self::PreValidation(_))
+    }
 }
 
 /// Full pre-validation steps for a block
@@ -4482,6 +4614,137 @@ mod tests {
             &config,
             &epoch_snapshot,
         )?;
+        assert!(assigned.is_empty());
+        assert_eq!(miners, 0);
+
+        Ok(())
+    }
+
+    /// Same setup as `assigned_ingress_proofs_uses_canonical_tx_metadata`,
+    /// but with a deliberately-corrupt [`CachedDataRoot`] row alongside the
+    /// canonical metadata: `block_set` filled with random hashes that point
+    /// nowhere, `txid_set` augmented with stale txids that do not match the
+    /// canonical tx, and a bogus `data_size`.  Asserts the validation lookup
+    /// is unaffected — `get_assigned_ingress_proofs` returns the same
+    /// `(vec![], 0)` as the no-CDR case because
+    /// `tx_inclusion::find_canonical_ledger_range` derives canonical truth
+    /// from `IrysDataTxMetadata` + `MigratedBlockHashes` and never reads
+    /// `CachedDataRoots`.  Regression guard against a future refactor
+    /// accidentally re-introducing a CDR read into the validation path.
+    #[test_log::test(tokio::test)]
+    async fn corrupt_cdr_does_not_affect_assigned_ingress_proofs() -> eyre::Result<()> {
+        use irys_database::{
+            IrysDatabaseArgs as _,
+            db_cache::CachedDataRoot,
+            insert_tx_header, open_or_create_db, set_data_tx_included_height,
+            tables::{CachedDataRoots, IrysBlockHeaders, IrysTables, MigratedBlockHashes},
+        };
+        use irys_domain::{BlockTree, BlockTreeReadGuard, EpochSnapshot};
+        use irys_testing_utils::IrysBlockHeaderTestExt as _;
+        use irys_testing_utils::utils::TempDirBuilder;
+        use irys_types::{
+            ConsensusConfig, DataTransactionHeader, DataTransactionHeaderV1,
+            DataTransactionHeaderV1WithMetadata, DataTransactionMetadata, H256, H256List,
+            UnixTimestamp,
+        };
+        use reth_db::Database as _;
+        use reth_db::mdbx::DatabaseArguments;
+        use reth_db::transaction::DbTxMut as _;
+        use std::sync::RwLock;
+
+        let tmp = TempDirBuilder::new().build();
+        let env = open_or_create_db(
+            tmp.path(),
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        let db = DatabaseProvider(Arc::new(env));
+
+        let node_config = NodeConfig::testing();
+        let config = Config::new_with_random_peer_id(node_config);
+
+        let tx_id = H256::random();
+        let data_root = H256::random();
+
+        let mut h0 = IrysBlockHeader::new_mock_header();
+        h0.height = 0;
+        h0.previous_block_hash = H256::zero();
+        h0.cumulative_diff = U256::from(0);
+        h0.data_ledgers[DataLedger::Submit as usize].total_chunks = 10;
+        h0.data_ledgers[DataLedger::Submit as usize].tx_ids = H256List(vec![]);
+        h0.test_sign();
+
+        let mut h1 = IrysBlockHeader::new_mock_header();
+        h1.height = 1;
+        h1.previous_block_hash = h0.block_hash;
+        h1.cumulative_diff = U256::from(1);
+        h1.data_ledgers[DataLedger::Submit as usize].total_chunks = 25;
+        h1.data_ledgers[DataLedger::Submit as usize].tx_ids = H256List(vec![tx_id]);
+        h1.test_sign();
+
+        db.update(|tx| -> eyre::Result<()> {
+            tx.put::<IrysBlockHeaders>(h0.block_hash, h0.clone().into())?;
+            tx.put::<IrysBlockHeaders>(h1.block_hash, h1.clone().into())?;
+            tx.put::<MigratedBlockHashes>(0, h0.block_hash)?;
+            tx.put::<MigratedBlockHashes>(1, h1.block_hash)?;
+            Ok(())
+        })??;
+
+        let header = DataTransactionHeader::V1(DataTransactionHeaderV1WithMetadata {
+            tx: DataTransactionHeaderV1 {
+                id: tx_id,
+                data_root,
+                ledger_id: DataLedger::Submit as u32,
+                ..Default::default()
+            },
+            metadata: DataTransactionMetadata::new(),
+        });
+        db.update(|tx| -> eyre::Result<()> {
+            insert_tx_header(tx, &header)?;
+            set_data_tx_included_height(tx, &tx_id, 1)?;
+            Ok(())
+        })??;
+
+        // Inject a deliberately-corrupt CachedDataRoot:
+        //   - block_set points at random hashes that resolve to nothing
+        //   - txid_set contains stale txids alongside the canonical tx
+        //   - data_size is bogus and marked "confirmed"
+        // Any of these, if the validation path were silly enough to consult
+        // them, would change the returned range / corrupt the assignment.
+        let corrupt_cdr = CachedDataRoot {
+            data_size: u64::MAX,
+            data_size_confirmed: true,
+            txid_set: vec![H256::random(), tx_id, H256::random()],
+            block_set: vec![H256::random(), H256::random(), H256::random()],
+            expiry_height: Some(0),
+            cached_at: UnixTimestamp::from_secs(0),
+        };
+        db.update(|tx| -> eyre::Result<()> {
+            tx.put::<CachedDataRoots>(data_root, corrupt_cdr)?;
+            Ok(())
+        })??;
+
+        let mut genesis = IrysBlockHeader::new_mock_header();
+        genesis.height = 0;
+        genesis.previous_block_hash = H256::zero();
+        genesis.cumulative_diff = U256::from(0);
+        genesis.test_sign();
+        let tree = BlockTree::new(&genesis, ConsensusConfig::testing());
+        let block_tree_guard = BlockTreeReadGuard::new(Arc::new(RwLock::new(tree)));
+        let epoch_snapshot = EpochSnapshot::default();
+
+        let (assigned, miners) = get_assigned_ingress_proofs(
+            &[],
+            &header,
+            /* parent_height */ 5,
+            &block_tree_guard,
+            &db,
+            &config,
+            &epoch_snapshot,
+        )?;
+        // Identical result to the no-CDR case in
+        // `assigned_ingress_proofs_uses_canonical_tx_metadata` — proof that
+        // the corrupt CDR was not consulted.
         assert!(assigned.is_empty());
         assert_eq!(miners, 0);
 

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -3442,7 +3442,6 @@ pub fn get_assigned_ingress_proofs(
 ) -> Result<(Vec<IngressProof>, usize), PreValidationError> {
     // Returns (assigned_proofs, assigned_miners)
     let mut assigned_proofs = Vec::new();
-    let mut assigned_miners = 0;
 
     //  a) Get the canonical Submit-ledger range this tx contributed to at or
     //     before `parent_height`.  This replaces the historical
@@ -3470,7 +3469,76 @@ pub fn get_assigned_ingress_proofs(
         return Ok((vec![], 0));
     };
 
-    // Loop through all the ingress proofs for the published transaction and pre-validate them
+    // CONSENSUS RULE CHANGE (vs. the code this replaces):
+    //
+    // Old semantics: `assigned_miners` was set inside the per-proof loop, once
+    // per intersecting slot found for *that proof's* signer address.  Because
+    // the inner `slot_ranges` was a `HashMap`, iteration order was
+    // non-deterministic (RandomState), so when a miner held multiple
+    // intersecting slots the value written was whichever slot the HashMap
+    // happened to yield first.  In addition, the value was re-overwritten on
+    // each proof iteration ("last write wins"), so the final result depended on
+    // both proof ordering and HashMap randomness — a consensus-fork vector.
+    //
+    // New semantics: `assigned_miners` is the count of **unique miner
+    // addresses** assigned to *any* Submit-ledger slot whose chunk range
+    // intersects `block_range`.  It is a pure function of `(block_range,
+    // epoch_snapshot)` and is computed once, before the per-proof loop.
+    //
+    // Why the new semantics is correct:
+    //   1. Deterministic: the result is the same on every node regardless of
+    //      HashMap/BTreeMap key order or proof submission order.
+    //   2. Matches the variable name and the intent of the caller (the
+    //      `expected_assigned_proofs` clamp at the call site): "how many
+    //      distinct miners are eligible to contribute an assigned proof for
+    //      this tx?"  That is a property of the epoch, not of which proofs
+    //      were actually submitted.
+    //   3. Robust: if the "same miner never assigned to the same slot twice"
+    //      invariant is ever violated we still get a correct unique-address
+    //      count rather than double-counting.
+    //
+    // When `block_range` spans multiple slots whose miner sets overlap, the
+    // new value will be >= the old value (strictly larger if any miner covers
+    // more than one intersecting slot).  This is a consensus rule change and
+    // must be coordinated with a network upgrade.
+
+    // 1. Collect the slot indices of all Submit-ledger partitions whose
+    //    chunk range intersects block_range.
+    let intersecting_slots: HashSet<usize> = epoch_snapshot
+        .partition_assignments
+        .data_partitions
+        .iter()
+        .filter(|(_, pa)| pa.ledger_id == Some(DataLedger::Submit.into()))
+        .filter_map(|(_, pa)| pa.slot_index)
+        .filter(|&slot| {
+            let start = slot as u64 * config.consensus.num_chunks_in_partition;
+            let end = start + config.consensus.num_chunks_in_partition;
+            let slot_range = LedgerChunkRange(ie(
+                LedgerChunkOffset::from(start),
+                LedgerChunkOffset::from(end),
+            ));
+            block_range.intersection(&slot_range).is_some()
+        })
+        .collect();
+
+    // 2. Unique miner addresses across all intersecting slots.  This is the
+    //    eligibility population used to clamp `expected_assigned_proofs`.
+    let assigned_miners: usize = epoch_snapshot
+        .partition_assignments
+        .data_partitions
+        .iter()
+        .filter(|(_, pa)| {
+            pa.ledger_id == Some(DataLedger::Submit.into())
+                && pa
+                    .slot_index
+                    .is_some_and(|i| intersecting_slots.contains(&i))
+        })
+        .map(|(_, pa)| pa.miner_address)
+        .collect::<HashSet<IrysAddress>>()
+        .len();
+
+    // 3. Per-proof: classify each proof as assigned-or-not.  Never mutates
+    //    `assigned_miners` — that value is now fixed above.
     for ingress_proof in tx_proofs.iter() {
         // Validate ingress proof signature and data_root match the transaction
         let proof_address = ingress_proof
@@ -3480,36 +3548,10 @@ pub fn get_assigned_ingress_proofs(
                 reason: e.to_string(),
             })?;
 
-        // 1.) is the proof from a miner assigned to store the data in the submit ledger?
-
-        //  c) Get the slots the proof address is assigned to store
-        let slot_indexes = get_submit_ledger_slot_assignments(&proof_address, epoch_snapshot);
-
-        // d) Get the ledger ranges of the slot indexes
-        let slot_ranges: HashMap<usize, LedgerChunkRange> = slot_indexes
-            .iter()
-            .map(|index| {
-                let num_chunks_in_partition = config.consensus.num_chunks_in_partition;
-                let start = *index as u64 * num_chunks_in_partition;
-                let end = start + num_chunks_in_partition;
-                let range = LedgerChunkRange(ie(
-                    LedgerChunkOffset::from(start),
-                    LedgerChunkOffset::from(end),
-                ));
-                (*index, range)
-            })
-            .collect();
-
-        // e) Get the number of unique addresses assigned to each slot
-        let slot_address_counts = get_submit_ledger_slot_addresses(&slot_indexes, epoch_snapshot);
-
-        //  f) are there any intersections of block and slot ranges?
-        for (slot_index, slot_range) in &slot_ranges {
-            if block_range.intersection(slot_range).is_some() {
-                assigned_miners = *slot_address_counts.get(slot_index).unwrap();
-                assigned_proofs.push(ingress_proof.clone());
-                break;
-            }
+        // Is the proof from a miner assigned to store the data in the submit ledger?
+        let proof_slots = get_submit_ledger_slot_assignments(&proof_address, epoch_snapshot);
+        if proof_slots.iter().any(|i| intersecting_slots.contains(i)) {
+            assigned_proofs.push(ingress_proof.clone());
         }
     }
 
@@ -3526,29 +3568,6 @@ fn get_submit_ledger_slot_assignments(
         .iter()
         .map(|pa| pa.slot_index.unwrap())
         .collect()
-}
-
-fn get_submit_ledger_slot_addresses(
-    slot_indexes: &Vec<usize>,
-    epoch_snapshot: &EpochSnapshot,
-) -> HashMap<usize, usize> {
-    let mut num_addresses_per_slot: HashMap<usize, usize> = HashMap::new();
-
-    for slot_index in slot_indexes {
-        let num_addresses = epoch_snapshot
-            .partition_assignments
-            .data_partitions
-            .iter()
-            .filter(|(_hash, pa)| {
-                pa.ledger_id == Some(DataLedger::Submit.into())
-                    && pa.slot_index == Some(*slot_index)
-            })
-            .count();
-
-        num_addresses_per_slot.insert(*slot_index, num_addresses);
-    }
-
-    num_addresses_per_slot
 }
 
 #[cfg(test)]
@@ -4918,6 +4937,387 @@ mod tests {
             miners, 1,
             "exactly one miner registered to the intersecting slot"
         );
+
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // assigned_miners determinism tests
+    //
+    // These tests exercise the new semantics introduced by the consensus rule
+    // change in `get_assigned_ingress_proofs`:
+    //
+    //   assigned_miners = count of unique miner addresses across ALL
+    //   Submit-ledger slots intersecting block_range.
+    //
+    // The shared DB / BlockTree setup is the same across all three tests:
+    //   h0: Submit total_chunks = 10  (slot 0 covers [0, 10))
+    //   h1: Submit total_chunks = 25  (tx contributes chunks 10..=24, slot 1
+    //       covers [10, 20) and slot 2 covers [20, 30))
+    //
+    // ConsensusConfig::testing() has num_chunks_in_partition = 10, so:
+    //   slot 0 = [0, 10), slot 1 = [10, 20), slot 2 = [20, 30)
+    //
+    // block_range resolves to ii(10, 24) which intersects both slot 1 and
+    // slot 2.
+    // -----------------------------------------------------------------------
+
+    /// Helper: build the shared DB + BlockTree used by the three determinism
+    /// tests.  Returns (db, block_tree_guard, config, tx_id, data_root,
+    /// tx_header).
+    fn build_determinism_test_fixtures() -> eyre::Result<(
+        DatabaseProvider,
+        irys_domain::BlockTreeReadGuard,
+        Config,
+        H256,
+        H256,
+        DataTransactionHeader,
+    )> {
+        use irys_database::{
+            IrysDatabaseArgs as _, insert_tx_header, open_or_create_db,
+            set_data_tx_included_height,
+            tables::{IrysBlockHeaders, IrysTables, MigratedBlockHashes},
+        };
+        use irys_domain::BlockTree;
+        use irys_testing_utils::IrysBlockHeaderTestExt as _;
+        use irys_testing_utils::utils::TempDirBuilder;
+        use irys_types::{
+            DataTransactionHeaderV1, DataTransactionHeaderV1WithMetadata, DataTransactionMetadata,
+            H256List,
+        };
+        use reth_db::Database as _;
+        use reth_db::mdbx::DatabaseArguments;
+        use reth_db::transaction::DbTxMut as _;
+        use std::sync::RwLock;
+
+        let tmp = TempDirBuilder::new().build();
+        // Leak the TempDir so it lives for the duration of the test; the OS
+        // will clean it up anyway.
+        let _tmp = Box::leak(Box::new(tmp));
+
+        let env = open_or_create_db(
+            _tmp.path(),
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        let db = DatabaseProvider(Arc::new(env));
+
+        let node_config = NodeConfig::testing();
+        let config = Config::new_with_random_peer_id(node_config);
+
+        let tx_id = H256::random();
+        let data_root = H256::random();
+
+        let mut h0 = IrysBlockHeader::new_mock_header();
+        h0.height = 0;
+        h0.previous_block_hash = H256::zero();
+        h0.cumulative_diff = U256::from(0);
+        h0.data_ledgers[DataLedger::Submit as usize].total_chunks = 10;
+        h0.data_ledgers[DataLedger::Submit as usize].tx_ids = H256List(vec![]);
+        h0.test_sign();
+
+        // tx contributes chunks 10..=24 to the Submit ledger
+        let mut h1 = IrysBlockHeader::new_mock_header();
+        h1.height = 1;
+        h1.previous_block_hash = h0.block_hash;
+        h1.cumulative_diff = U256::from(1);
+        h1.data_ledgers[DataLedger::Submit as usize].total_chunks = 25;
+        h1.data_ledgers[DataLedger::Submit as usize].tx_ids = H256List(vec![tx_id]);
+        h1.test_sign();
+
+        db.update(|tx| -> eyre::Result<()> {
+            tx.put::<IrysBlockHeaders>(h0.block_hash, h0.clone().into())?;
+            tx.put::<IrysBlockHeaders>(h1.block_hash, h1.clone().into())?;
+            tx.put::<MigratedBlockHashes>(0, h0.block_hash)?;
+            tx.put::<MigratedBlockHashes>(1, h1.block_hash)?;
+            Ok(())
+        })??;
+
+        let header = DataTransactionHeader::V1(DataTransactionHeaderV1WithMetadata {
+            tx: DataTransactionHeaderV1 {
+                id: tx_id,
+                data_root,
+                ledger_id: DataLedger::Submit as u32,
+                ..Default::default()
+            },
+            metadata: DataTransactionMetadata::new(),
+        });
+        db.update(|tx| -> eyre::Result<()> {
+            insert_tx_header(tx, &header)?;
+            set_data_tx_included_height(tx, &tx_id, 1)?;
+            Ok(())
+        })??;
+
+        let mut genesis = IrysBlockHeader::new_mock_header();
+        genesis.height = 0;
+        genesis.previous_block_hash = H256::zero();
+        genesis.cumulative_diff = U256::from(0);
+        genesis.test_sign();
+        let tree = BlockTree::new(&genesis, ConsensusConfig::testing());
+        let block_tree_guard = irys_domain::BlockTreeReadGuard::new(Arc::new(RwLock::new(tree)));
+
+        Ok((db, block_tree_guard, config, tx_id, data_root, header))
+    }
+
+    /// Regression: `block_range` spans two slots (slot 1 = [10,20), slot 2 =
+    /// [20,30)).  One signer is assigned to both slots (two partitions, same
+    /// miner).  `assigned_miners` must equal 1 (one unique address), be
+    /// stable across repeated calls, and the proof must be classified as
+    /// assigned.
+    #[test_log::test(tokio::test)]
+    async fn assigned_miners_multi_slot_unique_address_count() -> eyre::Result<()> {
+        use irys_types::{
+            ConsensusConfig, ingress::generate_ingress_proof, irys::IrysSigner,
+            partition::PartitionAssignment,
+        };
+
+        let (db, block_tree_guard, config, _tx_id, data_root, header) =
+            build_determinism_test_fixtures()?;
+
+        let consensus = ConsensusConfig::testing();
+        let signer = IrysSigner::random_signer(&consensus);
+
+        // Same miner assigned to two partitions, one in slot 1 and one in
+        // slot 2.  Both slots intersect block_range [10, 24].
+        let mut epoch_snapshot = EpochSnapshot::default();
+        for slot_index in [1_usize, 2_usize] {
+            let pa = PartitionAssignment {
+                partition_hash: H256::random(),
+                miner_address: signer.address(),
+                ledger_id: Some(DataLedger::Submit as u32),
+                slot_index: Some(slot_index),
+            };
+            epoch_snapshot
+                .partition_assignments
+                .data_partitions
+                .insert(pa.partition_hash, pa);
+        }
+
+        // Generate a proof signed by the miner
+        let chunk_bytes: [u8; 32] = [0; 32];
+        let proof = generate_ingress_proof(
+            &signer,
+            data_root,
+            std::iter::once(Ok::<_, eyre::Report>(chunk_bytes.as_slice())),
+            consensus.chain_id,
+            H256::zero(),
+        )?;
+
+        // Call multiple times — result must be identical every time.
+        for run in 0..5 {
+            let (assigned, miners) = get_assigned_ingress_proofs(
+                std::slice::from_ref(&proof),
+                &header,
+                /* parent_height */ 5,
+                &block_tree_guard,
+                &db,
+                &config,
+                &epoch_snapshot,
+            )?;
+            assert_eq!(
+                miners, 1,
+                "run {run}: assigned_miners must be 1 (one unique address across both slots)"
+            );
+            assert_eq!(
+                assigned.len(),
+                1,
+                "run {run}: proof from the assigned miner must be classified as assigned"
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Single-slot: `block_range` intersects exactly one slot.  Two distinct
+    /// miners each hold a partition in that slot.  `assigned_miners` == 2.
+    #[test_log::test(tokio::test)]
+    async fn assigned_miners_single_slot_two_miners() -> eyre::Result<()> {
+        use irys_types::{
+            ConsensusConfig, ingress::generate_ingress_proof, irys::IrysSigner,
+            partition::PartitionAssignment,
+        };
+
+        let (db, block_tree_guard, config, _tx_id, data_root, header) =
+            build_determinism_test_fixtures()?;
+
+        let consensus = ConsensusConfig::testing();
+        let signer_a = IrysSigner::random_signer(&consensus);
+        let signer_b = IrysSigner::random_signer(&consensus);
+
+        // Two miners, both assigned to slot 1 = [10, 20), which intersects
+        // the tx's block_range [10, 24].
+        let mut epoch_snapshot = EpochSnapshot::default();
+        for miner_address in [signer_a.address(), signer_b.address()] {
+            let pa = PartitionAssignment {
+                partition_hash: H256::random(),
+                miner_address,
+                ledger_id: Some(DataLedger::Submit as u32),
+                slot_index: Some(1),
+            };
+            epoch_snapshot
+                .partition_assignments
+                .data_partitions
+                .insert(pa.partition_hash, pa);
+        }
+
+        // Only signer_a submits a proof.
+        let chunk_bytes: [u8; 32] = [0; 32];
+        let proof = generate_ingress_proof(
+            &signer_a,
+            data_root,
+            std::iter::once(Ok::<_, eyre::Report>(chunk_bytes.as_slice())),
+            consensus.chain_id,
+            H256::zero(),
+        )?;
+
+        let (assigned, miners) = get_assigned_ingress_proofs(
+            std::slice::from_ref(&proof),
+            &header,
+            /* parent_height */ 5,
+            &block_tree_guard,
+            &db,
+            &config,
+            &epoch_snapshot,
+        )?;
+
+        assert_eq!(
+            miners, 2,
+            "assigned_miners must equal the replication count of the intersecting slot"
+        );
+        assert_eq!(assigned.len(), 1, "signer_a's proof must be classified");
+
+        Ok(())
+    }
+
+    /// Rule-change lock-in: distinct miners in DIFFERENT intersecting slots.
+    /// This is the exact scenario where the new semantics (unique addresses
+    /// across all intersecting slots) diverges from the old semantics (count
+    /// from whichever single slot the HashMap happened to yield first).
+    ///
+    /// Setup: `block_range` = [10, 24] spans slot 1 = [10, 20) and slot 2 =
+    /// [20, 30).  Alice holds the only partition in slot 1; Bob holds the
+    /// only partition in slot 2.  Alice submits a proof.
+    ///
+    /// - Old code: would have iterated Alice's slot list, found slot 1 as
+    ///   her sole intersecting slot, and returned `assigned_miners = 1`
+    ///   (count of addresses in slot 1).
+    /// - New code: counts unique addresses across all intersecting slots —
+    ///   {Alice, Bob} = 2.
+    ///
+    /// Asserting `miners == 2` locks in the new value.  A regression to the
+    /// old semantics would return 1 and fail this test.
+    #[test_log::test(tokio::test)]
+    async fn assigned_miners_distinct_miners_across_intersecting_slots() -> eyre::Result<()> {
+        use irys_types::{
+            ConsensusConfig, ingress::generate_ingress_proof, irys::IrysSigner,
+            partition::PartitionAssignment,
+        };
+
+        let (db, block_tree_guard, config, _tx_id, data_root, header) =
+            build_determinism_test_fixtures()?;
+
+        let consensus = ConsensusConfig::testing();
+        let alice = IrysSigner::random_signer(&consensus);
+        let bob = IrysSigner::random_signer(&consensus);
+
+        // Alice in slot 1, Bob in slot 2.  Both slots intersect block_range.
+        let mut epoch_snapshot = EpochSnapshot::default();
+        for (miner_address, slot_index) in [(alice.address(), 1_usize), (bob.address(), 2_usize)] {
+            let pa = PartitionAssignment {
+                partition_hash: H256::random(),
+                miner_address,
+                ledger_id: Some(DataLedger::Submit as u32),
+                slot_index: Some(slot_index),
+            };
+            epoch_snapshot
+                .partition_assignments
+                .data_partitions
+                .insert(pa.partition_hash, pa);
+        }
+
+        // Alice submits a proof.
+        let chunk_bytes: [u8; 32] = [0; 32];
+        let proof = generate_ingress_proof(
+            &alice,
+            data_root,
+            std::iter::once(Ok::<_, eyre::Report>(chunk_bytes.as_slice())),
+            consensus.chain_id,
+            H256::zero(),
+        )?;
+
+        let (assigned, miners) = get_assigned_ingress_proofs(
+            std::slice::from_ref(&proof),
+            &header,
+            /* parent_height */ 5,
+            &block_tree_guard,
+            &db,
+            &config,
+            &epoch_snapshot,
+        )?;
+
+        assert_eq!(
+            miners, 2,
+            "new semantics: unique addresses across both intersecting slots = 2 \
+             (old semantics would have returned 1 — the count from Alice's single slot)"
+        );
+        assert_eq!(
+            assigned.len(),
+            1,
+            "Alice's proof must be classified as assigned"
+        );
+
+        Ok(())
+    }
+
+    /// Zero proofs: with at least one intersecting slot `assigned_miners > 0`
+    /// and `assigned_proofs` is empty.  With no intersecting slot (block_range
+    /// is None / tx unconfirmed) both are 0.
+    #[test_log::test(tokio::test)]
+    async fn assigned_miners_zero_proofs_returns_correct_counts() -> eyre::Result<()> {
+        use irys_types::partition::PartitionAssignment;
+
+        let (db, block_tree_guard, config, _tx_id, _data_root, header) =
+            build_determinism_test_fixtures()?;
+
+        // Register one miner to slot 1 — intersects block_range [10, 24].
+        let mut epoch_snapshot = EpochSnapshot::default();
+        let pa = PartitionAssignment {
+            partition_hash: H256::random(),
+            miner_address: IrysAddress::random(),
+            ledger_id: Some(DataLedger::Submit as u32),
+            slot_index: Some(1),
+        };
+        epoch_snapshot
+            .partition_assignments
+            .data_partitions
+            .insert(pa.partition_hash, pa);
+
+        // Pass zero proofs — must still count the intersecting miners correctly.
+        let (assigned, miners) = get_assigned_ingress_proofs(
+            &[],
+            &header,
+            /* parent_height */ 5,
+            &block_tree_guard,
+            &db,
+            &config,
+            &epoch_snapshot,
+        )?;
+        assert!(assigned.is_empty(), "no proofs submitted");
+        assert_eq!(miners, 1, "one miner in the intersecting slot");
+
+        // With an empty epoch_snapshot (no partitions) assigned_miners == 0.
+        let empty_snapshot = EpochSnapshot::default();
+        let (assigned2, miners2) = get_assigned_ingress_proofs(
+            &[],
+            &header,
+            /* parent_height */ 5,
+            &block_tree_guard,
+            &db,
+            &config,
+            &empty_snapshot,
+        )?;
+        assert!(assigned2.is_empty());
+        assert_eq!(miners2, 0, "no partitions → zero assigned_miners");
 
         Ok(())
     }

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -1406,7 +1406,9 @@ mod prevalidation_error_classification_tests {
     /// never confused with a peer-supplied invalid block.
     #[test]
     fn publish_tx_missing_prior_submit_is_peer_attributable() {
-        let err = PreValidationError::PublishTxMissingPriorSubmit { tx_id: H256::zero() };
+        let err = PreValidationError::PublishTxMissingPriorSubmit {
+            tx_id: H256::zero(),
+        };
         assert!(!err.is_internal_failure());
         assert!(!err.is_fatal_corruption());
     }

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -3442,6 +3442,7 @@ pub fn get_assigned_ingress_proofs(
 ) -> Result<(Vec<IngressProof>, usize), PreValidationError> {
     // Returns (assigned_proofs, assigned_miners)
     let mut assigned_proofs = Vec::new();
+    let mut assigned_miners = 0;
 
     //  a) Get the canonical Submit-ledger range this tx contributed to at or
     //     before `parent_height`.  This replaces the historical
@@ -3469,76 +3470,7 @@ pub fn get_assigned_ingress_proofs(
         return Ok((vec![], 0));
     };
 
-    // CONSENSUS RULE CHANGE (vs. the code this replaces):
-    //
-    // Old semantics: `assigned_miners` was set inside the per-proof loop, once
-    // per intersecting slot found for *that proof's* signer address.  Because
-    // the inner `slot_ranges` was a `HashMap`, iteration order was
-    // non-deterministic (RandomState), so when a miner held multiple
-    // intersecting slots the value written was whichever slot the HashMap
-    // happened to yield first.  In addition, the value was re-overwritten on
-    // each proof iteration ("last write wins"), so the final result depended on
-    // both proof ordering and HashMap randomness — a consensus-fork vector.
-    //
-    // New semantics: `assigned_miners` is the count of **unique miner
-    // addresses** assigned to *any* Submit-ledger slot whose chunk range
-    // intersects `block_range`.  It is a pure function of `(block_range,
-    // epoch_snapshot)` and is computed once, before the per-proof loop.
-    //
-    // Why the new semantics is correct:
-    //   1. Deterministic: the result is the same on every node regardless of
-    //      HashMap/BTreeMap key order or proof submission order.
-    //   2. Matches the variable name and the intent of the caller (the
-    //      `expected_assigned_proofs` clamp at the call site): "how many
-    //      distinct miners are eligible to contribute an assigned proof for
-    //      this tx?"  That is a property of the epoch, not of which proofs
-    //      were actually submitted.
-    //   3. Robust: if the "same miner never assigned to the same slot twice"
-    //      invariant is ever violated we still get a correct unique-address
-    //      count rather than double-counting.
-    //
-    // When `block_range` spans multiple slots whose miner sets overlap, the
-    // new value will be >= the old value (strictly larger if any miner covers
-    // more than one intersecting slot).  This is a consensus rule change and
-    // must be coordinated with a network upgrade.
-
-    // 1. Collect the slot indices of all Submit-ledger partitions whose
-    //    chunk range intersects block_range.
-    let intersecting_slots: HashSet<usize> = epoch_snapshot
-        .partition_assignments
-        .data_partitions
-        .iter()
-        .filter(|(_, pa)| pa.ledger_id == Some(DataLedger::Submit.into()))
-        .filter_map(|(_, pa)| pa.slot_index)
-        .filter(|&slot| {
-            let start = slot as u64 * config.consensus.num_chunks_in_partition;
-            let end = start + config.consensus.num_chunks_in_partition;
-            let slot_range = LedgerChunkRange(ie(
-                LedgerChunkOffset::from(start),
-                LedgerChunkOffset::from(end),
-            ));
-            block_range.intersection(&slot_range).is_some()
-        })
-        .collect();
-
-    // 2. Unique miner addresses across all intersecting slots.  This is the
-    //    eligibility population used to clamp `expected_assigned_proofs`.
-    let assigned_miners: usize = epoch_snapshot
-        .partition_assignments
-        .data_partitions
-        .iter()
-        .filter(|(_, pa)| {
-            pa.ledger_id == Some(DataLedger::Submit.into())
-                && pa
-                    .slot_index
-                    .is_some_and(|i| intersecting_slots.contains(&i))
-        })
-        .map(|(_, pa)| pa.miner_address)
-        .collect::<HashSet<IrysAddress>>()
-        .len();
-
-    // 3. Per-proof: classify each proof as assigned-or-not.  Never mutates
-    //    `assigned_miners` — that value is now fixed above.
+    // Loop through all the ingress proofs for the published transaction and pre-validate them
     for ingress_proof in tx_proofs.iter() {
         // Validate ingress proof signature and data_root match the transaction
         let proof_address = ingress_proof
@@ -3548,10 +3480,36 @@ pub fn get_assigned_ingress_proofs(
                 reason: e.to_string(),
             })?;
 
-        // Is the proof from a miner assigned to store the data in the submit ledger?
-        let proof_slots = get_submit_ledger_slot_assignments(&proof_address, epoch_snapshot);
-        if proof_slots.iter().any(|i| intersecting_slots.contains(i)) {
-            assigned_proofs.push(ingress_proof.clone());
+        // 1.) is the proof from a miner assigned to store the data in the submit ledger?
+
+        //  c) Get the slots the proof address is assigned to store
+        let slot_indexes = get_submit_ledger_slot_assignments(&proof_address, epoch_snapshot);
+
+        // d) Get the ledger ranges of the slot indexes
+        let slot_ranges: HashMap<usize, LedgerChunkRange> = slot_indexes
+            .iter()
+            .map(|index| {
+                let num_chunks_in_partition = config.consensus.num_chunks_in_partition;
+                let start = *index as u64 * num_chunks_in_partition;
+                let end = start + num_chunks_in_partition;
+                let range = LedgerChunkRange(ie(
+                    LedgerChunkOffset::from(start),
+                    LedgerChunkOffset::from(end),
+                ));
+                (*index, range)
+            })
+            .collect();
+
+        // e) Get the number of unique addresses assigned to each slot
+        let slot_address_counts = get_submit_ledger_slot_addresses(&slot_indexes, epoch_snapshot);
+
+        //  f) are there any intersections of block and slot ranges?
+        for (slot_index, slot_range) in &slot_ranges {
+            if block_range.intersection(slot_range).is_some() {
+                assigned_miners = *slot_address_counts.get(slot_index).unwrap();
+                assigned_proofs.push(ingress_proof.clone());
+                break;
+            }
         }
     }
 
@@ -3568,6 +3526,29 @@ fn get_submit_ledger_slot_assignments(
         .iter()
         .map(|pa| pa.slot_index.unwrap())
         .collect()
+}
+
+fn get_submit_ledger_slot_addresses(
+    slot_indexes: &Vec<usize>,
+    epoch_snapshot: &EpochSnapshot,
+) -> HashMap<usize, usize> {
+    let mut num_addresses_per_slot: HashMap<usize, usize> = HashMap::new();
+
+    for slot_index in slot_indexes {
+        let num_addresses = epoch_snapshot
+            .partition_assignments
+            .data_partitions
+            .iter()
+            .filter(|(_hash, pa)| {
+                pa.ledger_id == Some(DataLedger::Submit.into())
+                    && pa.slot_index == Some(*slot_index)
+            })
+            .count();
+
+        num_addresses_per_slot.insert(*slot_index, num_addresses);
+    }
+
+    num_addresses_per_slot
 }
 
 #[cfg(test)]
@@ -4937,387 +4918,6 @@ mod tests {
             miners, 1,
             "exactly one miner registered to the intersecting slot"
         );
-
-        Ok(())
-    }
-
-    // -----------------------------------------------------------------------
-    // assigned_miners determinism tests
-    //
-    // These tests exercise the new semantics introduced by the consensus rule
-    // change in `get_assigned_ingress_proofs`:
-    //
-    //   assigned_miners = count of unique miner addresses across ALL
-    //   Submit-ledger slots intersecting block_range.
-    //
-    // The shared DB / BlockTree setup is the same across all three tests:
-    //   h0: Submit total_chunks = 10  (slot 0 covers [0, 10))
-    //   h1: Submit total_chunks = 25  (tx contributes chunks 10..=24, slot 1
-    //       covers [10, 20) and slot 2 covers [20, 30))
-    //
-    // ConsensusConfig::testing() has num_chunks_in_partition = 10, so:
-    //   slot 0 = [0, 10), slot 1 = [10, 20), slot 2 = [20, 30)
-    //
-    // block_range resolves to ii(10, 24) which intersects both slot 1 and
-    // slot 2.
-    // -----------------------------------------------------------------------
-
-    /// Helper: build the shared DB + BlockTree used by the three determinism
-    /// tests.  Returns (db, block_tree_guard, config, tx_id, data_root,
-    /// tx_header).
-    fn build_determinism_test_fixtures() -> eyre::Result<(
-        DatabaseProvider,
-        irys_domain::BlockTreeReadGuard,
-        Config,
-        H256,
-        H256,
-        DataTransactionHeader,
-    )> {
-        use irys_database::{
-            IrysDatabaseArgs as _, insert_tx_header, open_or_create_db,
-            set_data_tx_included_height,
-            tables::{IrysBlockHeaders, IrysTables, MigratedBlockHashes},
-        };
-        use irys_domain::BlockTree;
-        use irys_testing_utils::IrysBlockHeaderTestExt as _;
-        use irys_testing_utils::utils::TempDirBuilder;
-        use irys_types::{
-            DataTransactionHeaderV1, DataTransactionHeaderV1WithMetadata, DataTransactionMetadata,
-            H256List,
-        };
-        use reth_db::Database as _;
-        use reth_db::mdbx::DatabaseArguments;
-        use reth_db::transaction::DbTxMut as _;
-        use std::sync::RwLock;
-
-        let tmp = TempDirBuilder::new().build();
-        // Leak the TempDir so it lives for the duration of the test; the OS
-        // will clean it up anyway.
-        let _tmp = Box::leak(Box::new(tmp));
-
-        let env = open_or_create_db(
-            _tmp.path(),
-            IrysTables::ALL,
-            DatabaseArguments::irys_testing()?,
-        )?;
-        let db = DatabaseProvider(Arc::new(env));
-
-        let node_config = NodeConfig::testing();
-        let config = Config::new_with_random_peer_id(node_config);
-
-        let tx_id = H256::random();
-        let data_root = H256::random();
-
-        let mut h0 = IrysBlockHeader::new_mock_header();
-        h0.height = 0;
-        h0.previous_block_hash = H256::zero();
-        h0.cumulative_diff = U256::from(0);
-        h0.data_ledgers[DataLedger::Submit as usize].total_chunks = 10;
-        h0.data_ledgers[DataLedger::Submit as usize].tx_ids = H256List(vec![]);
-        h0.test_sign();
-
-        // tx contributes chunks 10..=24 to the Submit ledger
-        let mut h1 = IrysBlockHeader::new_mock_header();
-        h1.height = 1;
-        h1.previous_block_hash = h0.block_hash;
-        h1.cumulative_diff = U256::from(1);
-        h1.data_ledgers[DataLedger::Submit as usize].total_chunks = 25;
-        h1.data_ledgers[DataLedger::Submit as usize].tx_ids = H256List(vec![tx_id]);
-        h1.test_sign();
-
-        db.update(|tx| -> eyre::Result<()> {
-            tx.put::<IrysBlockHeaders>(h0.block_hash, h0.clone().into())?;
-            tx.put::<IrysBlockHeaders>(h1.block_hash, h1.clone().into())?;
-            tx.put::<MigratedBlockHashes>(0, h0.block_hash)?;
-            tx.put::<MigratedBlockHashes>(1, h1.block_hash)?;
-            Ok(())
-        })??;
-
-        let header = DataTransactionHeader::V1(DataTransactionHeaderV1WithMetadata {
-            tx: DataTransactionHeaderV1 {
-                id: tx_id,
-                data_root,
-                ledger_id: DataLedger::Submit as u32,
-                ..Default::default()
-            },
-            metadata: DataTransactionMetadata::new(),
-        });
-        db.update(|tx| -> eyre::Result<()> {
-            insert_tx_header(tx, &header)?;
-            set_data_tx_included_height(tx, &tx_id, 1)?;
-            Ok(())
-        })??;
-
-        let mut genesis = IrysBlockHeader::new_mock_header();
-        genesis.height = 0;
-        genesis.previous_block_hash = H256::zero();
-        genesis.cumulative_diff = U256::from(0);
-        genesis.test_sign();
-        let tree = BlockTree::new(&genesis, ConsensusConfig::testing());
-        let block_tree_guard = irys_domain::BlockTreeReadGuard::new(Arc::new(RwLock::new(tree)));
-
-        Ok((db, block_tree_guard, config, tx_id, data_root, header))
-    }
-
-    /// Regression: `block_range` spans two slots (slot 1 = [10,20), slot 2 =
-    /// [20,30)).  One signer is assigned to both slots (two partitions, same
-    /// miner).  `assigned_miners` must equal 1 (one unique address), be
-    /// stable across repeated calls, and the proof must be classified as
-    /// assigned.
-    #[test_log::test(tokio::test)]
-    async fn assigned_miners_multi_slot_unique_address_count() -> eyre::Result<()> {
-        use irys_types::{
-            ConsensusConfig, ingress::generate_ingress_proof, irys::IrysSigner,
-            partition::PartitionAssignment,
-        };
-
-        let (db, block_tree_guard, config, _tx_id, data_root, header) =
-            build_determinism_test_fixtures()?;
-
-        let consensus = ConsensusConfig::testing();
-        let signer = IrysSigner::random_signer(&consensus);
-
-        // Same miner assigned to two partitions, one in slot 1 and one in
-        // slot 2.  Both slots intersect block_range [10, 24].
-        let mut epoch_snapshot = EpochSnapshot::default();
-        for slot_index in [1_usize, 2_usize] {
-            let pa = PartitionAssignment {
-                partition_hash: H256::random(),
-                miner_address: signer.address(),
-                ledger_id: Some(DataLedger::Submit as u32),
-                slot_index: Some(slot_index),
-            };
-            epoch_snapshot
-                .partition_assignments
-                .data_partitions
-                .insert(pa.partition_hash, pa);
-        }
-
-        // Generate a proof signed by the miner
-        let chunk_bytes: [u8; 32] = [0; 32];
-        let proof = generate_ingress_proof(
-            &signer,
-            data_root,
-            std::iter::once(Ok::<_, eyre::Report>(chunk_bytes.as_slice())),
-            consensus.chain_id,
-            H256::zero(),
-        )?;
-
-        // Call multiple times — result must be identical every time.
-        for run in 0..5 {
-            let (assigned, miners) = get_assigned_ingress_proofs(
-                std::slice::from_ref(&proof),
-                &header,
-                /* parent_height */ 5,
-                &block_tree_guard,
-                &db,
-                &config,
-                &epoch_snapshot,
-            )?;
-            assert_eq!(
-                miners, 1,
-                "run {run}: assigned_miners must be 1 (one unique address across both slots)"
-            );
-            assert_eq!(
-                assigned.len(),
-                1,
-                "run {run}: proof from the assigned miner must be classified as assigned"
-            );
-        }
-
-        Ok(())
-    }
-
-    /// Single-slot: `block_range` intersects exactly one slot.  Two distinct
-    /// miners each hold a partition in that slot.  `assigned_miners` == 2.
-    #[test_log::test(tokio::test)]
-    async fn assigned_miners_single_slot_two_miners() -> eyre::Result<()> {
-        use irys_types::{
-            ConsensusConfig, ingress::generate_ingress_proof, irys::IrysSigner,
-            partition::PartitionAssignment,
-        };
-
-        let (db, block_tree_guard, config, _tx_id, data_root, header) =
-            build_determinism_test_fixtures()?;
-
-        let consensus = ConsensusConfig::testing();
-        let signer_a = IrysSigner::random_signer(&consensus);
-        let signer_b = IrysSigner::random_signer(&consensus);
-
-        // Two miners, both assigned to slot 1 = [10, 20), which intersects
-        // the tx's block_range [10, 24].
-        let mut epoch_snapshot = EpochSnapshot::default();
-        for miner_address in [signer_a.address(), signer_b.address()] {
-            let pa = PartitionAssignment {
-                partition_hash: H256::random(),
-                miner_address,
-                ledger_id: Some(DataLedger::Submit as u32),
-                slot_index: Some(1),
-            };
-            epoch_snapshot
-                .partition_assignments
-                .data_partitions
-                .insert(pa.partition_hash, pa);
-        }
-
-        // Only signer_a submits a proof.
-        let chunk_bytes: [u8; 32] = [0; 32];
-        let proof = generate_ingress_proof(
-            &signer_a,
-            data_root,
-            std::iter::once(Ok::<_, eyre::Report>(chunk_bytes.as_slice())),
-            consensus.chain_id,
-            H256::zero(),
-        )?;
-
-        let (assigned, miners) = get_assigned_ingress_proofs(
-            std::slice::from_ref(&proof),
-            &header,
-            /* parent_height */ 5,
-            &block_tree_guard,
-            &db,
-            &config,
-            &epoch_snapshot,
-        )?;
-
-        assert_eq!(
-            miners, 2,
-            "assigned_miners must equal the replication count of the intersecting slot"
-        );
-        assert_eq!(assigned.len(), 1, "signer_a's proof must be classified");
-
-        Ok(())
-    }
-
-    /// Rule-change lock-in: distinct miners in DIFFERENT intersecting slots.
-    /// This is the exact scenario where the new semantics (unique addresses
-    /// across all intersecting slots) diverges from the old semantics (count
-    /// from whichever single slot the HashMap happened to yield first).
-    ///
-    /// Setup: `block_range` = [10, 24] spans slot 1 = [10, 20) and slot 2 =
-    /// [20, 30).  Alice holds the only partition in slot 1; Bob holds the
-    /// only partition in slot 2.  Alice submits a proof.
-    ///
-    /// - Old code: would have iterated Alice's slot list, found slot 1 as
-    ///   her sole intersecting slot, and returned `assigned_miners = 1`
-    ///   (count of addresses in slot 1).
-    /// - New code: counts unique addresses across all intersecting slots —
-    ///   {Alice, Bob} = 2.
-    ///
-    /// Asserting `miners == 2` locks in the new value.  A regression to the
-    /// old semantics would return 1 and fail this test.
-    #[test_log::test(tokio::test)]
-    async fn assigned_miners_distinct_miners_across_intersecting_slots() -> eyre::Result<()> {
-        use irys_types::{
-            ConsensusConfig, ingress::generate_ingress_proof, irys::IrysSigner,
-            partition::PartitionAssignment,
-        };
-
-        let (db, block_tree_guard, config, _tx_id, data_root, header) =
-            build_determinism_test_fixtures()?;
-
-        let consensus = ConsensusConfig::testing();
-        let alice = IrysSigner::random_signer(&consensus);
-        let bob = IrysSigner::random_signer(&consensus);
-
-        // Alice in slot 1, Bob in slot 2.  Both slots intersect block_range.
-        let mut epoch_snapshot = EpochSnapshot::default();
-        for (miner_address, slot_index) in [(alice.address(), 1_usize), (bob.address(), 2_usize)] {
-            let pa = PartitionAssignment {
-                partition_hash: H256::random(),
-                miner_address,
-                ledger_id: Some(DataLedger::Submit as u32),
-                slot_index: Some(slot_index),
-            };
-            epoch_snapshot
-                .partition_assignments
-                .data_partitions
-                .insert(pa.partition_hash, pa);
-        }
-
-        // Alice submits a proof.
-        let chunk_bytes: [u8; 32] = [0; 32];
-        let proof = generate_ingress_proof(
-            &alice,
-            data_root,
-            std::iter::once(Ok::<_, eyre::Report>(chunk_bytes.as_slice())),
-            consensus.chain_id,
-            H256::zero(),
-        )?;
-
-        let (assigned, miners) = get_assigned_ingress_proofs(
-            std::slice::from_ref(&proof),
-            &header,
-            /* parent_height */ 5,
-            &block_tree_guard,
-            &db,
-            &config,
-            &epoch_snapshot,
-        )?;
-
-        assert_eq!(
-            miners, 2,
-            "new semantics: unique addresses across both intersecting slots = 2 \
-             (old semantics would have returned 1 — the count from Alice's single slot)"
-        );
-        assert_eq!(
-            assigned.len(),
-            1,
-            "Alice's proof must be classified as assigned"
-        );
-
-        Ok(())
-    }
-
-    /// Zero proofs: with at least one intersecting slot `assigned_miners > 0`
-    /// and `assigned_proofs` is empty.  With no intersecting slot (block_range
-    /// is None / tx unconfirmed) both are 0.
-    #[test_log::test(tokio::test)]
-    async fn assigned_miners_zero_proofs_returns_correct_counts() -> eyre::Result<()> {
-        use irys_types::partition::PartitionAssignment;
-
-        let (db, block_tree_guard, config, _tx_id, _data_root, header) =
-            build_determinism_test_fixtures()?;
-
-        // Register one miner to slot 1 — intersects block_range [10, 24].
-        let mut epoch_snapshot = EpochSnapshot::default();
-        let pa = PartitionAssignment {
-            partition_hash: H256::random(),
-            miner_address: IrysAddress::random(),
-            ledger_id: Some(DataLedger::Submit as u32),
-            slot_index: Some(1),
-        };
-        epoch_snapshot
-            .partition_assignments
-            .data_partitions
-            .insert(pa.partition_hash, pa);
-
-        // Pass zero proofs — must still count the intersecting miners correctly.
-        let (assigned, miners) = get_assigned_ingress_proofs(
-            &[],
-            &header,
-            /* parent_height */ 5,
-            &block_tree_guard,
-            &db,
-            &config,
-            &epoch_snapshot,
-        )?;
-        assert!(assigned.is_empty(), "no proofs submitted");
-        assert_eq!(miners, 1, "one miner in the intersecting slot");
-
-        // With an empty epoch_snapshot (no partitions) assigned_miners == 0.
-        let empty_snapshot = EpochSnapshot::default();
-        let (assigned2, miners2) = get_assigned_ingress_proofs(
-            &[],
-            &header,
-            /* parent_height */ 5,
-            &block_tree_guard,
-            &db,
-            &config,
-            &empty_snapshot,
-        )?;
-        assert!(assigned2.is_empty());
-        assert_eq!(miners2, 0, "no partitions → zero assigned_miners");
 
         Ok(())
     }

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -4750,6 +4750,172 @@ mod tests {
 
         Ok(())
     }
+
+    /// Proof-bearing complement to `assigned_ingress_proofs_uses_canonical_tx_metadata`.
+    /// The earlier test exits before the per-proof loop because it passes
+    /// `&[]`, so the intersection / classification path at the bottom of
+    /// `get_assigned_ingress_proofs` is unexercised.  Here we:
+    ///   - run the same canonical-metadata setup so the helper resolves
+    ///     `block_range = [10, 24]` (h1's Submit added chunks 10..=24),
+    ///   - register one signer to Submit slot 1 (chunks `[10, 20)` under
+    ///     `ConsensusConfig::testing().num_chunks_in_partition = 10`, so the
+    ///     slot range intersects the block range),
+    ///   - feed one ingress proof signed by that signer for the same
+    ///     `data_root`,
+    /// and assert the proof is classified as assigned with `assigned_miners == 1`.
+    /// This covers the loop-body and slot-intersection code paths that the
+    /// empty-proof tests skip.
+    #[test_log::test(tokio::test)]
+    async fn assigned_ingress_proofs_classifies_intersecting_proof() -> eyre::Result<()> {
+        use crate::tx_inclusion;
+        use irys_database::{
+            IrysDatabaseArgs as _, insert_tx_header, open_or_create_db,
+            set_data_tx_included_height,
+            tables::{IrysBlockHeaders, IrysTables, MigratedBlockHashes},
+        };
+        use irys_domain::{BlockTree, BlockTreeReadGuard, EpochSnapshot};
+        use irys_testing_utils::IrysBlockHeaderTestExt as _;
+        use irys_testing_utils::utils::TempDirBuilder;
+        use irys_types::ingress::generate_ingress_proof;
+        use irys_types::partition::PartitionAssignment;
+        use irys_types::{
+            ConsensusConfig, DataTransactionHeader, DataTransactionHeaderV1,
+            DataTransactionHeaderV1WithMetadata, DataTransactionMetadata, H256, H256List,
+            irys::IrysSigner,
+        };
+        use reth_db::Database as _;
+        use reth_db::mdbx::DatabaseArguments;
+        use reth_db::transaction::DbTxMut as _;
+        use std::sync::RwLock;
+
+        let tmp = TempDirBuilder::new().build();
+        let env = open_or_create_db(
+            tmp.path(),
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        let db = DatabaseProvider(Arc::new(env));
+
+        let node_config = NodeConfig::testing();
+        let config = Config::new_with_random_peer_id(node_config);
+        let consensus = ConsensusConfig::testing();
+
+        // Canonical setup: same as the sibling tests.  h1 adds chunks 10..=24
+        // to the Submit ledger, so the helper resolves the range [10, 24].
+        let tx_id = H256::random();
+        let data_root = H256::random();
+
+        let mut h0 = IrysBlockHeader::new_mock_header();
+        h0.height = 0;
+        h0.previous_block_hash = H256::zero();
+        h0.cumulative_diff = U256::from(0);
+        h0.data_ledgers[DataLedger::Submit as usize].total_chunks = 10;
+        h0.data_ledgers[DataLedger::Submit as usize].tx_ids = H256List(vec![]);
+        h0.test_sign();
+
+        let mut h1 = IrysBlockHeader::new_mock_header();
+        h1.height = 1;
+        h1.previous_block_hash = h0.block_hash;
+        h1.cumulative_diff = U256::from(1);
+        h1.data_ledgers[DataLedger::Submit as usize].total_chunks = 25;
+        h1.data_ledgers[DataLedger::Submit as usize].tx_ids = H256List(vec![tx_id]);
+        h1.test_sign();
+
+        db.update(|tx| -> eyre::Result<()> {
+            tx.put::<IrysBlockHeaders>(h0.block_hash, h0.clone().into())?;
+            tx.put::<IrysBlockHeaders>(h1.block_hash, h1.clone().into())?;
+            tx.put::<MigratedBlockHashes>(0, h0.block_hash)?;
+            tx.put::<MigratedBlockHashes>(1, h1.block_hash)?;
+            Ok(())
+        })??;
+
+        let header = DataTransactionHeader::V1(DataTransactionHeaderV1WithMetadata {
+            tx: DataTransactionHeaderV1 {
+                id: tx_id,
+                data_root,
+                ledger_id: DataLedger::Submit as u32,
+                ..Default::default()
+            },
+            metadata: DataTransactionMetadata::new(),
+        });
+        db.update(|tx| -> eyre::Result<()> {
+            insert_tx_header(tx, &header)?;
+            set_data_tx_included_height(tx, &tx_id, 1)?;
+            Ok(())
+        })??;
+
+        let mut genesis = IrysBlockHeader::new_mock_header();
+        genesis.height = 0;
+        genesis.previous_block_hash = H256::zero();
+        genesis.cumulative_diff = U256::from(0);
+        genesis.test_sign();
+        let tree = BlockTree::new(&genesis, ConsensusConfig::testing());
+        let block_tree_guard = BlockTreeReadGuard::new(Arc::new(RwLock::new(tree)));
+
+        // Sanity: helper resolves [10, 24] as expected.
+        let resolved = tx_inclusion::find_canonical_ledger_range(
+            &tx_id,
+            5,
+            config.consensus.block_migration_depth,
+            &block_tree_guard,
+            &db,
+        )?
+        .ok_or_else(|| eyre::eyre!("test setup error: range should resolve"))?;
+        assert_eq!(u64::from(resolved.start()), 10);
+        assert_eq!(u64::from(resolved.end()), 24);
+
+        // Register one signer to Submit slot 1 = chunks [10, 20).  That
+        // overlaps the block range [10, 24], so the proof must classify.
+        let signer = IrysSigner::random_signer(&consensus);
+        let mut epoch_snapshot = EpochSnapshot::default();
+        let assignment = PartitionAssignment {
+            partition_hash: H256::random(),
+            miner_address: signer.address(),
+            ledger_id: Some(DataLedger::Submit as u32),
+            slot_index: Some(1),
+        };
+        epoch_snapshot
+            .partition_assignments
+            .data_partitions
+            .insert(assignment.partition_hash, assignment);
+
+        // One ingress proof for the canonical data_root, signed by the
+        // miner registered to the intersecting slot above.
+        let chunk_bytes: [u8; 32] = [0; 32];
+        let proof = generate_ingress_proof(
+            &signer,
+            data_root,
+            std::iter::once(Ok::<_, eyre::Report>(chunk_bytes.as_slice())),
+            consensus.chain_id,
+            H256::zero(),
+        )?;
+
+        let (assigned, miners) = get_assigned_ingress_proofs(
+            std::slice::from_ref(&proof),
+            &header,
+            /* parent_height */ 5,
+            &block_tree_guard,
+            &db,
+            &config,
+            &epoch_snapshot,
+        )?;
+
+        assert_eq!(
+            assigned.len(),
+            1,
+            "the proof should be classified as assigned"
+        );
+        assert_eq!(
+            assigned[0], proof,
+            "the returned proof should be the one we passed in"
+        );
+        assert_eq!(
+            miners, 1,
+            "exactly one miner registered to the intersecting slot"
+        );
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -8,7 +8,7 @@ use crate::{
 use alloy_eips::eip7685::{Requests, RequestsOrHash};
 use alloy_rpc_types_engine::ExecutionData;
 use eyre::{OptionExt as _, ensure, eyre};
-use irys_database::{cached_data_root_by_data_root, tx_header_by_txid_canonical};
+use irys_database::tx_header_by_txid_canonical;
 use irys_domain::{
     BlockIndex, BlockIndexReadGuard, BlockTreeReadGuard, CommitmentSnapshot,
     CommitmentSnapshotStatus, EmaSnapshot, EpochSnapshot, ExecutionPayloadCache,
@@ -2705,6 +2705,7 @@ pub async fn data_txs_are_valid(
             let (assigned_proofs, assigned_miners) = get_assigned_ingress_proofs(
                 &tx_proofs,
                 tx_header,
+                block.height.saturating_sub(1),
                 block_tree_guard,
                 db,
                 config,
@@ -3296,6 +3297,7 @@ fn merge_same_block_historical_ledgers(
 pub fn get_assigned_ingress_proofs(
     tx_proofs: &[IngressProof],
     tx_header: &DataTransactionHeader,
+    parent_height: u64,
     block_tree: &BlockTreeReadGuard,
     db: &DatabaseProvider,
     config: &Config,
@@ -3305,57 +3307,31 @@ pub fn get_assigned_ingress_proofs(
     let mut assigned_proofs = Vec::new();
     let mut assigned_miners = 0;
 
-    //  a) Get the block hashes from the cached data_root (invariant across all proofs)
-    let block_hashes = db
-        .view(|tx| cached_data_root_by_data_root(tx, tx_header.data_root))
-        .map_err(|e| PreValidationError::DatabaseError {
-            error: format!(
-                "Failed to open DB read tx for data_root {} (tx_id {}): {}",
-                tx_header.data_root, tx_header.id, e
-            ),
-        })?
-        .map_err(|e| PreValidationError::DatabaseError {
-            error: format!(
-                "DB query failed for data_root {} (tx_id {}): {}",
-                tx_header.data_root, tx_header.id, e
-            ),
-        })?
-        .ok_or_else(|| PreValidationError::DatabaseError {
-            error: format!(
-                "CachedDataRoot not found for data_root {} (tx_id {})",
-                tx_header.data_root, tx_header.id
-            ),
-        })?
-        .block_set;
+    //  a) Get the canonical Submit-ledger range this tx contributed to at or
+    //     before `parent_height`.  This replaces the historical
+    //     CachedDataRoots.block_set lookup, which retained reorg'd-out hashes
+    //     and could produce stale BlockBoundsLookupError.
+    let block_range = crate::tx_inclusion::find_canonical_ledger_range(
+        &tx_header.id,
+        parent_height,
+        config.consensus.block_migration_depth,
+        block_tree,
+        db,
+    )
+    .map_err(|e| {
+        PreValidationError::BlockBoundsLookupError(format!(
+            "find_canonical_ledger_range failed for tx {} (data_root {}): {}",
+            tx_header.id, tx_header.data_root, e
+        ))
+    })?;
 
-    // Empty block_set is valid for single-block promotion: the data_root hasn't
-    // been included in any confirmed block yet.  With no block_ranges, no proofs
-    // will be classified as "assigned" and assigned_miners stays 0.  The caller
-    // clamps expected_assigned_proofs to 0, so all proofs count as unassigned and
-    // only the total-proof-count gate applies.
-    if block_hashes.is_empty() {
+    // No canonical confirmation at or before parent_height (single-block
+    // promotion or unconfirmed).  Preserve historical semantics: no proofs are
+    // classified as "assigned" and assigned_miners stays 0, so the caller's
+    // clamp leaves only the total-proof-count gate applicable.
+    let Some(block_range) = block_range else {
         return Ok((vec![], 0));
-    }
-
-    //  b) Get the submit ledger offset intervals for each of the blocks (invariant across all proofs)
-    let mut block_ranges = Vec::new();
-    for block_hash in block_hashes.iter() {
-        match get_ledger_range(block_hash, block_tree, db) {
-            Ok(Some(block_range)) => block_ranges.push(block_range),
-            Ok(None) => {
-                return Err(PreValidationError::BlockBoundsLookupError(format!(
-                    "get_ledger_range returned None for block {}, assigned_miners would remain unset (tx_id {})",
-                    block_hash, tx_header.id
-                )));
-            }
-            Err(e) => {
-                return Err(PreValidationError::BlockBoundsLookupError(format!(
-                    "Failed to get ledger range for block {}: {}",
-                    block_hash, e
-                )));
-            }
-        }
-    }
+    };
 
     // Loop through all the ingress proofs for the published transaction and pre-validate them
     for ingress_proof in tx_proofs.iter() {
@@ -3391,16 +3367,9 @@ pub fn get_assigned_ingress_proofs(
         let slot_address_counts = get_submit_ledger_slot_addresses(&slot_indexes, epoch_snapshot);
 
         //  f) are there any intersections of block and slot ranges?
-        let mut is_intersected = false;
-        for block_range in &block_ranges {
-            for (slot_index, slot_range) in &slot_ranges {
-                if block_range.intersection(slot_range).is_some() {
-                    is_intersected = true;
-                    assigned_miners = *slot_address_counts.get(slot_index).unwrap();
-                    break;
-                }
-            }
-            if is_intersected {
+        for (slot_index, slot_range) in &slot_ranges {
+            if block_range.intersection(slot_range).is_some() {
+                assigned_miners = *slot_address_counts.get(slot_index).unwrap();
                 assigned_proofs.push(ingress_proof.clone());
                 break;
             }
@@ -3408,59 +3377,6 @@ pub fn get_assigned_ingress_proofs(
     }
 
     Ok((assigned_proofs, assigned_miners))
-}
-
-fn get_ledger_range(
-    hash: &H256,
-    block_tree: &BlockTreeReadGuard,
-    db: &DatabaseProvider,
-) -> eyre::Result<Option<LedgerChunkRange>> {
-    let block = match get_block_by_hash(hash, block_tree, db)? {
-        Some(b) => b,
-        None => return Ok(None),
-    };
-    let prev_block_hash = block.previous_block_hash;
-
-    let block_total_chunks = block.data_ledgers[DataLedger::Submit].total_chunks;
-
-    if block.height == 0 {
-        if block_total_chunks == 0 {
-            return Ok(None);
-        }
-        Ok(Some(LedgerChunkRange(ii(
-            LedgerChunkOffset::from(0),
-            LedgerChunkOffset::from(block_total_chunks - 1),
-        ))))
-    } else {
-        let prev_block = match get_block_by_hash(&prev_block_hash, block_tree, db)? {
-            Some(b) => b,
-            None => return Ok(None),
-        };
-        let prev_total_chunks = prev_block.data_ledgers[DataLedger::Submit].total_chunks;
-        if block_total_chunks < prev_total_chunks {
-            return Err(eyre::eyre!(
-                "Block {} has total_chunks ({}) < prev block total_chunks ({}), data corruption",
-                hash,
-                block_total_chunks,
-                prev_total_chunks
-            ));
-        }
-        if block_total_chunks == 0 || block_total_chunks == prev_total_chunks {
-            return Ok(None);
-        }
-        Ok(Some(LedgerChunkRange(ii(
-            LedgerChunkOffset::from(prev_total_chunks),
-            LedgerChunkOffset::from(block_total_chunks - 1),
-        ))))
-    }
-}
-
-fn get_block_by_hash(
-    hash: &H256,
-    block_tree: &BlockTreeReadGuard,
-    db: &DatabaseProvider,
-) -> eyre::Result<Option<IrysBlockHeader>> {
-    crate::block_tree_service::get_block_header(block_tree, db, *hash, false)
 }
 
 fn get_submit_ledger_slot_assignments(
@@ -4440,6 +4356,133 @@ mod tests {
         } else {
             panic!("expected PreValidationError::PreviousCumulativeDifficultyMismatch");
         }
+    }
+
+    /// Integration check for `get_assigned_ingress_proofs`: with a tx
+    /// canonically confirmed via `IrysDataTxMetadata`+`MigratedBlockHashes`,
+    /// the function looks up the Submit-ledger range via
+    /// `tx_inclusion::find_canonical_ledger_range` and returns successfully.
+    ///
+    /// Regression coverage for the 2026-05-15 self-fork: the previous
+    /// implementation walked `CachedDataRoots.block_set`, which retained
+    /// orphaned hashes after reorgs and caused `BlockBoundsLookupError`
+    /// once those blocks were purged.  `block_set` has since been removed
+    /// from `CachedDataRoot` entirely.
+    #[test_log::test(tokio::test)]
+    async fn assigned_ingress_proofs_uses_canonical_tx_metadata() -> eyre::Result<()> {
+        use crate::tx_inclusion;
+        use irys_database::{
+            IrysDatabaseArgs as _, insert_tx_header, open_or_create_db,
+            set_data_tx_included_height,
+            tables::{IrysBlockHeaders, IrysTables, MigratedBlockHashes},
+        };
+        use irys_domain::{BlockTree, BlockTreeReadGuard, EpochSnapshot};
+        use irys_testing_utils::IrysBlockHeaderTestExt as _;
+        use irys_testing_utils::utils::TempDirBuilder;
+        use irys_types::{
+            ConsensusConfig, DataTransactionHeader, DataTransactionHeaderV1,
+            DataTransactionHeaderV1WithMetadata, DataTransactionMetadata, H256, H256List,
+        };
+        use reth_db::Database as _;
+        use reth_db::mdbx::DatabaseArguments;
+        use reth_db::transaction::DbTxMut as _;
+        use std::sync::RwLock;
+
+        let tmp = TempDirBuilder::new().build();
+        let env = open_or_create_db(
+            tmp.path(),
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        let db = DatabaseProvider(Arc::new(env));
+
+        let node_config = NodeConfig::testing();
+        let config = Config::new_with_random_peer_id(node_config);
+
+        // Build a two-block canonical chain.  h1 includes tx_id in Submit.
+        let tx_id = H256::random();
+        let data_root = H256::random();
+
+        let mut h0 = IrysBlockHeader::new_mock_header();
+        h0.height = 0;
+        h0.previous_block_hash = H256::zero();
+        h0.cumulative_diff = U256::from(0);
+        h0.data_ledgers[DataLedger::Submit as usize].total_chunks = 10;
+        h0.data_ledgers[DataLedger::Submit as usize].tx_ids = H256List(vec![]);
+        h0.test_sign();
+
+        let mut h1 = IrysBlockHeader::new_mock_header();
+        h1.height = 1;
+        h1.previous_block_hash = h0.block_hash;
+        h1.cumulative_diff = U256::from(1);
+        h1.data_ledgers[DataLedger::Submit as usize].total_chunks = 25;
+        h1.data_ledgers[DataLedger::Submit as usize].tx_ids = H256List(vec![tx_id]);
+        h1.test_sign();
+
+        // Persist block headers + mark both heights migrated to canonical.
+        db.update(|tx| -> eyre::Result<()> {
+            tx.put::<IrysBlockHeaders>(h0.block_hash, h0.clone().into())?;
+            tx.put::<IrysBlockHeaders>(h1.block_hash, h1.clone().into())?;
+            tx.put::<MigratedBlockHashes>(0, h0.block_hash)?;
+            tx.put::<MigratedBlockHashes>(1, h1.block_hash)?;
+            Ok(())
+        })??;
+
+        // Write the canonical tx metadata so the migrated-path lookup succeeds.
+        let header = DataTransactionHeader::V1(DataTransactionHeaderV1WithMetadata {
+            tx: DataTransactionHeaderV1 {
+                id: tx_id,
+                data_root,
+                ledger_id: DataLedger::Submit as u32,
+                ..Default::default()
+            },
+            metadata: DataTransactionMetadata::new(),
+        });
+        db.update(|tx| -> eyre::Result<()> {
+            insert_tx_header(tx, &header)?;
+            set_data_tx_included_height(tx, &tx_id, 1)?;
+            Ok(())
+        })??;
+
+        // Empty BlockTree + default EpochSnapshot are sufficient since
+        // the tx is found via the migrated-metadata path and no proofs
+        // are passed (so partition assignments are unused).
+        let mut genesis = IrysBlockHeader::new_mock_header();
+        genesis.height = 0;
+        genesis.previous_block_hash = H256::zero();
+        genesis.cumulative_diff = U256::from(0);
+        genesis.test_sign();
+        let tree = BlockTree::new(&genesis, ConsensusConfig::testing());
+        let block_tree_guard = BlockTreeReadGuard::new(Arc::new(RwLock::new(tree)));
+
+        let epoch_snapshot = EpochSnapshot::default();
+
+        // Sanity: helper resolves the canonical range directly.
+        let direct = tx_inclusion::find_canonical_ledger_range(
+            &tx_id,
+            5,
+            config.consensus.block_migration_depth,
+            &block_tree_guard,
+            &db,
+        )?;
+        assert!(
+            direct.is_some(),
+            "test setup error: helper should resolve migrated tx"
+        );
+
+        let (assigned, miners) = get_assigned_ingress_proofs(
+            &[],
+            &header,
+            /* parent_height */ 5,
+            &block_tree_guard,
+            &db,
+            &config,
+            &epoch_snapshot,
+        )?;
+        assert!(assigned.is_empty());
+        assert_eq!(miners, 0);
+
+        Ok(())
     }
 }
 

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -401,13 +401,18 @@ impl InnerCacheTask {
             }
             // Pruning horizon priority: canonical tx inclusion > expiry height > skip
             // Rationale: Migrated tx metadata provides a stable canonical
-            // inclusion height even after reorgs.  Unconfirmed mempool entries
-            // use expiry_height as a conservative fallback.  Entries without
-            // either are likely still active and are skipped.
+            // inclusion height even after reorgs.  Pre-confirmation mempool
+            // entries use expiry_height as a fallback.  Entries with neither
+            // are skipped (conservative).
             //
-            // No block_tree fallback is needed here: pre-migration entries are
-            // already covered by expiry_height (set at cache_data_root time)
-            // and by the local-proof exemption further below.
+            // Note: cache_data_root *clears* expiry_height when a block_header
+            // is provided (database.rs).  So a confirmed-but-not-yet-migrated
+            // entry temporarily has expiry_height=None and included_height=None
+            // and lands in the skip arm below.  Once migration writes
+            // included_height (within ~block_migration_depth blocks) the entry
+            // becomes eligible for pruning.  No block_tree fallback is added
+            // here: the local-proof exemption further below covers the case
+            // we care most about, and the window is bounded.
             let mut inclusion_max_height: Option<u64> = None;
             for tx_id in cached.txid_set.iter() {
                 if let Some(metadata) = irys_database::get_data_tx_metadata(&write_tx, tx_id)?

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -399,20 +399,24 @@ impl InnerCacheTask {
                 );
                 break;
             }
-            // Pruning horizon priority: canonical tx inclusion > expiry height > skip
-            // Rationale: Migrated tx metadata provides a stable canonical
-            // inclusion height even after reorgs.  Pre-confirmation mempool
-            // entries use expiry_height as a fallback.  Entries with neither
-            // are skipped (conservative).
+            // Pruning horizon priority: canonical tx inclusion > expiry height > evict-anomalous.
             //
-            // Note: cache_data_root *clears* expiry_height when a block_header
-            // is provided (database.rs).  So a confirmed-but-not-yet-migrated
-            // entry temporarily has expiry_height=None and included_height=None
-            // and lands in the skip arm below.  Once migration writes
-            // included_height (within ~block_migration_depth blocks) the entry
-            // becomes eligible for pruning.  No block_tree fallback is added
-            // here: the local-proof exemption further below covers the case
-            // we care most about, and the window is bounded.
+            // CDR lifetime is bounded by either (a) `expiry_height` set at tx
+            // ingress (`cache_data_root_with_expiry`), or (b) `included_height`
+            // set atomically with the confirming tip change in
+            // `BlockMigrationService::persist_metadata` (Phase 2 sets
+            // `included_height`, Phase 3 clears `expiry_height` — same write
+            // tx).  The local-proof exemption below extends (b) indefinitely
+            // while a local ingress proof is present.
+            //
+            // The `(None, None)` arm is reachable only when a CDR has lost
+            // both bounds: a reorg cleared `included_height` for every tx in
+            // `txid_set` after the confirmation already cleared
+            // `expiry_height`, and the mempool re-anchor path did not restore
+            // expiry (e.g. orphan resubmission failed).  Under the lifetime
+            // model such an entry should not exist, so treat it as a
+            // candidate for eviction — but keep the local-proof exemption so
+            // an entry that still carries a useful commitment survives.
             let mut inclusion_max_height: Option<u64> = None;
             for tx_id in cached.txid_set.iter() {
                 if let Some(metadata) = irys_database::get_data_tx_metadata(&write_tx, tx_id)?
@@ -426,23 +430,25 @@ impl InnerCacheTask {
                 (None, Some(e)) => Some(e),
                 (None, None) => None,
             };
-            let max_height: u64 = match horizon {
-                Some(h) => h,
-                None => {
-                    trace!(
-                        data_root.data_root = ?data_root,
-                        "Skipping prune for data root without inclusion or expiry"
-                    );
-                    continue;
-                }
+
+            // Decide whether this entry is a candidate for eviction.
+            //  * horizon present: the historical "past the bound" check.
+            //  * horizon absent: anomalous (None, None) state — evict unless
+            //    the local-proof exemption below applies.
+            let is_eviction_candidate = match horizon {
+                Some(max_height) => max_height < prune_height,
+                None => true,
             };
 
             trace!(
-                "Processing data root {} max height: {}, prune height: {}",
-                &data_root, &max_height, &prune_height
+                data_root.data_root = ?data_root,
+                horizon = ?horizon,
+                prune_height,
+                is_eviction_candidate,
+                "Processing data root for prune evaluation"
             );
 
-            if max_height < prune_height {
+            if is_eviction_candidate {
                 // Check for locally generated ingress proof
                 let mut proofs_cursor = write_tx.cursor_read::<IngressProofs>()?;
                 let mut has_local_proof = false;
@@ -460,6 +466,7 @@ impl InnerCacheTask {
                 if has_local_proof {
                     trace!(
                         data_root.data_root = ?data_root,
+                        horizon = ?horizon,
                         "Skipping prune for data root with locally generated ingress proof"
                     );
                     continue;
@@ -471,6 +478,7 @@ impl InnerCacheTask {
                     txid_set_size = cached.txid_set.len(),
                     last_inclusion_height = ?inclusion_max_height,
                     expiry_height = ?cached.expiry_height,
+                    horizon = ?horizon,
                     %prune_height,
                     has_local_proof,
                     "cached_data_root.evict"
@@ -1011,6 +1019,14 @@ mod tests {
 
     // This test prevents a regression of bug: mempool-only data roots (with empty block_set field)
     // are pruned once prune_height > 0 and they should not be pruned!
+    //
+    // Real prod ingress goes through `cache_data_root_with_expiry`, which sets
+    // `expiry_height` to `anchor + tx_anchor_expiry_depth`.  Direct callers of
+    // `cache_data_root(_, _, None)` (this fixture, pre-fix code paths) leave
+    // `expiry_height = None`.  We set it manually here to mirror what the
+    // mempool ingress path produces, so the test exercises the realistic
+    // "unconfirmed entry with expiry in the future" state rather than the
+    // anomalous (None, None) state.
     #[tokio::test]
     async fn does_not_prune_unconfirmed_data_roots() -> eyre::Result<()> {
         let node_config = NodeConfig::testing();
@@ -1033,6 +1049,17 @@ mod tests {
         });
         db.update(|wtx| {
             database::cache_data_root(wtx, &tx_header, None)?;
+            eyre::Ok(())
+        })??;
+
+        // Mirror `cache_data_root_with_expiry`: set expiry_height to a future
+        // height so the entry has a valid lifetime bound (pre-confirmation arm).
+        db.update(|wtx| {
+            let mut cdr = wtx
+                .get::<CachedDataRoots>(tx_header.data_root)?
+                .ok_or_else(|| eyre::eyre!("missing CachedDataRoots entry"))?;
+            cdr.expiry_height = Some(100);
+            wtx.put::<CachedDataRoots>(tx_header.data_root, cdr)?;
             eyre::Ok(())
         })??;
 
@@ -1771,6 +1798,162 @@ mod tests {
             eyre::ensure!(
                 has_root,
                 "CachedDataRoots should NOT have been pruned due to local proof"
+            );
+            Ok(())
+        })??;
+
+        Ok(())
+    }
+
+    /// Anomalous `(None, None)` state — no `expiry_height`, no
+    /// `included_height` for any txid in `txid_set`, no local ingress proof.
+    /// Under the lifetime model this entry has lost both bounds and should be
+    /// evicted on the next prune cycle.  Reachable in practice when a reorg
+    /// cleared `included_height` for an orphaned tx, `expiry_height` had
+    /// already been cleared at the now-orphaned confirmation, and the mempool
+    /// orphan re-anchor path did not restore expiry.
+    #[tokio::test]
+    async fn prunes_anomalous_none_none_state() -> eyre::Result<()> {
+        let node_config = NodeConfig::testing();
+        let config = Config::new_with_random_peer_id(node_config);
+        let _temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db_env = open_or_create_db(
+            &_temp_dir,
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        let db = DatabaseProvider(Arc::new(db_env));
+
+        let tx_header = DataTransactionHeader::V1(DataTransactionHeaderV1WithMetadata {
+            tx: DataTransactionHeaderV1 {
+                data_size: 64,
+                ..Default::default()
+            },
+            metadata: DataTransactionMetadata::new(),
+        });
+        // cache_data_root(_, _, None) leaves expiry_height=None, and we never
+        // populate IrysDataTxMetadata for the tx — so the txid_set walk in
+        // prune_data_root_cache produces inclusion_max_height=None.  The
+        // resulting CDR is in the (None, None) state.
+        db.update(|wtx| {
+            database::cache_data_root(wtx, &tx_header, None)?;
+            eyre::Ok(())
+        })??;
+
+        // Sanity: entry exists and is in the (None, None) state.
+        db.view(|rtx| -> eyre::Result<()> {
+            let cdr = rtx
+                .get::<CachedDataRoots>(tx_header.data_root)?
+                .ok_or_else(|| eyre::eyre!("CachedDataRoots missing before prune"))?;
+            eyre::ensure!(
+                cdr.expiry_height.is_none(),
+                "fixture expected expiry_height=None, got {:?}",
+                cdr.expiry_height
+            );
+            Ok(())
+        })??;
+
+        let genesis_block = new_mock_signed_header();
+        let block_tree = BlockTree::new(&genesis_block, config.consensus.clone());
+        let block_tree_guard =
+            irys_domain::BlockTreeReadGuard::new(Arc::new(RwLock::new(block_tree)));
+        let block_index = BlockIndex::new_for_testing(db.clone());
+        let block_index_guard =
+            irys_domain::block_index_guard::BlockIndexReadGuard::new(block_index);
+
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let service_task = InnerCacheTask {
+            db: db.clone(),
+            block_tree_guard,
+            block_index_guard,
+            config,
+            gossip_broadcast: tokio::sync::mpsc::unbounded_channel().0,
+            ingress_proof_generation_state: IngressProofGenerationState::new(),
+            cache_sender: tx,
+        };
+
+        // Any prune_height — the (None, None) state has no bound, so the
+        // entry is an eviction candidate regardless.
+        service_task.prune_data_root_cache(1)?;
+
+        db.view(|rtx| -> eyre::Result<()> {
+            let has_root = rtx.get::<CachedDataRoots>(tx_header.data_root)?.is_some();
+            eyre::ensure!(
+                !has_root,
+                "anomalous (None, None) CachedDataRoots entry should have been pruned"
+            );
+            Ok(())
+        })??;
+
+        Ok(())
+    }
+
+    /// Companion to `prunes_anomalous_none_none_state`: the same anomalous
+    /// `(None, None)` state, but with a local ingress proof present.  The
+    /// local-proof exemption should override the eviction so any useful
+    /// commitment is preserved.
+    #[tokio::test]
+    async fn does_not_prune_anomalous_none_none_state_with_local_proof() -> eyre::Result<()> {
+        let node_config = NodeConfig::testing();
+        let config = Config::new_with_random_peer_id(node_config);
+        let _temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db_env = open_or_create_db(
+            &_temp_dir,
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        let db = DatabaseProvider(Arc::new(db_env));
+
+        let tx_header = DataTransactionHeader::V1(DataTransactionHeaderV1WithMetadata {
+            tx: DataTransactionHeaderV1 {
+                data_size: 64,
+                ..Default::default()
+            },
+            metadata: DataTransactionMetadata::new(),
+        });
+        db.update(|wtx| {
+            database::cache_data_root(wtx, &tx_header, None)?;
+            eyre::Ok(())
+        })??;
+
+        // Add a local ingress proof for this data_root.
+        let signer = config.irys_signer();
+        let local_addr = signer.address();
+        db.update(|wtx| {
+            let mut ingress_proof = IngressProof::default();
+            ingress_proof.data_root = tx_header.data_root;
+            irys_database::store_external_ingress_proof_checked(wtx, &ingress_proof, local_addr)?;
+            eyre::Ok(())
+        })??;
+
+        let genesis_block = new_mock_signed_header();
+        let block_tree = BlockTree::new(&genesis_block, config.consensus.clone());
+        let block_tree_guard =
+            irys_domain::BlockTreeReadGuard::new(Arc::new(RwLock::new(block_tree)));
+        let block_index = BlockIndex::new_for_testing(db.clone());
+        let block_index_guard =
+            irys_domain::block_index_guard::BlockIndexReadGuard::new(block_index);
+
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let service_task = InnerCacheTask {
+            db: db.clone(),
+            block_tree_guard,
+            block_index_guard,
+            config,
+            gossip_broadcast: tokio::sync::mpsc::unbounded_channel().0,
+            ingress_proof_generation_state: IngressProofGenerationState::new(),
+            cache_sender: tx,
+        };
+
+        // Without the local-proof exemption the (None, None) state would be
+        // evicted; with it the entry must survive.
+        service_task.prune_data_root_cache(1)?;
+
+        db.view(|rtx| -> eyre::Result<()> {
+            let has_root = rtx.get::<CachedDataRoots>(tx_header.data_root)?.is_some();
+            eyre::ensure!(
+                has_root,
+                "CachedDataRoots in (None, None) state with local proof should NOT have been pruned"
             );
             Ok(())
         })??;

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -4,7 +4,8 @@ use crate::chunk_ingress_service::ingress_proofs::{
 };
 use crate::metrics;
 use irys_database::{
-    cached_data_root_by_data_root, delete_cached_chunks_by_data_root_older_than, tx_header_by_txid,
+    cached_data_root_by_data_root, delete_cached_chunks_by_data_root_older_than,
+    get_data_tx_metadata, tx_header_by_txid,
 };
 use irys_database::{
     db::IrysDatabaseExt as _,
@@ -577,12 +578,31 @@ impl InnerCacheTask {
 
     /// Spawns a background thread to remove specific txids from `CachedDataRoot.txid_set` entries.
     ///
-    /// Called when the mempool prunes expired txs. If a tx was never included in a
-    /// block, its txid becomes a dangling reference in `CachedDataRoot.txid_set`.
-    /// Cleaning it here prevents stale txids from blocking publish candidate selection.
+    /// Called when the mempool prunes expired txs or the reorg handler observes
+    /// a failed orphan re-ingress.  In both cases the *decision to scrub* is
+    /// made on stale state (either pre-TTL or pre-reorg-cleanup); by the time
+    /// this task runs the world may have moved on — most importantly, the tx
+    /// may have been re-confirmed by a new block that arrived in the gap.
     ///
-    /// Uses a background thread (matching `spawn_pruning_task`) to avoid blocking the actor loop.
-    /// Sends `PruneTxidsCompleted` when done so the service can drive the queue.
+    /// `txid_set` is **authoritative state** (see [`CachedDataRoot::txid_set`]
+    /// docs).  Removing an entry whose tx has since been (re-)confirmed
+    /// would make the prune loop miss that confirmation's chunk-retention
+    /// constraint and evict the CDR before chunk migration completes,
+    /// destroying chunks that are still needed.  Per-txid metadata recheck
+    /// inside the write tx closes that race: if `IrysDataTxMetadata[tx_id]`
+    /// is `Some` now, the tx is confirmed and the txid_set entry must stay.
+    ///
+    /// Residual race the recheck does not close: a peer gossips the tx back
+    /// in during the scrub window and `cache_data_root` re-adds it to
+    /// `txid_set`, but the tx has not yet confirmed (no metadata row).  The
+    /// scrub would drop it.  Bounded by mempool TTL re-population and
+    /// `cache_data_root` idempotency on the next ingress.  Acceptable for
+    /// the current architecture; revisit if the mempool grows a strong
+    /// "currently-pending" signal that can be consulted from MDBX context.
+    ///
+    /// Uses a background thread (matching `spawn_pruning_task`) to avoid
+    /// blocking the actor loop.  Sends `PruneTxidsCompleted` when done so
+    /// the service can drive the queue.
     fn spawn_prune_txids_task(&self, by_data_root: HashMap<H256, Vec<H256>>) {
         let clone = self.clone();
         std::thread::spawn(move || {
@@ -592,7 +612,30 @@ impl InnerCacheTask {
                         continue;
                     };
 
-                    let removal_set: HashSet<H256> = txids_to_remove.iter().copied().collect();
+                    // Build the actually-safe-to-remove set: any tx_id whose
+                    // metadata row exists now was (re-)confirmed since the
+                    // scrub was queued and must stay in txid_set — see the
+                    // race rationale in the function docs above.
+                    let mut removal_set: HashSet<H256> = HashSet::new();
+                    let mut raced_confirmed: usize = 0;
+                    for tx_id in txids_to_remove {
+                        if get_data_tx_metadata(db_tx, tx_id)?.is_some() {
+                            raced_confirmed += 1;
+                            continue;
+                        }
+                        removal_set.insert(*tx_id);
+                    }
+                    if raced_confirmed > 0 {
+                        debug!(
+                            data_root = %data_root,
+                            raced_confirmed,
+                            "Skipped txid scrub for tx(es) (re-)confirmed during scrub window"
+                        );
+                    }
+                    if removal_set.is_empty() {
+                        continue;
+                    }
+
                     let before_len = cached.txid_set.len();
                     cached.txid_set.retain(|id| !removal_set.contains(id));
 

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -405,147 +405,171 @@ impl InnerCacheTask {
         .entered();
         let write_tx = self.db.tx_mut()?;
         let mut cursor = write_tx.cursor_write::<CachedDataRoots>()?;
-        let mut walker = cursor.walk(None)?;
-        while let Some((data_root, cached)) = walker.next().transpose()? {
-            if eviction_count >= MAX_EVICTIONS_PER_RUN {
-                warn!(
-                    evictions_performed = eviction_count,
-                    "Hit max eviction limit in prune_data_root_cache, will continue next cycle"
+        // Seed the cursor with a random data_root so MDBX seeks to the
+        // nearest key; without this, a stable backlog of CDRs protected by
+        // the pending-tx / local-proof exemptions re-scans from the front
+        // every cycle and starves later entries.  Mirrors the TODO at
+        // `prune_ingress_proofs` (~L696).  When the first walk runs out of
+        // entries without hitting `MAX_EVICTIONS_PER_RUN`, fall through to
+        // a second walk from the beginning so total coverage stays
+        // wrap-around-complete (otherwise tests + small tables with all
+        // keys above the random seek would silently scan zero entries).
+        let seek_key: DataRoot = H256::random();
+        let mut walker = cursor.walk(Some(seek_key))?;
+        let mut wrapped = false;
+        loop {
+            while let Some((data_root, cached)) = walker.next().transpose()? {
+                if eviction_count >= MAX_EVICTIONS_PER_RUN {
+                    warn!(
+                        evictions_performed = eviction_count,
+                        "Hit max eviction limit in prune_data_root_cache, will continue next cycle"
+                    );
+                    break;
+                }
+                // Pruning horizon priority: canonical tx inclusion > expiry height > evict-anomalous.
+                //
+                // CDR lifetime is bounded by either (a) `expiry_height` set at tx
+                // ingress (`cache_data_root_with_expiry`), or (b) `included_height`
+                // set atomically with the confirming tip change in
+                // `BlockMigrationService::persist_metadata` (Phase 2 sets
+                // `included_height`, Phase 3 clears `expiry_height` — same write
+                // tx).  The local-proof exemption below extends (b) indefinitely
+                // while a local ingress proof is present.
+                //
+                // The `(None, None)` arm is reachable only when a CDR has lost
+                // both bounds: a reorg cleared `included_height` for every tx in
+                // `txid_set` after the confirmation already cleared
+                // `expiry_height`, and the mempool re-anchor path did not restore
+                // expiry (e.g. orphan resubmission failed).  Under the lifetime
+                // model such an entry should not exist, so treat it as a
+                // candidate for eviction — but keep the local-proof exemption so
+                // an entry that still carries a useful commitment survives.
+                let mut inclusion_max_height: Option<u64> = None;
+                let mut all_txs_confirmed = true;
+                for tx_id in cached.txid_set.iter() {
+                    match irys_database::get_data_tx_metadata(&write_tx, tx_id)?
+                        .and_then(|m| m.included_height)
+                    {
+                        Some(h) => {
+                            inclusion_max_height =
+                                Some(inclusion_max_height.map_or(h, |x| x.max(h)));
+                        }
+                        // No metadata row, or row exists with `included_height = None`:
+                        // this tx (sharing `data_root` with the rest of `txid_set`) is
+                        // still pending.  `inclusion_max_height` alone would prematurely
+                        // prune chunks the pending tx still needs — e.g. a Publish-
+                        // promotion sibling of an already-confirmed term-ledger tx that
+                        // shares the same `data_root`.
+                        //
+                        // Once any tx is pending, the horizon below ignores
+                        // `inclusion_max_height` and defers to `expiry_height`, so
+                        // further metadata reads are wasted DB work inside the open
+                        // write tx.  Bail early.
+                        None => {
+                            all_txs_confirmed = false;
+                            break;
+                        }
+                    }
+                }
+
+                // Horizon policy:
+                //  - All txs confirmed: use the latest `included_height` as the
+                //    boundary (falling back to `expiry_height`, then `(None, None)`
+                //    anomalous-eviction).
+                //  - Any tx still pending: defer to `expiry_height`.  An already-
+                //    confirmed sibling's `included_height` does NOT bind the
+                //    pending tx's chunk lifetime; using it as the horizon would
+                //    prematurely prune chunks the pending tx still needs.  If
+                //    expiry was already cleared by the sibling confirmation,
+                //    `horizon` is `None` and the eviction-candidate arm protects
+                //    the entry until the pending tx either confirms or is dropped
+                //    by mempool TTL.
+                let horizon = if all_txs_confirmed {
+                    match (inclusion_max_height, cached.expiry_height) {
+                        (Some(h), _) => Some(h),
+                        (None, Some(e)) => Some(e),
+                        (None, None) => None,
+                    }
+                } else {
+                    cached.expiry_height
+                };
+
+                // Decide whether this entry is a candidate for eviction.
+                //  * horizon present: the historical "past the bound" check.
+                //  * horizon absent + all txs confirmed: truly anomalous state
+                //    (empty `txid_set`, or all txs confirmed-and-orphaned with
+                //    expiry already cleared) — evict unless the local-proof
+                //    exemption below applies.
+                //  * horizon absent + pending tx remains: protect (see horizon
+                //    policy above).
+                let is_eviction_candidate = match (horizon, all_txs_confirmed) {
+                    (Some(max_height), _) => max_height < prune_height,
+                    (None, true) => true,
+                    (None, false) => false,
+                };
+
+                trace!(
+                    data_root.data_root = ?data_root,
+                    horizon = ?horizon,
+                    prune_height,
+                    is_eviction_candidate,
+                    "Processing data root for prune evaluation"
                 );
+
+                if is_eviction_candidate {
+                    // Check for locally generated ingress proof
+                    let mut proofs_cursor = write_tx.cursor_read::<IngressProofs>()?;
+                    let mut has_local_proof = false;
+                    let mut proof_walker = proofs_cursor.walk(Some(data_root))?;
+                    while let Some((key, compact)) = proof_walker.next().transpose()? {
+                        if key != data_root {
+                            break;
+                        }
+                        if compact.0.address == local_addr {
+                            has_local_proof = true;
+                            break;
+                        }
+                    }
+
+                    if has_local_proof {
+                        trace!(
+                            data_root.data_root = ?data_root,
+                            horizon = ?horizon,
+                            "Skipping prune for data root with locally generated ingress proof"
+                        );
+                        continue;
+                    }
+
+                    // Capture txid_set_size before `cached` is partially moved below.
+                    let txid_set_size = cached.txid_set.len();
+                    let expiry_height = cached.expiry_height;
+
+                    write_tx.delete::<IngressProofs>(data_root, None)?;
+                    chunks_pruned = chunks_pruned
+                        .saturating_add(delete_cached_chunks_by_data_root(&write_tx, data_root)?);
+                    write_tx.delete::<CachedDataRoots>(data_root, None)?;
+                    eviction_count += 1;
+
+                    evictions.push(EvictionRecord {
+                        data_root,
+                        block_set: cached.block_set,
+                        txid_set_size,
+                        inclusion_max_height,
+                        expiry_height,
+                        horizon,
+                    });
+                }
+            }
+            if wrapped || eviction_count >= MAX_EVICTIONS_PER_RUN {
                 break;
             }
-            // Pruning horizon priority: canonical tx inclusion > expiry height > evict-anomalous.
-            //
-            // CDR lifetime is bounded by either (a) `expiry_height` set at tx
-            // ingress (`cache_data_root_with_expiry`), or (b) `included_height`
-            // set atomically with the confirming tip change in
-            // `BlockMigrationService::persist_metadata` (Phase 2 sets
-            // `included_height`, Phase 3 clears `expiry_height` — same write
-            // tx).  The local-proof exemption below extends (b) indefinitely
-            // while a local ingress proof is present.
-            //
-            // The `(None, None)` arm is reachable only when a CDR has lost
-            // both bounds: a reorg cleared `included_height` for every tx in
-            // `txid_set` after the confirmation already cleared
-            // `expiry_height`, and the mempool re-anchor path did not restore
-            // expiry (e.g. orphan resubmission failed).  Under the lifetime
-            // model such an entry should not exist, so treat it as a
-            // candidate for eviction — but keep the local-proof exemption so
-            // an entry that still carries a useful commitment survives.
-            let mut inclusion_max_height: Option<u64> = None;
-            let mut all_txs_confirmed = true;
-            for tx_id in cached.txid_set.iter() {
-                match irys_database::get_data_tx_metadata(&write_tx, tx_id)?
-                    .and_then(|m| m.included_height)
-                {
-                    Some(h) => {
-                        inclusion_max_height = Some(inclusion_max_height.map_or(h, |x| x.max(h)));
-                    }
-                    // No metadata row, or row exists with `included_height = None`:
-                    // this tx (sharing `data_root` with the rest of `txid_set`) is
-                    // still pending.  `inclusion_max_height` alone would prematurely
-                    // prune chunks the pending tx still needs — e.g. a Publish-
-                    // promotion sibling of an already-confirmed term-ledger tx that
-                    // shares the same `data_root`.
-                    //
-                    // Once any tx is pending, the horizon below ignores
-                    // `inclusion_max_height` and defers to `expiry_height`, so
-                    // further metadata reads are wasted DB work inside the open
-                    // write tx.  Bail early.
-                    None => {
-                        all_txs_confirmed = false;
-                        break;
-                    }
-                }
-            }
-
-            // Horizon policy:
-            //  - All txs confirmed: use the latest `included_height` as the
-            //    boundary (falling back to `expiry_height`, then `(None, None)`
-            //    anomalous-eviction).
-            //  - Any tx still pending: defer to `expiry_height`.  An already-
-            //    confirmed sibling's `included_height` does NOT bind the
-            //    pending tx's chunk lifetime; using it as the horizon would
-            //    prematurely prune chunks the pending tx still needs.  If
-            //    expiry was already cleared by the sibling confirmation,
-            //    `horizon` is `None` and the eviction-candidate arm protects
-            //    the entry until the pending tx either confirms or is dropped
-            //    by mempool TTL.
-            let horizon = if all_txs_confirmed {
-                match (inclusion_max_height, cached.expiry_height) {
-                    (Some(h), _) => Some(h),
-                    (None, Some(e)) => Some(e),
-                    (None, None) => None,
-                }
-            } else {
-                cached.expiry_height
-            };
-
-            // Decide whether this entry is a candidate for eviction.
-            //  * horizon present: the historical "past the bound" check.
-            //  * horizon absent + all txs confirmed: truly anomalous state
-            //    (empty `txid_set`, or all txs confirmed-and-orphaned with
-            //    expiry already cleared) — evict unless the local-proof
-            //    exemption below applies.
-            //  * horizon absent + pending tx remains: protect (see horizon
-            //    policy above).
-            let is_eviction_candidate = match (horizon, all_txs_confirmed) {
-                (Some(max_height), _) => max_height < prune_height,
-                (None, true) => true,
-                (None, false) => false,
-            };
-
-            trace!(
-                data_root.data_root = ?data_root,
-                horizon = ?horizon,
-                prune_height,
-                is_eviction_candidate,
-                "Processing data root for prune evaluation"
-            );
-
-            if is_eviction_candidate {
-                // Check for locally generated ingress proof
-                let mut proofs_cursor = write_tx.cursor_read::<IngressProofs>()?;
-                let mut has_local_proof = false;
-                let mut proof_walker = proofs_cursor.walk(Some(data_root))?;
-                while let Some((key, compact)) = proof_walker.next().transpose()? {
-                    if key != data_root {
-                        break;
-                    }
-                    if compact.0.address == local_addr {
-                        has_local_proof = true;
-                        break;
-                    }
-                }
-
-                if has_local_proof {
-                    trace!(
-                        data_root.data_root = ?data_root,
-                        horizon = ?horizon,
-                        "Skipping prune for data root with locally generated ingress proof"
-                    );
-                    continue;
-                }
-
-                // Capture txid_set_size before `cached` is partially moved below.
-                let txid_set_size = cached.txid_set.len();
-                let expiry_height = cached.expiry_height;
-
-                write_tx.delete::<IngressProofs>(data_root, None)?;
-                chunks_pruned = chunks_pruned
-                    .saturating_add(delete_cached_chunks_by_data_root(&write_tx, data_root)?);
-                write_tx.delete::<CachedDataRoots>(data_root, None)?;
-                eviction_count += 1;
-
-                evictions.push(EvictionRecord {
-                    data_root,
-                    block_set: cached.block_set,
-                    txid_set_size,
-                    inclusion_max_height,
-                    expiry_height,
-                    horizon,
-                });
-            }
+            // First walk ran from `Some(seek_key)` to end without hitting the
+            // eviction cap.  Wrap around and scan the prefix `[start,
+            // seek_key)` so coverage is complete.  Without this fall-through
+            // a small table whose keys all sort above `seek_key` would
+            // silently scan zero entries this cycle.
+            wrapped = true;
+            walker = cursor.walk(None)?;
         }
         write_tx.commit()?;
 

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -418,26 +418,59 @@ impl InnerCacheTask {
             // candidate for eviction — but keep the local-proof exemption so
             // an entry that still carries a useful commitment survives.
             let mut inclusion_max_height: Option<u64> = None;
+            let mut all_txs_confirmed = true;
             for tx_id in cached.txid_set.iter() {
-                if let Some(metadata) = irys_database::get_data_tx_metadata(&write_tx, tx_id)?
-                    && let Some(h) = metadata.included_height
+                match irys_database::get_data_tx_metadata(&write_tx, tx_id)?
+                    .and_then(|m| m.included_height)
                 {
-                    inclusion_max_height = Some(inclusion_max_height.map_or(h, |x| x.max(h)));
+                    Some(h) => {
+                        inclusion_max_height =
+                            Some(inclusion_max_height.map_or(h, |x| x.max(h)));
+                    }
+                    // No metadata row, or row exists with `included_height = None`:
+                    // this tx (sharing `data_root` with the rest of `txid_set`) is
+                    // still pending.  `inclusion_max_height` alone would prematurely
+                    // prune chunks the pending tx still needs — e.g. a Publish-
+                    // promotion sibling of an already-confirmed term-ledger tx that
+                    // shares the same `data_root`.
+                    None => all_txs_confirmed = false,
                 }
             }
-            let horizon = match (inclusion_max_height, cached.expiry_height) {
-                (Some(h), _) => Some(h),
-                (None, Some(e)) => Some(e),
-                (None, None) => None,
+
+            // Horizon policy:
+            //  - All txs confirmed: use the latest `included_height` as the
+            //    boundary (falling back to `expiry_height`, then `(None, None)`
+            //    anomalous-eviction).
+            //  - Any tx still pending: defer to `expiry_height`.  An already-
+            //    confirmed sibling's `included_height` does NOT bind the
+            //    pending tx's chunk lifetime; using it as the horizon would
+            //    prematurely prune chunks the pending tx still needs.  If
+            //    expiry was already cleared by the sibling confirmation,
+            //    `horizon` is `None` and the eviction-candidate arm protects
+            //    the entry until the pending tx either confirms or is dropped
+            //    by mempool TTL.
+            let horizon = if all_txs_confirmed {
+                match (inclusion_max_height, cached.expiry_height) {
+                    (Some(h), _) => Some(h),
+                    (None, Some(e)) => Some(e),
+                    (None, None) => None,
+                }
+            } else {
+                cached.expiry_height
             };
 
             // Decide whether this entry is a candidate for eviction.
             //  * horizon present: the historical "past the bound" check.
-            //  * horizon absent: anomalous (None, None) state — evict unless
-            //    the local-proof exemption below applies.
-            let is_eviction_candidate = match horizon {
-                Some(max_height) => max_height < prune_height,
-                None => true,
+            //  * horizon absent + all txs confirmed: truly anomalous state
+            //    (empty `txid_set`, or all txs confirmed-and-orphaned with
+            //    expiry already cleared) — evict unless the local-proof
+            //    exemption below applies.
+            //  * horizon absent + pending tx remains: protect (see horizon
+            //    policy above).
+            let is_eviction_candidate = match (horizon, all_txs_confirmed) {
+                (Some(max_height), _) => max_height < prune_height,
+                (None, true) => true,
+                (None, false) => false,
             };
 
             trace!(
@@ -1003,7 +1036,7 @@ impl ChunkCacheService {
 mod tests {
     use super::*;
     use irys_database::{
-        IrysDatabaseArgs as _, database, open_or_create_db,
+        IrysDatabaseArgs as _, database, db_cache::CachedDataRoot, open_or_create_db,
         tables::{CachedChunks, CachedChunksIndex, CachedDataRoots, IrysTables},
     };
     use irys_domain::{BlockIndex, BlockTree};
@@ -1805,15 +1838,19 @@ mod tests {
         Ok(())
     }
 
-    /// Anomalous `(None, None)` state — no `expiry_height`, no
-    /// `included_height` for any txid in `txid_set`, no local ingress proof.
-    /// Under the lifetime model this entry has lost both bounds and should be
-    /// evicted on the next prune cycle.  Reachable in practice when a reorg
-    /// cleared `included_height` for an orphaned tx, `expiry_height` had
-    /// already been cleared at the now-orphaned confirmation, and the mempool
-    /// orphan re-anchor path did not restore expiry.
+    /// Truly anomalous `(None, None)` state: empty `txid_set`, no
+    /// `expiry_height`, no local ingress proof.  Under the lifetime model
+    /// this entry has no remaining tenants and no bound — evict on next
+    /// prune cycle.
+    ///
+    /// Note: the prior version of this test exercised a CDR with a pending
+    /// tx in `txid_set` and asserted eviction.  That semantics was changed
+    /// when the pending-tx guard was added to protect cross-ledger
+    /// same-`data_root` sibling txs from premature prune; pending txs now
+    /// keep the CDR alive (see `does_not_prune_cdr_with_pending_sibling_tx`).
+    /// The truly-anomalous arm now only fires when `txid_set` is empty.
     #[tokio::test]
-    async fn prunes_anomalous_none_none_state() -> eyre::Result<()> {
+    async fn prunes_truly_anomalous_empty_txid_set() -> eyre::Result<()> {
         let node_config = NodeConfig::testing();
         let config = Config::new_with_random_peer_id(node_config);
         let _temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
@@ -1824,32 +1861,20 @@ mod tests {
         )?;
         let db = DatabaseProvider(Arc::new(db_env));
 
-        let tx_header = DataTransactionHeader::V1(DataTransactionHeaderV1WithMetadata {
-            tx: DataTransactionHeaderV1 {
-                data_size: 64,
-                ..Default::default()
-            },
-            metadata: DataTransactionMetadata::new(),
-        });
-        // cache_data_root(_, _, None) leaves expiry_height=None, and we never
-        // populate IrysDataTxMetadata for the tx — so the txid_set walk in
-        // prune_data_root_cache produces inclusion_max_height=None.  The
-        // resulting CDR is in the (None, None) state.
-        db.update(|wtx| {
-            database::cache_data_root(wtx, &tx_header, None)?;
-            eyre::Ok(())
-        })??;
-
-        // Sanity: entry exists and is in the (None, None) state.
-        db.view(|rtx| -> eyre::Result<()> {
-            let cdr = rtx
-                .get::<CachedDataRoots>(tx_header.data_root)?
-                .ok_or_else(|| eyre::eyre!("CachedDataRoots missing before prune"))?;
-            eyre::ensure!(
-                cdr.expiry_height.is_none(),
-                "fixture expected expiry_height=None, got {:?}",
-                cdr.expiry_height
-            );
+        // Construct a CDR with empty txid_set directly — the only state
+        // reachable by `(horizon=None, all_txs_confirmed=true)` after the
+        // pending-tx guard.
+        let data_root = H256::random();
+        let cdr = CachedDataRoot {
+            data_size: 64,
+            data_size_confirmed: false,
+            txid_set: vec![],
+            block_set: vec![],
+            expiry_height: None,
+            cached_at: irys_types::UnixTimestamp::now()?,
+        };
+        db.update(|wtx| -> eyre::Result<()> {
+            wtx.put::<CachedDataRoots>(data_root, cdr)?;
             Ok(())
         })??;
 
@@ -1872,15 +1897,13 @@ mod tests {
             cache_sender: tx,
         };
 
-        // Any prune_height — the (None, None) state has no bound, so the
-        // entry is an eviction candidate regardless.
         service_task.prune_data_root_cache(1)?;
 
         db.view(|rtx| -> eyre::Result<()> {
-            let has_root = rtx.get::<CachedDataRoots>(tx_header.data_root)?.is_some();
+            let has_root = rtx.get::<CachedDataRoots>(data_root)?.is_some();
             eyre::ensure!(
                 !has_root,
-                "anomalous (None, None) CachedDataRoots entry should have been pruned"
+                "truly-anomalous CachedDataRoots entry (empty txid_set, no bounds) should be pruned"
             );
             Ok(())
         })??;
@@ -1888,10 +1911,10 @@ mod tests {
         Ok(())
     }
 
-    /// Companion to `prunes_anomalous_none_none_state`: the same anomalous
-    /// `(None, None)` state, but with a local ingress proof present.  The
-    /// local-proof exemption should override the eviction so any useful
-    /// commitment is preserved.
+    /// Pending-tx + local-proof: the local-proof exemption is a second
+    /// safety net.  The pending-tx guard already protects this CDR (so the
+    /// local-proof check is not reached), but verifying the entry survives
+    /// covers both protections by construction.
     #[tokio::test]
     async fn does_not_prune_anomalous_none_none_state_with_local_proof() -> eyre::Result<()> {
         let node_config = NodeConfig::testing();
@@ -1954,6 +1977,90 @@ mod tests {
             eyre::ensure!(
                 has_root,
                 "CachedDataRoots in (None, None) state with local proof should NOT have been pruned"
+            );
+            Ok(())
+        })??;
+
+        Ok(())
+    }
+
+    /// Cross-ledger same-`data_root` regression: when two txs share a
+    /// `data_root` and one is confirmed (has `included_height`) while the
+    /// other is still pending (no metadata row), the CDR must NOT be evicted
+    /// on the confirmed tx's height alone — the pending tx still needs the
+    /// chunks.  Without the `all_txs_confirmed` guard, `inclusion_max_height`
+    /// derived from the confirmed sibling would shadow the now-cleared
+    /// `expiry_height` and the CDR would be pruned prematurely, breaking
+    /// Publish-promotion liveness when two ledgers reference the same data.
+    #[tokio::test]
+    async fn does_not_prune_cdr_with_pending_sibling_tx() -> eyre::Result<()> {
+        let node_config = NodeConfig::testing();
+        let config = Config::new_with_random_peer_id(node_config);
+        let _temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db_env = open_or_create_db(
+            &_temp_dir,
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        let db = DatabaseProvider(Arc::new(db_env));
+
+        let data_root = H256::random();
+        let confirmed_tx_id = H256::random();
+        let pending_tx_id = H256::random();
+        let make_tx = |id: H256| {
+            DataTransactionHeader::V1(DataTransactionHeaderV1WithMetadata {
+                tx: DataTransactionHeaderV1 {
+                    id,
+                    data_root,
+                    data_size: 64,
+                    ..Default::default()
+                },
+                metadata: DataTransactionMetadata::new(),
+            })
+        };
+        let confirmed_tx = make_tx(confirmed_tx_id);
+        let pending_tx = make_tx(pending_tx_id);
+
+        db.update(|wtx| -> eyre::Result<()> {
+            // Both txs land in the same CDR.txid_set via the shared data_root.
+            database::cache_data_root(wtx, &confirmed_tx, None)?;
+            database::cache_data_root(wtx, &pending_tx, None)?;
+            // The confirmed sibling gets an inclusion height (term-ledger
+            // confirmation); the pending tx remains without a metadata row.
+            irys_database::set_data_tx_included_height(wtx, &confirmed_tx_id, 5)
+                .map_err(|e| eyre::eyre!("set_data_tx_included_height: {:?}", e))?;
+            Ok(())
+        })??;
+
+        let genesis_block = new_mock_signed_header();
+        let block_tree = BlockTree::new(&genesis_block, config.consensus.clone());
+        let block_tree_guard =
+            irys_domain::BlockTreeReadGuard::new(Arc::new(RwLock::new(block_tree)));
+        let block_index = BlockIndex::new_for_testing(db.clone());
+        let block_index_guard =
+            irys_domain::block_index_guard::BlockIndexReadGuard::new(block_index);
+
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let service_task = InnerCacheTask {
+            db: db.clone(),
+            block_tree_guard,
+            block_index_guard,
+            config,
+            gossip_broadcast: tokio::sync::mpsc::unbounded_channel().0,
+            ingress_proof_generation_state: IngressProofGenerationState::new(),
+            cache_sender: tx,
+        };
+
+        // `prune_height = 100` is well past the confirmed tx's `included_height`
+        // = 5.  Without the pending-tx guard the CDR would be evicted on
+        // inclusion alone.
+        service_task.prune_data_root_cache(100)?;
+
+        db.view(|rtx| -> eyre::Result<()> {
+            let has_root = rtx.get::<CachedDataRoots>(data_root)?.is_some();
+            eyre::ensure!(
+                has_root,
+                "CDR with pending sibling tx (no included_height) must NOT be pruned"
             );
             Ok(())
         })??;

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -465,17 +465,22 @@ impl InnerCacheTask {
                     continue;
                 }
 
-                debug!(
-                    data_root.data_root = ?data_root,
-                    data_root.max_height = ?max_height,
-                    data_root.prune_height = ?prune_height,
-                    "expiring cached data for data root",
+                info!(
+                    %data_root,
+                    block_set_at_eviction = ?cached.block_set,
+                    txid_set_size = cached.txid_set.len(),
+                    last_inclusion_height = ?inclusion_max_height,
+                    expiry_height = ?cached.expiry_height,
+                    %prune_height,
+                    has_local_proof,
+                    "cached_data_root.evict"
                 );
                 write_tx.delete::<IngressProofs>(data_root, None)?;
                 chunks_pruned = chunks_pruned
                     .saturating_add(delete_cached_chunks_by_data_root(&write_tx, data_root)?);
                 write_tx.delete::<CachedDataRoots>(data_root, None)?;
                 eviction_count += 1;
+                metrics::record_cached_data_root_evicted();
             }
         }
         debug!(data_root.chunks_pruned = ?chunks_pruned, "Pruned chunks");

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -424,8 +424,7 @@ impl InnerCacheTask {
                     .and_then(|m| m.included_height)
                 {
                     Some(h) => {
-                        inclusion_max_height =
-                            Some(inclusion_max_height.map_or(h, |x| x.max(h)));
+                        inclusion_max_height = Some(inclusion_max_height.map_or(h, |x| x.max(h)));
                     }
                     // No metadata row, or row exists with `included_height = None`:
                     // this tx (sharing `data_root` with the rest of `txid_set`) is
@@ -1036,7 +1035,9 @@ impl ChunkCacheService {
 mod tests {
     use super::*;
     use irys_database::{
-        IrysDatabaseArgs as _, database, db_cache::CachedDataRoot, open_or_create_db,
+        IrysDatabaseArgs as _, database,
+        db_cache::CachedDataRoot,
+        open_or_create_db,
         tables::{CachedChunks, CachedChunksIndex, CachedDataRoots, IrysTables},
     };
     use irys_domain::{BlockIndex, BlockTree};

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -603,6 +603,21 @@ impl InnerCacheTask {
                             remaining = cached.txid_set.len(),
                             "Pruned stale txids from CachedDataRoot.txid_set"
                         );
+                        // Mirrors the `(None, None)` warn in
+                        // `remove_data_root_block_set_entry`: draining the
+                        // last txid while `expiry_height` is already None
+                        // leaves the CDR vacuously eviction-eligible (only
+                        // the local-proof exemption keeps it alive).
+                        // Surface this transition so observability is
+                        // symmetric across the two paths that produce it.
+                        if cached.txid_set.is_empty() && cached.expiry_height.is_none() {
+                            warn!(
+                                data_root = %data_root,
+                                "CachedDataRoot left in anomalous (no expiry, empty txid_set) state \
+                                 after stale-txid prune; entry now eviction-eligible unless held by \
+                                 a local ingress proof"
+                            );
+                        }
                         db_tx.put::<CachedDataRoots>(*data_root, cached)?;
                     }
                 }

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -432,7 +432,15 @@ impl InnerCacheTask {
                     // prune chunks the pending tx still needs — e.g. a Publish-
                     // promotion sibling of an already-confirmed term-ledger tx that
                     // shares the same `data_root`.
-                    None => all_txs_confirmed = false,
+                    //
+                    // Once any tx is pending, the horizon below ignores
+                    // `inclusion_max_height` and defers to `expiry_height`, so
+                    // further metadata reads are wasted DB work inside the open
+                    // write tx.  Bail early.
+                    None => {
+                        all_txs_confirmed = false;
+                        break;
+                    }
                 }
             }
 
@@ -1917,10 +1925,15 @@ mod tests {
         Ok(())
     }
 
-    /// Pending-tx + local-proof: the local-proof exemption is a second
-    /// safety net.  The pending-tx guard already protects this CDR (so the
-    /// local-proof check is not reached), but verifying the entry survives
-    /// covers both protections by construction.
+    /// `(None, None)` anomalous-state arm with local-proof exemption:
+    /// `all_txs_confirmed == true` (only reachable with empty `txid_set`,
+    /// since any non-confirmed tx flips the flag false) combined with
+    /// `inclusion_max_height == None` and `expiry_height == None`.  Under
+    /// the eviction-candidate rule this fires the `(None, true)` arm and
+    /// would evict — except the local-proof check at the bottom of the arm
+    /// preserves any entry that still carries a useful commitment.  This
+    /// test exercises that exact path: clearing `txid_set` to reach
+    /// `all_txs_confirmed = true` without metadata, then asserting survival.
     #[tokio::test]
     async fn does_not_prune_anomalous_none_none_state_with_local_proof() -> eyre::Result<()> {
         let node_config = NodeConfig::testing();
@@ -1940,8 +1953,20 @@ mod tests {
             },
             metadata: DataTransactionMetadata::new(),
         });
+        // Seed the CDR via the normal path, then clear `txid_set` and
+        // `expiry_height` to reach the `(None, None)` + `all_txs_confirmed`
+        // state.  An empty `txid_set` is the only way to get
+        // `all_txs_confirmed = true` together with `inclusion_max_height = None`:
+        // every other path through the prune loop flips the flag to false
+        // whenever metadata is missing.
         db.update(|wtx| {
             database::cache_data_root(wtx, &tx_header, None)?;
+            let mut cdr = wtx
+                .get::<CachedDataRoots>(tx_header.data_root)?
+                .ok_or_else(|| eyre::eyre!("missing CachedDataRoots entry after seed"))?;
+            cdr.txid_set.clear();
+            cdr.expiry_height = None;
+            wtx.put::<CachedDataRoots>(tx_header.data_root, cdr)?;
             eyre::Ok(())
         })??;
 

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -1204,9 +1204,23 @@ impl ChunkCacheService {
                     self.cache_task.spawn_prune_txids_task(work);
                 }
             }
-            CacheServiceAction::PruneTxidsCompleted(_res) => {
+            CacheServiceAction::PruneTxidsCompleted(res) => {
                 // Mark txid pruning idle and kick next if queued
                 self.txid_prune_running = false;
+                // Surface batch failure so the silent drop is observable.
+                // The worker already `warn!`s on Err (see
+                // `spawn_prune_txids_task`); we only want a stable counter
+                // here so dashboards can alert on it.  Stale tombstones
+                // self-heal on the next scrub trigger for that data_root
+                // (mempool TTL eviction or another failed reorg
+                // re-ingress), so we don't requeue.
+                if let Err(e) = res {
+                    debug!(
+                        error = %e,
+                        "PruneTxidsCompleted reported worker Err — recording metric and continuing"
+                    );
+                    metrics::record_cache_txid_scrub_failed();
+                }
                 if let Some(work) = self.txid_prune_queue.pop_front() {
                     self.txid_prune_running = true;
                     self.cache_task.spawn_prune_txids_task(work);

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -379,10 +379,24 @@ impl InnerCacheTask {
 
     #[tracing::instrument(level = "trace", skip_all, fields(prune_height))]
     fn prune_data_root_cache(&self, prune_height: u64) -> eyre::Result<()> {
+        // Per-eviction observability state, buffered inside the write tx and
+        // emitted only after `commit()` succeeds — otherwise a failed commit
+        // (or a mid-loop delete error that drops the tx) would report
+        // evictions/chunks that never persisted.
+        struct EvictionRecord {
+            data_root: H256,
+            block_set: Vec<H256>,
+            txid_set_size: usize,
+            inclusion_max_height: Option<u64>,
+            expiry_height: Option<u64>,
+            horizon: Option<u64>,
+        }
+
         let signer = self.config.irys_signer();
         let local_addr = signer.address();
         let mut chunks_pruned: u64 = 0;
         let mut eviction_count: usize = 0;
+        let mut evictions: Vec<EvictionRecord> = Vec::new();
         let _span = info_span!(
             irys_utils::MDBX_RW_TX_SPAN,
             db_scope = irys_utils::DB_SCOPE_IRYS_CONSENSUS
@@ -512,32 +526,51 @@ impl InnerCacheTask {
                     continue;
                 }
 
-                info!(
-                    %data_root,
-                    block_set_size = cached.block_set.len(),
-                    txid_set_size = cached.txid_set.len(),
-                    last_inclusion_height = ?inclusion_max_height,
-                    expiry_height = ?cached.expiry_height,
-                    horizon = ?horizon,
-                    %prune_height,
-                    has_local_proof,
-                    "cached_data_root.evict"
-                );
-                debug!(
-                    %data_root,
-                    block_set = ?cached.block_set,
-                    "cached_data_root.evict.block_set"
-                );
+                // Capture txid_set_size before `cached` is partially moved below.
+                let txid_set_size = cached.txid_set.len();
+                let expiry_height = cached.expiry_height;
+
                 write_tx.delete::<IngressProofs>(data_root, None)?;
                 chunks_pruned = chunks_pruned
                     .saturating_add(delete_cached_chunks_by_data_root(&write_tx, data_root)?);
                 write_tx.delete::<CachedDataRoots>(data_root, None)?;
                 eviction_count += 1;
-                metrics::record_cached_data_root_evicted();
+
+                evictions.push(EvictionRecord {
+                    data_root,
+                    block_set: cached.block_set,
+                    txid_set_size,
+                    inclusion_max_height,
+                    expiry_height,
+                    horizon,
+                });
             }
         }
-        debug!(data_root.chunks_pruned = ?chunks_pruned, "Pruned chunks");
         write_tx.commit()?;
+
+        // Post-commit: only now is it safe to report what actually persisted.
+        // `has_local_proof` is hardcoded false because the eviction branch
+        // `continue`s on `has_local_proof == true` before reaching this buffer.
+        for entry in &evictions {
+            info!(
+                data_root = %entry.data_root,
+                block_set_size = entry.block_set.len(),
+                txid_set_size = entry.txid_set_size,
+                last_inclusion_height = ?entry.inclusion_max_height,
+                expiry_height = ?entry.expiry_height,
+                horizon = ?entry.horizon,
+                %prune_height,
+                has_local_proof = false,
+                "cached_data_root.evict"
+            );
+            debug!(
+                data_root = %entry.data_root,
+                block_set = ?entry.block_set,
+                "cached_data_root.evict.block_set"
+            );
+            metrics::record_cached_data_root_evicted();
+        }
+        debug!(data_root.chunks_pruned = ?chunks_pruned, "Pruned chunks");
 
         Ok(())
     }

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -399,19 +399,21 @@ impl InnerCacheTask {
                 );
                 break;
             }
-            // Pruning horizon priority: block inclusion > expiry height > skip
-            // Rationale: Confirmed blocks provide the most reliable pruning point.
-            // Unconfirmed mempool entries use expiry_height as a conservative fallback.
-            // Entries without either metadata are likely still active and should not be pruned.
+            // Pruning horizon priority: canonical tx inclusion > expiry height > skip
+            // Rationale: Migrated tx metadata provides a stable canonical
+            // inclusion height even after reorgs.  Unconfirmed mempool entries
+            // use expiry_height as a conservative fallback.  Entries without
+            // either are likely still active and are skipped.
+            //
+            // No block_tree fallback is needed here: pre-migration entries are
+            // already covered by expiry_height (set at cache_data_root time)
+            // and by the local-proof exemption further below.
             let mut inclusion_max_height: Option<u64> = None;
-            for block_hash in cached.block_set.iter() {
-                if let Some(block_header) =
-                    irys_database::block_header_by_hash(&write_tx, block_hash, false)?
+            for tx_id in cached.txid_set.iter() {
+                if let Some(metadata) = irys_database::get_data_tx_metadata(&write_tx, tx_id)?
+                    && let Some(h) = metadata.included_height
                 {
-                    inclusion_max_height = Some(
-                        inclusion_max_height
-                            .map_or(block_header.height, |h| h.max(block_header.height)),
-                    );
+                    inclusion_max_height = Some(inclusion_max_height.map_or(h, |x| x.max(h)));
                 }
             }
             let horizon = match (inclusion_max_height, cached.expiry_height) {

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -506,7 +506,7 @@ impl InnerCacheTask {
 
                 info!(
                     %data_root,
-                    block_set_at_eviction = ?cached.block_set,
+                    block_set_size = cached.block_set.len(),
                     txid_set_size = cached.txid_set.len(),
                     last_inclusion_height = ?inclusion_max_height,
                     expiry_height = ?cached.expiry_height,
@@ -514,6 +514,11 @@ impl InnerCacheTask {
                     %prune_height,
                     has_local_proof,
                     "cached_data_root.evict"
+                );
+                debug!(
+                    %data_root,
+                    block_set = ?cached.block_set,
+                    "cached_data_root.evict.block_set"
                 );
                 write_tx.delete::<IngressProofs>(data_root, None)?;
                 chunks_pruned = chunks_pruned

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -630,7 +630,15 @@ impl InnerCacheTask {
     fn spawn_prune_txids_task(&self, by_data_root: HashMap<H256, Vec<H256>>) {
         let clone = self.clone();
         std::thread::spawn(move || {
-            let result = clone.db.update_eyre(|db_tx| {
+            // catch_unwind so a panic inside the body still drives a
+            // `PruneTxidsCompleted` back to the actor; without it the
+            // `txid_prune_running` flag stays `true` forever and the queue
+            // jams permanently.  `AssertUnwindSafe` is sound here — the
+            // captured `clone` is `Send + Clone`, and on the panic path we
+            // immediately stop using it after the catch.
+            let result: eyre::Result<()> = match std::panic::catch_unwind(
+                std::panic::AssertUnwindSafe(|| {
+                    clone.db.update_eyre(|db_tx| {
                 for (data_root, txids_to_remove) in &by_data_root {
                     let Some(mut cached) = cached_data_root_by_data_root(db_tx, *data_root)? else {
                         continue;
@@ -689,7 +697,16 @@ impl InnerCacheTask {
                     }
                 }
                 Ok(())
-            });
+            })
+                }),
+            ) {
+                Ok(r) => r,
+                Err(payload) => {
+                    let msg = panic_payload_string(payload);
+                    error!(custom.panic = %msg, "spawn_prune_txids_task body panicked");
+                    Err(eyre::eyre!("spawn_prune_txids_task panicked: {msg}"))
+                }
+            };
 
             let completion = match &result {
                 Ok(_) => Ok(()),
@@ -893,7 +910,21 @@ impl InnerCacheTask {
     ) {
         let clone = self.clone();
         std::thread::spawn(move || {
-            let res = clone.prune_cache(migration_height);
+            // Same panic-survival rationale as `spawn_prune_txids_task`:
+            // without `catch_unwind`, a panic anywhere in `prune_cache`
+            // leaves `pruning_running = true` forever and waiters of
+            // `response_sender` hang.
+            let res: eyre::Result<()> =
+                match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    clone.prune_cache(migration_height)
+                })) {
+                    Ok(r) => r,
+                    Err(payload) => {
+                        let msg = panic_payload_string(payload);
+                        error!(custom.panic = %msg, "spawn_pruning_task body panicked");
+                        Err(eyre::eyre!("spawn_pruning_task panicked: {msg}"))
+                    }
+                };
             let completion = match &res {
                 Ok(_) => Ok(()),
                 Err(e) => Err(eyre::eyre!(e.to_string())),
@@ -920,7 +951,19 @@ impl InnerCacheTask {
     ) {
         let clone = self.clone();
         std::thread::spawn(move || {
-            let res = clone.on_epoch_processed(epoch_snapshot);
+            // Mirror of `spawn_pruning_task`: panic survival so the
+            // `epoch_running` flag is cleared and waiters resolve.
+            let res: eyre::Result<()> =
+                match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    clone.on_epoch_processed(epoch_snapshot)
+                })) {
+                    Ok(r) => r,
+                    Err(payload) => {
+                        let msg = panic_payload_string(payload);
+                        error!(custom.panic = %msg, "spawn_epoch_processing body panicked");
+                        Err(eyre::eyre!("spawn_epoch_processing panicked: {msg}"))
+                    }
+                };
             let completion = match &res {
                 Ok(_) => Ok(()),
                 Err(e) => Err(eyre::eyre!(e.to_string())),
@@ -938,6 +981,20 @@ impl InnerCacheTask {
                 warn!(custom.error = ?e, "Failed to notify EpochProcessingCompleted");
             }
         });
+    }
+}
+
+/// Extract a human-readable message from a `catch_unwind` payload.
+/// `Box<dyn Any + Send>` panic payloads in practice carry either `&'static
+/// str` or `String`; fall back to a generic label otherwise so the
+/// resulting `eyre` chain is never empty.
+fn panic_payload_string(payload: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_owned()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "<non-string panic payload>".to_owned()
     }
 }
 

--- a/crates/actors/src/chunk_ingress_service/chunks.rs
+++ b/crates/actors/src/chunk_ingress_service/chunks.rs
@@ -504,7 +504,8 @@ impl ChunkIngressServiceInner {
     /// Checks whether an ingress proof should be generated for the given `data_root`
     /// and spawns proof generation if all prerequisites are met:
     /// - data_size is confirmed (rightmost chunk merkle validation)
-    /// - data_root is included in a confirmed block (block_set non-empty)
+    /// - some tx referencing this data_root is canonically confirmed in a
+    ///   Submit ledger at or before the current canonical tip
     /// - no local proof already exists
     /// - all expected chunks are present
     pub(crate) fn try_generate_ingress_proof_for_root(
@@ -526,10 +527,39 @@ impl ChunkIngressServiceInner {
             return Ok(());
         }
 
-        // Only generate ingress proofs for txs confirmed in a block's submit ledger.
-        // block_set is populated by cache_data_root() when called with a block header
-        // during block confirmation (lifecycle.rs). Empty means mempool-only.
+        // Cheap hint: `block_set` is best-effort and not fork-tolerant, but
+        // an empty `block_set` means no `BlockConfirmed` event has ever
+        // touched this data_root.  In that case there's nothing to verify
+        // canonically yet; skip the more expensive helper lookup.  The
+        // next `BlockConfirmed` event will retrigger this code path with a
+        // non-empty `block_set`.
         if cdr.block_set.is_empty() {
+            return Ok(());
+        }
+
+        // Trustworthy verification: a non-empty `block_set` can still hold
+        // only orphan hashes (append-only across reorgs).  Confirm at least
+        // one tx in `txid_set` is canonically confirmed in a Submit ledger
+        // at or before the current tip via `tx_inclusion` — this is the
+        // trust root.  Without it, validation could proceed for data_roots
+        // that only ever made it into reorg'd-out forks.
+        let current_height = self
+            .block_tree_read_guard
+            .latest_canonical_block_height()
+            .unwrap_or(0);
+        let any_confirmed = cdr.txid_set.iter().any(|tx_id| {
+            matches!(
+                crate::tx_inclusion::find_canonical_ledger_range(
+                    tx_id,
+                    current_height,
+                    self.config.consensus.block_migration_depth,
+                    &self.block_tree_read_guard,
+                    &self.irys_db,
+                ),
+                Ok(Some(_))
+            )
+        });
+        if !any_confirmed {
             return Ok(());
         }
 

--- a/crates/actors/src/chunk_ingress_service/chunks.rs
+++ b/crates/actors/src/chunk_ingress_service/chunks.rs
@@ -527,22 +527,18 @@ impl ChunkIngressServiceInner {
             return Ok(());
         }
 
-        // Cheap hint: `block_set` is best-effort and not fork-tolerant, but
-        // an empty `block_set` means no `BlockConfirmed` event has ever
-        // touched this data_root.  In that case there's nothing to verify
-        // canonically yet; skip the more expensive helper lookup.  The
-        // next `BlockConfirmed` event will retrigger this code path with a
-        // non-empty `block_set`.
-        if cdr.block_set.is_empty() {
-            return Ok(());
-        }
-
-        // Trustworthy verification: a non-empty `block_set` can still hold
-        // only orphan hashes (append-only across reorgs).  Confirm at least
-        // one tx in `txid_set` is canonically confirmed in a Submit ledger
-        // at or before the current tip via `tx_inclusion` — this is the
-        // trust root.  Without it, validation could proceed for data_roots
-        // that only ever made it into reorg'd-out forks.
+        // Trustworthy verification: `block_set` is append-only across reorgs
+        // (orphan hashes are retained) AND it is only populated by the
+        // `BlockConfirmed` handler — so it can be either non-empty with only
+        // orphan hashes, or empty even when a tx IS canonical (e.g. after a
+        // restart where `BlockConfirmed` was missed, or before the
+        // `TryGenerateProofsForConfirmedRoots` notification fires).  Skip the
+        // `block_set` hint entirely and consult the canonical trust root:
+        // confirm at least one tx in `txid_set` is canonically confirmed in
+        // a Submit ledger at or before the current tip via `tx_inclusion`.
+        // Without this, validation could proceed for data_roots that only
+        // ever made it into reorg'd-out forks, or be silently skipped for
+        // canonical data_roots whose `block_set` happens to be empty.
         let current_height = self
             .block_tree_read_guard
             .latest_canonical_block_height()

--- a/crates/actors/src/chunk_ingress_service/chunks.rs
+++ b/crates/actors/src/chunk_ingress_service/chunks.rs
@@ -504,8 +504,8 @@ impl ChunkIngressServiceInner {
     /// Checks whether an ingress proof should be generated for the given `data_root`
     /// and spawns proof generation if all prerequisites are met:
     /// - data_size is confirmed (rightmost chunk merkle validation)
-    /// - some tx referencing this data_root is canonically confirmed in a
-    ///   Submit ledger at or before the current canonical tip
+    /// - `block_set` is non-empty (cheap "has this data_root been confirmed
+    ///   in some block?" hint maintained by `cache_data_root`)
     /// - no local proof already exists
     /// - all expected chunks are present
     pub(crate) fn try_generate_ingress_proof_for_root(
@@ -527,35 +527,14 @@ impl ChunkIngressServiceInner {
             return Ok(());
         }
 
-        // Trustworthy verification: `block_set` is append-only across reorgs
-        // (orphan hashes are retained) AND it is only populated by the
-        // `BlockConfirmed` handler — so it can be either non-empty with only
-        // orphan hashes, or empty even when a tx IS canonical (e.g. after a
-        // restart where `BlockConfirmed` was missed, or before the
-        // `TryGenerateProofsForConfirmedRoots` notification fires).  Skip the
-        // `block_set` hint entirely and consult the canonical trust root:
-        // confirm at least one tx in `txid_set` is canonically confirmed in
-        // a Submit ledger at or before the current tip via `tx_inclusion`.
-        // Without this, validation could proceed for data_roots that only
-        // ever made it into reorg'd-out forks, or be silently skipped for
-        // canonical data_roots whose `block_set` happens to be empty.
-        let current_height = self
-            .block_tree_read_guard
-            .latest_canonical_block_height()
-            .unwrap_or(0);
-        let any_confirmed = cdr.txid_set.iter().any(|tx_id| {
-            matches!(
-                crate::tx_inclusion::find_canonical_ledger_range(
-                    tx_id,
-                    current_height,
-                    self.config.consensus.block_migration_depth,
-                    &self.block_tree_read_guard,
-                    &self.irys_db,
-                ),
-                Ok(Some(_))
-            )
-        });
-        if !any_confirmed {
+        // Cheap "has this data_root been confirmed in any canonical block?"
+        // gate.  `block_set` is maintained atomically with tip changes by
+        // `BlockMigrationService::persist_metadata` (scrub + add in one DB
+        // tx), so a non-empty set means at least one canonical block has
+        // included a referencing tx.  Range / slot lookups still go through
+        // `tx_inclusion::find_canonical_ledger_range` at validation /
+        // promotion time.
+        if cdr.block_set.is_empty() {
             return Ok(());
         }
 

--- a/crates/actors/src/chunk_ingress_service/chunks.rs
+++ b/crates/actors/src/chunk_ingress_service/chunks.rs
@@ -28,6 +28,33 @@ use std::time::Instant;
 use std::{collections::HashSet, fmt::Display};
 use tracing::{Instrument as _, debug, error, info, info_span, instrument, warn};
 
+/// CDR-only ingress-proof eligibility gate, factored out so the contract is
+/// unit-testable without standing up the full service.  Returns `true` iff
+/// the caller should short-circuit `try_generate_ingress_proof_for_root`.
+///
+/// Two checks:
+///   - `!data_size_confirmed`: the rightmost-chunk merkle validation hasn't
+///     attested the size yet, so we don't know which chunks are required.
+///   - `block_set.is_empty()`: cheap "has this data_root been seen in any
+///     block yet?" gate.  `block_set` is a hint with two writers (mempool
+///     `BlockConfirmed` pre-migration forward-fill + `persist_metadata`
+///     canonical writer); a stale `BlockConfirmed` processed after a reorg
+///     can leave an orphan hash here, so non-empty does NOT prove canonical
+///     inclusion.  An over-permissive gate is correctness-safe: ingress
+///     proofs are keyed on `data_root` (see the `IngressProofs` table), so a
+///     proof generated for an orphan-tx data_root remains valid if any future
+///     canonical tx references the same data_root — i.e. speculative, not
+///     wasted.  Canonical truth is re-derived by
+///     `tx_inclusion::find_canonical_ledger_range` at validation /
+///     promotion time.  An empty set, by contrast, means no writer has ever
+///     attached this data_root to a block, so we short-circuit.  After a
+///     reorg that empties block_set, the next canonical confirmation
+///     re-populates it via the mempool `BlockConfirmed` path
+///     (`lifecycle.rs:96`).
+fn should_skip_ingress_proof_generation(cdr: &irys_database::db_cache::CachedDataRoot) -> bool {
+    !cdr.data_size_confirmed || cdr.block_set.is_empty()
+}
+
 /// Represents data_size information and if it comes from the publish ledger.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DataSizeInfo {
@@ -503,11 +530,7 @@ impl ChunkIngressServiceInner {
 
     /// Checks whether an ingress proof should be generated for the given `data_root`
     /// and spawns proof generation if all prerequisites are met:
-    /// - data_size is confirmed (rightmost chunk merkle validation)
-    /// - `block_set` is non-empty (cheap presence hint — see the field doc on
-    ///   `CachedDataRoot.block_set`; treat as best-effort, not authoritative
-    ///   proof of canonical inclusion).  Canonical range / slot lookups go
-    ///   through `tx_inclusion::find_canonical_ledger_range`.
+    /// - the CDR-only prerequisites in [`should_skip_ingress_proof_generation`]
     /// - no local proof already exists
     /// - all expected chunks are present
     pub(crate) fn try_generate_ingress_proof_for_root(
@@ -525,26 +548,7 @@ impl ChunkIngressServiceInner {
             return Ok(());
         };
 
-        if !cdr.data_size_confirmed {
-            return Ok(());
-        }
-
-        // Cheap "has this data_root been seen in any block yet?" gate.
-        // `block_set` is a best-effort hint with two writers (mempool
-        // `BlockConfirmed` pre-migration forward-fill + `persist_metadata`
-        // canonical writer); a stale BlockConfirmed processed after a reorg
-        // can leave an orphan hash here, so non-empty does NOT prove canonical
-        // inclusion.  An over-permissive gate is correctness-safe: ingress
-        // proofs are keyed on `data_root` (see the `IngressProofs` table), so
-        // a proof generated for an orphan-tx data_root remains valid if any
-        // future canonical tx references the same data_root — i.e. the work
-        // is speculative, not wasted.  Canonical truth is re-derived by
-        // `tx_inclusion::find_canonical_ledger_range` at validation /
-        // promotion time.  An empty set, by contrast, means no writer has
-        // ever attached this data_root to a block, so we short-circuit.
-        // After a reorg that empties block_set, the next canonical confirmation
-        // re-populates it via the mempool BlockConfirmed path (lifecycle.rs:96).
-        if cdr.block_set.is_empty() {
+        if should_skip_ingress_proof_generation(&cdr) {
             return Ok(());
         }
 
@@ -899,8 +903,61 @@ pub fn generate_ingress_proof(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use irys_database::db_cache::CachedDataRoot;
+    use irys_types::UnixTimestamp;
     use proptest::prelude::*;
     use rstest::rstest;
+
+    /// Build a `CachedDataRoot` with explicit gate-relevant fields.
+    fn cdr_gate_fixture(
+        data_size_confirmed: bool,
+        block_set: Vec<H256>,
+        txid_set: Vec<H256>,
+        expiry_height: Option<u64>,
+    ) -> CachedDataRoot {
+        CachedDataRoot {
+            data_size: 64,
+            data_size_confirmed,
+            txid_set,
+            block_set,
+            expiry_height,
+            cached_at: UnixTimestamp::from_secs(0),
+        }
+    }
+
+    /// Happy path: confirmed size + any block in `block_set` → proceed.
+    #[test]
+    fn ingress_gate_proceeds_when_size_confirmed_and_block_set_populated() {
+        let cdr = cdr_gate_fixture(true, vec![H256::random()], vec![H256::random()], None);
+        assert!(!should_skip_ingress_proof_generation(&cdr));
+    }
+
+    /// Confirmed-but-not-block-set state: pending tx with chunks staged but
+    /// no `BlockConfirmed` has populated `block_set` yet.  Today the gate
+    /// **short-circuits** — pinning this so a future widening to a
+    /// `txid_set` + canonical-metadata fall-through is a deliberate change.
+    #[test]
+    fn ingress_gate_skips_when_txid_set_populated_but_block_set_empty() {
+        let cdr = cdr_gate_fixture(true, vec![], vec![H256::random()], Some(100));
+        assert!(
+            should_skip_ingress_proof_generation(&cdr),
+            "current contract: empty block_set short-circuits even when txid_set is populated"
+        );
+    }
+
+    /// Unconfirmed data_size: skip regardless of `block_set` state.
+    #[test]
+    fn ingress_gate_skips_when_data_size_unconfirmed() {
+        let cdr = cdr_gate_fixture(false, vec![H256::random()], vec![H256::random()], None);
+        assert!(should_skip_ingress_proof_generation(&cdr));
+    }
+
+    /// Both gate inputs negative: skip.
+    #[test]
+    fn ingress_gate_skips_when_both_inputs_negative() {
+        let cdr = cdr_gate_fixture(false, vec![], vec![H256::random()], None);
+        assert!(should_skip_ingress_proof_generation(&cdr));
+    }
 
     /// Helper to create a submit ledger data size entry for test cases
     fn submit(data_size: u64) -> DataSizeInfo {

--- a/crates/actors/src/chunk_ingress_service/chunks.rs
+++ b/crates/actors/src/chunk_ingress_service/chunks.rs
@@ -504,8 +504,10 @@ impl ChunkIngressServiceInner {
     /// Checks whether an ingress proof should be generated for the given `data_root`
     /// and spawns proof generation if all prerequisites are met:
     /// - data_size is confirmed (rightmost chunk merkle validation)
-    /// - `block_set` is non-empty (cheap "has this data_root been confirmed
-    ///   in some block?" hint maintained by `cache_data_root`)
+    /// - `block_set` is non-empty (cheap presence hint — see the field doc on
+    ///   `CachedDataRoot.block_set`; treat as best-effort, not authoritative
+    ///   proof of canonical inclusion).  Canonical range / slot lookups go
+    ///   through `tx_inclusion::find_canonical_ledger_range`.
     /// - no local proof already exists
     /// - all expected chunks are present
     pub(crate) fn try_generate_ingress_proof_for_root(
@@ -527,13 +529,19 @@ impl ChunkIngressServiceInner {
             return Ok(());
         }
 
-        // Cheap "has this data_root been confirmed in any canonical block?"
-        // gate.  `block_set` is maintained atomically with tip changes by
-        // `BlockMigrationService::persist_metadata` (scrub + add in one DB
-        // tx), so a non-empty set means at least one canonical block has
-        // included a referencing tx.  Range / slot lookups still go through
+        // Cheap "has this data_root been seen in any block yet?" gate.
+        // `block_set` is a best-effort hint with two writers (mempool
+        // `BlockConfirmed` pre-migration forward-fill + `persist_metadata`
+        // canonical writer); a stale BlockConfirmed processed after a reorg
+        // can leave an orphan hash here, so non-empty does NOT prove canonical
+        // inclusion.  An over-permissive gate is correctness-safe: ingress
+        // proofs are keyed on `data_root` (see the `IngressProofs` table), so
+        // a proof generated for an orphan-tx data_root remains valid if any
+        // future canonical tx references the same data_root — i.e. the work
+        // is speculative, not wasted.  Canonical truth is re-derived by
         // `tx_inclusion::find_canonical_ledger_range` at validation /
-        // promotion time.
+        // promotion time.  An empty set, by contrast, means no writer has
+        // ever attached this data_root to a block, so we short-circuit.
         if cdr.block_set.is_empty() {
             return Ok(());
         }

--- a/crates/actors/src/chunk_ingress_service/chunks.rs
+++ b/crates/actors/src/chunk_ingress_service/chunks.rs
@@ -542,6 +542,8 @@ impl ChunkIngressServiceInner {
         // `tx_inclusion::find_canonical_ledger_range` at validation /
         // promotion time.  An empty set, by contrast, means no writer has
         // ever attached this data_root to a block, so we short-circuit.
+        // After a reorg that empties block_set, the next canonical confirmation
+        // re-populates it via the mempool BlockConfirmed path (lifecycle.rs:96).
         if cdr.block_set.is_empty() {
             return Ok(());
         }

--- a/crates/actors/src/lib.rs
+++ b/crates/actors/src/lib.rs
@@ -36,7 +36,7 @@ pub use chunk_ingress_service::{
 pub use data_sync_service::*;
 pub use mempool_guard::*;
 pub use mempool_service::*;
-pub use metrics::record_reth_fcu_head_height;
+pub use metrics::{record_chain_sync_block_rejected, record_reth_fcu_head_height};
 pub use mining_bus::MiningBus;
 pub use partition_mining_service::*;
 pub use reth_ethereum_primitives;

--- a/crates/actors/src/lib.rs
+++ b/crates/actors/src/lib.rs
@@ -23,6 +23,7 @@ pub mod storage_module_service;
 pub mod supply_state_calculator;
 pub mod test_helpers;
 pub mod transaction_status;
+pub mod tx_inclusion;
 pub mod tx_selector;
 pub mod validation_service;
 

--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -1478,6 +1478,7 @@ impl AtomicMempoolState {
     ) -> Result<(), MempoolError> {
         let mut state = self.write().await?;
 
+        // Callers must pass only term-ledger tx_ids in this slice; the function does not check the stored ledger_id.
         // 1. Set included_height for term-ledger txs (Submit / OneYear / ThirtyDay).
         //    Publish-ledger txs are excluded: they only receive promoted_height (phase 3
         //    below). Setting included_height on a Publish tx would overwrite the
@@ -1525,8 +1526,8 @@ impl AtomicMempoolState {
             if let Some(wrapped_header) = state.valid_submit_ledger_tx.get_mut(txid) {
                 if wrapped_header.metadata().promoted_height.is_none() {
                     wrapped_header.metadata_mut().promoted_height = Some(height);
+                    tracing::debug!(tx.id = %txid, promoted_height = height, "Set promoted_height in mempool");
                 }
-                tracing::debug!(tx.id = %txid, promoted_height = height, "Set promoted_height in mempool");
                 state.recent_valid_tx.put(*txid, ());
             }
         }

--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -1134,50 +1134,6 @@ impl AtomicMempoolState {
         }
     }
 
-    /// Set included_height for a data transaction with optional overwrite
-    ///
-    /// # Parameters
-    /// - `tx_id`: Transaction ID to update
-    /// - `height`: Block height to set
-    /// - `overwrite`: If false, only sets height if currently None; if true, sets unconditionally
-    ///
-    /// Returns true if the included_height was actually changed, false otherwise.
-    /// Also updates the recent_valid_tx cache when the transaction is found.
-    async fn set_data_tx_included_height_inner(
-        &self,
-        tx_id: H256,
-        height: u64,
-        overwrite: bool,
-    ) -> bool {
-        let mut state = match self.write().await {
-            Ok(g) => g,
-            Err(e) => {
-                warn!(
-                    ?e,
-                    "Mempool write lock contention; set_data_tx_included_height_inner returning false"
-                );
-                return false;
-            }
-        };
-        if let Some(wrapped_tx) = state.valid_submit_ledger_tx.get_mut(&tx_id) {
-            let updated = overwrite || wrapped_tx.metadata().included_height.is_none();
-            if updated {
-                wrapped_tx.metadata_mut().included_height = Some(height);
-                tracing::debug!(
-                    tx.id = %tx_id,
-                    included_height = height,
-                    overwrite = overwrite,
-                    "Set included_height in mempool"
-                );
-            }
-            // Always update recent_valid_tx cache when tx is found
-            state.recent_valid_tx.put(tx_id, ());
-            updated
-        } else {
-            false
-        }
-    }
-
     /// Clear included_height for a data transaction (re-org handling).
     ///
     /// Returns:
@@ -1494,28 +1450,11 @@ impl AtomicMempoolState {
         Some(result)
     }
 
-    /// Atomically sets the included_height on a data transaction in the mempool.
-    /// This is a convenience wrapper around set_tx_included_height with overwrite=false.
-    /// Returns true if the tx was found and updated, false otherwise.
-    pub async fn set_data_tx_included_height(&self, txid: H256, height: u64) -> bool {
-        // Use the consolidated method with overwrite=false to maintain backward compatibility
-        self.set_data_tx_included_height_inner(txid, height, false)
-            .await
-    }
-
-    /// Set included_height for a data transaction with overwrite enabled
-    /// This is used when processing canonical confirmations to ensure the height
-    /// is updated even if previously set (e.g., after a reorg)
-    pub async fn set_data_tx_included_height_overwrite(&self, txid: H256, height: u64) -> bool {
-        self.set_data_tx_included_height_inner(txid, height, true)
-            .await
-    }
-
     /// Applies all metadata updates for a confirmed block under a single write lock.
     ///
-    /// This batches the work of `set_data_tx_included_height_overwrite`,
-    /// `set_commitment_tx_included_height`, and `set_promoted_height` to avoid
-    /// acquiring the write lock once per transaction (~120 times per block).
+    /// Batches included_height, commitment-included_height, and promoted_height
+    /// writes to avoid acquiring the write lock once per transaction (~120
+    /// times per block).
     ///
     /// All three update phases run atomically under a single write guard: either
     /// every applicable tx in the mempool gets its metadata updated, or none do.

--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -3661,3 +3661,39 @@ mod batch_prune_result_tests {
         );
     }
 }
+
+/// Pins the classification logic used by `handle_confirmed_data_tx_reorg` to
+/// decide whether a failed re-ingress leaves a CDR tombstone that must be scrubbed.
+/// `Skipped` means "already in mempool" — no scrub needed.  All other errors mean
+/// the tx is absent from the mempool and the CDR txid_set entry is a tombstone.
+#[cfg(test)]
+mod reorg_reingress_classification_tests {
+    use super::*;
+
+    #[test]
+    fn skipped_is_detected_by_direct_pattern_match() {
+        let err = TxIngressError::Skipped;
+        assert!(
+            matches!(err, TxIngressError::Skipped),
+            "Skipped must match TxIngressError::Skipped so the reorg handler can skip CDR scrub"
+        );
+    }
+
+    #[test]
+    fn non_skipped_errors_do_not_match_skipped() {
+        let errors = [
+            TxIngressError::InvalidSignature(irys_types::IrysAddress::random()),
+            TxIngressError::Unfunded(H256::zero()),
+            TxIngressError::InvalidAnchor(H256::zero()),
+            TxIngressError::MempoolFull("test".to_owned()),
+            TxIngressError::Other("test".to_owned()),
+        ];
+        for e in &errors {
+            assert!(
+                !matches!(e, TxIngressError::Skipped),
+                "variant {:?} must NOT match Skipped — it means the tx is absent from mempool",
+                e
+            );
+        }
+    }
+}

--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -1532,21 +1532,28 @@ impl AtomicMempoolState {
     /// mempool still treats its txs as pending.
     pub async fn apply_block_confirmed_updates(
         &self,
-        submit_and_publish_txids: &[H256],
+        term_ledger_txids: &[H256],
         commitment_txids: &[H256],
         publish_txids: &[H256],
         height: u64,
     ) -> Result<(), MempoolError> {
         let mut state = self.write().await?;
 
-        // 1. Set included_height (with overwrite) for submit + publish data txs
-        for txid in submit_and_publish_txids {
+        // 1. Set included_height for term-ledger txs (Submit / OneYear / ThirtyDay).
+        //    Publish-ledger txs are excluded: they only receive promoted_height (phase 3
+        //    below). Setting included_height on a Publish tx would overwrite the
+        //    Submit-block height that was recorded when the tx was first confirmed.
+        for txid in term_ledger_txids {
             if let Some(wrapped_tx) = state.valid_submit_ledger_tx.get_mut(txid) {
+                let prior = wrapped_tx.metadata().included_height;
                 wrapped_tx.metadata_mut().included_height = Some(height);
+                // `overwrite` flags the intentional-clobber case (reorg replay
+                // re-confirming a tx that already carried an included_height).
+                // Useful when diffing logs across replays.
                 tracing::debug!(
                     tx.id = %txid,
                     included_height = height,
-                    overwrite = true,
+                    overwrite = prior.is_some(),
                     "Set included_height in mempool"
                 );
                 state.recent_valid_tx.put(*txid, ());
@@ -3115,6 +3122,10 @@ mod test_helpers {
     }
 
     pub(super) fn data_tx_with_id(id: H256) -> DataTransactionHeader {
+        data_tx_with_ledger(id, DataLedger::Submit)
+    }
+
+    pub(super) fn data_tx_with_ledger(id: H256, ledger: DataLedger) -> DataTransactionHeader {
         DataTransactionHeader::V1(irys_types::DataTransactionHeaderV1WithMetadata {
             tx: DataTransactionHeaderV1 {
                 id,
@@ -3125,7 +3136,7 @@ mod test_helpers {
                 header_size: 0,
                 term_fee: U256::from(1_u64).into(),
                 perm_fee: Some(U256::from(1_u64).into()),
-                ledger_id: DataLedger::Submit as u32,
+                ledger_id: ledger as u32,
                 metadata_format: 0,
                 signature: IrysSignature::default(),
                 chain_id: 1,
@@ -3339,12 +3350,19 @@ mod lock_contention_tests {
 /// the confirmed canonical chain.
 #[cfg(test)]
 mod apply_block_confirmed_updates_tests {
-    use super::test_helpers::{commitment_tx_with_id, data_tx_with_id, empty_mempool_state};
+    use super::test_helpers::{
+        commitment_tx_with_id, data_tx_with_id, data_tx_with_ledger, empty_mempool_state,
+    };
     use super::*;
+    use irys_types::DataLedger;
 
-    /// Success path: all three update phases (data tx included_height,
+    /// Success path: all three update phases (term-ledger tx included_height,
     /// commitment tx included_height, publish tx promoted_height) apply
     /// atomically under a single write lock and the function returns Ok.
+    ///
+    /// Crucially, `publish_id` receives `promoted_height` (phase 3) but NOT
+    /// `included_height` (phase 1) — the phase-1 slice only contains term-ledger
+    /// txids, mirroring the call-site filtering in `handle_block_confirmed_message`.
     #[tokio::test]
     async fn success_path_applies_all_three_update_phases_atomically() {
         let data_id = H256::random();
@@ -3366,13 +3384,9 @@ mod apply_block_confirmed_updates_tests {
         let mempool_state = AtomicMempoolState::new(state);
         let height = 42_u64;
 
+        // phase-1 only contains term-ledger txids; publish_id is excluded
         let result = mempool_state
-            .apply_block_confirmed_updates(
-                &[data_id, publish_id],
-                &[commitment_id],
-                &[publish_id],
-                height,
-            )
+            .apply_block_confirmed_updates(&[data_id], &[commitment_id], &[publish_id], height)
             .await;
         assert!(
             result.is_ok(),
@@ -3388,7 +3402,7 @@ mod apply_block_confirmed_updates_tests {
                 .metadata()
                 .included_height,
             Some(height),
-            "data tx must have included_height set"
+            "term-ledger tx must have included_height set"
         );
         assert_eq!(
             guard
@@ -3407,8 +3421,8 @@ mod apply_block_confirmed_updates_tests {
                 .unwrap()
                 .metadata()
                 .included_height,
-            Some(height),
-            "publish tx must also have included_height set (covered by submit_and_publish_txids)"
+            None,
+            "publish tx must NOT have included_height set by the Publish-block confirmation"
         );
         assert_eq!(
             guard
@@ -3467,6 +3481,147 @@ mod apply_block_confirmed_updates_tests {
                 .included_height,
             Some(7),
             "present tx must still get its update"
+        );
+    }
+
+    /// A Submit→Publish promotion: the Publish-block `apply_block_confirmed_updates`
+    /// call must NOT overwrite the `included_height` that was set when the tx was
+    /// first confirmed in a Submit block.
+    ///
+    /// Sequence:
+    ///   1. Submit-block confirmation sets included_height = submit_height.
+    ///   2. Publish-block confirmation sets promoted_height but must leave
+    ///      included_height unchanged.
+    #[tokio::test]
+    async fn publish_confirmation_does_not_overwrite_submit_included_height() {
+        let tx_id = H256::random();
+        let submit_height = 10_u64;
+        let publish_height = 20_u64;
+
+        let mut state = empty_mempool_state();
+        state
+            .valid_submit_ledger_tx
+            .insert(tx_id, data_tx_with_ledger(tx_id, DataLedger::Publish));
+        let mempool_state = AtomicMempoolState::new(state);
+
+        // Step 1: simulate Submit-block confirmation (tx_id is a term-ledger txid here)
+        mempool_state
+            .apply_block_confirmed_updates(&[tx_id], &[], &[], submit_height)
+            .await
+            .unwrap();
+
+        // Step 2: simulate Publish-block confirmation (tx_id only in publish_txids,
+        // not in term_ledger_txids)
+        mempool_state
+            .apply_block_confirmed_updates(&[], &[], &[tx_id], publish_height)
+            .await
+            .unwrap();
+
+        let guard = mempool_state.state.read().await;
+        let meta = guard.valid_submit_ledger_tx.get(&tx_id).unwrap().metadata();
+        assert_eq!(
+            meta.included_height,
+            Some(submit_height),
+            "included_height must remain at Submit-block height after Publish confirmation"
+        );
+        assert_eq!(
+            meta.promoted_height,
+            Some(publish_height),
+            "promoted_height must be set to Publish-block height"
+        );
+    }
+
+    /// A OneYear-ledger tx confirmed directly: `apply_block_confirmed_updates` must
+    /// set `included_height` to the OneYear-block height.
+    #[tokio::test]
+    async fn oneyear_direct_confirmation_sets_included_height() {
+        let tx_id = H256::random();
+        let height = 15_u64;
+
+        let mut state = empty_mempool_state();
+        state
+            .valid_submit_ledger_tx
+            .insert(tx_id, data_tx_with_ledger(tx_id, DataLedger::OneYear));
+        let mempool_state = AtomicMempoolState::new(state);
+
+        mempool_state
+            .apply_block_confirmed_updates(&[tx_id], &[], &[], height)
+            .await
+            .unwrap();
+
+        let guard = mempool_state.state.read().await;
+        assert_eq!(
+            guard
+                .valid_submit_ledger_tx
+                .get(&tx_id)
+                .unwrap()
+                .metadata()
+                .included_height,
+            Some(height),
+            "OneYear tx must have included_height set to its confirmation block height"
+        );
+    }
+
+    /// A ThirtyDay-ledger tx confirmed directly: `apply_block_confirmed_updates` must
+    /// set `included_height` to the ThirtyDay-block height.
+    #[tokio::test]
+    async fn thirtyday_direct_confirmation_sets_included_height() {
+        let tx_id = H256::random();
+        let height = 25_u64;
+
+        let mut state = empty_mempool_state();
+        state
+            .valid_submit_ledger_tx
+            .insert(tx_id, data_tx_with_ledger(tx_id, DataLedger::ThirtyDay));
+        let mempool_state = AtomicMempoolState::new(state);
+
+        mempool_state
+            .apply_block_confirmed_updates(&[tx_id], &[], &[], height)
+            .await
+            .unwrap();
+
+        let guard = mempool_state.state.read().await;
+        assert_eq!(
+            guard
+                .valid_submit_ledger_tx
+                .get(&tx_id)
+                .unwrap()
+                .metadata()
+                .included_height,
+            Some(height),
+            "ThirtyDay tx must have included_height set to its confirmation block height"
+        );
+    }
+
+    /// A Publish-only tx (never in Submit; `ledger_id == Publish`) confirmed in a
+    /// Publish block must receive `promoted_height` but NOT `included_height`.
+    #[tokio::test]
+    async fn publish_only_tx_gets_promoted_height_not_included_height() {
+        let tx_id = H256::random();
+        let height = 30_u64;
+
+        let mut state = empty_mempool_state();
+        state
+            .valid_submit_ledger_tx
+            .insert(tx_id, data_tx_with_ledger(tx_id, DataLedger::Publish));
+        let mempool_state = AtomicMempoolState::new(state);
+
+        // Publish-block confirmation: tx_id only in publish_txids, not in term_ledger_txids
+        mempool_state
+            .apply_block_confirmed_updates(&[], &[], &[tx_id], height)
+            .await
+            .unwrap();
+
+        let guard = mempool_state.state.read().await;
+        let meta = guard.valid_submit_ledger_tx.get(&tx_id).unwrap().metadata();
+        assert_eq!(
+            meta.included_height, None,
+            "Publish-only tx must not have included_height set"
+        );
+        assert_eq!(
+            meta.promoted_height,
+            Some(height),
+            "Publish-only tx must have promoted_height set"
         );
     }
 }

--- a/crates/actors/src/mempool_service/data_txs.rs
+++ b/crates/actors/src/mempool_service/data_txs.rs
@@ -465,14 +465,21 @@ impl Inner {
         }) {
             Ok(()) => {
                 info!(
-                    "Successfully cached data_root {:?} for tx {:?}",
-                    tx.data_root, tx.id
+                    data_root = %tx.data_root,
+                    tx.id = %tx.id,
+                    source = "tx_ingress",
+                    expiry_height,
+                    "cached_data_root.write"
                 );
             }
             Err(db_error) => {
                 error!(
-                    "Failed to cache data_root {:?} for tx {:?}: {:?}",
-                    tx.data_root, tx.id, db_error
+                    data_root = %tx.data_root,
+                    tx.id = %tx.id,
+                    source = "tx_ingress",
+                    expiry_height,
+                    error = ?db_error,
+                    "cached_data_root.write_failed"
                 );
             }
         };

--- a/crates/actors/src/mempool_service/lifecycle.rs
+++ b/crates/actors/src/mempool_service/lifecycle.rs
@@ -42,9 +42,13 @@ impl Inner {
             .unwrap_or(&[]);
         let commitment_txids = block.commitment_tx_ids();
 
-        let all_data_txids: Vec<H256> = submit_txids
+        // Only term-ledger txids (Submit / OneYear / ThirtyDay) receive
+        // `included_height`. Publish txids are excluded here because Publish
+        // confirmation sets `promoted_height` (passed separately below), not
+        // `included_height`; the `included_height` for a Publish tx was already
+        // recorded at the time the tx was first confirmed in Submit.
+        let term_ledger_txids: Vec<H256> = submit_txids
             .iter()
-            .chain(publish_txids.iter())
             .chain(one_year_txids.iter())
             .chain(thirty_day_txids.iter())
             .copied()
@@ -52,7 +56,7 @@ impl Inner {
         if let Err(e) = self
             .mempool_state
             .apply_block_confirmed_updates(
-                &all_data_txids,
+                &term_ledger_txids,
                 commitment_txids,
                 publish_txids,
                 block.height,
@@ -754,28 +758,16 @@ impl Inner {
             .cloned()
             .unwrap_or_default();
 
-        // Clear included_height for orphaned publish transactions. Same
-        // contention semantics as the term-tx loop above.
-        for tx_id in orphaned_confirmed_publish_txs.iter().copied() {
-            match self
-                .mempool_state
-                .clear_data_tx_included_height(tx_id)
-                .await
-            {
-                Ok(true) => {
-                    tracing::debug!(tx.id = %tx_id, "Cleared included_height for orphaned publish tx");
-                }
-                Ok(false) => {}
-                Err(e) => {
-                    warn!(
-                        ?e,
-                        tx.id = %tx_id,
-                        "Mempool contention during publish-tx reorg cleanup; aborting"
-                    );
-                    return Ok(());
-                }
-            }
-        }
+        // NOTE: do NOT clear `included_height` for orphaned Publish txs here.
+        // `included_height` is owned by term-ledger confirmations (Submit /
+        // OneYear / ThirtyDay).  If only the Publish-promotion is orphaned
+        // (the underlying Submit is on a shared ancestor and still
+        // canonical), clearing `included_height` would undo a still-valid
+        // confirmation.  The term-tx loop above is responsible for clearing
+        // `included_height` whenever the term confirmation itself is
+        // orphaned; the Publish-orphan path only needs to clear
+        // `promoted_height`, which the next loop (`mark_unpromoted_in_mempool`)
+        // does.
 
         // these txs have been confirmed, but NOT migrated
         for tx_id in orphaned_confirmed_publish_txs.iter().copied() {

--- a/crates/actors/src/mempool_service/lifecycle.rs
+++ b/crates/actors/src/mempool_service/lifecycle.rs
@@ -76,9 +76,10 @@ impl Inner {
             return Ok(());
         }
 
-        // Update `CachedDataRoots` so that this block_hash is cached for each data_root.
-        // Track which roots were successfully cached so we only trigger proof generation
-        // for roots whose block_set was actually updated.
+        // Update `CachedDataRoots` so this block_hash is recorded in each
+        // data_root's block_set hint, and any pre-confirmation expiry is
+        // cleared.  Track which roots were successfully cached so we only
+        // trigger proof generation for those.
         let mut confirmed_data_roots = Vec::new();
         for submit_tx in sealed_block
             .transactions()
@@ -105,9 +106,10 @@ impl Inner {
             };
         }
 
-        // After block_set is populated for each confirmed data_root, notify the
-        // chunk ingress service to try generating ingress proofs. These will now
-        // pass the block_set gate since the block hash was just recorded above.
+        // After block_set is populated for each confirmed data_root, notify
+        // the chunk ingress service to try generating ingress proofs.  The
+        // block_set hint will now be non-empty and the canonical-tx
+        // verification will succeed since the tx was just included above.
         if !confirmed_data_roots.is_empty()
             && let Err(e) = self.service_senders.chunk_ingress.send_traced(
                 ChunkIngressMessage::TryGenerateProofsForConfirmedRoots(confirmed_data_roots),

--- a/crates/actors/src/mempool_service/lifecycle.rs
+++ b/crates/actors/src/mempool_service/lifecycle.rs
@@ -734,20 +734,46 @@ impl Inner {
 
         // 2. Re-post any reorged term ledger transactions through handle_tx_ingress_message so account balances and anchors are checked
         // 3. Filter out any invalidated transactions
+        //
+        // If re-ingress fails (other than Skipped), the tx is NOT in the mempool.
+        // BlockMigrationService already deleted its IrysDataTxMetadata row, so the
+        // CDR's txid_set still holds a tombstone entry.  The prune-loop pending-tx
+        // guard treats "txid_set entry with no metadata row" as "still pending", so
+        // the CDR + cached chunks + ingress proofs would be pinned indefinitely.
+        // Scrubbing the txid here closes that leak.  If the tx later becomes valid,
+        // fresh gossip naturally recreates the CDR entry.
+        let mut dropped_by_data_root: HashMap<H256, Vec<H256>> = HashMap::new();
         for tx_id in orphaned_term_txs.iter() {
             if let Some(tx) = orphaned_term_tx_map.remove(tx_id) {
-                // TODO: handle errors better
-                // note: the Skipped error is valid, so we'll need to match over the errors and abort on problematic ones (if/when appropriate)
-                if let Err(e) = self
-                    .handle_data_tx_ingress_message_gossip(tx)
-                    .await
-                    .inspect_err(|e| error!("Error re-submitting orphaned tx {} {:?}", tx_id, &e))
-                {
-                    error!("Failed to re-submit orphaned tx {} {:?}", tx_id, &e);
+                let data_root = tx.data_root;
+                match self.handle_data_tx_ingress_message_gossip(tx).await {
+                    Ok(_) => {}
+                    Err(TxIngressError::Skipped) => {
+                        debug!("Orphaned tx {} already in mempool (Skipped)", tx_id);
+                    }
+                    Err(e) => {
+                        error!("Failed to re-submit orphaned tx {} {:?}", tx_id, &e);
+                        dropped_by_data_root
+                            .entry(data_root)
+                            .or_default()
+                            .push(*tx_id);
+                    }
                 }
             } else {
                 warn!("Unable to get orphaned tx {:?} from sealed blocks", tx_id)
             }
+        }
+        if !dropped_by_data_root.is_empty()
+            && let Err(e) = self.service_senders.chunk_cache.send_traced(
+                crate::cache_service::CacheServiceAction::PruneTxidsFromCachedDataRoots(
+                    dropped_by_data_root,
+                ),
+            )
+        {
+            warn!(
+                "Failed to send PruneTxidsFromCachedDataRoots after reorg re-ingress: {}",
+                e
+            );
         }
 
         // 4. If a transaction was promoted in the orphaned fork but not the new canonical chain, clear promotion state in mempool (promoted_height = None)

--- a/crates/actors/src/mempool_service/lifecycle.rs
+++ b/crates/actors/src/mempool_service/lifecycle.rs
@@ -76,10 +76,12 @@ impl Inner {
             return Ok(());
         }
 
-        // Update `CachedDataRoots` so this block_hash is recorded in each
-        // data_root's block_set hint, and any pre-confirmation expiry is
-        // cleared.  Track which roots were successfully cached so we only
-        // trigger proof generation for those.
+        // Idempotently touch `CachedDataRoots` for each Submit-ledger tx in
+        // the confirmed block.  Authoritative block_set + expiry_height
+        // maintenance already happened atomically with the tip change in
+        // `BlockMigrationService::persist_metadata`; this loop only tracks
+        // which data_roots had a CDR row so the proof-generation
+        // notification below targets them.
         let mut confirmed_data_roots = Vec::new();
         for submit_tx in sealed_block
             .transactions()
@@ -106,10 +108,11 @@ impl Inner {
             };
         }
 
-        // After block_set is populated for each confirmed data_root, notify
-        // the chunk ingress service to try generating ingress proofs.  The
-        // block_set hint will now be non-empty and the canonical-tx
-        // verification will succeed since the tx was just included above.
+        // Notify chunk ingress to try generating ingress proofs for the
+        // confirmed data_roots.  `persist_metadata` has already populated
+        // `block_set` so the cheap gate in
+        // `try_generate_ingress_proof_for_root` will pass; downstream
+        // validation/promotion paths still re-verify canonicality.
         if !confirmed_data_roots.is_empty()
             && let Err(e) = self.service_senders.chunk_ingress.send_traced(
                 ChunkIngressMessage::TryGenerateProofsForConfirmedRoots(confirmed_data_roots),

--- a/crates/actors/src/mempool_service/lifecycle.rs
+++ b/crates/actors/src/mempool_service/lifecycle.rs
@@ -94,15 +94,23 @@ impl Inner {
             }) {
                 Ok(()) => {
                     info!(
-                        "Successfully cached data_root {:?} for tx {:?}",
-                        data_root, submit_tx.id
+                        %data_root,
+                        tx.id = %submit_tx.id,
+                        source = "block_confirmed",
+                        incoming_block.hash = %block.block_hash,
+                        incoming_block.height = block.height,
+                        "cached_data_root.write"
                     );
                     confirmed_data_roots.push(data_root);
                 }
                 Err(db_error) => {
                     error!(
-                        "Failed to cache data_root {:?} for tx {:?}: {:?}",
-                        data_root, submit_tx.id, db_error
+                        %data_root,
+                        tx.id = %submit_tx.id,
+                        source = "block_confirmed",
+                        incoming_block.hash = %block.block_hash,
+                        error = ?db_error,
+                        "cached_data_root.write_failed"
                     );
                 }
             };

--- a/crates/actors/src/metrics.rs
+++ b/crates/actors/src/metrics.rs
@@ -30,6 +30,7 @@ irys_utils::define_metrics! {
     counter BLOCK_VALIDATION_FAILED("irys.block.validation_failed_total", "Block full-validation failures (post pre-validation) by reason (labelled)");
     counter CHAIN_SYNC_BLOCK_REJECTED("irys.chain_sync.block_rejected_total", "Chain-sync block rejections by reason (labelled)");
     counter BLOCK_PRODUCTION_LOOKUP_FAILED("irys.block_production.lookup_failed_total", "Block-production canonical DB lookup failures by site (labelled). Currently observed: tx_selector silently skips affected publish candidates.");
+    counter CACHE_TXID_SCRUB_FAILED("irys.cache.txid_scrub_failed_total", "CachedDataRoot.txid_set scrub batches that returned Err. Visible signal that stale tombstones may pin CDRs until the next scrub trigger.");
 
     histogram PREVALIDATION_DURATION_MS(
         "irys.validation.prevalidation_duration_ms",
@@ -259,4 +260,8 @@ pub fn record_chain_sync_block_rejected(reason: &'static str) {
 
 pub(crate) fn record_block_production_lookup_failed(site: &'static str) {
     BLOCK_PRODUCTION_LOOKUP_FAILED.add(1, &[KeyValue::new("site", site)]);
+}
+
+pub(crate) fn record_cache_txid_scrub_failed() {
+    CACHE_TXID_SCRUB_FAILED.add(1, &[]);
 }

--- a/crates/actors/src/metrics.rs
+++ b/crates/actors/src/metrics.rs
@@ -29,6 +29,7 @@ irys_utils::define_metrics! {
     counter BLOCK_PRE_VALIDATION_FAILED("irys.block.pre_validation_failed_total", "Block pre-validation failures by reason (labelled)");
     counter BLOCK_VALIDATION_FAILED("irys.block.validation_failed_total", "Block full-validation failures (post pre-validation) by reason (labelled)");
     counter CHAIN_SYNC_BLOCK_REJECTED("irys.chain_sync.block_rejected_total", "Chain-sync block rejections by reason (labelled)");
+    counter BLOCK_PRODUCTION_LOOKUP_FAILED("irys.block_production.lookup_failed_total", "Block-production canonical DB lookup failures by site (labelled). Currently observed: tx_selector silently skips affected publish candidates.");
 
     histogram PREVALIDATION_DURATION_MS(
         "irys.validation.prevalidation_duration_ms",
@@ -254,4 +255,8 @@ pub(crate) fn record_block_validation_failed(reason: &'static str) {
 
 pub fn record_chain_sync_block_rejected(reason: &'static str) {
     CHAIN_SYNC_BLOCK_REJECTED.add(1, &[KeyValue::new("reason", reason)]);
+}
+
+pub(crate) fn record_block_production_lookup_failed(site: &'static str) {
+    BLOCK_PRODUCTION_LOOKUP_FAILED.add(1, &[KeyValue::new("site", site)]);
 }

--- a/crates/actors/src/metrics.rs
+++ b/crates/actors/src/metrics.rs
@@ -25,6 +25,9 @@ irys_utils::define_metrics! {
     gauge PACKING_SEMAPHORE_AVAILABLE("irys.packing.semaphore_available", "Available packing semaphore permits");
     counter DATA_TX_INGESTED("irys.mempool.data_tx_ingested_total", "Data transactions ingested into mempool");
     counter DATA_TX_UNFUNDED("irys.mempool.data_tx_unfunded_total", "Data transactions rejected due to insufficient funds");
+    counter CACHED_DATA_ROOT_EVICTED("irys.cache.cached_data_root_evicted_total", "CachedDataRoots entries evicted by prune_data_root_cache");
+    counter BLOCK_PRE_VALIDATION_FAILED("irys.block.pre_validation_failed_total", "Block pre-validation failures by reason (labelled)");
+    counter CHAIN_SYNC_BLOCK_REJECTED("irys.chain_sync.block_rejected_total", "Chain-sync block rejections by reason (labelled)");
 
     histogram PREVALIDATION_DURATION_MS(
         "irys.validation.prevalidation_duration_ms",
@@ -234,4 +237,16 @@ pub(crate) fn record_data_tx_ingested() {
 
 pub(crate) fn record_data_tx_unfunded() {
     DATA_TX_UNFUNDED.add(1, &[]);
+}
+
+pub(crate) fn record_cached_data_root_evicted() {
+    CACHED_DATA_ROOT_EVICTED.add(1, &[]);
+}
+
+pub(crate) fn record_block_pre_validation_failed(reason: &'static str) {
+    BLOCK_PRE_VALIDATION_FAILED.add(1, &[KeyValue::new("reason", reason)]);
+}
+
+pub fn record_chain_sync_block_rejected(reason: &'static str) {
+    CHAIN_SYNC_BLOCK_REJECTED.add(1, &[KeyValue::new("reason", reason)]);
 }

--- a/crates/actors/src/metrics.rs
+++ b/crates/actors/src/metrics.rs
@@ -27,6 +27,7 @@ irys_utils::define_metrics! {
     counter DATA_TX_UNFUNDED("irys.mempool.data_tx_unfunded_total", "Data transactions rejected due to insufficient funds");
     counter CACHED_DATA_ROOT_EVICTED("irys.cache.cached_data_root_evicted_total", "CachedDataRoots entries evicted by prune_data_root_cache");
     counter BLOCK_PRE_VALIDATION_FAILED("irys.block.pre_validation_failed_total", "Block pre-validation failures by reason (labelled)");
+    counter BLOCK_VALIDATION_FAILED("irys.block.validation_failed_total", "Block full-validation failures (post pre-validation) by reason (labelled)");
     counter CHAIN_SYNC_BLOCK_REJECTED("irys.chain_sync.block_rejected_total", "Chain-sync block rejections by reason (labelled)");
 
     histogram PREVALIDATION_DURATION_MS(
@@ -245,6 +246,10 @@ pub(crate) fn record_cached_data_root_evicted() {
 
 pub(crate) fn record_block_pre_validation_failed(reason: &'static str) {
     BLOCK_PRE_VALIDATION_FAILED.add(1, &[KeyValue::new("reason", reason)]);
+}
+
+pub(crate) fn record_block_validation_failed(reason: &'static str) {
+    BLOCK_VALIDATION_FAILED.add(1, &[KeyValue::new("reason", reason)]);
 }
 
 pub fn record_chain_sync_block_rejected(reason: &'static str) {

--- a/crates/actors/src/tx_inclusion.rs
+++ b/crates/actors/src/tx_inclusion.rs
@@ -137,8 +137,8 @@ fn lookup_via_block_tree(
             // Same invariant as the migrated path: a non-genesis canonical
             // block's parent must be reachable.  None from both tree and DB
             // would silently degrade the range; treat it as corruption.
-            let from_db = db
-                .view(|tx| block_header_by_hash(tx, &block.previous_block_hash, false))??;
+            let from_db =
+                db.view(|tx| block_header_by_hash(tx, &block.previous_block_hash, false))??;
             Some(from_db.ok_or_else(|| {
                 eyre::eyre!(
                     "block header storage inconsistent: block {} at height {} references prev {} which is missing from both block_tree and IrysBlockHeaders",
@@ -539,4 +539,32 @@ mod tests {
         Ok(())
     }
 
+    /// `max_height` below the first cached canonical height returns
+    /// `Ok(None)` — the `rposition` short-circuit handles the case where the
+    /// canonical chain cache has rolled past the requested height (e.g. tip
+    /// is thousands of blocks ahead, cache holds only the last
+    /// `block_tree_depth`).  Guards against a future refactor accidentally
+    /// indexing into an out-of-range slice.
+    #[test_log::test(tokio::test)]
+    async fn pre_migration_lookup_max_height_below_canonical_returns_none() -> eyre::Result<()> {
+        let (db, _tmp) = open_db()?;
+
+        let tx_id = H256::random();
+        // Genesis sits at height 5 (no tx_ids, so the seal check passes).
+        // h6 contains the tx_id.  Canonical cache therefore covers heights
+        // 5..=6 — there is no entry at or below max_height=3.
+        let h5 = make_signed_header(5, H256::zero(), 0, 0, vec![]);
+        let h6 = make_signed_header(6, h5.block_hash, 1, 12, vec![tx_id]);
+        let guard = build_tree(h5, vec![h6]);
+
+        let result = find_canonical_ledger_range(
+            &tx_id,
+            /* max_height */ 3,
+            ConsensusConfig::testing().block_migration_depth,
+            &guard,
+            &db,
+        )?;
+        assert!(result.is_none());
+        Ok(())
+    }
 }

--- a/crates/actors/src/tx_inclusion.rs
+++ b/crates/actors/src/tx_inclusion.rs
@@ -4,11 +4,14 @@
 //! Used by validation, chunk ingress, and cache pruning to determine the
 //! canonical confirming block for a tx without consulting `CachedDataRoots`.
 //!
-//! Two-stage lookup:
-//!   1. Migrated path: [`IrysDataTxMetadata`].`included_height` +
-//!      `MigratedBlockHashes` — O(1) DB read.
-//!   2. Pre-migration fallback: walk `block_tree` ≤ `block_migration_depth`
-//!      blocks back from `max_height`, filtered to `ChainState::Onchain`.
+//! Two-stage lookup (live tree first, migrated DB as backstop):
+//!   1. Pre-migration walk of `block_tree` ≤ `block_migration_depth` blocks
+//!      back from `max_height`, filtered to `ChainState::Onchain`.  Data
+//!      flows tree → DB on migration and never back, so the tree is the
+//!      live source of truth at the migration boundary.
+//!   2. Migrated-metadata fallback: [`IrysDataTxMetadata`].`included_height`
+//!      + `MigratedBlockHashes` — O(1) DB read once the confirming block
+//!      has migrated out of the tree window.
 
 use irys_database::{
     block_header_by_hash, tables::MigratedBlockHashes, tx_header_by_txid_canonical,

--- a/crates/actors/src/tx_inclusion.rs
+++ b/crates/actors/src/tx_inclusion.rs
@@ -106,7 +106,8 @@ fn lookup_via_block_tree(
     // tip-anchored window silently dropped canonical confirmations whenever
     // max_height was far enough below the tip that the tip-anchored slice
     // contained only blocks with `height > max_height`.
-    let depth = block_migration_depth as usize;
+    let depth = usize::try_from(block_migration_depth)
+        .expect("convert block_migration_depth to usize failed: value out of range");
     let Some(max_idx) = canonical
         .iter()
         .rposition(|entry| entry.header().height <= max_height)

--- a/crates/actors/src/tx_inclusion.rs
+++ b/crates/actors/src/tx_inclusion.rs
@@ -132,12 +132,7 @@ fn lookup_via_block_tree(
     // tip-anchored window silently dropped canonical confirmations whenever
     // max_height was far enough below the tip that the tip-anchored slice
     // contained only blocks with `height > max_height`.
-    // u32 → usize: usize is ≥ u32 on every supported target, so this is
-    // infallible in practice.  Kept as `try_from + expect` rather than
-    // `as usize` so a future widening of `block_migration_depth` to u64
-    // surfaces here at the call site instead of truncating silently.
-    let depth = usize::try_from(block_migration_depth)
-        .expect("convert block_migration_depth to usize failed: value out of range");
+    let depth = block_migration_depth as usize;
     let Some(max_idx) = canonical
         .iter()
         .rposition(|entry| entry.header().height <= max_height)

--- a/crates/actors/src/tx_inclusion.rs
+++ b/crates/actors/src/tx_inclusion.rs
@@ -54,23 +54,31 @@ fn lookup_via_migrated_metadata(
     max_height: u64,
     db: &DatabaseProvider,
 ) -> eyre::Result<Option<LedgerChunkRange>> {
-    // `tx_header_by_txid_canonical` already enforces:
+    // `tx_header_by_txid_canonical` already enforces, inside this same MDBX
+    // snapshot:
     //   - tx exists
     //   - included_height is set
     //   - included_height ≤ max_height
-    //   - MigratedBlockHashes[included_height] is canonical
+    //   - `MigratedBlockHashes[included_height]` is `Some` (canonical)
     db.view(|tx| -> eyre::Result<Option<LedgerChunkRange>> {
         let Some(header) = tx_header_by_txid_canonical(tx, tx_id, max_height)? else {
             return Ok(None);
         };
-        // `tx_header_by_txid_canonical` guarantees included_height is Some.
+        // Both `included_height` and `MigratedBlockHashes[included_height]`
+        // are guaranteed `Some` by the canonical-lookup contract above.  A
+        // missing row here would mean MDBX returned a different value for
+        // the same key within one snapshot — treat as corruption, matching
+        // the IrysBlockHeaders / prev-header arms below.
         let included_height = header
             .metadata()
             .included_height
             .expect("tx_header_by_txid_canonical guarantees included_height is Some");
-        let Some(block_hash) = tx.get::<MigratedBlockHashes>(included_height)? else {
-            return Ok(None);
-        };
+        let block_hash = tx.get::<MigratedBlockHashes>(included_height)?.ok_or_else(|| {
+            eyre::eyre!(
+                "canonical metadata inconsistent: tx_header_by_txid_canonical attested MigratedBlockHashes[{}] was Some, but a re-read in the same snapshot returned None",
+                included_height,
+            )
+        })?;
         // MigratedBlockHashes attested this hash is canonical at this height;
         // a missing IrysBlockHeaders entry means the two tables disagree.
         let block = block_header_by_hash(tx, &block_hash, false)?.ok_or_else(|| {

--- a/crates/actors/src/tx_inclusion.rs
+++ b/crates/actors/src/tx_inclusion.rs
@@ -762,9 +762,7 @@ mod tests {
     #[case::oneyear(DataLedger::OneYear)]
     #[case::thirtyday(DataLedger::ThirtyDay)]
     #[tokio::test]
-    async fn migrated_term_only_tx_returns_none(
-        #[case] ledger: DataLedger,
-    ) -> eyre::Result<()> {
+    async fn migrated_term_only_tx_returns_none(#[case] ledger: DataLedger) -> eyre::Result<()> {
         let (db, _tmp) = open_db()?;
 
         let tx_id = H256::random();

--- a/crates/actors/src/tx_inclusion.rs
+++ b/crates/actors/src/tx_inclusion.rs
@@ -825,4 +825,70 @@ mod tests {
         assert_eq!(u64::from(range.end()), 24);
         Ok(())
     }
+
+    /// `find_canonical_ledger_range` derives canonical truth from
+    /// `IrysDataTxMetadata` + `MigratedBlockHashes` + block headers — it
+    /// never reads `CachedDataRoots`.  Pin this contract: even if the CDR
+    /// for the query's `data_root` carries garbage in `block_set` and
+    /// `txid_set`, the returned range is identical to the no-CDR case.
+    ///
+    /// Companion to `corrupt_cdr_does_not_affect_assigned_ingress_proofs`
+    /// in `block_validation.rs`, which exercises the same contract at the
+    /// validation entry point.  Both tests guard against a future refactor
+    /// accidentally re-introducing a CDR read into a canonical-truth path.
+    #[test_log::test(tokio::test)]
+    async fn corrupt_cdr_does_not_affect_canonical_range_lookup() -> eyre::Result<()> {
+        use irys_database::db_cache::CachedDataRoot;
+        use irys_database::tables::CachedDataRoots;
+        use irys_types::UnixTimestamp;
+
+        let (db, _tmp) = open_db()?;
+
+        let tx_id = H256::random();
+        let data_root = H256::random();
+
+        // Identical setup to `migrated_tx_returns_canonical_range` — yields
+        // a canonical range of [10, 24].
+        let h0 = make_signed_header(0, H256::zero(), 0, 10, vec![]);
+        let h1 = make_signed_header(1, h0.block_hash, 1, 25, vec![tx_id]);
+        put_block_header(&db, &h0)?;
+        put_block_header(&db, &h1)?;
+        mark_migrated(&db, 0, h0.block_hash)?;
+        mark_migrated(&db, 1, h1.block_hash)?;
+        write_tx_with_included_height(&db, tx_id, data_root, 1)?;
+
+        // Inject a deliberately-corrupt CachedDataRoot for the same
+        // data_root.  If the helper were to consult `block_set`, the random
+        // hashes resolve to nothing; if it consulted `txid_set`, the stale
+        // entries would foul the lookup; if it consulted `data_size`, the
+        // u64::MAX value would alias an absurd chunk range.  Any read would
+        // produce a different (or Err) result than the baseline.
+        db.update(|tx| -> eyre::Result<()> {
+            let cdr = CachedDataRoot {
+                data_size: u64::MAX,
+                data_size_confirmed: true,
+                txid_set: vec![H256::random(), tx_id, H256::random()],
+                block_set: vec![H256::random(), H256::random(), H256::random()],
+                expiry_height: Some(0),
+                cached_at: UnixTimestamp::from_secs(0),
+            };
+            tx.put::<CachedDataRoots>(data_root, cdr)?;
+            Ok(())
+        })??;
+
+        let guard = empty_block_tree_guard();
+        let range = find_canonical_ledger_range(
+            &tx_id,
+            /* max_height */ 5,
+            ConsensusConfig::testing().block_migration_depth,
+            &guard,
+            &db,
+        )?
+        .ok_or_else(|| eyre::eyre!("expected Some(range) — corrupt CDR must not interfere"))?;
+
+        // Identical to the baseline `migrated_tx_returns_canonical_range`.
+        assert_eq!(range.start(), LedgerChunkOffset::from(10_u64));
+        assert_eq!(range.end(), LedgerChunkOffset::from(24_u64));
+        Ok(())
+    }
 }

--- a/crates/actors/src/tx_inclusion.rs
+++ b/crates/actors/src/tx_inclusion.rs
@@ -41,10 +41,25 @@ pub fn find_canonical_ledger_range(
     // the long-term backstop.  Preferring the tree here avoids any timing
     // edge case at the migration boundary and is more defensive against a
     // future bug in migrated-path metadata.
-    if let Some(range) =
-        lookup_via_block_tree(tx_id, max_height, block_migration_depth, block_tree, db)?
-    {
-        return Ok(Some(range));
+    //
+    // Tree-path errors (storage inconsistencies surfaced by
+    // `lookup_via_block_tree`) MUST NOT block the migrated-metadata
+    // fallback: a narrow race can evict the parent from both tree and DB
+    // briefly while migration is in flight, and the migrated path may
+    // resolve correctly once the row appears.  Log + try DB; if the DB
+    // path also fails, propagate that error (it has the more actionable
+    // diagnostic).
+    match lookup_via_block_tree(tx_id, max_height, block_migration_depth, block_tree, db) {
+        Ok(Some(range)) => return Ok(Some(range)),
+        Ok(None) => {}
+        Err(tree_err) => {
+            tracing::debug!(
+                %tx_id,
+                max_height,
+                error = %tree_err,
+                "tx_inclusion: tree-path lookup errored; falling through to migrated-metadata"
+            );
+        }
     }
     lookup_via_migrated_metadata(tx_id, max_height, db)
 }
@@ -980,6 +995,85 @@ mod tests {
 
         assert_eq!(range.start(), LedgerChunkOffset::from(5_u64));
         assert_eq!(range.end(), LedgerChunkOffset::from(11_u64));
+        Ok(())
+    }
+
+    /// Tree-path returns Err (parent unresolvable in tree AND DB), but the
+    /// migrated path resolves the tx via `IrysDataTxMetadata` +
+    /// `MigratedBlockHashes` pointing at a different, fully-stored canonical
+    /// chain.  Without the orchestrator's fall-through, the tree-path Err
+    /// would short-circuit the lookup and the caller would see a
+    /// `BlockBoundsLookupError` even though authoritative migrated metadata
+    /// can answer the query.
+    ///
+    /// Construction:
+    ///   - Tree contains genesis_tree → h_parent_tree → h_tx_tree with
+    ///     `tx_id`; h_parent_tree is then deleted from the tree and is NOT
+    ///     persisted to the DB, so walking back from h_tx_tree can't resolve
+    ///     its parent in either tier → `lookup_via_block_tree` errors.
+    ///   - DB independently contains genesis_db → h_tx_db (with `tx_id`) +
+    ///     matching `MigratedBlockHashes` entries + tx metadata
+    ///     `included_height = 1` pointing at h_tx_db.  The migrated path
+    ///     answers from these.
+    #[test_log::test(tokio::test)]
+    async fn tree_path_err_falls_through_to_migrated_metadata() -> eyre::Result<()> {
+        let (db, _tmp) = open_db()?;
+
+        let tx_id = H256::random();
+
+        // ---- Tree side: tree-path Err setup ----
+        // Note: tree-side block hashes are unrelated to DB-side block hashes —
+        // they live in different stores.  The tree's parent lookup fails
+        // because h_parent_tree never enters the DB.
+        let genesis_tree = make_signed_header(0, H256::zero(), 0, 0, vec![]);
+        let h_parent_tree = make_signed_header(1, genesis_tree.block_hash, 1, 5, vec![]);
+        let h_tx_tree = make_signed_header(2, h_parent_tree.block_hash, 2, 8, vec![tx_id]);
+
+        let mut tree = BlockTree::new(&genesis_tree, ConsensusConfig::testing());
+        for header in [&h_parent_tree, &h_tx_tree] {
+            let sealed = Arc::new(SealedBlock::new_unchecked(
+                Arc::new(header.clone()),
+                BlockTransactions::default(),
+            ));
+            tree.add_common(
+                header.block_hash,
+                &sealed,
+                Arc::new(CommitmentSnapshot::default()),
+                Arc::new(EpochSnapshot::default()),
+                dummy_ema_snapshot(),
+                ChainState::Onchain,
+            )
+            .expect("add_common succeeds");
+        }
+        tree.test_delete(&h_parent_tree.block_hash)
+            .expect("test_delete of intermediate block succeeds");
+        let guard = BlockTreeReadGuard::new(Arc::new(RwLock::new(tree)));
+
+        // ---- DB side: migrated-path success setup ----
+        let genesis_db = make_signed_header(0, H256::zero(), 0, 10, vec![]);
+        let h_tx_db = make_signed_header(1, genesis_db.block_hash, 1, 25, vec![tx_id]);
+        put_block_header(&db, &genesis_db)?;
+        put_block_header(&db, &h_tx_db)?;
+        mark_migrated(&db, 0, genesis_db.block_hash)?;
+        mark_migrated(&db, 1, h_tx_db.block_hash)?;
+        write_tx_with_included_height(&db, tx_id, H256::random(), 1)?;
+
+        let range = find_canonical_ledger_range(
+            &tx_id,
+            /* max_height */ 5,
+            ConsensusConfig::testing().block_migration_depth,
+            &guard,
+            &db,
+        )?
+        .ok_or_else(|| {
+            eyre::eyre!("expected Some(range) via migrated-path fall-through after tree Err")
+        })?;
+
+        // Range is derived from the DB chain (genesis_db total = 10,
+        // h_tx_db total = 25), so [10, 24].  The tree's [5, 8] would have
+        // surfaced only if the orchestrator returned the tree-path result.
+        assert_eq!(u64::from(range.start()), 10);
+        assert_eq!(u64::from(range.end()), 24);
         Ok(())
     }
 }

--- a/crates/actors/src/tx_inclusion.rs
+++ b/crates/actors/src/tx_inclusion.rs
@@ -24,6 +24,7 @@ use irys_types::{
 use nodit::interval::ii;
 use reth_db::Database as _;
 use reth_db::transaction::DbTx as _;
+use std::sync::Arc;
 
 /// Returns the Submit-ledger chunk range that this tx contributed to its
 /// confirming canonical block, or `None` if the tx is not yet confirmed on
@@ -158,26 +159,31 @@ fn lookup_via_block_tree(
             continue;
         }
 
-        let prev = if let Some(p) = tree.get_block(&block.previous_block_hash).cloned() {
-            Some(p)
-        } else if block.height == 0 {
-            None
-        } else {
-            // Same invariant as the migrated path: a non-genesis canonical
-            // block's parent must be reachable.  None from both tree and DB
-            // would silently degrade the range; treat it as corruption.
-            let from_db =
-                db.view(|tx| block_header_by_hash(tx, &block.previous_block_hash, false))??;
-            Some(from_db.ok_or_else(|| {
-                eyre::eyre!(
-                    "block header storage inconsistent: block {} at height {} references prev {} which is missing from both block_tree and IrysBlockHeaders",
-                    block.block_hash,
-                    block.height,
-                    block.previous_block_hash
-                )
-            })?)
-        };
-        return compute_submit_range(block.as_ref(), prev.as_ref());
+        // Tree-resident parent: cheap clone, no DB I/O, guard stays held.
+        if let Some(prev) = tree.get_block(&block.previous_block_hash).cloned() {
+            return compute_submit_range(block.as_ref(), Some(&prev));
+        }
+        if block.height == 0 {
+            return compute_submit_range(block.as_ref(), None);
+        }
+        // Parent is past the tree window — fall back to the DB.  Clone the
+        // current block (Arc bump) and release the read guard before issuing
+        // the MDBX read so we don't hold the BlockTree lock across I/O.  Same
+        // invariant as the migrated path: a non-genesis canonical block's
+        // parent must be reachable; None from both tree and DB is corruption.
+        let block = Arc::clone(block);
+        let prev_hash = block.previous_block_hash;
+        drop(tree);
+        let from_db = db.view(|tx| block_header_by_hash(tx, &prev_hash, false))??;
+        let prev = from_db.ok_or_else(|| {
+            eyre::eyre!(
+                "block header storage inconsistent: block {} at height {} references prev {} which is missing from both block_tree and IrysBlockHeaders",
+                block.block_hash,
+                block.height,
+                block.previous_block_hash
+            )
+        })?;
+        return compute_submit_range(block.as_ref(), Some(&prev));
     }
     Ok(None)
 }
@@ -754,18 +760,22 @@ mod tests {
     // Submit-membership guard on the migrated path
     // -----------------------------------------------------------------------
 
-    /// A tx whose `included_height` points at a block where the tx is in the
-    /// OneYear ledger (not Submit) must return `Ok(None)` — the Submit guard
-    /// must fire.
-    #[test_log::test(tokio::test)]
-    async fn migrated_oneyear_only_tx_returns_none() -> eyre::Result<()> {
+    /// A tx whose `included_height` points at a block where the tx lives in a
+    /// non-Submit term ledger (OneYear / ThirtyDay) must return `Ok(None)` —
+    /// the Submit-membership guard must fire.
+    #[rstest::rstest]
+    #[case::oneyear(DataLedger::OneYear)]
+    #[case::thirtyday(DataLedger::ThirtyDay)]
+    #[tokio::test]
+    async fn migrated_term_only_tx_returns_none(
+        #[case] ledger: DataLedger,
+    ) -> eyre::Result<()> {
         let (db, _tmp) = open_db()?;
 
         let tx_id = H256::random();
         let h0 = make_signed_header(0, H256::zero(), 0, 10, vec![]);
-        // h1 has the tx in OneYear ledger, NOT in Submit.
-        let h1 =
-            make_signed_header_with_term_tx(1, h0.block_hash, 1, 10, DataLedger::OneYear, tx_id);
+        // h1 has the tx in the term ledger only, NOT in Submit.
+        let h1 = make_signed_header_with_term_tx(1, h0.block_hash, 1, 10, ledger, tx_id);
 
         put_block_header(&db, &h0)?;
         put_block_header(&db, &h1)?;
@@ -784,40 +794,7 @@ mod tests {
         )?;
         assert!(
             result.is_none(),
-            "OneYear-only tx must not produce a Submit range"
-        );
-        Ok(())
-    }
-
-    /// A tx whose `included_height` points at a block where the tx is in the
-    /// ThirtyDay ledger (not Submit) must return `Ok(None)`.
-    #[test_log::test(tokio::test)]
-    async fn migrated_thirtyday_only_tx_returns_none() -> eyre::Result<()> {
-        let (db, _tmp) = open_db()?;
-
-        let tx_id = H256::random();
-        let h0 = make_signed_header(0, H256::zero(), 0, 10, vec![]);
-        // h1 has the tx in ThirtyDay ledger, NOT in Submit.
-        let h1 =
-            make_signed_header_with_term_tx(1, h0.block_hash, 1, 10, DataLedger::ThirtyDay, tx_id);
-
-        put_block_header(&db, &h0)?;
-        put_block_header(&db, &h1)?;
-        mark_migrated(&db, 0, h0.block_hash)?;
-        mark_migrated(&db, 1, h1.block_hash)?;
-        write_tx_with_included_height(&db, tx_id, H256::random(), 1)?;
-
-        let guard = empty_block_tree_guard();
-        let result = find_canonical_ledger_range(
-            &tx_id,
-            /* max_height */ 5,
-            ConsensusConfig::testing().block_migration_depth,
-            &guard,
-            &db,
-        )?;
-        assert!(
-            result.is_none(),
-            "ThirtyDay-only tx must not produce a Submit range"
+            "{ledger:?}-only tx must not produce a Submit range"
         );
         Ok(())
     }

--- a/crates/actors/src/tx_inclusion.rs
+++ b/crates/actors/src/tx_inclusion.rs
@@ -106,6 +106,10 @@ fn lookup_via_block_tree(
     // tip-anchored window silently dropped canonical confirmations whenever
     // max_height was far enough below the tip that the tip-anchored slice
     // contained only blocks with `height > max_height`.
+    // u32 → usize: usize is ≥ u32 on every supported target, so this is
+    // infallible in practice.  Kept as `try_from + expect` rather than
+    // `as usize` so a future widening of `block_migration_depth` to u64
+    // surfaces here at the call site instead of truncating silently.
     let depth = usize::try_from(block_migration_depth)
         .expect("convert block_migration_depth to usize failed: value out of range");
     let Some(max_idx) = canonical

--- a/crates/actors/src/tx_inclusion.rs
+++ b/crates/actors/src/tx_inclusion.rs
@@ -32,10 +32,17 @@ pub fn find_canonical_ledger_range(
     block_tree: &BlockTreeReadGuard,
     db: &DatabaseProvider,
 ) -> eyre::Result<Option<LedgerChunkRange>> {
-    if let Some(range) = lookup_via_migrated_metadata(tx_id, max_height, db)? {
+    // Try the live block_tree first: it is the authoritative source for
+    // blocks still within the migration window.  The DB (migrated path) is
+    // the long-term backstop.  Preferring the tree here avoids any timing
+    // edge case at the migration boundary and is more defensive against a
+    // future bug in migrated-path metadata.
+    if let Some(range) =
+        lookup_via_block_tree(tx_id, max_height, block_migration_depth, block_tree, db)?
+    {
         return Ok(Some(range));
     }
-    lookup_via_block_tree(tx_id, max_height, block_migration_depth, block_tree, db)
+    lookup_via_migrated_metadata(tx_id, max_height, db)
 }
 
 fn lookup_via_migrated_metadata(
@@ -67,6 +74,15 @@ fn lookup_via_migrated_metadata(
                 block_hash
             )
         })?;
+        // Defense-in-depth: after P0-1, `included_height` for OneYear/ThirtyDay
+        // txs points at their own term-ledger block, not a Submit block.  If any
+        // future caller passes such a tx_id here, `compute_submit_range` would
+        // return a wrong, unrelated Submit delta.  Mirror the same guard that
+        // `lookup_via_block_tree` already applies (see line ~124).
+        let submit_txs = &block.data_ledgers[DataLedger::Submit].tx_ids.0;
+        if !submit_txs.iter().any(|t| t == tx_id) {
+            return Ok(None);
+        }
         let prev = if block.height == 0 {
             None
         } else {
@@ -95,6 +111,12 @@ fn lookup_via_block_tree(
     block_tree: &BlockTreeReadGuard,
     db: &DatabaseProvider,
 ) -> eyre::Result<Option<LedgerChunkRange>> {
+    // Today's config validation ensures depth > 0, but the function silently
+    // degrades to a 1-block window if violated.
+    debug_assert!(
+        block_migration_depth > 0,
+        "block_migration_depth must be positive"
+    );
     let tree = block_tree.read();
     let (canonical, _tip_idx) = tree.get_canonical_chain();
 
@@ -167,6 +189,13 @@ fn compute_submit_range(
     block: &IrysBlockHeader,
     prev: Option<&IrysBlockHeader>,
 ) -> eyre::Result<Option<LedgerChunkRange>> {
+    // Locks in caller invariant: both existing callers already enforce this
+    // with ok_or_else(eyre!...), so the assert won't fire today — it's
+    // defense for future callers.
+    debug_assert!(
+        prev.is_some() || block.height == 0,
+        "prev must be Some for non-genesis block"
+    );
     let total = block.data_ledgers[DataLedger::Submit].total_chunks;
     let prev_total = prev
         .map(|p| p.data_ledgers[DataLedger::Submit].total_chunks)
@@ -623,6 +652,204 @@ mod tests {
             &db,
         )?;
         assert!(result.is_none());
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // P1-1 tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: build a block header whose tx_id appears in the given non-Submit
+    /// ledger (e.g. OneYear or ThirtyDay) but NOT in Submit.
+    fn make_signed_header_with_term_tx(
+        height: u64,
+        previous_block_hash: H256,
+        cumulative_diff: u64,
+        submit_total_chunks: u64,
+        term_ledger: DataLedger,
+        term_tx_id: H256,
+    ) -> IrysBlockHeader {
+        use irys_types::DataTransactionLedger;
+        let mut header = IrysBlockHeader::new_mock_header();
+        header.height = height;
+        header.previous_block_hash = previous_block_hash;
+        header.cumulative_diff = U256::from(cumulative_diff);
+        let submit = &mut header.data_ledgers[DataLedger::Submit];
+        submit.total_chunks = submit_total_chunks;
+        // Submit has no tx_ids — the tx lives only in the term ledger.
+        submit.tx_ids = H256List(vec![]);
+        // new_mock_header() only creates Publish and Submit ledgers; push the
+        // requested term ledger entry before indexing into it.
+        header.data_ledgers.push(DataTransactionLedger {
+            ledger_id: term_ledger.into(),
+            tx_root: H256::zero(),
+            tx_ids: H256List(vec![term_tx_id]),
+            total_chunks: 0,
+            expires: Some(1000),
+            proofs: None,
+            required_proof_count: None,
+        });
+        header.test_sign();
+        header
+    }
+
+    /// P1-1: when the DB has a corrupt entry but the block_tree has the
+    /// correct block, `find_canonical_ledger_range` must return the tree's
+    /// value, proving the tree path wins.
+    ///
+    /// Corruption: h1 in the DB has a wrong `total_chunks` for the Submit
+    /// ledger (999 instead of 25).  The block_tree holds the correct h1 with
+    /// total=25, so the correct range is [10, 24].  A migrated-path-first
+    /// implementation would return [10, 998] (wrong); a tree-first
+    /// implementation returns [10, 24] (correct).
+    #[test_log::test(tokio::test)]
+    async fn tree_wins_over_corrupt_db_entry() -> eyre::Result<()> {
+        let (db, _tmp) = open_db()?;
+
+        let tx_id = H256::random();
+
+        // Correct blocks in the tree (h0: total=10, h1: total=25, adds [10,24]).
+        let h0_correct = make_signed_header(0, H256::zero(), 0, 10, vec![]);
+        let h1_correct = make_signed_header(1, h0_correct.block_hash, 1, 25, vec![tx_id]);
+
+        let guard = build_tree(h0_correct.clone(), vec![h1_correct.clone()]);
+
+        // Corrupt DB: store h1 with wrong total_chunks=999, and mark migrated.
+        let mut h1_corrupt = h1_correct.clone();
+        h1_corrupt.data_ledgers[DataLedger::Submit as usize].total_chunks = 999;
+        // The block hash changes if we re-sign, so deliberately keep same hash
+        // to simulate a silent DB corruption (no hash change).
+        put_block_header(&db, &h0_correct)?;
+        put_block_header(&db, &h1_corrupt)?;
+        mark_migrated(&db, 0, h0_correct.block_hash)?;
+        mark_migrated(&db, 1, h1_correct.block_hash)?;
+        write_tx_with_included_height(&db, tx_id, H256::random(), 1)?;
+
+        let range = find_canonical_ledger_range(
+            &tx_id,
+            /* max_height */ 1,
+            ConsensusConfig::testing().block_migration_depth,
+            &guard,
+            &db,
+        )?
+        .ok_or_else(|| eyre::eyre!("expected Some(range)"))?;
+
+        // Tree path gives [10, 24]; corrupt DB path would give [10, 998].
+        assert_eq!(
+            u64::from(range.start()),
+            10,
+            "start should come from tree, not corrupt DB"
+        );
+        assert_eq!(
+            u64::from(range.end()),
+            24,
+            "end should come from tree (total=25), not corrupt DB (total=999)"
+        );
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // P1-2 tests
+    // -----------------------------------------------------------------------
+
+    /// P1-2: a tx whose `included_height` points at a block where the tx is
+    /// in the OneYear ledger (not Submit) must return `Ok(None)` — the Submit
+    /// guard must fire.
+    #[test_log::test(tokio::test)]
+    async fn migrated_oneyear_only_tx_returns_none() -> eyre::Result<()> {
+        let (db, _tmp) = open_db()?;
+
+        let tx_id = H256::random();
+        let h0 = make_signed_header(0, H256::zero(), 0, 10, vec![]);
+        // h1 has the tx in OneYear ledger, NOT in Submit.
+        let h1 =
+            make_signed_header_with_term_tx(1, h0.block_hash, 1, 10, DataLedger::OneYear, tx_id);
+
+        put_block_header(&db, &h0)?;
+        put_block_header(&db, &h1)?;
+        mark_migrated(&db, 0, h0.block_hash)?;
+        mark_migrated(&db, 1, h1.block_hash)?;
+        write_tx_with_included_height(&db, tx_id, H256::random(), 1)?;
+
+        // Empty tree so the migrated path is the only candidate.
+        let guard = empty_block_tree_guard();
+        let result = find_canonical_ledger_range(
+            &tx_id,
+            /* max_height */ 5,
+            ConsensusConfig::testing().block_migration_depth,
+            &guard,
+            &db,
+        )?;
+        assert!(
+            result.is_none(),
+            "OneYear-only tx must not produce a Submit range"
+        );
+        Ok(())
+    }
+
+    /// P1-2: a tx whose `included_height` points at a block where the tx is
+    /// in the ThirtyDay ledger (not Submit) must return `Ok(None)`.
+    #[test_log::test(tokio::test)]
+    async fn migrated_thirtyday_only_tx_returns_none() -> eyre::Result<()> {
+        let (db, _tmp) = open_db()?;
+
+        let tx_id = H256::random();
+        let h0 = make_signed_header(0, H256::zero(), 0, 10, vec![]);
+        // h1 has the tx in ThirtyDay ledger, NOT in Submit.
+        let h1 =
+            make_signed_header_with_term_tx(1, h0.block_hash, 1, 10, DataLedger::ThirtyDay, tx_id);
+
+        put_block_header(&db, &h0)?;
+        put_block_header(&db, &h1)?;
+        mark_migrated(&db, 0, h0.block_hash)?;
+        mark_migrated(&db, 1, h1.block_hash)?;
+        write_tx_with_included_height(&db, tx_id, H256::random(), 1)?;
+
+        let guard = empty_block_tree_guard();
+        let result = find_canonical_ledger_range(
+            &tx_id,
+            /* max_height */ 5,
+            ConsensusConfig::testing().block_migration_depth,
+            &guard,
+            &db,
+        )?;
+        assert!(
+            result.is_none(),
+            "ThirtyDay-only tx must not produce a Submit range"
+        );
+        Ok(())
+    }
+
+    /// P1-2 happy path: a Submit tx (Publish-promoted, tx in Submit ledger)
+    /// must still return the correct range after the guard is introduced.
+    #[test_log::test(tokio::test)]
+    async fn migrated_submit_tx_returns_correct_range_after_guard() -> eyre::Result<()> {
+        let (db, _tmp) = open_db()?;
+
+        let tx_id = H256::random();
+        let h0 = make_signed_header(0, H256::zero(), 0, 10, vec![]);
+        let h1 = make_signed_header(1, h0.block_hash, 1, 25, vec![tx_id]);
+
+        put_block_header(&db, &h0)?;
+        put_block_header(&db, &h1)?;
+        mark_migrated(&db, 0, h0.block_hash)?;
+        mark_migrated(&db, 1, h1.block_hash)?;
+        write_tx_with_included_height(&db, tx_id, H256::random(), 1)?;
+
+        // Empty tree: forces the migrated path.
+        let guard = empty_block_tree_guard();
+        let range = find_canonical_ledger_range(
+            &tx_id,
+            /* max_height */ 5,
+            ConsensusConfig::testing().block_migration_depth,
+            &guard,
+            &db,
+        )?
+        .ok_or_else(|| eyre::eyre!("expected Some(range) for Submit tx"))?;
+
+        // [10, 24] — Submit guard must not block a legitimate Submit tx.
+        assert_eq!(u64::from(range.start()), 10);
+        assert_eq!(u64::from(range.end()), 24);
         Ok(())
     }
 }

--- a/crates/actors/src/tx_inclusion.rs
+++ b/crates/actors/src/tx_inclusion.rs
@@ -63,9 +63,11 @@ fn lookup_via_migrated_metadata(
         let Some(header) = tx_header_by_txid_canonical(tx, tx_id, max_height)? else {
             return Ok(None);
         };
-        let Some(included_height) = header.metadata().included_height else {
-            return Ok(None);
-        };
+        // `tx_header_by_txid_canonical` guarantees included_height is Some.
+        let included_height = header
+            .metadata()
+            .included_height
+            .expect("tx_header_by_txid_canonical guarantees included_height is Some");
         let Some(block_hash) = tx.get::<MigratedBlockHashes>(included_height)? else {
             return Ok(None);
         };
@@ -115,8 +117,9 @@ fn lookup_via_block_tree(
     block_tree: &BlockTreeReadGuard,
     db: &DatabaseProvider,
 ) -> eyre::Result<Option<LedgerChunkRange>> {
-    // Today's config validation ensures depth > 0, but the function silently
-    // degrades to a 1-block window if violated.
+    // With saturating math, depth = 0 yields a single-block window at max_height —
+    // not a useful default, but not catastrophic either. The debug_assert below
+    // catches the misconfiguration in tests.
     debug_assert!(
         block_migration_depth > 0,
         "block_migration_depth must be positive"
@@ -150,6 +153,10 @@ fn lookup_via_block_tree(
         let Some((_, state)) = tree.get_block_and_status(&block.block_hash) else {
             continue;
         };
+        debug_assert!(
+            matches!(state, ChainState::Onchain),
+            "canonical chain entry must be Onchain"
+        );
         if !matches!(state, ChainState::Onchain) {
             continue;
         }

--- a/crates/actors/src/tx_inclusion.rs
+++ b/crates/actors/src/tx_inclusion.rs
@@ -157,14 +157,16 @@ fn lookup_via_block_tree(
         if !submit_txs.iter().any(|t| t == tx_id) {
             continue;
         }
-        // Canonical-chain entries should be Onchain, but check defensively.
+        // Canonical-chain entries are *almost* always `Onchain`, but during
+        // reorg replay an entry can briefly be `Validated` before the
+        // longest-chain walk promotes it.  Skip non-Onchain entries — both
+        // states are valid in transient windows and the next canonical block
+        // either confirms or evicts them.  (Originally a `debug_assert!`,
+        // but the heavy reorg tests exposed that the assumption doesn't
+        // hold under concurrent validation.)
         let Some((_, state)) = tree.get_block_and_status(&block.block_hash) else {
             continue;
         };
-        debug_assert!(
-            matches!(state, ChainState::Onchain),
-            "canonical chain entry must be Onchain"
-        );
         if !matches!(state, ChainState::Onchain) {
             continue;
         }

--- a/crates/actors/src/tx_inclusion.rs
+++ b/crates/actors/src/tx_inclusion.rs
@@ -77,11 +77,11 @@ fn lookup_via_migrated_metadata(
                 block_hash
             )
         })?;
-        // Defense-in-depth: after P0-1, `included_height` for OneYear/ThirtyDay
-        // txs points at their own term-ledger block, not a Submit block.  If any
-        // future caller passes such a tx_id here, `compute_submit_range` would
-        // return a wrong, unrelated Submit delta.  Mirror the same guard that
-        // `lookup_via_block_tree` already applies (see line ~124).
+        // `included_height` for OneYear/ThirtyDay txs points at their own
+        // term-ledger block, not a Submit block.  Without this guard,
+        // `compute_submit_range` would return a wrong, unrelated Submit
+        // delta for any such tx_id passed in.  Mirrors the same Submit-
+        // membership check the tree path applies.
         let submit_txs = &block.data_ledgers[DataLedger::Submit].tx_ids.0;
         if !submit_txs.iter().any(|t| t == tx_id) {
             return Ok(None);
@@ -158,8 +158,7 @@ fn lookup_via_block_tree(
             continue;
         }
 
-        let prev_in_tree = tree.get_block(&block.previous_block_hash).cloned();
-        let prev = if let Some(p) = prev_in_tree {
+        let prev = if let Some(p) = tree.get_block(&block.previous_block_hash).cloned() {
             Some(p)
         } else if block.height == 0 {
             None
@@ -659,7 +658,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // P1-1 tests
+    // Tree-vs-migrated-DB precedence + Submit-membership guard
     // -----------------------------------------------------------------------
 
     /// Helper: build a block header whose tx_id appears in the given non-Submit
@@ -696,9 +695,9 @@ mod tests {
         header
     }
 
-    /// P1-1: when the DB has a corrupt entry but the block_tree has the
-    /// correct block, `find_canonical_ledger_range` must return the tree's
-    /// value, proving the tree path wins.
+    /// When the DB has a corrupt entry but the block_tree has the correct
+    /// block, `find_canonical_ledger_range` must return the tree's value,
+    /// proving the tree path wins.
     ///
     /// Corruption: h1 in the DB has a wrong `total_chunks` for the Submit
     /// ledger (999 instead of 25).  The block_tree holds the correct h1 with
@@ -752,12 +751,12 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // P1-2 tests
+    // Submit-membership guard on the migrated path
     // -----------------------------------------------------------------------
 
-    /// P1-2: a tx whose `included_height` points at a block where the tx is
-    /// in the OneYear ledger (not Submit) must return `Ok(None)` — the Submit
-    /// guard must fire.
+    /// A tx whose `included_height` points at a block where the tx is in the
+    /// OneYear ledger (not Submit) must return `Ok(None)` — the Submit guard
+    /// must fire.
     #[test_log::test(tokio::test)]
     async fn migrated_oneyear_only_tx_returns_none() -> eyre::Result<()> {
         let (db, _tmp) = open_db()?;
@@ -790,8 +789,8 @@ mod tests {
         Ok(())
     }
 
-    /// P1-2: a tx whose `included_height` points at a block where the tx is
-    /// in the ThirtyDay ledger (not Submit) must return `Ok(None)`.
+    /// A tx whose `included_height` points at a block where the tx is in the
+    /// ThirtyDay ledger (not Submit) must return `Ok(None)`.
     #[test_log::test(tokio::test)]
     async fn migrated_thirtyday_only_tx_returns_none() -> eyre::Result<()> {
         let (db, _tmp) = open_db()?;
@@ -823,8 +822,9 @@ mod tests {
         Ok(())
     }
 
-    /// P1-2 happy path: a Submit tx (Publish-promoted, tx in Submit ledger)
-    /// must still return the correct range after the guard is introduced.
+    /// Happy path: a Submit tx (Publish-promoted, tx in Submit ledger) must
+    /// still return the correct range — the Submit-membership guard must not
+    /// block a legitimate Submit inclusion.
     #[test_log::test(tokio::test)]
     async fn migrated_submit_tx_returns_correct_range_after_guard() -> eyre::Result<()> {
         let (db, _tmp) = open_db()?;

--- a/crates/actors/src/tx_inclusion.rs
+++ b/crates/actors/src/tx_inclusion.rs
@@ -58,13 +58,31 @@ fn lookup_via_migrated_metadata(
         let Some(block_hash) = tx.get::<MigratedBlockHashes>(included_height)? else {
             return Ok(None);
         };
-        let Some(block) = block_header_by_hash(tx, &block_hash, false)? else {
-            return Ok(None);
-        };
+        // MigratedBlockHashes attested this hash is canonical at this height;
+        // a missing IrysBlockHeaders entry means the two tables disagree.
+        let block = block_header_by_hash(tx, &block_hash, false)?.ok_or_else(|| {
+            eyre::eyre!(
+                "canonical metadata inconsistent: MigratedBlockHashes[{}] = {} but IrysBlockHeaders has no entry for that hash",
+                included_height,
+                block_hash
+            )
+        })?;
         let prev = if block.height == 0 {
             None
         } else {
-            block_header_by_hash(tx, &block.previous_block_hash, false)?
+            // Non-genesis: parent must be stored (parents migrate before
+            // children).  A None here would silently turn into prev_total = 0
+            // and produce a wrong range, so treat it as corruption.
+            Some(
+                block_header_by_hash(tx, &block.previous_block_hash, false)?.ok_or_else(|| {
+                    eyre::eyre!(
+                        "block header storage inconsistent: block {} at height {} references prev {} which is missing from IrysBlockHeaders",
+                        block.block_hash,
+                        block.height,
+                        block.previous_block_hash
+                    )
+                })?,
+            )
         };
         compute_submit_range(&block, prev.as_ref())
     })?
@@ -80,15 +98,24 @@ fn lookup_via_block_tree(
     let tree = block_tree.read();
     let (canonical, _tip_idx) = tree.get_canonical_chain();
 
-    // Only the most recent `block_migration_depth` canonical entries can be
-    // pre-migration; older heights are already in the migrated-path table.
+    // Anchor the migration window to `max_height`, not the chain tip.  For
+    // callers asking about a historical height (e.g. validation of a block
+    // at height H using parent_height = H-1, during reorg replay), the
+    // unmigrated entries we care about are the `block_migration_depth` blocks
+    // ending at max_height — not the blocks at the current tip.  The old
+    // tip-anchored window silently dropped canonical confirmations whenever
+    // max_height was far enough below the tip that the tip-anchored slice
+    // contained only blocks with `height > max_height`.
     let depth = block_migration_depth as usize;
-    let start_idx = canonical.len().saturating_sub(depth);
-    for entry in canonical[start_idx..].iter().rev() {
+    let Some(max_idx) = canonical
+        .iter()
+        .rposition(|entry| entry.header().height <= max_height)
+    else {
+        return Ok(None);
+    };
+    let start_idx = max_idx.saturating_sub(depth.saturating_sub(1));
+    for entry in canonical[start_idx..=max_idx].iter().rev() {
         let block = entry.header();
-        if block.height > max_height {
-            continue;
-        }
         let submit_txs = &block.data_ledgers[DataLedger::Submit].tx_ids.0;
         if !submit_txs.iter().any(|t| t == tx_id) {
             continue;
@@ -107,7 +134,19 @@ fn lookup_via_block_tree(
         } else if block.height == 0 {
             None
         } else {
-            db.view(|tx| block_header_by_hash(tx, &block.previous_block_hash, false))??
+            // Same invariant as the migrated path: a non-genesis canonical
+            // block's parent must be reachable.  None from both tree and DB
+            // would silently degrade the range; treat it as corruption.
+            let from_db = db
+                .view(|tx| block_header_by_hash(tx, &block.previous_block_hash, false))??;
+            Some(from_db.ok_or_else(|| {
+                eyre::eyre!(
+                    "block header storage inconsistent: block {} at height {} references prev {} which is missing from both block_tree and IrysBlockHeaders",
+                    block.block_hash,
+                    block.height,
+                    block.previous_block_hash
+                )
+            })?)
         };
         return compute_submit_range(block.as_ref(), prev.as_ref());
     }
@@ -321,6 +360,75 @@ mod tests {
         Ok(())
     }
 
+    /// Regression: migrated lookup must error when MigratedBlockHashes points
+    /// at a hash that IrysBlockHeaders has no entry for.  Earlier code returned
+    /// `Ok(None)` silently and let the caller treat a tx as unconfirmed even
+    /// though the canonical-height table disagreed.
+    #[test_log::test(tokio::test)]
+    async fn migrated_lookup_errors_when_canonical_header_missing() -> eyre::Result<()> {
+        let (db, _tmp) = open_db()?;
+
+        let tx_id = H256::random();
+        // Mark a hash as canonical at height 1 in MigratedBlockHashes but
+        // *omit* the matching IrysBlockHeaders entry, simulating cross-table
+        // inconsistency.
+        let phantom_hash = H256::random();
+        mark_migrated(&db, 1, phantom_hash)?;
+        write_tx_with_included_height(&db, tx_id, H256::random(), 1)?;
+
+        let guard = empty_block_tree_guard();
+        let err = find_canonical_ledger_range(
+            &tx_id,
+            /* max_height */ 5,
+            ConsensusConfig::testing().block_migration_depth,
+            &guard,
+            &db,
+        )
+        .expect_err("missing canonical header must surface as Err");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("canonical metadata inconsistent"),
+            "unexpected error message: {msg}"
+        );
+        Ok(())
+    }
+
+    /// Regression: migrated lookup must error when a non-genesis block's
+    /// `previous_block_hash` is missing from IrysBlockHeaders.  Otherwise
+    /// `compute_submit_range` would run with `prev_total = 0` and emit a
+    /// silently-wrong range starting at offset 0.
+    #[test_log::test(tokio::test)]
+    async fn migrated_lookup_errors_when_prev_header_missing() -> eyre::Result<()> {
+        let (db, _tmp) = open_db()?;
+
+        let tx_id = H256::random();
+        // Write h1 (the confirming block) but *not* h0 (its parent) to
+        // IrysBlockHeaders.  Mark both heights migrated.
+        let h0_phantom = H256::random();
+        let h1 = make_signed_header(1, h0_phantom, 1, 25, vec![tx_id]);
+
+        put_block_header(&db, &h1)?;
+        mark_migrated(&db, 0, h0_phantom)?;
+        mark_migrated(&db, 1, h1.block_hash)?;
+        write_tx_with_included_height(&db, tx_id, H256::random(), 1)?;
+
+        let guard = empty_block_tree_guard();
+        let err = find_canonical_ledger_range(
+            &tx_id,
+            /* max_height */ 5,
+            ConsensusConfig::testing().block_migration_depth,
+            &guard,
+            &db,
+        )
+        .expect_err("missing prev header must surface as Err");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("block header storage inconsistent"),
+            "unexpected error message: {msg}"
+        );
+        Ok(())
+    }
+
     /// Regression: `compute_submit_range` must flag `total < prev_total` as
     /// corruption even when `total == 0`.  An earlier shape of this function
     /// short-circuited on `total == 0` before the regression check and would
@@ -378,4 +486,57 @@ mod tests {
         assert_eq!(range.end(), LedgerChunkOffset::from(11_u64));
         Ok(())
     }
+
+    /// Regression test: the block-tree fallback must anchor its scan window
+    /// to `max_height`, not the canonical-chain tip.  Build a canonical chain
+    /// long enough that a tip-anchored window of `block_migration_depth`
+    /// blocks contains *only* entries with `height > max_height`, then put
+    /// the only `tx_id` reference at a height that is within the migration
+    /// window relative to `max_height`.  A tip-anchored implementation
+    /// returns `None`; the correct max-height-anchored implementation
+    /// returns the canonical range.
+    #[test_log::test(tokio::test)]
+    async fn pre_migration_lookup_anchored_to_max_height_not_tip() -> eyre::Result<()> {
+        let (db, _tmp) = open_db()?;
+
+        let tx_id = H256::random();
+        // 10-block canonical chain.  Tx sits at height 2 in the Submit ledger
+        // (chunks [5, 11]).  Heights 3..=9 carry no Submit txs but advance
+        // the chain past block_migration_depth = 6 from height 2.
+        let h0 = make_signed_header(0, H256::zero(), 0, 5, vec![]);
+        let h1 = make_signed_header(1, h0.block_hash, 1, 5, vec![]);
+        let h2 = make_signed_header(2, h1.block_hash, 2, 12, vec![tx_id]);
+        let h3 = make_signed_header(3, h2.block_hash, 3, 12, vec![]);
+        let h4 = make_signed_header(4, h3.block_hash, 4, 12, vec![]);
+        let h5 = make_signed_header(5, h4.block_hash, 5, 12, vec![]);
+        let h6 = make_signed_header(6, h5.block_hash, 6, 12, vec![]);
+        let h7 = make_signed_header(7, h6.block_hash, 7, 12, vec![]);
+        let h8 = make_signed_header(8, h7.block_hash, 8, 12, vec![]);
+        let h9 = make_signed_header(9, h8.block_hash, 9, 12, vec![]);
+        let guard = build_tree(h0, vec![h1, h2, h3, h4, h5, h6, h7, h8, h9]);
+
+        // Query a historical height (3) far below the tip (9).  Migration
+        // window relative to max_height=3 with depth=6 covers heights -2..=3
+        // → 0..=3, which includes h2 where the tx lives.  A tip-anchored
+        // window (heights 4..=9) would not.
+        let range = find_canonical_ledger_range(
+            &tx_id,
+            /* max_height */ 3,
+            ConsensusConfig::testing().block_migration_depth,
+            &guard,
+            &db,
+        )?
+        .ok_or_else(|| {
+            eyre::eyre!(
+                "expected Some(range) at max_height=3 — scan must be anchored \
+                 to max_height, not the canonical tip"
+            )
+        })?;
+
+        // h2 added chunks 5..=11 (h1.total=5, h2.total=12).
+        assert_eq!(range.start(), LedgerChunkOffset::from(5_u64));
+        assert_eq!(range.end(), LedgerChunkOffset::from(11_u64));
+        Ok(())
+    }
+
 }

--- a/crates/actors/src/tx_inclusion.rs
+++ b/crates/actors/src/tx_inclusion.rs
@@ -464,6 +464,59 @@ mod tests {
         );
     }
 
+    /// Happy path: genesis-style block (`prev = None`, `prev_total = 0`)
+    /// with non-zero `total`.  Range is `[0, total - 1]`.
+    #[test_log::test(tokio::test)]
+    async fn compute_submit_range_genesis_returns_zero_anchored_range() -> eyre::Result<()> {
+        let block = make_signed_header(
+            /* height */ 0,
+            H256::zero(),
+            /* cumulative_diff */ 0,
+            /* submit_total_chunks */ 10,
+            vec![],
+        );
+        let range = compute_submit_range(&block, None)?
+            .ok_or_else(|| eyre::eyre!("expected Some(range) for non-empty genesis"))?;
+        assert_eq!(u64::from(range.start()), 0);
+        assert_eq!(u64::from(range.end()), 9);
+        Ok(())
+    }
+
+    /// Happy path: intermediate block with `total > prev_total`.  Range is
+    /// `[prev_total, total - 1]`.
+    #[test_log::test(tokio::test)]
+    async fn compute_submit_range_intermediate_returns_delta_range() -> eyre::Result<()> {
+        let prev = make_signed_header(0, H256::zero(), 0, 100, vec![]);
+        let block = make_signed_header(1, prev.block_hash, 1, 250, vec![]);
+        let range = compute_submit_range(&block, Some(&prev))?
+            .ok_or_else(|| eyre::eyre!("expected Some(range) for non-zero delta"))?;
+        assert_eq!(u64::from(range.start()), 100);
+        assert_eq!(u64::from(range.end()), 249);
+        Ok(())
+    }
+
+    /// Zero-delta: `total == prev_total` (no new Submit chunks in this
+    /// block).  Returns `Ok(None)` — caller treats this as "tx not
+    /// contributing here".
+    #[test_log::test(tokio::test)]
+    async fn compute_submit_range_zero_delta_returns_none() -> eyre::Result<()> {
+        let prev = make_signed_header(0, H256::zero(), 0, 42, vec![]);
+        let block = make_signed_header(1, prev.block_hash, 1, 42, vec![]);
+        assert!(compute_submit_range(&block, Some(&prev))?.is_none());
+        Ok(())
+    }
+
+    /// Zero-zero edge: both `total == 0` and `prev_total == 0` — the
+    /// regression check at the top of `compute_submit_range` must let this
+    /// through to the `total == prev_total` arm rather than erroring.
+    #[test_log::test(tokio::test)]
+    async fn compute_submit_range_zero_zero_returns_none() -> eyre::Result<()> {
+        let prev = make_signed_header(0, H256::zero(), 0, 0, vec![]);
+        let block = make_signed_header(1, prev.block_hash, 1, 0, vec![]);
+        assert!(compute_submit_range(&block, Some(&prev))?.is_none());
+        Ok(())
+    }
+
     #[test_log::test(tokio::test)]
     async fn pre_migration_tx_returns_range_via_block_tree() -> eyre::Result<()> {
         let (db, _tmp) = open_db()?;

--- a/crates/actors/src/tx_inclusion.rs
+++ b/crates/actors/src/tx_inclusion.rs
@@ -1,0 +1,351 @@
+//! Canonical-only lookup: given a tx_id and a height bound, find the ledger
+//! chunk range the tx contributed to its Submit ledger.
+//!
+//! Used by validation, chunk ingress, and cache pruning to determine the
+//! canonical confirming block for a tx without consulting `CachedDataRoots`.
+//!
+//! Two-stage lookup:
+//!   1. Migrated path: [`IrysDataTxMetadata`].`included_height` +
+//!      `MigratedBlockHashes` — O(1) DB read.
+//!   2. Pre-migration fallback: walk `block_tree` ≤ `block_migration_depth`
+//!      blocks back from `max_height`, filtered to `ChainState::Onchain`.
+
+use irys_database::{
+    block_header_by_hash, tables::MigratedBlockHashes, tx_header_by_txid_canonical,
+};
+use irys_domain::{BlockTreeReadGuard, ChainState};
+use irys_types::{
+    DataLedger, IrysBlockHeader, IrysTransactionId, LedgerChunkOffset, LedgerChunkRange,
+    app_state::DatabaseProvider,
+};
+use nodit::interval::ii;
+use reth_db::Database as _;
+use reth_db::transaction::DbTx as _;
+
+/// Returns the Submit-ledger chunk range that this tx contributed to its
+/// confirming canonical block, or `None` if the tx is not yet confirmed on
+/// canonical at or before `max_height`.
+pub fn find_canonical_ledger_range(
+    tx_id: &IrysTransactionId,
+    max_height: u64,
+    block_migration_depth: u32,
+    block_tree: &BlockTreeReadGuard,
+    db: &DatabaseProvider,
+) -> eyre::Result<Option<LedgerChunkRange>> {
+    if let Some(range) = lookup_via_migrated_metadata(tx_id, max_height, db)? {
+        return Ok(Some(range));
+    }
+    lookup_via_block_tree(tx_id, max_height, block_migration_depth, block_tree, db)
+}
+
+fn lookup_via_migrated_metadata(
+    tx_id: &IrysTransactionId,
+    max_height: u64,
+    db: &DatabaseProvider,
+) -> eyre::Result<Option<LedgerChunkRange>> {
+    // `tx_header_by_txid_canonical` already enforces:
+    //   - tx exists
+    //   - included_height is set
+    //   - included_height ≤ max_height
+    //   - MigratedBlockHashes[included_height] is canonical
+    db.view(|tx| -> eyre::Result<Option<LedgerChunkRange>> {
+        let Some(header) = tx_header_by_txid_canonical(tx, tx_id, max_height)? else {
+            return Ok(None);
+        };
+        let Some(included_height) = header.metadata().included_height else {
+            return Ok(None);
+        };
+        let Some(block_hash) = tx.get::<MigratedBlockHashes>(included_height)? else {
+            return Ok(None);
+        };
+        let Some(block) = block_header_by_hash(tx, &block_hash, false)? else {
+            return Ok(None);
+        };
+        let prev = if block.height == 0 {
+            None
+        } else {
+            block_header_by_hash(tx, &block.previous_block_hash, false)?
+        };
+        compute_submit_range(&block, prev.as_ref())
+    })?
+}
+
+fn lookup_via_block_tree(
+    tx_id: &IrysTransactionId,
+    max_height: u64,
+    block_migration_depth: u32,
+    block_tree: &BlockTreeReadGuard,
+    db: &DatabaseProvider,
+) -> eyre::Result<Option<LedgerChunkRange>> {
+    let tree = block_tree.read();
+    let (canonical, _tip_idx) = tree.get_canonical_chain();
+
+    // Only the most recent `block_migration_depth` canonical entries can be
+    // pre-migration; older heights are already in the migrated-path table.
+    let depth = block_migration_depth as usize;
+    let start_idx = canonical.len().saturating_sub(depth);
+    for entry in canonical[start_idx..].iter().rev() {
+        let block = entry.header();
+        if block.height > max_height {
+            continue;
+        }
+        let submit_txs = &block.data_ledgers[DataLedger::Submit].tx_ids.0;
+        if !submit_txs.iter().any(|t| t == tx_id) {
+            continue;
+        }
+        // Canonical-chain entries should be Onchain, but check defensively.
+        let Some((_, state)) = tree.get_block_and_status(&block.block_hash) else {
+            continue;
+        };
+        if !matches!(state, ChainState::Onchain) {
+            continue;
+        }
+
+        let prev_in_tree = tree.get_block(&block.previous_block_hash).cloned();
+        let prev = if let Some(p) = prev_in_tree {
+            Some(p)
+        } else if block.height == 0 {
+            None
+        } else {
+            db.view(|tx| block_header_by_hash(tx, &block.previous_block_hash, false))??
+        };
+        return compute_submit_range(block.as_ref(), prev.as_ref());
+    }
+    Ok(None)
+}
+
+/// Compute `[prev.submit.total_chunks, block.submit.total_chunks - 1]` as a
+/// `LedgerChunkRange` (inclusive-inclusive), matching the historical
+/// `get_ledger_range` semantics.  Returns `None` if the block added no
+/// Submit-ledger chunks.  Returns `Err` if `block.total < prev.total` (data
+/// corruption).
+fn compute_submit_range(
+    block: &IrysBlockHeader,
+    prev: Option<&IrysBlockHeader>,
+) -> eyre::Result<Option<LedgerChunkRange>> {
+    let total = block.data_ledgers[DataLedger::Submit].total_chunks;
+    if total == 0 {
+        return Ok(None);
+    }
+    let prev_total = prev
+        .map(|p| p.data_ledgers[DataLedger::Submit].total_chunks)
+        .unwrap_or(0);
+    if total < prev_total {
+        return Err(eyre::eyre!(
+            "Block {} has total_chunks ({}) < prev block total_chunks ({}), data corruption",
+            block.block_hash,
+            total,
+            prev_total
+        ));
+    }
+    if total == prev_total {
+        return Ok(None);
+    }
+    Ok(Some(LedgerChunkRange(ii(
+        LedgerChunkOffset::from(prev_total),
+        LedgerChunkOffset::from(total - 1),
+    ))))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use irys_database::{
+        IrysDatabaseArgs as _, insert_tx_header, open_or_create_db, set_data_tx_included_height,
+        tables::{IrysBlockHeaders, IrysTables},
+    };
+    use irys_domain::{
+        BlockTree, BlockTreeReadGuard, ChainState, CommitmentSnapshot, EpochSnapshot,
+        dummy_ema_snapshot,
+    };
+    use irys_testing_utils::IrysBlockHeaderTestExt as _;
+    use irys_testing_utils::utils::{TempDirBuilder, tempfile};
+    use irys_types::{
+        BlockTransactions, ConsensusConfig, DataTransactionHeader, DataTransactionHeaderV1,
+        DataTransactionHeaderV1WithMetadata, DataTransactionMetadata, H256, H256List,
+        IrysBlockHeader, SealedBlock, U256, app_state::DatabaseProvider,
+    };
+    use reth_db::mdbx::DatabaseArguments;
+    use reth_db::transaction::DbTxMut as _;
+    use std::sync::{Arc, RwLock};
+
+    fn open_db() -> eyre::Result<(DatabaseProvider, tempfile::TempDir)> {
+        let tmp = TempDirBuilder::new().build();
+        let env = open_or_create_db(
+            tmp.path(),
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        Ok((DatabaseProvider(Arc::new(env)), tmp))
+    }
+
+    /// Build a signed block header with custom Submit-ledger totals and tx_ids.
+    fn make_signed_header(
+        height: u64,
+        previous_block_hash: H256,
+        cumulative_diff: u64,
+        submit_total_chunks: u64,
+        submit_tx_ids: Vec<H256>,
+    ) -> IrysBlockHeader {
+        let mut header = IrysBlockHeader::new_mock_header();
+        header.height = height;
+        header.previous_block_hash = previous_block_hash;
+        header.cumulative_diff = U256::from(cumulative_diff);
+        let submit = &mut header.data_ledgers[DataLedger::Submit as usize];
+        submit.total_chunks = submit_total_chunks;
+        submit.tx_ids = H256List(submit_tx_ids);
+        header.test_sign();
+        header
+    }
+
+    fn put_block_header(db: &DatabaseProvider, header: &IrysBlockHeader) -> eyre::Result<()> {
+        db.update(|tx| -> eyre::Result<()> {
+            tx.put::<IrysBlockHeaders>(header.block_hash, header.clone().into())?;
+            Ok(())
+        })??;
+        Ok(())
+    }
+
+    fn mark_migrated(db: &DatabaseProvider, height: u64, hash: H256) -> eyre::Result<()> {
+        db.update(|tx| -> eyre::Result<()> {
+            tx.put::<MigratedBlockHashes>(height, hash)?;
+            Ok(())
+        })??;
+        Ok(())
+    }
+
+    fn write_tx_with_included_height(
+        db: &DatabaseProvider,
+        tx_id: H256,
+        data_root: H256,
+        included_height: u64,
+    ) -> eyre::Result<()> {
+        let mut metadata = DataTransactionMetadata::new();
+        metadata.included_height = Some(included_height);
+        let header = DataTransactionHeader::V1(DataTransactionHeaderV1WithMetadata {
+            tx: DataTransactionHeaderV1 {
+                id: tx_id,
+                data_root,
+                ledger_id: DataLedger::Submit as u32,
+                ..Default::default()
+            },
+            metadata,
+        });
+        db.update(|tx| -> eyre::Result<()> {
+            insert_tx_header(tx, &header)?;
+            set_data_tx_included_height(tx, &tx_id, included_height)?;
+            Ok(())
+        })??;
+        Ok(())
+    }
+
+    /// Build a BlockTree with `genesis` seeded as Onchain, then add `extra` blocks
+    /// via `add_common` using `SealedBlock::new_unchecked` (so we don't have to
+    /// populate matching tx bodies).
+    fn build_tree(genesis: IrysBlockHeader, extras: Vec<IrysBlockHeader>) -> BlockTreeReadGuard {
+        // Genesis must seal successfully — it has no tx_ids in either ledger.
+        let mut tree = BlockTree::new(&genesis, ConsensusConfig::testing());
+        for header in extras {
+            let sealed = Arc::new(SealedBlock::new_unchecked(
+                Arc::new(header.clone()),
+                BlockTransactions::default(),
+            ));
+            tree.add_common(
+                header.block_hash,
+                &sealed,
+                Arc::new(CommitmentSnapshot::default()),
+                Arc::new(EpochSnapshot::default()),
+                dummy_ema_snapshot(),
+                ChainState::Onchain,
+            )
+            .expect("add_common succeeds");
+        }
+        BlockTreeReadGuard::new(Arc::new(RwLock::new(tree)))
+    }
+
+    fn empty_block_tree_guard() -> BlockTreeReadGuard {
+        let mut genesis = IrysBlockHeader::new_mock_header();
+        genesis.height = 0;
+        genesis.previous_block_hash = H256::zero();
+        genesis.cumulative_diff = U256::from(0);
+        genesis.test_sign();
+        let tree = BlockTree::new(&genesis, ConsensusConfig::testing());
+        BlockTreeReadGuard::new(Arc::new(RwLock::new(tree)))
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn migrated_tx_returns_canonical_range() -> eyre::Result<()> {
+        let (db, _tmp) = open_db()?;
+
+        let tx_id = H256::random();
+        let h0 = make_signed_header(0, H256::zero(), 0, 10, vec![]);
+        let h1 = make_signed_header(1, h0.block_hash, 1, 25, vec![tx_id]);
+
+        put_block_header(&db, &h0)?;
+        put_block_header(&db, &h1)?;
+        mark_migrated(&db, 0, h0.block_hash)?;
+        mark_migrated(&db, 1, h1.block_hash)?;
+
+        write_tx_with_included_height(&db, tx_id, H256::random(), 1)?;
+
+        let guard = empty_block_tree_guard();
+        let range = find_canonical_ledger_range(
+            &tx_id,
+            /* max_height */ 5,
+            ConsensusConfig::testing().block_migration_depth,
+            &guard,
+            &db,
+        )?
+        .ok_or_else(|| eyre::eyre!("expected Some(range)"))?;
+
+        // [10, 24] inclusive — the 15 chunks added in h1.
+        assert_eq!(range.start(), LedgerChunkOffset::from(10_u64));
+        assert_eq!(range.end(), LedgerChunkOffset::from(24_u64));
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn missing_metadata_and_no_block_tree_returns_none() -> eyre::Result<()> {
+        let (db, _tmp) = open_db()?;
+        let guard = empty_block_tree_guard();
+
+        let tx_id = H256::random();
+        let result = find_canonical_ledger_range(
+            &tx_id,
+            10,
+            ConsensusConfig::testing().block_migration_depth,
+            &guard,
+            &db,
+        )?;
+        assert!(result.is_none());
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn pre_migration_tx_returns_range_via_block_tree() -> eyre::Result<()> {
+        let (db, _tmp) = open_db()?;
+
+        let tx_id = H256::random();
+        // h0: 5 Submit chunks (no tx) - serves as genesis with empty tx_ids.
+        let h0 = make_signed_header(0, H256::zero(), 0, 5, vec![]);
+        let h1 = make_signed_header(1, h0.block_hash, 1, 12, vec![tx_id]);
+
+        let guard = build_tree(h0, vec![h1]);
+        // Deliberately do NOT write IrysDataTxMetadata or MigratedBlockHashes —
+        // the helper must fall back to the block_tree walk.
+
+        let range = find_canonical_ledger_range(
+            &tx_id,
+            /* max_height */ 1,
+            ConsensusConfig::testing().block_migration_depth,
+            &guard,
+            &db,
+        )?
+        .ok_or_else(|| eyre::eyre!("expected Some(range) via block_tree fallback"))?;
+
+        // [5, 11] inclusive.
+        assert_eq!(range.start(), LedgerChunkOffset::from(5_u64));
+        assert_eq!(range.end(), LedgerChunkOffset::from(11_u64));
+        Ok(())
+    }
+}

--- a/crates/actors/src/tx_inclusion.rs
+++ b/crates/actors/src/tx_inclusion.rs
@@ -906,4 +906,78 @@ mod tests {
         assert_eq!(range.end(), LedgerChunkOffset::from(24_u64));
         Ok(())
     }
+
+    /// Migration-boundary regression: the confirming block is still in
+    /// `block_tree` but its parent has aged out of the tree window and lives
+    /// only in `IrysBlockHeaders`.  This is the path at
+    /// `lookup_via_block_tree`'s L171-188 — Arc-clone the block, drop the
+    /// read guard, then read the parent from MDBX.  Without this test,
+    /// regressions in the `drop(tree)` / DB-fallback handoff would only
+    /// surface as silently-wrong chunk ranges during reorg replay.
+    ///
+    /// Construction: build a g → h_parent → h_tx chain in the tree (so the
+    /// chain's parent-pointer chain is intact at insertion time), then
+    /// `test_delete` h_parent and persist it to MDBX.  The canonical chain
+    /// cache truncates to `[h_tx]` once `delete_block` runs
+    /// `update_longest_chain_cache`, and `tree.get_block(h_parent_hash)`
+    /// now returns `None` — forcing the DB-fallback parent read.
+    #[test_log::test(tokio::test)]
+    async fn tree_hit_parent_in_db_returns_correct_range() -> eyre::Result<()> {
+        let (db, _tmp) = open_db()?;
+
+        let tx_id = H256::random();
+        // Empty genesis required by `BlockTree::new`'s seal check.
+        let genesis = make_signed_header(0, H256::zero(), 0, 0, vec![]);
+        // h_parent: built into the tree so `add_common` can verify the
+        // parent link, then surgically removed below.
+        let h_parent = make_signed_header(1, genesis.block_hash, 1, 5, vec![]);
+        // h_tx: tip block, contains tx_id, Submit grows 5 → 12 → range
+        // [5, 11].
+        let h_tx = make_signed_header(2, h_parent.block_hash, 2, 12, vec![tx_id]);
+
+        // The DB needs h_parent so the fallback finds it.
+        put_block_header(&db, &h_parent)?;
+
+        // Build the tree with the full chain so `add_common` can resolve
+        // each parent at insertion time.
+        let mut tree = BlockTree::new(&genesis, ConsensusConfig::testing());
+        for header in [&h_parent, &h_tx] {
+            let sealed = Arc::new(SealedBlock::new_unchecked(
+                Arc::new(header.clone()),
+                BlockTransactions::default(),
+            ));
+            tree.add_common(
+                header.block_hash,
+                &sealed,
+                Arc::new(CommitmentSnapshot::default()),
+                Arc::new(EpochSnapshot::default()),
+                dummy_ema_snapshot(),
+                ChainState::Onchain,
+            )
+            .expect("add_common succeeds");
+        }
+        // Surgically drop h_parent from the tree.  `delete_block` calls
+        // `update_longest_chain_cache`, which walks back from the tip and
+        // stops where the parent chain breaks — leaving canonical = [h_tx].
+        tree.test_delete(&h_parent.block_hash)
+            .expect("test_delete of intermediate block succeeds");
+        let guard = BlockTreeReadGuard::new(Arc::new(RwLock::new(tree)));
+
+        let range = find_canonical_ledger_range(
+            &tx_id,
+            /* max_height */ 2,
+            ConsensusConfig::testing().block_migration_depth,
+            &guard,
+            &db,
+        )?
+        .ok_or_else(|| {
+            eyre::eyre!(
+                "expected Some(range) — tree-resident block must resolve its parent via the DB fallback"
+            )
+        })?;
+
+        assert_eq!(range.start(), LedgerChunkOffset::from(5_u64));
+        assert_eq!(range.end(), LedgerChunkOffset::from(11_u64));
+        Ok(())
+    }
 }

--- a/crates/actors/src/tx_inclusion.rs
+++ b/crates/actors/src/tx_inclusion.rs
@@ -124,12 +124,11 @@ fn compute_submit_range(
     prev: Option<&IrysBlockHeader>,
 ) -> eyre::Result<Option<LedgerChunkRange>> {
     let total = block.data_ledgers[DataLedger::Submit].total_chunks;
-    if total == 0 {
-        return Ok(None);
-    }
     let prev_total = prev
         .map(|p| p.data_ledgers[DataLedger::Submit].total_chunks)
         .unwrap_or(0);
+    // Regression must be checked before any short-circuit: total < prev_total
+    // is corruption regardless of whether total is zero.
     if total < prev_total {
         return Err(eyre::eyre!(
             "Block {} has total_chunks ({}) < prev block total_chunks ({}), data corruption",
@@ -141,6 +140,7 @@ fn compute_submit_range(
     if total == prev_total {
         return Ok(None);
     }
+    // total > prev_total ≥ 0, so total > 0 and `total - 1` cannot underflow.
     Ok(Some(LedgerChunkRange(ii(
         LedgerChunkOffset::from(prev_total),
         LedgerChunkOffset::from(total - 1),
@@ -319,6 +319,36 @@ mod tests {
         )?;
         assert!(result.is_none());
         Ok(())
+    }
+
+    /// Regression: `compute_submit_range` must flag `total < prev_total` as
+    /// corruption even when `total == 0`.  An earlier shape of this function
+    /// short-circuited on `total == 0` before the regression check and would
+    /// have silently returned `Ok(None)` for a `prev_total = 100, total = 0`
+    /// header pair.
+    #[test_log::test(tokio::test)]
+    async fn compute_submit_range_detects_zero_total_regression() {
+        let prev = make_signed_header(
+            /* height */ 0,
+            H256::zero(),
+            /* cumulative_diff */ 0,
+            /* submit_total_chunks */ 100,
+            vec![],
+        );
+        let block = make_signed_header(
+            /* height */ 1,
+            prev.block_hash,
+            /* cumulative_diff */ 1,
+            /* submit_total_chunks */ 0,
+            vec![],
+        );
+        let err = compute_submit_range(&block, Some(&prev))
+            .expect_err("total=0 with prev_total=100 must error as data corruption");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("data corruption"),
+            "unexpected error message: {msg}"
+        );
     }
 
     #[test_log::test(tokio::test)]

--- a/crates/actors/src/tx_selector/mod.rs
+++ b/crates/actors/src/tx_selector/mod.rs
@@ -977,6 +977,7 @@ async fn get_publish_txs_and_proofs(
             let (assigned_proofs, assigned_miners) = match get_assigned_ingress_proofs(
                 &proofs_only,
                 tx_header,
+                current_height,
                 ctx.block_tree,
                 ctx.db,
                 ctx.config,

--- a/crates/actors/src/tx_selector/mod.rs
+++ b/crates/actors/src/tx_selector/mod.rs
@@ -904,6 +904,20 @@ async fn get_publish_txs_and_proofs(
                         continue;
                     }
                     Err(e) => {
+                        // TODO(block-producer-errors): the analogous lookup in
+                        // `data_txs_are_valid` (block_validation.rs:2783) treats
+                        // this Err as `BlockBoundsLookupError` — an internal
+                        // failure that the validation taxonomy promotes to
+                        // node-fault under `fix/validation-error-disamb`.  Here
+                        // we silently drop the publish candidate, which causes
+                        // quiet liveness loss for affected txs while the local
+                        // DB is inconsistent.  Re-evaluate as part of the
+                        // block-producer error-handling pass: should we abort
+                        // the round (Irrecoverable) so the producer's stance
+                        // matches validation's?
+                        crate::metrics::record_block_production_lookup_failed(
+                            "publish_prior_submit",
+                        );
                         warn!(
                             tx.id = ?tx_header.id,
                             tx.data_root = ?tx_header.data_root,

--- a/crates/actors/src/tx_selector/mod.rs
+++ b/crates/actors/src/tx_selector/mod.rs
@@ -986,8 +986,11 @@ async fn get_publish_txs_and_proofs(
                 Ok(result) => result,
                 Err(e) => {
                     warn!(
-                        "Failed to get assigned proofs for tx {}: {}",
-                        &tx_header.id, e
+                        tx.id = %tx_header.id,
+                        data_root = %tx_header.data_root,
+                        current_height,
+                        error = %e,
+                        "tx_selector.assigned_proofs_lookup_failed"
                     );
                     continue;
                 }

--- a/crates/actors/src/tx_selector/mod.rs
+++ b/crates/actors/src/tx_selector/mod.rs
@@ -881,23 +881,37 @@ async fn get_publish_txs_and_proofs(
                 );
                 continue;
             }
-            // check for previous submit inclusion in a parent block
-            // we do this by checking if the tx is in the block tree or database.
-            // if it is, we know it could've only gotten there by being included in the submit ledger.
+            // check for previous submit inclusion in a parent block.
+            // The Publish-targeting tx (ledger_id == Publish) can only have
+            // gotten `included_height` set via Submit-ledger inclusion: term
+            // ledgers (OneYear / ThirtyDay) reject `ledger_id == Publish` at
+            // structural validation, so a `Some` from the canonical DB index
+            // is sufficient evidence of prior Submit.
             if !submit_txs_from_canonical.contains(&tx_header.id) {
-                // check database — constrained to canonical chain at or before parent
-                if ctx
+                match ctx
                     .db
-                    .view_eyre(|tx| tx_header_by_txid_canonical(tx, &tx_header.id, current_height))?
-                    .is_none()
+                    .view_eyre(|tx| tx_header_by_txid_canonical(tx, &tx_header.id, current_height))
                 {
-                    // no previous inclusion
-                    warn!(
-                        tx.id = ?tx_header.id,
-                        tx.data_root = ?tx_header.data_root,
-                        "Unable to find previous submit inclusion for publish candidate"
-                    );
-                    continue;
+                    Ok(Some(_)) => {
+                        // canonical Submit inclusion past the live-tree window
+                    }
+                    Ok(None) => {
+                        warn!(
+                            tx.id = ?tx_header.id,
+                            tx.data_root = ?tx_header.data_root,
+                            "Unable to find previous submit inclusion for publish candidate"
+                        );
+                        continue;
+                    }
+                    Err(e) => {
+                        warn!(
+                            tx.id = ?tx_header.id,
+                            tx.data_root = ?tx_header.data_root,
+                            error = %e,
+                            "tx_header_by_txid_canonical failed for publish candidate; skipping"
+                        );
+                        continue;
+                    }
                 }
             }
 

--- a/crates/actors/src/tx_selector/mod.rs
+++ b/crates/actors/src/tx_selector/mod.rs
@@ -1013,6 +1013,18 @@ async fn get_publish_txs_and_proofs(
             ) {
                 Ok(result) => result,
                 Err(e) => {
+                    // TODO(block-producer-errors): same asymmetry as the
+                    // `tx_header_by_txid_canonical` call above — the
+                    // validator-side invocation of `get_assigned_ingress_proofs`
+                    // (block_validation.rs:2969) uses `?` to surface this
+                    // `Err` as `BlockBoundsLookupError` → internal failure
+                    // under the disamb taxonomy.  Here we silently drop the
+                    // publish candidate.  Resolve in the block-producer
+                    // error-handling pass; for now, surface the drop via the
+                    // same counter so the asymmetry is operationally visible.
+                    crate::metrics::record_block_production_lookup_failed(
+                        "assigned_ingress_proofs",
+                    );
                     warn!(
                         tx.id = %tx_header.id,
                         data_root = %tx_header.data_root,

--- a/crates/chain-tests/src/block_production/block_production.rs
+++ b/crates/chain-tests/src/block_production/block_production.rs
@@ -1359,6 +1359,13 @@ async fn spiky_heavy3_test_always_build_on_max_difficulty_block() -> eyre::Resul
     // Enable validation on the peer and wait until it processes the backlog.
     peer_node.node_ctx.set_validation_enabled(true);
 
+    // Wait for the queued backlog to land on the canonical chain. Without this,
+    // `mine_block` may snapshot a pre-drain height and return a backlog block
+    // that arrives during the wait instead of the locally produced one.
+    peer_node
+        .wait_for_block_at_height(last_source_block.height, 30)
+        .await?;
+
     // Mine a block on the peer using the standard production flow.
     let normal_block = peer_node.mine_block().await?;
 

--- a/crates/chain-tests/src/block_production/block_validation.rs
+++ b/crates/chain-tests/src/block_production/block_validation.rs
@@ -539,3 +539,179 @@ async fn test_prevalidation_rejects_too_many_commitment_txs() -> Result<()> {
     ctx.stop().await;
     Ok(())
 }
+
+/// Regression for the double-publish bypass via the canonical-DB fallback at
+/// `data_txs_are_valid`'s `Searching { ledger_current: Publish }` arm.
+///
+/// **Exploit shape:** a tx has already been canonically Submit-confirmed and
+/// Publish-promoted, but the prior Publish block sits outside
+/// `anchor_expiry_depth` from the new block's parent.  The in-window walk's
+/// `Found { historical: Publish, current: Publish }` arm — which would emit
+/// `PublishTxAlreadyIncluded` — never fires because the prior Publish is
+/// past the scan window.  Without a `promoted_height` check in the fallback,
+/// the canonical-DB lookup would accept the tx (warns + continues) and the
+/// peer would succeed in re-publishing.  The fix is to inspect the
+/// metadata's `promoted_height` and reject when set to a migrated height
+/// ≤ parent_height.
+///
+/// **Test driver:** force the in-window walk to be empty by overriding
+/// `tx_anchor_expiry_depth = 0`, then construct a Publish-ledger block whose
+/// tx already has both `included_height` and `promoted_height` set in
+/// `IrysDataTxMetadata` (with matching `MigratedBlockHashes` rows).  Expect
+/// `Err(PublishTxAlreadyIncluded { tx_id, block_hash })` matching the
+/// pre-populated promoted block hash.
+#[tokio::test]
+async fn test_prevalidation_rejects_doubly_published_tx_via_fallback() -> Result<()> {
+    use irys_database::db::IrysDatabaseExt as _;
+    use irys_database::{
+        insert_tx_header, set_data_tx_included_height, set_data_tx_promoted_height,
+    };
+    use irys_types::H256List;
+
+    let ctx = PrevalidationTestContext::new().await?;
+
+    // `PrevalidationTestContext` lands `ctx.block` at height 1 (parent =
+    // genesis at height 0), so the bad block we'll build below has
+    // `parent_height = 0`.  Both `included_height` and `promoted_height`
+    // must be ≤ 0 for the fallback to consider the tx "already canonical";
+    // we collapse both onto the genesis row and pin the assertion to the
+    // genesis block hash already populated in `MigratedBlockHashes[0]`.
+    let genesis_block_hash = ctx
+        .node
+        .get_block_by_height(0)
+        .await
+        .expect("genesis block")
+        .block_hash;
+
+    // A Publish-ledger tx that will impersonate "already canonically
+    // promoted" via the pre-populated metadata below.
+    let mut tx = DataTransactionHeader::new(&ctx.config.consensus_config());
+    tx.data_root = H256::from_low_u64_be(0x517A_1EBA_DD15);
+    tx.data_size = 0;
+    tx.term_fee = BoundedFee::from_u64(1_000_000_000_000_000_000);
+    tx.perm_fee = Some(BoundedFee::from_u64(1_000_000_000_000_000_000));
+    tx.ledger_id = DataLedger::Publish as u32;
+    let tx = tx
+        .sign(&ctx.config.signer())
+        .expect("Failed to sign test transaction");
+
+    // Pre-populate canonical metadata: tx was Submit-included AND
+    // Publish-promoted at genesis (same-block promotion).  Both heights are
+    // ≤ parent_height = 0; both share `MigratedBlockHashes[0]` which the
+    // node already populated with `genesis_block_hash`.  This is the
+    // minimum-viable canonical-storage state that exercises the fallback's
+    // `promoted_height` rejection without touching adjacent canonical
+    // rows.
+    let prior_submit_height = 0_u64;
+    let prior_publish_height = 0_u64;
+    ctx.node.node_ctx.db.update_eyre(|db_tx| {
+        // `tx_header_by_txid_canonical` reads `IrysDataTxHeaders` first, so
+        // metadata-only writes would surface as "tx unknown" — also
+        // populate the header table.
+        insert_tx_header(db_tx, &tx)?;
+        set_data_tx_included_height(db_tx, &tx.id, prior_submit_height)?;
+        set_data_tx_promoted_height(db_tx, &tx.id, prior_publish_height)?;
+        Ok(())
+    })?;
+
+    // Build a block whose Publish ledger re-includes `tx`.  Mirror the
+    // pattern from `test_prevalidation_rejects_submit_targeted_tx`: keep
+    // ctx.block as the structural baseline and swap the data ledgers.
+    let mut body = ctx.block.to_block_body();
+    body.data_transactions = vec![tx.clone()];
+
+    let mut header = (**ctx.block.header()).clone();
+    let publish_ledger = header
+        .data_ledgers
+        .iter_mut()
+        .find(|l| l.ledger_id == DataLedger::Publish as u32)
+        .expect("Publish ledger should exist");
+    publish_ledger.tx_ids = H256List(vec![tx.id]);
+    let submit_ledger = header
+        .data_ledgers
+        .iter_mut()
+        .find(|l| l.ledger_id == DataLedger::Submit as u32)
+        .expect("Submit ledger should exist");
+    submit_ledger.tx_ids = H256List(Vec::new());
+
+    ctx.config.signer().sign_block_header(&mut header)?;
+    body.block_hash = header.block_hash;
+    let bad_block = Arc::new(SealedBlock::new(header, body)?);
+
+    {
+        let mut tree = ctx.node.node_ctx.block_tree_guard.write();
+        let parent_hash = bad_block.header().previous_block_hash;
+        let commitment_snapshot = tree
+            .get_commitment_snapshot(&parent_hash)
+            .expect("parent commitment snapshot");
+        let epoch_snapshot = tree
+            .get_epoch_snapshot(&parent_hash)
+            .expect("parent epoch snapshot");
+        let ema_snapshot = tree
+            .get_ema_snapshot(&parent_hash)
+            .expect("parent ema snapshot");
+        tree.add_block(
+            &bad_block,
+            commitment_snapshot,
+            epoch_snapshot,
+            ema_snapshot,
+        )?;
+    }
+
+    let (service_senders, mut service_receivers) = build_test_service_senders();
+    let block_tree_guard = ctx.node.node_ctx.block_tree_guard.clone();
+    tokio::spawn(async move {
+        while let Some(msg) = service_receivers.block_tree.recv().await {
+            let BlockTreeServiceMessage::GetBlockTreeReadGuard { response } = msg.inner else {
+                continue;
+            };
+            let _ = response.send(block_tree_guard.clone());
+        }
+    });
+
+    // `tx_anchor_expiry_depth = 0` collapses the in-window walk to zero
+    // blocks, forcing every Publish-ledger tx to take the canonical-DB
+    // fallback path that this regression exists to cover.
+    let mut consensus = ctx.config.consensus_config();
+    consensus.mempool.tx_anchor_expiry_depth = 0;
+    let mut node_config = ctx.config.clone();
+    node_config.consensus = ConsensusOptions::Custom(consensus);
+    let config_override = Config::new_with_random_peer_id(node_config);
+
+    let cascade_active = {
+        let tree = ctx.node.node_ctx.block_tree_guard.read();
+        let epoch_snapshot = tree.canonical_epoch_snapshot();
+        config_override
+            .consensus
+            .hardforks
+            .is_cascade_active_for_epoch(&epoch_snapshot)
+    };
+
+    let result = irys_actors::block_validation::data_txs_are_valid(
+        &config_override,
+        &service_senders,
+        bad_block.header(),
+        &ctx.node.node_ctx.db,
+        &ctx.node.node_ctx.block_tree_guard,
+        bad_block.transactions(),
+        cascade_active,
+    )
+    .await;
+
+    match result {
+        Err(PreValidationError::PublishTxAlreadyIncluded { tx_id, block_hash }) => {
+            assert_eq!(tx_id, tx.id, "rejection must name the doubly-published tx");
+            assert_eq!(
+                block_hash, genesis_block_hash,
+                "rejection must surface the canonical promoted-block hash from MigratedBlockHashes (= genesis hash in this fixture)"
+            );
+        }
+        other => panic!(
+            "expected PublishTxAlreadyIncluded via canonical-DB fallback, got {:?}",
+            other
+        ),
+    }
+
+    ctx.stop().await;
+    Ok(())
+}

--- a/crates/chain-tests/src/promotion/promotion_with_multiple_proofs.rs
+++ b/crates/chain-tests/src/promotion/promotion_with_multiple_proofs.rs
@@ -24,10 +24,15 @@ async fn spiky_heavy4_promotion_with_multiple_proofs_test() -> eyre::Result<()> 
             // Set the total number of proofs required to promote above the number of nodes (3)
             // to validate the clamping to 3 proofs to promote.
             consensus.hardforks.frontier.number_of_ingress_proofs_total = 5;
+            // Keep `from_assignees` at 0: the test's assertions
+            // (`wait_for_multiple_ingress_proofs_no_mining`, count = 3)
+            // verify the *total*-proof codepath only, and the startup
+            // guard in `Config::validate` rejects any non-zero value
+            // until `fix/assigned-miners-determinism` lands.
             consensus
                 .hardforks
                 .frontier
-                .number_of_ingress_proofs_from_assignees = 2;
+                .number_of_ingress_proofs_from_assignees = 0;
             consensus.num_partitions_per_slot = 3;
             consensus.epoch.num_blocks_in_epoch = 3;
             consensus.block_migration_depth = 1;

--- a/crates/chain-tests/src/promotion/stale_txid_in_cached_data_root.rs
+++ b/crates/chain-tests/src/promotion/stale_txid_in_cached_data_root.rs
@@ -202,8 +202,29 @@ async fn stale_txid_in_cached_data_root_does_not_block_after_fix() -> eyre::Resu
         .start_and_wait_for_packing("GENESIS", seconds_to_wait)
         .await;
 
-    // Mine initial blocks
-    genesis_node.mine_blocks(2).await?;
+    // Mine to the edge of anchor acceptance: ingress still accepts a
+    // genesis anchor at tip height 3 (`min_anchor_height = 3 - 3 = 0`,
+    // anchor at 0 is *not* too old by `<` comparison), but block production
+    // at the next height uses a stricter `[parent_height - (expiry_depth -
+    // block_migration_depth), parent_height - block_migration_depth]`
+    // window which puts the genesis anchor out of range immediately.
+    //
+    // With `tx_anchor_expiry_depth = 3` and `block_migration_depth = 1`,
+    // mining 3 blocks here parks the chain at height 3 — the gossip
+    // ingress below succeeds, but every subsequent block production call
+    // rejects the tx in `tx_selector`, so it never accumulates
+    // `included_height`/`promoted_height` metadata.  This is exactly the
+    // "stale txid pinned in CDR.txid_set" tombstone the test wants the
+    // mempool TTL + cache scrub to clean up.
+    //
+    // The earlier `mine_blocks(2)` form was passing only by accident:
+    // it left the genesis anchor still acceptable to block production
+    // (`parent_height - block_migration_depth = 1`, so an anchor at 0
+    // sat just inside the inclusion window), the tx confirmed at height
+    // 3, promoted at height 4, and the pre-`7c801780d` scrub deleted
+    // the `txid_set` entry of a confirmed tx — the exact bug the new
+    // metadata-recheck guard refuses to repeat.
+    genesis_node.mine_blocks(3).await?;
 
     let chunks: Vec<[u8; 32]> = vec![[10; 32], [20; 32], [30; 32]];
     let data: Vec<u8> = chunks.iter().flat_map(|c| c.iter()).copied().collect();
@@ -270,10 +291,12 @@ async fn stale_txid_in_cached_data_root_does_not_block_after_fix() -> eyre::Resu
         Ok(())
     })?;
 
-    // Mine enough blocks to expire the anchor.
-    // Anchor at height 0, effective_expiry = tx_anchor_expiry_depth(3) + block_migration_depth(1) + 5 = 9
-    // Prune when: anchor_height(0) < current_height - 9 → current_height > 9
-    // We're at height 2, so mine 9 more blocks to reach height 11.
+    // Mine enough blocks to cross the mempool prune horizon.
+    // Anchor at height 0, effective_expiry = tx_anchor_expiry_depth(3) +
+    // block_migration_depth(1) + 5 = 9.  Mempool prunes when
+    // anchor_height(0) < current_height - 9 → current_height > 9.  After
+    // the initial `mine_blocks(3)` we are at height 3; mining 9 more
+    // reaches height 12, well past the prune horizon.
     genesis_node.mine_blocks(9).await?;
 
     // Poll until the stale txid is gone from CachedDataRoot.txid_set (or the entry is

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -374,6 +374,13 @@ pub fn cached_data_root_by_data_root<T: DbTx>(
 /// helper is intended for migration-time consistency and must not fabricate
 /// cache entries for data_roots whose chunks the node never tracked.
 ///
+/// **Append-before-clear ordering** (mirrors the `(empty, None)` warn in
+/// `remove_data_root_block_set_entry`): the `block_set.push` happens before
+/// `expiry_height` is cleared in the same write tx, so the
+/// `(block_set.is_empty(), expiry_height.is_none())` post-condition is
+/// unreachable here — the new block_hash anchors the lifetime bound before
+/// the pre-confirmation expiry is dropped.  No warn arm needed.
+///
 /// Returns `true` if the row was modified.
 pub fn update_data_root_block_set<T: DbTx + DbTxMut>(
     tx: &T,

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -316,11 +316,15 @@ pub fn cache_data_root<T: DbTx + DbTxMut>(
         cached_data_root.data_size = tx_header.data_size;
     }
 
-    // If a block header is provided, record it in block_set as a *hint*
-    // (best-effort, not fork-tolerant — orphan hashes are retained across
-    // reorgs).  Consumers that need canonical truth must verify via
-    // `irys_actors::tx_inclusion`.  Also clear any pre-confirmation expiry
-    // since the data_root is now associated with at least one block.
+    // If a block header is provided, record it in block_set and clear any
+    // pre-confirmation expiry.  Authoritative block_set maintenance happens
+    // atomically with the tip change in
+    // `BlockMigrationService::persist_metadata` (see
+    // `update_data_root_block_set` / `remove_data_root_block_set_entry`) —
+    // by the time this is called from mempool's `on_block_confirmed`, the
+    // hash is already present.  The append is kept as a defensive idempotent
+    // write so direct callers of `cache_data_root` (tests, etc.) get
+    // consistent state.
     if let Some(block_header) = block_header {
         if !cached_data_root
             .block_set
@@ -343,6 +347,60 @@ pub fn cached_data_root_by_data_root<T: DbTx>(
     data_root: DataRoot,
 ) -> eyre::Result<Option<CachedDataRoot>> {
     Ok(tx.get::<CachedDataRoots>(data_root)?)
+}
+
+/// Ensures `block_hash` is present in the `block_set` of an existing
+/// [`CachedDataRoot`] and clears `expiry_height` (matching `cache_data_root`'s
+/// confirmation semantics).  No-op if no entry exists for `data_root` — this
+/// helper is intended for migration-time consistency and must not fabricate
+/// cache entries for data_roots whose chunks the node never tracked.
+///
+/// Returns `true` if the row was modified.
+pub fn update_data_root_block_set<T: DbTx + DbTxMut>(
+    tx: &T,
+    data_root: DataRoot,
+    block_hash: H256,
+) -> eyre::Result<bool> {
+    let Some(mut cdr) = tx.get::<CachedDataRoots>(data_root)? else {
+        return Ok(false);
+    };
+    let already_present = cdr.block_set.contains(&block_hash);
+    let needs_expiry_clear = cdr.expiry_height.is_some();
+    if !already_present {
+        cdr.block_set.push(block_hash);
+    }
+    if needs_expiry_clear {
+        cdr.expiry_height = None;
+    }
+    if already_present && !needs_expiry_clear {
+        return Ok(false);
+    }
+    tx.put::<CachedDataRoots>(data_root, cdr)?;
+    Ok(true)
+}
+
+/// Removes `block_hash` from the `block_set` of an existing [`CachedDataRoot`].
+/// Used when migration clears an orphaned block during reorg so `block_set`
+/// stops accumulating dead references.  No-op if the entry is absent or the
+/// hash is not present.  `expiry_height` is intentionally left untouched: any
+/// re-anchoring of an orphaned tx is handled by the mempool reorg path.
+///
+/// Returns `true` if the row was modified.
+pub fn remove_data_root_block_set_entry<T: DbTx + DbTxMut>(
+    tx: &T,
+    data_root: DataRoot,
+    block_hash: H256,
+) -> eyre::Result<bool> {
+    let Some(mut cdr) = tx.get::<CachedDataRoots>(data_root)? else {
+        return Ok(false);
+    };
+    let before = cdr.block_set.len();
+    cdr.block_set.retain(|h| h != &block_hash);
+    if cdr.block_set.len() == before {
+        return Ok(false);
+    }
+    tx.put::<CachedDataRoots>(data_root, cdr)?;
+    Ok(true)
 }
 
 type IsDuplicate = bool;

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -316,7 +316,11 @@ pub fn cache_data_root<T: DbTx + DbTxMut>(
         cached_data_root.data_size = tx_header.data_size;
     }
 
-    // If the entry exists and a block header reference was provided, add the block hash reference if necessary
+    // If a block header is provided, record it in block_set as a *hint*
+    // (best-effort, not fork-tolerant — orphan hashes are retained across
+    // reorgs).  Consumers that need canonical truth must verify via
+    // `irys_actors::tx_inclusion`.  Also clear any pre-confirmation expiry
+    // since the data_root is now associated with at least one block.
     if let Some(block_header) = block_header {
         if !cached_data_root
             .block_set
@@ -324,7 +328,6 @@ pub fn cache_data_root<T: DbTx + DbTxMut>(
         {
             cached_data_root.block_set.push(block_header.block_hash);
         }
-        // Clear any pre-confirmation expiry once the data_root is included in a block
         cached_data_root.expiry_height = None;
     }
 

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -385,14 +385,14 @@ pub fn update_data_root_block_set<T: DbTx + DbTxMut>(
     };
     let already_present = cdr.block_set.contains(&block_hash);
     let needs_expiry_clear = cdr.expiry_height.is_some();
+    if already_present && !needs_expiry_clear {
+        return Ok(false);
+    }
     if !already_present {
         cdr.block_set.push(block_hash);
     }
     if needs_expiry_clear {
         cdr.expiry_height = None;
-    }
-    if already_present && !needs_expiry_clear {
-        return Ok(false);
     }
     tx.put::<CachedDataRoots>(data_root, cdr)?;
     Ok(true)

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -338,6 +338,25 @@ pub fn cache_data_root<T: DbTx + DbTxMut>(
     // Update the database with the modified or new entry
     tx.put::<CachedDataRoots>(key, cached_data_root.clone())?;
 
+    // Surface anomalous writes: a CDR with `block_set.is_empty()` and
+    // `expiry_height.is_none()` has no lifetime bound and will land in the
+    // `(None, None)` arm of `prune_data_root_cache` (evicted unless a local
+    // ingress proof is present).  Under the authoritative-writer model this
+    // should not be produced by the normal flow: confirmed entries get
+    // their block_set populated by `BlockMigrationService::persist_metadata`
+    // Phase 3, and unconfirmed entries get `expiry_height` set by
+    // `cache_data_root_with_expiry`.  Direct callers of `cache_data_root`
+    // that bypass both paths (test fixtures, pre-fix code) can produce
+    // this state — warn so operators see them.
+    if cached_data_root.block_set.is_empty() && cached_data_root.expiry_height.is_none() {
+        warn!(
+            data_root = %key,
+            tx.id = %tx_header.id,
+            had_block_header = block_header.is_some(),
+            "cached_data_root.anomalous_write: block_set empty and expiry_height None — entry has no lifetime bound"
+        );
+    }
+
     Ok(Some(cached_data_root))
 }
 
@@ -399,7 +418,22 @@ pub fn remove_data_root_block_set_entry<T: DbTx + DbTxMut>(
     if cdr.block_set.len() == before {
         return Ok(false);
     }
+    let now_anomalous = cdr.block_set.is_empty() && cdr.expiry_height.is_none();
     tx.put::<CachedDataRoots>(data_root, cdr)?;
+    if now_anomalous {
+        // Reorg scrub left the CDR with no canonical block hashes and no
+        // pre-confirmation expiry.  Mempool's orphan re-anchor path
+        // (`handle_confirmed_data_tx_reorg`) is expected to re-ingest the
+        // orphaned tx and restore `expiry_height` via
+        // `cache_data_root_with_expiry`.  If that doesn't happen, the entry
+        // sits in the `(None, None)` arm and is only evicted by
+        // `prune_data_root_cache` after the local-proof exemption check.
+        warn!(
+            %data_root,
+            removed_block_hash = %block_hash,
+            "cached_data_root.anomalous_state_after_scrub: block_set now empty and expiry_height None — awaiting mempool orphan re-anchor or prune"
+        );
+    }
     Ok(true)
 }
 

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -1086,4 +1086,231 @@ mod tests {
             );
         }
     }
+
+    /// Direct tests for the `update_data_root_block_set` /
+    /// `remove_data_root_block_set_entry` helpers introduced for the
+    /// `BlockMigrationService`-as-authoritative-writer refactor.  These pin
+    /// the idempotency / no-op / expiry-handling semantics independently of
+    /// the migration call site.
+    mod data_root_block_set_helpers {
+        use crate::{
+            IrysDatabaseArgs as _, cache_data_root,
+            db::IrysDatabaseExt as _,
+            open_or_create_db, remove_data_root_block_set_entry,
+            tables::{CachedDataRoots, IrysTables},
+            update_data_root_block_set,
+        };
+        use irys_testing_utils::utils::tempfile;
+        use irys_types::{DataTransactionHeader, H256};
+        use reth_db::{
+            Database as _,
+            mdbx::DatabaseArguments,
+            transaction::{DbTx as _, DbTxMut as _},
+        };
+
+        /// Returns `(env, tempdir)`.  The caller must bind the tempdir to a
+        /// variable that lives the duration of the test — dropping it before
+        /// the env removes the underlying directory.
+        fn open_db() -> (reth_db::mdbx::DatabaseEnv, tempfile::TempDir) {
+            let tmp = irys_testing_utils::utils::TempDirBuilder::new().build();
+            let env = open_or_create_db(
+                tmp.path(),
+                IrysTables::ALL,
+                DatabaseArguments::irys_testing().unwrap(),
+            )
+            .unwrap();
+            (env, tmp)
+        }
+
+        /// Build a CDR for `data_root` with the given txid in its txid_set
+        /// and `block_set = initial_block_set`, `expiry_height = expiry`.
+        fn seed_cdr(
+            db: &reth_db::mdbx::DatabaseEnv,
+            data_root: H256,
+            tx_id: H256,
+            initial_block_set: Vec<H256>,
+            expiry: Option<u64>,
+        ) {
+            let tx_header =
+                DataTransactionHeader::V1(irys_types::DataTransactionHeaderV1WithMetadata {
+                    tx: irys_types::DataTransactionHeaderV1 {
+                        id: tx_id,
+                        data_root,
+                        data_size: 64,
+                        ..Default::default()
+                    },
+                    metadata: Default::default(),
+                });
+            db.update(|tx| -> eyre::Result<()> {
+                cache_data_root(tx, &tx_header, None)?;
+                let mut cdr = tx
+                    .get::<CachedDataRoots>(data_root)?
+                    .expect("seed_cdr: cache_data_root must produce an entry");
+                cdr.block_set = initial_block_set;
+                cdr.expiry_height = expiry;
+                tx.put::<CachedDataRoots>(data_root, cdr)?;
+                Ok(())
+            })
+            .unwrap()
+            .unwrap();
+        }
+
+        fn read_cdr(
+            db: &reth_db::mdbx::DatabaseEnv,
+            data_root: H256,
+        ) -> Option<crate::db_cache::CachedDataRoot> {
+            db.view(|tx| tx.get::<CachedDataRoots>(data_root))
+                .unwrap()
+                .unwrap()
+        }
+
+        #[test]
+        fn update_returns_false_when_cdr_missing() {
+            let (db, _tmp) = open_db();
+            let res = db
+                .update_eyre(|tx| update_data_root_block_set(tx, H256::random(), H256::random()))
+                .unwrap();
+            assert!(!res, "missing CDR must be a no-op returning false");
+        }
+
+        #[test]
+        fn update_appends_hash_and_clears_expiry() {
+            let (db, _tmp) = open_db();
+            let data_root = H256::random();
+            let tx_id = H256::random();
+            let new_hash = H256::random();
+            seed_cdr(&db, data_root, tx_id, vec![], Some(42));
+
+            let res = db
+                .update_eyre(|tx| update_data_root_block_set(tx, data_root, new_hash))
+                .unwrap();
+            assert!(res, "append + clear-expiry must report a modification");
+
+            let cdr = read_cdr(&db, data_root).expect("CDR present");
+            assert_eq!(cdr.block_set, vec![new_hash]);
+            assert!(cdr.expiry_height.is_none(), "expiry must be cleared");
+        }
+
+        #[test]
+        fn update_is_idempotent_when_hash_present_and_expiry_already_cleared() {
+            let (db, _tmp) = open_db();
+            let data_root = H256::random();
+            let tx_id = H256::random();
+            let existing_hash = H256::random();
+            seed_cdr(&db, data_root, tx_id, vec![existing_hash], None);
+
+            let res = db
+                .update_eyre(|tx| update_data_root_block_set(tx, data_root, existing_hash))
+                .unwrap();
+            assert!(
+                !res,
+                "no-op when hash already present and expiry already cleared"
+            );
+
+            let cdr = read_cdr(&db, data_root).expect("CDR present");
+            assert_eq!(cdr.block_set, vec![existing_hash], "block_set unchanged");
+        }
+
+        #[test]
+        fn update_clears_expiry_even_if_hash_already_present() {
+            let (db, _tmp) = open_db();
+            let data_root = H256::random();
+            let tx_id = H256::random();
+            let existing_hash = H256::random();
+            seed_cdr(&db, data_root, tx_id, vec![existing_hash], Some(99));
+
+            let res = db
+                .update_eyre(|tx| update_data_root_block_set(tx, data_root, existing_hash))
+                .unwrap();
+            assert!(res, "modification reported when expiry is cleared");
+
+            let cdr = read_cdr(&db, data_root).expect("CDR present");
+            assert_eq!(cdr.block_set, vec![existing_hash], "block_set unchanged");
+            assert!(cdr.expiry_height.is_none(), "expiry cleared");
+        }
+
+        #[test]
+        fn remove_returns_false_when_cdr_missing() {
+            let (db, _tmp) = open_db();
+            let res = db
+                .update_eyre(|tx| {
+                    remove_data_root_block_set_entry(tx, H256::random(), H256::random())
+                })
+                .unwrap();
+            assert!(!res, "missing CDR must be a no-op returning false");
+        }
+
+        #[test]
+        fn remove_returns_false_when_hash_absent() {
+            let (db, _tmp) = open_db();
+            let data_root = H256::random();
+            let tx_id = H256::random();
+            let other_hash = H256::random();
+            seed_cdr(&db, data_root, tx_id, vec![other_hash], Some(5));
+
+            let res = db
+                .update_eyre(|tx| remove_data_root_block_set_entry(tx, data_root, H256::random()))
+                .unwrap();
+            assert!(!res, "hash not in block_set must be a no-op");
+
+            let cdr = read_cdr(&db, data_root).expect("CDR present");
+            assert_eq!(cdr.block_set, vec![other_hash], "block_set unchanged");
+            assert_eq!(cdr.expiry_height, Some(5), "expiry unchanged");
+        }
+
+        #[test]
+        fn remove_strips_hash_and_leaves_expiry_alone() {
+            let (db, _tmp) = open_db();
+            let data_root = H256::random();
+            let tx_id = H256::random();
+            let target_hash = H256::random();
+            let keep_hash = H256::random();
+            seed_cdr(
+                &db,
+                data_root,
+                tx_id,
+                vec![target_hash, keep_hash],
+                Some(50),
+            );
+
+            let res = db
+                .update_eyre(|tx| remove_data_root_block_set_entry(tx, data_root, target_hash))
+                .unwrap();
+            assert!(res, "hash present must report a modification");
+
+            let cdr = read_cdr(&db, data_root).expect("CDR present");
+            assert_eq!(cdr.block_set, vec![keep_hash], "only target removed");
+            assert_eq!(
+                cdr.expiry_height,
+                Some(50),
+                "expiry_height intentionally left untouched per helper docblock"
+            );
+        }
+
+        /// Scrubbing the last hash from `block_set` while `expiry_height` is
+        /// already `None` leaves the CDR in the anomalous (None, None)
+        /// state.  The helper still completes successfully; the warn! at the
+        /// call site (logged but not test-asserted here) is the observable
+        /// signal for operators.
+        #[test]
+        fn remove_can_leave_cdr_in_anomalous_state() {
+            let (db, _tmp) = open_db();
+            let data_root = H256::random();
+            let tx_id = H256::random();
+            let only_hash = H256::random();
+            seed_cdr(&db, data_root, tx_id, vec![only_hash], None);
+
+            let res = db
+                .update_eyre(|tx| remove_data_root_block_set_entry(tx, data_root, only_hash))
+                .unwrap();
+            assert!(res, "hash present must report a modification");
+
+            let cdr = read_cdr(&db, data_root).expect("CDR present");
+            assert!(cdr.block_set.is_empty(), "block_set scrubbed to empty");
+            assert!(
+                cdr.expiry_height.is_none(),
+                "expiry intentionally left untouched"
+            );
+        }
+    }
 }

--- a/crates/database/src/db_cache.rs
+++ b/crates/database/src/db_cache.rs
@@ -93,22 +93,23 @@ pub struct CachedDataRoot {
     /// The set of all tx.ids' that contain this `data_root`
     pub txid_set: Vec<H256>,
 
-    /// Block hashes for canonical blocks that have included a tx referencing
-    /// this `data_root`.  Maintained authoritatively by
-    /// `BlockMigrationService::persist_metadata` inside the same DB
-    /// transaction as the tip change: it appends the new tip's block hash
-    /// for any existing entry and scrubs hashes for `blocks_to_clear`, so
-    /// orphan entries do not survive past the reorg that produced them.
-    /// `cache_data_root` (called later from mempool's `on_block_confirmed`)
-    /// idempotently re-adds the same hash; it does not introduce orphans
-    /// because the migration write that precedes it has already established
-    /// the canonical contents for the tip.
+    /// Block hashes for blocks whose **Submit ledger** has included a tx
+    /// referencing this `data_root`.  Maintained by two writers:
+    ///   - **Mempool `BlockConfirmed`** writes the confirming block hash on
+    ///     each newly confirmed tip (pre-migration forward-fill).  This is
+    ///     what lets chunks arriving *after* block confirmation find a
+    ///     populated `block_set`.
+    ///   - **`BlockMigrationService::persist_metadata`** scrubs orphaned
+    ///     block hashes during reorgs and idempotently appends the
+    ///     canonical hash for any tx whose CDR exists at migration time
+    ///     (update-only — never fabricates).
     ///
-    /// Use as a cheap "has this data_root been confirmed in any block?"
-    /// gate.  Range / slot lookups still belong to
+    /// Treat as a hint, not consensus state.  A stale `BlockConfirmed`
+    /// processed after a reorg can leave an orphan hash here; range / slot
+    /// lookups belong to
     /// `irys_actors::tx_inclusion::find_canonical_ledger_range`, which
     /// derives canonical truth from `IrysDataTxMetadata` +
-    /// `MigratedBlockHashes` rather than this set.
+    /// `MigratedBlockHashes` instead of trusting this set.
     pub block_set: Vec<H256>,
 
     /// Optional expiry height (e.g. anchor_height + anchor_expiry_depth) used

--- a/crates/database/src/db_cache.rs
+++ b/crates/database/src/db_cache.rs
@@ -90,7 +90,35 @@ pub struct CachedDataRoot {
     /// Has this data_size been confirmed by the data_path of the rightmost chunk in the data_root
     pub data_size_confirmed: bool,
 
-    /// The set of all tx.ids' that contain this `data_root`
+    /// Set of tx.ids that *currently* reference this `data_root` — i.e. the
+    /// txs whose chunk-retention needs keep the CDR alive.
+    ///
+    /// **Authoritative state, not a hint.**  Unlike `block_set` (below), this
+    /// field is the load-bearing input to the prune loop's pending-tx guard
+    /// (`cache_service::InnerCacheTask::prune_data_root_cache`): an entry
+    /// with no `IrysDataTxMetadata` row is interpreted as a *currently
+    /// pending* tx whose chunks must be preserved.  `tx_selector::
+    /// get_publish_txs_and_proofs` similarly drives publish-candidate
+    /// selection off this set and treats stale entries as a bug (see its
+    /// `debug_assert!` on "stale CachedDataRoot references").
+    ///
+    /// Writer model:
+    ///   - **`cache_data_root`** appends idempotently on every tx-ingress
+    ///     path (mempool ingress, gossip ingress, on_block_confirmed).
+    ///     Adds, never removes.
+    ///   - **`cache_service::spawn_prune_txids_task`** is the sole removal
+    ///     path, driven by two signals: mempool TTL eviction
+    ///     (`prune_pending_txs` Phase 4) and reorg failed-reingress
+    ///     (`handle_confirmed_data_tx_reorg`).  Both signals are
+    ///     "this tx is no longer relevant".  Per-txid metadata recheck
+    ///     inside the scrub task guards against the "tx re-confirmed during
+    ///     the scrub window" race.
+    ///
+    /// Future-proofing: any consumer that promotes this field's semantics
+    /// to fork-tolerant truth (e.g. cross-restart reconciliation) must
+    /// reconcile against `IrysDataTxMetadata` + `MigratedBlockHashes` plus
+    /// live mempool state — `txid_set` alone has no restart-survivable
+    /// signal for "still in mempool".
     pub txid_set: Vec<H256>,
 
     /// Block hashes for blocks whose **Submit ledger** has included a tx

--- a/crates/database/src/db_cache.rs
+++ b/crates/database/src/db_cache.rs
@@ -93,13 +93,22 @@ pub struct CachedDataRoot {
     /// The set of all tx.ids' that contain this `data_root`
     pub txid_set: Vec<H256>,
 
-    /// Block hashes for blocks that have included a tx referencing this
-    /// `data_root`.  **Hint only — NOT fork-tolerant.**  Append-only across
-    /// reorgs (orphan hashes are retained), so this field must not be
-    /// trusted as a canonical-inclusion oracle.  Consumers that need
-    /// canonical truth must verify via `irys_actors::tx_inclusion`.
-    /// Useful as a cheap "has this ever been in a block" pre-check before
-    /// the more expensive canonical lookup.
+    /// Block hashes for canonical blocks that have included a tx referencing
+    /// this `data_root`.  Maintained authoritatively by
+    /// `BlockMigrationService::persist_metadata` inside the same DB
+    /// transaction as the tip change: it appends the new tip's block hash
+    /// for any existing entry and scrubs hashes for `blocks_to_clear`, so
+    /// orphan entries do not survive past the reorg that produced them.
+    /// `cache_data_root` (called later from mempool's `on_block_confirmed`)
+    /// idempotently re-adds the same hash; it does not introduce orphans
+    /// because the migration write that precedes it has already established
+    /// the canonical contents for the tip.
+    ///
+    /// Use as a cheap "has this data_root been confirmed in any block?"
+    /// gate.  Range / slot lookups still belong to
+    /// `irys_actors::tx_inclusion::find_canonical_ledger_range`, which
+    /// derives canonical truth from `IrysDataTxMetadata` +
+    /// `MigratedBlockHashes` rather than this set.
     pub block_set: Vec<H256>,
 
     /// Optional expiry height (e.g. anchor_height + anchor_expiry_depth) used

--- a/crates/database/src/db_cache.rs
+++ b/crates/database/src/db_cache.rs
@@ -93,11 +93,18 @@ pub struct CachedDataRoot {
     /// The set of all tx.ids' that contain this `data_root`
     pub txid_set: Vec<H256>,
 
-    /// Block hashes for blocks containing transactions with this `data_root`
+    /// Block hashes for blocks that have included a tx referencing this
+    /// `data_root`.  **Hint only — NOT fork-tolerant.**  Append-only across
+    /// reorgs (orphan hashes are retained), so this field must not be
+    /// trusted as a canonical-inclusion oracle.  Consumers that need
+    /// canonical truth must verify via `irys_actors::tx_inclusion`.
+    /// Useful as a cheap "has this ever been in a block" pre-check before
+    /// the more expensive canonical lookup.
     pub block_set: Vec<H256>,
 
-    /// Optional expiry height (e.g. anchor_height + anchor_expiry_depth) used for pruning while unconfirmed.
-    /// If None, pruning falls back to block inclusion history.
+    /// Optional expiry height (e.g. anchor_height + anchor_expiry_depth) used
+    /// for pruning while unconfirmed.  If `None`, pruning falls back to the
+    /// canonical inclusion heights of the txs in `txid_set`.
     #[serde(default)]
     pub expiry_height: Option<u64>,
 

--- a/crates/database/src/db_index.rs
+++ b/crates/database/src/db_index.rs
@@ -203,29 +203,26 @@ pub fn batch_clear_data_tx_promoted_height<'a>(
 
 /// Clear the included_height for a data transaction (used during re-orgs of term-ledger blocks).
 ///
-/// If `promoted_height` is still set, the row is kept with only `included_height` cleared.
-/// If neither field would remain set after the clear, the row is deleted entirely.
+/// Always deletes the row. A row with `{included: None, promoted: Some}` is
+/// semantically illegal — `promoted_height` requires the tx to have been
+/// included at some prior height, and the reorg invariant in
+/// `BlockMigrationService::persist_metadata` guarantees the matching Publish
+/// block is also in `blocks_to_clear`. Its `clear_data_tx_promoted_height`
+/// call becomes a no-op on the already-deleted row. If the tx is
+/// re-canonical on the new fork, Phase 2 recreates the row via
+/// `set_data_tx_included_height` and any matching Publish re-confirmation
+/// restores `promoted_height` in the same transaction.
 pub fn clear_data_tx_included_height(
-    tx: &(impl DbTxMut + DbTx),
+    tx: &impl DbTxMut,
     tx_id: &H256,
 ) -> Result<(), reth_db::DatabaseError> {
-    let Some(mut metadata) = get_data_tx_metadata(tx, tx_id)? else {
-        // Row absent — no-op; delete is safe but unnecessary.
-        return Ok(());
-    };
-    metadata.included_height = None;
-    // Only keep the row if promoted_height is still meaningful.
-    if metadata.promoted_height.is_some() {
-        tx.put::<IrysDataTxMetadata>(*tx_id, metadata.into())
-    } else {
-        tx.delete::<IrysDataTxMetadata>(*tx_id, None)?;
-        Ok(())
-    }
+    tx.delete::<IrysDataTxMetadata>(*tx_id, None)?;
+    Ok(())
 }
 
 /// Batch operation: Clear included_height for multiple data transactions (re-org handling).
 pub fn batch_clear_data_tx_included_height<'a>(
-    tx: &(impl DbTxMut + DbTx),
+    tx: &impl DbTxMut,
     tx_ids: impl IntoIterator<Item = &'a H256>,
 ) -> Result<(), reth_db::DatabaseError> {
     for tx_id in tx_ids {
@@ -429,10 +426,13 @@ mod tests {
         );
     }
 
-    /// When both `included_height` and `promoted_height` are set, clearing
-    /// `included_height` should keep the row with only `promoted_height`.
+    /// Clearing `included_height` always deletes the row, even when
+    /// `promoted_height` was set. A `{included: None, promoted: Some}` row is
+    /// semantically illegal — `promoted_height` requires the tx to have been
+    /// included at a prior height, and the reorg invariant guarantees the
+    /// matching Publish block is also being cleared in the same Phase 1.
     #[test]
-    fn clear_included_height_preserves_promoted_height() {
+    fn clear_included_height_deletes_row_even_when_promoted_is_set() {
         let temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
         let db = open_or_create_db(
             temp_dir.path(),
@@ -456,16 +456,10 @@ mod tests {
         let meta = db
             .view(|tx| get_data_tx_metadata(tx, &tx_id))
             .unwrap()
-            .unwrap()
             .unwrap();
-        assert_eq!(
-            meta.included_height, None,
-            "included_height must be cleared"
-        );
-        assert_eq!(
-            meta.promoted_height,
-            Some(20),
-            "promoted_height must be preserved"
+        assert!(
+            meta.is_none(),
+            "row must be deleted; {{None, Some}} is an illegal persistent state"
         );
     }
 

--- a/crates/database/src/db_index.rs
+++ b/crates/database/src/db_index.rs
@@ -489,6 +489,32 @@ mod tests {
         assert!(meta.is_none());
     }
 
+    /// Calling `clear_data_tx_promoted_height` on a missing row is a no-op and
+    /// must not return an error.
+    #[test]
+    fn clear_promoted_height_missing_row_is_noop() {
+        let temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db = open_or_create_db(
+            temp_dir.path(),
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing().unwrap(),
+        )
+        .unwrap();
+
+        let tx_id = H256::random();
+        // No setup — row doesn't exist.
+        db.update(|tx| clear_data_tx_promoted_height(tx, &tx_id))
+            .unwrap()
+            .unwrap();
+
+        // Still absent, no panic/error.
+        let meta = db
+            .view(|tx| get_data_tx_metadata(tx, &tx_id))
+            .unwrap()
+            .unwrap();
+        assert!(meta.is_none());
+    }
+
     /// `batch_clear_data_tx_included_height` clears all supplied tx_ids.
     #[test]
     fn batch_clear_included_height_happy_path() {

--- a/crates/database/src/db_index.rs
+++ b/crates/database/src/db_index.rs
@@ -134,13 +134,19 @@ pub fn clear_data_tx_metadata(
 }
 
 /// Clear the promoted_height for a data transaction (used during re-orgs)
+///
+/// If `included_height` is still set, the row is kept with only `promoted_height` cleared.
+/// If neither field would remain set after the clear, the row is deleted entirely.
 pub fn clear_data_tx_promoted_height(
     tx: &(impl DbTxMut + DbTx),
     tx_id: &H256,
 ) -> Result<(), reth_db::DatabaseError> {
-    let mut metadata = get_data_tx_metadata(tx, tx_id)?.unwrap_or_default();
+    let Some(mut metadata) = get_data_tx_metadata(tx, tx_id)? else {
+        // Row absent — no-op; delete is safe but unnecessary.
+        return Ok(());
+    };
     metadata.promoted_height = None;
-    // Only store if included_height is set, otherwise delete entirely
+    // Only keep the row if included_height is still meaningful.
     if metadata.is_included() {
         put_data_tx_metadata(tx, tx_id, metadata)
     } else {
@@ -191,6 +197,39 @@ pub fn batch_clear_data_tx_promoted_height<'a>(
 ) -> Result<(), reth_db::DatabaseError> {
     for tx_id in tx_ids {
         clear_data_tx_promoted_height(tx, tx_id)?;
+    }
+    Ok(())
+}
+
+/// Clear the included_height for a data transaction (used during re-orgs of term-ledger blocks).
+///
+/// If `promoted_height` is still set, the row is kept with only `included_height` cleared.
+/// If neither field would remain set after the clear, the row is deleted entirely.
+pub fn clear_data_tx_included_height(
+    tx: &(impl DbTxMut + DbTx),
+    tx_id: &H256,
+) -> Result<(), reth_db::DatabaseError> {
+    let Some(mut metadata) = get_data_tx_metadata(tx, tx_id)? else {
+        // Row absent — no-op; delete is safe but unnecessary.
+        return Ok(());
+    };
+    metadata.included_height = None;
+    // Only keep the row if promoted_height is still meaningful.
+    if metadata.promoted_height.is_some() {
+        tx.put::<IrysDataTxMetadata>(*tx_id, metadata.into())
+    } else {
+        tx.delete::<IrysDataTxMetadata>(*tx_id, None)?;
+        Ok(())
+    }
+}
+
+/// Batch operation: Clear included_height for multiple data transactions (re-org handling).
+pub fn batch_clear_data_tx_included_height<'a>(
+    tx: &(impl DbTxMut + DbTx),
+    tx_ids: impl IntoIterator<Item = &'a H256>,
+) -> Result<(), reth_db::DatabaseError> {
+    for tx_id in tx_ids {
+        clear_data_tx_included_height(tx, tx_id)?;
     }
     Ok(())
 }
@@ -343,6 +382,149 @@ mod tests {
                 .unwrap()
                 .unwrap();
             assert!(metadata.is_none());
+        }
+    }
+
+    // ---- clear_data_tx_included_height tests ----
+
+    /// When only `included_height` is set, clearing it should delete the row entirely
+    /// (since a row with neither field set cannot be stored).
+    #[test]
+    fn clear_included_height_only_set_deletes_row() {
+        let temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db = open_or_create_db(
+            temp_dir.path(),
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing().unwrap(),
+        )
+        .unwrap();
+
+        let tx_id = H256::random();
+        db.update(|tx| set_data_tx_included_height(tx, &tx_id, 42))
+            .unwrap()
+            .unwrap();
+
+        // Verify it's there
+        let meta = db
+            .view(|tx| get_data_tx_metadata(tx, &tx_id))
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(meta.included_height, Some(42));
+        assert_eq!(meta.promoted_height, None);
+
+        // Clear it
+        db.update(|tx| clear_data_tx_included_height(tx, &tx_id))
+            .unwrap()
+            .unwrap();
+
+        // Row should be gone
+        let meta = db
+            .view(|tx| get_data_tx_metadata(tx, &tx_id))
+            .unwrap()
+            .unwrap();
+        assert!(
+            meta.is_none(),
+            "row should be deleted when no fields remain"
+        );
+    }
+
+    /// When both `included_height` and `promoted_height` are set, clearing
+    /// `included_height` should keep the row with only `promoted_height`.
+    #[test]
+    fn clear_included_height_preserves_promoted_height() {
+        let temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db = open_or_create_db(
+            temp_dir.path(),
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing().unwrap(),
+        )
+        .unwrap();
+
+        let tx_id = H256::random();
+        db.update(|tx| set_data_tx_included_height(tx, &tx_id, 10))
+            .unwrap()
+            .unwrap();
+        db.update(|tx| set_data_tx_promoted_height(tx, &tx_id, 20))
+            .unwrap()
+            .unwrap();
+
+        db.update(|tx| clear_data_tx_included_height(tx, &tx_id))
+            .unwrap()
+            .unwrap();
+
+        let meta = db
+            .view(|tx| get_data_tx_metadata(tx, &tx_id))
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            meta.included_height, None,
+            "included_height must be cleared"
+        );
+        assert_eq!(
+            meta.promoted_height,
+            Some(20),
+            "promoted_height must be preserved"
+        );
+    }
+
+    /// Calling `clear_data_tx_included_height` on a missing row is a no-op and
+    /// must not return an error.
+    #[test]
+    fn clear_included_height_missing_row_is_noop() {
+        let temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db = open_or_create_db(
+            temp_dir.path(),
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing().unwrap(),
+        )
+        .unwrap();
+
+        let tx_id = H256::random();
+        // No setup — row doesn't exist.
+        db.update(|tx| clear_data_tx_included_height(tx, &tx_id))
+            .unwrap()
+            .unwrap();
+
+        // Still absent, no panic/error.
+        let meta = db
+            .view(|tx| get_data_tx_metadata(tx, &tx_id))
+            .unwrap()
+            .unwrap();
+        assert!(meta.is_none());
+    }
+
+    /// `batch_clear_data_tx_included_height` clears all supplied tx_ids.
+    #[test]
+    fn batch_clear_included_height_happy_path() {
+        let temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db = open_or_create_db(
+            temp_dir.path(),
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing().unwrap(),
+        )
+        .unwrap();
+
+        let tx_ids: Vec<H256> = (0..3).map(|_| H256::random()).collect();
+
+        // Set included height for all
+        db.update(|tx| batch_set_data_tx_included_height(tx, &tx_ids, 55))
+            .unwrap()
+            .unwrap();
+
+        // Batch-clear
+        db.update(|tx| batch_clear_data_tx_included_height(tx, &tx_ids))
+            .unwrap()
+            .unwrap();
+
+        // All rows should be gone (only included_height was set)
+        for tx_id in &tx_ids {
+            let meta = db
+                .view(|tx| get_data_tx_metadata(tx, tx_id))
+                .unwrap()
+                .unwrap();
+            assert!(meta.is_none(), "row for {tx_id:?} should be deleted");
         }
     }
 

--- a/crates/domain/src/models/block_tree.rs
+++ b/crates/domain/src/models/block_tree.rs
@@ -2721,42 +2721,46 @@ mod tests {
     /// `BTreeMap<_, BTreeSet<_>>`, iteration order was random, and which of
     /// the qualifying blocks was returned varied across nodes — a
     /// consensus-fork vector for any future caller of this function.
+    ///
+    /// Test shape: insert the two tied blocks in *opposite* orders into two
+    /// independent caches and assert both return the same block.  Repeating
+    /// the call on a single cache wouldn't catch a regression to
+    /// `HashMap`/`HashSet`, because a single hashed container is
+    /// iteration-stable within its own lifetime — only cross-instance variance
+    /// surfaces the bug.
     #[tokio::test]
     async fn get_by_solution_hash_is_deterministic_under_exact_match_tie() {
         let b1 = random_block(U256::from(0));
         let comm_cache = Arc::new(CommitmentSnapshot::default());
-        let mut cache = BlockTree::new(&b1, ConsensusConfig::testing());
 
         // Two competing children of b1 with the same solution_hash and the
         // same cumulative_diff — both qualify under Case 1 (exact match).
         let shared_solution = H256::random();
         let mut b2 = extend_chain(random_block(U256::from(5)), &b1);
         b2.solution_hash = shared_solution;
-        cache
-            .add_block(
-                &seal_block(&mut b2),
-                comm_cache.clone(),
-                dummy_epoch_snapshot(),
-                dummy_ema_snapshot(),
-            )
-            .expect("add b2");
+        let sealed_b2 = seal_block(&mut b2);
 
         let mut b3 = extend_chain(random_block(U256::from(5)), &b1);
         b3.solution_hash = shared_solution;
-        cache
-            .add_block(
-                &seal_block(&mut b3),
-                comm_cache,
-                dummy_epoch_snapshot(),
-                dummy_ema_snapshot(),
-            )
-            .expect("add b3");
+        let sealed_b3 = seal_block(&mut b3);
 
         let expected = std::cmp::min(b2.block_hash, b3.block_hash);
 
-        // 100 iterations: every call must return the same block (smallest
-        // block_hash under BTreeSet's ascending order).
-        for _ in 0..100 {
+        for inserts in [
+            [&sealed_b2, &sealed_b3], // forward order
+            [&sealed_b3, &sealed_b2], // reversed order
+        ] {
+            let mut cache = BlockTree::new(&b1, ConsensusConfig::testing());
+            for sealed in inserts {
+                cache
+                    .add_block(
+                        sealed,
+                        comm_cache.clone(),
+                        dummy_epoch_snapshot(),
+                        dummy_ema_snapshot(),
+                    )
+                    .expect("add block");
+            }
             let got = cache
                 .get_by_solution_hash(
                     &shared_solution,
@@ -2768,19 +2772,18 @@ mod tests {
                 .block_hash;
             assert_eq!(
                 got, expected,
-                "selection must be deterministic; expected smallest block_hash"
+                "selection must be deterministic across insertion orders; expected smallest block_hash"
             );
         }
     }
 
     /// Regression companion: when no candidate matches Case 1 or Case 2, the
     /// `best_block` fallback must also be deterministic — same root cause,
-    /// different arm.
+    /// different arm.  Same cross-instance shape as the exact-match-tie test.
     #[tokio::test]
     async fn get_by_solution_hash_is_deterministic_under_fallback() {
         let b1 = random_block(U256::from(0));
         let comm_cache = Arc::new(CommitmentSnapshot::default());
-        let mut cache = BlockTree::new(&b1, ConsensusConfig::testing());
 
         // Two children with shared solution_hash but DIFFERENT cumulative_diff
         // values, neither matching the query cumdiff — both fall through to
@@ -2788,31 +2791,31 @@ mod tests {
         let shared_solution = H256::random();
         let mut b2 = extend_chain(random_block(U256::from(7)), &b1);
         b2.solution_hash = shared_solution;
-        cache
-            .add_block(
-                &seal_block(&mut b2),
-                comm_cache.clone(),
-                dummy_epoch_snapshot(),
-                dummy_ema_snapshot(),
-            )
-            .expect("add b2");
+        let sealed_b2 = seal_block(&mut b2);
 
         let mut b3 = extend_chain(random_block(U256::from(11)), &b1);
         b3.solution_hash = shared_solution;
-        cache
-            .add_block(
-                &seal_block(&mut b3),
-                comm_cache,
-                dummy_epoch_snapshot(),
-                dummy_ema_snapshot(),
-            )
-            .expect("add b3");
+        let sealed_b3 = seal_block(&mut b3);
 
         let expected = std::cmp::min(b2.block_hash, b3.block_hash);
 
-        // Query cumdiff (=3) doesn't match either block; Case 2 also can't
-        // fire because the previous_cumulative_difficulty bound is high.
-        for _ in 0..100 {
+        for inserts in [
+            [&sealed_b2, &sealed_b3], // forward order
+            [&sealed_b3, &sealed_b2], // reversed order
+        ] {
+            let mut cache = BlockTree::new(&b1, ConsensusConfig::testing());
+            for sealed in inserts {
+                cache
+                    .add_block(
+                        sealed,
+                        comm_cache.clone(),
+                        dummy_epoch_snapshot(),
+                        dummy_ema_snapshot(),
+                    )
+                    .expect("add block");
+            }
+            // Query cumdiff (=3) doesn't match either block; Case 2 also can't
+            // fire because the previous_cumulative_difficulty bound is high.
             let got = cache
                 .get_by_solution_hash(
                     &shared_solution,
@@ -2824,7 +2827,7 @@ mod tests {
                 .block_hash;
             assert_eq!(
                 got, expected,
-                "fallback selection must be deterministic; expected smallest block_hash"
+                "fallback selection must be deterministic across insertion orders; expected smallest block_hash"
             );
         }
     }

--- a/crates/domain/src/models/block_tree.rs
+++ b/crates/domain/src/models/block_tree.rs
@@ -6,7 +6,7 @@ use irys_types::{
 };
 use reth_db::Database as _;
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     sync::Arc,
     time::SystemTime,
 };
@@ -62,7 +62,12 @@ pub struct BlockTree {
     pub blocks: HashMap<BlockHash, BlockMetadata>,
 
     // Track solutions -> block hashes
-    solutions: HashMap<H256, HashSet<BlockHash>>,
+    /// Index of blocks by their solution hash. Used to detect competing blocks
+    /// with the same PoA solution (re-mining of the same VDF step, or
+    /// double-signing). Ordered containers (BTreeMap/BTreeSet) make iteration
+    /// deterministic across nodes — `get_by_solution_hash` relies on this for
+    /// stable, fork-safe selection when multiple candidates qualify.
+    solutions: BTreeMap<H256, BTreeSet<BlockHash>>,
 
     // Current tip
     pub tip: BlockHash,
@@ -139,7 +144,7 @@ impl BlockTree {
         let cumulative_diff = genesis_block_header.cumulative_diff;
 
         let mut blocks = HashMap::new();
-        let mut solutions = HashMap::new();
+        let mut solutions = BTreeMap::new();
         let mut height_index = BTreeMap::new();
 
         // Create a dummy commitment snapshot
@@ -177,7 +182,7 @@ impl BlockTree {
 
         // Initialize all indices
         blocks.insert(block_hash, block_entry);
-        solutions.insert(solution_hash, HashSet::from([block_hash]));
+        solutions.insert(solution_hash, BTreeSet::from([block_hash]));
         height_index.insert(height, HashSet::from([block_hash]));
 
         Self {
@@ -295,7 +300,7 @@ impl BlockTree {
         let entry = make_block_tree_entry(Arc::clone(&sealed_start_block));
         let mut block_tree_cache = Self {
             blocks: HashMap::new(),
-            solutions: HashMap::new(),
+            solutions: BTreeMap::new(),
             tip: start_block_hash,
             max_cumulative_difficulty: (start_block.cumulative_diff, start_block_hash),
             height_index: BTreeMap::new(),
@@ -333,9 +338,10 @@ impl BlockTree {
         block_tree_cache
             .blocks
             .insert(start_block_hash, block_entry);
-        block_tree_cache
-            .solutions
-            .insert(start_block.solution_hash, HashSet::from([start_block_hash]));
+        block_tree_cache.solutions.insert(
+            start_block.solution_hash,
+            BTreeSet::from([start_block_hash]),
+        );
         block_tree_cache
             .height_index
             .insert(start_block.height, HashSet::from([start_block_hash]));
@@ -1166,6 +1172,13 @@ impl BlockTree {
     /// - Has matching `solution_hash`
     /// - Is not the excluded block
     /// - Either has same `cumulative_diff` as input or meets double-signing criteria
+    ///
+    /// **Determinism:** when multiple blocks qualify under the same arm
+    /// (exact-diff, double-signing, or fallback), this returns the block with
+    /// the **lexicographically smallest `BlockHash`**.  `BTreeSet<BlockHash>`
+    /// iterates in sorted order, so the first qualifying hash is the smallest
+    /// by construction.  The selection is identical across nodes — a
+    /// prerequisite for any consensus-path use of this function.
     #[must_use]
     pub fn get_by_solution_hash(
         &self,
@@ -1179,7 +1192,8 @@ impl BlockTree {
 
         let mut best_block = None;
 
-        // Examine each block hash
+        // Examine each block hash (BTreeSet iterates ascending by BlockHash —
+        // see the determinism note in the doc comment above).
         for &hash in block_hashes {
             // Skip the excluded block
             if hash == *excluding {
@@ -2693,5 +2707,120 @@ mod tests {
             )
         );
         Ok(())
+    }
+
+    /// Regression: when multiple blocks share the same `solution_hash` AND
+    /// satisfy the same arm of `get_by_solution_hash` (exact-cumdiff match
+    /// here), the selection must be deterministic across runs.  Before the
+    /// `solutions` field was switched from `HashMap<_, HashSet<_>>` to
+    /// `BTreeMap<_, BTreeSet<_>>`, iteration order was random, and which of
+    /// the qualifying blocks was returned varied across nodes — a
+    /// consensus-fork vector for any future caller of this function.
+    #[tokio::test]
+    async fn get_by_solution_hash_is_deterministic_under_exact_match_tie() {
+        let b1 = random_block(U256::from(0));
+        let comm_cache = Arc::new(CommitmentSnapshot::default());
+        let mut cache = BlockTree::new(&b1, ConsensusConfig::testing());
+
+        // Two competing children of b1 with the same solution_hash and the
+        // same cumulative_diff — both qualify under Case 1 (exact match).
+        let shared_solution = H256::random();
+        let mut b2 = extend_chain(random_block(U256::from(5)), &b1);
+        b2.solution_hash = shared_solution;
+        cache
+            .add_block(
+                &seal_block(&mut b2),
+                comm_cache.clone(),
+                dummy_epoch_snapshot(),
+                dummy_ema_snapshot(),
+            )
+            .expect("add b2");
+
+        let mut b3 = extend_chain(random_block(U256::from(5)), &b1);
+        b3.solution_hash = shared_solution;
+        cache
+            .add_block(
+                &seal_block(&mut b3),
+                comm_cache,
+                dummy_epoch_snapshot(),
+                dummy_ema_snapshot(),
+            )
+            .expect("add b3");
+
+        let expected = std::cmp::min(b2.block_hash, b3.block_hash);
+
+        // 100 iterations: every call must return the same block (smallest
+        // block_hash under BTreeSet's ascending order).
+        for _ in 0..100 {
+            let got = cache
+                .get_by_solution_hash(
+                    &shared_solution,
+                    &H256::random(),
+                    U256::from(5),
+                    U256::one(),
+                )
+                .expect("solution exists")
+                .block_hash;
+            assert_eq!(
+                got, expected,
+                "selection must be deterministic; expected smallest block_hash"
+            );
+        }
+    }
+
+    /// Regression companion: when no candidate matches Case 1 or Case 2, the
+    /// `best_block` fallback must also be deterministic — same root cause,
+    /// different arm.
+    #[tokio::test]
+    async fn get_by_solution_hash_is_deterministic_under_fallback() {
+        let b1 = random_block(U256::from(0));
+        let comm_cache = Arc::new(CommitmentSnapshot::default());
+        let mut cache = BlockTree::new(&b1, ConsensusConfig::testing());
+
+        // Two children with shared solution_hash but DIFFERENT cumulative_diff
+        // values, neither matching the query cumdiff — both fall through to
+        // the `best_block` fallback.
+        let shared_solution = H256::random();
+        let mut b2 = extend_chain(random_block(U256::from(7)), &b1);
+        b2.solution_hash = shared_solution;
+        cache
+            .add_block(
+                &seal_block(&mut b2),
+                comm_cache.clone(),
+                dummy_epoch_snapshot(),
+                dummy_ema_snapshot(),
+            )
+            .expect("add b2");
+
+        let mut b3 = extend_chain(random_block(U256::from(11)), &b1);
+        b3.solution_hash = shared_solution;
+        cache
+            .add_block(
+                &seal_block(&mut b3),
+                comm_cache,
+                dummy_epoch_snapshot(),
+                dummy_ema_snapshot(),
+            )
+            .expect("add b3");
+
+        let expected = std::cmp::min(b2.block_hash, b3.block_hash);
+
+        // Query cumdiff (=3) doesn't match either block; Case 2 also can't
+        // fire because the previous_cumulative_difficulty bound is high.
+        for _ in 0..100 {
+            let got = cache
+                .get_by_solution_hash(
+                    &shared_solution,
+                    &H256::random(),
+                    U256::from(3),
+                    U256::from(1000),
+                )
+                .expect("solution exists")
+                .block_hash;
+            assert_eq!(
+                got, expected,
+                "fallback selection must be deterministic; expected smallest block_hash"
+            );
+        }
     }
 }

--- a/crates/domain/src/models/block_tree.rs
+++ b/crates/domain/src/models/block_tree.rs
@@ -75,7 +75,12 @@ pub struct BlockTree {
     // Track max cumulative difficulty
     max_cumulative_difficulty: (U256, BlockHash), // (difficulty, block_hash)
 
-    // Height -> Hash mapping
+    // Height -> Hash mapping.  The inner container is intentionally
+    // `HashSet`: the only reader (`get_hashes_for_height`) is API-server
+    // observability and does not feed consensus.  If a consensus-path
+    // caller is ever added, switch to `BTreeSet<BlockHash>` — mirroring
+    // the `solutions` field — to keep iteration deterministic across
+    // nodes.
     height_index: BTreeMap<u64, HashSet<BlockHash>>,
 
     // Cache of longest chain: (block/tx pairs, count of non-onchain blocks)

--- a/crates/p2p/src/chain_sync.rs
+++ b/crates/p2p/src/chain_sync.rs
@@ -316,7 +316,14 @@ impl<B: BlockDiscoveryFacade, M: MempoolFacade> ChainSyncServiceInner<B, M> {
             .get_orphaned_blocks_by_parent(&block_hash)
             .await;
 
-        if let Some(orphaned_blocks) = maybe_orphaned_blocks {
+        if let Some(mut orphaned_blocks) = maybe_orphaned_blocks {
+            // Sort by block_hash before dispatch so that when multiple orphans share the same
+            // parent, the order in which they are submitted to the block pool is deterministic.
+            // `get_orphaned_blocks_by_parent` returns a Vec built upstream from a HashSet, so
+            // its element order varies across runs; sorting here pins the dispatch order. Without
+            // this, transient-tip selection is non-deterministic and potentially observable via
+            // RPC/gossip before the next canonical update resolves it.
+            orphaned_blocks.sort_by_key(|b| b.block.header().block_hash);
             let mut futures = Vec::new();
             for orphaned_block in orphaned_blocks {
                 info!(

--- a/crates/p2p/src/chain_sync.rs
+++ b/crates/p2p/src/chain_sync.rs
@@ -1,4 +1,4 @@
-use crate::block_pool::{BlockRemovalReason, FailureReason};
+use crate::block_pool::{BlockRemovalReason, CriticalBlockPoolError, FailureReason};
 use crate::gossip_data_handler::GossipDataHandler;
 use crate::{BlockPool, GossipClient, GossipError, GossipResult};
 use irys_actors::MempoolFacade;
@@ -426,9 +426,24 @@ impl<B: BlockDiscoveryFacade, M: MempoolFacade> ChainSyncServiceInner<B, M> {
             .pull_and_process_block(block_hash, self.sync_state.is_trusted_sync())
             .await
         {
+            let rejection_reason = match &err {
+                GossipError::BlockPool(CriticalBlockPoolError::ForkedBlock(_)) => {
+                    Some("forked_block")
+                }
+                GossipError::BlockPool(CriticalBlockPoolError::PreviousBlockNotFound(_)) => {
+                    Some("prev_block_not_found")
+                }
+                GossipError::BlockPool(_) => Some("block_pool_other"),
+                _ => None,
+            };
+            if let Some(reason) = rejection_reason {
+                irys_actors::record_chain_sync_block_rejected(reason);
+            }
             error!(
-                "Failed to pull and process block {:?}: {:?}",
-                block_hash, err
+                %block_hash,
+                rejection_reason = ?rejection_reason,
+                error = ?err,
+                "chain_sync.pull_and_process_block_failed"
             );
 
             if !err.is_advisory() {

--- a/crates/p2p/src/chain_sync.rs
+++ b/crates/p2p/src/chain_sync.rs
@@ -317,13 +317,18 @@ impl<B: BlockDiscoveryFacade, M: MempoolFacade> ChainSyncServiceInner<B, M> {
             .await;
 
         if let Some(orphaned_blocks) = maybe_orphaned_blocks {
-            // Dispatch order is intentionally arrival-order (FCFS), not sorted: when multiple
-            // orphans share a parent and tie on cumulative_diff, the block pool's first-insert
-            // tiebreaker rewards whichever orphan was gossiped to us first — a soft signal of
-            // honest, well-connected behavior. Sorting by block_hash here would replace that
-            // signal with a network-wide arbitrary order an attacker could bias via hash
-            // grinding. The per-node nondeterminism is bounded: the next canonical block
-            // resolves the tip across the network, so any transient disagreement is self-healing.
+            // Dispatch order is deliberately *not* sorted by `block_hash`.  The
+            // orphans come out of `get_orphaned_blocks_by_parent`'s HashSet
+            // (so iteration order is arbitrary per-node-per-run, not arrival
+            // order) and we hand them to `join_all` below for concurrent
+            // processing — there's no real "first-gossiped wins" semantics
+            // here, only "no canonical order".  That property is the point:
+            // a deterministic hash-sort would replace per-node randomization
+            // with a network-wide order an attacker could bias via hash
+            // grinding for fork-tiebreak influence.  Local nondeterminism is
+            // bounded because the next canonical block resolves the tip
+            // across the network and makes any transient disagreement
+            // self-healing.
             let mut futures = Vec::new();
             for orphaned_block in orphaned_blocks {
                 info!(

--- a/crates/p2p/src/chain_sync.rs
+++ b/crates/p2p/src/chain_sync.rs
@@ -316,14 +316,14 @@ impl<B: BlockDiscoveryFacade, M: MempoolFacade> ChainSyncServiceInner<B, M> {
             .get_orphaned_blocks_by_parent(&block_hash)
             .await;
 
-        if let Some(mut orphaned_blocks) = maybe_orphaned_blocks {
-            // Sort by block_hash before dispatch so that when multiple orphans share the same
-            // parent, the order in which they are submitted to the block pool is deterministic.
-            // `get_orphaned_blocks_by_parent` returns a Vec built upstream from a HashSet, so
-            // its element order varies across runs; sorting here pins the dispatch order. Without
-            // this, transient-tip selection is non-deterministic and potentially observable via
-            // RPC/gossip before the next canonical update resolves it.
-            orphaned_blocks.sort_by_key(|b| b.block.header().block_hash);
+        if let Some(orphaned_blocks) = maybe_orphaned_blocks {
+            // Dispatch order is intentionally arrival-order (FCFS), not sorted: when multiple
+            // orphans share a parent and tie on cumulative_diff, the block pool's first-insert
+            // tiebreaker rewards whichever orphan was gossiped to us first — a soft signal of
+            // honest, well-connected behavior. Sorting by block_hash here would replace that
+            // signal with a network-wide arbitrary order an attacker could bias via hash
+            // grinding. The per-node nondeterminism is bounded: the next canonical block
+            // resolves the tip across the network, so any transient disagreement is self-healing.
             let mut futures = Vec::new();
             for orphaned_block in orphaned_blocks {
                 info!(

--- a/crates/p2p/src/tests/util.rs
+++ b/crates/p2p/src/tests/util.rs
@@ -1028,7 +1028,6 @@ pub(crate) fn data_handler_stub(
         chunk_ingress,
         block_pool: block_pool_stub,
         cache: Arc::new(GossipCache::new()),
-
         gossip_client: GossipClient::with_circuit_breaker_config(
             Duration::from_secs(5),
             IrysAddress::repeat_byte(2),

--- a/crates/p2p/src/tests/util.rs
+++ b/crates/p2p/src/tests/util.rs
@@ -1028,8 +1028,9 @@ pub(crate) fn data_handler_stub(
         chunk_ingress,
         block_pool: block_pool_stub,
         cache: Arc::new(GossipCache::new()),
+
         gossip_client: GossipClient::with_circuit_breaker_config(
-            Duration::from_millis(100000),
+            Duration::from_secs(5),
             IrysAddress::repeat_byte(2),
             IrysPeerId::from([0xAA_u8; 20]),
             CircuitBreakerConfig::testing(),
@@ -1084,7 +1085,7 @@ pub(crate) fn data_handler_with_stubbed_pool(
         block_pool,
         cache: Arc::new(GossipCache::new()),
         gossip_client: GossipClient::with_circuit_breaker_config(
-            Duration::from_millis(100000),
+            Duration::from_secs(5),
             IrysAddress::repeat_byte(2),
             IrysPeerId::from([0xAA_u8; 20]),
             CircuitBreakerConfig::testing(),

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -224,6 +224,44 @@ impl Config {
             );
         }
 
+        // `number_of_ingress_proofs_from_assignees` MUST stay 0 in this codebase
+        // version.  When > 0, the value flows through `get_assigned_ingress_proofs`
+        // (block_validation.rs) where the per-proof intersection loop picks
+        // `assigned_miners` via HashMap iteration order over `slot_ranges` — a
+        // consensus-fork vector when `block_range` straddles multiple Submit
+        // slots.  The determinism fix lives on `fix/assigned-miners-determinism`
+        // and is a consensus rule change that must be coordinated with a
+        // network upgrade.  Under all currently-deployed configs the value is
+        // 0 and the non-deterministic path is vacuous; raising it without the
+        // determinism fix risks divergence between nodes.
+        //
+        // When the determinism fix lands and gets activated, REMOVE this guard
+        // (and the matching test in this file).  Until then this assert errs
+        // loudly at startup so a config bump can't silently activate the bug.
+        ensure!(
+            self.consensus
+                .hardforks
+                .frontier
+                .number_of_ingress_proofs_from_assignees
+                == 0,
+            "consensus.hardforks.frontier.number_of_ingress_proofs_from_assignees ({}) must be 0 \
+             until fix/assigned-miners-determinism lands — the current `get_assigned_ingress_proofs` \
+             impl picks `assigned_miners` via non-deterministic HashMap iteration when \
+             block_range intersects multiple Submit slots",
+            self.consensus
+                .hardforks
+                .frontier
+                .number_of_ingress_proofs_from_assignees,
+        );
+        if let Some(ref fork) = self.consensus.hardforks.next_name_tbd {
+            ensure!(
+                fork.number_of_ingress_proofs_from_assignees == 0,
+                "consensus.hardforks.next_name_tbd.number_of_ingress_proofs_from_assignees ({}) \
+                 must be 0 until fix/assigned-miners-determinism lands — see frontier guard above",
+                fork.number_of_ingress_proofs_from_assignees,
+            );
+        }
+
         Ok(())
     }
 }

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -1166,6 +1166,62 @@ mod validate_tests {
         );
     }
 
+    /// Guard for `number_of_ingress_proofs_from_assignees`: the consensus
+    /// rule that consumes this value (`get_assigned_ingress_proofs`) only
+    /// became deterministic once `slot_ranges` switched to a `BTreeMap`.
+    /// Until that fix is gated behind a hardfork activation, the value MUST
+    /// stay `0` everywhere (no nondeterministic path is exercised because
+    /// the caller's clamp zeroes the requirement when the input is 0).
+    /// These tests pin both ensure! arms.
+    #[test]
+    fn validate_rejects_nonzero_assignee_proofs_on_frontier() {
+        let cfg = config_with_consensus(|c| {
+            c.hardforks.frontier.number_of_ingress_proofs_from_assignees = 1;
+        });
+        let err = cfg.validate().unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("frontier.number_of_ingress_proofs_from_assignees"),
+            "expected frontier guard error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_nonzero_assignee_proofs_on_next_name_tbd() {
+        use crate::hardfork_config::NextNameTBD;
+        let cfg = config_with_consensus(|c| {
+            c.hardforks.next_name_tbd = Some(NextNameTBD {
+                activation_timestamp: crate::UnixTimestamp::from_secs(u64::MAX),
+                number_of_ingress_proofs_total: 1,
+                number_of_ingress_proofs_from_assignees: 1,
+            });
+        });
+        let err = cfg.validate().unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("next_name_tbd.number_of_ingress_proofs_from_assignees"),
+            "expected next_name_tbd guard error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_assignee_proofs_zero_on_both_arms() {
+        // Default `NodeConfig::testing()` already pins both arms to 0; this
+        // asserts that the guard does NOT spuriously reject the happy path
+        // (e.g. by mishandling the `Option` arm when next_name_tbd is set).
+        use crate::hardfork_config::NextNameTBD;
+        let cfg = config_with_consensus(|c| {
+            c.hardforks.frontier.number_of_ingress_proofs_from_assignees = 0;
+            c.hardforks.next_name_tbd = Some(NextNameTBD {
+                activation_timestamp: crate::UnixTimestamp::from_secs(u64::MAX),
+                number_of_ingress_proofs_total: 1,
+                number_of_ingress_proofs_from_assignees: 0,
+            });
+        });
+        cfg.validate()
+            .expect("both arms set to 0 should pass the assignee-proofs guard");
+    }
+
     #[rstest]
     #[case::zero_percent(0.0, "too low")]
     #[case::negative_percent(-1.0, "too low")]


### PR DESCRIPTION
**Describe the changes**
This PR aims to fix a class of issues due to the CachedDataRoots (which are a best-effort data structure) being relied upon as constant in the validation path. Now it's used as a performance-enhancing hint, instead of the sole source of truth. the block tree/database are now used as a fallback.
This PR also includes various small logging/observability tweaks.

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public canonical transaction-inclusion lookup, deterministic block-selection tie‑breaking, and new metrics for cached-data-root evictions and block rejections.

* **Bug Fixes**
  * Safer, ledger-aware metadata persistence to prevent submit/publish races; improved ingress-proof assignment; more conservative cached-data-root pruning/eviction.

* **Documentation**
  * Clarified cached-data-root and ingress-proof semantics and lifecycle.

* **Tests**
  * Expanded migration, pruning, promotion, reorg, determinism, and regression coverage.

* **Chores**
  * Structured logging and test stability/timeouts adjustments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Irys-xyz/irys/pull/1421?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->