### PR TITLE
feat(p2p): evict peers on chain_id (network) mismatch handshake rejection

### DIFF
--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -694,6 +694,13 @@ pub fn insert_peer_list_item<T: DbTxMut>(
     Ok(tx.put::<PeerListItems>(*peer_id, inner.into())?)
 }
 
+/// Deletes a peer from the persistent peer list. Returns `true` if a row was
+/// present. Used to evict a peer we can no longer peer with (e.g. a `chain_id`
+/// mismatch surfaced during a handshake) so it is not reloaded on restart.
+pub fn delete_peer_list_item<T: DbTxMut>(tx: &T, peer_id: &IrysPeerId) -> eyre::Result<bool> {
+    Ok(tx.delete::<PeerListItems>(*peer_id, None)?)
+}
+
 /// Gets all ingress proofs associated with a specific data_root
 ///
 pub fn ingress_proofs_by_data_root<TX: DbTx>(
@@ -1085,6 +1092,51 @@ mod tests {
         // check block is retrieved without its chunk
         block_header.poa.chunk = None;
         assert_eq!(result2, block_header);
+        Ok(())
+    }
+
+    #[test]
+    fn delete_peer_list_item_removes_it() -> eyre::Result<()> {
+        use super::{delete_peer_list_item, insert_peer_list_item};
+        use crate::tables::PeerListItems;
+        use reth_db::transaction::DbTx as _;
+
+        let path = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db = open_or_create_db(
+            path.path(),
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing().unwrap(),
+        )
+        .unwrap();
+
+        let peer_id = irys_types::IrysPeerId::from([7_u8; 20]);
+        let peer = irys_types::PeerListItem {
+            peer_id,
+            mining_address: irys_types::IrysAddress::from([7_u8; 20]),
+            reputation_score: irys_types::PeerScore::new(irys_types::PeerScore::INITIAL),
+            response_time: 10,
+            address: irys_types::PeerAddress {
+                gossip: "127.0.0.1:8000".parse().unwrap(),
+                api: "127.0.0.1:9000".parse().unwrap(),
+                execution: irys_types::RethPeerInfo::default(),
+            },
+            last_seen: 0,
+            is_online: true,
+            protocol_version: irys_types::ProtocolVersion::default(),
+        };
+
+        db.update_eyre(|tx| insert_peer_list_item(tx, &peer_id, &peer))?;
+        assert!(
+            db.view_eyre(|tx| Ok(tx.get::<PeerListItems>(peer_id)?.is_some()))?,
+            "peer should be present after insert"
+        );
+
+        let deleted = db.update_eyre(|tx| delete_peer_list_item(tx, &peer_id))?;
+        assert!(deleted, "delete should report the row existed");
+        assert!(
+            db.view_eyre(|tx| Ok(tx.get::<PeerListItems>(peer_id)?.is_none()))?,
+            "peer should be gone after delete"
+        );
         Ok(())
     }
 

--- a/crates/domain/src/models/peer_list.rs
+++ b/crates/domain/src/models/peer_list.rs
@@ -545,6 +545,17 @@ impl PeerList {
             .cloned()
     }
 
+    /// Evict a peer (identified by its API address) from the in-memory cache and
+    /// every lookup index, returning the removed peer if it was present. Used
+    /// when a handshake is rejected on network-membership grounds (e.g. a
+    /// `chain_id` mismatch): the gossip data plane (`check_peer_v*`) trusts cache
+    /// membership, so a peer we can no longer peer with must be removed from the
+    /// cache, not merely left un-handshaked.
+    pub fn remove_peer_by_api_address(&self, api_address: &SocketAddr) -> Option<PeerListItem> {
+        let mut guard = self.0.write().expect("PeerListDataInner lock poisoned");
+        guard.remove_peer_by_api_address(api_address)
+    }
+
     pub fn get_trusted_peer_gossip_address(&self, api_address: SocketAddr) -> Option<SocketAddr> {
         let binding = self.read();
         binding
@@ -987,6 +998,33 @@ impl PeerListDataInner {
         }
     }
 
+    /// Remove a peer from the persistent cache (or purgatory) and every lookup
+    /// map, mirroring the purgatory-eviction cleanup above. Emits `PeerRemoved`.
+    /// Returns the removed peer if it was present.
+    fn remove_peer_by_api_address(&mut self, api_address: &SocketAddr) -> Option<PeerListItem> {
+        let peer_id = *self.api_addr_to_peer_id_map.get(api_address)?;
+        let peer = self
+            .persistent_peers_cache
+            .remove(&peer_id)
+            .or_else(|| self.unstaked_peer_purgatory.pop(&peer_id))?;
+        let mining_addr = peer.mining_address;
+        self.gossip_addr_to_peer_id_map
+            .remove(&peer.address.gossip.ip());
+        self.api_addr_to_peer_id_map.remove(&peer.address.api);
+        self.miner_addr_to_peer_id_map.remove(&mining_addr);
+        self.peer_id_to_miner_addr_map.remove(&peer_id);
+        self.known_peers_cache.remove(&peer.address);
+        debug!(
+            "Evicted peer {:?} (api {:?}) from all caches",
+            peer_id, api_address
+        );
+        self.emit_peer_event(PeerEvent::PeerRemoved {
+            mining_addr,
+            peer: peer.clone(),
+        });
+        Some(peer)
+    }
+
     /// Helper method to update a peer in any cache (persistent or purgatory)
     fn update_peer_in_cache<F>(
         &mut self,
@@ -1397,6 +1435,48 @@ mod tests {
             config,
         };
         PeerList(Arc::new(RwLock::new(peer_list_data)))
+    }
+
+    /// Evicting a staked peer by its API address must clear it from every
+    /// lookup path so the gossip data plane (`check_peer_v*`) stops trusting it.
+    #[test]
+    fn remove_peer_by_api_address_clears_all_lookups() {
+        let peer_list =
+            create_test_peer_list(Config::new_with_random_peer_id(NodeConfig::testing()));
+        let (mining_addr, peer_id, peer) = create_test_peer(1);
+        let api = peer.address.api;
+        peer_list.add_or_update_peer(peer.clone(), true);
+
+        // Sanity: present via every lookup before eviction.
+        assert!(peer_list.peer_by_api_address(api).is_some());
+        assert!(peer_list.get_peer(&peer_id).is_some());
+        assert!(peer_list.peer_by_mining_address(&mining_addr).is_some());
+        assert_eq!(peer_list.peer_count(), 1);
+
+        let removed = peer_list.remove_peer_by_api_address(&api);
+
+        assert_eq!(
+            removed.map(|p| p.peer_id),
+            Some(peer_id),
+            "eviction should return the removed peer"
+        );
+        assert!(
+            peer_list.peer_by_api_address(api).is_none(),
+            "peer must be gone from the api-address index"
+        );
+        assert!(
+            peer_list.get_peer(&peer_id).is_none(),
+            "peer must be gone from the persistent cache"
+        );
+        assert!(
+            peer_list.peer_by_mining_address(&mining_addr).is_none(),
+            "peer must be gone from the mining-address index"
+        );
+        assert!(
+            !peer_list.all_known_peers().contains(&peer.address),
+            "peer must be gone from the known-peers cache"
+        );
+        assert_eq!(peer_list.peer_count(), 0);
     }
 
     mod peer_list_scoring_tests {

--- a/crates/domain/src/models/peer_list.rs
+++ b/crates/domain/src/models/peer_list.rs
@@ -1446,9 +1446,16 @@ mod tests {
         let (mining_addr, peer_id, peer) = create_test_peer(1);
         let api = peer.address.api;
         peer_list.add_or_update_peer(peer.clone(), true);
+        // Subscribe after the add so the only event we observe is the removal.
+        let mut events = peer_list.subscribe_to_peer_events();
 
         // Sanity: present via every lookup before eviction.
         assert!(peer_list.peer_by_api_address(api).is_some());
+        assert!(
+            peer_list
+                .peer_by_gossip_address(peer.address.gossip)
+                .is_some()
+        );
         assert!(peer_list.get_peer(&peer_id).is_some());
         assert!(peer_list.peer_by_mining_address(&mining_addr).is_some());
         assert_eq!(peer_list.peer_count(), 1);
@@ -1476,7 +1483,23 @@ mod tests {
             !peer_list.all_known_peers().contains(&peer.address),
             "peer must be gone from the known-peers cache"
         );
+        assert!(
+            peer_list
+                .peer_by_gossip_address(peer.address.gossip)
+                .is_none(),
+            "peer must be gone from the gossip-address index"
+        );
         assert_eq!(peer_list.peer_count(), 0);
+
+        match events.try_recv() {
+            Ok(PeerEvent::PeerRemoved {
+                peer: removed_peer, ..
+            }) => assert_eq!(
+                removed_peer.peer_id, peer_id,
+                "PeerRemoved must carry the evicted peer"
+            ),
+            other => panic!("expected a PeerRemoved event, got {other:?}"),
+        }
     }
 
     mod peer_list_scoring_tests {

--- a/crates/p2p/src/peer_network_service.rs
+++ b/crates/p2p/src/peer_network_service.rs
@@ -243,7 +243,7 @@ impl PeerNetworkServiceInner {
         };
 
         let persistable_peers = self.peer_list.persistable_peers_with_mining_addr();
-        let _ = db
+        let result = db
             .update_scoped(|tx| {
                 for (peer_id, peer) in persistable_peers.iter() {
                     // A peer staged for removal must not be re-persisted from a
@@ -258,9 +258,16 @@ impl PeerNetworkServiceInner {
                 }
                 Ok::<(), PeerListServiceError>(())
             })
-            .map_err(PeerListServiceError::Database)?;
+            .map_err(PeerListServiceError::Database)
+            .and_then(|inner| inner);
 
-        Ok(())
+        // A failed flush must not silently drop staged removals: re-stage them
+        // (merge, so evictions staged during the lock-free write survive) for the
+        // next flush to retry. Deletes are idempotent.
+        if result.is_err() {
+            self.state.lock().await.pending_db_removals.extend(removals);
+        }
+        result
     }
 
     fn increase_peer_score(&self, peer_id: &IrysPeerId, reason: ScoreIncreaseReason) {

--- a/crates/p2p/src/peer_network_service.rs
+++ b/crates/p2p/src/peer_network_service.rs
@@ -3,8 +3,8 @@ use crate::{GossipClient, GossipError, gossip_client::GossipClientError};
 use eyre::{Report, Result as EyreResult};
 use futures::{StreamExt as _, future::BoxFuture, stream::FuturesUnordered};
 use irys_database::db::IrysDatabaseExt as _;
-use irys_database::insert_peer_list_item;
 use irys_database::reth_db::DatabaseError;
+use irys_database::{delete_peer_list_item, insert_peer_list_item};
 use irys_domain::{PeerEvent, PeerList, ScoreDecreaseReason, ScoreIncreaseReason};
 use irys_types::v2::GossipDataRequestV2;
 use irys_types::{
@@ -1081,10 +1081,56 @@ impl PeerNetworkService {
                 }
                 Ok(())
             }
-            PeerResponse::Rejected(rejected_response) => Err(
-                PeerListServiceError::PeerHandshakeRejected(rejected_response),
-            ),
+            PeerResponse::Rejected(rejected_response) => {
+                // A chain_id mismatch (mapped to NetworkMismatch) means the peer
+                // is on a different network. The gossip data plane trusts cache
+                // membership, not handshake outcome, so we must evict the peer
+                // rather than leave it cached and trusted.
+                let db = inner.state.lock().await.db.clone();
+                evict_peer_on_network_mismatch(&peer_list, &db, api_address, &rejected_response);
+                Err(PeerListServiceError::PeerHandshakeRejected(
+                    rejected_response,
+                ))
+            }
         }
+    }
+}
+
+/// On a terminal network-membership rejection (a `chain_id` mismatch is surfaced
+/// as [`RejectionReason::NetworkMismatch`]), evict the peer from the in-memory
+/// cache and the persistent DB. The gossip data plane (`check_peer_v*`) trusts
+/// cache membership rather than handshake outcome, so a peer we can no longer
+/// peer with must be removed from the cache — not merely left un-handshaked.
+/// No-op for any other rejection reason.
+fn evict_peer_on_network_mismatch(
+    peer_list: &PeerList,
+    db: &DatabaseProvider,
+    api_address: SocketAddr,
+    rejected: &RejectedResponse,
+) {
+    if !matches!(
+        rejected.reason,
+        irys_types::version::RejectionReason::NetworkMismatch
+    ) {
+        return;
+    }
+    let Some(removed) = peer_list.remove_peer_by_api_address(&api_address) else {
+        return;
+    };
+    warn!(
+        "Evicted peer {} (mining {}) after its handshake was rejected with NetworkMismatch",
+        api_address, removed.mining_address
+    );
+    match db.update_scoped(|tx| delete_peer_list_item(tx, &removed.peer_id)) {
+        Ok(Ok(_)) => {}
+        Ok(Err(err)) => warn!(
+            "Failed to delete evicted peer {} from the peer DB: {:?}",
+            api_address, err
+        ),
+        Err(err) => warn!(
+            "DB transaction failed deleting evicted peer {}: {:?}",
+            api_address, err
+        ),
     }
 }
 
@@ -1243,6 +1289,92 @@ mod tests {
         fn peer_list(&self) -> PeerList {
             self.inner.peer_list()
         }
+    }
+
+    fn build_peer_list(config: &Config, db: &DatabaseProvider) -> PeerList {
+        let (sender, _receiver) = PeerNetworkSender::new_with_receiver();
+        PeerList::new(
+            config,
+            db,
+            sender,
+            tokio::sync::broadcast::channel::<irys_domain::PeerEvent>(100).0,
+        )
+        .expect("peer list")
+    }
+
+    #[test]
+    async fn network_mismatch_rejection_evicts_peer_from_cache_and_db() {
+        use irys_database::reth_db::transaction::DbTx as _;
+
+        let temp_dir = TempDirBuilder::new().build();
+        let config = Config::new_with_random_peer_id(NodeConfig::testing());
+        let db = open_db(temp_dir.path());
+        let peer_list = build_peer_list(&config, &db);
+
+        let (_mining, peer) = create_test_peer(
+            "0x1234567890123456789012345678901234567890",
+            8080,
+            true,
+            None,
+        );
+        let peer_id = peer.peer_id;
+        let api = peer.address.api;
+        peer_list.add_or_update_peer(peer.clone(), true);
+        db.update_scoped(|tx| insert_peer_list_item(tx, &peer_id, &peer))
+            .expect("db tx")
+            .expect("insert peer");
+
+        assert!(peer_list.peer_by_api_address(api).is_some());
+        assert!(
+            db.view_eyre(|tx| Ok(tx.get::<PeerListItems>(peer_id)?.is_some()))
+                .unwrap()
+        );
+
+        let rejected = RejectedResponse {
+            reason: irys_types::version::RejectionReason::NetworkMismatch,
+            message: None,
+            retry_after: None,
+        };
+        evict_peer_on_network_mismatch(&peer_list, &db, api, &rejected);
+
+        assert!(
+            peer_list.peer_by_api_address(api).is_none(),
+            "chain/network-mismatch rejection should evict the peer from the cache"
+        );
+        assert!(
+            db.view_eyre(|tx| Ok(tx.get::<PeerListItems>(peer_id)?.is_none()))
+                .unwrap(),
+            "chain/network-mismatch rejection should delete the peer from the DB"
+        );
+    }
+
+    #[test]
+    async fn non_network_rejection_retains_peer() {
+        let temp_dir = TempDirBuilder::new().build();
+        let config = Config::new_with_random_peer_id(NodeConfig::testing());
+        let db = open_db(temp_dir.path());
+        let peer_list = build_peer_list(&config, &db);
+
+        let (_mining, peer) = create_test_peer(
+            "0x1234567890123456789012345678901234567890",
+            8080,
+            true,
+            None,
+        );
+        let api = peer.address.api;
+        peer_list.add_or_update_peer(peer, true);
+
+        let rejected = RejectedResponse {
+            reason: irys_types::version::RejectionReason::InternalError,
+            message: None,
+            retry_after: None,
+        };
+        evict_peer_on_network_mismatch(&peer_list, &db, api, &rejected);
+
+        assert!(
+            peer_list.peer_by_api_address(api).is_some(),
+            "a non-network rejection must not evict the peer"
+        );
     }
 
     #[test]

--- a/crates/p2p/src/peer_network_service.rs
+++ b/crates/p2p/src/peer_network_service.rs
@@ -234,15 +234,23 @@ impl PeerNetworkServiceInner {
         // set and applies removals staged by `evict_peer_on_network_mismatch`.
         // Doing the delete here (rather than in a standalone transaction) keeps
         // it from racing with the snapshot insert below and resurrecting a peer.
-        let (db, removals) = {
+        //
+        // Snapshot the peers and drain the staged removals under the *same* state
+        // lock so the two are mutually consistent. Evictions also serialize on
+        // this lock (see the handshake-rejection path), so flush never observes a
+        // half-applied eviction — a peer removed from the cache but whose delete
+        // is not yet staged, or vice versa. The lock is released before the
+        // lock-free DB write; an eviction landing during that write can still
+        // re-persist a peer for one flush cycle, which is benign: the in-memory
+        // eviction is already in effect and the next flush deletes it.
+        let (db, persistable_peers, removals) = {
             let mut state = self.state.lock().await;
-            (
-                state.db.clone(),
-                std::mem::take(&mut state.pending_db_removals),
-            )
+            let db = state.db.clone();
+            let persistable_peers = self.peer_list.persistable_peers_with_mining_addr();
+            let removals = std::mem::take(&mut state.pending_db_removals);
+            (db, persistable_peers, removals)
         };
 
-        let persistable_peers = self.peer_list.persistable_peers_with_mining_addr();
         let result = db
             .update_scoped(|tx| {
                 for (peer_id, peer) in persistable_peers.iter() {
@@ -1116,10 +1124,17 @@ impl PeerNetworkService {
                 // rather than leave it cached and trusted. The DB delete is
                 // staged for `flush` (the sole peer-DB writer) so it cannot race
                 // with the snapshot insert and resurrect the peer.
-                if let Some(peer_id) =
-                    evict_peer_on_network_mismatch(&peer_list, api_address, &rejected_response)
+                //
+                // Remove from the cache and stage the delete under the same state
+                // lock `flush` takes, so flush never observes a half-applied
+                // eviction (cache-removed but not staged, or vice versa).
                 {
-                    inner.state.lock().await.pending_db_removals.insert(peer_id);
+                    let mut state = inner.state.lock().await;
+                    if let Some(peer_id) =
+                        evict_peer_on_network_mismatch(&peer_list, api_address, &rejected_response)
+                    {
+                        state.pending_db_removals.insert(peer_id);
+                    }
                 }
                 Err(PeerListServiceError::PeerHandshakeRejected(
                     rejected_response,

--- a/crates/p2p/src/peer_network_service.rs
+++ b/crates/p2p/src/peer_network_service.rs
@@ -58,6 +58,11 @@ struct PeerNetworkServiceState {
     currently_running_announcements: HashSet<SocketAddr>,
     successful_announcements: Cache<SocketAddr, AnnouncementFinishedMessage>,
     failed_announcements: HashMap<SocketAddr, AnnouncementFinishedMessage>,
+    /// Peers evicted on a chain/network mismatch, staged for deletion by the
+    /// next `flush`. Routing the delete through `flush` (the sole peer-DB
+    /// writer) keeps it from racing with the snapshot insert and resurrecting
+    /// the peer.
+    pending_db_removals: HashSet<IrysPeerId>,
     gossip_client: GossipClient,
     chain_id: u64,
     peer_address: PeerAddress,
@@ -199,6 +204,7 @@ impl PeerNetworkServiceInner {
                 .time_to_live(SUCCESSFUL_ANNOUNCEMENT_CACHE_TTL)
                 .build(),
             failed_announcements: HashMap::new(),
+            pending_db_removals: HashSet::new(),
             gossip_client: GossipClient::new(
                 Duration::from_secs(5),
                 config.node_config.miner_address(),
@@ -224,16 +230,31 @@ impl PeerNetworkServiceInner {
     }
 
     async fn flush(&self) -> Result<(), PeerListServiceError> {
-        let db = {
-            let state = self.state.lock().await;
-            state.db.clone()
+        // `flush` is the sole peer-DB writer: it both persists the current peer
+        // set and applies removals staged by `evict_peer_on_network_mismatch`.
+        // Doing the delete here (rather than in a standalone transaction) keeps
+        // it from racing with the snapshot insert below and resurrecting a peer.
+        let (db, removals) = {
+            let mut state = self.state.lock().await;
+            (
+                state.db.clone(),
+                std::mem::take(&mut state.pending_db_removals),
+            )
         };
 
         let persistable_peers = self.peer_list.persistable_peers_with_mining_addr();
         let _ = db
             .update_scoped(|tx| {
                 for (peer_id, peer) in persistable_peers.iter() {
+                    // A peer staged for removal must not be re-persisted from a
+                    // snapshot that predated its eviction.
+                    if removals.contains(peer_id) {
+                        continue;
+                    }
                     insert_peer_list_item(tx, peer_id, peer).map_err(PeerListServiceError::from)?;
+                }
+                for peer_id in &removals {
+                    delete_peer_list_item(tx, peer_id).map_err(PeerListServiceError::from)?;
                 }
                 Ok::<(), PeerListServiceError>(())
             })
@@ -1085,9 +1106,14 @@ impl PeerNetworkService {
                 // A chain_id mismatch (mapped to NetworkMismatch) means the peer
                 // is on a different network. The gossip data plane trusts cache
                 // membership, not handshake outcome, so we must evict the peer
-                // rather than leave it cached and trusted.
-                let db = inner.state.lock().await.db.clone();
-                evict_peer_on_network_mismatch(&peer_list, &db, api_address, &rejected_response);
+                // rather than leave it cached and trusted. The DB delete is
+                // staged for `flush` (the sole peer-DB writer) so it cannot race
+                // with the snapshot insert and resurrect the peer.
+                if let Some(peer_id) =
+                    evict_peer_on_network_mismatch(&peer_list, api_address, &rejected_response)
+                {
+                    inner.state.lock().await.pending_db_removals.insert(peer_id);
+                }
                 Err(PeerListServiceError::PeerHandshakeRejected(
                     rejected_response,
                 ))
@@ -1098,40 +1124,29 @@ impl PeerNetworkService {
 
 /// On a terminal network-membership rejection (a `chain_id` mismatch is surfaced
 /// as [`RejectionReason::NetworkMismatch`]), evict the peer from the in-memory
-/// cache and the persistent DB. The gossip data plane (`check_peer_v*`) trusts
-/// cache membership rather than handshake outcome, so a peer we can no longer
-/// peer with must be removed from the cache — not merely left un-handshaked.
-/// No-op for any other rejection reason.
+/// cache and return its id so the caller can stage it for deletion by `flush`.
+/// The gossip data plane (`check_peer_v*`) trusts cache membership rather than
+/// handshake outcome, so a peer we can no longer peer with must be removed from
+/// the cache — not merely left un-handshaked. The DB delete is deferred to
+/// `flush` (the sole peer-DB writer) so it cannot race with the snapshot insert
+/// and resurrect the peer. Returns `None` for any other rejection reason.
 fn evict_peer_on_network_mismatch(
     peer_list: &PeerList,
-    db: &DatabaseProvider,
     api_address: SocketAddr,
     rejected: &RejectedResponse,
-) {
+) -> Option<IrysPeerId> {
     if !matches!(
         rejected.reason,
         irys_types::version::RejectionReason::NetworkMismatch
     ) {
-        return;
+        return None;
     }
-    let Some(removed) = peer_list.remove_peer_by_api_address(&api_address) else {
-        return;
-    };
+    let removed = peer_list.remove_peer_by_api_address(&api_address)?;
     warn!(
         "Evicted peer {} (mining {}) after its handshake was rejected with NetworkMismatch",
         api_address, removed.mining_address
     );
-    match db.update_scoped(|tx| delete_peer_list_item(tx, &removed.peer_id)) {
-        Ok(Ok(_)) => {}
-        Ok(Err(err)) => warn!(
-            "Failed to delete evicted peer {} from the peer DB: {:?}",
-            api_address, err
-        ),
-        Err(err) => warn!(
-            "DB transaction failed deleting evicted peer {}: {:?}",
-            api_address, err
-        ),
-    }
+    Some(removed.peer_id)
 }
 
 pub fn spawn_peer_network_service(
@@ -1303,9 +1318,7 @@ mod tests {
     }
 
     #[test]
-    async fn network_mismatch_rejection_evicts_peer_from_cache_and_db() {
-        use irys_database::reth_db::transaction::DbTx as _;
-
+    async fn network_mismatch_rejection_evicts_from_cache_and_returns_id() {
         let temp_dir = TempDirBuilder::new().build();
         let config = Config::new_with_random_peer_id(NodeConfig::testing());
         let db = open_db(temp_dir.path());
@@ -1319,32 +1332,24 @@ mod tests {
         );
         let peer_id = peer.peer_id;
         let api = peer.address.api;
-        peer_list.add_or_update_peer(peer.clone(), true);
-        db.update_scoped(|tx| insert_peer_list_item(tx, &peer_id, &peer))
-            .expect("db tx")
-            .expect("insert peer");
-
+        peer_list.add_or_update_peer(peer, true);
         assert!(peer_list.peer_by_api_address(api).is_some());
-        assert!(
-            db.view_eyre(|tx| Ok(tx.get::<PeerListItems>(peer_id)?.is_some()))
-                .unwrap()
-        );
 
         let rejected = RejectedResponse {
             reason: irys_types::version::RejectionReason::NetworkMismatch,
             message: None,
             retry_after: None,
         };
-        evict_peer_on_network_mismatch(&peer_list, &db, api, &rejected);
+        let evicted = evict_peer_on_network_mismatch(&peer_list, api, &rejected);
 
-        assert!(
-            peer_list.peer_by_api_address(api).is_none(),
-            "chain/network-mismatch rejection should evict the peer from the cache"
+        assert_eq!(
+            evicted,
+            Some(peer_id),
+            "a chain/network-mismatch rejection should evict the peer and return its id for staged DB removal"
         );
         assert!(
-            db.view_eyre(|tx| Ok(tx.get::<PeerListItems>(peer_id)?.is_none()))
-                .unwrap(),
-            "chain/network-mismatch rejection should delete the peer from the DB"
+            peer_list.peer_by_api_address(api).is_none(),
+            "the peer should be removed from the cache"
         );
     }
 
@@ -1369,11 +1374,57 @@ mod tests {
             message: None,
             retry_after: None,
         };
-        evict_peer_on_network_mismatch(&peer_list, &db, api, &rejected);
+        let evicted = evict_peer_on_network_mismatch(&peer_list, api, &rejected);
 
         assert!(
-            peer_list.peer_by_api_address(api).is_some(),
+            evicted.is_none(),
             "a non-network rejection must not evict the peer"
+        );
+        assert!(
+            peer_list.peer_by_api_address(api).is_some(),
+            "a non-network rejection must not evict the peer from the cache"
+        );
+    }
+
+    #[test]
+    async fn flush_deletes_pending_removals_without_resurrecting() {
+        use irys_database::reth_db::transaction::DbTx as _;
+
+        let temp_dir = TempDirBuilder::new().build();
+        let config = Config::new_with_random_peer_id(NodeConfig::testing());
+        let harness = TestHarness::new(temp_dir.path(), config);
+        let peer_list = harness.peer_list();
+        let db = harness.inner.state.lock().await.db.clone();
+
+        let (_mining, peer) = create_test_peer(
+            "0x1234567890123456789012345678901234567890",
+            8080,
+            true,
+            None,
+        );
+        let peer_id = peer.peer_id;
+        // The peer is still in the cache (so the flush snapshot includes it) and
+        // also staged for removal — exactly the race where an eviction lands
+        // after the snapshot is taken but before the write. Flush must delete it,
+        // not resurrect it from the snapshot.
+        peer_list.add_or_update_peer(peer.clone(), true);
+        db.update_scoped(|tx| insert_peer_list_item(tx, &peer_id, &peer))
+            .expect("db tx")
+            .expect("insert peer");
+        harness
+            .inner
+            .state
+            .lock()
+            .await
+            .pending_db_removals
+            .insert(peer_id);
+
+        harness.inner.flush().await.expect("flush");
+
+        assert!(
+            db.view_eyre(|tx| Ok(tx.get::<PeerListItems>(peer_id)?.is_none()))
+                .unwrap(),
+            "a peer staged for removal must be deleted by flush and not re-inserted from the snapshot"
         );
     }
 

--- a/crates/p2p/src/peer_network_service.rs
+++ b/crates/p2p/src/peer_network_service.rs
@@ -1045,19 +1045,13 @@ impl PeerNetworkService {
             PeerListServiceError::PostVersionError(e.to_string())
         });
 
+        // A transport-level Ok still carries either an Accepted or a Rejected
+        // handshake; only an Accepted is a real success. Defer the
+        // success/failure `AnnouncementFinished` notification to the match below
+        // so a rejection (e.g. NetworkMismatch) is never recorded in
+        // `successful_announcements`.
         let peer_response = match peer_response_result {
-            Ok(peer_response) => {
-                send_message_and_log_error(
-                    &sender,
-                    PeerNetworkServiceMessage::AnnouncementFinished(AnnouncementFinishedMessage {
-                        peer_api_address: api_address,
-                        peer_gossip_address: gossip_address,
-                        success: true,
-                        retry: false,
-                    }),
-                );
-                Ok(peer_response)
-            }
+            Ok(peer_response) => peer_response,
             Err(error) => {
                 debug!(
                     "Retrying to announce yourself to address {}: {:?}",
@@ -1072,12 +1066,23 @@ impl PeerNetworkService {
                         retry: true,
                     }),
                 );
-                Err(error)
+                return Err(error);
             }
-        }?;
+        };
 
         match peer_response {
             PeerResponse::Accepted(mut accepted_peers) => {
+                // An accepted handshake is the only real success.
+                send_message_and_log_error(
+                    &sender,
+                    PeerNetworkServiceMessage::AnnouncementFinished(AnnouncementFinishedMessage {
+                        peer_api_address: api_address,
+                        peer_gossip_address: gossip_address,
+                        success: true,
+                        retry: false,
+                    }),
+                );
+
                 // Only log mismatch if the version is not V1 - V1 peers have zero hash
                 if protocol_version != ProtocolVersion::V1 {
                     let our_hash = inner.state.lock().await.config.consensus.keccak256_hash();
@@ -1118,6 +1123,20 @@ impl PeerNetworkService {
                 Ok(())
             }
             PeerResponse::Rejected(rejected_response) => {
+                // A rejection is a terminal failure, not a success: report it so
+                // it is not cached in `successful_announcements` (which would
+                // suppress future announce attempts as if it had succeeded).
+                // retry=false because re-announcing won't change the peer's mind.
+                send_message_and_log_error(
+                    &sender,
+                    PeerNetworkServiceMessage::AnnouncementFinished(AnnouncementFinishedMessage {
+                        peer_api_address: api_address,
+                        peer_gossip_address: gossip_address,
+                        success: false,
+                        retry: false,
+                    }),
+                );
+
                 // A chain_id mismatch (mapped to NetworkMismatch) means the peer
                 // is on a different network. The gossip data plane trusts cache
                 // membership, not handshake outcome, so we must evict the peer

--- a/docs/superpowers/specs/2026-06-02-gossip-handshake-enforcement-design.md
+++ b/docs/superpowers/specs/2026-06-02-gossip-handshake-enforcement-design.md
@@ -1,0 +1,221 @@
+# Gossip handshake enforcement & chain_id isolation
+
+**Date:** 2026-06-02
+**Status:** Near-term fix implemented (evict-on-rejection); larger follow-up scoped, pending plan
+
+## Problem
+
+PR #1435 (commit `12614c191`) added a hard chain_id rejection to the V1/V2
+handshake handlers: a handshake declaring a different `chain_id` is rejected
+before signature verification. The intent was to prevent a node from peering
+with a different network.
+
+In testing on devnet, a node configured for a different chain **kept
+communicating with the network anyway**. Investigation shows why: the chain_id
+gate lives **only in the handshake handler**, but on the current stateless-HTTP
+gossip plane the handshake is not on the critical path for data exchange once a
+peer is known.
+
+### Root cause (verified)
+
+1. **Data routes gate on cache-membership, not on a handshake.** Every gossip
+   data handler funnels through exactly three origin chokepoints:
+   - `check_peer_v1_reason` (`crates/p2p/src/server.rs:176`)
+   - `check_peer_v2` (`crates/p2p/src/server.rs:229`)
+   - `compute_health_check` (`crates/p2p/src/server.rs:1067`)
+
+   All three authorize purely on *"is this peer in my cache + does the source IP
+   match its stored gossip IP (+ peer_id for v2)"*. None checks `chain_id`, and
+   none requires that a handshake occurred in the current process lifetime. (Block,
+   tx, commitment, ingress-proof, and chunk routes all call `check_peer_v1/v2` —
+   e.g. chunk at `server.rs:134`.)
+
+2. **Cache membership is durable across restarts.** Staked peers are persisted to
+   the DB (`insert_peer_list_item`, `crates/p2p/src/peer_network_service.rs:232`)
+   and reloaded at startup by `PeerList::new`
+   (`crates/domain/src/models/peer_list.rs:92`, via `walk_all::<PeerListItems>`),
+   with `is_online` restored verbatim (`from_inner`,
+   `crates/types/src/peer_list.rs:171`).
+
+The combination: a peer learned once (on a previous run, when both sides were on
+the correct chain) returns as known + online with **zero handshakes**, and the
+data plane accepts it forever. The chain_id check only guards *new* handshakes,
+which never re-run for a cached peer. That is why a node whose `chain_id` was
+changed kept talking to its previously-cached peers.
+
+### Asymmetry (verified)
+
+The chain_id check validates the chain_id of whoever **POSTs** the handshake —
+the receiver checks the sender. In the outbound announce path
+(`announce_yourself_to_address`, `crates/p2p/src/peer_network_service.rs:1043`)
+we POST our handshake and consume their `Accepted` response, which carries **no
+chain_id** (`HandshakeResponseV2`, `crates/types/src/version.rs:380`). So we
+never verify the *responder's* chain. Inbound is protected; outbound pulls from
+an already-cached foreign peer are not.
+
+### What the V2 gossip protocol authenticates today
+
+| Message | Authenticated? | Carries chain_id? |
+|---|---|---|
+| `HandshakeRequestV2` (`version.rs:125`) | Yes — signed over RLP of all fields incl. `chain_id`, `peer_id`, `consensus_config_hash`; verified against `mining_address` | Yes (hard-checked, #1435) |
+| `HandshakeResponseV2` (`version.rs:380`) | **No** — no signature, no responder identity, no `chain_id` | **No** |
+| `GossipRequestV2<T>` envelope (`gossip.rs:480`) | Envelope: source-IP-bound only. Payload: self-signed downstream (block/tx sigs) | n/a |
+
+The protocol authenticates the **initiator to the responder, but never the
+responder to the initiator**.
+
+## Near-term fix (chosen): evict peers on chain-rejection
+
+Scope: close the chain_id-isolation bug with no persistence and no wire change.
+Decision basis: the devnet under test is **fully on the #1435 build**, so we can
+rely on peers enforcing the chain_id check — a foreign node's announce is rejected
+by every (upgraded) peer.
+
+### Why "just re-handshake on startup" is not enough by itself
+
+The node already re-handshakes every cached peer at startup
+(`spawn_announce_yourself_to_all_peers_task`,
+`crates/p2p/src/peer_network_service.rs:300`). The gap is that the rejection is
+discarded: a terminal chain rejection (`ChainIdMismatch` → `NetworkMismatch`)
+lands in `handle_announcement_finished`'s terminal branch
+(`peer_network_service.rs:604`), which only inserts into `failed_announcements` —
+a map that is **written but never read** (`:605`, single usage). The data plane
+(`check_peer_v1/v2`) never consults handshake outcome; it trusts cache membership
++ IP. So a rejected peer stays fully trusted. The fix is to make the rejection
+*evict* the peer.
+
+### Design
+
+1. Add an in-memory eviction primitive that removes a peer from the cache,
+   mirroring the existing purgatory-eviction map cleanup
+   (`crates/domain/src/models/peer_list.rs:976-986`): drop from
+   `persistent_peers_cache`/purgatory and the
+   `gossip`/`api`/`miner`/`peer_id`/`known_peers` index maps; emit
+   `PeerEvent::PeerRemoved`. Expose `PeerList::remove_peer_by_api_address`.
+2. Add `delete_peer_list_item(tx, peer_id)` to `irys-database` (mirror of
+   `insert_peer_list_item`, using `tx.delete::<PeerListItems>`).
+3. At the outbound-announce rejection site (`announce_yourself_to_address`, the
+   `PeerResponse::Rejected` arm, `peer_network_service.rs:1084`): when
+   `rejected_response.reason == version::RejectionReason::NetworkMismatch`, evict
+   the peer from the cache (`remove_peer_by_api_address`) and delete it from the
+   DB (via `inner`'s `DatabaseProvider`, using the `flush`-style
+   `db.update_scoped`), then return the existing error.
+4. Inbound ("we reject them") is already correct: #1435 returns `ChainIdMismatch`
+   *before* `add_or_update_peer`, so a foreign peer is never added. A cached
+   foreign peer cannot occur on a fully-upgraded network, so inbound eviction is
+   omitted as unnecessary.
+
+### Behavior
+
+- Foreign-chain node restart: re-announces to all cached peers → every upgraded
+  peer rejects with `ChainIdMismatch` → node evicts each from cache + DB → empty
+  peer set → isolated. Subsequent gossip/pulls have no peers to talk to.
+
+### Limitations (accepted)
+
+- Relies on peers enforcing #1435. Against an unupgraded peer (none on this
+  devnet) there is no rejection to trigger eviction. The self-enforcing variants
+  (per-peer stored `chain_id`, or `chain_id` in the handshake response) remain
+  available if the network is ever mixed-version — see the follow-up section.
+- Small startup window: between DB load and the announce round completing, the
+  data plane trusts cached peers. Accepted; cross-chain data fails consensus
+  validation downstream regardless.
+
+### Size
+
+~50–70 LOC (eviction primitive + DB delete + one wiring arm) + tests. No wire
+change, no persistence.
+
+### Limitations (why this is "for now")
+
+- Does **not** make the protocol "always require a handshake to set up a
+  connection." A still-running peer that has us cached from before keeps serving
+  us until *it* restarts; the data plane still trusts cache membership.
+- Does not close the outbound asymmetry in general (only the persisted-peer
+  instance of it).
+
+## Follow-up (larger): enforce a session handshake + authenticate the response
+
+This is the real fix for the invariant *"our networking protocol should always
+require a handshake to set up a connection"*, and the bridge to the planned
+stateful-socket model (where the handshake literally establishes the socket and
+must mutually authenticate both ends). Because Part B changes the
+`HandshakeResponseV2` wire format, this is the right window to fix the response's
+authentication gap at the same time — retrofitting it later is another
+coordinated protocol change.
+
+### Part A — session-scoped handshake gate
+
+- Add an in-memory `session_handshaked: HashSet<IrysPeerId>` to
+  `PeerListDataInner` — **never persisted** (a restart must force re-handshake;
+  that is the point).
+- Set it in `handle_handshake_v1`/`v2` right after `add_or_update_peer`
+  (`server.rs:1279` / V2 equivalent) — i.e. *after* chain_id + signature pass, so
+  only valid same-chain peers are flagged.
+- Gate the three origin chokepoints (`check_peer_v1_reason`, `check_peer_v2`,
+  `compute_health_check`): require cache-membership **and** session-handshaked,
+  else return `HandshakeRequired(SessionHandshakeRequired)` (new diagnostic
+  variant).
+- **No new client recovery needed.** Clients already react to `HandshakeRequired`
+  with `initiate_handshake(force=true)` + retry (`gossip_client.rs:952, 1846,
+  2037, 2378`; wait-then-retry loop `:2165/2465`). A restart yields one
+  `HandshakeRequired` per peer, a re-handshake, then resumption.
+
+Part A alone fully closes the realistic threat (a genuinely foreign node trying
+to join a patched network) in **both** directions, because the gate forces the
+joining node to handshake — proving its chain — before any data flows.
+
+### Part B′ — authenticate the handshake response (subsumes the chain_id fix)
+
+The narrow "add chain_id to the response" fix is a symptom of the response being
+anonymous and unauthenticated. Fix the larger gap:
+
+- Add to `HandshakeResponseV2`: `mining_address`, `peer_id`, `chain_id`, and a
+  `signature` — and bind it to *this* handshake by signing over the initiator's
+  request `signature_hash` (or a request nonce) to prevent replay by an on-path
+  attacker.
+- Responder signs with its mining key (same scheme as the request).
+- Announcer (`peer_network_service.rs:1043`) verifies: signature valid → responder
+  identity matches what we expected for that address → `chain_id == ours`. Any
+  failure ⇒ don't mark success, drop/blocklist.
+- **Back-compat:** old V2 peers send the legacy (unsigned, no-chain_id) response;
+  treat absent fields as "legacy, unverifiable" and fall back to today's advisory
+  behavior — the same posture #1435 used for `ChainIdMismatch`. Stays
+  additive-within-V2 with graceful degradation, unless we decide to *require*
+  authenticated responses (then it becomes a V3 negotiation gate).
+
+This yields mutual authentication — the primitive the stateful-socket migration
+needs — and independently closes the outbound chain asymmetry regardless of the
+counterparty's patch state.
+
+### Size (follow-up)
+
+- Part A: ~60–90 LOC + ~100 LOC tests. Contained.
+- Part B′: ~80–140 LOC — response fields + an `encode_for_signing` for the
+  response + sign/verify + back-compat-absent decode + announce-side verify/drop +
+  request-binding nonce + round-trip/back-compat tests. The only part with
+  wire-format + signing risk; the part most needing care since the protocol window
+  is rare.
+
+## Tier-3 hardening (cheap, fold into whichever change ships)
+
+- **Origin-check `handle_stake_and_pledge_whitelist`** (`server.rs:1134` →
+  `gossip_data_handler.rs:986`). It currently returns the node's stake/pledge
+  whitelist to any unauthenticated caller with no `check_peer` gate and no rate
+  limit. **Low severity** — the data is largely on-chain public (the only nuance:
+  it may include mempool-pending entries). The fix is about *consistency* (every
+  other `/gossip/*` route requires a handshaked peer; this one silently does not)
+  and removing a free unauthenticated probe/DoS surface. Non-wire, trivial.
+- **`consensus_config_hash` policy.** Today a mismatch is advisory (logged only,
+  `peer_network_service.rs:1047`). Recommendation: at most a *soft* gate (score
+  penalty), **not** a hard reject — a hard reject risks partitioning the network on
+  benign config drift during rolling upgrades.
+
+## Deferred / explicitly speculative (not now)
+
+- Session-id / nonce negotiation for the socket layer — wait until the socket work
+  defines its needs; adding unused fields now is speculative.
+- Per-message gossip-envelope signatures — payloads are already self-authenticating
+  and relay identity is IP-bound; not worth the cost.
+- A genesis/network-fingerprint field beyond `chain_id` (two networks can share a
+  `chain_id`) — revisit only if real deployments collide on `chain_id`.

--- a/docs/superpowers/specs/2026-06-02-gossip-handshake-enforcement-design.md
+++ b/docs/superpowers/specs/2026-06-02-gossip-handshake-enforcement-design.md
@@ -95,11 +95,14 @@ a map that is **written but never read** (`:605`, single usage). The data plane
 2. Add `delete_peer_list_item(tx, peer_id)` to `irys-database` (mirror of
    `insert_peer_list_item`, using `tx.delete::<PeerListItems>`).
 3. At the outbound-announce rejection site (`announce_yourself_to_address`, the
-   `PeerResponse::Rejected` arm, `peer_network_service.rs:1084`): when
-   `rejected_response.reason == version::RejectionReason::NetworkMismatch`, evict
-   the peer from the cache (`remove_peer_by_api_address`) and delete it from the
-   DB (via `inner`'s `DatabaseProvider`, using the `flush`-style
-   `db.update_scoped`), then return the existing error.
+   `PeerResponse::Rejected` arm): when `rejected_response.reason ==
+   version::RejectionReason::NetworkMismatch`, evict the peer from the in-memory
+   cache (`remove_peer_by_api_address`) and **stage its id in
+   `pending_db_removals`** — do *not* delete from the DB inline. `flush`, the sole
+   `DatabaseProvider` peer-DB writer, applies the delete (`delete_peer_list_item`)
+   within its `db.update_scoped` transaction. The cache removal and the staging
+   are performed under the same state lock `flush` takes, so flush never observes
+   a half-applied eviction. The existing error return is preserved.
 4. Inbound ("we reject them") is already correct: #1435 returns `ChainIdMismatch`
    *before* `add_or_update_peer`, so a foreign peer is never added. A cached
    foreign peer cannot occur on a fully-upgraded network, so inbound eviction is


### PR DESCRIPTION
## Problem

PR #1435 hard-rejects handshakes from a different `chain_id`, but a node configured for a different chain still kept communicating on devnet. Root cause: the chain_id check lives only in the **handshake**, while the gossip **data plane** (`check_peer_v*`) authorizes purely on cache membership + source IP — it never consults handshake outcome.

When our outbound announce is rejected for a chain mismatch (`ChainIdMismatch` → `NetworkMismatch`), the rejection was only recorded in `failed_announcements` — a map that is **written but never read**. The peer stayed in the cache and fully trusted, so gossip kept flowing.

## Fix

A `NetworkMismatch` handshake rejection now **evicts** the peer from the in-memory cache (all lookup maps) and **deletes** it from the persistent peer DB. A node re-announcing to its cached peers while on the wrong chain is therefore isolated after the startup announce round (every upgraded peer rejects it → each is evicted → empty peer set).

This relies on peers enforcing #1435, which is acceptable since the target devnet is fully upgraded. Self-enforcing variants and the larger "always require a session handshake + authenticated handshake response" work are scoped in the included design doc for a follow-up.

### Changes
- **domain** (`peer_list.rs`): `PeerList::remove_peer_by_api_address` — removes a peer from the persistent cache/purgatory and every index map, emitting `PeerRemoved` (mirrors the existing purgatory-eviction cleanup).
- **database** (`database.rs`): `delete_peer_list_item` — removes a peer from the `PeerListItems` table (mirror of `insert_peer_list_item`).
- **p2p** (`peer_network_service.rs`): `evict_peer_on_network_mismatch` wired into the outbound-announce `Rejected` arm; no-op for any non-network rejection reason.
- **docs**: design doc capturing the diagnosis, this fix, and the follow-up plan.

## Test plan
Added (TDD, red→green):
- `remove_peer_by_api_address_clears_all_lookups` (domain)
- `delete_peer_list_item_removes_it` (database)
- `network_mismatch_rejection_evicts_peer_from_cache_and_db` (p2p)
- `non_network_rejection_retains_peer` (p2p)

`cargo fmt --all` clean; `cargo clippy -p irys-p2p -p irys-domain -p irys-database --tests --all-targets` clean. Existing rejection-coverage tests still pass. Full-workspace `cargo xtask test` not yet run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Evict peers by API address and fully clear them from all lookup paths and caches.
  * Added an internal DB helper to remove peer-list entries so deletions can be confirmed durably.

* **Bug Fixes**
  * Peers rejected for network/chain mismatches are evicted from memory and staged for durable removal during DB flush to avoid resurrection.

* **Documentation**
  * Added design spec for gossip handshake enforcement and network isolation.

* **Tests**
  * Added tests covering eviction, staged persistence, and non-network rejection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->