### PR TITLE
fix: backport CI hardening and tooling fixes from gateway

### DIFF
--- a/.github/workflows/conventional-pr.yaml
+++ b/.github/workflows/conventional-pr.yaml
@@ -2,6 +2,14 @@ name: Ensure Conventional Commit message
 
 on: pull_request
 
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: conventional-pr-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ensure-CC:
     runs-on: ubuntu-latest

--- a/.github/workflows/flaky.yml
+++ b/.github/workflows/flaky.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           fetch-depth: 1
           clean: true  # Always start with clean workspace
+          persist-credentials: false
 
       - name: Setup repo
         uses: ./.github/actions/setup-repo

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,6 +2,9 @@ name: Rust Checks
 
 permissions:
   contents: read
+  # the gate job queries the "PRs associated with commit" / PR description
+  # APIs, which need pull-requests read access on private repos
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
@@ -29,7 +32,9 @@ jobs:
     outputs:
       should-run: ${{ steps.set-output.outputs.should-run }} # register we have some output other actions should reference
     steps:
-      - uses: actions/checkout@v3
+      # NOTE: the gate intentionally keeps persisted credentials — the
+      # "Check if CI should run" step does authenticated `git fetch` calls.
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Need full history for comparison
         # this script checks whether we should run on the current commit, based on:
@@ -42,6 +47,10 @@ jobs:
         id: set-output
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # pass branch refs via env rather than interpolating them into the
+          # script body — branch names may contain shell metacharacters
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           # default to running
           SHOULD_RUN=true
@@ -82,9 +91,12 @@ jobs:
           if [[ "${{ github.event_name }}" == "push" && "$SHOULD_RUN" == "true" ]]; then
             # Find any PRs associated with this commit
             COMMIT_SHA="${{ github.event.after }}"
+            # `if type == "array"` guards against API error objects (e.g. missing
+            # token permissions return {"message": ...}, which `.[].number` would
+            # choke on and fail the whole gate)
             ASSOCIATED_PRS=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
               "https://api.github.com/repos/${{ github.repository }}/commits/$COMMIT_SHA/pulls" | \
-              jq --raw-output '.[].number')
+              jq --raw-output 'if type == "array" then .[].number else empty end')
 
             if [[ -n "$ASSOCIATED_PRS" ]]; then
               echo "Found PRs associated with this commit: $ASSOCIATED_PRS"
@@ -123,8 +135,8 @@ jobs:
 
             # Only perform branch comparison check if we haven't already decided to skip
             if [[ "$SHOULD_RUN" == "true" ]]; then
-              git fetch origin ${{ github.event.pull_request.base.ref }}:base_branch
-              git fetch origin ${{ github.event.pull_request.head.ref }}:head_branch
+              git fetch origin "$BASE_REF:base_branch"
+              git fetch origin "$HEAD_REF:head_branch"
 
               # check if base branch has commits that head branch doesn't have (so we can test against the auto merge)
               AHEAD_COMMITS=$(git rev-list --count head_branch..base_branch)
@@ -173,6 +185,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup repo
         uses: ./.github/actions/setup-repo
@@ -195,6 +208,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup repo
         uses: ./.github/actions/setup-repo
@@ -220,6 +234,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup repo
         uses: ./.github/actions/setup-repo
@@ -237,6 +252,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup repo
         uses: ./.github/actions/setup-repo
@@ -259,6 +275,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup repo
         uses: ./.github/actions/setup-repo
@@ -284,6 +301,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup repo
         uses: ./.github/actions/setup-repo
@@ -303,6 +321,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: crate-ci/typos@v1.29.7
         with:
           files: .

--- a/crates/utils/nextest-monitor/src/bin/nextest-wrapper.rs
+++ b/crates/utils/nextest-monitor/src/bin/nextest-wrapper.rs
@@ -276,10 +276,13 @@ fn run_with_monitoring(config: MonitorConfig<'_>) -> std::io::Result<i32> {
 
     // Skip RSS monitoring when heap profiling to avoid measuring heaptrack's overhead
     let effective_monitor_memory = monitor_memory && !heap_profile;
+    // Skip CPU monitoring too — under heaptrack, `pid` refers to heaptrack
+    // itself, so CPU samples would measure the profiler rather than the test
+    let effective_monitor_cpu = monitor_cpu && !heap_profile;
 
-    let monitoring_enabled = monitor_cpu || effective_monitor_memory;
+    let monitoring_enabled = effective_monitor_cpu || effective_monitor_memory;
 
-    let mut cpu_monitor = monitor_cpu.then(|| CpuMonitor::new(pid));
+    let mut cpu_monitor = effective_monitor_cpu.then(|| CpuMonitor::new(pid));
     let memory_monitor = effective_monitor_memory.then(|| MemoryMonitor::new(pid));
 
     // Writes a minimal stats entry the moment SIGTERM is detected, so the test
@@ -391,7 +394,7 @@ fn run_with_monitoring(config: MonitorConfig<'_>) -> std::io::Result<i32> {
     let exit_code = status.code();
     let passed = !timed_out && exit_code == Some(0);
 
-    let cpu_stats = monitor_cpu.then(|| calculate_cpu_stats(&cpu_samples, duration_ms));
+    let cpu_stats = effective_monitor_cpu.then(|| calculate_cpu_stats(&cpu_samples, duration_ms));
     let mem_stats =
         effective_monitor_memory.then(|| calculate_memory_stats(&memory_samples, duration_ms));
 
@@ -413,7 +416,7 @@ fn run_with_monitoring(config: MonitorConfig<'_>) -> std::io::Result<i32> {
         time_above_2t_ms: cpu_stats.as_ref().map(|s| s.time_above_2t_ms),
         time_above_3t_ms: cpu_stats.as_ref().map(|s| s.time_above_3t_ms),
         time_above_4t_ms: cpu_stats.as_ref().map(|s| s.time_above_4t_ms),
-        cpu_samples: (record_samples && monitor_cpu).then_some(cpu_samples),
+        cpu_samples: (record_samples && effective_monitor_cpu).then_some(cpu_samples),
         peak_rss_bytes: mem_stats.as_ref().map(|s| s.peak_rss_bytes),
         avg_rss_bytes: mem_stats.as_ref().map(|s| s.avg_rss_bytes),
         p50_rss_bytes: mem_stats.as_ref().map(|s| s.p50_rss_bytes),

--- a/crates/utils/nextest-monitor/src/types.rs
+++ b/crates/utils/nextest-monitor/src/types.rs
@@ -108,10 +108,21 @@ impl AggregatedStats {
     }
 
     /// Load stats from the `.d/` directory, returning empty default if it
-    /// doesn't exist yet.
+    /// doesn't exist yet. Other IO errors are logged rather than silently
+    /// swallowed, since they indicate stats data is being lost.
     pub fn load_or_default(path: &Path) -> Self {
         let dir = stats_dir(path);
-        let mut tests = parse_stats_dir(&dir).unwrap_or_default();
+        let mut tests = match parse_stats_dir(&dir) {
+            Ok(tests) => tests,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+            Err(e) => {
+                eprintln!(
+                    "[nextest-monitor] warning: failed to read stats dir {}: {e}",
+                    dir.display()
+                );
+                Vec::new()
+            }
+        };
         tests.sort_by_key(|t| t.started_at);
         AggregatedStats { tests }
     }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,4 @@
-edition = "2021"
+edition = "2024"
 use_small_heuristics = "Default"
 use_field_init_shorthand = true
 reorder_imports = true

--- a/xtask/src/failures.rs
+++ b/xtask/src/failures.rs
@@ -218,10 +218,12 @@ pub fn generate_nextest_config(
     if !config_content.contains("experimental") {
         config_content.push_str("experimental = [\"wrapper-scripts\"]\n\n");
     } else if !config_content.contains("wrapper-scripts") {
-        // Need to modify existing experimental line - this is tricky
-        // For now, just add it and hope TOML merges correctly or warn the user
-        eprintln!(
-            "Warning: existing config has 'experimental' key - you may need to add 'wrapper-scripts' manually"
+        // Injecting run-wrapper without the experimental flag produces a config
+        // nextest rejects — fail fast instead of generating a broken config.
+        eyre::bail!(
+            "nextest config at {NEXTEST_CONFIG_PATH} has an `experimental` key without \
+             \"wrapper-scripts\"; add \"wrapper-scripts\" to it so xtask can inject the \
+             monitoring run-wrapper"
         );
     }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -577,14 +577,18 @@ fn run_command(command: Commands, sh: &Shell) -> eyre::Result<()> {
         }
         Commands::Clippy { args } => {
             println!("cargo clippy");
-            cmd!(sh, "cargo clippy --workspace --tests --locked {args...}").remove_and_run()?;
+            cmd!(
+                sh,
+                "cargo clippy --workspace --tests --all-targets --locked {args...}"
+            )
+            .remove_and_run()?;
         }
         Commands::Fmt {
             check_only: only_check,
             args,
         } => {
             if only_check {
-                cmd!(sh, "cargo fmt --check {args...}").remove_and_run()?;
+                cmd!(sh, "cargo fmt --all --check {args...}").remove_and_run()?;
             } else {
                 println!("cargo fmt & clippy fix");
                 cmd!(sh, "cargo fmt --all").remove_and_run()?;
@@ -594,7 +598,7 @@ fn run_command(command: Commands, sh: &Shell) -> eyre::Result<()> {
                 let _rustflags_guard = sh.push_env("RUSTFLAGS", "-D warnings");
                 cmd!(
                     sh,
-                    "cargo clippy --fix --allow-dirty --allow-staged --workspace --tests {args...}"
+                    "cargo clippy --fix --allow-dirty --allow-staged --workspace --tests --all-targets {args...}"
                 )
                 .remove_and_run()?;
             }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -945,26 +945,37 @@ fn run_command(command: Commands, sh: &Shell) -> eyre::Result<()> {
                 )
                 .remove_and_run()?;
 
-                // Use script command to preserve TTY and tee to save output
+                // Shell-quote each arg — these strings are interpreted by
+                // `bash -c`, so unquoted args with spaces/metacharacters
+                // would be re-split or executed
+                let quoted_args = command_args
+                    .iter()
+                    .map(|a| shell_quote(a))
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                let quoted_output = shell_quote(&output_file);
+
+                // Use script command to preserve TTY and tee to save output.
+                // `set -o pipefail` so a cargo/script failure isn't masked by
+                // tee's (successful) exit status. Commands go through
+                // remove_ring_env_vars like every other cargo invocation here.
                 // Handle different script syntax between platforms
                 let script_result = if cfg!(target_os = "macos") {
                     // macOS script syntax
                     let script_command = format!(
-                        "script -q /dev/stdout cargo {} | tee -a '{}'",
-                        command_args.join(" "),
-                        output_file
+                        "set -o pipefail; script -q /dev/stdout cargo {quoted_args} | tee -a {quoted_output}"
                     );
-                    cmd!(sh, "bash -c {script_command}")
+                    remove_ring_env_vars(cmd!(sh, "bash -c {script_command}"))
                         .env("RUST_BACKTRACE", "1")
                         .run()
                 } else if cfg!(target_os = "linux") {
-                    // Linux script syntax
+                    // Linux script syntax (-c takes the whole command as one
+                    // argument, so quote the assembled cargo invocation again)
+                    let inner = shell_quote(&format!("cargo {quoted_args}"));
                     let script_command = format!(
-                        "script -q -e -c 'cargo {}' /dev/stdout | tee -a '{}'",
-                        command_args.join(" "),
-                        output_file
+                        "set -o pipefail; script -q -e -c {inner} /dev/stdout | tee -a {quoted_output}"
                     );
-                    cmd!(sh, "bash -c {script_command}")
+                    remove_ring_env_vars(cmd!(sh, "bash -c {script_command}"))
                         .env("RUST_BACKTRACE", "1")
                         .run()
                 } else {
@@ -973,26 +984,26 @@ fn run_command(command: Commands, sh: &Shell) -> eyre::Result<()> {
                         "Warning: script command may not be available on this platform, progress bars may not display correctly"
                     );
                     let tee_command = format!(
-                        "cargo {} 2>&1 | tee -a '{}'",
-                        command_args.join(" "),
-                        output_file
+                        "set -o pipefail; cargo {quoted_args} 2>&1 | tee -a {quoted_output}"
                     );
-                    cmd!(sh, "bash -c {tee_command}")
+                    remove_ring_env_vars(cmd!(sh, "bash -c {tee_command}"))
                         .env("RUST_BACKTRACE", "1")
                         .run()
                 };
 
-                // If script command fails, fallback to basic tee
-                if script_result.is_err() {
+                // If the `script` command itself is unavailable, fall back to
+                // basic tee. Only retry in that case — with pipefail a cargo
+                // failure also surfaces here, and rerunning the whole flaky
+                // suite on a genuine test failure would be very expensive.
+                let script_missing = cmd!(sh, "which script").quiet().run().is_err();
+                if script_result.is_err() && script_missing {
                     eprintln!(
-                        "Warning: script command failed, falling back to basic output capture"
+                        "Warning: script command unavailable, falling back to basic output capture"
                     );
                     let tee_command = format!(
-                        "cargo {} 2>&1 | tee -a '{}'",
-                        command_args.join(" "),
-                        output_file
+                        "set -o pipefail; cargo {quoted_args} 2>&1 | tee -a {quoted_output}"
                     );
-                    cmd!(sh, "bash -c {tee_command}")
+                    remove_ring_env_vars(cmd!(sh, "bash -c {tee_command}"))
                         .env("RUST_BACKTRACE", "1")
                         .run()?;
                 } else {
@@ -1009,7 +1020,7 @@ fn run_command(command: Commands, sh: &Shell) -> eyre::Result<()> {
                 )
                 .remove_and_run()?;
 
-                cmd!(sh, "cargo {command_args...}")
+                remove_ring_env_vars(cmd!(sh, "cargo {command_args...}"))
                     .env("RUST_BACKTRACE", "1")
                     .run()?;
             }
@@ -1023,6 +1034,12 @@ fn main() -> eyre::Result<()> {
     let sh = Shell::new()?;
     let args = Args::parse();
     run_command(args.command, &sh)
+}
+
+/// Quote a string for safe inclusion in a `bash -c` command line.
+/// Wraps in single quotes; embedded single quotes become `'\''`.
+fn shell_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
 }
 
 /// Scans per-test `.status` marker files and writes an aggregate `status.txt`.


### PR DESCRIPTION
## Summary

Backports fixes from the gateway repo's shared utility/CI setup (nextest-monitor, xtask, workflows) into irys-rs. Four topic commits:

- **ci: harden workflows** — `persist-credentials: false` on checkouts that don't need credentials (gate keeps them for its authenticated fetches; cargo-check's submodules are public and clone anonymously), least-privilege `permissions` + concurrency on conventional-pr, PR base/head refs passed via env instead of script interpolation (shell-injection hardening), jq guard against non-array API error responses in the gate, gate checkout v3→v4
- **fix(nextest-monitor)** — skip CPU sampling under heaptrack (the monitored pid is heaptrack's, so samples measured the profiler; mirrors the existing RSS gate), and log stats-dir read errors instead of silently swallowing them
- **chore: lint flags** — xtask clippy/clippy-fix now pass `--all-targets` (picks up benches/examples, matches the documented pre-push check), fmt check gets `--all`, rustfmt edition 2021→2024 to match the workspace edition
- **fix(xtask)** — shell-quote all args interpolated into the flaky runner's `bash -c` command lines, `set -o pipefail` so cargo-flake failures aren't masked by tee, fall back to plain tee only when `script` is actually missing, route invocations through `remove_ring_env_vars`, and fail fast on nextest configs with `experimental` missing `wrapper-scripts`

## Behavior changes to be aware of

- `cargo xtask flaky --save` now exits nonzero when flaky tests are found (previously masked by tee). flaky.yml already tolerates this via `set +e` + `continue-on-error`, and its `exit_code.txt` becomes truthful.
- clippy now lints 3 previously-uncovered targets (`dupsort` example, `recall_range`/`vdf_bench` benches) — all clean.

## Validation

- `cargo clippy --workspace --tests --all-targets --locked --all-features -- -Dwarnings` (exact CI invocation with the new flag) — passes
- `cargo fmt --all --check` with the new rustfmt.toml — passes, zero churn from the edition bump
- `typos .` — clean
- nextest-monitor sources, rustfmt.toml, and flaky.yml verified byte-identical to gateway; rust.yml/conventional-pr diffs preserve irys-specific bits (submodule step, `IRYS_CUSTOM_TMP_DIR`)
- repo + both submodules confirmed public, so anonymous submodule clones work under `persist-credentials: false` (note: this assumption breaks if a private submodule is ever added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow security with refined permission scoping and improved concurrent job handling to prevent overlapping checks.
  * Updated build configuration to Rust 2024 edition.

* **Bug Fixes**
  * Fixed profiling tool compatibility by correcting CPU monitoring behavior.
  * Improved error handling and logging for build configuration validation.
  * Enhanced build tool functionality with better argument handling and output capture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->