### PR TITLE
fix(ci): drop literal expression from docker-setup input description

### DIFF
--- a/.config/cliff.toml
+++ b/.config/cliff.toml
@@ -30,8 +30,10 @@ sort_commits = "oldest"
 # Releases live on diverged branches (deployment/testnet/<major>.x vs
 # deployment/mainnet/<major>.x), each with its own tag lineage. Restrict version
 # boundaries to tags reachable on the branch being released so a tag from another
-# release line can't be picked as the previous-release boundary. (release.yml
-# also passes --ignore-tags ^testnet- for mainnet as a backstop.)
+# release line can't be picked as the previous-release boundary. release.yml
+# additionally overrides this pattern per env via GIT_CLIFF_TAG_PATTERN, so each
+# release's changelog is bounded by the previous release of the SAME env (testnet
+# vs mainnet) rather than whichever stream tagged most recently.
 use_branch_tags = true
 
 commit_preprocessors = [

--- a/.github/actions/docker-setup/action.yaml
+++ b/.github/actions/docker-setup/action.yaml
@@ -7,7 +7,11 @@ inputs:
     required: false
     default: "ghcr.io"
   username:
-    description: "Username for `docker login`. Callers must pass this explicitly (e.g. ${{ github.actor }}); composite-action input defaults do not reliably expand expressions."
+    # NOTE: do not embed a literal Actions expression in this description — the
+    # action manifest loader evaluates expressions even inside description text,
+    # and the github context is unavailable at load time, so it fails the whole
+    # action to load. Refer to contexts by name only (e.g. github.actor).
+    description: "Username for `docker login`. Callers must pass this explicitly (e.g. github.actor); composite-action input defaults do not reliably expand expressions."
     required: true
   password:
     description: "Token piped to `docker login` via stdin. Must be a secret."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,11 +218,7 @@ jobs:
         uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
         with:
           config: .config/cliff.toml
-          # -vv logs each non-conventional/unparseable commit (to stderr, i.e. the
-          # Actions log) so the "N commit(s) skipped due to parse error" warning is
-          # actionable. The changelog itself still goes to the OUTPUT file.
           args: >-
-            -vv
             --unreleased
             --tag ${{ env.GIT_TAG }}
             ${{ inputs.release_type == 'mainnet' && '--ignore-tags ^testnet-' || '' }}
@@ -230,6 +226,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPO: ${{ github.repository }}
           OUTPUT: /tmp/cliff-changelog.md
+          # Name each skipped/non-conventional commit in the Actions log so the
+          # "N commit(s) skipped due to parse error" warning is actionable. Scope
+          # trace to git-cliff itself — do NOT pass the `-vv` flag, which enables
+          # GLOBAL trace and floods the log with thousands of hyper/HTTP lines from
+          # git-cliff's GitHub remote-data fetch, burying (and truncating) the useful line.
+          RUST_LOG: git_cliff_core=trace
 
       # --- Publish phase: tag, push image, update head-tracking, create release ---
       # If any step here fails, cleanup steps at the bottom delete pushed git tags.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,7 +218,11 @@ jobs:
         uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
         with:
           config: .config/cliff.toml
+          # -vv logs each non-conventional/unparseable commit (to stderr, i.e. the
+          # Actions log) so the "N commit(s) skipped due to parse error" warning is
+          # actionable. The changelog itself still goes to the OUTPUT file.
           args: >-
+            -vv
             --unreleased
             --tag ${{ env.GIT_TAG }}
             ${{ inputs.release_type == 'mainnet' && '--ignore-tags ^testnet-' || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,16 +221,21 @@ jobs:
           args: >-
             --unreleased
             --tag ${{ env.GIT_TAG }}
-            ${{ inputs.release_type == 'mainnet' && '--ignore-tags ^testnet-' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPO: ${{ github.repository }}
           OUTPUT: /tmp/cliff-changelog.md
+          # Bound the changelog to the previous release of THIS env: restrict the
+          # release-tag pattern to the env's own tags so --unreleased anchors to the
+          # last <env>-X.Y.Z. testnet-3.0.0 then spans since testnet-0.2.0, not since
+          # the (newer) mainnet-0.1.3. NB: git-cliff's --ignore-tags only relabels the
+          # "previous" link — --tag-pattern (this env var) is what moves the commit
+          # range. First release of an env (no prior tag) spans the full history.
+          GIT_CLIFF_TAG_PATTERN: ${{ inputs.release_type == 'mainnet' && '^mainnet-[0-9]+\.[0-9]+\.[0-9]+$' || '^testnet-[0-9]+\.[0-9]+\.[0-9]+$' }}
           # Name each skipped/non-conventional commit in the Actions log so the
           # "N commit(s) skipped due to parse error" warning is actionable. Scope
-          # trace to git-cliff itself — do NOT pass the `-vv` flag, which enables
-          # GLOBAL trace and floods the log with thousands of hyper/HTTP lines from
-          # git-cliff's GitHub remote-data fetch, burying (and truncating) the useful line.
+          # trace to git-cliff itself — NOT the `-vv` flag, which enables GLOBAL trace
+          # and floods the log with hyper/HTTP lines from the GitHub remote-data fetch.
           RUST_LOG: git_cliff_core=trace
 
       # --- Publish phase: tag, push image, update head-tracking, create release ---


### PR DESCRIPTION
## Summary
- The `username` input description in `.github/actions/docker-setup/action.yaml` contained a literal `${{ github.actor }}` example.
- GitHub's action manifest loader evaluates `${{ }}` expressions even inside `description` text, and the `github` context isn't available at load time — so the composite action fails to load with `Unrecognized named-value: 'github'`.
- This broke the **Start rootless Docker and log in to GHCR** step in every job using the action (`release.yml`, `docker.yml`, `devnet.yml`). The real `username: ${{ github.actor }}` lives in the calling workflows, where it's valid — only the description needed fixing.

## How it was found
A testnet `dry_run=true` of `release.yml` got through all validation and started the build/publish job (no approval prompt — env-gate skip works), then failed at docker-setup with the manifest load error.

## Test plan
- [ ] Re-run a testnet dry-run against this branch: `gh workflow run release.yml --ref fix/release-process -f release_type=testnet -f version=3.0.0 -f commit=<release/testnet/3.x tip> -f dry_run=true`
- [ ] Confirm **Start rootless Docker and log in to GHCR** now succeeds and the build proceeds (publish steps remain skipped under dry_run).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Clarified an internal action input description to avoid suggesting expressions that are evaluated early, reducing confusion and improving configuration guidance.
  * Increased changelog-generation verbosity so warnings about skipped or unparsable commits are captured in release logs for easier diagnostics.
  * Updated comment guidance about how release tag boundaries are determined across environments to improve maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Irys-xyz/irys/pull/1427?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->