### PR TITLE
fix(release): disable git-cliff GitHub remote fetch (panics on flaky API)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,19 +223,24 @@ jobs:
             --tag ${{ env.GIT_TAG }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPO: ${{ github.repository }}
           OUTPUT: /tmp/cliff-changelog.md
+          # Deliberately NOT setting GITHUB_REPO. That env var is what enables
+          # git-cliff's GitHub remote-data fetch (every commit + every closed PR via
+          # the API). We use none of it — the cliff.toml template references only
+          # local commit fields — and on a repo this size the fetch is slow and
+          # *panics* on a flaky/truncated API response (git-cliff changelog.rs:493 ->
+          # exit 101), which failed the release. git-cliff v2.13.1 (pinned by the
+          # action) does not auto-detect the repo from origin, so omitting GITHUB_REPO
+          # disables the fetch. The action still injects a token for its binary download.
+          #
           # Bound the changelog to the previous release of THIS env: restrict the
           # release-tag pattern to the env's own tags so --unreleased anchors to the
-          # last <env>-X.Y.Z. testnet-3.0.0 then spans since testnet-0.2.0, not since
-          # the (newer) mainnet-0.1.3. NB: git-cliff's --ignore-tags only relabels the
-          # "previous" link — --tag-pattern (this env var) is what moves the commit
-          # range. First release of an env (no prior tag) spans the full history.
+          # last <env>-X.Y.Z (testnet-3.0.0 spans since testnet-0.2.0, not the newer
+          # mainnet-0.1.3). --ignore-tags only relabels "previous"; --tag-pattern moves
+          # the range. First release of an env (no prior tag) spans the full history.
           GIT_CLIFF_TAG_PATTERN: ${{ inputs.release_type == 'mainnet' && '^mainnet-[0-9]+\.[0-9]+\.[0-9]+$' || '^testnet-[0-9]+\.[0-9]+\.[0-9]+$' }}
-          # Name each skipped/non-conventional commit in the Actions log so the
-          # "N commit(s) skipped due to parse error" warning is actionable. Scope
-          # trace to git-cliff itself — NOT the `-vv` flag, which enables GLOBAL trace
-          # and floods the log with hyper/HTTP lines from the GitHub remote-data fetch.
+          # Log each skipped/non-conventional commit (the "N commit(s) skipped due to
+          # parse error" warning) without the global -vv flood.
           RUST_LOG: git_cliff_core=trace
 
       # --- Publish phase: tag, push image, update head-tracking, create release ---


### PR DESCRIPTION
## Problem
The testnet dry-run failed at **Generate changelog** with a git-cliff panic:
```
thread 'main' panicked at git-cliff-core/src/changelog.rs:493:18:
Could not get github metadata: ... error reading a body from connection: end of file before message length reached
```
git-cliff was fetching **every commit + every closed PR** from the GitHub API (`add_remote_data`) and panicked on a flaky/truncated response (exit 101).

## Why it's safe to remove
The `cliff.toml` body template uses only local commit fields (`message`/`scope`/`breaking`/`group`) — **none** of the GitHub remote data. The fetch is pure overhead and the sole failure source.

## Fix
Stop passing `GITHUB_REPO` to the changelog step. git-cliff (v2.13.1, pinned by the action) does not fetch remote data without an explicit repo and does not auto-detect it from `origin` (verified locally: token present + no `GITHUB_REPO` => zero API requests). The action still injects a token for its own binary download.

## Test plan
- [ ] Dry-run `--ref fix/changelog-no-remote` building `release/testnet/3.x`: Generate changelog succeeds, no API fetch, publish steps skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to generate changelogs using local commit metadata only, preventing potential API-related failures during changelog generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Irys-xyz/irys/pull/1428?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->