### PR TITLE
fix: align genesis cascade activation with the epoch-layer predicate

### DIFF
--- a/crates/actors/src/chunk_migration_service.rs
+++ b/crates/actors/src/chunk_migration_service.rs
@@ -337,11 +337,18 @@ fn get_block_offsets_in_ledger(
     // Use the block index to get the ledger relative chunk offset of the
     // start of this new block from the previous block.
     let start_chunk_offset = if block.height > 0 {
-        // We subtract 1 from `total_chunks` to get the offsets
-        block_index
-            .get_item(block.height - 1)
-            .map(|prev| prev.ledgers[ledger].total_chunks)
-            .unwrap_or(0)
+        // We subtract 1 from `total_chunks` to get the offsets.
+        // The previous block may legitimately lack this ledger entirely — e.g.
+        // a Cascade term ledger (OneYear/ThirtyDay) whose first block sits right
+        // after the prior block's epoch predates activation. Treat a missing
+        // entry as zero chunks (the ledger started at this block) instead of
+        // indexing into it, which would panic.
+        block_index.get_item(block.height - 1).map_or(0, |prev| {
+            prev.ledgers
+                .iter()
+                .find(|item| item.ledger == ledger)
+                .map_or(0, |item| item.total_chunks)
+        })
     } else {
         0
     };

--- a/crates/actors/src/chunk_migration_service.rs
+++ b/crates/actors/src/chunk_migration_service.rs
@@ -337,7 +337,9 @@ fn get_block_offsets_in_ledger(
     // Use the block index to get the ledger relative chunk offset of the
     // start of this new block from the previous block.
     let start_chunk_offset = if block.height > 0 {
-        // We subtract 1 from `total_chunks` to get the offsets.
+        // The previous block's `total_chunks` is used directly as this block's
+        // start offset (the count of chunks already in the ledger is the next
+        // 0-indexed offset).
         // The previous block may legitimately lack this ledger entirely — e.g.
         // a Cascade term ledger (OneYear/ThirtyDay) whose first block sits right
         // after the prior block's epoch predates activation. Treat a missing

--- a/crates/actors/src/data_sync_service/chunk_orchestrator.rs
+++ b/crates/actors/src/data_sync_service/chunk_orchestrator.rs
@@ -276,8 +276,7 @@ impl ChunkOrchestrator {
                     // (e.g. a pre-Cascade block for the OneYear/ThirtyDay term
                     // ledgers) legitimately has no entry for it — nothing to
                     // sync for this ledger yet.
-                    None if self
-                        .config
+                    None if tree
                         .consensus_config()
                         .hardforks
                         .ledger_absence_expected(self.ledger_id, block.timestamp_secs()) =>

--- a/crates/actors/src/data_sync_service/chunk_orchestrator.rs
+++ b/crates/actors/src/data_sync_service/chunk_orchestrator.rs
@@ -13,7 +13,7 @@ use std::{
     sync::{Arc, RwLock},
     time::Instant,
 };
-use tracing::{Instrument as _, debug};
+use tracing::{Instrument as _, debug, error};
 
 #[derive(Debug, PartialEq)]
 pub enum ChunkRequestState {
@@ -271,16 +271,33 @@ impl ChunkOrchestrator {
                     .iter()
                     .find(|dl| dl.ledger_id == self.ledger_id);
 
-                // A migrated block that predates this ledger's hardfork
-                // activation (e.g. a pre-Cascade block for the OneYear or
-                // ThirtyDay term ledgers) has no entry for the ledger —
-                // treat it as "no migrated chunks for this ledger yet".
                 match data_ledger {
-                    None => {
+                    // A migrated block that predates this ledger's activation
+                    // (e.g. a pre-Cascade block for the OneYear/ThirtyDay term
+                    // ledgers) legitimately has no entry for it — nothing to
+                    // sync for this ledger yet.
+                    None if self
+                        .config
+                        .consensus_config()
+                        .hardforks
+                        .ledger_absence_expected(self.ledger_id, block.timestamp_secs()) =>
+                    {
                         debug!(
                             ledger_id = self.ledger_id,
                             block_height = block.height,
-                            "migrated block has no entry for this data ledger; nothing to sync yet"
+                            "migrated block predates this ledger's activation; nothing to sync yet"
+                        );
+                        None
+                    }
+                    // Consensus requires a block to carry the full ledger set
+                    // for its activation state, so a missing entry here is an
+                    // invariant violation. Surface it loudly instead of masking
+                    // it — but still return None rather than aborting the task.
+                    None => {
+                        error!(
+                            ledger_id = self.ledger_id,
+                            block_height = block.height,
+                            "data ledger missing from migrated block where consensus requires it; nothing to sync"
                         );
                         None
                     }

--- a/crates/actors/src/data_sync_service/chunk_orchestrator.rs
+++ b/crates/actors/src/data_sync_service/chunk_orchestrator.rs
@@ -269,15 +269,23 @@ impl ChunkOrchestrator {
                 let data_ledger = block
                     .data_ledgers
                     .iter()
-                    .find(|dl| dl.ledger_id == self.ledger_id)
-                    .expect("should be able to look up data_ledger by id");
+                    .find(|dl| dl.ledger_id == self.ledger_id);
 
-                // info!("block: {:#?}", block);
-
-                if data_ledger.total_chunks == 0 {
-                    None
-                } else {
-                    Some(data_ledger.total_chunks.saturating_sub(1))
+                // A migrated block that predates this ledger's hardfork
+                // activation (e.g. a pre-Cascade block for the OneYear or
+                // ThirtyDay term ledgers) has no entry for the ledger —
+                // treat it as "no migrated chunks for this ledger yet".
+                match data_ledger {
+                    None => {
+                        debug!(
+                            ledger_id = self.ledger_id,
+                            block_height = block.height,
+                            "migrated block has no entry for this data ledger; nothing to sync yet"
+                        );
+                        None
+                    }
+                    Some(dl) if dl.total_chunks == 0 => None,
+                    Some(dl) => Some(dl.total_chunks.saturating_sub(1)),
                 }
             } else {
                 None

--- a/crates/actors/src/data_sync_service/chunk_orchestrator.rs
+++ b/crates/actors/src/data_sync_service/chunk_orchestrator.rs
@@ -7,13 +7,14 @@ use crate::{
 use irys_domain::{BlockTreeReadGuard, ChunkTimeRecord, ChunkType, CircularBuffer, StorageModule};
 use irys_types::{
     IrysAddress, LedgerChunkOffset, NodeConfig, PartitionChunkOffset, SendTraced as _,
+    hardfork_config::DataLedgerLookup,
 };
 use std::{
     collections::{HashMap, HashSet, hash_map},
     sync::{Arc, RwLock},
     time::Instant,
 };
-use tracing::{Instrument as _, debug, error};
+use tracing::{Instrument as _, debug, warn};
 
 #[derive(Debug, PartialEq)]
 pub enum ChunkRequestState {
@@ -266,21 +267,18 @@ impl ChunkOrchestrator {
 
                 let block = most_recent_migrated_block.header();
 
-                let data_ledger = block
-                    .data_ledgers
-                    .iter()
-                    .find(|dl| dl.ledger_id == self.ledger_id);
-
-                match data_ledger {
+                match tree
+                    .consensus_config()
+                    .hardforks
+                    .classify_data_ledger(block, self.ledger_id)
+                {
+                    DataLedgerLookup::Present(dl) if dl.total_chunks == 0 => None,
+                    DataLedgerLookup::Present(dl) => Some(dl.total_chunks.saturating_sub(1)),
                     // A migrated block that predates this ledger's activation
                     // (e.g. a pre-Cascade block for the OneYear/ThirtyDay term
                     // ledgers) legitimately has no entry for it — nothing to
                     // sync for this ledger yet.
-                    None if tree
-                        .consensus_config()
-                        .hardforks
-                        .ledger_absence_expected(self.ledger_id, block.timestamp_secs()) =>
-                    {
+                    DataLedgerLookup::ExpectedAbsent => {
                         debug!(
                             ledger_id = self.ledger_id,
                             block_height = block.height,
@@ -288,20 +286,17 @@ impl ChunkOrchestrator {
                         );
                         None
                     }
-                    // Consensus requires a block to carry the full ledger set
-                    // for its activation state, so a missing entry here is an
-                    // invariant violation. Surface it loudly instead of masking
-                    // it — but still return None rather than aborting the task.
-                    None => {
-                        error!(
+                    // The block's shape is validated upstream, so this should be
+                    // unreachable; surface it (defense-in-depth) but still degrade
+                    // to None rather than aborting the task.
+                    DataLedgerLookup::UnexpectedAbsent => {
+                        warn!(
                             ledger_id = self.ledger_id,
                             block_height = block.height,
-                            "data ledger missing from migrated block where consensus requires it; nothing to sync"
+                            "data ledger missing from migrated block where consensus expects it; nothing to sync"
                         );
                         None
                     }
-                    Some(dl) if dl.total_chunks == 0 => None,
-                    Some(dl) => Some(dl.total_chunks.saturating_sub(1)),
                 }
             } else {
                 None

--- a/crates/actors/tests/data_sync_test.rs
+++ b/crates/actors/tests/data_sync_test.rs
@@ -1,6 +1,7 @@
 use irys_actors::{
     DataSyncServiceInner, DataSyncServiceMessage,
     chunk_fetcher::{ChunkFetchError, ChunkFetcher, ChunkFetcherFactory, MockChunkFetcher},
+    chunk_orchestrator::ChunkOrchestrator,
     peer_bandwidth_manager::PeerBandwidthManager,
     services::{ServiceReceivers, ServiceSenders},
 };
@@ -889,4 +890,93 @@ impl ChunkFetcher for PeerAwareChunkFetcher {
 
         result
     }
+}
+
+/// Regression: a migrated block whose header predates a term ledger's
+/// activation has no entry for that ledger. get_max_chunk_offset must treat
+/// that as "no migrated chunks yet" (None), not panic.
+/// Devnet incident 2026-06-11: chunk_orchestrator.rs:273 .expect() aborted
+/// the genesis node 34 times when the migration depth reached a genesis
+/// header that lacked the OneYear/ThirtyDay ledgers.
+#[tokio::test]
+async fn term_ledger_orchestrator_handles_block_without_ledger_entry() {
+    let tmp_dir = TempDirBuilder::new().with_tracing().build();
+
+    let chunk_size: u64 = 256 * 1024;
+    let num_chunks: u64 = 5;
+    let node_config = NodeConfig {
+        consensus: irys_types::ConsensusOptions::Custom(ConsensusConfig {
+            chunk_size,
+            num_chunks_in_partition: num_chunks,
+            num_chunks_in_recall_range: 2,
+            num_partitions_per_slot: 1,
+            entropy_packing_iterations: 1,
+            // Canonical chain holds only the mock genesis (length 1), so a
+            // depth of 1 makes genesis the most recently migrated block.
+            block_migration_depth: 1,
+            chain_id: 1,
+            ..ConsensusConfig::testing()
+        }),
+        base_directory: tmp_dir.path().to_path_buf(),
+        ..NodeConfig::testing()
+    };
+    let config = Config::new_with_random_peer_id(node_config);
+
+    // Storage module assigned to the OneYear term ledger, slot 0.
+    let pa = PartitionAssignment {
+        ledger_id: Some(DataLedger::OneYear.into()),
+        slot_index: Some(0),
+        miner_address: IrysAddress::from([9_u8; 20]),
+        partition_hash: H256::random(),
+    };
+    let storage_module_info = StorageModuleInfo {
+        id: 0,
+        partition_assignment: Some(pa),
+        submodules: vec![(
+            partition_chunk_offset_ie!(0, num_chunks as u32),
+            "chunks".into(),
+        )],
+    };
+    let storage_module =
+        Arc::new(StorageModule::new(&storage_module_info, &config).expect("storage module"));
+
+    // Mock genesis carries only Publish + Submit — no OneYear entry, exactly
+    // like a block that predates Cascade activation.
+    let fake_genesis = irys_testing_utils::new_mock_signed_header();
+    assert!(
+        fake_genesis
+            .data_ledgers
+            .iter()
+            .all(|dl| dl.ledger_id != u32::from(DataLedger::OneYear)),
+        "precondition: mock genesis must not contain a OneYear ledger entry"
+    );
+
+    let block_tree = BlockTree::new(&fake_genesis, config.consensus.clone());
+    let block_tree_guard = BlockTreeReadGuard::new(Arc::new(RwLock::new(block_tree)));
+
+    let (service_senders, _receivers) = irys_actors::test_helpers::build_test_service_senders();
+    let mock_fetcher = Arc::new(MockChunkFetcher::new(
+        u32::from(DataLedger::OneYear) as usize
+    ));
+
+    let orchestrator = ChunkOrchestrator::new(
+        storage_module,
+        Arc::new(RwLock::new(HashMap::new())),
+        block_tree_guard.clone(),
+        &service_senders,
+        mock_fetcher,
+        config.node_config.clone(),
+        tokio::runtime::Handle::current(),
+    );
+
+    // Before the fix this panics: "should be able to look up data_ledger by id".
+    assert_eq!(orchestrator.get_max_chunk_offset(), None);
+
+    // Same scenario through the second lookup site: a block height whose header
+    // predates the ledger must yield None, not panic (the mock genesis sits at
+    // height 42).
+    assert_eq!(
+        block_tree_guard.get_total_chunks(fake_genesis.height, DataLedger::OneYear.into()),
+        None
+    );
 }

--- a/crates/actors/tests/data_sync_test.rs
+++ b/crates/actors/tests/data_sync_test.rs
@@ -15,8 +15,9 @@ use irys_types::{
     Base64, Config, ConsensusConfig, DataLedger, DataSyncServiceConfig, DataTransaction, H256,
     IrysAddress, IrysBlockHeader, IrysPeerId, LedgerChunkOffset, LedgerChunkRange, NodeConfig,
     PackedChunk, PartitionChunkOffset, PeerAddress, PeerListItem, PeerScore, ProtocolVersion,
-    StorageSyncConfig, TxChunkOffset, UnpackedChunk, irys::IrysSigner, ledger_chunk_offset_ie,
-    partition::PartitionAssignment, partition_chunk_offset_ie,
+    StorageSyncConfig, TxChunkOffset, UnixTimestamp, UnpackedChunk, hardfork_config::Cascade,
+    irys::IrysSigner, ledger_chunk_offset_ie, partition::PartitionAssignment,
+    partition_chunk_offset_ie,
 };
 use nodit::Interval;
 use rust_decimal::prelude::ToPrimitive as _;
@@ -951,7 +952,24 @@ async fn term_ledger_orchestrator_handles_block_without_ledger_entry() {
         "precondition: mock genesis must not contain a OneYear ledger entry"
     );
 
-    let block_tree = BlockTree::new(&fake_genesis, config.consensus.clone());
+    // Configure Cascade so it activates strictly *after* the genesis timestamp.
+    // The genesis block then genuinely predates activation, so its missing
+    // OneYear ledger is an expected pre-activation gap — the realistic case
+    // (not merely "Cascade unconfigured").
+    let pre_activation_consensus = {
+        let mut consensus = config.consensus.clone();
+        consensus.hardforks.cascade = Some(Cascade {
+            activation_timestamp: UnixTimestamp::from_secs(
+                fake_genesis.timestamp_secs().as_secs() + 1_000_000,
+            ),
+            one_year_epoch_length: 365,
+            thirty_day_epoch_length: 30,
+            annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
+        });
+        consensus
+    };
+
+    let block_tree = BlockTree::new(&fake_genesis, pre_activation_consensus);
     let block_tree_guard = BlockTreeReadGuard::new(Arc::new(RwLock::new(block_tree)));
 
     let (service_senders, _receivers) = irys_actors::test_helpers::build_test_service_senders();
@@ -970,6 +988,8 @@ async fn term_ledger_orchestrator_handles_block_without_ledger_entry() {
     );
 
     // Before the fix this panics: "should be able to look up data_ledger by id".
+    // With Cascade configured but not yet active, the absent OneYear ledger is an
+    // expected pre-activation gap, so the orchestrator degrades to None.
     assert_eq!(orchestrator.get_max_chunk_offset(), None);
 
     // Same scenario through the second lookup site: a block height whose header
@@ -985,7 +1005,6 @@ async fn term_ledger_orchestrator_handles_block_without_ledger_entry() {
     // validation would reject), both lookup sites must surface the anomaly in the
     // logs but still degrade to None rather than aborting. Reuse the same mock
     // genesis — which carries no OneYear entry — under a Cascade-active config.
-    use irys_types::{UnixTimestamp, hardfork_config::Cascade};
     let cascade = Cascade {
         activation_timestamp: UnixTimestamp::from_secs(1),
         one_year_epoch_length: 365,

--- a/crates/actors/tests/data_sync_test.rs
+++ b/crates/actors/tests/data_sync_test.rs
@@ -979,4 +979,24 @@ async fn term_ledger_orchestrator_handles_block_without_ledger_entry() {
         block_tree_guard.get_total_chunks(fake_genesis.height, DataLedger::OneYear.into()),
         None
     );
+
+    // Defense-in-depth: if Cascade *is* active at the block's timestamp yet the
+    // block still lacks the term ledger (a structurally invalid block that block
+    // validation would reject), the guard must surface the anomaly in the logs
+    // but still degrade to None rather than aborting. Reuse the same mock genesis
+    // — which carries no OneYear entry — under a Cascade-active config.
+    use irys_types::{UnixTimestamp, hardfork_config::Cascade};
+    let mut cascade_consensus = config.consensus.clone();
+    cascade_consensus.hardforks.cascade = Some(Cascade {
+        activation_timestamp: UnixTimestamp::from_secs(1),
+        one_year_epoch_length: 365,
+        thirty_day_epoch_length: 30,
+        annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
+    });
+    let cascade_tree = BlockTree::new(&fake_genesis, cascade_consensus);
+    let cascade_guard = BlockTreeReadGuard::new(Arc::new(RwLock::new(cascade_tree)));
+    assert_eq!(
+        cascade_guard.get_total_chunks(fake_genesis.height, DataLedger::OneYear.into()),
+        None
+    );
 }

--- a/crates/actors/tests/data_sync_test.rs
+++ b/crates/actors/tests/data_sync_test.rs
@@ -992,6 +992,11 @@ async fn term_ledger_orchestrator_handles_block_without_ledger_entry() {
         thirty_day_epoch_length: 30,
         annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
     };
+    assert!(
+        fake_genesis.timestamp_secs() >= cascade.activation_timestamp,
+        "precondition: Cascade must be active at the mock genesis timestamp so the \
+         anomaly branch (not the pre-activation branch) is exercised"
+    );
     let mut cascade_consensus = config.consensus.clone();
     cascade_consensus.hardforks.cascade = Some(cascade.clone());
     let cascade_tree = BlockTree::new(&fake_genesis, cascade_consensus);

--- a/crates/actors/tests/data_sync_test.rs
+++ b/crates/actors/tests/data_sync_test.rs
@@ -960,7 +960,7 @@ async fn term_ledger_orchestrator_handles_block_without_ledger_entry() {
     ));
 
     let orchestrator = ChunkOrchestrator::new(
-        storage_module,
+        storage_module.clone(),
         Arc::new(RwLock::new(HashMap::new())),
         block_tree_guard.clone(),
         &service_senders,
@@ -982,21 +982,43 @@ async fn term_ledger_orchestrator_handles_block_without_ledger_entry() {
 
     // Defense-in-depth: if Cascade *is* active at the block's timestamp yet the
     // block still lacks the term ledger (a structurally invalid block that block
-    // validation would reject), the guard must surface the anomaly in the logs
-    // but still degrade to None rather than aborting. Reuse the same mock genesis
-    // — which carries no OneYear entry — under a Cascade-active config.
+    // validation would reject), both lookup sites must surface the anomaly in the
+    // logs but still degrade to None rather than aborting. Reuse the same mock
+    // genesis — which carries no OneYear entry — under a Cascade-active config.
     use irys_types::{UnixTimestamp, hardfork_config::Cascade};
-    let mut cascade_consensus = config.consensus.clone();
-    cascade_consensus.hardforks.cascade = Some(Cascade {
+    let cascade = Cascade {
         activation_timestamp: UnixTimestamp::from_secs(1),
         one_year_epoch_length: 365,
         thirty_day_epoch_length: 30,
         annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
-    });
+    };
+    let mut cascade_consensus = config.consensus.clone();
+    cascade_consensus.hardforks.cascade = Some(cascade.clone());
     let cascade_tree = BlockTree::new(&fake_genesis, cascade_consensus);
     let cascade_guard = BlockTreeReadGuard::new(Arc::new(RwLock::new(cascade_tree)));
+
+    // Lookup site 1: block_tree_guard.
     assert_eq!(
         cascade_guard.get_total_chunks(fake_genesis.height, DataLedger::OneYear.into()),
         None
     );
+
+    // Lookup site 2: the orchestrator's get_max_chunk_offset hot path (the
+    // original panic site) — must also degrade to None, not abort.
+    let cascade_node_config = config
+        .node_config
+        .clone()
+        .with_consensus(|c| c.hardforks.cascade = Some(cascade));
+    let anomaly_orchestrator = ChunkOrchestrator::new(
+        storage_module,
+        Arc::new(RwLock::new(HashMap::new())),
+        cascade_guard,
+        &service_senders,
+        Arc::new(MockChunkFetcher::new(
+            u32::from(DataLedger::OneYear) as usize
+        )),
+        cascade_node_config,
+        tokio::runtime::Handle::current(),
+    );
+    assert_eq!(anomaly_orchestrator.get_max_chunk_offset(), None);
 }

--- a/crates/actors/tests/data_sync_test.rs
+++ b/crates/actors/tests/data_sync_test.rs
@@ -898,7 +898,7 @@ impl ChunkFetcher for PeerAwareChunkFetcher {
 /// Devnet incident 2026-06-11: chunk_orchestrator.rs:273 .expect() aborted
 /// the genesis node 34 times when the migration depth reached a genesis
 /// header that lacked the OneYear/ThirtyDay ledgers.
-#[tokio::test]
+#[test_log::test(tokio::test)]
 async fn term_ledger_orchestrator_handles_block_without_ledger_entry() {
     let tmp_dir = TempDirBuilder::new().with_tracing().build();
 

--- a/crates/chain-tests/src/multi_node/cascade_reorg.rs
+++ b/crates/chain-tests/src/multi_node/cascade_reorg.rs
@@ -1,6 +1,6 @@
 use crate::utils::IrysNodeTest;
 use irys_config::submodules::StorageSubmodulesConfig;
-use irys_types::{hardfork_config::Cascade, BoundedFee, DataLedger, NodeConfig, UnixTimestamp};
+use irys_types::{BoundedFee, DataLedger, NodeConfig, UnixTimestamp, hardfork_config::Cascade};
 use std::sync::Arc;
 
 /// Verify that when a reorg occurs, OneYear and ThirtyDay term ledger transactions

--- a/crates/chain-tests/src/multi_node/mod.rs
+++ b/crates/chain-tests/src/multi_node/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod api_ingress_validation;
+pub(crate) mod cascade_reorg;
 pub(crate) mod ema_forks;
 pub(crate) mod epoch_replay;
 pub(crate) mod fork_recovery;

--- a/crates/chain-tests/src/validation/cascade_ledger_shape.rs
+++ b/crates/chain-tests/src/validation/cascade_ledger_shape.rs
@@ -93,3 +93,84 @@ async fn heavy_cascade_block_header_ledger_shape_at_activation_epoch() -> eyre::
     ctx.stop().await;
     Ok(())
 }
+
+/// Regression test for the 2026-06-11 devnet incident: a positive Cascade
+/// activation timestamp at or before the genesis timestamp must yield a
+/// genesis header with all four data ledgers, and a node hosting term-ledger
+/// partitions must mine past block_migration_depth — the point where the
+/// migrated-block pointer reaches genesis — without the chunk orchestrator
+/// panicking.
+#[test_log::test(tokio::test)]
+async fn heavy_cascade_pre_genesis_activation_active_from_genesis() -> eyre::Result<()> {
+    use irys_config::submodules::StorageSubmodulesConfig;
+    use irys_types::hardfork_config::Cascade;
+
+    let seconds_to_wait = 20;
+    let config = NodeConfig::testing().with_consensus(|c| {
+        c.hardforks.cascade = Some(Cascade {
+            // Non-zero and earlier than any realistic genesis timestamp —
+            // the devnet encoding of "active from genesis" that previously
+            // produced a two-ledger genesis header.
+            activation_timestamp: UnixTimestamp::from_secs(1),
+            one_year_epoch_length: 365,
+            thirty_day_epoch_length: 30,
+            annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
+        });
+    });
+
+    // Pre-configure 5 storage submodules so there are enough partitions for
+    // all 4 data ledgers (Publish, Submit, OneYear, ThirtyDay).
+    let test = IrysNodeTest::new_genesis(config);
+    StorageSubmodulesConfig::load_for_test(test.cfg.base_directory.clone(), 5)?;
+    let ctx = test
+        .start_and_wait_for_packing("GENESIS", seconds_to_wait)
+        .await;
+
+    // The genesis header must carry all four data ledgers.
+    let genesis_block = ctx.get_block_by_height(0).await?;
+    let ledger_ids: Vec<u32> = genesis_block
+        .data_ledgers
+        .iter()
+        .map(|l| l.ledger_id)
+        .collect();
+    assert_eq!(
+        ledger_ids,
+        vec![
+            DataLedger::Publish as u32,
+            DataLedger::Submit as u32,
+            DataLedger::OneYear as u32,
+            DataLedger::ThirtyDay as u32,
+        ],
+        "genesis header must contain all four data ledgers"
+    );
+
+    // The node must own term-ledger partition assignments, so its term-ledger
+    // chunk orchestrators actually run (regression precondition).
+    let miner_address = ctx.node_ctx.config.node_config.miner_address();
+    let assignments = ctx.get_partition_assignments(miner_address);
+    for ledger in [DataLedger::OneYear, DataLedger::ThirtyDay] {
+        assert!(
+            assignments
+                .iter()
+                .any(|pa| pa.ledger_id == Some(ledger as u32)),
+            "node must own a {ledger:?} partition assignment"
+        );
+    }
+
+    // Mine past block_migration_depth so the migrated-block pointer crosses
+    // the genesis block — the exact window where the devnet node panicked.
+    let depth = ctx.node_ctx.config.consensus.block_migration_depth as u64;
+    for h in 1..=depth + 1 {
+        ctx.mine_block().await?;
+        let block = ctx.get_block_by_height(h).await?;
+        assert_eq!(
+            block.data_ledgers.len(),
+            4,
+            "block {h} must carry four data ledgers"
+        );
+    }
+
+    // Reaching this point without an abort is the core regression assertion.
+    ctx.stop().await;
+    Ok(())
+}

--- a/crates/chain/src/genesis_builder.rs
+++ b/crates/chain/src/genesis_builder.rs
@@ -242,7 +242,10 @@ fn prepare_unsigned_genesis(config: &Config) -> eyre::Result<GenesisPrelude> {
         &config.consensus.genesis,
         reth_chain_spec.genesis_hash(),
         number_of_ingress_proofs_total,
-        config.consensus.hardforks.cascade.as_ref(),
+        config
+            .consensus
+            .hardforks
+            .cascade_at(UnixTimestamp::from_secs(timestamp_secs)),
     )?;
 
     // Set timestamp fields

--- a/crates/chain/tests/genesis_builder_tests.rs
+++ b/crates/chain/tests/genesis_builder_tests.rs
@@ -103,6 +103,61 @@ fn test_config() -> Config {
     Config::new_with_random_peer_id(node_config)
 }
 
+fn test_config_with_cascade(activation_secs: u64) -> Config {
+    use irys_types::{UnixTimestamp, hardfork_config::Cascade};
+    let node_config = NodeConfig::testing().with_consensus(|c| {
+        // Ensure deterministic timestamp — testing() defaults to 0 which means "use now()"
+        if c.genesis.timestamp_millis == 0 {
+            c.genesis.timestamp_millis = 1_700_000_000_000;
+        }
+        c.genesis.initial_packed_partitions = Some(5.0);
+        c.hardforks.cascade = Some(Cascade {
+            activation_timestamp: UnixTimestamp::from_secs(activation_secs),
+            one_year_epoch_length: 365,
+            thirty_day_epoch_length: 30,
+            annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
+        });
+    });
+    Config::new_with_random_peer_id(node_config)
+}
+
+/// Regression for the devnet cascade-from-genesis incident: a positive
+/// activation timestamp at or before the genesis timestamp must produce a
+/// genesis header with all four data ledgers. Before the fix, only a literal
+/// zero activation timestamp did.
+#[tokio::test]
+async fn cascade_active_at_genesis_yields_four_ledger_genesis() {
+    // Non-zero and before the resolved genesis timestamp (1_700_000_000 s) —
+    // the encoding devnet used.
+    let config = test_config_with_cascade(1_600_000_000);
+    let miners = test_miners();
+    let output = build_signed_genesis_block(&config, &miners).await.unwrap();
+    assert_eq!(
+        output.block.data_ledgers.len(),
+        4,
+        "pre-genesis activation timestamp must include the term ledgers"
+    );
+}
+
+#[tokio::test]
+async fn cascade_activation_at_exact_genesis_timestamp_yields_four_ledger_genesis() {
+    // Boundary: activation equal to the resolved genesis timestamp counts as
+    // active (>= comparison, matching the epoch-layer predicate).
+    let config = test_config_with_cascade(1_700_000_000);
+    let miners = test_miners();
+    let output = build_signed_genesis_block(&config, &miners).await.unwrap();
+    assert_eq!(output.block.data_ledgers.len(), 4);
+}
+
+#[tokio::test]
+async fn cascade_activating_after_genesis_yields_two_ledger_genesis() {
+    // Activation after the resolved genesis timestamp: term ledgers absent.
+    let config = test_config_with_cascade(1_800_000_000);
+    let miners = test_miners();
+    let output = build_signed_genesis_block(&config, &miners).await.unwrap();
+    assert_eq!(output.block.data_ledgers.len(), 2);
+}
+
 fn test_miners() -> Vec<GenesisMinerEntry> {
     let key_a = SigningKey::from_slice(&hex::decode(KEY_A).unwrap()).unwrap();
     let key_b = SigningKey::from_slice(&hex::decode(KEY_B).unwrap()).unwrap();

--- a/crates/chain/tests/genesis_builder_tests.rs
+++ b/crates/chain/tests/genesis_builder_tests.rs
@@ -122,40 +122,24 @@ fn test_config_with_cascade(activation_secs: u64) -> Config {
 }
 
 /// Regression for the devnet cascade-from-genesis incident: a positive
-/// activation timestamp at or before the genesis timestamp must produce a
-/// genesis header with all four data ledgers. Before the fix, only a literal
-/// zero activation timestamp did.
+/// activation timestamp at or before the resolved genesis timestamp
+/// (1_700_000_000 s) must produce a genesis header with all four data ledgers
+/// (>= comparison, matching the epoch-layer predicate); a later activation
+/// leaves the two pre-Cascade ledgers. Before the fix, only a literal zero
+/// activation timestamp produced four.
+#[rstest::rstest]
+#[case::before_genesis(1_600_000_000, 4)]
+#[case::at_exact_genesis_timestamp(1_700_000_000, 4)]
+#[case::after_genesis(1_800_000_000, 2)]
 #[tokio::test]
-async fn cascade_active_at_genesis_yields_four_ledger_genesis() {
-    // Non-zero and before the resolved genesis timestamp (1_700_000_000 s) —
-    // the encoding devnet used.
-    let config = test_config_with_cascade(1_600_000_000);
+async fn cascade_activation_genesis_ledger_count(
+    #[case] activation_secs: u64,
+    #[case] expected_ledgers: usize,
+) {
+    let config = test_config_with_cascade(activation_secs);
     let miners = test_miners();
     let output = build_signed_genesis_block(&config, &miners).await.unwrap();
-    assert_eq!(
-        output.block.data_ledgers.len(),
-        4,
-        "pre-genesis activation timestamp must include the term ledgers"
-    );
-}
-
-#[tokio::test]
-async fn cascade_activation_at_exact_genesis_timestamp_yields_four_ledger_genesis() {
-    // Boundary: activation equal to the resolved genesis timestamp counts as
-    // active (>= comparison, matching the epoch-layer predicate).
-    let config = test_config_with_cascade(1_700_000_000);
-    let miners = test_miners();
-    let output = build_signed_genesis_block(&config, &miners).await.unwrap();
-    assert_eq!(output.block.data_ledgers.len(), 4);
-}
-
-#[tokio::test]
-async fn cascade_activating_after_genesis_yields_two_ledger_genesis() {
-    // Activation after the resolved genesis timestamp: term ledgers absent.
-    let config = test_config_with_cascade(1_800_000_000);
-    let miners = test_miners();
-    let output = build_signed_genesis_block(&config, &miners).await.unwrap();
-    assert_eq!(output.block.data_ledgers.len(), 2);
+    assert_eq!(output.block.data_ledgers.len(), expected_ledgers);
 }
 
 fn test_miners() -> Vec<GenesisMinerEntry> {

--- a/crates/config/src/chain/chainspec.rs
+++ b/crates/config/src/chain/chainspec.rs
@@ -1,10 +1,16 @@
 use alloy_primitives::B256;
 use irys_types::{
     DataLedger, DataTransactionLedger, GenesisConfig, H256, H256List, IrysBlockHeader,
-    IrysBlockHeaderV1, IrysSignature, PoaData, U256, UnixTimestamp, UnixTimestampMs,
-    VDFLimiterInfo, hardfork_config::Cascade, partition::PartitionHash,
+    IrysBlockHeaderV1, IrysSignature, PoaData, U256, UnixTimestampMs, VDFLimiterInfo,
+    hardfork_config::Cascade, partition::PartitionHash,
 };
 
+/// Builds the unsigned genesis block header.
+///
+/// `cascade` must be `Some` only when the Cascade hardfork is active at the
+/// genesis timestamp — callers filter via `IrysHardforkConfig::cascade_at`.
+/// When present, the OneYear and ThirtyDay term ledgers are included in the
+/// genesis header.
 pub fn build_unsigned_irys_genesis_block(
     config: &GenesisConfig,
     evm_block_hash: B256,
@@ -38,9 +44,10 @@ pub fn build_unsigned_irys_genesis_block(
             required_proof_count: None,
         },
     ];
-    // Only include OneYear/ThirtyDay ledgers if Cascade activates at genesis (timestamp 0)
-    if let Some(cascade) = cascade.filter(|c| c.activation_timestamp == UnixTimestamp::from_secs(0))
-    {
+    // Include OneYear/ThirtyDay ledgers when Cascade is active at genesis.
+    // The caller passes the cascade config only in that case (filtered via
+    // IrysHardforkConfig::cascade_at against the resolved genesis timestamp).
+    if let Some(cascade) = cascade {
         data_ledgers.push(DataTransactionLedger {
             ledger_id: DataLedger::OneYear.into(),
             tx_root: H256::zero(),
@@ -108,7 +115,7 @@ pub fn build_unsigned_irys_genesis_block(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use irys_types::{Amount, Decimal, IrysAddress};
+    use irys_types::{Amount, Decimal, IrysAddress, UnixTimestamp};
     use proptest::prelude::*;
 
     fn test_genesis_config() -> GenesisConfig {
@@ -179,9 +186,11 @@ mod tests {
     }
 
     #[test]
-    fn test_genesis_block_with_cascade_at_genesis_has_four_ledgers() {
+    fn test_genesis_block_with_active_cascade_has_four_ledgers() {
+        // The activation timestamp no longer gates the builder — the caller
+        // passes the cascade config only when it is active at genesis.
         let cascade = Cascade {
-            activation_timestamp: UnixTimestamp::from_secs(0),
+            activation_timestamp: UnixTimestamp::from_secs(1000),
             one_year_epoch_length: 365,
             thirty_day_epoch_length: 30,
             annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
@@ -201,20 +210,6 @@ mod tests {
         assert_eq!(block.data_ledgers[3].expires, Some(30));
         assert!(block.data_ledgers[2].proofs.is_none());
         assert!(block.data_ledgers[3].required_proof_count.is_none());
-    }
-
-    #[test]
-    fn test_genesis_block_with_cascade_not_at_genesis_has_two_ledgers() {
-        let cascade = Cascade {
-            activation_timestamp: UnixTimestamp::from_secs(1000),
-            one_year_epoch_length: 365,
-            thirty_day_epoch_length: 30,
-            annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
-        };
-        let block =
-            build_unsigned_irys_genesis_block(&genesis_config(), B256::ZERO, 2, Some(&cascade))
-                .unwrap();
-        assert_eq!(block.data_ledgers.len(), 2);
     }
 
     #[test]

--- a/crates/domain/src/guards/block_tree_guard.rs
+++ b/crates/domain/src/guards/block_tree_guard.rs
@@ -53,12 +53,14 @@ impl BlockTreeReadGuard {
                 .get_block(&block_entry.block_hash())
                 .expect("Block to be in block tree");
 
-            let data_ledger = block
+            // A block that predates the ledger's hardfork activation (e.g. a
+            // pre-Cascade block for the OneYear/ThirtyDay term ledgers) has no
+            // entry for it — report "no chunks for this ledger at that height".
+            block
                 .data_ledgers
                 .iter()
                 .find(|dl| dl.ledger_id == ledger_id)
-                .expect("should be able to look up data_ledger by id");
-            Some(data_ledger.total_chunks.into())
+                .map(|data_ledger| data_ledger.total_chunks.into())
         } else {
             None
         }

--- a/crates/domain/src/guards/block_tree_guard.rs
+++ b/crates/domain/src/guards/block_tree_guard.rs
@@ -1,6 +1,7 @@
 use crate::BlockTree;
 use irys_types::LedgerChunkOffset;
 use std::sync::{Arc, RwLock, RwLockReadGuard};
+use tracing::{debug, error};
 
 /// Wraps the internal `Arc<RwLock<_>>` to make the reference readonly
 #[derive(Debug, Clone)]
@@ -53,14 +54,40 @@ impl BlockTreeReadGuard {
                 .get_block(&block_entry.block_hash())
                 .expect("Block to be in block tree");
 
-            // A block that predates the ledger's hardfork activation (e.g. a
-            // pre-Cascade block for the OneYear/ThirtyDay term ledgers) has no
-            // entry for it — report "no chunks for this ledger at that height".
-            block
+            match block
                 .data_ledgers
                 .iter()
                 .find(|dl| dl.ledger_id == ledger_id)
-                .map(|data_ledger| data_ledger.total_chunks.into())
+            {
+                Some(data_ledger) => Some(data_ledger.total_chunks.into()),
+                // A pre-activation block legitimately predates a term ledger
+                // (e.g. a pre-Cascade block for OneYear/ThirtyDay) and carries
+                // no entry for it — report "no chunks for this ledger yet".
+                None if tree
+                    .consensus_config()
+                    .hardforks
+                    .ledger_absence_expected(ledger_id, block.timestamp_secs()) =>
+                {
+                    debug!(
+                        ledger_id,
+                        block_height = block.height,
+                        "ledger not present at this height (pre-activation); reporting no chunks"
+                    );
+                    None
+                }
+                // Consensus requires a block to carry the full ledger set for
+                // its activation state, so a missing entry here is an invariant
+                // violation. Surface it loudly instead of masking it — but still
+                // return None rather than aborting the process.
+                None => {
+                    error!(
+                        ledger_id,
+                        block_height = block.height,
+                        "data ledger missing from a block where consensus requires it; reporting no chunks"
+                    );
+                    None
+                }
+            }
         } else {
             None
         }

--- a/crates/domain/src/guards/block_tree_guard.rs
+++ b/crates/domain/src/guards/block_tree_guard.rs
@@ -1,7 +1,7 @@
 use crate::BlockTree;
-use irys_types::LedgerChunkOffset;
+use irys_types::{LedgerChunkOffset, hardfork_config::DataLedgerLookup};
 use std::sync::{Arc, RwLock, RwLockReadGuard};
-use tracing::{debug, error};
+use tracing::{debug, warn};
 
 /// Wraps the internal `Arc<RwLock<_>>` to make the reference readonly
 #[derive(Debug, Clone)]
@@ -54,20 +54,16 @@ impl BlockTreeReadGuard {
                 .get_block(&block_entry.block_hash())
                 .expect("Block to be in block tree");
 
-            match block
-                .data_ledgers
-                .iter()
-                .find(|dl| dl.ledger_id == ledger_id)
+            match tree
+                .consensus_config()
+                .hardforks
+                .classify_data_ledger(block, ledger_id)
             {
-                Some(data_ledger) => Some(data_ledger.total_chunks.into()),
+                DataLedgerLookup::Present(data_ledger) => Some(data_ledger.total_chunks.into()),
                 // A pre-activation block legitimately predates a term ledger
                 // (e.g. a pre-Cascade block for OneYear/ThirtyDay) and carries
                 // no entry for it — report "no chunks for this ledger yet".
-                None if tree
-                    .consensus_config()
-                    .hardforks
-                    .ledger_absence_expected(ledger_id, block.timestamp_secs()) =>
-                {
+                DataLedgerLookup::ExpectedAbsent => {
                     debug!(
                         ledger_id,
                         block_height = block.height,
@@ -75,15 +71,14 @@ impl BlockTreeReadGuard {
                     );
                     None
                 }
-                // Consensus requires a block to carry the full ledger set for
-                // its activation state, so a missing entry here is an invariant
-                // violation. Surface it loudly instead of masking it — but still
-                // return None rather than aborting the process.
-                None => {
-                    error!(
+                // The block's shape is validated upstream, so this should be
+                // unreachable; surface it (defense-in-depth) but still report no
+                // chunks rather than aborting the process.
+                DataLedgerLookup::UnexpectedAbsent => {
+                    warn!(
                         ledger_id,
                         block_height = block.height,
-                        "data ledger missing from a block where consensus requires it; reporting no chunks"
+                        "data ledger missing from a block where consensus expects it; reporting no chunks"
                     );
                     None
                 }

--- a/crates/domain/src/hardfork_ext.rs
+++ b/crates/domain/src/hardfork_ext.rs
@@ -14,16 +14,10 @@ pub trait HardforkConfigExt {
 
 impl HardforkConfigExt for IrysHardforkConfig {
     fn is_update_reward_address_allowed_for_epoch(&self, epoch_snapshot: &EpochSnapshot) -> bool {
-        let epoch_block_timestamp = epoch_snapshot.epoch_block.timestamp_secs();
-        self.borealis
-            .as_ref()
-            .is_some_and(|f| epoch_block_timestamp >= f.activation_timestamp)
+        self.is_borealis_active_at(epoch_snapshot.epoch_block.timestamp_secs())
     }
 
     fn is_cascade_active_for_epoch(&self, epoch_snapshot: &EpochSnapshot) -> bool {
-        let epoch_block_timestamp = epoch_snapshot.epoch_block.timestamp_secs();
-        self.cascade
-            .as_ref()
-            .is_some_and(|f| epoch_block_timestamp >= f.activation_timestamp)
+        self.is_cascade_active_at(epoch_snapshot.epoch_block.timestamp_secs())
     }
 }

--- a/crates/domain/src/models/block_tree.rs
+++ b/crates/domain/src/models/block_tree.rs
@@ -1047,6 +1047,12 @@ impl BlockTree {
             .map(|entry| -> &IrysBlockHeader { entry.block.header() })
     }
 
+    /// Read access to the consensus config backing this tree.
+    #[must_use]
+    pub const fn consensus_config(&self) -> &ConsensusConfig {
+        &self.consensus_config
+    }
+
     /// Gets the sealed block (header + body) by hash
     #[must_use]
     pub fn get_sealed_block(&self, block_hash: &BlockHash) -> Option<Arc<SealedBlock>> {

--- a/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
+++ b/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
@@ -121,9 +121,7 @@ impl EpochSnapshot {
         let cascade_active = config
             .consensus
             .hardforks
-            .cascade
-            .as_ref()
-            .is_some_and(|f| genesis_block.timestamp_secs() >= f.activation_timestamp);
+            .is_cascade_active_at(genesis_block.timestamp_secs());
         let mut new_self = Self {
             ledgers: Ledgers::new(&config.consensus, cascade_active),
             partition_assignments: PartitionAssignments::new(),
@@ -312,9 +310,7 @@ impl EpochSnapshot {
             .config
             .consensus
             .hardforks
-            .cascade
-            .as_ref()
-            .is_some_and(|f| new_epoch_block.timestamp_secs() >= f.activation_timestamp)
+            .is_cascade_active_at(new_epoch_block.timestamp_secs())
         {
             self.ledgers.activate_cascade(&self.config.consensus);
         }

--- a/crates/types/src/config/consensus.rs
+++ b/crates/types/src/config/consensus.rs
@@ -546,9 +546,7 @@ impl ConsensusConfig {
         &self,
         timestamp: UnixTimestamp,
     ) -> Amount<(CostPerGb, Usd)> {
-        if let Some(cascade) = self.hardforks.cascade.as_ref()
-            && timestamp >= cascade.activation_timestamp
-        {
+        if let Some(cascade) = self.hardforks.cascade_at(timestamp) {
             return cascade.annual_cost_per_gb;
         }
         self.annual_cost_per_gb

--- a/crates/types/src/hardfork_config.rs
+++ b/crates/types/src/hardfork_config.rs
@@ -1,7 +1,7 @@
 //! Configurable hardfork parameters.
 
 use crate::{
-    UnixTimestamp, VersionDiscriminant,
+    DataLedger, UnixTimestamp, VersionDiscriminant,
     serialization::unix_timestamp_string_serde,
     storage_pricing::{
         Amount,
@@ -189,6 +189,20 @@ impl IrysHardforkConfig {
             .is_some_and(|f| timestamp >= f.activation_timestamp)
     }
 
+    /// Whether a data ledger may legitimately be absent from a block produced at
+    /// `timestamp`. Only the Cascade term ledgers (OneYear/ThirtyDay) qualify,
+    /// and only before Cascade activates: block validation (`extract_data_ledgers`)
+    /// requires a block to carry the exact ledger set for its activation state,
+    /// so a missing-ledger lookup in any other case is an invariant violation,
+    /// not an expected pre-activation gap.
+    #[must_use]
+    pub fn ledger_absence_expected(&self, ledger_id: u32, timestamp: UnixTimestamp) -> bool {
+        matches!(
+            DataLedger::try_from(ledger_id),
+            Ok(DataLedger::OneYear | DataLedger::ThirtyDay)
+        ) && !self.is_cascade_active_at(timestamp)
+    }
+
     /// Check if a commitment transaction version is valid at a given timestamp.
     /// Returns true if no hardfork is active or if version meets minimum requirement.
     #[must_use]
@@ -328,6 +342,47 @@ mod tests {
                 .is_none()
         );
         assert!(!no_cascade.is_cascade_active_at(UnixTimestamp::from_secs(2000)));
+    }
+
+    #[test]
+    fn test_ledger_absence_expected() {
+        let config = IrysHardforkConfig {
+            frontier: FrontierParams {
+                number_of_ingress_proofs_total: 5,
+                number_of_ingress_proofs_from_assignees: 2,
+            },
+            next_name_tbd: None,
+            aurora: None,
+            borealis: None,
+            cascade: Some(Cascade {
+                activation_timestamp: UnixTimestamp::from_secs(1500),
+                one_year_epoch_length: 365,
+                thirty_day_epoch_length: 30,
+                annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
+            }),
+        };
+
+        let before = UnixTimestamp::from_secs(1499);
+        let at = UnixTimestamp::from_secs(1500);
+
+        // Cascade term ledgers may be legitimately absent only before activation.
+        assert!(config.ledger_absence_expected(DataLedger::OneYear as u32, before));
+        assert!(config.ledger_absence_expected(DataLedger::ThirtyDay as u32, before));
+        assert!(!config.ledger_absence_expected(DataLedger::OneYear as u32, at));
+        assert!(!config.ledger_absence_expected(DataLedger::ThirtyDay as u32, at));
+
+        // Publish/Submit are never Cascade-gated: their absence is never expected.
+        assert!(!config.ledger_absence_expected(DataLedger::Publish as u32, before));
+        assert!(!config.ledger_absence_expected(DataLedger::Submit as u32, before));
+
+        // With Cascade unconfigured the term ledgers never exist, so their
+        // absence is always expected (never an invariant violation).
+        let no_cascade = IrysHardforkConfig {
+            cascade: None,
+            ..config
+        };
+        assert!(no_cascade.ledger_absence_expected(DataLedger::OneYear as u32, at));
+        assert!(!no_cascade.ledger_absence_expected(DataLedger::Publish as u32, at));
     }
 
     #[test]

--- a/crates/types/src/hardfork_config.rs
+++ b/crates/types/src/hardfork_config.rs
@@ -1,7 +1,7 @@
 //! Configurable hardfork parameters.
 
 use crate::{
-    DataLedger, UnixTimestamp, VersionDiscriminant,
+    DataLedger, DataTransactionLedger, IrysBlockHeader, UnixTimestamp, VersionDiscriminant,
     serialization::unix_timestamp_string_serde,
     storage_pricing::{
         Amount,
@@ -125,6 +125,24 @@ impl Cascade {
     }
 }
 
+/// Result of looking up a data ledger in a block header via
+/// [`IrysHardforkConfig::classify_data_ledger`].
+///
+/// A block in the block tree has already passed validation
+/// (`extract_data_ledgers`), which requires it to carry exactly the ledger set
+/// its epoch activation state allows. So [`Self::UnexpectedAbsent`] is not
+/// reachable for validated blocks and exists only as defense in depth.
+#[derive(Debug)]
+pub enum DataLedgerLookup<'a> {
+    /// The ledger is present in the block.
+    Present(&'a DataTransactionLedger),
+    /// The ledger is legitimately absent — a Cascade term ledger
+    /// (OneYear/ThirtyDay) on a block whose epoch predates Cascade activation.
+    ExpectedAbsent,
+    /// The ledger is absent where consensus normally requires it.
+    UnexpectedAbsent,
+}
+
 impl IrysHardforkConfig {
     /// Check if the NextNameTBD hardfork is active at a given timestamp (in seconds).
     pub fn is_next_name_tbd_active(&self, timestamp: UnixTimestamp) -> bool {
@@ -189,18 +207,47 @@ impl IrysHardforkConfig {
             .is_some_and(|f| timestamp >= f.activation_timestamp)
     }
 
-    /// Whether a data ledger may legitimately be absent from a block produced at
-    /// `timestamp`. Only the Cascade term ledgers (OneYear/ThirtyDay) qualify,
-    /// and only before Cascade activates: block validation (`extract_data_ledgers`)
-    /// requires a block to carry the exact ledger set for its activation state,
-    /// so a missing-ledger lookup in any other case is an invariant violation,
-    /// not an expected pre-activation gap.
+    /// Whether a data ledger may legitimately be absent from a block.
+    ///
+    /// Only the Cascade term ledgers (OneYear/ThirtyDay) qualify, and only before
+    /// Cascade activates. This uses the block's own `timestamp` as a proxy,
+    /// whereas the authoritative ledger-set check (`extract_data_ledgers`) is
+    /// epoch-aligned (`is_cascade_active_for_epoch`). In the window between
+    /// Cascade's activation timestamp and the next epoch boundary the two can
+    /// disagree, so callers treat an "unexpected" absence as a warning — the
+    /// block's shape is already validated upstream — and degrade gracefully
+    /// rather than aborting.
     #[must_use]
     pub fn ledger_absence_expected(&self, ledger_id: u32, timestamp: UnixTimestamp) -> bool {
         matches!(
             DataLedger::try_from(ledger_id),
             Ok(DataLedger::OneYear | DataLedger::ThirtyDay)
         ) && !self.is_cascade_active_at(timestamp)
+    }
+
+    /// Look up `ledger_id` in `block`, classifying a missing entry as either an
+    /// expected pre-activation gap or an invariant violation. This is the single
+    /// source of truth shared by the data-sync orchestrator and the block-tree
+    /// guard, so the "expected vs unexpected" predicate cannot drift between the
+    /// two layers — the kind of cross-layer drift that caused the 2026-06-11
+    /// genesis incident.
+    #[must_use]
+    pub fn classify_data_ledger<'a>(
+        &self,
+        block: &'a IrysBlockHeader,
+        ledger_id: u32,
+    ) -> DataLedgerLookup<'a> {
+        match block
+            .data_ledgers
+            .iter()
+            .find(|dl| dl.ledger_id == ledger_id)
+        {
+            Some(dl) => DataLedgerLookup::Present(dl),
+            None if self.ledger_absence_expected(ledger_id, block.timestamp_secs()) => {
+                DataLedgerLookup::ExpectedAbsent
+            }
+            None => DataLedgerLookup::UnexpectedAbsent,
+        }
     }
 
     /// Check if a commitment transaction version is valid at a given timestamp.
@@ -383,6 +430,49 @@ mod tests {
         };
         assert!(no_cascade.ledger_absence_expected(DataLedger::OneYear as u32, at));
         assert!(!no_cascade.ledger_absence_expected(DataLedger::Publish as u32, at));
+    }
+
+    #[test]
+    fn test_classify_data_ledger() {
+        // Mock header carries Publish + Submit only (no term ledgers).
+        let block = IrysBlockHeader::new_mock_header();
+        let genesis_secs = block.timestamp_secs().as_secs();
+
+        let make = |activation_secs: u64| IrysHardforkConfig {
+            frontier: FrontierParams {
+                number_of_ingress_proofs_total: 5,
+                number_of_ingress_proofs_from_assignees: 2,
+            },
+            next_name_tbd: None,
+            aurora: None,
+            borealis: None,
+            cascade: Some(Cascade {
+                activation_timestamp: UnixTimestamp::from_secs(activation_secs),
+                one_year_epoch_length: 365,
+                thirty_day_epoch_length: 30,
+                annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
+            }),
+        };
+
+        // Cascade active at the block's timestamp.
+        let active = make(1);
+        assert!(matches!(
+            active.classify_data_ledger(&block, DataLedger::Publish as u32),
+            DataLedgerLookup::Present(_)
+        ));
+        // Term ledger missing while Cascade is active → invariant violation.
+        assert!(matches!(
+            active.classify_data_ledger(&block, DataLedger::OneYear as u32),
+            DataLedgerLookup::UnexpectedAbsent
+        ));
+
+        // Cascade configured but not yet active at the block's timestamp →
+        // a missing term ledger is an expected pre-activation gap.
+        let pre_activation = make(genesis_secs + 1_000_000);
+        assert!(matches!(
+            pre_activation.classify_data_ledger(&block, DataLedger::OneYear as u32),
+            DataLedgerLookup::ExpectedAbsent
+        ));
     }
 
     #[test]

--- a/crates/types/src/hardfork_config.rs
+++ b/crates/types/src/hardfork_config.rs
@@ -165,6 +165,30 @@ impl IrysHardforkConfig {
             .filter(|f| timestamp >= f.activation_timestamp)
     }
 
+    /// Get the Cascade hardfork config if it is active at the given timestamp
+    /// (in seconds). Raw timestamp check — epoch alignment is the caller's
+    /// concern (pass an epoch block's timestamp for epoch-aligned semantics).
+    #[must_use]
+    pub fn cascade_at(&self, timestamp: UnixTimestamp) -> Option<&Cascade> {
+        self.cascade
+            .as_ref()
+            .filter(|f| timestamp >= f.activation_timestamp)
+    }
+
+    /// Check if the Cascade hardfork is active at the given timestamp (in seconds).
+    #[must_use]
+    pub fn is_cascade_active_at(&self, timestamp: UnixTimestamp) -> bool {
+        self.cascade_at(timestamp).is_some()
+    }
+
+    /// Check if the Borealis hardfork is active at the given timestamp (in seconds).
+    #[must_use]
+    pub fn is_borealis_active_at(&self, timestamp: UnixTimestamp) -> bool {
+        self.borealis
+            .as_ref()
+            .is_some_and(|f| timestamp >= f.activation_timestamp)
+    }
+
     /// Check if a commitment transaction version is valid at a given timestamp.
     /// Returns true if no hardfork is active or if version meets minimum requirement.
     #[must_use]
@@ -255,6 +279,81 @@ mod tests {
         // After activation timestamp
         let aurora = config.aurora_at(UnixTimestamp::from_secs(1501));
         assert_eq!(aurora, config.aurora.as_ref());
+    }
+
+    #[test]
+    fn test_cascade_at() {
+        let config = IrysHardforkConfig {
+            frontier: FrontierParams {
+                number_of_ingress_proofs_total: 5,
+                number_of_ingress_proofs_from_assignees: 2,
+            },
+            next_name_tbd: None,
+            aurora: None,
+            borealis: None,
+            cascade: Some(Cascade {
+                activation_timestamp: UnixTimestamp::from_secs(1500),
+                one_year_epoch_length: 365,
+                thirty_day_epoch_length: 30,
+                annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
+            }),
+        };
+
+        // Before activation timestamp
+        assert!(config.cascade_at(UnixTimestamp::from_secs(1499)).is_none());
+        assert!(!config.is_cascade_active_at(UnixTimestamp::from_secs(1499)));
+
+        // At activation timestamp
+        assert_eq!(
+            config.cascade_at(UnixTimestamp::from_secs(1500)),
+            config.cascade.as_ref()
+        );
+        assert!(config.is_cascade_active_at(UnixTimestamp::from_secs(1500)));
+
+        // After activation timestamp
+        assert_eq!(
+            config.cascade_at(UnixTimestamp::from_secs(1501)),
+            config.cascade.as_ref()
+        );
+        assert!(config.is_cascade_active_at(UnixTimestamp::from_secs(1501)));
+
+        // No cascade configured
+        let no_cascade = IrysHardforkConfig {
+            cascade: None,
+            ..config
+        };
+        assert!(
+            no_cascade
+                .cascade_at(UnixTimestamp::from_secs(2000))
+                .is_none()
+        );
+        assert!(!no_cascade.is_cascade_active_at(UnixTimestamp::from_secs(2000)));
+    }
+
+    #[test]
+    fn test_is_borealis_active_at() {
+        let config = IrysHardforkConfig {
+            frontier: FrontierParams {
+                number_of_ingress_proofs_total: 5,
+                number_of_ingress_proofs_from_assignees: 2,
+            },
+            next_name_tbd: None,
+            aurora: None,
+            borealis: Some(Borealis {
+                activation_timestamp: UnixTimestamp::from_secs(1500),
+            }),
+            cascade: None,
+        };
+
+        assert!(!config.is_borealis_active_at(UnixTimestamp::from_secs(1499)));
+        assert!(config.is_borealis_active_at(UnixTimestamp::from_secs(1500)));
+        assert!(config.is_borealis_active_at(UnixTimestamp::from_secs(1501)));
+
+        let no_borealis = IrysHardforkConfig {
+            borealis: None,
+            ..config
+        };
+        assert!(!no_borealis.is_borealis_active_at(UnixTimestamp::from_secs(2000)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

**Before:**
The genesis header builder included the OneYear/ThirtyDay term ledgers only when cascade's `activation_timestamp` was zero, while the epoch layer activates cascade whenever the epoch block's timestamp is at or after activation. A positive pre-genesis activation timestamp (devnet's encoding of "active from genesis") produced a chain whose epoch state assigned partitions to four data ledgers while the genesis header carried two; once `block_migration_depth` reached genesis, missing-ledger lookups hit `.expect()` calls and aborted the node — devnet node-1 crash-looped 34 times on 2026-06-11 and stayed down. The same panic fires during any mid-chain cascade activation, for roughly `block_migration_depth` blocks after the activation epoch.

**After:**
Any cascade `activation_timestamp` at or before the resolved genesis timestamp yields a four-ledger genesis header that matches the epoch layer. The activation predicate lives in one place (`IrysHardforkConfig` helpers), and both missing-ledger lookup sites treat a pre-activation block as "no migrated chunks yet" instead of panicking, closing the mid-chain activation crash window.

## Changes

### Hardfork predicate (`irys-types`)
- Add `cascade_at(timestamp)`, `is_cascade_active_at(timestamp)` and `is_borealis_active_at(timestamp)` raw-timestamp helpers to `IrysHardforkConfig`, following the existing `aurora_at` idiom
- Delegate the inline `>=` activation check in `ConsensusConfig::effective_annual_cost_per_gb` to `cascade_at` (no behavioural change)

### Genesis construction (`irys-config`, `irys-chain`)
- `prepare_unsigned_genesis` filters cascade via `cascade_at(resolved_genesis_timestamp)` — using the resolved timestamp, which handles the `timestamp_millis = 0` "use now" sentinel
- `build_unsigned_irys_genesis_block` drops its literal-zero gate; the `cascade` parameter now means "active at genesis" and the doc comment states the caller contract

### Epoch layer (`irys-domain`)
- `EpochSnapshot::new` and the epoch-transition activation check delegate to `is_cascade_active_at`
- `HardforkConfigExt` trait methods delegate to the new helpers

### Panic sites (`irys-actors`, `irys-domain`)
- `ChunkOrchestrator::get_max_chunk_offset` returns `None` (with a debug log) when the migrated block has no entry for its ledger, instead of `.expect()` aborting the process
- `BlockTreeReadGuard::get_total_chunks` returns `None` for a missing ledger entry; its sole caller already maps `None` to zero

### Tests
- Unit: helper activation boundaries (before/at/after, unconfigured); missing-ledger regression covering both lookup sites
- Caller contract: `build_signed_genesis_block` filters against the resolved genesis timestamp (below/at/above boundary)
- E2E: devnet scenario — `activation_timestamp = 1`, five storage submodules, asserts a four-ledger genesis header, OneYear/ThirtyDay partition ownership, and mining past `block_migration_depth` without panic
- Register the orphaned `multi_node/cascade_reorg` test module (never declared in `mod.rs`, so `slow_heavy_cascade_reorg_reinjects_term_ledger_txs` had never compiled or run; it passes)

## Technical Notes

- **Breaking changes**: ⚠️ The genesis hash changes for configs whose cascade `activation_timestamp` is positive and ≤ the genesis timestamp. Intended: Such configs previously produced the inconsistent two-ledger genesis. Mainnet, testnet and `testing()` presets carry `cascade: None` and are unaffected; existing chains load their stored genesis. All pre-existing cascade integration tests use `activation_timestamp = 0`, which behaves the same way.
- **Architecture**: activation predicate reduced from six call-site copies (one divergent) to single-source helpers; epoch alignment remains with callers, which pass the epoch block's timestamp.

## Testing
- [x] Tests added/updated (unit, caller-contract, e2e regression)
- [x] Manual testing done (`cargo xtask local-checks` clean; 937 types/config/domain/database, 351 actors lib, 13 genesis-builder, 12 cascade/partition integration tests green)
- [x] Edge cases covered (exact activation-timestamp boundary, zero-sentinel genesis timestamp, unconfigured forks, mid-chain activation window)

## Related
- Incident analysis: devnet node-1 outage, 2026-06-11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents panics during data sync and chunk counting when migrated/genesis blocks omit Cascade term ledgers.
  * Missing term-ledger entries now degrade safely (no abort) while still flagging unexpected absences.

* **Refactor**
  * Makes Cascade/Borealis activation decisions consistently timestamp-based across genesis and epoch processing.
  * Improves genesis construction and block-tree reporting to align ledger inclusion/counting with hardfork activation.

* **Tests**
  * Adds/updates regressions covering missing-ledger behavior, Cascade genesis/ledger shape, activation boundary scenarios, and multi-node reorg coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->