### PR TITLE
refactor(block_tree): compute reorg split via parent-walk LCA

### DIFF
--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -12,10 +12,10 @@ use crate::{
 use eyre::OptionExt as _;
 use irys_database::db::IrysDatabaseExt as _;
 use irys_domain::{
-    BlockState, BlockTree, BlockTreeEntry, BlockTreeReadGuard, ChainState,
+    BlockState, BlockTree, BlockTreeReadGuard, ChainState, ReorgSplit,
     block_index_guard::BlockIndexReadGuard, chain_sync_state::ChainSyncState,
     create_commitment_snapshot_for_block, create_epoch_snapshot_for_block,
-    forkchoice_markers::ForkChoiceMarkers, make_block_tree_entry,
+    forkchoice_markers::ForkChoiceMarkers,
 };
 use irys_types::{
     BlockHash, Config, DatabaseProvider, H256, H256List, IrysAddress, IrysBlockHeader, SealedBlock,
@@ -962,97 +962,32 @@ impl BlockTreeServiceInner {
                 )?;
                 let new_fcu_markers = Some(markers);
 
-                // Snapshot the orphaned-chain view BEFORE pruning so a deep new tip
-                // cannot evict `old_tip_block` from the cache mid-reorg and turn a
-                // valid reorg into a service-level error.
-                let orphaned_snapshot = if is_reorg {
-                    let mut orphaned_blocks =
-                        cache.get_fork_blocks(old_tip_block.previous_block_hash);
-                    let old_tip_entry =
-                        cache.blocks.get(&old_tip_block.block_hash).ok_or_else(|| {
-                            error!(
-                                old_tip = %old_tip_block.block_hash,
-                                "old tip pruned from cache before reorg fork-point snapshot"
-                            );
-                            eyre::eyre!(
-                                "old tip {} not in cache during reorg fork-point snapshot",
-                                old_tip_block.block_hash
-                            )
-                        })?;
-                    orphaned_blocks.push(old_tip_entry.block.clone());
-                    Some(orphaned_blocks)
+                // Compute the reorg split BEFORE pruning so the parent-walk
+                // sees both lineages in `cache.blocks`. Independent of
+                // `ChainState` flags by construction.
+                let split: Option<ReorgSplit> = if is_reorg {
+                    Some(cache.find_reorg_split(block_hash, old_tip_block.block_hash)?)
                 } else {
                     None
                 };
 
-                // Prune the cache after tip changes.
+                // Prune the cache after the LCA is captured.
                 //
                 // Subtract 1 to ensure we keep exactly `depth` blocks.
                 // The cache.prune() implementation does not count `tip` into the depth
                 // equation, so it's always tip + `depth` that's kept around
                 cache.prune(self.config.consensus.block_tree_depth.saturating_sub(1));
 
-                if is_reorg {
+                if let Some(split) = split {
                     // Handle blockchain reorganization
-
-                    let orphaned_blocks = orphaned_snapshot
-                        .expect("orphaned_snapshot is captured above when is_reorg");
-
-                    // Find the fork point where the old and new chains diverged.
-                    // orphaned_blocks must be non-empty: we just pushed the old tip above.
-                    // If this fires, the invariant was violated by a concurrent mutation
-                    // — log and abort the reorg rather than panicking.
-                    let fork_block_sealed = orphaned_blocks.first().ok_or_else(|| {
-                        error!(
-                            old_tip = %old_tip_block.block_hash,
-                            "no orphaned blocks present for reorg fork-point search"
-                        );
-                        eyre::eyre!("no orphaned blocks to determine fork point")
-                    })?;
-                    let fork_hash = fork_block_sealed.header().block_hash;
-                    let fork_height = fork_block_sealed.header().height;
-                    let fork_block = fork_block_sealed.header().clone();
-
-                    // Convert orphaned blocks to BlockTreeEntry to make a snapshot of the old canonical chain
-                    let mut old_canonical = Vec::with_capacity(orphaned_blocks.len());
-                    for block in &orphaned_blocks {
-                        let entry = make_block_tree_entry(Arc::clone(block));
-                        old_canonical.push(entry);
-                    }
-
-                    // Get the new canonical chain that's replacing the orphaned blocks
-                    let new_canonical = cache.get_canonical_chain();
-
-                    for o in old_canonical.iter() {
-                        debug!("old_canonical({}) - {}", o.height(), o.block_hash());
-                    }
-
-                    for o in new_canonical.0.iter() {
-                        debug!("new_canonical({}) - {}", o.height(), o.block_hash());
-                    }
+                    let fork_block: Arc<IrysBlockHeader> = split.lca.header().clone();
+                    let fork_hash: BlockHash = fork_block.block_hash;
+                    let fork_height: u64 = fork_block.height;
+                    let old_fork_blocks: Vec<Arc<SealedBlock>> = split.old_divergent;
+                    let new_fork_blocks: Vec<Arc<SealedBlock>> = split.new_divergent;
+                    let blocks_to_confirm = new_fork_blocks.clone();
 
                     debug!("fork_height: {} fork_hash: {}", fork_height, fork_hash);
-
-                    // Trim both chains back to their common ancestor to isolate the divergent portions
-                    let (old_fork, new_fork) = prune_chains_at_ancestor(
-                        old_canonical,
-                        new_canonical.0,
-                        fork_hash,
-                        fork_height,
-                    )?;
-
-                    // Pass sealed blocks directly (cheap Arc::clone, no deep copy)
-                    let old_fork_blocks: Vec<Arc<SealedBlock>> = old_fork
-                        .iter()
-                        .map(|e| Arc::clone(e.sealed_block()))
-                        .collect();
-
-                    let new_fork_blocks: Vec<Arc<SealedBlock>> = new_fork
-                        .iter()
-                        .map(|e| Arc::clone(e.sealed_block()))
-                        .collect();
-
-                    let blocks_to_confirm = new_fork_blocks.clone();
 
                     debug!(
                         "Reorg at block height {} with {}, old fork is {} blocks long, new one is {} blocks",
@@ -1525,54 +1460,6 @@ impl BlockTreeServiceInner {
         )?;
         Ok(())
     }
-}
-
-/// Prunes two canonical chains at the specified common ancestor, returning only the divergent portions.
-///
-/// Returns `Err` when the ancestor is missing from either chain — this is a
-/// no-common-ancestor reorg, the same divergence class F4 detects at startup.
-/// The reorg path callers log and abort the reorg instead of panicking.
-pub fn prune_chains_at_ancestor(
-    old_chain: Vec<BlockTreeEntry>,
-    new_chain: Vec<BlockTreeEntry>,
-    ancestor_hash: BlockHash,
-    ancestor_height: u64,
-) -> eyre::Result<(Vec<BlockTreeEntry>, Vec<BlockTreeEntry>)> {
-    // Find the ancestor index in the old chain
-    let old_ancestor_idx = old_chain
-        .iter()
-        .position(|e| e.block_hash() == ancestor_hash && e.height() == ancestor_height)
-        .ok_or_else(|| {
-            error!(
-                ancestor.hash = %ancestor_hash,
-                ancestor.height = ancestor_height,
-                "common ancestor missing from old chain during reorg fork-point trim"
-            );
-            eyre::eyre!(
-                "common ancestor {ancestor_hash} (height {ancestor_height}) not in old chain"
-            )
-        })?;
-
-    // Find the ancestor index in the new chain
-    let new_ancestor_idx = new_chain
-        .iter()
-        .position(|e| e.block_hash() == ancestor_hash && e.height() == ancestor_height)
-        .ok_or_else(|| {
-            error!(
-                ancestor.hash = %ancestor_hash,
-                ancestor.height = ancestor_height,
-                "common ancestor missing from new chain during reorg fork-point trim"
-            );
-            eyre::eyre!(
-                "common ancestor {ancestor_hash} (height {ancestor_height}) not in new chain"
-            )
-        })?;
-
-    // Return the portions after the common ancestor (excluding the ancestor itself)
-    let old_divergent = old_chain[old_ancestor_idx + 1..].to_vec();
-    let new_divergent = new_chain[new_ancestor_idx + 1..].to_vec();
-
-    Ok((old_divergent, new_divergent))
 }
 
 /// Reject reorgs that would un-migrate already-finalised blocks.
@@ -2464,74 +2351,6 @@ mod tests {
             panic!("expected InternalFailure for ParentBlockMissing");
         };
         assert!(!inner.is_node_fault());
-    }
-
-    fn entry_at(height: u64, hash_byte: u8) -> BlockTreeEntry {
-        let mut header = IrysBlockHeader::new_mock_header();
-        header.height = height;
-        header.block_hash = H256([hash_byte; 32]);
-        let sealed = SealedBlock::new_unchecked(Arc::new(header), BlockTransactions::default());
-        make_block_tree_entry(Arc::new(sealed))
-    }
-
-    /// Common-ancestor present at the same hash and height in both chains:
-    /// the function returns the divergent suffix of each chain (excluding the
-    /// ancestor itself).
-    #[test]
-    fn prune_chains_at_ancestor_returns_divergent_suffixes_when_ancestor_present() {
-        let ancestor = entry_at(10, 0xAA);
-        let old = vec![ancestor.clone(), entry_at(11, 0xB1), entry_at(12, 0xB2)];
-        let new = vec![ancestor.clone(), entry_at(11, 0xC1)];
-
-        let (old_div, new_div) =
-            prune_chains_at_ancestor(old, new, ancestor.block_hash(), ancestor.height())
-                .expect("ancestor present in both chains");
-
-        assert_eq!(old_div.len(), 2);
-        assert_eq!(old_div[0].height(), 11);
-        assert_eq!(old_div[1].height(), 12);
-        assert_eq!(new_div.len(), 1);
-        assert_eq!(new_div[0].height(), 11);
-        assert_eq!(new_div[0].block_hash(), H256([0xC1; 32]));
-    }
-
-    /// Reorg fork-point trim must surface a typed error rather than panic when
-    /// the supposed common ancestor is missing from one or both chains. F4
-    /// catches this class of divergence at startup; here we ensure runtime
-    /// reorg paths do not abort the node.
-    #[rstest]
-    #[case::missing_in_old(
-        vec![entry_at(11, 0xB1), entry_at(12, 0xB2)],
-        vec![entry_at(10, 0xAA), entry_at(11, 0xC1)],
-        "old chain"
-    )]
-    #[case::missing_in_new(
-        vec![entry_at(10, 0xAA), entry_at(11, 0xB1)],
-        vec![entry_at(11, 0xC1), entry_at(12, 0xC2)],
-        "new chain"
-    )]
-    #[case::missing_in_both(
-        vec![entry_at(11, 0xB1), entry_at(12, 0xB2)],
-        vec![entry_at(11, 0xC1), entry_at(12, 0xC2)],
-        "old chain"
-    )]
-    fn prune_chains_at_ancestor_returns_err_when_ancestor_missing(
-        #[case] old: Vec<BlockTreeEntry>,
-        #[case] new: Vec<BlockTreeEntry>,
-        #[case] expected_chain_in_msg: &str,
-    ) {
-        let ancestor_hash = H256([0xAA; 32]);
-        let result = prune_chains_at_ancestor(old, new, ancestor_hash, 10);
-        let err = result.expect_err("expected Err when ancestor is missing");
-        let msg = format!("{err}");
-        assert!(
-            msg.contains(expected_chain_in_msg),
-            "error must name the chain missing the ancestor; got: {msg}"
-        );
-        assert!(
-            !msg.contains("panic"),
-            "must not surface panic-style messages; got: {msg}"
-        );
     }
 
     /// Reorgs at or within `migration_depth` are reversible: nothing on the

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -12,7 +12,7 @@ use crate::{
 use eyre::OptionExt as _;
 use irys_database::db::IrysDatabaseExt as _;
 use irys_domain::{
-    BlockState, BlockTree, BlockTreeReadGuard, ChainState, ReorgSplit,
+    BlockState, BlockTree, BlockTreeReadGuard, ChainState, ReorgSplit, ReorgTips,
     block_index_guard::BlockIndexReadGuard, chain_sync_state::ChainSyncState,
     create_commitment_snapshot_for_block, create_epoch_snapshot_for_block,
     forkchoice_markers::ForkChoiceMarkers,
@@ -966,10 +966,50 @@ impl BlockTreeServiceInner {
                 // sees both lineages in `cache.blocks`. Independent of
                 // `ChainState` flags by construction.
                 let split: Option<ReorgSplit> = if is_reorg {
-                    Some(cache.find_reorg_split(block_hash, old_tip_block.block_hash)?)
+                    Some(cache.find_reorg_split(ReorgTips {
+                        new_tip: block_hash,
+                        old_tip: old_tip_block.block_hash,
+                    })?)
                 } else {
                     None
                 };
+
+                // A reorg whose fork point predates the post-prune cache window
+                // cannot complete safely. `cache.prune()` below drops every block
+                // below `new_tip.height - (block_tree_depth - 1)`; once the LCA is
+                // in that range, `BlockTree::prune`'s recursive child removal
+                // cascades the whole old fork (and the new-fork blocks below the
+                // window) out of the cache, evicting their epoch and commitment
+                // snapshots. Downstream reorg consumers re-read those by hash
+                // (`send_epoch_events` -> `get_epoch_snapshot`,
+                // `handle_confirmed_commitment_tx_reorg` -> `get_commitment_snapshot`)
+                // and would fail mid-reorg, after the event was broadcast and
+                // metadata persisted.
+                //
+                // Abort before prune mutates the cache, so the failure is pre-commit
+                // with an accurate diagnostic. Matches master, whose post-prune
+                // `prune_chains_at_ancestor` errored whenever the LCA had been
+                // evicted from the canonical chain. The trigger — a new fork at
+                // least `block_tree_depth` long diverging inside the window — is
+                // pathological (attack / severe partition); halting is correct.
+                // Returning `Err` drives the controlled-shutdown path.
+                if let Some(split) = &split {
+                    let fork_height = split.lca.header().height;
+                    if let Err(e) = validate_reorg_within_cache_window(
+                        fork_height,
+                        arc_block.height,
+                        self.config.consensus.block_tree_depth,
+                    ) {
+                        error!(
+                            fork_height,
+                            new_tip = %block_hash,
+                            new_tip_height = arc_block.height,
+                            block_tree_depth = self.config.consensus.block_tree_depth,
+                            "reorg fork point is older than the block-tree cache window; aborting before prune evicts divergent blocks (and their epoch/commitment snapshots) that downstream reorg consumers re-read, to trigger controlled shutdown",
+                        );
+                        return Err(e);
+                    }
+                }
 
                 // Prune the cache after the LCA is captured.
                 //
@@ -1481,6 +1521,37 @@ pub fn validate_reorg_within_migration_depth(
             old_fork_len,
             migration_depth,
             fork_height,
+        ));
+    }
+    Ok(())
+}
+
+/// Reject reorgs whose fork point would be evicted by the cache prune that runs
+/// immediately after split computation.
+///
+/// `BlockTree::prune` keeps blocks at or above
+/// `new_tip_height - (block_tree_depth - 1)`. Once the fork point (LCA) drops
+/// below that, prune's recursive child removal cascades the divergent blocks —
+/// and the epoch/commitment snapshots keyed by their hashes — out of the cache,
+/// leaving downstream reorg consumers re-reading evicted blocks. Aborting here
+/// keeps that failure pre-commit (before the reorg event is broadcast and
+/// metadata persisted).
+///
+/// Fires only when the new fork is at least `block_tree_depth` blocks long yet
+/// diverges inside the cache window — attack / severe-partition territory, the
+/// same class master halted on when the LCA fell outside the post-prune
+/// canonical chain.
+pub fn validate_reorg_within_cache_window(
+    fork_height: u64,
+    new_tip_height: u64,
+    block_tree_depth: u64,
+) -> eyre::Result<()> {
+    let min_keep_height = new_tip_height.saturating_sub(block_tree_depth.saturating_sub(1));
+    if fork_height < min_keep_height {
+        return Err(eyre::eyre!(
+            "reorg deeper than cache window: fork point at height {fork_height} \
+             is below the post-prune minimum keep height {min_keep_height} \
+             (new tip height {new_tip_height}, block_tree_depth {block_tree_depth})"
         ));
     }
     Ok(())
@@ -2409,6 +2480,54 @@ mod tests {
         let err = validate_reorg_within_migration_depth(usize::MAX, 5, 0)
             .expect_err("usize::MAX must be treated as exceeding migration depth");
         assert!(err.to_string().contains("reorg depth"));
+    }
+
+    /// A reorg whose fork point stays within the post-prune cache window
+    /// (`new_tip - (block_tree_depth - 1)`) keeps every divergent block — and
+    /// the epoch/commitment snapshots keyed by their hashes — in the cache, so
+    /// downstream reorg consumers can re-read them. Boundary: a fork point at
+    /// exactly `min_keep_height` survives the prune.
+    #[rstest]
+    #[case::fork_at_window_boundary(51, 100, 50)]
+    #[case::fork_just_below_tip(99, 100, 50)]
+    #[case::fork_at_tip(100, 100, 50)]
+    #[case::small_depth_boundary(98, 100, 3)]
+    #[case::window_covers_genesis(0, 5, 50)]
+    fn validate_reorg_within_cache_window_passes_inside_window(
+        #[case] fork_height: u64,
+        #[case] new_tip_height: u64,
+        #[case] block_tree_depth: u64,
+    ) {
+        validate_reorg_within_cache_window(fork_height, new_tip_height, block_tree_depth)
+            .expect("reorg whose fork point survives the prune must be permitted");
+    }
+
+    /// A fork point one block below the window is evicted by `cache.prune()`,
+    /// cascading the divergent blocks (and their snapshots) out of the cache.
+    /// The gate must surface a typed error pre-prune so the caller triggers
+    /// controlled shutdown instead of crashing mid-reorg. The new-fork length at
+    /// the boundary equals `block_tree_depth` exactly.
+    #[rstest]
+    #[case::fork_one_below_window(50, 100, 50)]
+    #[case::deep_fork_small_window(10, 100, 50)]
+    #[case::small_depth_just_over(97, 100, 3)]
+    #[case::small_depth_well_over(80, 100, 3)]
+    fn validate_reorg_within_cache_window_returns_err_below_window(
+        #[case] fork_height: u64,
+        #[case] new_tip_height: u64,
+        #[case] block_tree_depth: u64,
+    ) {
+        let err = validate_reorg_within_cache_window(fork_height, new_tip_height, block_tree_depth)
+            .expect_err("fork point below the cache window must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("reorg deeper than cache window"),
+            "error must name the cache-window violation; got: {msg}"
+        );
+        assert!(
+            msg.contains(&format!("fork point at height {fork_height}")),
+            "error must include the fork height; got: {msg}"
+        );
     }
 
     /// `PreValidation` reaches `soft_internal_reason_tag` whenever its

--- a/crates/chain-tests/src/multi_node/fork_recovery.rs
+++ b/crates/chain-tests/src/multi_node/fork_recovery.rs
@@ -1,4 +1,4 @@
-use crate::utils::IrysNodeTest;
+use crate::utils::{IrysNodeTest, assert_reorg_event_lca_contract};
 use irys_chain::IrysNodeCtx;
 use irys_types::{DataLedger, DataTransaction, H256, NodeConfig, U256, UnixTimestamp};
 use reth::rpc::types::BlockNumberOrTag;
@@ -339,30 +339,7 @@ async fn heavy4_fork_recovery_submit_tx_test() -> eyre::Result<()> {
 
     // fork_parent must be the LCA — the common parent of both divergent
     // suffixes' first blocks. This is the contract find_reorg_split holds.
-    if let (Some(first_old), Some(first_new)) =
-        (reorg_event.old_fork.first(), reorg_event.new_fork.first())
-    {
-        assert_eq!(
-            reorg_event.fork_parent.block_hash,
-            first_old.header().previous_block_hash,
-            "fork_parent must be the previous_block_hash of old_fork[0]",
-        );
-        assert_eq!(
-            reorg_event.fork_parent.block_hash,
-            first_new.header().previous_block_hash,
-            "fork_parent must be the previous_block_hash of new_fork[0]",
-        );
-        assert_eq!(
-            reorg_event.fork_parent.height + 1,
-            first_old.header().height,
-            "fork_parent must be one height below old_fork[0]",
-        );
-        assert_eq!(
-            reorg_event.fork_parent.height + 1,
-            first_new.header().height,
-            "fork_parent must be one height below new_fork[0]",
-        );
-    }
+    assert_reorg_event_lca_contract(&reorg_event);
 
     // Wind down test
     tokio::join!(genesis_node.stop(), peer1_node.stop(), peer2_node.stop());

--- a/crates/chain-tests/src/multi_node/fork_recovery.rs
+++ b/crates/chain-tests/src/multi_node/fork_recovery.rs
@@ -337,6 +337,33 @@ async fn heavy4_fork_recovery_submit_tx_test() -> eyre::Result<()> {
 
     assert_eq!(reorg_event.new_tip, *new_fork.last().unwrap());
 
+    // fork_parent must be the LCA — the common parent of both divergent
+    // suffixes' first blocks. This is the contract find_reorg_split holds.
+    if let (Some(first_old), Some(first_new)) =
+        (reorg_event.old_fork.first(), reorg_event.new_fork.first())
+    {
+        assert_eq!(
+            reorg_event.fork_parent.block_hash,
+            first_old.header().previous_block_hash,
+            "fork_parent must be the previous_block_hash of old_fork[0]",
+        );
+        assert_eq!(
+            reorg_event.fork_parent.block_hash,
+            first_new.header().previous_block_hash,
+            "fork_parent must be the previous_block_hash of new_fork[0]",
+        );
+        assert_eq!(
+            reorg_event.fork_parent.height + 1,
+            first_old.header().height,
+            "fork_parent must be one height below old_fork[0]",
+        );
+        assert_eq!(
+            reorg_event.fork_parent.height + 1,
+            first_new.header().height,
+            "fork_parent must be one height below new_fork[0]",
+        );
+    }
+
     // Wind down test
     tokio::join!(genesis_node.stop(), peer1_node.stop(), peer2_node.stop());
     Ok(())

--- a/crates/chain-tests/src/multi_node/mempool_tests.rs
+++ b/crates/chain-tests/src/multi_node/mempool_tests.rs
@@ -967,30 +967,7 @@ async fn heavy3_mempool_submit_tx_fork_recovery_test() -> eyre::Result<()> {
 
     // fork_parent must be the LCA — the common parent of both divergent
     // suffixes' first blocks. This is the contract find_reorg_split holds.
-    if let (Some(first_old), Some(first_new)) =
-        (reorg_event.old_fork.first(), reorg_event.new_fork.first())
-    {
-        assert_eq!(
-            reorg_event.fork_parent.block_hash,
-            first_old.header().previous_block_hash,
-            "fork_parent must be the previous_block_hash of old_fork[0]",
-        );
-        assert_eq!(
-            reorg_event.fork_parent.block_hash,
-            first_new.header().previous_block_hash,
-            "fork_parent must be the previous_block_hash of new_fork[0]",
-        );
-        assert_eq!(
-            reorg_event.fork_parent.height + 1,
-            first_old.header().height,
-            "fork_parent must be one height below old_fork[0]",
-        );
-        assert_eq!(
-            reorg_event.fork_parent.height + 1,
-            first_new.header().height,
-            "fork_parent must be one height below new_fork[0]",
-        );
-    }
+    assert_reorg_event_lca_contract(&reorg_event);
 
     assert!(
         reorg_block.data_ledgers[DataLedger::Submit]

--- a/crates/chain-tests/src/multi_node/mempool_tests.rs
+++ b/crates/chain-tests/src/multi_node/mempool_tests.rs
@@ -965,6 +965,33 @@ async fn heavy3_mempool_submit_tx_fork_recovery_test() -> eyre::Result<()> {
 
     assert_eq!(reorg_event.new_tip, *new_fork.last().unwrap());
 
+    // fork_parent must be the LCA — the common parent of both divergent
+    // suffixes' first blocks. This is the contract find_reorg_split holds.
+    if let (Some(first_old), Some(first_new)) =
+        (reorg_event.old_fork.first(), reorg_event.new_fork.first())
+    {
+        assert_eq!(
+            reorg_event.fork_parent.block_hash,
+            first_old.header().previous_block_hash,
+            "fork_parent must be the previous_block_hash of old_fork[0]",
+        );
+        assert_eq!(
+            reorg_event.fork_parent.block_hash,
+            first_new.header().previous_block_hash,
+            "fork_parent must be the previous_block_hash of new_fork[0]",
+        );
+        assert_eq!(
+            reorg_event.fork_parent.height + 1,
+            first_old.header().height,
+            "fork_parent must be one height below old_fork[0]",
+        );
+        assert_eq!(
+            reorg_event.fork_parent.height + 1,
+            first_new.header().height,
+            "fork_parent must be one height below new_fork[0]",
+        );
+    }
+
     assert!(
         reorg_block.data_ledgers[DataLedger::Submit]
             .tx_ids

--- a/crates/chain-tests/src/utils.rs
+++ b/crates/chain-tests/src/utils.rs
@@ -3819,13 +3819,15 @@ pub fn assert_validation_error(
 /// Assert the LCA contract that `find_reorg_split` upholds on a [`ReorgEvent`]:
 /// `fork_parent` is the common parent of both divergent suffixes, so its hash is
 /// the `previous_block_hash` of each fork's first block and its height is one
-/// below them. No-op when either fork is empty (nothing to anchor against).
+/// below them. A reorg always diverges on both sides, so empty forks are a
+/// contract violation that fails the assertion rather than being skipped.
 pub fn assert_reorg_event_lca_contract(reorg_event: &ReorgEvent) {
-    let (Some(first_old), Some(first_new)) =
-        (reorg_event.old_fork.first(), reorg_event.new_fork.first())
-    else {
-        return;
-    };
+    assert!(
+        !reorg_event.old_fork.is_empty() && !reorg_event.new_fork.is_empty(),
+        "a reorg must produce non-empty old_fork and new_fork",
+    );
+    let first_old = reorg_event.old_fork.first().expect("old_fork non-empty");
+    let first_new = reorg_event.new_fork.first().expect("new_fork non-empty");
     assert_eq!(
         reorg_event.fork_parent.block_hash,
         first_old.header().previous_block_hash,

--- a/crates/chain-tests/src/utils.rs
+++ b/crates/chain-tests/src/utils.rs
@@ -3816,6 +3816,38 @@ pub fn assert_validation_error(
     }
 }
 
+/// Assert the LCA contract that `find_reorg_split` upholds on a [`ReorgEvent`]:
+/// `fork_parent` is the common parent of both divergent suffixes, so its hash is
+/// the `previous_block_hash` of each fork's first block and its height is one
+/// below them. No-op when either fork is empty (nothing to anchor against).
+pub fn assert_reorg_event_lca_contract(reorg_event: &ReorgEvent) {
+    let (Some(first_old), Some(first_new)) =
+        (reorg_event.old_fork.first(), reorg_event.new_fork.first())
+    else {
+        return;
+    };
+    assert_eq!(
+        reorg_event.fork_parent.block_hash,
+        first_old.header().previous_block_hash,
+        "fork_parent must be the previous_block_hash of old_fork[0]",
+    );
+    assert_eq!(
+        reorg_event.fork_parent.block_hash,
+        first_new.header().previous_block_hash,
+        "fork_parent must be the previous_block_hash of new_fork[0]",
+    );
+    assert_eq!(
+        reorg_event.fork_parent.height + 1,
+        first_old.header().height,
+        "fork_parent must be one height below old_fork[0]",
+    );
+    assert_eq!(
+        reorg_event.fork_parent.height + 1,
+        first_new.header().height,
+        "fork_parent must be one height below new_fork[0]",
+    );
+}
+
 #[diag_slow(state = format!("block_hash={}", block_hash))]
 pub async fn read_block_from_state(
     node_ctx: &IrysNodeCtx,

--- a/crates/domain/src/models/block_tree.rs
+++ b/crates/domain/src/models/block_tree.rs
@@ -100,6 +100,18 @@ pub struct ReorgSplit {
     pub new_divergent: Vec<Arc<SealedBlock>>,
 }
 
+/// The two competing chain tips handed to [`BlockTree::find_reorg_split`]. Both
+/// are `BlockHash`, so positional arguments invite silent transposition (which
+/// would swap the old/new divergent suffixes); the named fields make the
+/// new-vs-old roles explicit at every call site.
+#[derive(Debug, Clone, Copy)]
+pub struct ReorgTips {
+    /// Tip of the incoming (heavier) chain the node is switching to.
+    pub new_tip: BlockHash,
+    /// Tip of the chain currently considered canonical.
+    pub old_tip: BlockHash,
+}
+
 #[derive(Debug)]
 pub struct BlockTree {
     // Main block storage
@@ -744,18 +756,17 @@ impl BlockTree {
     ///
     /// Both `old_divergent` and `new_divergent` are oldest-first and exclude
     /// the LCA itself, matching the existing `old_fork_blocks`/`new_fork_blocks`
-    /// contract observed by `mempool_service/lifecycle.rs:446` and other reorg
-    /// consumers.
+    /// contract observed by the mempool's `get_confirmed_range` (which slices
+    /// `fork[0..migration_depth]`, so the oldest-first ordering is load-bearing)
+    /// and other reorg consumers.
     ///
     /// Returns `Err` if either tip is missing from the cache, or if the walks
     /// exhaust without intersecting (cache miss before reaching a shared
     /// ancestor). Never panics.
-    pub fn find_reorg_split(
-        &self,
-        new_tip: BlockHash,
-        old_tip: BlockHash,
-    ) -> eyre::Result<ReorgSplit> {
+    pub fn find_reorg_split(&self, tips: ReorgTips) -> eyre::Result<ReorgSplit> {
         use std::collections::HashSet;
+
+        let ReorgTips { new_tip, old_tip } = tips;
 
         // Walk back from new_tip, recording every hash seen.
         let mut new_walk: Vec<Arc<SealedBlock>> = Vec::new();
@@ -3044,7 +3055,10 @@ mod tests {
         }
 
         let split = cache
-            .find_reorg_split(c3.block_hash, b4.block_hash)
+            .find_reorg_split(ReorgTips {
+                new_tip: c3.block_hash,
+                old_tip: b4.block_hash,
+            })
             .expect("LCA exists in cache");
 
         // LCA == b2
@@ -3094,7 +3108,10 @@ mod tests {
 
         let bogus = H256([0xFF; 32]);
         let err = cache
-            .find_reorg_split(bogus, b1.block_hash)
+            .find_reorg_split(ReorgTips {
+                new_tip: bogus,
+                old_tip: b1.block_hash,
+            })
             .expect_err("missing new tip must produce Err, not panic");
         assert!(
             format!("{err}").contains("new tip"),
@@ -3119,7 +3136,10 @@ mod tests {
 
         let bogus = H256([0xEE; 32]);
         let err = cache
-            .find_reorg_split(b1.block_hash, bogus)
+            .find_reorg_split(ReorgTips {
+                new_tip: b1.block_hash,
+                old_tip: bogus,
+            })
             .expect_err("missing old tip must produce Err, not panic");
         assert!(
             format!("{err}").contains("old tip"),
@@ -3144,7 +3164,10 @@ mod tests {
             .expect("add_block");
 
         let split = cache
-            .find_reorg_split(b1.block_hash, b1.block_hash)
+            .find_reorg_split(ReorgTips {
+                new_tip: b1.block_hash,
+                old_tip: b1.block_hash,
+            })
             .expect("identical tips share themselves as LCA");
         assert_eq!(split.lca.header().block_hash, b1.block_hash);
         assert!(split.old_divergent.is_empty());
@@ -3172,7 +3195,10 @@ mod tests {
         }
 
         let split = cache
-            .find_reorg_split(n2.block_hash, g.block_hash)
+            .find_reorg_split(ReorgTips {
+                new_tip: n2.block_hash,
+                old_tip: g.block_hash,
+            })
             .expect("genesis is a shared ancestor");
         assert_eq!(split.lca.header().block_hash, g.block_hash);
         assert!(split.old_divergent.is_empty());
@@ -3218,7 +3244,10 @@ mod tests {
             .chain_state = ChainState::Onchain;
 
         let split = cache
-            .find_reorg_split(c3.block_hash, b3.block_hash)
+            .find_reorg_split(ReorgTips {
+                new_tip: c3.block_hash,
+                old_tip: b3.block_hash,
+            })
             .expect("LCA exists in cache via parent walk");
 
         // True LCA = b1, NOT b2 (even though b2 carries a stale Onchain flag).
@@ -3233,5 +3262,68 @@ mod tests {
         assert_eq!(split.old_divergent[1].header().block_hash, b3.block_hash);
         // new_divergent = [c1, c2, c3]
         assert_eq!(split.new_divergent.len(), 3);
+    }
+
+    #[test]
+    fn find_reorg_split_errs_when_chains_share_no_ancestor() {
+        // Two chains rooted at independent genesis blocks share no ancestor in
+        // the cache. Walking the old tip's lineage reaches its own genesis
+        // without ever intersecting the new chain — find_reorg_split must
+        // surface this no-common-ancestor divergence as Err, never panic.
+        let g = random_block(U256::from(0));
+        let mut n1 = extend_chain(random_block(U256::from(1)), &g);
+        let mut n2 = extend_chain(random_block(U256::from(2)), &n1);
+        let comm = Arc::new(CommitmentSnapshot::default());
+        let mut cache = BlockTree::new(&g, ConsensusConfig::testing());
+        for hdr in [&mut n1, &mut n2] {
+            cache
+                .add_block(
+                    &seal_block(hdr),
+                    comm.clone(),
+                    dummy_epoch_snapshot(),
+                    dummy_ema_snapshot(),
+                )
+                .expect("add_block");
+        }
+
+        // Plant a second, disjoint genesis. `add_common` requires the parent to
+        // be in `self.blocks`, so insert the root directly (mirroring
+        // `BlockTree::new`) before extending a chain on top of it.
+        let mut g2 = random_block(U256::from(100));
+        let g2_hash = g2.block_hash;
+        let g2_sealed = seal_block(&mut g2);
+        cache.blocks.insert(
+            g2_hash,
+            BlockMetadata {
+                block: g2_sealed,
+                chain_state: ChainState::Onchain,
+                timestamp: SystemTime::now(),
+                children: HashSet::new(),
+                epoch_snapshot: dummy_epoch_snapshot(),
+                commitment_snapshot: comm.clone(),
+                ema_snapshot: dummy_ema_snapshot(),
+            },
+        );
+        let mut o1 = extend_chain(random_block(U256::from(101)), &g2);
+        let mut o2 = extend_chain(random_block(U256::from(102)), &o1);
+        for hdr in [&mut o1, &mut o2] {
+            cache
+                .add_block(
+                    &seal_block(hdr),
+                    comm.clone(),
+                    dummy_epoch_snapshot(),
+                    dummy_ema_snapshot(),
+                )
+                .expect("add_block");
+        }
+
+        let err = cache
+            .find_reorg_split(ReorgTips {
+                new_tip: n2.block_hash,
+                old_tip: o2.block_hash,
+            })
+            .expect_err("chains with no shared ancestor must Err, not panic");
+        let msg = format!("{err}");
+        assert!(msg.contains("no common ancestor"), "unexpected err: {msg}");
     }
 }

--- a/crates/domain/src/models/block_tree.rs
+++ b/crates/domain/src/models/block_tree.rs
@@ -84,6 +84,22 @@ impl PartialEq for BlockTreeEntry {
 
 impl Eq for BlockTreeEntry {}
 
+/// Result of finding the divergence point between two competing chains in the
+/// block tree cache. `old_divergent` and `new_divergent` are oldest-first and
+/// exclude the LCA itself; iterating them in order walks each fork from the
+/// block immediately above the LCA to its respective tip. The LCA is reported
+/// separately as a full `Arc<SealedBlock>` so callers can extract its header
+/// for downstream events (e.g., `ReorgEvent::fork_parent`).
+///
+/// Independent of `ChainState` flags by construction — produced only from
+/// parent pointers via `BlockTree::find_reorg_split`.
+#[derive(Debug, Clone)]
+pub struct ReorgSplit {
+    pub lca: Arc<SealedBlock>,
+    pub old_divergent: Vec<Arc<SealedBlock>>,
+    pub new_divergent: Vec<Arc<SealedBlock>>,
+}
+
 #[derive(Debug)]
 pub struct BlockTree {
     // Main block storage
@@ -719,6 +735,91 @@ impl BlockTree {
             .0
             .last()
             .expect("canonical chain must always have an entry in it")
+    }
+
+    /// Find the lowest common ancestor of two tips by walking both lineages
+    /// through `previous_block_hash` links in `self.blocks`, then return both
+    /// divergent suffixes. Independent of `ChainState` flags — operates only on
+    /// parent pointers, the same source `update_longest_chain_cache` walks.
+    ///
+    /// Both `old_divergent` and `new_divergent` are oldest-first and exclude
+    /// the LCA itself, matching the existing `old_fork_blocks`/`new_fork_blocks`
+    /// contract observed by `mempool_service/lifecycle.rs:446` and other reorg
+    /// consumers.
+    ///
+    /// Returns `Err` if either tip is missing from the cache, or if the walks
+    /// exhaust without intersecting (cache miss before reaching a shared
+    /// ancestor). Never panics.
+    pub fn find_reorg_split(
+        &self,
+        new_tip: BlockHash,
+        old_tip: BlockHash,
+    ) -> eyre::Result<ReorgSplit> {
+        use std::collections::HashSet;
+
+        // Walk back from new_tip, recording every hash seen.
+        let mut new_walk: Vec<Arc<SealedBlock>> = Vec::new();
+        let mut new_hashes: HashSet<BlockHash> = HashSet::new();
+        let mut cursor = new_tip;
+        loop {
+            let Some(entry) = self.blocks.get(&cursor) else {
+                break;
+            };
+            new_hashes.insert(cursor);
+            new_walk.push(Arc::clone(&entry.block));
+            if entry.block.header().height == 0 {
+                break;
+            }
+            cursor = entry.block.header().previous_block_hash;
+        }
+        if new_walk.is_empty() {
+            return Err(eyre::eyre!("new tip {new_tip} not in block tree cache",));
+        }
+
+        // Walk back from old_tip, stopping at the first hash that appears in new_hashes.
+        let mut old_walk: Vec<Arc<SealedBlock>> = Vec::new();
+        let mut cursor = old_tip;
+        let lca = loop {
+            let Some(entry) = self.blocks.get(&cursor) else {
+                if old_walk.is_empty() {
+                    return Err(eyre::eyre!("old tip {old_tip} not in block tree cache",));
+                }
+                return Err(eyre::eyre!(
+                    "no common ancestor in cache between new tip {new_tip} \
+                     and old tip {old_tip}: old chain walk exhausted",
+                ));
+            };
+            if new_hashes.contains(&cursor) {
+                break Arc::clone(&entry.block);
+            }
+            old_walk.push(Arc::clone(&entry.block));
+            if entry.block.header().height == 0 {
+                return Err(eyre::eyre!(
+                    "no common ancestor in cache between new tip {new_tip} \
+                     and old tip {old_tip}: old chain reached genesis without intersecting",
+                ));
+            }
+            cursor = entry.block.header().previous_block_hash;
+        };
+
+        // Trim new_walk to drop blocks at or below LCA. new_walk is tip-first;
+        // LCA must appear in it because new_hashes contained it.
+        let lca_hash = lca.header().block_hash;
+        let lca_idx = new_walk
+            .iter()
+            .position(|sb| sb.header().block_hash == lca_hash)
+            .expect("lca_hash must appear in new_walk because new_hashes contained it");
+        let mut new_divergent: Vec<Arc<SealedBlock>> = new_walk.drain(..lca_idx).collect();
+
+        // Both walks are tip-first; downstream consumers require oldest-first.
+        new_divergent.reverse();
+        old_walk.reverse();
+
+        Ok(ReorgSplit {
+            lca,
+            old_divergent: old_walk,
+            new_divergent,
+        })
     }
 
     fn update_longest_chain_cache(&mut self) {
@@ -2911,5 +3012,226 @@ mod tests {
                 "fallback selection must be deterministic across insertion orders; expected smallest block_hash"
             );
         }
+    }
+
+    #[test]
+    fn find_reorg_split_returns_oldest_first_lca_exclusive_suffixes() {
+        // Build chain: G -> b1 -> b2 -> b3 -> old_tip(b4)
+        //                          \-> c1 -> c2 -> new_tip(c3)
+        // LCA = b2. old_divergent = [b3, b4]. new_divergent = [c1, c2, c3].
+        let g = random_block(U256::from(0));
+        let mut b1 = extend_chain(random_block(U256::from(1)), &g);
+        let mut b2 = extend_chain(random_block(U256::from(2)), &b1);
+        let mut b3 = extend_chain(random_block(U256::from(3)), &b2);
+        let mut b4 = extend_chain(random_block(U256::from(4)), &b3);
+        let mut c1 = extend_chain(random_block(U256::from(5)), &b2);
+        let mut c2 = extend_chain(random_block(U256::from(6)), &c1);
+        let mut c3 = extend_chain(random_block(U256::from(7)), &c2);
+
+        let comm = Arc::new(CommitmentSnapshot::default());
+        let mut cache = BlockTree::new(&g, ConsensusConfig::testing());
+        for hdr in [
+            &mut b1, &mut b2, &mut b3, &mut b4, &mut c1, &mut c2, &mut c3,
+        ] {
+            cache
+                .add_block(
+                    &seal_block(hdr),
+                    comm.clone(),
+                    dummy_epoch_snapshot(),
+                    dummy_ema_snapshot(),
+                )
+                .expect("add_block");
+        }
+
+        let split = cache
+            .find_reorg_split(c3.block_hash, b4.block_hash)
+            .expect("LCA exists in cache");
+
+        // LCA == b2
+        assert_eq!(split.lca.header().block_hash, b2.block_hash);
+        assert_eq!(split.lca.header().height, b2.height);
+
+        // old_divergent = [b3, b4], oldest-first, LCA-exclusive
+        assert_eq!(split.old_divergent.len(), 2);
+        assert_eq!(split.old_divergent[0].header().block_hash, b3.block_hash);
+        assert_eq!(split.old_divergent[1].header().block_hash, b4.block_hash);
+
+        // new_divergent = [c1, c2, c3], oldest-first, LCA-exclusive
+        assert_eq!(split.new_divergent.len(), 3);
+        assert_eq!(split.new_divergent[0].header().block_hash, c1.block_hash);
+        assert_eq!(split.new_divergent[1].header().block_hash, c2.block_hash);
+        assert_eq!(split.new_divergent[2].header().block_hash, c3.block_hash);
+
+        // LCA must not appear in either divergent Vec
+        assert!(
+            split
+                .old_divergent
+                .iter()
+                .all(|sb| sb.header().block_hash != b2.block_hash)
+        );
+        assert!(
+            split
+                .new_divergent
+                .iter()
+                .all(|sb| sb.header().block_hash != b2.block_hash)
+        );
+    }
+
+    #[test]
+    fn find_reorg_split_errs_when_new_tip_missing_from_cache() {
+        let g = random_block(U256::from(0));
+        let mut b1 = extend_chain(random_block(U256::from(1)), &g);
+        let comm = Arc::new(CommitmentSnapshot::default());
+        let mut cache = BlockTree::new(&g, ConsensusConfig::testing());
+        cache
+            .add_block(
+                &seal_block(&mut b1),
+                comm,
+                dummy_epoch_snapshot(),
+                dummy_ema_snapshot(),
+            )
+            .expect("add_block");
+
+        let bogus = H256([0xFF; 32]);
+        let err = cache
+            .find_reorg_split(bogus, b1.block_hash)
+            .expect_err("missing new tip must produce Err, not panic");
+        assert!(
+            format!("{err}").contains("new tip"),
+            "Err must identify the missing chain side: {err}",
+        );
+    }
+
+    #[test]
+    fn find_reorg_split_errs_when_old_tip_missing_from_cache() {
+        let g = random_block(U256::from(0));
+        let mut b1 = extend_chain(random_block(U256::from(1)), &g);
+        let comm = Arc::new(CommitmentSnapshot::default());
+        let mut cache = BlockTree::new(&g, ConsensusConfig::testing());
+        cache
+            .add_block(
+                &seal_block(&mut b1),
+                comm,
+                dummy_epoch_snapshot(),
+                dummy_ema_snapshot(),
+            )
+            .expect("add_block");
+
+        let bogus = H256([0xEE; 32]);
+        let err = cache
+            .find_reorg_split(b1.block_hash, bogus)
+            .expect_err("missing old tip must produce Err, not panic");
+        assert!(
+            format!("{err}").contains("old tip"),
+            "Err must identify the missing chain side: {err}",
+        );
+    }
+
+    #[test]
+    fn find_reorg_split_handles_identical_tips() {
+        // old_tip == new_tip → LCA is that block, both divergent Vecs empty.
+        let g = random_block(U256::from(0));
+        let mut b1 = extend_chain(random_block(U256::from(1)), &g);
+        let comm = Arc::new(CommitmentSnapshot::default());
+        let mut cache = BlockTree::new(&g, ConsensusConfig::testing());
+        cache
+            .add_block(
+                &seal_block(&mut b1),
+                comm,
+                dummy_epoch_snapshot(),
+                dummy_ema_snapshot(),
+            )
+            .expect("add_block");
+
+        let split = cache
+            .find_reorg_split(b1.block_hash, b1.block_hash)
+            .expect("identical tips share themselves as LCA");
+        assert_eq!(split.lca.header().block_hash, b1.block_hash);
+        assert!(split.old_divergent.is_empty());
+        assert!(split.new_divergent.is_empty());
+    }
+
+    #[test]
+    fn find_reorg_split_handles_old_tip_at_genesis() {
+        // Old chain is genesis only. New chain extends from genesis.
+        // LCA = genesis. old_divergent = []. new_divergent = full new chain.
+        let g = random_block(U256::from(0));
+        let mut n1 = extend_chain(random_block(U256::from(1)), &g);
+        let mut n2 = extend_chain(random_block(U256::from(2)), &n1);
+        let comm = Arc::new(CommitmentSnapshot::default());
+        let mut cache = BlockTree::new(&g, ConsensusConfig::testing());
+        for hdr in [&mut n1, &mut n2] {
+            cache
+                .add_block(
+                    &seal_block(hdr),
+                    comm.clone(),
+                    dummy_epoch_snapshot(),
+                    dummy_ema_snapshot(),
+                )
+                .expect("add_block");
+        }
+
+        let split = cache
+            .find_reorg_split(n2.block_hash, g.block_hash)
+            .expect("genesis is a shared ancestor");
+        assert_eq!(split.lca.header().block_hash, g.block_hash);
+        assert!(split.old_divergent.is_empty());
+        assert_eq!(split.new_divergent.len(), 2);
+        assert_eq!(split.new_divergent[0].header().block_hash, n1.block_hash);
+        assert_eq!(split.new_divergent[1].header().block_hash, n2.block_hash);
+    }
+
+    #[test]
+    fn find_reorg_split_ignores_stale_onchain_flag_regression() {
+        // Topology: G -> b1 -> b2(STALE Onchain) -> old_tip(b3)
+        //                 \-> c1 -> c2 -> new_tip(c3)
+        // True LCA via parent walk = b1.
+        // If the algorithm depended on the flag, it would mistakenly select b2.
+        let g = random_block(U256::from(0));
+        let mut b1 = extend_chain(random_block(U256::from(1)), &g);
+        let mut b2 = extend_chain(random_block(U256::from(2)), &b1);
+        let mut b3 = extend_chain(random_block(U256::from(3)), &b2);
+        let mut c1 = extend_chain(random_block(U256::from(4)), &b1);
+        let mut c2 = extend_chain(random_block(U256::from(5)), &c1);
+        let mut c3 = extend_chain(random_block(U256::from(6)), &c2);
+
+        let comm = Arc::new(CommitmentSnapshot::default());
+        let mut cache = BlockTree::new(&g, ConsensusConfig::testing());
+        for hdr in [&mut b1, &mut b2, &mut b3, &mut c1, &mut c2, &mut c3] {
+            cache
+                .add_block(
+                    &seal_block(hdr),
+                    comm.clone(),
+                    dummy_epoch_snapshot(),
+                    dummy_ema_snapshot(),
+                )
+                .expect("add_block");
+        }
+
+        // Inject a stale Onchain flag on b2. b2 is NOT on the new canonical
+        // (which goes G -> b1 -> c1 -> c2 -> c3). If find_reorg_split scanned
+        // for an Onchain anchor, it would pick b2 and produce a wrong LCA.
+        cache
+            .blocks
+            .get_mut(&b2.block_hash)
+            .expect("b2 in cache")
+            .chain_state = ChainState::Onchain;
+
+        let split = cache
+            .find_reorg_split(c3.block_hash, b3.block_hash)
+            .expect("LCA exists in cache via parent walk");
+
+        // True LCA = b1, NOT b2 (even though b2 carries a stale Onchain flag).
+        assert_eq!(
+            split.lca.header().block_hash,
+            b1.block_hash,
+            "find_reorg_split must use parent-walk truth, not the Onchain flag",
+        );
+        // old_divergent = [b2, b3]
+        assert_eq!(split.old_divergent.len(), 2);
+        assert_eq!(split.old_divergent[0].header().block_hash, b2.block_hash);
+        assert_eq!(split.old_divergent[1].header().block_hash, b3.block_hash);
+        // new_divergent = [c1, c2, c3]
+        assert_eq!(split.new_divergent.len(), 3);
     }
 }


### PR DESCRIPTION
**Describe the changes**
Before: LCA derived from ChainState::Onchain flag scan via get_fork_blocks, fed into prune_chains_at_ancestor. Stale flags → wrong LCA →Err("common ancestor X not in new chain") → service exit.

  After: BlockTree::find_reorg_split walks both lineages through previous_block_hash links, intersects them, returns LCA's sealed block +  oldest-first LCA-exclusive divergent suffixes. Caller invokes it before cache.prune. prune_chains_at_ancestor deleted.



**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More accurate reorganization handling with improved fork-point detection and safer pruning to reduce spurious downstream errors.
  * Added a cache-window safety check to abort reorg processing when pruning would remove required state.

* **Tests**
  * Strengthened fork-recovery and mempool tests to enforce lowest-common-ancestor correctness and cover additional edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Irys-xyz/irys/pull/1432?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->