### PR TITLE
chore: backport release/3.x changes to master (3.0.3 + 3.0.4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5057,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "irys-chain"
-version = "3.0.2"
+version = "3.0.3"
 dependencies = [
  "actix-web",
  "alloy-contract",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5057,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "irys-chain"
-version = "3.0.3"
+version = "3.0.4"
 dependencies = [
  "actix-web",
  "alloy-contract",

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition.workspace = true
 name = "irys-chain"
-version = "3.0.2"
+version = "3.0.3"
 
 [[bin]]
 name = "irys"

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition.workspace = true
 name = "irys-chain"
-version = "3.0.3"
+version = "3.0.4"
 
 [[bin]]
 name = "irys"

--- a/crates/p2p/src/rate_limiting.rs
+++ b/crates/p2p/src/rate_limiting.rs
@@ -74,14 +74,14 @@ impl DataRequestRecord {
     /// Check if the tracking window has expired
     pub fn is_window_expired(&self) -> bool {
         let now = now_as_millis();
-        now - self.window_start > WINDOW_DURATION_MS
+        now.saturating_sub(self.window_start) > WINDOW_DURATION_MS
     }
 
     /// Check if enough time has passed since last request (deduplication window)
     pub fn is_duplicate_request(&self) -> bool {
         let now = now_as_millis();
         // Consider duplicate if within the configured milliseconds
-        (now - self.last_request) < self.duplicate_request_milliseconds
+        now.saturating_sub(self.last_request) < self.duplicate_request_milliseconds
     }
 
     /// Reset for new tracking window
@@ -229,7 +229,7 @@ impl DataRequestTracker {
         // Collect keys to remove (can't remove while iterating)
         let mut keys_to_remove = Vec::new();
         for entry in self.request_history.iter() {
-            let age = now - entry.window_start;
+            let age = now.saturating_sub(entry.window_start);
             if age > ENTRY_EXPIRY_MS {
                 keys_to_remove.push(*entry.key());
             }
@@ -255,7 +255,7 @@ impl DataRequestTracker {
         let last_cleanup = self.last_cleanup.load(Ordering::Relaxed) as u128;
         let cleanup_interval_ms = self.cleanup_interval.as_millis();
 
-        if now - last_cleanup > cleanup_interval_ms {
+        if now.saturating_sub(last_cleanup) > cleanup_interval_ms {
             // Use compare_exchange to ensure only one thread does cleanup
             if self
                 .last_cleanup
@@ -377,6 +377,52 @@ mod tests {
         // Reset should make it fresh again
         record.reset_window();
         assert!(!record.is_window_expired());
+    }
+
+    #[test]
+    fn cleanup_does_not_panic_when_window_start_is_in_the_future() {
+        let tracker = DataRequestTracker::new();
+        let peer_id = IrysPeerId::from(IrysAddress::from([4_u8; 20]));
+
+        // Simulate the race / backward-clock case: an entry whose window_start is
+        // slightly ahead of the wall clock that cleanup will read.
+        let future = now_as_millis() + 5_000;
+        tracker.request_history.insert(
+            peer_id,
+            DataRequestRecord {
+                window_start: future,
+                request_count: 1,
+                score_given: 0,
+                last_request: future,
+                duplicate_request_milliseconds: 0,
+            },
+        );
+
+        tracker.cleanup_expired_entries();
+        assert!(
+            tracker.get_peer_stats(&peer_id).is_some(),
+            "fresh entry must not be evicted"
+        );
+    }
+
+    #[test]
+    fn record_checks_do_not_panic_when_timestamps_are_in_the_future() {
+        let mut record = DataRequestRecord::new(TEST_DEDUP_WINDOW_MS);
+        let future = now_as_millis() + 5_000;
+        record.window_start = future;
+        record.last_request = future;
+
+        assert!(!record.is_window_expired());
+        assert!(record.is_duplicate_request());
+    }
+
+    #[test]
+    fn cleanup_if_needed_does_not_panic_when_last_cleanup_is_in_the_future() {
+        let tracker = DataRequestTracker::new();
+        let future = (now_as_millis() + 5_000) as u64;
+        tracker.last_cleanup.store(future, Ordering::Relaxed);
+
+        tracker.cleanup_if_needed();
     }
 
     #[rstest]

--- a/crates/types/src/config/consensus.rs
+++ b/crates/types/src/config/consensus.rs
@@ -731,8 +731,25 @@ impl ConsensusConfig {
                     number_of_ingress_proofs_from_assignees: 0,
                 },
                 next_name_tbd: None,
-                aurora: None,
-                borealis: None,
+                // Aurora hardfork - deprecates V1 commitment transactions
+                aurora: Some(Aurora {
+                    activation_timestamp: unix_timestamp_string_serde::deserialize(
+                        StringDeserializer::<serde::de::value::Error>::new(
+                            "2026-06-23T12:00:00+00:00".to_owned(),
+                        ),
+                    )
+                    .unwrap(),
+                    minimum_commitment_tx_version: 2,
+                }),
+                // Borealis hardfork - enables UpdateRewardAddress commitment transactions
+                borealis: Some(Borealis {
+                    activation_timestamp: unix_timestamp_string_serde::deserialize(
+                        StringDeserializer::<serde::de::value::Error>::new(
+                            "2026-06-30T12:00:00+00:00".to_owned(),
+                        ),
+                    )
+                    .unwrap(),
+                }),
                 cascade: None,
             },
         }
@@ -975,8 +992,15 @@ impl ConsensusConfig {
                     minimum_commitment_tx_version: 2,
                 }),
                 next_name_tbd: None,
-                // Borealis hardfork - disabled for testnet (controlled activation)
-                borealis: None,
+                // Borealis hardfork - controlled activation on testnet
+                borealis: Some(Borealis {
+                    activation_timestamp: unix_timestamp_string_serde::deserialize(
+                        StringDeserializer::<serde::de::value::Error>::new(
+                            "2026-06-10T12:00:00+00:00".to_owned(),
+                        ),
+                    )
+                    .unwrap(),
+                }),
                 cascade: None,
             },
         }
@@ -1027,6 +1051,61 @@ mod tests {
             genesis_config.keccak256_hash(),
             peer_config.keccak256_hash(),
             "Genesis and Peer nodes with same expected_genesis_hash must have matching consensus hashes"
+        );
+    }
+
+    /// Pins the mainnet Aurora/Borealis activation times so an accidental edit
+    /// or merge that shifts a hardfork boundary fails CI. These are consensus
+    /// values — any change is a protocol change.
+    #[test]
+    fn test_mainnet_hardfork_activation_times() {
+        let config = ConsensusConfig::mainnet();
+
+        // Aurora — 2026-06-23T12:00:00+00:00
+        let aurora_ts = UnixTimestamp::from_secs(1782216000);
+        let aurora = config
+            .hardforks
+            .aurora
+            .as_ref()
+            .expect("mainnet Aurora must be configured");
+        assert_eq!(aurora.activation_timestamp, aurora_ts);
+        assert_eq!(aurora.minimum_commitment_tx_version, 2);
+        // Inactive one second before the boundary, active at it.
+        assert!(
+            config
+                .hardforks
+                .aurora_at(UnixTimestamp::from_secs(1782216000 - 1))
+                .is_none()
+        );
+        assert!(config.hardforks.aurora_at(aurora_ts).is_some());
+
+        // Borealis — 2026-06-30T12:00:00+00:00 (epoch-aligned at runtime; pin the
+        // configured activation timestamp).
+        assert_eq!(
+            config
+                .hardforks
+                .borealis
+                .as_ref()
+                .expect("mainnet Borealis must be configured")
+                .activation_timestamp,
+            UnixTimestamp::from_secs(1782820800)
+        );
+    }
+
+    /// Pins the testnet Borealis activation time (controlled rollout).
+    #[test]
+    fn test_testnet_borealis_activation_time() {
+        let config = ConsensusConfig::testnet();
+
+        // Borealis — 2026-06-10T12:00:00+00:00 (epoch-aligned at runtime).
+        assert_eq!(
+            config
+                .hardforks
+                .borealis
+                .as_ref()
+                .expect("testnet Borealis must be configured")
+                .activation_timestamp,
+            UnixTimestamp::from_secs(1781092800)
         );
     }
 


### PR DESCRIPTION
## Summary

Cherry-picks the four commits on `release/3.x` that were missing from `master` (clean cherry-picks, no conflicts — backported files are byte-identical to `release/3.x`):

- `3d2aee118` feat(consensus): set aurora/borealis mainnet activation times, enable testnet borealis
- `137af7981` release: bump irys-chain to 3.0.3
- `7a715ce3e` fix(p2p): prevent underflow panic in gossip rate limiter timestamp math (#1445)
- `9cf5826ff` release: 3.0.4

This brings master's `irys-chain` version from 3.0.2 to 3.0.4, matching the released line.

## Verification

- `cargo fmt --all` — no changes
- `cargo clippy --workspace --tests --all-targets` — clean
- `git diff origin/release/3.x HEAD -- <backported files>` — empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential underflow issues in rate-limiting checks when timestamps go backwards.
  * Improved request cleanup logic to handle edge cases with future timestamps.

* **Chores**
  * Updated consensus configurations with hardfork activation parameters for mainnet and testnet.
  * Bumped irys-chain crate version.

* **Tests**
  * Added unit tests for rate-limiting cleanup and timestamp edge cases.
  * Added tests to verify hardfork activation behavior boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->