### PR TITLE
fix(block-producer): reject sub-difficulty solutions before production

### DIFF
--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -38,6 +38,7 @@ use irys_types::{
     SystemTransactionLedger, TokioServiceHandle, Traced, U256, UnixTimestamp, UnixTimestampMs,
     VDFLimiterInfo, app_state::DatabaseProvider, block_production::SolutionContext,
     calculate_difficulty, next_cumulative_diff, storage_pricing::Amount,
+    u256_from_le_bytes as hash_to_number,
 };
 use irys_vdf::state::VdfStateReadonly;
 use ledger_expiry::LedgerExpiryBalanceDelta;
@@ -119,6 +120,12 @@ pub enum InvalidReason {
     VdfTooOld {
         parent_vdf_step: u64,
         solution_vdf_step: u64,
+    },
+    /// Solution hash no longer clears the new parent's difficulty (e.g. the tip
+    /// advanced onto a difficulty-adjustment block that raised `diff`).
+    BelowDifficulty {
+        parent_diff: U256,
+        solution_diff: U256,
     },
 }
 
@@ -513,11 +520,10 @@ pub trait BlockProdStrategy {
             return ParentCheckResult::ParentStillBest;
         }
 
-        // Parent changed - get new parent's VDF step
-        let new_parent_vdf_step = tree
-            .get_block(&current_best)
-            .map(|b| b.vdf_limiter_info.global_step_number)
-            .unwrap_or(0);
+        // Parent changed - inspect the new parent's VDF step and difficulty.
+        let new_parent_block = tree.get_block(&current_best);
+        let new_parent_vdf_step =
+            new_parent_block.map_or(0, |b| b.vdf_limiter_info.global_step_number);
 
         // Check if solution is too old (at or before new parent's VDF step)
         if solution.vdf_step <= new_parent_vdf_step {
@@ -528,6 +534,23 @@ pub trait BlockProdStrategy {
                     solution_vdf_step: solution.vdf_step,
                 },
             };
+        }
+
+        // Check the solution still clears the new parent's difficulty. When the tip
+        // advances onto a difficulty-adjustment block that raised `diff`, a solution
+        // mined against the lower target no longer qualifies — discard it instead of
+        // rebuilding into a block that can only fail its own pre-validation.
+        if let Some(new_parent_block) = new_parent_block {
+            let solution_diff = hash_to_number(&solution.solution_hash.0);
+            if solution_diff < new_parent_block.diff {
+                return ParentCheckResult::SolutionInvalid {
+                    new_parent: current_best,
+                    reason: InvalidReason::BelowDifficulty {
+                        parent_diff: new_parent_block.diff,
+                        solution_diff,
+                    },
+                };
+            }
         }
 
         // Parent changed but solution is valid - must rebuild on new parent
@@ -555,6 +578,25 @@ pub trait BlockProdStrategy {
                 "Skipping solution for old step number {}, previous block step number {} for block {}",
                 solution.vdf_step,
                 prev_block_header.vdf_limiter_info.global_step_number,
+                prev_block_header.block_hash
+            );
+            return Ok(None);
+        }
+
+        // Reject solutions that don't clear the parent's difficulty before building.
+        // A miner targets its own (possibly stale) difficulty, so a solution can clear
+        // that target yet fall below the canonical parent's `diff`; the same can happen
+        // on a rebuild against a higher-difficulty parent. Without this gate the block is
+        // built and only rejected at terminal pre-validation (`SolutionHashBelowDifficulty`),
+        // whose failure panics the producer service. Discard early and re-mine,
+        // mirroring `solution_hash_is_valid` exactly: valid iff `solution_diff >= diff`.
+        let solution_diff = hash_to_number(&solution.solution_hash.0);
+        if solution_diff < prev_block_header.diff {
+            warn!(
+                "Skipping solution {} below parent difficulty (got {}, need >= {}) for block {}",
+                solution.solution_hash,
+                solution_diff,
+                prev_block_header.diff,
                 prev_block_header.block_hash
             );
             return Ok(None);
@@ -798,6 +840,19 @@ pub trait BlockProdStrategy {
                                 "Solution is too old for new parent (vdf_step {} <= {}), discarding",
                                 solution_vdf_step,
                                 parent_vdf_step
+                            );
+                        }
+                        InvalidReason::BelowDifficulty {
+                            parent_diff,
+                            solution_diff,
+                        } => {
+                            warn!(
+                                solution.hash = %solution.solution_hash,
+                                solution.vdf_step = solution.vdf_step,
+                                block.new_parent = %new_parent,
+                                "Solution below new parent difficulty (got {} < {}), discarding",
+                                solution_diff,
+                                parent_diff
                             );
                         }
                     }

--- a/crates/chain-tests/src/block_production/block_rebuilding.rs
+++ b/crates/chain-tests/src/block_production/block_rebuilding.rs
@@ -8,9 +8,13 @@
 //! Test scenarios covered:
 //! 1. VDF too old - solution's VDF step is not greater than parent's VDF step
 //! 2. Valid solution reuse - parent changes but solution remains valid
+//! 3. Below difficulty - solution hash does not clear the parent's difficulty
 
-use irys_actors::{BlockProdStrategy, BlockProducerInner, ProductionStrategy, async_trait};
-use irys_types::{NodeConfig, block_production::SolutionContext};
+use irys_actors::{
+    BlockProdStrategy, BlockProducerInner, InvalidReason, ParentCheckResult, ProductionStrategy,
+    async_trait,
+};
+use irys_types::{H256, NodeConfig, U256, block_production::SolutionContext};
 use std::sync::Arc;
 use tokio::sync::{Mutex, oneshot};
 use tracing::info;
@@ -166,6 +170,151 @@ async fn heavy_solution_discarded_vdf_too_old() -> eyre::Result<()> {
     // Cleanup
     node1.stop().await;
     node2.stop().await;
+    Ok(())
+}
+
+/// Test that solutions below the parent's difficulty are discarded during
+/// production rather than built and shipped to pre-validation.
+///
+/// A miner can surface a solution that clears its own difficulty target but
+/// falls below the canonical parent's `diff` (e.g. the miner's target lags the
+/// tip, or a higher-difficulty parent became canonical mid-production). Without
+/// the producer-side gate, such a solution is built into a block and only
+/// rejected at terminal pre-validation (`SolutionHashBelowDifficulty`), whose
+/// error panics the block producer service. The gate must discard it early
+/// (`Ok(None)`), so it is never built.
+#[test_log::test(tokio::test)]
+async fn heavy_solution_discarded_below_difficulty() -> eyre::Result<()> {
+    // Setup
+    let mut config = NodeConfig::testing();
+    config.consensus.get_mut().chunk_size = 32;
+    config.consensus.get_mut().epoch.num_blocks_in_epoch = 4;
+
+    let node = IrysNodeTest::new_genesis(config).start().await;
+
+    // Mine a couple of blocks so we have a stable parent and an advancing VDF.
+    for _ in 0..2 {
+        let block = node.mine_block().await?;
+        node.wait_for_block_at_height(block.height, 10).await?;
+    }
+
+    // The parent the producer will build on, and its difficulty.
+    let prev_block = {
+        let read = node.node_ctx.block_tree_guard.read();
+        let parent_hash = read.get_max_cumulative_difficulty_block().1;
+        read.get_block(&parent_hash)
+            .cloned()
+            .expect("parent block present in block tree")
+    };
+    assert!(
+        prev_block.diff > U256::zero(),
+        "test premise requires a non-zero parent difficulty"
+    );
+
+    // Start from a real, otherwise-valid solution. Retry until its VDF step is
+    // strictly greater than the parent's, so the VDF-too-old gate cannot be the
+    // reason for a discard — otherwise this test would pass without exercising
+    // the difficulty gate at all.
+    let mut solution = solution_context(&node.node_ctx).await?;
+    let mut attempts = 0;
+    while solution.vdf_step <= prev_block.vdf_limiter_info.global_step_number {
+        attempts += 1;
+        assert!(
+            attempts < 30,
+            "VDF did not advance past parent step {} after {} attempts",
+            prev_block.vdf_limiter_info.global_step_number,
+            attempts
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        solution = solution_context(&node.node_ctx).await?;
+    }
+
+    // Force the solution hash just below the parent difficulty. Crafting
+    // `diff - 1` in little-endian (the same interpretation the validator uses
+    // via `hash_to_number`/`u256_from_le_bytes`) guarantees
+    // `hash_to_number(solution_hash) < parent.diff` while every other field
+    // stays genuine.
+    let below_difficulty = prev_block.diff - U256::one();
+    solution.solution_hash = H256(below_difficulty.to_le_bytes());
+
+    let strategy = ProductionStrategy {
+        inner: node.node_ctx.block_producer_inner.clone(),
+    };
+
+    // Must be discarded, not built. Without the gate this returns `Err`
+    // (terminal pre-validation failure), which the service turns into a panic.
+    let result = strategy.fully_produce_new_block(solution).await?;
+    assert!(
+        result.is_none(),
+        "a sub-difficulty solution must be discarded (Ok(None)), not built"
+    );
+
+    node.stop().await;
+    Ok(())
+}
+
+/// Directly exercises the parent-change rebuild guard: a solution that was valid
+/// for the parent it was built on, but whose hash no longer clears a
+/// *higher-difficulty* tip that became canonical mid-production. The guard must
+/// report `SolutionInvalid { BelowDifficulty }` (so the candidate loop discards
+/// it) rather than `MustRebuild` it into a block that can only fail its own
+/// pre-validation.
+#[test_log::test(tokio::test)]
+async fn heavy_rebuild_guard_rejects_below_difficulty_parent() -> eyre::Result<()> {
+    // Setup
+    let mut config = NodeConfig::testing();
+    config.consensus.get_mut().chunk_size = 32;
+    config.consensus.get_mut().epoch.num_blocks_in_epoch = 4;
+
+    let node = IrysNodeTest::new_genesis(config).start().await;
+
+    // Mine so the tip has a real parent (height 2 on parent height 1).
+    for _ in 0..2 {
+        let block = node.mine_block().await?;
+        node.wait_for_block_at_height(block.height, 10).await?;
+    }
+
+    // The current canonical tip plays the role of the higher-difficulty parent
+    // that became canonical while a block was being produced on its parent.
+    let tip = {
+        let read = node.node_ctx.block_tree_guard.read();
+        let tip_hash = read.get_max_cumulative_difficulty_block().1;
+        read.get_block(&tip_hash)
+            .cloned()
+            .expect("tip block present in block tree")
+    };
+    assert!(tip.diff > U256::one(), "test premise requires tip diff > 1");
+
+    // A solution the producer was building on the tip's parent: still ahead on
+    // VDF (so the VDF-too-old branch cannot be the reason), but with a hash that
+    // falls below the tip's difficulty.
+    let mut solution = solution_context(&node.node_ctx).await?;
+    solution.vdf_step = tip.vdf_limiter_info.global_step_number + 1;
+    solution.solution_hash = H256((tip.diff - U256::one()).to_le_bytes());
+
+    let strategy = ProductionStrategy {
+        inner: node.node_ctx.block_producer_inner.clone(),
+    };
+
+    // Evaluate against the tip's parent, so the guard sees the tip as a *changed*,
+    // higher-difficulty parent.
+    let result = strategy
+        .check_parent_and_solution_validity(&tip.previous_block_hash, &solution)
+        .await;
+
+    assert!(
+        matches!(
+            result,
+            ParentCheckResult::SolutionInvalid {
+                reason: InvalidReason::BelowDifficulty { .. },
+                ..
+            }
+        ),
+        "expected SolutionInvalid::BelowDifficulty for a higher-difficulty new parent, got {:?}",
+        result
+    );
+
+    node.stop().await;
     Ok(())
 }
 


### PR DESCRIPTION
## Problem

A mining solution valid for the difficulty at solve-time could be **rebuilt onto a newer, higher-difficulty canonical parent** without re-checking the solution against that parent's difficulty. When the tip advanced onto a difficulty-adjustment block mid-production, the reused solution no longer cleared the new parent's `diff`. The rebuilt block then failed its **own** pre-validation (`SolutionHashBelowDifficulty`), which the block producer treated as irrecoverable and **panicked** (graceful shutdown → restart).

The only difficulty gate was the terminal pre-validation in `broadcast_block`; the parent-change rebuild guard (`check_parent_and_solution_validity`) and the production path (`produce_block_with_parent`) validated only the VDF step, never difficulty.

## Fix

Add a difficulty gate to the production path, mirroring the validator's `solution_hash_is_valid` exactly (valid iff `solution_diff >= parent.diff`, using the same `hash_to_number`/`u256_from_le_bytes` conversion):

- **`check_parent_and_solution_validity`** now reports a new `InvalidReason::BelowDifficulty` when the tip advances onto a higher-difficulty parent, so the candidate loop discards the solution at the rebuild-decision point (with an accurate log) instead of rebuilding a doomed block.
- **`produce_block_with_parent`** gates every production — initial and rebuild — against the parent's `diff`. This is the single chokepoint every block passes through before being built, and also catches a solution below the *current* tip at initial production (the `ParentStillBest` path that never reaches the rebuild guard).

A sub-difficulty solution is now discarded (`Ok(None)`) and re-mined rather than reaching pre-validation, so the producer never panics for this case. The terminal pre-validation / panic remains in place as a backstop for genuinely unexpected faults.

## Tests

Two regression tests in `block_rebuilding.rs`:
- `heavy_solution_discarded_below_difficulty` — feeds a sub-difficulty solution through the full production path and asserts it is discarded (`Ok(None)`), not built. Verified RED→GREEN (RED reproduced the exact `SolutionHashBelowDifficulty` failure).
- `heavy_rebuild_guard_rejects_below_difficulty_parent` — deterministically asserts `check_parent_and_solution_validity` returns `SolutionInvalid { BelowDifficulty }` for a higher-difficulty new parent.

Existing siblings (`heavy_solution_discarded_vdf_too_old`, `heavy_solution_reused_when_parent_changes_but_valid`, `test_invalid_solution_hash_rejected`) still pass. `cargo fmt` + `cargo clippy --tests` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block solution validation with difficulty-based checks to prevent invalid solutions from being processed.
  * Enhanced logging for discarded solutions with detailed difficulty information.

* **Tests**
  * Added test coverage for difficulty-based solution validation and rejection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->