### PR TITLE
feat(release): gate releases on green CI for the release/<major>.x merge-base

### DIFF
--- a/.github/actions/require-green-ci/action.yaml
+++ b/.github/actions/require-green-ci/action.yaml
@@ -1,0 +1,107 @@
+name: "Require green CI"
+description: >-
+  Fails unless a commit has a fully passing CI result. The release workflow uses
+  this to gate a release on the release/<major>.x merge-base — the substantive
+  upstream code being shipped — having passed CI, as defense-in-depth on top of
+  branch protection. A commit is "fully green" when:
+    - it has at least one successful check run (or a green combined commit
+      status), proving CI actually ran; AND
+    - no check run is still running, and none concluded failure / cancelled /
+      timed_out / action_required / stale / startup_failure; AND
+    - the combined legacy commit status (if any contexts exist) is success.
+  A commit with no CI results at all is a hard failure — absence of a run is not
+  proof of a passing run. skipped/neutral check runs are treated as non-blocking,
+  matching GitHub's own required-status-check semantics. The caller must pass a
+  token with checks:read and statuses:read.
+
+inputs:
+  commit:
+    description: "Full commit SHA to verify CI status for."
+    required: true
+  github-token:
+    description: "Token with checks:read and statuses:read on this repo."
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Require green CI for commit
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.commit }}
+      run: |
+        set -euo pipefail
+        if [ -z "${SHA}" ]; then
+          echo "::error::require-green-ci: empty commit input"
+          exit 1
+        fi
+
+        # GitHub Actions jobs surface as "check runs"; external CI / bots surface
+        # as legacy "commit statuses". A fully passing CI result must satisfy both.
+        # filter=latest (the API default) collapses re-runs to the most recent run
+        # per check name, so a red run that was later re-run green is not counted.
+        runs_tsv=$(gh api --paginate \
+          "repos/${REPO}/commits/${SHA}/check-runs?per_page=100" \
+          -q '.check_runs[] | [.name, .status, (.conclusion // "")] | @tsv')
+
+        fail=0
+        successes=0
+        total_runs=0
+        if [ -n "${runs_tsv}" ]; then
+          while IFS=$'\t' read -r name status conclusion; do
+            [ -z "${name}" ] && continue
+            total_runs=$((total_runs + 1))
+            if [ "${status}" != "completed" ]; then
+              echo "::error::Check '${name}' has not completed (status=${status}); CI is still running on ${SHA}."
+              fail=1
+              continue
+            fi
+            case "${conclusion}" in
+              success)
+                successes=$((successes + 1))
+                ;;
+              skipped|neutral)
+                # Non-blocking, mirrors GitHub's required-status-check semantics.
+                ;;
+              *)
+                echo "::error::Check '${name}' did not pass (conclusion=${conclusion}) on ${SHA}."
+                fail=1
+                ;;
+            esac
+          done <<< "${runs_tsv}"
+        fi
+
+        # Combined legacy status: the .state field is aggregated server-side across
+        # every context, so one read is authoritative regardless of context count.
+        status_state=$(gh api "repos/${REPO}/commits/${SHA}/status" -q '.state')
+        status_total=$(gh api "repos/${REPO}/commits/${SHA}/status" -q '.total_count')
+        if [ "${status_total}" -gt 0 ]; then
+          if [ "${status_state}" = "success" ]; then
+            successes=$((successes + 1))
+          else
+            echo "::error::Combined commit status for ${SHA} is '${status_state}' (expected success)."
+            fail=1
+          fi
+        fi
+
+        if [ "${total_runs}" -eq 0 ] && [ "${status_total}" -eq 0 ]; then
+          echo "::error::No CI check runs or commit statuses found for ${SHA}. Cannot prove the release base passed CI. (Emergency hotfixes can bypass with force=true.)"
+          exit 1
+        fi
+
+        if [ "${fail}" -ne 0 ]; then
+          echo "::error::CI for ${SHA} is not fully green; refusing to release. (Emergency hotfixes can bypass with force=true.)"
+          exit 1
+        fi
+
+        # Every check was skipped/neutral and no green status exists: CI never
+        # actually ran (e.g. a #disable-ci gate short-circuit), so there is no
+        # passing run to stand behind.
+        if [ "${successes}" -eq 0 ]; then
+          echo "::error::No successful CI result for ${SHA} (all checks skipped/neutral, no green status). Cannot prove a real CI run passed. (Emergency hotfixes can bypass with force=true.)"
+          exit 1
+        fi
+
+        echo "CI for ${SHA} is fully green (${successes} successful result(s) across ${total_runs} check run(s))."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ on:
         required: true
         type: string
       force:
-        description: 'Skip testnet-tag validation check (emergency hotfixes only)'
+        description: 'Skip testnet-tag validation and release-base CI gate (emergency hotfixes only)'
         required: false
         type: boolean
         default: false
@@ -42,6 +42,9 @@ jobs:
     runs-on: [self-hosted, misc-runner]
     permissions:
       contents: read
+      # Read check runs and commit statuses to CI-gate the release base below.
+      checks: read
+      statuses: read
     steps:
       - name: Validate inputs
         env:
@@ -77,6 +80,40 @@ jobs:
           environment: ${{ inputs.release_type }}
           commit: ${{ inputs.commit }}
           version: ${{ inputs.version }}
+
+      # Defense-in-depth CI gate. The deployment branch only adds a forward-merge
+      # of release/<major>.x plus env-specific patches on top of it; the
+      # substantive released code is the merge-base on release/<major>.x. Require
+      # that commit's CI to be fully green before releasing. Scoped to real
+      # releases: force=true (emergency hotfixes) and dry_run=true (which may run
+      # before release/<major>.x even exists — see RELEASE_PLAYBOOK.md dry-run
+      # section) both bypass it.
+      - name: Resolve release/<major>.x merge-base
+        id: base
+        if: ${{ !inputs.force && !inputs.dry_run }}
+        env:
+          INPUT_COMMIT: ${{ inputs.commit }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          MAJOR="${INPUT_VERSION%%.*}"
+          RELEASE_BRANCH="origin/release/${MAJOR}.x"
+          if ! git rev-parse --verify "$RELEASE_BRANCH" >/dev/null 2>&1; then
+            echo "::error::Release branch $RELEASE_BRANCH does not exist; cannot CI-gate the release base."
+            exit 1
+          fi
+          if ! MERGE_BASE=$(git merge-base "${INPUT_COMMIT}" "$RELEASE_BRANCH"); then
+            echo "::error::No common ancestor between ${INPUT_COMMIT} and $RELEASE_BRANCH"
+            exit 1
+          fi
+          echo "Release base (merge-base of ${INPUT_COMMIT} and $RELEASE_BRANCH): $MERGE_BASE"
+          echo "sha=$MERGE_BASE" >> "$GITHUB_OUTPUT"
+
+      - name: Require green CI on release base
+        if: ${{ !inputs.force && !inputs.dry_run }}
+        uses: ./.github/actions/require-green-ci
+        with:
+          commit: ${{ steps.base.outputs.sha }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Determine tag name
         id: tag

--- a/docs/99-reference/RELEASE_PLAYBOOK.md
+++ b/docs/99-reference/RELEASE_PLAYBOOK.md
@@ -99,10 +99,11 @@ The workflow will:
 
 1. Verify the commit is on `release/testnet/<major>.x`.
 2. Verify `crates/chain/Cargo.toml` version equals `1.2.3`.
-3. Build `ghcr.io/<owner>/irys-testnet:1.2.3`.
-4. Push git tag `testnet-1.2.3`, push the Docker image, move the `testnet-latest` git tag.
-5. Auto-publish a GitHub **prerelease** with the auto-generated changelog body.
-6. As the final, non-fatal step, retag and push `irys-testnet:latest` (a failure here leaves `:latest` on the previous release rather than rolling back the published one — see [`RELEASE_PROCESS.md` § Atomicity](./RELEASE_PROCESS.md#atomicity)).
+3. Verify the commit's `release/1.x` merge-base (the upstream code being shipped, env-patches aside) had a fully passing CI run. Skipped with `force=true` or `dry_run=true`.
+4. Build `ghcr.io/<owner>/irys-testnet:1.2.3`.
+5. Push git tag `testnet-1.2.3`, push the Docker image, move the `testnet-latest` git tag.
+6. Auto-publish a GitHub **prerelease** with the auto-generated changelog body.
+7. As the final, non-fatal step, retag and push `irys-testnet:latest` (a failure here leaves `:latest` on the previous release rather than rolling back the published one — see [`RELEASE_PROCESS.md` § Atomicity](./RELEASE_PROCESS.md#atomicity)).
 
 Then deploy `irys-testnet:1.2.3` to testnet and validate.
 
@@ -291,13 +292,14 @@ After publishing, deploy `irys-mainnet:1.2.3` to mainnet.
 | Critical mainnet hotfix without testnet? | Dispatch with `force=true`. See [`RELEASE_PROCESS.md` § Hotfixes](./RELEASE_PROCESS.md#hotfixes). |
 | Wrong changelog scope on mainnet? | Edit the draft before publishing — nothing assumes the auto-generated text is final. |
 | Need to roll back? | Dispatch `docker-retag.yml`. See [`RELEASE_PROCESS.md` § Rollback](./RELEASE_PROCESS.md#rollback). |
-| Want to test the workflow without publishing? | Dispatch with `dry_run=true`. Validates and builds; skips tag/image push and GH Release creation, and runs without the environment approval gate (so a mainnet dry-run needs no reviewer and won't block a queued real release). |
+| Want to test the workflow without publishing? | Dispatch with `dry_run=true`. Validates and builds; skips tag/image push and GH Release creation, skips the release-base CI gate, and runs without the environment approval gate (so a mainnet dry-run needs no reviewer and won't block a queued real release). |
 
 ## Hotfixes and emergencies
 
 For the abbreviated path (skip testnet, deploy direct to mainnet), see
 [`RELEASE_PROCESS.md` § Hotfixes](./RELEASE_PROCESS.md#hotfixes). The same
-phases apply; you use `force=true` to bypass the testnet-merge-base check.
+phases apply; you use `force=true` to bypass the testnet-merge-base check and the
+release-base CI gate.
 
 ## Rollback
 
@@ -313,6 +315,10 @@ provenance, version match, the **real Docker build**, and changelog generation �
 then skips every mutating step: no git tag, no image push, no `latest` move, no
 GitHub Release. Use it to prove the workflow and the build are healthy before a
 real cut, or after changing the workflow itself.
+
+A dry-run also skips the release-base CI gate (it can run before `release/<major>.x`
+exists — the setup below branches only the `release/<env>/<major>.x` branch from
+`master`), so it does not require the merge-base commit to have a passing CI run.
 
 A dry-run resolves its `environment` to empty, so it does **not** wait on the
 `testnet`/`mainnet` approval gate and does **not** require those Environments to

--- a/docs/99-reference/RELEASE_PROCESS.md
+++ b/docs/99-reference/RELEASE_PROCESS.md
@@ -62,7 +62,7 @@ release/<major>.x  (canonical version source; never deployed directly)
 
 1. Work merges into `master`. Devnet builds from `release/devnet` (merged forward from `master` on demand).
 2. When ready to release, cherry-pick changes from `master` into `release/<major>.x`, bump the version in `crates/chain/Cargo.toml`, and stabilize.
-3. Merge `release/<major>.x` forward into `release/testnet/<major>.x`. Apply any per-release testnet patches as additional commits. Trigger the **Release** workflow as `testnet` → validates, builds, pushes `testnet-X.Y.Z` git tag, pushes image to `irys-testnet:X.Y.Z`, updates `testnet-latest` (both Docker and git), creates auto-published prerelease. Deploy to testnet.
+3. Merge `release/<major>.x` forward into `release/testnet/<major>.x`. Apply any per-release testnet patches as additional commits. Trigger the **Release** workflow as `testnet` → validates (including that the commit's `release/<major>.x` merge-base had a fully passing CI run), builds, pushes `testnet-X.Y.Z` git tag, pushes image to `irys-testnet:X.Y.Z`, updates `testnet-latest` (both Docker and git), creates auto-published prerelease. Deploy to testnet.
 4. After testnet validation, merge `release/<major>.x` forward into `release/mainnet/<major>.x`. Apply any per-release mainnet patches as additional commits. Trigger the **Release** workflow as `mainnet` on a commit whose `release/<major>.x` merge-base matches the testnet release's → validates, builds, pushes `mainnet-X.Y.Z` git tag, pushes image to `irys-mainnet:X.Y.Z`, updates `mainnet-latest`, creates **draft** release. A maintainer reviews the notes and publishes.
 
 ### Atomicity
@@ -167,7 +167,7 @@ The bug is in environment-local code or config (chain IDs, bootstrap peers, env-
 
 ### Emergency (skip testnet, straight to mainnet)
 
-Apply the fix directly to `release/mainnet/<major>.x` and dispatch with the `force` flag to skip the testnet-merge-base validation, bypassing the normal master → release → deployment progression. Once the fire is out, reconcile: port the fix to `release/<major>.x` and `master` so it isn't stranded on the deployment branch.
+Apply the fix directly to `release/mainnet/<major>.x` and dispatch with the `force` flag to skip the testnet-merge-base validation and the release-base CI gate, bypassing the normal master → release → deployment progression. Once the fire is out, reconcile: port the fix to `release/<major>.x` and `master` so it isn't stranded on the deployment branch.
 
 ## Rollback
 
@@ -214,3 +214,4 @@ Deployment-specific patches (e.g., chain IDs, bootstrap peer addresses, env-spec
 - Patches that should apply to multiple envs go on `release/<major>.x`, not on individual deployment branches.
 - Patches that change protocol behavior should never be env-specific. Env patches are for env-bound values only.
 - The testnet ↔ mainnet validation in the release workflow enforces that both commits share the same `release/<major>.x` merge-base — i.e. same upstream code, only env-patches differ.
+- The release workflow also requires that `release/<major>.x` merge-base to have had a fully passing CI run (defense-in-depth on top of branch protection). `force=true` bypasses this for emergency hotfixes; `dry_run=true` skips it. Note this gates the upstream merge-base, not the env-patch commits on the deployment branch — keep env patches to env-bound values only (per the rule above) so untested protocol behavior cannot ride in via a deployment-branch patch.


### PR DESCRIPTION
## Summary

The release workflow's `validate` job verified provenance, version match, and tag freshness — but never that the code being released actually passed CI. That guarantee rested entirely on deployment-branch protection at PR-merge time, with no defense-in-depth at release-dispatch time.

This PR adds a CI gate to the `validate` job: it resolves the `release/<major>.x` merge-base of the release commit (the substantive upstream code being shipped, env-patches aside) and refuses to release unless that commit's CI is fully green.

## What "fully green" means

New composite action `.github/actions/require-green-ci` queries the commit's GitHub Actions check runs and legacy commit statuses, and requires:

- **at least one successful result** — proves CI actually ran; a commit with *no* CI results at all is a hard failure (absence of a run is not proof of a passing run), as is an all-skipped run (e.g. a `#disable-ci` gate short-circuit)
- **nothing still running** — dispatching before the merge-base's CI finishes fails the gate
- **no `failure` / `cancelled` / `timed_out` / `action_required` / `stale` / `startup_failure` conclusions**; `skipped`/`neutral` are non-blocking, matching GitHub's own required-status-check semantics
- **combined legacy commit status is `success`** if any status contexts exist

Re-runs are handled by the API's `filter=latest` default, so a red run later re-run green doesn't block.

## Scope and bypasses

- Applies to **both testnet and mainnet** releases.
- `force=true` (the existing emergency-hotfix flag) bypasses it.
- `dry_run=true` skips it — the documented dry-run setup branches only `release/<env>/<major>.x` from `master` and may run before `release/<major>.x` exists, so there is no merge-base to gate. This matches how the existing release-safety gates already behave on dry-runs.
- The `validate` job gains `checks: read` + `statuses: read` to query the APIs.

Note the gate covers the upstream merge-base, not the env-patch commits on the deployment branch — consistent with the documented rule that env patches are for env-bound values only (documented in `RELEASE_PROCESS.md`).

## Verification

- YAML parses; action script passes `bash -n`; jq projection validated against sample API JSON.
- The classification/exit logic was extracted and driven through 12 scenarios (all-green, single failure, still-running, cancelled, timed_out, no-runs hard-fail, all-skipped, skipped+success, status-only green/red, runs+red-status) — all pass.
- Not exercised against a live dispatch; a `dry_run=true` dispatch won't cover the new steps (skipped by design), so the first real testnet cut is the live validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced continuous integration validation gate in the release workflow to ensure commits have fully passing CI checks before releases proceed, with bypass option available for emergency scenarios

* **Documentation**
  * Updated release process documentation to clarify the new CI validation gate requirements, when it's skipped (dry-runs, emergency releases), and how it affects the release workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->