### PR TITLE
docs: route hotfixes through the release line, not master-first

### DIFF
--- a/docs/99-reference/RELEASE_PLAYBOOK.md
+++ b/docs/99-reference/RELEASE_PLAYBOOK.md
@@ -110,7 +110,7 @@ Then deploy `irys-testnet:1.2.3` to testnet and validate.
 
 | Where the bug lives | What to do |
 |---|---|
-| Upstream code (would also affect mainnet) | Cherry-pick the fix from `master` to `release/1.x` → bump version to `1.2.4` → repeat Phase B |
+| Upstream code (would also affect mainnet) | Fix on `release/1.x` → bump version to `1.2.4` → backport (cherry-pick) to `master` → repeat Phase B |
 | Testnet-only (e.g. wrong bootstrap peer) | Commit the fix directly to `release/testnet/1.x` → bump `release/1.x` version to `1.2.4` and merge forward → repeat Phase B |
 
 Each iteration gets a new SemVer; earlier `testnet-1.2.X` tags are orphaned
@@ -287,7 +287,7 @@ After publishing, deploy `irys-mainnet:1.2.3` to mainnet.
 |---|---|
 | Where do I bump the version? | Only on `release/1.x`. Deployment branches inherit via merge. |
 | Cargo.toml conflicts during merge-forward? | Always resolve to `release/1.x`'s value. |
-| Bug found on testnet — where do I fix it? | Upstream code: `master` → cherry-pick to `release/1.x` → bump version → re-do Phase B. Env-specific: commit to the affected `release/<env>/1.x` + bump version on `release/1.x`. |
+| Bug found on testnet — where do I fix it? | Shared code: fix on `release/1.x` → bump version → backport (cherry-pick) to `master` → re-do Phase B. Env-specific: commit to the affected `release/<env>/1.x` + bump version on `release/1.x` (no master backport). |
 | Critical mainnet hotfix without testnet? | Dispatch with `force=true`. See [`RELEASE_PROCESS.md` § Hotfixes](./RELEASE_PROCESS.md#hotfixes). |
 | Wrong changelog scope on mainnet? | Edit the draft before publishing — nothing assumes the auto-generated text is final. |
 | Need to roll back? | Dispatch `docker-retag.yml`. See [`RELEASE_PROCESS.md` § Rollback](./RELEASE_PROCESS.md#rollback). |

--- a/docs/99-reference/RELEASE_PROCESS.md
+++ b/docs/99-reference/RELEASE_PROCESS.md
@@ -149,7 +149,25 @@ After the branches exist, follow [`RELEASE_PLAYBOOK.md`](./RELEASE_PLAYBOOK.md) 
 
 ## Hotfixes
 
-Hotfixes follow the same flow — fix on `master`, cherry-pick to `release/<major>.x`, merge forward to the appropriate `release/<env>/<major>.x` branch, tag, deploy. In an emergency, a hotfix can be applied directly to a deployment branch and deployed to its environment immediately, bypassing the normal master → release → deployment progression (use the `force` flag to skip the testnet-merge-base validation).
+Hotfixes **invert** the normal direction. The normal flow develops on `master` — which runs *ahead* of production, carrying unreleased work — and curates changes *down* into the release line. A hotfix targets code that is already **deployed**, i.e. the release line, which sits *behind* `master`. So the fix originates on the release line and is ported *up* to `master`, never developed on `master` first — that would build it against unstable, ahead-of-production code. Pick the path by where the bug lives.
+
+### Shared-code hotfix (must reach every environment)
+
+The bug is in code shared across environments. The fix routes through `release/<major>.x` — the env-agnostic source of truth and the only shared ancestor of both deployment branches.
+
+1. Branch off `release/<major>.x`, write the fix + a regression test, and pre-flight on **devnet**. (You may instead branch off a `release/<env>/<major>.x` to reproduce against exactly what's deployed — but the commit that *lands* must be the isolated, env-agnostic fix. If it won't apply to `release/<major>.x`, it's really an env-specific fix — see below.)
+2. Land the fix on `release/<major>.x` (cherry-pick the isolated fix commit if you developed off an env branch) and bump the PATCH version in `crates/chain/Cargo.toml` there — the canonical version source.
+3. **Backport to `master` (mandatory)** — otherwise the fix regresses the next time a release is cut from `master`. Cherry-pick the *named* commit(s) up to `master` (carry the version-bump commit too, to keep master's version mirroring the latest release; drop that hunk in the rare case master is already version-ahead). Cherry-pick the specific commits — do **not** merge, and do **not** later re-cherry-pick them downward (they now exist under two SHAs, so a range cherry-pick from `master` could re-apply and conflict).
+4. Merge `release/<major>.x` forward into `release/testnet/<major>.x`, dispatch the **Release** workflow as `testnet`, deploy, and endurance-test — testnet is the release candidate.
+5. After the testnet soak, merge `release/<major>.x` forward into `release/mainnet/<major>.x`, dispatch as `mainnet`, deploy.
+
+### Env-specific hotfix (one environment only)
+
+The bug is in environment-local code or config (chain IDs, bootstrap peers, env-only consensus divergence). The fix must **not** leave that environment, or it would contaminate the shared branches. Branch off the affected `release/<env>/<major>.x`, fix, and merge back into that same branch; bump the version on `release/<major>.x` (still the canonical source) and merge forward; dispatch the env's release. **No `master` backport** — the change is environment-local.
+
+### Emergency (skip testnet, straight to mainnet)
+
+Apply the fix directly to `release/mainnet/<major>.x` and dispatch with the `force` flag to skip the testnet-merge-base validation, bypassing the normal master → release → deployment progression. Once the fire is out, reconcile: port the fix to `release/<major>.x` and `master` so it isn't stranded on the deployment branch.
 
 ## Rollback
 
@@ -180,7 +198,7 @@ Starting from a new major version:
 3. Bump version in `crates/chain/Cargo.toml` on `release/1.x`, commit.
 4. Branch `release/testnet/1.x` from `release/1.x` (first time only). Apply any sticky testnet patches.
 5. Trigger the release workflow as `testnet` targeting a commit on `release/testnet/1.x` → validates, builds, pushes `testnet-1.0.0` tag + image to `irys-testnet`, updates `testnet-latest`, auto-publishes prerelease. Deploy to testnet.
-6. Validate on testnet. Fix issues via cherry-pick to `release/1.x` (if upstream) or direct commit to `release/testnet/1.x` (if env-specific), bump version on `release/1.x` and merge forward, tag `testnet-1.0.1`, repeat as needed. Earlier testnet versions are orphaned.
+6. Validate on testnet. Fix issues on `release/1.x` and backport (cherry-pick) to `master` (if upstream) or by direct commit to `release/testnet/1.x` (if env-specific), bump version on `release/1.x` and merge forward, tag `testnet-1.0.1`, repeat as needed. Earlier testnet versions are orphaned.
 7. Once stable, branch `release/mainnet/1.x` from `release/1.x` (first time only). Apply any sticky mainnet patches. Merge `release/1.x` forward.
 8. Trigger the release workflow as `mainnet` on a commit on `release/mainnet/1.x` whose `release/1.x` merge-base matches the testnet release's → validates, builds, pushes `mainnet-1.0.1` tag + image, updates `mainnet-latest`, creates draft release. Maintainer reviews and publishes. Deploy to mainnet.
 9. Future minor/patch releases continue on `release/1.x` and flow through the same deployment branches. A new `release/2.x` branch plus new `release/testnet/2.x` and `release/mainnet/2.x` are created when a major version bump is needed.


### PR DESCRIPTION
## Why

The release docs told you to fix hotfixes on `master` first, then cherry-pick down to the release line. But a hotfix targets code that is already **deployed** — i.e. `release/<major>.x` (+ env patches), which sits *behind* `master`. Developing the fix against ahead-of-production `master` code risks a fix that won't cherry-pick cleanly downward and entangles it with unstable, unreleased work.

## What changed

Invert the direction for **every fix path**: the fix originates on `release/<major>.x` (the env-agnostic source of truth), the version bump happens there, then it's backported (cherry-pick) *up* to `master` and merged *forward* to the deployment branches.

`RELEASE_PROCESS.md` § Hotfixes is rewritten into three explicit paths:

- **Shared-code hotfix** — fix on `release/<major>.x` → bump → mandatory backport to `master` → merge forward to testnet (RC) then mainnet.
- **Env-specific hotfix** — commit on the affected `release/<env>/<major>.x`, no `master` backport (it would contaminate the shared branches).
- **Emergency** — `force` straight to the mainnet branch, then reconcile the fix onto `release/<major>.x` and `master`.

The same story is applied consistently across all four locations that previously implied master-first:

| File | Spot |
|---|---|
| `RELEASE_PROCESS.md` | § Hotfixes (rewritten) |
| `RELEASE_PROCESS.md` | "Process in Action" step 6 |
| `RELEASE_PLAYBOOK.md` | Phase B — "If testnet fails" table |
| `RELEASE_PLAYBOOK.md` | Quick decision points table |

The normal **feature-curation** flow (`master` → cherry-pick → `release/<major>.x`) is intentionally **unchanged**.

## Notes

- Backport carries the version-bump commit along (keeps master's version mirroring the latest release), with a caveat to drop that hunk if master is ever version-ahead.
- Backport discipline documented: cherry-pick the named commits (not a merge), and don't re-cherry-pick them downward (duplicate-SHA conflict risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Documentation**
- Updated release playbook guidance for managing testnet-identified issues with improved workflow paths.
- Enhanced hotfix workflow documentation with clearer distinctions between shared-code, environment-specific, and emergency fix types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->