### PR TITLE
feat: Per-version frozen release branches + tag-trust rebuild provenance

### DIFF
--- a/.github/actions/verify-commit-provenance/action.yaml
+++ b/.github/actions/verify-commit-provenance/action.yaml
@@ -3,10 +3,13 @@ description: >-
   Verifies a commit is a legitimate build source for an environment: it exists,
   lives on the matching deployment branch, and — for testnet/mainnet — carries
   the expected crates/chain version, optionally requiring that the
-  <env>-<version> release tag points at it. The caller must have already checked
-  out the repo (fetch-depth: 0); for testnet/mainnet it must also have synced tags
-  from origin (devnet does only the branch check and reads no tags). This action
-  only reads local refs.
+  <env>-<version> release tag points at it. When require-release-tag is true (the
+  rebuild path) the deployment-branch check is skipped and provenance rests on the
+  exact <env>-<version> tag match instead — the trunk release/<env>/<major>.x
+  branch is rebased, so a prior release's commit is legitimately no longer on it.
+  The caller must have already checked out the repo (fetch-depth: 0); for
+  testnet/mainnet it must also have synced tags from origin (devnet does only the
+  branch check and reads no tags). This action only reads local refs.
 
 inputs:
   environment:
@@ -53,22 +56,30 @@ runs:
           MAJOR="${VERSION%%.*}"
           EXPECTED_BRANCH="origin/release/${ENVIRONMENT}/${MAJOR}.x"
         fi
-        # Distinguish "deployment branch missing locally" (a setup/fetch problem)
-        # from "commit not on it" — otherwise a missing branch surfaces as a
-        # confusing provenance failure for the commit.
-        if ! git show-ref --verify --quiet "refs/remotes/$EXPECTED_BRANCH"; then
-          echo "::error::Expected branch $EXPECTED_BRANCH not found locally. Create it on origin (per-release-branch setup) and ensure the checkout used fetch-depth: 0."
-          exit 1
+        # Branch-membership proves the commit lives on the env's deployment branch.
+        # Skip it on the rebuild path (require-release-tag=true): there we prove
+        # provenance via the exact <env>-<version> tag match below, which is
+        # strictly stronger. The trunk release/<env>/<major>.x branch is rebased,
+        # so a prior release's commit is legitimately no longer on it — requiring
+        # membership there is exactly what blocked rebuilding past releases.
+        if [[ "$REQUIRE_RELEASE_TAG" != "true" ]]; then
+          # Distinguish "deployment branch missing locally" (a setup/fetch problem)
+          # from "commit not on it" — otherwise a missing branch surfaces as a
+          # confusing provenance failure for the commit.
+          if ! git show-ref --verify --quiet "refs/remotes/$EXPECTED_BRANCH"; then
+            echo "::error::Expected branch $EXPECTED_BRANCH not found locally. Create it on origin (per-release-branch setup) and ensure the checkout used fetch-depth: 0."
+            exit 1
+          fi
+          if ! git branch -r --contains "${COMMIT}" \
+              | sed 's/^[[:space:]]*//' \
+              | grep -Fxq "$EXPECTED_BRANCH"; then
+            echo "::error::Commit ${COMMIT} is not on $EXPECTED_BRANCH"
+            echo "Found on branches:"
+            git branch -r --contains "${COMMIT}"
+            exit 1
+          fi
+          echo "Commit ${COMMIT} found on $EXPECTED_BRANCH"
         fi
-        if ! git branch -r --contains "${COMMIT}" \
-            | sed 's/^[[:space:]]*//' \
-            | grep -Fxq "$EXPECTED_BRANCH"; then
-          echo "::error::Commit ${COMMIT} is not on $EXPECTED_BRANCH"
-          echo "Found on branches:"
-          git branch -r --contains "${COMMIT}"
-          exit 1
-        fi
-        echo "Commit ${COMMIT} found on $EXPECTED_BRANCH"
 
         if [[ "$ENVIRONMENT" != "devnet" ]]; then
           CARGO_VER=$(git show "${COMMIT}:crates/chain/Cargo.toml" \

--- a/.github/actions/verify-commit-provenance/action.yaml
+++ b/.github/actions/verify-commit-provenance/action.yaml
@@ -46,6 +46,16 @@ runs:
           exit 1
         fi
 
+        # devnet has no release tags. With require-release-tag=true the branch
+        # check below is skipped (rebuild path) AND the version/tag block is skipped
+        # (it is gated on env != devnet), which would wave a commit through on
+        # commit-existence alone. No caller sets this combination; reject it
+        # explicitly so the action fails safe on its own.
+        if [[ "$ENVIRONMENT" == "devnet" && "$REQUIRE_RELEASE_TAG" == "true" ]]; then
+          echo "::error::require-release-tag=true is not supported for devnet"
+          exit 1
+        fi
+
         if [[ "$ENVIRONMENT" == "devnet" ]]; then
           EXPECTED_BRANCH="origin/release/devnet"
         else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -408,7 +408,15 @@ jobs:
           BRANCH: ${{ steps.push_branch.outputs.branch }}
         run: |
           echo "::warning::Cleaning up per-version release branch $BRANCH"
-          git push origin --delete "$BRANCH" || true
+          # Surface a failed remote delete instead of swallowing it. The snapshot is
+          # delete-protected by the 'release branches' ruleset and the bot is not a
+          # bypass actor, so a blocked delete leaves a stray branch that an admin must
+          # remove — fail loudly here rather than hide it behind `|| true`.
+          if ! git push origin --delete "$BRANCH"; then
+            echo "::error::Failed to delete stray release branch $BRANCH from origin. If it is protected by the 'release branches' ruleset (github-actions[bot] is not a bypass actor), an admin must delete it manually."
+            exit 1
+          fi
+          # Local-only hygiene on the reused runner; a missing local branch is benign.
           git branch -D "$BRANCH" 2>/dev/null || true
 
       - name: 'Cleanup: revert head-tracking git tag'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,6 +262,31 @@ jobs:
           git tag -a "$GIT_TAG" -m "Release ${INPUT_VERSION} (${INPUT_RELEASE_TYPE})" "${INPUT_COMMIT}"
           git push origin "$GIT_TAG"
 
+      # Per-version frozen snapshot branch. Unlike the rebased trunk
+      # release/<env>/<major>.x branch, this is never rebased, so it keeps the
+      # released commit reachable from a branch forever: GitHub no longer flags
+      # the release commit as orphaned, and the commit survives later rebases of
+      # the trunk env branch. Provenance on the rebuild path is proven by the
+      # <env>-<version> tag (see verify-commit-provenance), not this branch, so a
+      # missing or deleted frozen branch is cosmetic only.
+      - name: Push per-version release branch
+        id: push_branch
+        if: ${{ !inputs.dry_run }}
+        env:
+          INPUT_COMMIT: ${{ inputs.commit }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_RELEASE_TYPE: ${{ inputs.release_type }}
+        run: |
+          BRANCH="release/${INPUT_RELEASE_TYPE}/${INPUT_VERSION}"
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+          # Force-move any stale local branch left by a failed run on this reused
+          # runner, then push without --force: a fresh branch is created, a re-run
+          # at the same commit is "Everything up-to-date" (exit 0), and an existing
+          # branch at a DIFFERENT commit is rejected loudly — the right behavior for
+          # an immutable per-version snapshot.
+          git branch -f "$BRANCH" "${INPUT_COMMIT}"
+          git push origin "refs/heads/$BRANCH"
+
       - name: Push Docker image
         id: push_image
         if: ${{ !inputs.dry_run }}
@@ -375,6 +400,15 @@ jobs:
           echo "::warning::Cleaning up orphaned git tag $GIT_TAG"
           git push origin --delete "$GIT_TAG" || true
           git tag -d "$GIT_TAG" 2>/dev/null || true
+
+      - name: 'Cleanup: delete per-version release branch'
+        if: failure() && steps.push_branch.outcome == 'success'
+        env:
+          BRANCH: ${{ steps.push_branch.outputs.branch }}
+        run: |
+          echo "::warning::Cleaning up per-version release branch $BRANCH"
+          git push origin --delete "$BRANCH" || true
+          git branch -D "$BRANCH" 2>/dev/null || true
 
       - name: 'Cleanup: revert head-tracking git tag'
         if: failure() && steps.head_git.outcome == 'success'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,11 +262,11 @@ jobs:
           git tag -a "$GIT_TAG" -m "Release ${INPUT_VERSION} (${INPUT_RELEASE_TYPE})" "${INPUT_COMMIT}"
           git push origin "$GIT_TAG"
 
-      # Per-version frozen snapshot branch. Unlike the rebased trunk
-      # release/<env>/<major>.x branch, this is never rebased, so it keeps the
-      # released commit reachable from a branch forever: GitHub no longer flags
-      # the release commit as orphaned, and the commit survives later rebases of
-      # the trunk env branch. Provenance on the rebuild path is proven by the
+      # Per-version frozen snapshot branch, never rebased (unlike the trunk
+      # release/<env>/<major>.x branch). The <env>-<version> tag already keeps the
+      # released commit reachable and GC-safe; what this branch adds is *branch*
+      # reachability, which clears GitHub's "commit does not belong to any branch"
+      # flag on the release. Provenance on the rebuild path is proven by the
       # <env>-<version> tag (see verify-commit-provenance), not this branch, so a
       # missing or deleted frozen branch is cosmetic only.
       - name: Push per-version release branch
@@ -280,10 +280,11 @@ jobs:
           BRANCH="release/${INPUT_RELEASE_TYPE}/${INPUT_VERSION}"
           echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
           # Force-move any stale local branch left by a failed run on this reused
-          # runner, then push without --force: a fresh branch is created, a re-run
-          # at the same commit is "Everything up-to-date" (exit 0), and an existing
-          # branch at a DIFFERENT commit is rejected loudly — the right behavior for
-          # an immutable per-version snapshot.
+          # runner, then push without --force. The branch is effectively write-once
+          # per (env, version): the validate job refuses an already-existing tag, so
+          # this step runs at most once per version. The non-force push is only a
+          # backstop — it refuses to clobber a divergent (non-fast-forward) remote
+          # branch; it is not itself the source of immutability.
           git branch -f "$BRANCH" "${INPUT_COMMIT}"
           git push origin "refs/heads/$BRANCH"
 


### PR DESCRIPTION
## Summary

The per-env trunk branch `release/<env>/<major>.x` is **rebased** to pull master forward, which detaches previously-released commits from any branch. That caused two problems; this PR fixes both with surgical changes and no change to the rebase model.

- **Tag-trust the rebuild gate** (`verify-commit-provenance`): on the rebuild path (`require-release-tag=true`, used by `docker.yml` for testnet/mainnet) the branch-membership check is skipped in favor of the exact `<env>-<version>` tag-commit match (already present, and strictly stronger proof). This unblocks **rebuilding prior releases** whose commit the trunk branch has since rebased away. The new-release path (`require-release-tag=false`) and devnet are unchanged.
- **Frozen per-version branch** (`release.yml`): the publish phase now creates and pushes a never-rebased `release/<env>/<version>` branch (e.g. `release/testnet/3.0.1`) at the released commit, with matching failure-cleanup. Its sole purpose is **branch reachability** — clearing GitHub's "commit does not belong to any branch" flag on the release. (The `<env>-<version>` tag already provides reachability/GC-safety.)
- **Fail-safe devnet guard** (`verify-commit-provenance`): explicitly reject `devnet + require-release-tag=true` (a combination no caller sets, but which would otherwise skip every check except commit-existence).

## Notes / out of scope

- **Backfill** (one-time, operator-run): create `release/<env>/<version>` branches for existing `<env>-<version>` tags so historical releases also clear the orphan flag. Not required for rebuilds (tag-trust covers those immediately).
- **Branch protection**: an optional `release/**` ruleset (restrict deletions / block force-pushes) is recommended but not in this PR.
- `rust.yml` is intentionally left unchanged — frozen-branch pushes will trigger it (harmless read-only checks; adding a branch filter is the riskier change).
- **Pre-existing, not touched:** `release.yml:125` derives `origin/release/<major>.x` (no env segment) for the mainnet merge-base gate, vs the env-scoped naming used elsewhere. Consistent only if a shared `release/<major>.x` trunk intentionally exists — flagging since this PR touches the branch-naming scheme.

## Test plan

Local (done): both workflow YAMLs parse; `bash -n` clean on all changed run-blocks; a synthetic-git sim confirms the orphan-after-rebase premise and that the frozen branch + tag still reach the commit; behavioral check confirms the devnet guard fires only for the unsupported combo.

CI acceptance (authoritative):
- [ ] Rebuild a known-orphaned testnet version via `docker.yml` — provenance now passes via tag-trust where it previously failed.
- [ ] `release.yml` dry-run — confirm no `release/<env>/<version>` branch is created.
- [ ] Real testnet release — confirm `release/testnet/<version>` exists at the released commit and the commit no longer shows as orphaned in the GitHub UI.
- [ ] Confirm a forced failure after the branch push deletes `release/<env>/<version>` from origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened release provenance checks and added validation to reject invalid parameter combinations early.
  * Skipped branch-membership verification in specific tag-driven cases to streamline validation where appropriate.
  * Publish now creates per-version frozen snapshot branches; cleanup will attempt remote branch deletion and surface failures if deletion fails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Irys-xyz/irys/pull/1434?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->