### PR TITLE
fix(p2p): prevent underflow panic in gossip rate limiter timestamp math

### DIFF
--- a/crates/p2p/src/rate_limiting.rs
+++ b/crates/p2p/src/rate_limiting.rs
@@ -74,14 +74,14 @@ impl DataRequestRecord {
     /// Check if the tracking window has expired
     pub fn is_window_expired(&self) -> bool {
         let now = now_as_millis();
-        now - self.window_start > WINDOW_DURATION_MS
+        now.saturating_sub(self.window_start) > WINDOW_DURATION_MS
     }
 
     /// Check if enough time has passed since last request (deduplication window)
     pub fn is_duplicate_request(&self) -> bool {
         let now = now_as_millis();
         // Consider duplicate if within the configured milliseconds
-        (now - self.last_request) < self.duplicate_request_milliseconds
+        now.saturating_sub(self.last_request) < self.duplicate_request_milliseconds
     }
 
     /// Reset for new tracking window
@@ -229,7 +229,7 @@ impl DataRequestTracker {
         // Collect keys to remove (can't remove while iterating)
         let mut keys_to_remove = Vec::new();
         for entry in self.request_history.iter() {
-            let age = now - entry.window_start;
+            let age = now.saturating_sub(entry.window_start);
             if age > ENTRY_EXPIRY_MS {
                 keys_to_remove.push(*entry.key());
             }
@@ -255,7 +255,7 @@ impl DataRequestTracker {
         let last_cleanup = self.last_cleanup.load(Ordering::Relaxed) as u128;
         let cleanup_interval_ms = self.cleanup_interval.as_millis();
 
-        if now - last_cleanup > cleanup_interval_ms {
+        if now.saturating_sub(last_cleanup) > cleanup_interval_ms {
             // Use compare_exchange to ensure only one thread does cleanup
             if self
                 .last_cleanup
@@ -377,6 +377,52 @@ mod tests {
         // Reset should make it fresh again
         record.reset_window();
         assert!(!record.is_window_expired());
+    }
+
+    #[test]
+    fn cleanup_does_not_panic_when_window_start_is_in_the_future() {
+        let tracker = DataRequestTracker::new();
+        let peer_id = IrysPeerId::from(IrysAddress::from([4_u8; 20]));
+
+        // Simulate the race / backward-clock case: an entry whose window_start is
+        // slightly ahead of the wall clock that cleanup will read.
+        let future = now_as_millis() + 5_000;
+        tracker.request_history.insert(
+            peer_id,
+            DataRequestRecord {
+                window_start: future,
+                request_count: 1,
+                score_given: 0,
+                last_request: future,
+                duplicate_request_milliseconds: 0,
+            },
+        );
+
+        tracker.cleanup_expired_entries();
+        assert!(
+            tracker.get_peer_stats(&peer_id).is_some(),
+            "fresh entry must not be evicted"
+        );
+    }
+
+    #[test]
+    fn record_checks_do_not_panic_when_timestamps_are_in_the_future() {
+        let mut record = DataRequestRecord::new(TEST_DEDUP_WINDOW_MS);
+        let future = now_as_millis() + 5_000;
+        record.window_start = future;
+        record.last_request = future;
+
+        assert!(!record.is_window_expired());
+        assert!(record.is_duplicate_request());
+    }
+
+    #[test]
+    fn cleanup_if_needed_does_not_panic_when_last_cleanup_is_in_the_future() {
+        let tracker = DataRequestTracker::new();
+        let future = (now_as_millis() + 5_000) as u64;
+        tracker.last_cleanup.store(future, Ordering::Relaxed);
+
+        tracker.cleanup_if_needed();
     }
 
     #[rstest]


### PR DESCRIPTION
## What happened

mainnet-node-1 (genesis) panicked on 2026-06-10 11:34:30 UTC (running `release/mainnet/3.0.2 @ e30f336af`) and was restarted by pm2:

```
Message:  attempt to subtract with overflow
Location: crates/p2p/src/rate_limiting.rs:232
```

Reached from inbound gossip traffic: `POST /gossip/pull_data` → `handle_get_data_sync` → `DataRequestTracker::check_request` → `cleanup_expired_entries`.

## Root cause

The tracker stamps per-peer timestamps (`window_start`, `last_request`, `last_cleanup`) from the **non-monotonic wall clock** (`SystemTime::now()` as epoch millis) and computes elapsed time by **unsigned subtraction** (`now - stored`). Because the workspace sets `overflow-checks = true` in `[profile.release]`, an underflow is a hard panic in every shipped profile.

A stored timestamp can exceed the captured `now` via either mechanism:

1. **Concurrent insert during cleanup iteration (most likely trigger):** `cleanup_expired_entries` captures `now`, then iterates the `DashMap` (not a snapshot). A concurrent `check_request` inserts a fresh record stamped a moment *after* the captured `now`; the iterator visits it and `now - window_start` underflows. Rare per-event, inevitable over time on a busy node.
2. **Backward wall-clock movement** (NTP correction, VM clock sync).

## Fix

`saturating_sub` at all four subtraction sites (`is_window_expired`, `is_duplicate_request`, `cleanup_expired_entries`, `cleanup_if_needed`). An out-of-order timestamp now reads as elapsed `0` — "just happened / not yet aged / not expired" — which is the safe, intended behavior at each call site. No rate-limiting thresholds, windows, or signatures change.

Regression tests were written first and confirmed to panic with `attempt to subtract with overflow` at the exact production lines on the unfixed code; they pass after the fix.

## Note: this is a surgical hotfix — the proper fix is PR #1402

**#1402 (`fix: clock drift/monotonic timers`) is the proper fix**: it rewrites this tracker to use the monotonic `std::time::Instant` (whose arithmetic saturates by design), eliminating the wall-clock dependency entirely. That PR is open against `master` and should be revived and landed there. This PR is the minimal, low-risk hotfix appropriate for the release line so deployed nodes stop panicking now; #1402 supersedes it on `master` when it lands.

Per the [shared-code hotfix process](docs/99-reference/RELEASE_PROCESS.md#shared-code-hotfix-must-reach-every-environment), this fix originates on `release/3.x` and must be cherry-picked up to `master` after landing (or arrive there via #1402's rewrite).

## Verification

- `cargo test -p irys-p2p --lib rate_limiting` — 9/9 pass on this branch (new tests red before the fix)
- `cargo build -p irys-p2p --profile debug-release` — the overflow-checks profile builds clean
- `cargo fmt` / `cargo clippy -p irys-p2p --tests --all-targets` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved rate limiting stability to safely handle edge cases when system timestamps are unusual or adjusted.

* **Tests**
  * Added test coverage for rate limiting behavior under backward clock and future timestamp scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->