### PR TITLE
feat(p2p): hard-reject handshakes from a different chain_id

### DIFF
--- a/crates/chain-tests/src/multi_node/peer_discovery.rs
+++ b/crates/chain-tests/src/multi_node/peer_discovery.rs
@@ -135,6 +135,53 @@ async fn peer_discovery() -> eyre::Result<()> {
         }
     }
 
+    // Test that a handshake from a peer on a different chain is hard-rejected.
+    // The chain_id mismatch is checked before signature verification, so even a
+    // validly-signed handshake declaring a foreign chain_id is rejected outright
+    // (unlike the consensus-config-hash mismatch, which is only advisory).
+    let foreign_chain_signer = IrysSigner::random_signer(&config.consensus_config());
+    let mut foreign_chain_request = HandshakeRequestV2 {
+        chain_id: config.consensus_config().chain_id + 1,
+        address: PeerAddress {
+            gossip: "127.0.0.9:8080".parse().expect("valid socket address"),
+            api: "127.0.0.9:8081".parse().expect("valid socket address"),
+            execution: RethPeerInfo {
+                peering_tcp_addr: "127.0.0.9:8082".parse().unwrap(),
+                peer_id: "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000".parse().unwrap()
+            },
+        },
+        peer_id: IrysPeerId::random(),
+        mining_address: foreign_chain_signer.address(),
+        user_agent: Some(build_user_agent("foreign-miner", "0.1.0")),
+        ..Default::default()
+    };
+    foreign_chain_signer
+        .sign_p2p_handshake_v2(&mut foreign_chain_request)
+        .expect("sign p2p handshake");
+
+    let req = TestRequest::post()
+        .uri(&format!("/gossip/v2{}", GossipRoutes::Handshake))
+        .peer_addr("127.0.0.9:12345".parse().unwrap())
+        .set_json(&foreign_chain_request)
+        .to_request();
+    let resp = call_service(&gossip, req).await;
+    let body = read_body(resp).await;
+    let body_str = String::from_utf8(body.to_vec()).expect("Response body is not valid UTF-8");
+    let peer_response: GossipResponse<HandshakeResponse> =
+        serde_json::from_str(&body_str).expect("Failed to parse JSON");
+    match peer_response {
+        GossipResponse::Accepted(_) => {
+            panic!("Expected Rejected response for chain ID mismatch, got Accepted")
+        }
+        GossipResponse::Rejected(reason) => {
+            assert!(
+                matches!(reason, RejectionReason::ChainIdMismatch),
+                "Expected ChainIdMismatch, got {:?}",
+                reason
+            );
+        }
+    }
+
     // spellchecker:off
     // Fully literal JSON fixture — tests the server's JSON deserialization path.
     // All values are hardcoded: the signature was computed from the deterministic

--- a/crates/chain-tests/src/multi_node/peer_discovery.rs
+++ b/crates/chain-tests/src/multi_node/peer_discovery.rs
@@ -11,8 +11,8 @@ use alloy_genesis::GenesisAccount;
 use irys_domain::ScoreDecreaseReason;
 use irys_p2p::{GossipResponse, GossipRoutes, RejectionReason};
 use irys_types::{
-    BlockHash, HandshakeRequestV2, HandshakeResponse, IrysPeerId, NodeConfig, PeerAddress,
-    RethPeerInfo, build_user_agent, irys::IrysSigner,
+    BlockHash, HandshakeRequestV2, HandshakeResponse, IrysPeerId, IrysSignature, NodeConfig,
+    PeerAddress, RethPeerInfo, build_user_agent, irys::IrysSigner,
 };
 use tracing::{debug, error, info};
 
@@ -177,6 +177,37 @@ async fn peer_discovery() -> eyre::Result<()> {
             assert!(
                 matches!(reason, RejectionReason::ChainIdMismatch),
                 "Expected ChainIdMismatch, got {:?}",
+                reason
+            );
+        }
+    }
+
+    // Same foreign chain_id, but now with a deliberately invalid (zeroed)
+    // signature. Proves the chain_id check runs *before* signature
+    // verification: the response must be ChainIdMismatch, not
+    // InvalidCredentials. If the two checks were ever reordered, this fails.
+    let mut foreign_chain_bad_sig = foreign_chain_request.clone();
+    foreign_chain_bad_sig.signature = IrysSignature::default();
+
+    let req = TestRequest::post()
+        .uri(&format!("/gossip/v2{}", GossipRoutes::Handshake))
+        .peer_addr("127.0.0.9:12345".parse().unwrap())
+        .set_json(&foreign_chain_bad_sig)
+        .to_request();
+    let resp = call_service(&gossip, req).await;
+    let body = read_body(resp).await;
+    let body_str = String::from_utf8(body.to_vec()).expect("Response body is not valid UTF-8");
+    let peer_response: GossipResponse<HandshakeResponse> =
+        serde_json::from_str(&body_str).expect("Failed to parse JSON");
+    match peer_response {
+        GossipResponse::Accepted(_) => {
+            panic!("Expected Rejected response for chain ID mismatch, got Accepted")
+        }
+        GossipResponse::Rejected(reason) => {
+            assert!(
+                matches!(reason, RejectionReason::ChainIdMismatch),
+                "chain_id must be checked before signature verification; \
+                 expected ChainIdMismatch, got {:?}",
                 reason
             );
         }

--- a/crates/p2p/src/gossip_client.rs
+++ b/crates/p2p/src/gossip_client.rs
@@ -81,6 +81,7 @@ fn pull_rejection_reason(reason: &RejectionReason) -> &'static str {
         RejectionReason::ProtocolMismatch => "protocol_mismatch",
         RejectionReason::UnsupportedProtocolVersion(_) => "unsupported_protocol_version",
         RejectionReason::UnsupportedFeature => "unsupported_feature",
+        RejectionReason::ChainIdMismatch => "chain_id_mismatch",
     }
 }
 
@@ -654,6 +655,18 @@ impl GossipClient {
                         retry_after: None,
                     },
                 )),
+                // A chain-ID mismatch is terminal: the peer is on a different
+                // network and retrying won't help. Surface it as a rejection
+                // (not a retryable request error) so we stop announcing to it.
+                RejectionReason::ChainIdMismatch => Ok(PeerResponse::Rejected(
+                    irys_types::version::RejectedResponse {
+                        reason: irys_types::version::RejectionReason::NetworkMismatch,
+                        message: Some(
+                            "Chain ID mismatch — peer is on a different network".to_string(),
+                        ),
+                        retry_after: None,
+                    },
+                )),
                 _ => Err(GossipClientError::GetRequest(
                     peer.to_string(),
                     format!("Unexpected rejection reason: {:?}", reason),
@@ -714,6 +727,18 @@ impl GossipClient {
                     irys_types::version::RejectedResponse {
                         reason: irys_types::version::RejectionReason::ProtocolMismatch,
                         message: Some("Protocol mismatch".to_string()),
+                        retry_after: None,
+                    },
+                )),
+                // A chain-ID mismatch is terminal: the peer is on a different
+                // network and retrying won't help. Surface it as a rejection
+                // (not a retryable request error) so we stop announcing to it.
+                RejectionReason::ChainIdMismatch => Ok(PeerResponse::Rejected(
+                    irys_types::version::RejectedResponse {
+                        reason: irys_types::version::RejectionReason::NetworkMismatch,
+                        message: Some(
+                            "Chain ID mismatch — peer is on a different network".to_string(),
+                        ),
                         retry_after: None,
                     },
                 )),
@@ -2080,7 +2105,8 @@ impl GossipClient {
                                 errors_by_peer.insert(peer_id, synth);
                             }
                             RejectionReason::InvalidCredentials
-                            | RejectionReason::ProtocolMismatch => {
+                            | RejectionReason::ProtocolMismatch
+                            | RejectionReason::ChainIdMismatch => {
                                 let synth = GossipError::from(
                                     PeerNetworkError::FailedToRequestData(format!(
                                         "Request {:?}: Peer {:?} rejected with {:?}",
@@ -2398,7 +2424,8 @@ impl GossipClient {
                                 round_failures_were_handshake = false;
                             }
                             RejectionReason::InvalidCredentials
-                            | RejectionReason::ProtocolMismatch => {
+                            | RejectionReason::ProtocolMismatch
+                            | RejectionReason::ChainIdMismatch => {
                                 last_error = Some(GossipError::from(
                                     PeerNetworkError::FailedToRequestData(format!(
                                         "{}: Peer {:?} rejected with {:?}",

--- a/crates/p2p/src/gossip_fixture_tests.rs
+++ b/crates/p2p/src/gossip_fixture_tests.rs
@@ -498,6 +498,8 @@ fixture_tests! {
         GossipResponse::<()>::Rejected(RejectionReason::UnsupportedProtocolVersion(99)),
     gossip_response_rejected_unsupported_feature =>
         GossipResponse::<()>::Rejected(RejectionReason::UnsupportedFeature),
+    gossip_response_rejected_chain_id_mismatch =>
+        GossipResponse::<()>::Rejected(RejectionReason::ChainIdMismatch),
 
     // GossipResponse with typed payloads (not just unit)
     gossip_response_accepted_handshake_v1 =>
@@ -682,6 +684,8 @@ assert_fixture_coverage!(
         "gossip_response_rejected_unsupported_protocol_version",
     RejectionReason::UnsupportedFeature =>
         "gossip_response_rejected_unsupported_feature",
+    RejectionReason::ChainIdMismatch =>
+        "gossip_response_rejected_chain_id_mismatch",
 );
 
 assert_fixture_coverage!(

--- a/crates/p2p/src/peer_network_service.rs
+++ b/crates/p2p/src/peer_network_service.rs
@@ -803,7 +803,8 @@ impl PeerNetworkService {
                                 ));
                             }
                             RejectionReason::InvalidCredentials
-                            | RejectionReason::ProtocolMismatch => {
+                            | RejectionReason::ProtocolMismatch
+                            | RejectionReason::ChainIdMismatch => {
                                 last_error = Some(GossipError::PeerNetwork(
                                     PeerNetworkError::FailedToRequestData(format!(
                                         "Peer {:?} rejected data request {:?} with {:?}",

--- a/crates/p2p/src/server.rs
+++ b/crates/p2p/src/server.rs
@@ -1225,6 +1225,18 @@ where
             ));
         }
 
+        // Hard reject peers on a different chain (see the V2 handler for the
+        // rationale): a chain_id mismatch means the peer is on a different
+        // network entirely, so we must never peer with it.
+        let our_chain_id = server.data_handler.config.consensus.chain_id;
+        if version_request.chain_id != our_chain_id {
+            warn!(
+                "Rejecting V1 handshake: chain ID mismatch ours={} theirs={} peer_addr={} mining_address={}",
+                our_chain_id, version_request.chain_id, source_addr, version_request.mining_address,
+            );
+            return HttpResponse::Ok().json(Resp::Rejected(RejectionReason::ChainIdMismatch));
+        }
+
         if !version_request.verify_signature() {
             return HttpResponse::Ok().json(Resp::Rejected(RejectionReason::InvalidCredentials));
         }
@@ -1322,6 +1334,24 @@ where
                     version_request.protocol_version as u32,
                 ),
             ));
+        }
+
+        // Hard reject peers on a different chain. The consensus-config-hash
+        // mismatch logged below is advisory, but a chain_id mismatch means the
+        // peer belongs to a different network entirely — we must never peer
+        // with it. Checked before signature verification because it's a cheap
+        // network-membership gate (like the protocol-version check above).
+        let our_chain_id = server.data_handler.config.consensus.chain_id;
+        if version_request.chain_id != our_chain_id {
+            warn!(
+                "Rejecting V2 handshake: chain ID mismatch ours={} theirs={} peer_addr={} mining_address={} peer_id={}",
+                our_chain_id,
+                version_request.chain_id,
+                source_addr,
+                version_request.mining_address,
+                version_request.peer_id,
+            );
+            return HttpResponse::Ok().json(Resp::Rejected(RejectionReason::ChainIdMismatch));
         }
 
         if !version_request.verify_signature() {

--- a/crates/p2p/src/types.rs
+++ b/crates/p2p/src/types.rs
@@ -352,6 +352,10 @@ pub enum RejectionReason {
     ProtocolMismatch,
     UnsupportedProtocolVersion(u32),
     UnsupportedFeature,
+    /// The requesting peer is on a different chain (`chain_id` mismatch). Unlike
+    /// the advisory consensus-config-hash mismatch, this is a hard handshake
+    /// rejection — we never peer with a node on a different chain.
+    ChainIdMismatch,
 }
 
 const REJECTION_REASON_VARIANTS: &[&str] = &[
@@ -364,6 +368,7 @@ const REJECTION_REASON_VARIANTS: &[&str] = &[
     "ProtocolMismatch",
     "UnsupportedProtocolVersion",
     "UnsupportedFeature",
+    "ChainIdMismatch",
 ];
 
 impl Serialize for RejectionReason {
@@ -408,6 +413,9 @@ impl Serialize for RejectionReason {
             Self::UnsupportedFeature => {
                 serializer.serialize_unit_variant("RejectionReason", 8, "UnsupportedFeature")
             }
+            Self::ChainIdMismatch => {
+                serializer.serialize_unit_variant("RejectionReason", 9, "ChainIdMismatch")
+            }
         }
     }
 }
@@ -435,6 +443,7 @@ impl<'de> Deserialize<'de> for RejectionReason {
                     "InvalidCredentials" => Ok(RejectionReason::InvalidCredentials),
                     "ProtocolMismatch" => Ok(RejectionReason::ProtocolMismatch),
                     "UnsupportedFeature" => Ok(RejectionReason::UnsupportedFeature),
+                    "ChainIdMismatch" => Ok(RejectionReason::ChainIdMismatch),
                     other => Err(E::unknown_variant(other, REJECTION_REASON_VARIANTS)),
                 }
             }
@@ -489,6 +498,10 @@ impl<'de> Deserialize<'de> for RejectionReason {
                     "UnsupportedFeature" => {
                         map.next_value::<serde::de::IgnoredAny>()?;
                         RejectionReason::UnsupportedFeature
+                    }
+                    "ChainIdMismatch" => {
+                        map.next_value::<serde::de::IgnoredAny>()?;
+                        RejectionReason::ChainIdMismatch
                     }
                     other => {
                         return Err(serde::de::Error::unknown_variant(
@@ -610,6 +623,7 @@ mod tests {
             Just(RejectionReason::ProtocolMismatch),
             any::<u32>().prop_map(RejectionReason::UnsupportedProtocolVersion),
             Just(RejectionReason::UnsupportedFeature),
+            Just(RejectionReason::ChainIdMismatch),
         ]
     }
 
@@ -643,6 +657,7 @@ mod tests {
                 RejectionReason::InvalidCredentials => serde_json::json!("InvalidCredentials"),
                 RejectionReason::ProtocolMismatch => serde_json::json!("ProtocolMismatch"),
                 RejectionReason::UnsupportedFeature => serde_json::json!("UnsupportedFeature"),
+                RejectionReason::ChainIdMismatch => serde_json::json!("ChainIdMismatch"),
                 RejectionReason::UnsupportedProtocolVersion(n) => {
                     serde_json::json!({ "UnsupportedProtocolVersion": n })
                 }

--- a/fixtures/gossip_fixtures.json
+++ b/fixtures/gossip_fixtures.json
@@ -203,6 +203,9 @@
       "3chLuAB9CqrCNL42WFwjPLk4GEtr"
     ]
   },
+  "gossip_response_rejected_chain_id_mismatch": {
+    "Rejected": "ChainIdMismatch"
+  },
   "gossip_response_rejected_gossip_disabled": {
     "Rejected": "GossipDisabled"
   },


### PR DESCRIPTION
## What

A handshake declaring a different `chain_id` was previously **accepted** with only an advisory consensus-config-hash mismatch log. This makes the chain-ID mismatch a **hard handshake rejection** — we never peer with a node on a different chain. The consensus-config-hash mismatch stays advisory, as before.

## How

- **Server enforcement** (`server.rs`): both the V1 and V2 handshake handlers reject when `version_request.chain_id != our_chain_id`, checked *before* signature verification as a cheap network-membership gate (like the existing protocol-version check). Logs `ours`/`theirs` for operators.
- **New wire reason** (`types.rs`): a dedicated `RejectionReason::ChainIdMismatch`, kept distinct from `ProtocolMismatch` (a chain mismatch isn't a protocol mismatch) and from the advisory consensus-config-hash check. It serializes as the bare unit string `{"Rejected":"ChainIdMismatch"}` via the existing v1-compat shim.
- **Client handling** (`gossip_client.rs`): when *we* are rejected with `ChainIdMismatch` during our own handshake, it maps to a terminal `NetworkMismatch` rejection rather than a retryable request error — so we stop announcing to a cross-chain peer instead of retry-storming it.

## Backwards compatibility (verified against the Dec-2025 source)

The variant only ever goes on the wire when the peer declared a **different** `chain_id`. A same-chain peer running an older build (e.g. the Dec-2025 V1 endpoint, whose derived deserializer doesn't know the string) declares our `chain_id`, so the new check is a pass-through no-op and it flows through the identical path as before — **it never receives the new variant**. The only peers that see `ChainIdMismatch` are ones we're deliberately refusing because they're on a different chain.

## Test plan

- [x] p2p serde / fixture / coverage tests + proptest (`rejection_reason_serializes_to_v1_wire_form`, `test_all_rejection_reasons_covered`) — pass; `fixtures/gossip_fixtures.json` regenerated
- [x] `peer_discovery` integration test extended with a validly-signed handshake declaring a foreign `chain_id`, asserting `ChainIdMismatch` — pass (real V2 handler, end-to-end)
- [x] `cargo fmt`, `cargo clippy` on `irys-p2p` and `irys-chain-tests` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Peers with a mismatched chain ID are now immediately rejected during handshakes and labeled as "chain_id_mismatch", producing a clear "Chain ID mismatch — peer is on a different network" rejection.

* **Tests**
  * Added tests and fixtures covering chain ID mismatch handling, including validation order (chain ID checked before signature verification) and telemetry/rejection labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->