### PR TITLE
feat: node-internal block-stream contract over /internal endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5012,6 +5012,7 @@ dependencies = [
  "actix-cors",
  "actix-web",
  "alloy-eips",
+ "async-stream",
  "awc",
  "base58",
  "eyre",
@@ -5034,7 +5035,6 @@ dependencies = [
  "test-log",
  "thiserror 1.0.69",
  "tokio",
- "tokio-stream",
  "tracing",
  "tracing-actix-web",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5034,6 +5034,7 @@ dependencies = [
  "test-log",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tracing-actix-web",
 ]

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -634,14 +634,15 @@ impl BlockMigrationService {
 
         for sealed_block in &prepared {
             self.persist_block(sealed_block)?;
+            // Signal this block as finalized the moment its DB/index commit lands: that commit is
+            // irreversible, so the later reward and chunk-migration steps may fail without stranding
+            // an already-migrated block in the index but absent from the follower stream.
+            on_migrated(sealed_block);
             if let Some(supply_state) = &self.supply_state {
                 let block = sealed_block.header();
                 supply_state.add_block_reward(block.height, block.reward_amount)?;
             }
             self.send_chunk_migration(sealed_block)?;
-            // Signal this block as finalized now that it is fully persisted, so a failure on a
-            // later block in the batch cannot strand an already-migrated block without its frame.
-            on_migrated(sealed_block);
         }
 
         Ok(())

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -600,7 +600,12 @@ impl BlockMigrationService {
     /// The cache read lock is held only while collecting blocks, then released
     /// before performing DB writes and block index mutations.
     #[tracing::instrument(level = "trace", skip_all, fields(block.hash = %migration_block.block_hash, block.height = migration_block.height))]
-    pub fn migrate_blocks(&self, migration_block: &Arc<IrysBlockHeader>) -> eyre::Result<()> {
+    /// Migrates the slice of blocks from the index head up to `migration_block` and returns them
+    /// (oldest-first), so the caller can emit one `finalized` block-stream signal per migrated block.
+    pub fn migrate_blocks(
+        &self,
+        migration_block: &Arc<IrysBlockHeader>,
+    ) -> eyre::Result<Vec<Arc<SealedBlock>>> {
         debug!("migrating block via BlockMigrationService");
 
         // Collect blocks under the cache read lock, then release it.
@@ -633,7 +638,7 @@ impl BlockMigrationService {
             self.send_chunk_migration(sealed_block)?;
         }
 
-        Ok(())
+        Ok(prepared)
     }
 
     /// Validates height continuity and chain linkage across the migration slice.

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -599,13 +599,16 @@ impl BlockMigrationService {
     ///
     /// The cache read lock is held only while collecting blocks, then released
     /// before performing DB writes and block index mutations.
+    ///
+    /// Migrates the slice of blocks (oldest-first) from the index head up to `migration_block`,
+    /// invoking `on_migrated` for each block the moment it is fully persisted — so a mid-batch
+    /// failure still signals the blocks that did migrate.
     #[tracing::instrument(level = "trace", skip_all, fields(block.hash = %migration_block.block_hash, block.height = migration_block.height))]
-    /// Migrates the slice of blocks from the index head up to `migration_block` and returns them
-    /// (oldest-first), so the caller can emit one `finalized` block-stream signal per migrated block.
     pub fn migrate_blocks(
         &self,
         migration_block: &Arc<IrysBlockHeader>,
-    ) -> eyre::Result<Vec<Arc<SealedBlock>>> {
+        mut on_migrated: impl FnMut(&Arc<SealedBlock>),
+    ) -> eyre::Result<()> {
         debug!("migrating block via BlockMigrationService");
 
         // Collect blocks under the cache read lock, then release it.
@@ -636,9 +639,12 @@ impl BlockMigrationService {
                 supply_state.add_block_reward(block.height, block.reward_amount)?;
             }
             self.send_chunk_migration(sealed_block)?;
+            // Signal this block as finalized now that it is fully persisted, so a failure on a
+            // later block in the batch cannot strand an already-migrated block without its frame.
+            on_migrated(sealed_block);
         }
 
-        Ok(prepared)
+        Ok(())
     }
 
     /// Validates height continuity and chain linkage across the migration slice.

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -599,10 +599,6 @@ impl BlockMigrationService {
     ///
     /// The cache read lock is held only while collecting blocks, then released
     /// before performing DB writes and block index mutations.
-    ///
-    /// Migrates the slice of blocks (oldest-first) from the index head up to `migration_block`,
-    /// invoking `on_migrated` for each block the moment it is fully persisted — so a mid-batch
-    /// failure still signals the blocks that did migrate.
     #[tracing::instrument(level = "trace", skip_all, fields(block.hash = %migration_block.block_hash, block.height = migration_block.height))]
     pub fn migrate_blocks(
         &self,

--- a/crates/actors/src/block_stream_service.rs
+++ b/crates/actors/src/block_stream_service.rs
@@ -177,6 +177,15 @@ impl BlockStreamHandle {
         self.db
             .update_eyre(|tx| irys_database::prune_block_stream_below(tx, keep_from_seq))
     }
+
+    /// Drops every live subscriber sender so their SSE streams end and followers reconnect to
+    /// replay from the last durable `seq`. Called when the producer stops appending for good.
+    fn close_live_subscribers(&self) {
+        match self.live.lock() {
+            Ok(mut live) => live.clear(),
+            Err(_) => warn!("block-stream fan-out lock poisoned while closing subscribers"),
+        }
+    }
 }
 
 /// Bounded, lazy replay of the durable range captured by [`BlockStreamHandle::subscribe`].
@@ -360,6 +369,10 @@ impl Producer {
                 }
             }
         }
+        // The producer has stopped and will append no further frames; disconnect live subscribers
+        // rather than leave their SSE streams hanging, so followers reconnect and replay from the
+        // last durable `seq`.
+        self.handle.close_live_subscribers();
     }
 
     fn drain_queued_signals(&mut self) -> eyre::Result<()> {

--- a/crates/actors/src/block_stream_service.rs
+++ b/crates/actors/src/block_stream_service.rs
@@ -18,7 +18,7 @@ use lru::LruCache;
 use reth::tasks::shutdown::Shutdown;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
-use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use tokio::sync::mpsc::{self, Receiver, Sender, UnboundedReceiver};
 use tracing::{Instrument as _, error, info, warn};
 
 /// Count-based retention: keep at most this many events; older ones are pruned. Sized to comfortably
@@ -30,14 +30,19 @@ const PRUNE_INTERVAL: u64 = 1_000;
 /// De-dup window for emitted `observed` block hashes. Must comfortably exceed the reorg depth so a
 /// re-adopted block is still remembered.
 const DEDUP_CAPACITY: usize = 10_000;
+/// Per-subscriber live buffer. A consumer that lags beyond this many frames is dropped (its SSE
+/// stream ends) and reconnects with `from_seq` to replay from the durable log — bounding memory
+/// instead of letting a stuck follower accumulate frames without limit.
+const SUBSCRIBER_BUFFER: usize = 1_024;
 
 /// Shared handle: the live fan-out registry plus DB access. Held by the producer task and cloned
 /// into `ApiState` so every SSE handler shares the one producer.
 #[derive(Debug)]
 pub struct BlockStreamHandle {
     /// Live SSE subscribers. The lock is shared with [`Self::append_and_fanout`] so a subscribe's
-    /// snapshot+register pair cannot interleave with an append.
-    live: Mutex<Vec<UnboundedSender<StreamFrame>>>,
+    /// snapshot+register pair cannot interleave with an append. Bounded senders: a lagging
+    /// subscriber is dropped rather than buffered without limit.
+    live: Mutex<Vec<Sender<StreamFrame>>>,
     db: DatabaseProvider,
 }
 
@@ -54,7 +59,7 @@ impl BlockStreamHandle {
     pub fn subscribe(
         &self,
         from_seq: u64,
-    ) -> eyre::Result<(Vec<StreamFrame>, UnboundedReceiver<StreamFrame>)> {
+    ) -> eyre::Result<(Vec<StreamFrame>, Receiver<StreamFrame>)> {
         let mut live = self
             .live
             .lock()
@@ -66,7 +71,7 @@ impl BlockStreamHandle {
         for (seq, bytes) in stored {
             replay.push(decode_frame(seq, &bytes)?);
         }
-        let (tx, rx) = mpsc::unbounded_channel();
+        let (tx, rx) = mpsc::channel(SUBSCRIBER_BUFFER);
         live.push(tx);
         Ok((replay, rx))
     }
@@ -83,8 +88,9 @@ impl BlockStreamHandle {
             .db
             .update_eyre(|tx| irys_database::append_block_stream_event(tx, payload))?;
         let frame = StreamFrame { seq, event };
-        // Drop subscribers whose receiver has been closed.
-        live.retain(|sender| sender.send(frame.clone()).is_ok());
+        // Drop subscribers whose receiver is closed or lagging past `SUBSCRIBER_BUFFER`; a dropped
+        // follower reconnects and replays from the durable log via `subscribe(from_seq)`.
+        live.retain(|sender| sender.try_send(frame.clone()).is_ok());
         Ok(seq)
     }
 
@@ -142,8 +148,10 @@ struct Producer {
     /// `block_hash`es already emitted as `observed` (or carried in a reorg's `new_fork`), so a
     /// re-confirmed block is not re-emitted.
     emitted: LruCache<H256, ()>,
-    /// Highest finalised height, to guard against a double `finalized` for the same block.
-    last_finalized_height: Option<u64>,
+    /// `block_hash`es already emitted as `finalized`, to guard against a double `finalized` for the
+    /// same block. Keyed by hash (not height) so a block re-migrated at a previously-finalised
+    /// height after deep-reorg recovery (`recover_from_network_partition`) still emits.
+    finalized: LruCache<H256, ()>,
     appends_since_prune: u64,
 }
 
@@ -154,14 +162,14 @@ impl Producer {
         shutdown: Shutdown,
         signal_rx: UnboundedReceiver<BlockStreamSignal>,
     ) -> Self {
-        let (emitted, last_finalized_height) = rebuild_state(&handle.db);
+        let (emitted, finalized) = rebuild_state(&handle.db);
         Self {
             handle,
             chunk_size,
             shutdown,
             signal_rx,
             emitted,
-            last_finalized_height,
+            finalized,
             appends_since_prune: 0,
         }
     }
@@ -178,7 +186,11 @@ impl Producer {
                     match maybe_signal {
                         Some(signal) => {
                             if let Err(e) = self.handle_signal(signal) {
-                                error!(error = ?e, "block-stream producer failed to process signal");
+                                // A durable append failed: halt rather than silently skip the event
+                                // and keep assigning later `seq`s, which would break the lossless-log
+                                // contract. Followers reconnect and replay up to the last good `seq`.
+                                error!(error = ?e, "block-stream producer halting: durable append failed");
+                                break;
                             }
                         }
                         None => {
@@ -203,17 +215,14 @@ impl Producer {
                 self.emitted.put(hash, ());
             }
             BlockStreamSignal::Finalized(block) => {
-                let height = block.header().height;
-                if self
-                    .last_finalized_height
-                    .is_some_and(|last| height <= last)
-                {
+                let hash = block.header().block_hash;
+                if self.finalized.contains(&hash) {
                     return Ok(());
                 }
                 let event =
                     StreamEvent::Finalized(BlockEvent::from_sealed(&block, self.chunk_size));
                 self.append(event)?;
-                self.last_finalized_height = Some(height);
+                self.finalized.put(hash, ());
             }
             BlockStreamSignal::Reorged {
                 fork_parent,
@@ -236,7 +245,8 @@ impl Producer {
                 };
                 self.append(event)?;
                 // Mark the new-fork hashes seen so the `Confirmed` signals that follow this tick do
-                // not also emit `observed` for them (`:1174` precedes `:1205` in `propagate_block`).
+                // not also emit `observed` for them: `propagate_block` sends the `Reorged` signal
+                // before the per-block `Confirmed` signals, and the signal channel is FIFO.
                 for block in new_fork.iter() {
                     self.emitted.put(block.header().block_hash, ());
                 }
@@ -261,12 +271,12 @@ impl Producer {
     }
 }
 
-/// Rebuilds the producer's in-memory de-dup state from the durable log tail on startup, so a
-/// restart does not re-emit `observed` for blocks already in the log.
-fn rebuild_state(db: &DatabaseProvider) -> (LruCache<H256, ()>, Option<u64>) {
-    let mut emitted =
-        LruCache::new(NonZeroUsize::new(DEDUP_CAPACITY).expect("non-zero dedup capacity"));
-    let mut last_finalized_height: Option<u64> = None;
+/// Rebuilds the producer's in-memory de-dup state (`observed` and `finalized` hashes) from the
+/// durable log tail on startup, so a restart does not re-emit for blocks already in the log.
+fn rebuild_state(db: &DatabaseProvider) -> (LruCache<H256, ()>, LruCache<H256, ()>) {
+    let cap = NonZeroUsize::new(DEDUP_CAPACITY).expect("non-zero dedup capacity");
+    let mut emitted = LruCache::new(cap);
+    let mut finalized = LruCache::new(cap);
 
     let tail = (|| -> eyre::Result<Vec<(u64, Vec<u8>)>> {
         let Some(latest) = db.view_eyre(irys_database::block_stream_latest_seq)? else {
@@ -284,10 +294,7 @@ fn rebuild_state(db: &DatabaseProvider) -> (LruCache<H256, ()>, Option<u64>) {
                         emitted.put(block.header.block_hash, ());
                     }
                     Ok(StreamEvent::Finalized(block)) => {
-                        last_finalized_height = Some(
-                            last_finalized_height
-                                .map_or(block.header.height, |last| last.max(block.header.height)),
-                        );
+                        finalized.put(block.header.block_hash, ());
                     }
                     Ok(StreamEvent::Reorged { new_fork, .. }) => {
                         for block in new_fork {
@@ -305,5 +312,5 @@ fn rebuild_state(db: &DatabaseProvider) -> (LruCache<H256, ()>, Option<u64>) {
         }
     }
 
-    (emitted, last_finalized_height)
+    (emitted, finalized)
 }

--- a/crates/actors/src/block_stream_service.rs
+++ b/crates/actors/src/block_stream_service.rs
@@ -1,10 +1,18 @@
 //! The block-stream producer: the single, node-wide writer of the durable `seq` event log.
 //!
-//! The producer consumes a lossless, unbounded feed of [`BlockStreamSignal`]s emitted from the
-//! node's authoritative sites (the confirmation loop, the reorg site, and the per-block migration
-//! loop). For each signal it builds the wire [`StreamEvent`], appends it to the durable log
-//! (assigning the next `seq`), and fans it out to live SSE subscribers. Being the sole writer makes
-//! `seq` assignment monotonic and gap-free.
+//! The producer consumes an unbounded feed of [`BlockStreamSignal`]s emitted from the node's
+//! authoritative sites (the confirmation loop, the reorg site, and the per-block migration loop).
+//! For each signal it builds the wire [`StreamEvent`], appends it to the durable log (assigning
+//! the next `seq`), and fans it out to live SSE subscribers. Being the sole writer makes `seq`
+//! assignment monotonic and gap-free.
+//!
+//! The feed is lossless while the node runs — the channel is unbounded and an append failure halts
+//! the producer rather than skipping an event — but a signal is in-memory until its append
+//! commits, so a crash between a state transition and its append can lose that frame. For
+//! `finalized` the durable truth survives in the block index, and startup reconciliation
+//! ([`Producer::reconcile_finalized_tail`]) re-derives and appends the missing frames; `observed`
+//! and `reorged` frames lost this way are recovered by a follower through the canonical read
+//! endpoints, which serve current state rather than transition history.
 //!
 //! The HTTP handlers never touch `seq`: they hold an [`Arc<BlockStreamHandle>`] and call the atomic
 //! [`BlockStreamHandle::subscribe`], which snapshots the durable replay suffix and registers a live
@@ -42,6 +50,11 @@ const SUBSCRIBER_BUFFER: usize = 1_024;
 /// Max frames a single `GET /internal/blocks/events` page may return; an over-size `limit` is clamped to
 /// this rather than rejected, bounding per-request work.
 const MAX_PAGE: u64 = 1_024;
+
+/// Upper bound on the backward block-index scan in [`Producer::reconcile_finalized_tail`]. A real
+/// crash gap is at most the migration batch that was in flight; a scan this deep means the log and
+/// index tails do not meet at all, and reconciliation aborts instead of replaying history.
+const RECONCILE_SCAN_CAP: u64 = 1_000;
 
 /// Shared handle: the live fan-out registry plus DB access. Held by the producer task and cloned
 /// into `ApiState` so every SSE handler shares the one producer.
@@ -86,11 +99,8 @@ impl BlockStreamHandle {
             .map_err(|_| eyre::eyre!("block-stream fan-out lock poisoned"))?;
         let (start, end) = self.db.view_eyre(|tx| {
             let (lowest, logical_len) = irys_database::block_stream_log_bounds(tx)?;
-            // A cursor beyond the tip is stale — only reachable after a log reset shrank the log. Replay
-            // from the retained floor so the follower sees below-cursor frames and rewinds, matching the
-            // `/events` beyond-tip clamp; otherwise the SSE follower would silently continue onto the new
-            // chain at the same seq. In-window / caught-up cursors replay from `from_seq` (empty at the
-            // tip); a below-floor cursor also clamps to the retained floor.
+            // Below-floor and beyond-tip (post-reset) cursors replay from the retained floor — the
+            // SSE rewind; the poll endpoint instead signals `truncated` for a below-floor cursor.
             let start = if from_seq < lowest || from_seq > logical_len {
                 lowest
             } else {
@@ -118,15 +128,9 @@ impl BlockStreamHandle {
     /// empty `truncated` page whose `next_seq` is the floor (the follower discards frames and resyncs
     /// forward to it); a `from_seq` past the tip clamps to the floor.
     pub fn events_page(&self, from_seq: u64, limit: u64) -> eyre::Result<EventsPage> {
-        // checked conversions / arithmetic only — never silently manufacture a wrong cursor
         let limit = usize::try_from(limit.min(MAX_PAGE))?;
         self.db.view_eyre(|tx| {
             let (lowest, logical_len) = irys_database::block_stream_log_bounds(tx)?;
-            // A below-floor (truncated) page is a pure resync signal: the follower discards any frames
-            // and force-resets its cursor forward to `next_seq` (the floor), so carry no frames — with an
-            // empty page `next_seq == lowest` is exactly that floor. A beyond-tip cursor clamps to the
-            // floor so the follower instead sees a below-cursor frame and rewinds (chain reset, not a
-            // gap). In-window pages from `from_seq`, empty when caught up at `from_seq == logical_len`.
             let (start, read_limit, truncated) = if from_seq < lowest {
                 (lowest, 0, true) // below the retained floor → signal only, no frames
             } else if from_seq > logical_len {
@@ -160,9 +164,8 @@ impl BlockStreamHandle {
     /// advanced the retained floor past `cursor` mid-replay (a `truncated`/no-progress page). On abort the
     /// cursor has not reached `end`, which is how the caller tells "resync" from "done".
     ///
-    /// Bounding each page by `end` (not [`Self::events_page`]'s `has_more`, which tracks a moving tip)
-    /// keeps the replay→live handover gap- and duplicate-free; the abort check subsumes the cross-page
-    /// seq-contiguity and short-snapshot guards the old streaming replay carried.
+    /// Bounding each page by `end` (not [`Self::events_page`]'s `has_more`, which tracks a moving
+    /// tip) keeps the replay→live handover gap- and duplicate-free.
     pub fn replay_page(
         &self,
         cursor: u64,
@@ -181,11 +184,14 @@ impl BlockStreamHandle {
     /// Producer-only. Append `event` to the durable log (assigning `seq`) and fan it out, holding
     /// the same lock as [`Self::subscribe`].
     fn append_and_fanout(&self, event: StreamEvent) -> eyre::Result<u64> {
+        let payload = serde_json::to_vec(&event)?;
+        // The lock must cover the durable append, not just the fan-out: `subscribe` snapshots its
+        // replay bound and registers its live sender under this lock, so an append interleaving
+        // between those two would be both replayed and pushed live to the new subscriber.
         let mut live = self
             .live
             .lock()
             .map_err(|_| eyre::eyre!("block-stream fan-out lock poisoned"))?;
-        let payload = serde_json::to_vec(&event)?;
         let seq = self
             .db
             .update_eyre(|tx| irys_database::append_block_stream_event(tx, payload))?;
@@ -242,9 +248,18 @@ impl BlockStreamService {
 
         let join = runtime_handle.spawn(
             async move {
-                Producer::new(producer_handle, chunk_size, shutdown_rx, signal_rx)
-                    .run()
-                    .await;
+                // A failed de-dup rebuild halts the producer (duplicate re-emission would be the
+                // alternative); the node itself keeps running with a stale stream, and the halt is
+                // surfaced through the `irys.block_stream.halted` gauge.
+                let startup_handle = Arc::clone(&producer_handle);
+                match Producer::new(producer_handle, chunk_size, shutdown_rx, signal_rx) {
+                    Ok(mut producer) => producer.run().await,
+                    Err(e) => {
+                        error!(error = ?e, "block-stream producer failed to start: de-dup rebuild failed");
+                        crate::metrics::record_block_stream_halted();
+                        startup_handle.close_live_subscribers();
+                    }
+                }
             }
             .in_current_span(),
         );
@@ -279,9 +294,9 @@ impl Producer {
         chunk_size: u64,
         shutdown: Shutdown,
         signal_rx: UnboundedReceiver<BlockStreamSignal>,
-    ) -> Self {
-        let (emitted, finalized) = rebuild_state(&handle.db);
-        Self {
+    ) -> eyre::Result<Self> {
+        let (emitted, finalized) = rebuild_state(&handle.db)?;
+        Ok(Self {
             handle,
             chunk_size,
             shutdown,
@@ -289,11 +304,17 @@ impl Producer {
             emitted,
             finalized,
             appends_since_prune: 0,
-        }
+        })
     }
 
     async fn run(&mut self) {
         info!("block-stream producer started");
+        if let Err(e) = self.reconcile_finalized_tail() {
+            error!(error = ?e, "block-stream producer halting: finalized reconciliation failed");
+            crate::metrics::record_block_stream_halted();
+            self.handle.close_live_subscribers();
+            return;
+        }
         loop {
             tokio::select! {
                 _ = &mut self.shutdown => {
@@ -312,6 +333,7 @@ impl Producer {
                                 // and keep assigning later `seq`s, which would break the lossless-log
                                 // contract. Followers reconnect and replay up to the last good `seq`.
                                 error!(error = ?e, "block-stream producer halting: durable append failed");
+                                crate::metrics::record_block_stream_halted();
                                 break;
                             }
                         }
@@ -337,6 +359,81 @@ impl Producer {
                 Err(TryRecvError::Empty | TryRecvError::Disconnected) => return Ok(()),
             }
         }
+    }
+
+    /// Re-derives `finalized` frames lost to a crash between a block's migration commit and the
+    /// producer's append (a signal is in-memory until appended). Walks the block index backward
+    /// from its tip until it meets a hash the log already finalised, then appends the gap in
+    /// ascending height order.
+    ///
+    /// Runs only when the rebuilt de-dup state holds at least one finalised hash: on a young or
+    /// freshly-reset log the index tail predates the log entirely, and "reconciling" it would
+    /// emit `finalized` for deep history a follower bootstraps from the canonical reads instead.
+    /// The same reasoning caps the backward scan — the crash window loses at most the migration
+    /// batch that was in flight, so a scan that runs [`RECONCILE_SCAN_CAP`] deep means the log and
+    /// index tails do not meet, and reconciliation aborts rather than replay history.
+    fn reconcile_finalized_tail(&mut self) -> eyre::Result<()> {
+        if self.finalized.is_empty() {
+            return Ok(());
+        }
+        let missing = self.handle.db.view_eyre(|tx| {
+            let mut missing: Vec<(u64, H256)> = Vec::new();
+            let Some(latest) = irys_database::block_index_latest_height(tx)? else {
+                return Ok(missing);
+            };
+            for height in (0..=latest).rev() {
+                let Some(hash) = irys_database::block_index_hash_by_height(tx, height)? else {
+                    break;
+                };
+                if self.finalized.contains(&hash) {
+                    break;
+                }
+                missing.push((height, hash));
+                if missing.len() as u64 >= RECONCILE_SCAN_CAP {
+                    warn!(
+                        scanned = missing.len(),
+                        "block-stream finalized reconciliation hit its scan cap; skipping \
+                         (the log and index tails do not meet)"
+                    );
+                    missing.clear();
+                    break;
+                }
+            }
+            Ok(missing)
+        })?;
+
+        for (height, hash) in missing.into_iter().rev() {
+            let event = self.handle.db.view_eyre(|tx| {
+                let header =
+                    irys_database::block_header_by_hash(tx, &hash, false)?.ok_or_else(|| {
+                        eyre::eyre!("migrated block {hash} at height {height} has no header row")
+                    })?;
+                let mut resolve_err: Option<eyre::Report> = None;
+                let event = BlockEvent::from_header_and_txs(
+                    &header,
+                    |ledger| match irys_database::block_ledger_tx_headers(tx, &header, ledger) {
+                        Ok(txs) => txs,
+                        Err(e) => {
+                            resolve_err.get_or_insert(e);
+                            Vec::new()
+                        }
+                    },
+                    self.chunk_size,
+                );
+                match resolve_err {
+                    Some(e) => Err(e),
+                    None => Ok(event),
+                }
+            })?;
+            info!(
+                block.height = height,
+                block.hash = %hash,
+                "appending finalized frame reconciled from the block index"
+            );
+            self.append(StreamEvent::Finalized(event))?;
+            self.finalized.put(hash, ());
+        }
+        Ok(())
     }
 
     fn handle_signal(&mut self, signal: BlockStreamSignal) -> eyre::Result<()> {
@@ -386,6 +483,13 @@ impl Producer {
                 for block in new_fork.iter() {
                     self.emitted.put(block.header().block_hash, ());
                 }
+                // An orphaned block may have been migrated (and emitted `finalized`) before this
+                // reorg rolled it back. Evict it from the finalized de-dup so that if its fork is
+                // later re-adopted and it re-migrates, the fresh `finalized` is emitted rather than
+                // suppressed — a follower that demoted it on this frame is waiting for exactly that.
+                for block in old_fork.iter() {
+                    self.finalized.pop(&block.header().block_hash);
+                }
             }
         }
         Ok(())
@@ -396,7 +500,6 @@ impl Producer {
         self.appends_since_prune += 1;
         if self.appends_since_prune >= PRUNE_INTERVAL {
             self.appends_since_prune = 0;
-            // Fully checked: the subtraction was already guarded, but `seq + 1` was the unchecked add.
             if let Some(keep_from) = seq
                 .checked_add(1)
                 .and_then(|len| len.checked_sub(RETENTION_EVENTS))
@@ -411,26 +514,24 @@ impl Producer {
 
 /// Rebuilds the producer's in-memory de-dup state (`observed` and `finalized` hashes) from the
 /// durable log tail on startup, so a restart does not re-emit for blocks already in the log.
-fn rebuild_state(db: &DatabaseProvider) -> (LruCache<H256, ()>, LruCache<H256, ()>) {
+///
+/// A failed log read is an error — starting with empty de-dup state would re-emit duplicate
+/// frames for every recent block; the caller halts the producer instead. An individual entry that
+/// fails to decode is skipped with a warning: unlike the serving path (which must error rather
+/// than put a `seq` gap on the wire), the rebuild only mines hashes out of the tail.
+fn rebuild_state(db: &DatabaseProvider) -> eyre::Result<(LruCache<H256, ()>, LruCache<H256, ()>)> {
     let mut emitted = LruCache::new(DEDUP_CAPACITY);
     let mut finalized = LruCache::new(DEDUP_CAPACITY);
 
     // One read tx for both the latest seq and the tail it bounds — an atomic snapshot at startup.
-    let tail = db.view_eyre(|tx| {
+    let events = db.view_eyre(|tx| {
         let Some(latest) = irys_database::block_stream_latest_seq(tx)? else {
             return Ok(Vec::new());
         };
         let capacity = u64::try_from(DEDUP_CAPACITY.get()).unwrap_or(u64::MAX);
         irys_database::read_block_stream_from(tx, latest.saturating_sub(capacity))
-    });
+    })?;
 
-    let events = match tail {
-        Ok(events) => events,
-        Err(e) => {
-            warn!(error = ?e, "block-stream state rebuild failed; starting with empty de-dup state");
-            return (emitted, finalized);
-        }
-    };
     for (_seq, bytes) in &events {
         match serde_json::from_slice::<StreamEvent>(bytes) {
             Ok(StreamEvent::Observed(block)) => {
@@ -439,9 +540,16 @@ fn rebuild_state(db: &DatabaseProvider) -> (LruCache<H256, ()>, LruCache<H256, (
             Ok(StreamEvent::Finalized(block)) => {
                 finalized.put(block.header.block_hash, ());
             }
-            Ok(StreamEvent::Reorged { new_fork, .. }) => {
+            Ok(StreamEvent::Reorged {
+                orphaned, new_fork, ..
+            }) => {
                 for block in new_fork {
                     emitted.put(block.header.block_hash, ());
+                }
+                // Mirror the live `Reorged` handling: a rolled-back block must be free to emit
+                // `finalized` again if it re-migrates after re-adoption.
+                for block in orphaned {
+                    finalized.pop(&block.header.block_hash);
                 }
             }
             Err(e) => {
@@ -450,7 +558,7 @@ fn rebuild_state(db: &DatabaseProvider) -> (LruCache<H256, ()>, LruCache<H256, (
         }
     }
 
-    (emitted, finalized)
+    Ok((emitted, finalized))
 }
 
 #[cfg(test)]
@@ -647,7 +755,8 @@ mod tests {
             vec![3, 4]
         );
 
-        // Poll side: the raw below-floor cursor gets an empty, truncated resync page (the I6 asymmetry).
+        // Poll side: the raw below-floor cursor gets an empty, truncated resync page — the
+        // deliberate SSE-rewinds/poll-signals asymmetry.
         let page = handle.events_page(0, 10).unwrap();
         assert!(page.truncated && page.frames.is_empty());
         assert_eq!(page.next_seq, 3);
@@ -696,19 +805,6 @@ mod tests {
     }
 
     #[test]
-    fn live_subscribers_share_the_same_frame_allocation() {
-        let (handle, _tmp) = handle_with_events(0);
-        let (_, _, mut live_a) = handle.subscribe(0).unwrap();
-        let (_, _, mut live_b) = handle.subscribe(0).unwrap();
-
-        handle.append_and_fanout(sample_stream_event()).unwrap();
-        let frame_a = live_a.blocking_recv().expect("first live frame");
-        let frame_b = live_b.blocking_recv().expect("second live frame");
-
-        assert!(Arc::ptr_eq(&frame_a, &frame_b));
-    }
-
-    #[test]
     fn subscribe_reports_a_poisoned_fanout_lock() {
         let (handle, _tmp) = handle_with_events(0);
         let poisoned = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -748,7 +844,8 @@ mod tests {
         signal_tx
             .send(BlockStreamSignal::Confirmed(sample_block(2)))
             .expect("queue second signal");
-        let mut producer = Producer::new(Arc::clone(&handle), 1, shutdown, signal_rx);
+        let mut producer =
+            Producer::new(Arc::clone(&handle), 1, shutdown, signal_rx).expect("producer");
 
         producer.drain_queued_signals().expect("drain signals");
 
@@ -758,5 +855,129 @@ mod tests {
             frames.iter().map(|frame| frame.seq).collect::<Vec<_>>(),
             vec![0, 1]
         );
+    }
+
+    /// A producer whose signals these tests feed by direct `handle_signal` calls, so the returned
+    /// shutdown/sender halves are unused and may drop.
+    fn producer_over(handle: &Arc<BlockStreamHandle>) -> Producer {
+        let (_shutdown_tx, shutdown) = reth::tasks::shutdown::signal();
+        let (_signal_tx, signal_rx) = mpsc::unbounded_channel();
+        Producer::new(Arc::clone(handle), 1, shutdown, signal_rx).expect("producer")
+    }
+
+    /// The CX-1 regression: a block finalised, then orphaned by a reorg, must emit `finalized`
+    /// again when its fork is re-adopted and it re-migrates — live and across a restart's rebuild.
+    #[test]
+    fn orphaned_block_refinalizes_after_readoption() {
+        let (handle, _tmp) = handle_with_events(0);
+        let handle = Arc::new(handle);
+        let mut producer = producer_over(&handle);
+
+        let block_b = sample_block(1);
+        let block_c = sample_block(2);
+        let fork_parent = Arc::new(IrysBlockHeader::default());
+
+        producer
+            .handle_signal(BlockStreamSignal::Finalized(Arc::clone(&block_b)))
+            .expect("finalize B");
+        producer
+            .handle_signal(BlockStreamSignal::Reorged {
+                fork_parent: Arc::clone(&fork_parent),
+                old_fork: Arc::new(vec![Arc::clone(&block_b)]),
+                new_fork: Arc::new(vec![Arc::clone(&block_c)]),
+            })
+            .expect("reorg orphaning B");
+        producer
+            .handle_signal(BlockStreamSignal::Finalized(Arc::clone(&block_b)))
+            .expect("re-finalize B after re-adoption");
+
+        let (start, end, _live) = handle.subscribe(0).unwrap();
+        let kinds: Vec<&str> = collect_replay(&handle, start, end)
+            .iter()
+            .map(StreamFrame::kind)
+            .collect();
+        assert_eq!(
+            kinds,
+            vec!["finalized", "reorged", "finalized"],
+            "the re-migrated orphan must re-emit finalized, not be de-dup-suppressed"
+        );
+
+        // Restart: the rebuilt de-dup state must mirror the live eviction, so the re-finalise
+        // also survives a producer restart that happens between the reorg and the re-migration.
+        let (emitted, finalized) = rebuild_state(&handle.db).expect("rebuild");
+        assert!(
+            !finalized.contains(&block_b.header().block_hash),
+            "rebuild must evict the orphaned hash from the finalized de-dup"
+        );
+        assert!(emitted.contains(&block_c.header().block_hash));
+    }
+
+    /// The CR-7 reconciliation: a `finalized` frame lost to a crash between the migration commit
+    /// and the append is re-derived from the block index at startup and appended in height order.
+    #[test]
+    fn startup_reconciles_finalized_frames_missing_from_the_log_tail() {
+        use irys_types::BlockIndexItem;
+
+        let (handle, _tmp) = handle_with_events(0);
+        let handle = Arc::new(handle);
+
+        // Block 1 migrated AND logged; blocks 2 and 3 migrated (index + headers committed) but
+        // their finalized signals died with the process before the producer appended them.
+        let blocks: Vec<Arc<SealedBlock>> = (1_u64..=3).map(sample_block).collect();
+        {
+            let mut producer = producer_over(&handle);
+            producer
+                .handle_signal(BlockStreamSignal::Finalized(Arc::clone(&blocks[0])))
+                .expect("finalize block 1");
+        }
+        handle
+            .db
+            .update_eyre(|tx| {
+                for block in &blocks {
+                    let header = block.header();
+                    irys_database::insert_block_header(tx, header)?;
+                    irys_database::insert_block_index_item(
+                        tx,
+                        header.height,
+                        &BlockIndexItem {
+                            block_hash: header.block_hash,
+                            ..Default::default()
+                        },
+                    )?;
+                }
+                Ok(())
+            })
+            .expect("seed index and headers");
+
+        // A fresh producer (as after a restart) reconciles the gap before serving.
+        let mut producer = producer_over(&handle);
+        producer
+            .reconcile_finalized_tail()
+            .expect("reconciliation succeeds");
+
+        let (start, end, _live) = handle.subscribe(0).unwrap();
+        let frames = collect_replay(&handle, start, end);
+        let finalized_hashes: Vec<H256> = frames
+            .iter()
+            .filter(|f| f.kind() == "finalized")
+            .filter_map(StreamFrame::block_hash)
+            .collect();
+        assert_eq!(
+            finalized_hashes,
+            vec![
+                blocks[0].header().block_hash,
+                blocks[1].header().block_hash,
+                blocks[2].header().block_hash,
+            ],
+            "the missing tail is appended once, in ascending height order"
+        );
+
+        // Idempotent: a second reconciliation (say, another restart) appends nothing.
+        let mut producer = producer_over(&handle);
+        producer
+            .reconcile_finalized_tail()
+            .expect("second reconciliation");
+        let (_, end_after, _live) = handle.subscribe(0).unwrap();
+        assert_eq!(end, end_after, "reconciliation is idempotent");
     }
 }

--- a/crates/actors/src/block_stream_service.rs
+++ b/crates/actors/src/block_stream_service.rs
@@ -1,0 +1,309 @@
+//! The block-stream producer: the single, node-wide writer of the durable `seq` event log.
+//!
+//! The producer consumes a lossless, unbounded feed of [`BlockStreamSignal`]s emitted from the
+//! node's authoritative sites (the confirmation loop, the reorg site, and the per-block migration
+//! loop). For each signal it builds the wire [`StreamEvent`], appends it to the durable log
+//! (assigning the next `seq`), and fans it out to live SSE subscribers. Being the sole writer makes
+//! `seq` assignment monotonic and gap-free.
+//!
+//! The HTTP handlers never touch `seq`: they hold an [`Arc<BlockStreamHandle>`] and call the atomic
+//! [`BlockStreamHandle::subscribe`], which snapshots the durable replay suffix and registers a live
+//! receiver under one lock so the replay→live handover has no gap or duplicate.
+
+use crate::block_tree_service::BlockStreamSignal;
+use irys_database::db::IrysDatabaseExt as _;
+use irys_types::block_stream::{BlockEvent, BlockRef, StreamEvent, StreamFrame};
+use irys_types::{DatabaseProvider, H256, TokioServiceHandle};
+use lru::LruCache;
+use reth::tasks::shutdown::Shutdown;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use tracing::{Instrument as _, error, info, warn};
+
+/// Count-based retention: keep at most this many events; older ones are pruned. Sized to comfortably
+/// exceed the maximum expected follower downtime (the follower only ever resumes from a recent
+/// `seq`).
+const RETENTION_EVENTS: u64 = 100_000;
+/// Prune at most once per this many appends, to batch the delete writes.
+const PRUNE_INTERVAL: u64 = 1_000;
+/// De-dup window for emitted `observed` block hashes. Must comfortably exceed the reorg depth so a
+/// re-adopted block is still remembered.
+const DEDUP_CAPACITY: usize = 10_000;
+
+/// Shared handle: the live fan-out registry plus DB access. Held by the producer task and cloned
+/// into `ApiState` so every SSE handler shares the one producer.
+#[derive(Debug)]
+pub struct BlockStreamHandle {
+    /// Live SSE subscribers. The lock is shared with [`Self::append_and_fanout`] so a subscribe's
+    /// snapshot+register pair cannot interleave with an append.
+    live: Mutex<Vec<UnboundedSender<StreamFrame>>>,
+    db: DatabaseProvider,
+}
+
+impl BlockStreamHandle {
+    fn new(db: DatabaseProvider) -> Self {
+        Self {
+            live: Mutex::new(Vec::new()),
+            db,
+        }
+    }
+
+    /// Atomic replay→live handover: under one lock, snapshot the durable suffix `[from_seq..]` and
+    /// register a live sender, so no append interleaves between the snapshot and the registration.
+    pub fn subscribe(
+        &self,
+        from_seq: u64,
+    ) -> eyre::Result<(Vec<StreamFrame>, UnboundedReceiver<StreamFrame>)> {
+        let mut live = self
+            .live
+            .lock()
+            .expect("block-stream fan-out lock poisoned");
+        let stored = self
+            .db
+            .view_eyre(|tx| irys_database::read_block_stream_from(tx, from_seq))?;
+        let mut replay = Vec::with_capacity(stored.len());
+        for (seq, bytes) in stored {
+            replay.push(decode_frame(seq, &bytes)?);
+        }
+        let (tx, rx) = mpsc::unbounded_channel();
+        live.push(tx);
+        Ok((replay, rx))
+    }
+
+    /// Producer-only. Append `event` to the durable log (assigning `seq`) and fan it out, holding
+    /// the same lock as [`Self::subscribe`].
+    fn append_and_fanout(&self, event: StreamEvent) -> eyre::Result<u64> {
+        let mut live = self
+            .live
+            .lock()
+            .expect("block-stream fan-out lock poisoned");
+        let payload = serde_json::to_vec(&event)?;
+        let seq = self
+            .db
+            .update_eyre(|tx| irys_database::append_block_stream_event(tx, payload))?;
+        let frame = StreamFrame { seq, event };
+        // Drop subscribers whose receiver has been closed.
+        live.retain(|sender| sender.send(frame.clone()).is_ok());
+        Ok(seq)
+    }
+
+    fn prune(&self, keep_from_seq: u64) -> eyre::Result<()> {
+        self.db
+            .update_eyre(|tx| irys_database::prune_block_stream_below(tx, keep_from_seq))
+    }
+}
+
+/// Rebuilds a [`StreamFrame`] from a stored `(seq, event-json)` log entry.
+fn decode_frame(seq: u64, bytes: &[u8]) -> eyre::Result<StreamFrame> {
+    let event: StreamEvent = serde_json::from_slice(bytes)?;
+    Ok(StreamFrame { seq, event })
+}
+
+/// Spawns the block-stream producer task and returns its service handle plus the shared
+/// [`BlockStreamHandle`] for `ApiState`.
+pub struct BlockStreamService;
+
+impl BlockStreamService {
+    pub fn spawn_service(
+        signal_rx: UnboundedReceiver<BlockStreamSignal>,
+        db: DatabaseProvider,
+        chunk_size: u64,
+        runtime_handle: tokio::runtime::Handle,
+    ) -> (TokioServiceHandle, Arc<BlockStreamHandle>) {
+        info!("Spawning block-stream service");
+        let (shutdown_tx, shutdown_rx) = reth::tasks::shutdown::signal();
+        let handle = Arc::new(BlockStreamHandle::new(db));
+        let producer_handle = Arc::clone(&handle);
+
+        let join = runtime_handle.spawn(
+            async move {
+                Producer::new(producer_handle, chunk_size, shutdown_rx, signal_rx)
+                    .run()
+                    .await;
+            }
+            .in_current_span(),
+        );
+
+        let service_handle = TokioServiceHandle {
+            name: "block_stream_service".to_string(),
+            handle: join,
+            shutdown_signal: shutdown_tx,
+        };
+        (service_handle, handle)
+    }
+}
+
+struct Producer {
+    handle: Arc<BlockStreamHandle>,
+    chunk_size: u64,
+    shutdown: Shutdown,
+    signal_rx: UnboundedReceiver<BlockStreamSignal>,
+    /// `block_hash`es already emitted as `observed` (or carried in a reorg's `new_fork`), so a
+    /// re-confirmed block is not re-emitted.
+    emitted: LruCache<H256, ()>,
+    /// Highest finalised height, to guard against a double `finalized` for the same block.
+    last_finalized_height: Option<u64>,
+    appends_since_prune: u64,
+}
+
+impl Producer {
+    fn new(
+        handle: Arc<BlockStreamHandle>,
+        chunk_size: u64,
+        shutdown: Shutdown,
+        signal_rx: UnboundedReceiver<BlockStreamSignal>,
+    ) -> Self {
+        let (emitted, last_finalized_height) = rebuild_state(&handle.db);
+        Self {
+            handle,
+            chunk_size,
+            shutdown,
+            signal_rx,
+            emitted,
+            last_finalized_height,
+            appends_since_prune: 0,
+        }
+    }
+
+    async fn run(&mut self) {
+        info!("block-stream producer started");
+        loop {
+            tokio::select! {
+                _ = &mut self.shutdown => {
+                    info!("block-stream producer shutting down");
+                    break;
+                }
+                maybe_signal = self.signal_rx.recv() => {
+                    match maybe_signal {
+                        Some(signal) => {
+                            if let Err(e) = self.handle_signal(signal) {
+                                error!(error = ?e, "block-stream producer failed to process signal");
+                            }
+                        }
+                        None => {
+                            info!("block-stream signal channel closed; producer stopping");
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn handle_signal(&mut self, signal: BlockStreamSignal) -> eyre::Result<()> {
+        match signal {
+            BlockStreamSignal::Confirmed(block) => {
+                let hash = block.header().block_hash;
+                if self.emitted.contains(&hash) {
+                    return Ok(());
+                }
+                let event = StreamEvent::Observed(BlockEvent::from_sealed(&block, self.chunk_size));
+                self.append(event)?;
+                self.emitted.put(hash, ());
+            }
+            BlockStreamSignal::Finalized(block) => {
+                let height = block.header().height;
+                if self
+                    .last_finalized_height
+                    .is_some_and(|last| height <= last)
+                {
+                    return Ok(());
+                }
+                let event =
+                    StreamEvent::Finalized(BlockEvent::from_sealed(&block, self.chunk_size));
+                self.append(event)?;
+                self.last_finalized_height = Some(height);
+            }
+            BlockStreamSignal::Reorged {
+                fork_parent,
+                old_fork,
+                new_fork,
+            } => {
+                let event = StreamEvent::Reorged {
+                    fork_parent: BlockRef {
+                        height: fork_parent.height,
+                        block_hash: fork_parent.block_hash,
+                    },
+                    orphaned: old_fork
+                        .iter()
+                        .map(|b| BlockEvent::from_sealed(b, self.chunk_size))
+                        .collect(),
+                    new_fork: new_fork
+                        .iter()
+                        .map(|b| BlockEvent::from_sealed(b, self.chunk_size))
+                        .collect(),
+                };
+                self.append(event)?;
+                // Mark the new-fork hashes seen so the `Confirmed` signals that follow this tick do
+                // not also emit `observed` for them (`:1174` precedes `:1205` in `propagate_block`).
+                for block in new_fork.iter() {
+                    self.emitted.put(block.header().block_hash, ());
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn append(&mut self, event: StreamEvent) -> eyre::Result<()> {
+        let seq = self.handle.append_and_fanout(event)?;
+        self.appends_since_prune += 1;
+        if self.appends_since_prune >= PRUNE_INTERVAL {
+            self.appends_since_prune = 0;
+            if seq + 1 > RETENTION_EVENTS {
+                let keep_from = seq + 1 - RETENTION_EVENTS;
+                if let Err(e) = self.handle.prune(keep_from) {
+                    warn!(error = ?e, "block-stream log prune failed");
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Rebuilds the producer's in-memory de-dup state from the durable log tail on startup, so a
+/// restart does not re-emit `observed` for blocks already in the log.
+fn rebuild_state(db: &DatabaseProvider) -> (LruCache<H256, ()>, Option<u64>) {
+    let mut emitted =
+        LruCache::new(NonZeroUsize::new(DEDUP_CAPACITY).expect("non-zero dedup capacity"));
+    let mut last_finalized_height: Option<u64> = None;
+
+    let tail = (|| -> eyre::Result<Vec<(u64, Vec<u8>)>> {
+        let Some(latest) = db.view_eyre(irys_database::block_stream_latest_seq)? else {
+            return Ok(Vec::new());
+        };
+        let start = latest.saturating_sub(DEDUP_CAPACITY as u64);
+        db.view_eyre(|tx| irys_database::read_block_stream_from(tx, start))
+    })();
+
+    match tail {
+        Ok(events) => {
+            for (_seq, bytes) in &events {
+                match serde_json::from_slice::<StreamEvent>(bytes) {
+                    Ok(StreamEvent::Observed(block)) => {
+                        emitted.put(block.header.block_hash, ());
+                    }
+                    Ok(StreamEvent::Finalized(block)) => {
+                        last_finalized_height = Some(
+                            last_finalized_height
+                                .map_or(block.header.height, |last| last.max(block.header.height)),
+                        );
+                    }
+                    Ok(StreamEvent::Reorged { new_fork, .. }) => {
+                        for block in new_fork {
+                            emitted.put(block.header.block_hash, ());
+                        }
+                    }
+                    Err(e) => {
+                        warn!(error = ?e, "skipping undecodable block-stream log entry during rebuild");
+                    }
+                }
+            }
+        }
+        Err(e) => {
+            warn!(error = ?e, "block-stream state rebuild failed; starting with empty de-dup state");
+        }
+    }
+
+    (emitted, last_finalized_height)
+}

--- a/crates/actors/src/block_stream_service.rs
+++ b/crates/actors/src/block_stream_service.rs
@@ -87,8 +87,9 @@ impl BlockStreamHandle {
     /// fan-out lock.
     ///
     /// Three cursor regimes, all valid: an in-window `from_seq` pages from itself (the caught-up
-    /// `from_seq == logical_len` is a normal empty page); a `from_seq` below the retained floor pages from
-    /// the floor with `truncated = true`; a `from_seq` past the tip clamps to the floor.
+    /// `from_seq == logical_len` is a normal empty page); a `from_seq` below the retained floor returns an
+    /// empty `truncated` page whose `next_seq` is the floor (the follower discards frames and resyncs
+    /// forward to it); a `from_seq` past the tip clamps to the floor.
     pub fn events_page(&self, from_seq: u64, limit: u64) -> eyre::Result<EventsPage> {
         // checked conversions / arithmetic only — never silently manufacture a wrong cursor
         let limit = usize::try_from(limit.min(MAX_PAGE))?;
@@ -98,14 +99,19 @@ impl BlockStreamHandle {
                 Some(seq) => seq.checked_add(1).ok_or_eyre("block-stream seq overflow")?,
                 None => 0,
             };
-            let (start, truncated) = if from_seq < lowest {
-                (lowest, true) // below the retained floor
+            // A below-floor (truncated) page is a pure resync signal: the follower discards any frames
+            // and force-resets its cursor forward to `next_seq` (the floor), so carry no frames — with an
+            // empty page `next_seq == lowest` is exactly that floor. A beyond-tip cursor clamps to the
+            // floor so the follower instead sees a below-cursor frame and rewinds (chain reset, not a
+            // gap). In-window pages from `from_seq`, empty when caught up at `from_seq == logical_len`.
+            let (start, read_limit, truncated) = if from_seq < lowest {
+                (lowest, 0, true) // below the retained floor → signal only, no frames
             } else if from_seq > logical_len {
-                (lowest, false) // beyond the tip → clamp to the floor (0 on a fresh log)
+                (lowest, limit, false) // beyond the tip → clamp to the floor (0 on a fresh log)
             } else {
-                (from_seq, false) // in-window / at-tip (== logical_len yields an empty page)
+                (from_seq, limit, false) // in-window / at-tip (== logical_len yields an empty page)
             };
-            let raw = irys_database::read_block_stream_range(tx, start, limit)?;
+            let raw = irys_database::read_block_stream_range(tx, start, read_limit)?;
             let mut frames = Vec::with_capacity(raw.len());
             for (seq, bytes) in raw {
                 frames.push(decode_frame(seq, &bytes)?);
@@ -478,10 +484,12 @@ mod tests {
 
         let page = handle.events_page(0, 1).unwrap();
         assert!(page.truncated);
-        assert_eq!(page.frames.first().map(|f| f.seq), Some(3));
+        // A truncated page is a resync signal: no frames, and next_seq is the floor the follower
+        // force-resets forward to (it discards frames and resumes from next_seq).
+        assert!(page.frames.is_empty());
         assert_eq!(page.lowest_retained_seq, 3);
-        assert_eq!(page.next_seq, 4);
-        assert!(page.has_more);
+        assert_eq!(page.next_seq, 3);
+        assert!(page.has_more); // floor (3) < logical_len (5)
     }
 
     #[test]

--- a/crates/actors/src/block_stream_service.rs
+++ b/crates/actors/src/block_stream_service.rs
@@ -59,8 +59,9 @@ impl BlockStreamHandle {
         }
     }
 
-    /// Atomic replay→live handover: under one lock, snapshot the durable suffix `[from_seq..]` and
-    /// register a live sender, so no append interleaves between the snapshot and the registration.
+    /// Atomic replay→live handover: under one lock, snapshot the durable replay suffix (from `from_seq`,
+    /// or the retained floor when the cursor is stale past the tip) and register a live sender, so no
+    /// append interleaves between the snapshot and the registration.
     pub fn subscribe(
         &self,
         from_seq: u64,
@@ -69,9 +70,23 @@ impl BlockStreamHandle {
             .live
             .lock()
             .expect("block-stream fan-out lock poisoned");
-        let stored = self
-            .db
-            .view_eyre(|tx| irys_database::read_block_stream_from(tx, from_seq))?;
+        let stored = self.db.view_eyre(|tx| {
+            let logical_len = match irys_database::block_stream_latest_seq(tx)? {
+                Some(seq) => seq.checked_add(1).ok_or_eyre("block-stream seq overflow")?,
+                None => 0,
+            };
+            // A cursor beyond the tip is stale — only reachable after a log reset shrank the log. Replay
+            // from the retained floor so the follower sees below-cursor frames and rewinds, matching the
+            // `/events` beyond-tip clamp; otherwise the SSE follower would silently continue onto the new
+            // chain at the same seq. In-window / caught-up cursors replay from `from_seq` (empty at the
+            // tip); a below-floor cursor already starts at the floor via the range walk.
+            let start = if from_seq > logical_len {
+                irys_database::block_stream_lowest_seq(tx)?.unwrap_or(0)
+            } else {
+                from_seq
+            };
+            irys_database::read_block_stream_from(tx, start)
+        })?;
         let mut replay = Vec::with_capacity(stored.len());
         for (seq, bytes) in stored {
             replay.push(decode_frame(seq, &bytes)?);
@@ -502,5 +517,18 @@ mod tests {
             serde_json::to_value(&replay).unwrap(),
             "poll frames must be byte-identical to the SSE replay"
         );
+    }
+
+    #[test]
+    fn subscribe_clamps_stale_cursor_to_floor() {
+        let (handle, _tmp) = handle_with_events(3); // seqs 0,1,2 → logical_len = 3
+        // A cursor beyond the tip (only reachable after a reset shrank the log) replays from the floor,
+        // so the follower sees below-cursor frames and rewinds — not an empty replay.
+        let (replay, _live) = handle.subscribe(99).unwrap();
+        assert_eq!(replay.first().map(|f| f.seq), Some(0));
+        assert_eq!(replay.len(), 3);
+        // Caught up at the tip replays nothing — no re-stream of the whole log.
+        let (replay, _live) = handle.subscribe(3).unwrap();
+        assert!(replay.is_empty());
     }
 }

--- a/crates/actors/src/block_stream_service.rs
+++ b/crates/actors/src/block_stream_service.rs
@@ -887,6 +887,16 @@ mod tests {
                 new_fork: Arc::new(vec![Arc::clone(&block_c)]),
             })
             .expect("reorg orphaning B");
+
+        // Restart here — between the reorg and the re-migration: the rebuilt de-dup state must
+        // mirror the live eviction, so the re-finalise below survives either path.
+        let (emitted, finalized) = rebuild_state(&handle.db).expect("rebuild");
+        assert!(
+            !finalized.contains(&block_b.header().block_hash),
+            "rebuild must evict the orphaned hash from the finalized de-dup"
+        );
+        assert!(emitted.contains(&block_c.header().block_hash));
+
         producer
             .handle_signal(BlockStreamSignal::Finalized(Arc::clone(&block_b)))
             .expect("re-finalize B after re-adoption");
@@ -902,14 +912,9 @@ mod tests {
             "the re-migrated orphan must re-emit finalized, not be de-dup-suppressed"
         );
 
-        // Restart: the rebuilt de-dup state must mirror the live eviction, so the re-finalise
-        // also survives a producer restart that happens between the reorg and the re-migration.
-        let (emitted, finalized) = rebuild_state(&handle.db).expect("rebuild");
-        assert!(
-            !finalized.contains(&block_b.header().block_hash),
-            "rebuild must evict the orphaned hash from the finalized de-dup"
-        );
-        assert!(emitted.contains(&block_c.header().block_hash));
+        // After the re-finalise is durable, a rebuild suppresses a further duplicate again.
+        let (_, finalized) = rebuild_state(&handle.db).expect("rebuild after re-finalise");
+        assert!(finalized.contains(&block_b.header().block_hash));
     }
 
     /// The CR-7 reconciliation: a `finalized` frame lost to a crash between the migration commit

--- a/crates/actors/src/block_stream_service.rs
+++ b/crates/actors/src/block_stream_service.rs
@@ -209,14 +209,17 @@ impl ReplayStream {
             .db
             .view_eyre(|tx| irys_database::read_block_stream_range(tx, self.next_seq, limit))?;
         let mut expected = self.next_seq;
+        // Stage the whole page before publishing it: a mid-page decode/seq failure must leave
+        // `buffered` untouched so `poll_next` surfaces the error and then terminates, rather than
+        // draining already-decoded frames after the error (which would break replay ordering).
+        let mut page = VecDeque::new();
         for (seq, bytes) in raw {
             if seq != expected {
                 return Err(eyre::eyre!(
                     "block-stream replay lost seq {expected}; next retained seq is {seq}"
                 ));
             }
-            self.buffered
-                .push_back(Arc::new(decode_frame(seq, &bytes)?));
+            page.push_back(Arc::new(decode_frame(seq, &bytes)?));
             expected = expected
                 .checked_add(1)
                 .ok_or_eyre("block-stream replay seq overflow")?;
@@ -228,6 +231,7 @@ impl ReplayStream {
                 self.end_seq
             ));
         }
+        self.buffered = page;
         self.next_seq = expected;
         Ok(())
     }

--- a/crates/actors/src/block_stream_service.rs
+++ b/crates/actors/src/block_stream_service.rs
@@ -17,9 +17,12 @@ use irys_types::block_stream::{BlockEvent, BlockRef, EventsPage, StreamEvent, St
 use irys_types::{DatabaseProvider, H256, TokioServiceHandle};
 use lru::LruCache;
 use reth::tasks::shutdown::Shutdown;
+use std::collections::VecDeque;
 use std::num::NonZeroUsize;
+use std::pin::Pin;
 use std::sync::{Arc, Mutex};
-use tokio::sync::mpsc::{self, Receiver, Sender, UnboundedReceiver};
+use std::task::{Context, Poll};
+use tokio::sync::mpsc::{self, Receiver, Sender, UnboundedReceiver, error::TryRecvError};
 use tracing::{Instrument as _, error, info, warn};
 
 /// Count-based retention: keep at most this many events; older ones are pruned. Sized to comfortably
@@ -30,11 +33,16 @@ const RETENTION_EVENTS: u64 = 100_000;
 const PRUNE_INTERVAL: u64 = 1_000;
 /// De-dup window for emitted `observed` block hashes. Must comfortably exceed the reorg depth so a
 /// re-adopted block is still remembered.
-const DEDUP_CAPACITY: usize = 10_000;
+const DEDUP_CAPACITY: NonZeroUsize = match NonZeroUsize::new(10_000) {
+    Some(capacity) => capacity,
+    None => NonZeroUsize::MIN,
+};
 /// Per-subscriber live buffer. A consumer that lags beyond this many frames is dropped (its SSE
 /// stream ends) and reconnects with `from_seq` to replay from the durable log — bounding memory
 /// instead of letting a stuck follower accumulate frames without limit.
 const SUBSCRIBER_BUFFER: usize = 1_024;
+/// Maximum number of durable frames decoded at once for an SSE replay.
+const REPLAY_PAGE: usize = 1_024;
 
 /// Max frames a single `GET /internal/blocks/events` page may return; an over-size `limit` is clamped to
 /// this rather than rejected, bounding per-request work.
@@ -47,7 +55,7 @@ pub struct BlockStreamHandle {
     /// Live SSE subscribers. The lock is shared with [`Self::append_and_fanout`] so a subscribe's
     /// snapshot+register pair cannot interleave with an append. Bounded senders: a lagging
     /// subscriber is dropped rather than buffered without limit.
-    live: Mutex<Vec<Sender<StreamFrame>>>,
+    live: Mutex<Vec<Sender<Arc<StreamFrame>>>>,
     db: DatabaseProvider,
 }
 
@@ -59,18 +67,19 @@ impl BlockStreamHandle {
         }
     }
 
-    /// Atomic replay→live handover: under one lock, snapshot the durable replay suffix (from `from_seq`,
-    /// or the retained floor when the cursor is stale past the tip) and register a live sender, so no
-    /// append interleaves between the snapshot and the registration.
+    /// Atomic replay→live handover: under one lock, snapshot the durable replay bounds and register
+    /// a live sender, so no append interleaves between the snapshot and the registration. The returned
+    /// replay reads that immutable range in bounded pages after releasing the fan-out lock.
     pub fn subscribe(
         &self,
         from_seq: u64,
-    ) -> eyre::Result<(Vec<StreamFrame>, Receiver<StreamFrame>)> {
+    ) -> eyre::Result<(ReplayStream, Receiver<Arc<StreamFrame>>)> {
         let mut live = self
             .live
             .lock()
-            .expect("block-stream fan-out lock poisoned");
-        let stored = self.db.view_eyre(|tx| {
+            .map_err(|_| eyre::eyre!("block-stream fan-out lock poisoned"))?;
+        let (start, end) = self.db.view_eyre(|tx| {
+            let lowest = irys_database::block_stream_lowest_seq(tx)?.unwrap_or(0);
             let logical_len = match irys_database::block_stream_latest_seq(tx)? {
                 Some(seq) => seq.checked_add(1).ok_or_eyre("block-stream seq overflow")?,
                 None => 0,
@@ -79,21 +88,17 @@ impl BlockStreamHandle {
             // from the retained floor so the follower sees below-cursor frames and rewinds, matching the
             // `/events` beyond-tip clamp; otherwise the SSE follower would silently continue onto the new
             // chain at the same seq. In-window / caught-up cursors replay from `from_seq` (empty at the
-            // tip); a below-floor cursor already starts at the floor via the range walk.
-            let start = if from_seq > logical_len {
-                irys_database::block_stream_lowest_seq(tx)?.unwrap_or(0)
+            // tip); a below-floor cursor also clamps to the retained floor.
+            let start = if from_seq < lowest || from_seq > logical_len {
+                lowest
             } else {
                 from_seq
             };
-            irys_database::read_block_stream_from(tx, start)
+            Ok((start, logical_len))
         })?;
-        let mut replay = Vec::with_capacity(stored.len());
-        for (seq, bytes) in stored {
-            replay.push(decode_frame(seq, &bytes)?);
-        }
         let (tx, rx) = mpsc::channel(SUBSCRIBER_BUFFER);
         live.push(tx);
-        Ok((replay, rx))
+        Ok((ReplayStream::new(&self.db, start, end), rx))
     }
 
     /// One-shot page over the durable log for `GET /internal/blocks/events`, read in a single
@@ -152,21 +157,97 @@ impl BlockStreamHandle {
         let mut live = self
             .live
             .lock()
-            .expect("block-stream fan-out lock poisoned");
+            .map_err(|_| eyre::eyre!("block-stream fan-out lock poisoned"))?;
         let payload = serde_json::to_vec(&event)?;
         let seq = self
             .db
             .update_eyre(|tx| irys_database::append_block_stream_event(tx, payload))?;
-        let frame = StreamFrame { seq, event };
+        let frame = Arc::new(StreamFrame { seq, event });
         // Drop subscribers whose receiver is closed or lagging past `SUBSCRIBER_BUFFER`; a dropped
         // follower reconnects and replays from the durable log via `subscribe(from_seq)`.
-        live.retain(|sender| sender.try_send(frame.clone()).is_ok());
+        live.retain(|sender| {
+            sender
+                .try_send(Arc::clone(&frame)) // clone: live subscribers share one immutable frame allocation
+                .is_ok()
+        });
         Ok(seq)
     }
 
     fn prune(&self, keep_from_seq: u64) -> eyre::Result<()> {
         self.db
             .update_eyre(|tx| irys_database::prune_block_stream_below(tx, keep_from_seq))
+    }
+}
+
+/// Bounded, lazy replay of the durable range captured by [`BlockStreamHandle::subscribe`].
+#[derive(Debug)]
+pub struct ReplayStream {
+    db: DatabaseProvider,
+    next_seq: u64,
+    end_seq: u64,
+    buffered: VecDeque<Arc<StreamFrame>>,
+    failed: bool,
+}
+
+impl ReplayStream {
+    fn new(db: &DatabaseProvider, next_seq: u64, end_seq: u64) -> Self {
+        Self {
+            db: DatabaseProvider(Arc::clone(&db.0)), // clone: replay owns shared access to the DB environment
+            next_seq,
+            end_seq,
+            buffered: VecDeque::new(),
+            failed: false,
+        }
+    }
+
+    fn load_page(&mut self) -> eyre::Result<()> {
+        let remaining = self.end_seq.saturating_sub(self.next_seq);
+        let limit = usize::try_from(remaining)
+            .unwrap_or(usize::MAX)
+            .min(REPLAY_PAGE);
+        let raw = self
+            .db
+            .view_eyre(|tx| irys_database::read_block_stream_range(tx, self.next_seq, limit))?;
+        let mut expected = self.next_seq;
+        for (seq, bytes) in raw {
+            if seq != expected {
+                return Err(eyre::eyre!(
+                    "block-stream replay lost seq {expected}; next retained seq is {seq}"
+                ));
+            }
+            self.buffered
+                .push_back(Arc::new(decode_frame(seq, &bytes)?));
+            expected = expected
+                .checked_add(1)
+                .ok_or_eyre("block-stream replay seq overflow")?;
+        }
+        if expected == self.next_seq && self.next_seq < self.end_seq {
+            return Err(eyre::eyre!(
+                "block-stream replay ended at seq {} before snapshot end {}",
+                self.next_seq,
+                self.end_seq
+            ));
+        }
+        self.next_seq = expected;
+        Ok(())
+    }
+}
+
+impl futures::Stream for ReplayStream {
+    type Item = eyre::Result<Arc<StreamFrame>>;
+
+    fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if let Some(frame) = self.buffered.pop_front() {
+            return Poll::Ready(Some(Ok(frame)));
+        }
+        if self.failed || self.next_seq >= self.end_seq {
+            return Poll::Ready(None);
+        }
+        if let Err(error) = self.load_page() {
+            self.failed = true;
+            return Poll::Ready(Some(Err(error)));
+        }
+        Poll::Ready(self.buffered.pop_front().map(Ok))
     }
 }
 
@@ -190,7 +271,7 @@ impl BlockStreamService {
         info!("Spawning block-stream service");
         let (shutdown_tx, shutdown_rx) = reth::tasks::shutdown::signal();
         let handle = Arc::new(BlockStreamHandle::new(db));
-        let producer_handle = Arc::clone(&handle);
+        let producer_handle = Arc::clone(&handle); // clone: producer and API share the service handle
 
         let join = runtime_handle.spawn(
             async move {
@@ -249,7 +330,11 @@ impl Producer {
         loop {
             tokio::select! {
                 _ = &mut self.shutdown => {
-                    info!("block-stream producer shutting down");
+                    if let Err(e) = self.drain_queued_signals() {
+                        error!(error = ?e, "block-stream producer halting while draining shutdown queue");
+                    } else {
+                        info!("block-stream producer drained queued signals and is shutting down");
+                    }
                     break;
                 }
                 maybe_signal = self.signal_rx.recv() => {
@@ -269,6 +354,16 @@ impl Producer {
                         }
                     }
                 }
+            }
+        }
+    }
+
+    fn drain_queued_signals(&mut self) -> eyre::Result<()> {
+        self.signal_rx.close();
+        loop {
+            match self.signal_rx.try_recv() {
+                Ok(signal) => self.handle_signal(signal)?,
+                Err(TryRecvError::Empty | TryRecvError::Disconnected) => return Ok(()),
             }
         }
     }
@@ -344,15 +439,15 @@ impl Producer {
 /// Rebuilds the producer's in-memory de-dup state (`observed` and `finalized` hashes) from the
 /// durable log tail on startup, so a restart does not re-emit for blocks already in the log.
 fn rebuild_state(db: &DatabaseProvider) -> (LruCache<H256, ()>, LruCache<H256, ()>) {
-    let cap = NonZeroUsize::new(DEDUP_CAPACITY).expect("non-zero dedup capacity");
-    let mut emitted = LruCache::new(cap);
-    let mut finalized = LruCache::new(cap);
+    let mut emitted = LruCache::new(DEDUP_CAPACITY);
+    let mut finalized = LruCache::new(DEDUP_CAPACITY);
 
     let tail = (|| -> eyre::Result<Vec<(u64, Vec<u8>)>> {
         let Some(latest) = db.view_eyre(irys_database::block_stream_latest_seq)? else {
             return Ok(Vec::new());
         };
-        let start = latest.saturating_sub(DEDUP_CAPACITY as u64);
+        let capacity = u64::try_from(DEDUP_CAPACITY.get()).unwrap_or(u64::MAX);
+        let start = latest.saturating_sub(capacity);
         db.view_eyre(|tx| irys_database::read_block_stream_from(tx, start))
     })();
 
@@ -388,17 +483,19 @@ fn rebuild_state(db: &DatabaseProvider) -> (LruCache<H256, ()>, LruCache<H256, (
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures::{StreamExt as _, TryStreamExt as _};
     use irys_database::{
         IrysDatabaseArgs as _, append_block_stream_event, open_or_create_db,
         prune_block_stream_below, tables::IrysTables,
     };
     use irys_types::block_stream::{BlockEvent, BlockHeaderView, OwnerId};
+    use irys_types::{BlockTransactions, IrysBlockHeader, SealedBlock};
     use reth_db::mdbx::DatabaseArguments;
 
     /// A minimal but well-formed `observed` event, so `decode_frame` round-trips it. The frame's `seq`
     /// comes from the DB key, not this body, so a constant body is fine for the regime assertions.
-    fn sample_event() -> Vec<u8> {
-        let event = StreamEvent::Observed(BlockEvent {
+    fn sample_stream_event() -> StreamEvent {
+        StreamEvent::Observed(BlockEvent {
             header: BlockHeaderView {
                 height: 0,
                 block_hash: H256::zero(),
@@ -411,8 +508,25 @@ mod tests {
                 data_ledgers: vec![],
             },
             txs: vec![],
-        });
-        serde_json::to_vec(&event).expect("serialize sample event")
+        })
+    }
+
+    fn sample_event() -> Vec<u8> {
+        serde_json::to_vec(&sample_stream_event()).expect("serialize sample event")
+    }
+
+    fn collect_replay(replay: ReplayStream) -> Vec<Arc<StreamFrame>> {
+        futures::executor::block_on(replay.try_collect()).expect("collect replay")
+    }
+
+    fn sample_block(height: u64) -> Arc<SealedBlock> {
+        let mut header = IrysBlockHeader::default();
+        header.height = height;
+        header.block_hash = H256::from_low_u64_be(height);
+        Arc::new(SealedBlock::new_unchecked(
+            Arc::new(header),
+            BlockTransactions::default(),
+        ))
     }
 
     fn handle_with_events(
@@ -512,6 +626,7 @@ mod tests {
         let (handle, _tmp) = handle_with_events(3);
         let page = handle.events_page(0, 10).unwrap();
         let (replay, _live) = handle.subscribe(0).unwrap();
+        let replay = collect_replay(replay);
         assert_eq!(
             serde_json::to_value(&page.frames).unwrap(),
             serde_json::to_value(&replay).unwrap(),
@@ -525,10 +640,79 @@ mod tests {
         // A cursor beyond the tip (only reachable after a reset shrank the log) replays from the floor,
         // so the follower sees below-cursor frames and rewinds — not an empty replay.
         let (replay, _live) = handle.subscribe(99).unwrap();
+        let replay = collect_replay(replay);
         assert_eq!(replay.first().map(|f| f.seq), Some(0));
         assert_eq!(replay.len(), 3);
         // Caught up at the tip replays nothing — no re-stream of the whole log.
         let (replay, _live) = handle.subscribe(3).unwrap();
+        let replay = collect_replay(replay);
         assert!(replay.is_empty());
+    }
+
+    #[test]
+    fn subscribe_replay_decodes_at_most_one_page_at_a_time() {
+        let event_count = u64::try_from(REPLAY_PAGE).unwrap() + 1;
+        let (handle, _tmp) = handle_with_events(event_count);
+        let (mut replay, _live) = handle.subscribe(0).unwrap();
+
+        assert!(replay.buffered.is_empty());
+        let first = futures::executor::block_on(replay.next())
+            .expect("first replay item")
+            .expect("decode first replay item");
+
+        assert_eq!(first.seq, 0);
+        assert_eq!(replay.buffered.len(), REPLAY_PAGE - 1);
+    }
+
+    #[test]
+    fn live_subscribers_share_the_same_frame_allocation() {
+        let (handle, _tmp) = handle_with_events(0);
+        let (_replay_a, mut live_a) = handle.subscribe(0).unwrap();
+        let (_replay_b, mut live_b) = handle.subscribe(0).unwrap();
+
+        handle.append_and_fanout(sample_stream_event()).unwrap();
+        let frame_a = live_a.blocking_recv().expect("first live frame");
+        let frame_b = live_b.blocking_recv().expect("second live frame");
+
+        assert!(Arc::ptr_eq(&frame_a, &frame_b));
+    }
+
+    #[test]
+    fn subscribe_reports_a_poisoned_fanout_lock() {
+        let (handle, _tmp) = handle_with_events(0);
+        let poisoned = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = handle.live.lock().expect("lock fan-out registry");
+            panic!("poison fan-out registry");
+        }));
+        assert!(poisoned.is_err());
+
+        let error = handle
+            .subscribe(0)
+            .expect_err("poisoned lock must be an error");
+        assert!(error.to_string().contains("fan-out lock poisoned"));
+    }
+
+    #[test]
+    fn shutdown_drain_persists_every_queued_signal() {
+        let (handle, _tmp) = handle_with_events(0);
+        let handle = Arc::new(handle);
+        let (_shutdown_tx, shutdown) = reth::tasks::shutdown::signal();
+        let (signal_tx, signal_rx) = mpsc::unbounded_channel();
+        signal_tx
+            .send(BlockStreamSignal::Confirmed(sample_block(1)))
+            .expect("queue first signal");
+        signal_tx
+            .send(BlockStreamSignal::Confirmed(sample_block(2)))
+            .expect("queue second signal");
+        let mut producer = Producer::new(Arc::clone(&handle), 1, shutdown, signal_rx);
+
+        producer.drain_queued_signals().expect("drain signals");
+
+        let (replay, _live) = handle.subscribe(0).unwrap();
+        let frames = collect_replay(replay);
+        assert_eq!(
+            frames.iter().map(|frame| frame.seq).collect::<Vec<_>>(),
+            vec![0, 1]
+        );
     }
 }

--- a/crates/actors/src/block_stream_service.rs
+++ b/crates/actors/src/block_stream_service.rs
@@ -11,8 +11,9 @@
 //! receiver under one lock so the replay→live handover has no gap or duplicate.
 
 use crate::block_tree_service::BlockStreamSignal;
+use eyre::OptionExt as _;
 use irys_database::db::IrysDatabaseExt as _;
-use irys_types::block_stream::{BlockEvent, BlockRef, StreamEvent, StreamFrame};
+use irys_types::block_stream::{BlockEvent, BlockRef, EventsPage, StreamEvent, StreamFrame};
 use irys_types::{DatabaseProvider, H256, TokioServiceHandle};
 use lru::LruCache;
 use reth::tasks::shutdown::Shutdown;
@@ -34,6 +35,10 @@ const DEDUP_CAPACITY: usize = 10_000;
 /// stream ends) and reconnects with `from_seq` to replay from the durable log — bounding memory
 /// instead of letting a stuck follower accumulate frames without limit.
 const SUBSCRIBER_BUFFER: usize = 1_024;
+
+/// Max frames a single `GET /internal/blocks/events` page may return; an over-size `limit` is clamped to
+/// this rather than rejected, bounding per-request work.
+const MAX_PAGE: u64 = 1_024;
 
 /// Shared handle: the live fan-out registry plus DB access. Held by the producer task and cloned
 /// into `ApiState` so every SSE handler shares the one producer.
@@ -74,6 +79,50 @@ impl BlockStreamHandle {
         let (tx, rx) = mpsc::channel(SUBSCRIBER_BUFFER);
         live.push(tx);
         Ok((replay, rx))
+    }
+
+    /// One-shot page over the durable log for `GET /internal/blocks/events`, read in a single
+    /// transaction (first key + last key + bounded range) and decoded with the same [`decode_frame`] the
+    /// SSE replay uses, so the frames are byte-identical. Registers no live subscriber and takes no
+    /// fan-out lock.
+    ///
+    /// Three cursor regimes, all valid: an in-window `from_seq` pages from itself (the caught-up
+    /// `from_seq == logical_len` is a normal empty page); a `from_seq` below the retained floor pages from
+    /// the floor with `truncated = true`; a `from_seq` past the tip clamps to the floor.
+    pub fn events_page(&self, from_seq: u64, limit: u64) -> eyre::Result<EventsPage> {
+        // checked conversions / arithmetic only — never silently manufacture a wrong cursor
+        let limit = usize::try_from(limit.min(MAX_PAGE))?;
+        self.db.view_eyre(|tx| {
+            let lowest = irys_database::block_stream_lowest_seq(tx)?.unwrap_or(0);
+            let logical_len = match irys_database::block_stream_latest_seq(tx)? {
+                Some(seq) => seq.checked_add(1).ok_or_eyre("block-stream seq overflow")?,
+                None => 0,
+            };
+            let (start, truncated) = if from_seq < lowest {
+                (lowest, true) // below the retained floor
+            } else if from_seq > logical_len {
+                (lowest, false) // beyond the tip → clamp to the floor (0 on a fresh log)
+            } else {
+                (from_seq, false) // in-window / at-tip (== logical_len yields an empty page)
+            };
+            let raw = irys_database::read_block_stream_range(tx, start, limit)?;
+            let mut frames = Vec::with_capacity(raw.len());
+            for (seq, bytes) in raw {
+                frames.push(decode_frame(seq, &bytes)?);
+            }
+            let count = u64::try_from(frames.len())?;
+            let next_seq = start
+                .checked_add(count)
+                .ok_or_eyre("page cursor overflow")?;
+            Ok(EventsPage {
+                from_seq,
+                next_seq,
+                has_more: next_seq < logical_len,
+                lowest_retained_seq: lowest,
+                truncated,
+                frames,
+            })
+        })
     }
 
     /// Producer-only. Append `event` to the durable log (assigning `seq`) and fan it out, holding
@@ -313,4 +362,137 @@ fn rebuild_state(db: &DatabaseProvider) -> (LruCache<H256, ()>, LruCache<H256, (
     }
 
     (emitted, finalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use irys_database::{
+        IrysDatabaseArgs as _, append_block_stream_event, open_or_create_db,
+        prune_block_stream_below, tables::IrysTables,
+    };
+    use irys_types::block_stream::{BlockEvent, BlockHeaderView, OwnerId};
+    use reth_db::mdbx::DatabaseArguments;
+
+    /// A minimal but well-formed `observed` event, so `decode_frame` round-trips it. The frame's `seq`
+    /// comes from the DB key, not this body, so a constant body is fine for the regime assertions.
+    fn sample_event() -> Vec<u8> {
+        let event = StreamEvent::Observed(BlockEvent {
+            header: BlockHeaderView {
+                height: 0,
+                block_hash: H256::zero(),
+                previous_block_hash: H256::zero(),
+                timestamp: 0,
+                miner_address: OwnerId {
+                    sig_type: 0,
+                    bytes: vec![0_u8; 20],
+                },
+                data_ledgers: vec![],
+            },
+            txs: vec![],
+        });
+        serde_json::to_vec(&event).expect("serialize sample event")
+    }
+
+    fn handle_with_events(
+        n: u64,
+    ) -> (
+        BlockStreamHandle,
+        irys_testing_utils::utils::tempfile::TempDir,
+    ) {
+        let tmp = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db_env = open_or_create_db(
+            tmp.path(),
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing().unwrap(),
+        )
+        .unwrap();
+        let db = DatabaseProvider(Arc::new(db_env));
+        for _ in 0..n {
+            db.update_eyre(|tx| append_block_stream_event(tx, sample_event()))
+                .unwrap();
+        }
+        (BlockStreamHandle::new(db), tmp)
+    }
+
+    #[test]
+    fn events_page_regimes() {
+        let (handle, _tmp) = handle_with_events(3); // seqs 0,1,2 → logical_len = 3
+
+        // in-window: contiguous suffix from from_seq
+        let page = handle.events_page(1, 10).unwrap();
+        assert_eq!(
+            page.frames.iter().map(|f| f.seq).collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+        assert_eq!(page.from_seq, 1);
+        assert_eq!(page.next_seq, 3);
+        assert!(!page.has_more);
+        assert!(!page.truncated);
+        assert_eq!(page.lowest_retained_seq, 0);
+
+        // limit honoured
+        let page = handle.events_page(0, 1).unwrap();
+        assert_eq!(page.frames.len(), 1);
+        assert_eq!(page.next_seq, 1);
+        assert!(page.has_more);
+
+        // caught-up (== logical_len): empty page, not a clamp
+        let page = handle.events_page(3, 10).unwrap();
+        assert!(page.frames.is_empty());
+        assert_eq!(page.next_seq, 3);
+        assert!(!page.has_more);
+        assert!(!page.truncated);
+
+        // beyond tip (> logical_len): clamp to floor 0
+        let page = handle.events_page(8, 10).unwrap();
+        assert_eq!(page.frames.first().map(|f| f.seq), Some(0));
+        assert!(!page.truncated);
+
+        // limit == 0 probe: empty frames, correct envelope
+        let page = handle.events_page(1, 0).unwrap();
+        assert!(page.frames.is_empty());
+        assert_eq!(page.next_seq, 1);
+        assert!(page.has_more);
+    }
+
+    #[test]
+    fn events_page_empty_log() {
+        let (handle, _tmp) = handle_with_events(0);
+        let page = handle.events_page(0, 10).unwrap();
+        assert!(page.frames.is_empty());
+        assert_eq!(page.next_seq, 0);
+        assert!(!page.has_more);
+        assert!(!page.truncated);
+        assert_eq!(page.lowest_retained_seq, 0);
+    }
+
+    #[test]
+    fn events_page_below_floor_truncates() {
+        let (handle, _tmp) = handle_with_events(5); // seqs 0..=4 → logical_len = 5
+        // Drive pruning directly (RETENTION_EVENTS is a non-configurable const): floor → 3.
+        handle
+            .db
+            .update_eyre(|tx| prune_block_stream_below(tx, 3))
+            .unwrap();
+
+        let page = handle.events_page(0, 1).unwrap();
+        assert!(page.truncated);
+        assert_eq!(page.frames.first().map(|f| f.seq), Some(3));
+        assert_eq!(page.lowest_retained_seq, 3);
+        assert_eq!(page.next_seq, 4);
+        assert!(page.has_more);
+    }
+
+    #[test]
+    fn events_page_frames_match_sse_replay() {
+        let (handle, _tmp) = handle_with_events(3);
+        let page = handle.events_page(0, 10).unwrap();
+        let (replay, _live) = handle.subscribe(0).unwrap();
+        assert_eq!(
+            serde_json::to_value(&page.frames).unwrap(),
+            serde_json::to_value(&replay).unwrap(),
+            "poll frames must be byte-identical to the SSE replay"
+        );
+    }
 }

--- a/crates/actors/src/block_stream_service.rs
+++ b/crates/actors/src/block_stream_service.rs
@@ -17,11 +17,8 @@ use irys_types::block_stream::{BlockEvent, BlockRef, EventsPage, StreamEvent, St
 use irys_types::{DatabaseProvider, H256, TokioServiceHandle};
 use lru::LruCache;
 use reth::tasks::shutdown::Shutdown;
-use std::collections::VecDeque;
 use std::num::NonZeroUsize;
-use std::pin::Pin;
 use std::sync::{Arc, Mutex};
-use std::task::{Context, Poll};
 use tokio::sync::mpsc::{self, Receiver, Sender, UnboundedReceiver, error::TryRecvError};
 use tracing::{Instrument as _, error, info, warn};
 
@@ -41,8 +38,6 @@ const DEDUP_CAPACITY: NonZeroUsize = match NonZeroUsize::new(10_000) {
 /// stream ends) and reconnects with `from_seq` to replay from the durable log — bounding memory
 /// instead of letting a stuck follower accumulate frames without limit.
 const SUBSCRIBER_BUFFER: usize = 1_024;
-/// Maximum number of durable frames decoded at once for an SSE replay.
-const REPLAY_PAGE: usize = 1_024;
 
 /// Max frames a single `GET /internal/blocks/events` page may return; an over-size `limit` is clamped to
 /// this rather than rejected, bounding per-request work.
@@ -80,23 +75,17 @@ impl BlockStreamHandle {
         }
     }
 
-    /// Atomic replay→live handover: under one lock, snapshot the durable replay bounds and register
-    /// a live sender, so no append interleaves between the snapshot and the registration. The returned
-    /// replay reads that immutable range in bounded pages after releasing the fan-out lock.
-    pub fn subscribe(
-        &self,
-        from_seq: u64,
-    ) -> eyre::Result<(ReplayStream, Receiver<Arc<StreamFrame>>)> {
+    /// Atomic replay→live handover: under one lock, snapshot the durable replay bounds `[start, end)` and
+    /// register a live sender, so no append interleaves between the snapshot and the registration. The
+    /// caller replays `[start, end)` via [`Self::replay_page`] (after the fan-out lock is released), then
+    /// tails the live receiver.
+    pub fn subscribe(&self, from_seq: u64) -> eyre::Result<(u64, u64, Receiver<Arc<StreamFrame>>)> {
         let mut live = self
             .live
             .lock()
             .map_err(|_| eyre::eyre!("block-stream fan-out lock poisoned"))?;
         let (start, end) = self.db.view_eyre(|tx| {
-            let lowest = irys_database::block_stream_lowest_seq(tx)?.unwrap_or(0);
-            let logical_len = match irys_database::block_stream_latest_seq(tx)? {
-                Some(seq) => seq.checked_add(1).ok_or_eyre("block-stream seq overflow")?,
-                None => 0,
-            };
+            let (lowest, logical_len) = irys_database::block_stream_log_bounds(tx)?;
             // A cursor beyond the tip is stale — only reachable after a log reset shrank the log. Replay
             // from the retained floor so the follower sees below-cursor frames and rewinds, matching the
             // `/events` beyond-tip clamp; otherwise the SSE follower would silently continue onto the new
@@ -116,7 +105,7 @@ impl BlockStreamHandle {
         if !live.closed {
             live.senders.push(tx);
         }
-        Ok((ReplayStream::new(&self.db, start, end), rx))
+        Ok((start, end, rx))
     }
 
     /// One-shot page over the durable log for `GET /internal/blocks/events`, read in a single
@@ -132,11 +121,7 @@ impl BlockStreamHandle {
         // checked conversions / arithmetic only — never silently manufacture a wrong cursor
         let limit = usize::try_from(limit.min(MAX_PAGE))?;
         self.db.view_eyre(|tx| {
-            let lowest = irys_database::block_stream_lowest_seq(tx)?.unwrap_or(0);
-            let logical_len = match irys_database::block_stream_latest_seq(tx)? {
-                Some(seq) => seq.checked_add(1).ok_or_eyre("block-stream seq overflow")?,
-                None => 0,
-            };
+            let (lowest, logical_len) = irys_database::block_stream_log_bounds(tx)?;
             // A below-floor (truncated) page is a pure resync signal: the follower discards any frames
             // and force-resets its cursor forward to `next_seq` (the floor), so carry no frames — with an
             // empty page `next_seq == lowest` is exactly that floor. A beyond-tip cursor clamps to the
@@ -167,6 +152,30 @@ impl BlockStreamHandle {
                 frames,
             })
         })
+    }
+
+    /// One bounded page of an SSE subscriber's durable replay, capped by the immutable snapshot `end`
+    /// that [`Self::subscribe`] captured. Returns `(next_cursor, frames)` for a contiguous page from
+    /// `cursor`, or `None` when the replay is complete (`cursor >= end`) or must abort because a prune
+    /// advanced the retained floor past `cursor` mid-replay (a `truncated`/no-progress page). On abort the
+    /// cursor has not reached `end`, which is how the caller tells "resync" from "done".
+    ///
+    /// Bounding each page by `end` (not [`Self::events_page`]'s `has_more`, which tracks a moving tip)
+    /// keeps the replay→live handover gap- and duplicate-free; the abort check subsumes the cross-page
+    /// seq-contiguity and short-snapshot guards the old streaming replay carried.
+    pub fn replay_page(
+        &self,
+        cursor: u64,
+        end: u64,
+    ) -> eyre::Result<Option<(u64, Vec<StreamFrame>)>> {
+        if cursor >= end {
+            return Ok(None);
+        }
+        let page = self.events_page(cursor, end - cursor)?;
+        if page.truncated || page.next_seq <= cursor {
+            return Ok(None);
+        }
+        Ok(Some((page.next_seq, page.frames)))
     }
 
     /// Producer-only. Append `event` to the durable log (assigning `seq`) and fan it out, holding
@@ -206,82 +215,6 @@ impl BlockStreamHandle {
             }
             Err(_) => warn!("block-stream fan-out lock poisoned while closing subscribers"),
         }
-    }
-}
-
-/// Bounded, lazy replay of the durable range captured by [`BlockStreamHandle::subscribe`].
-#[derive(Debug)]
-pub struct ReplayStream {
-    db: DatabaseProvider,
-    next_seq: u64,
-    end_seq: u64,
-    buffered: VecDeque<Arc<StreamFrame>>,
-    failed: bool,
-}
-
-impl ReplayStream {
-    fn new(db: &DatabaseProvider, next_seq: u64, end_seq: u64) -> Self {
-        Self {
-            db: DatabaseProvider(Arc::clone(&db.0)), // clone: replay owns shared access to the DB environment
-            next_seq,
-            end_seq,
-            buffered: VecDeque::new(),
-            failed: false,
-        }
-    }
-
-    fn load_page(&mut self) -> eyre::Result<()> {
-        let remaining = self.end_seq.saturating_sub(self.next_seq);
-        let limit = usize::try_from(remaining)
-            .unwrap_or(usize::MAX)
-            .min(REPLAY_PAGE);
-        let raw = self
-            .db
-            .view_eyre(|tx| irys_database::read_block_stream_range(tx, self.next_seq, limit))?;
-        let mut expected = self.next_seq;
-        // Stage the whole page before publishing it: a mid-page decode/seq failure must leave
-        // `buffered` untouched so `poll_next` surfaces the error and then terminates, rather than
-        // draining already-decoded frames after the error (which would break replay ordering).
-        let mut page = VecDeque::new();
-        for (seq, bytes) in raw {
-            if seq != expected {
-                return Err(eyre::eyre!(
-                    "block-stream replay lost seq {expected}; next retained seq is {seq}"
-                ));
-            }
-            page.push_back(Arc::new(decode_frame(seq, &bytes)?));
-            expected = expected
-                .checked_add(1)
-                .ok_or_eyre("block-stream replay seq overflow")?;
-        }
-        if expected == self.next_seq && self.next_seq < self.end_seq {
-            return Err(eyre::eyre!(
-                "block-stream replay ended at seq {} before snapshot end {}",
-                self.next_seq,
-                self.end_seq
-            ));
-        }
-        self.buffered = page;
-        self.next_seq = expected;
-        Ok(())
-    }
-}
-
-impl futures::Stream for ReplayStream {
-    type Item = eyre::Result<Arc<StreamFrame>>;
-
-    fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        if let Some(frame) = self.buffered.pop_front() {
-            return Poll::Ready(Some(Ok(frame)));
-        }
-        if self.failed || self.next_seq >= self.end_seq {
-            return Poll::Ready(None);
-        }
-        if let Err(error) = self.load_page() {
-            self.failed = true;
-            return Poll::Ready(Some(Err(error)));
-        }
-        Poll::Ready(self.buffered.pop_front().map(Ok))
     }
 }
 
@@ -463,11 +396,13 @@ impl Producer {
         self.appends_since_prune += 1;
         if self.appends_since_prune >= PRUNE_INTERVAL {
             self.appends_since_prune = 0;
-            if seq + 1 > RETENTION_EVENTS {
-                let keep_from = seq + 1 - RETENTION_EVENTS;
-                if let Err(e) = self.handle.prune(keep_from) {
-                    warn!(error = ?e, "block-stream log prune failed");
-                }
+            // Fully checked: the subtraction was already guarded, but `seq + 1` was the unchecked add.
+            if let Some(keep_from) = seq
+                .checked_add(1)
+                .and_then(|len| len.checked_sub(RETENTION_EVENTS))
+                && let Err(e) = self.handle.prune(keep_from)
+            {
+                warn!(error = ?e, "block-stream log prune failed");
             }
         }
         Ok(())
@@ -480,38 +415,38 @@ fn rebuild_state(db: &DatabaseProvider) -> (LruCache<H256, ()>, LruCache<H256, (
     let mut emitted = LruCache::new(DEDUP_CAPACITY);
     let mut finalized = LruCache::new(DEDUP_CAPACITY);
 
-    let tail = (|| -> eyre::Result<Vec<(u64, Vec<u8>)>> {
-        let Some(latest) = db.view_eyre(irys_database::block_stream_latest_seq)? else {
+    // One read tx for both the latest seq and the tail it bounds — an atomic snapshot at startup.
+    let tail = db.view_eyre(|tx| {
+        let Some(latest) = irys_database::block_stream_latest_seq(tx)? else {
             return Ok(Vec::new());
         };
         let capacity = u64::try_from(DEDUP_CAPACITY.get()).unwrap_or(u64::MAX);
-        let start = latest.saturating_sub(capacity);
-        db.view_eyre(|tx| irys_database::read_block_stream_from(tx, start))
-    })();
+        irys_database::read_block_stream_from(tx, latest.saturating_sub(capacity))
+    });
 
-    match tail {
-        Ok(events) => {
-            for (_seq, bytes) in &events {
-                match serde_json::from_slice::<StreamEvent>(bytes) {
-                    Ok(StreamEvent::Observed(block)) => {
-                        emitted.put(block.header.block_hash, ());
-                    }
-                    Ok(StreamEvent::Finalized(block)) => {
-                        finalized.put(block.header.block_hash, ());
-                    }
-                    Ok(StreamEvent::Reorged { new_fork, .. }) => {
-                        for block in new_fork {
-                            emitted.put(block.header.block_hash, ());
-                        }
-                    }
-                    Err(e) => {
-                        warn!(error = ?e, "skipping undecodable block-stream log entry during rebuild");
-                    }
-                }
-            }
-        }
+    let events = match tail {
+        Ok(events) => events,
         Err(e) => {
             warn!(error = ?e, "block-stream state rebuild failed; starting with empty de-dup state");
+            return (emitted, finalized);
+        }
+    };
+    for (_seq, bytes) in &events {
+        match serde_json::from_slice::<StreamEvent>(bytes) {
+            Ok(StreamEvent::Observed(block)) => {
+                emitted.put(block.header.block_hash, ());
+            }
+            Ok(StreamEvent::Finalized(block)) => {
+                finalized.put(block.header.block_hash, ());
+            }
+            Ok(StreamEvent::Reorged { new_fork, .. }) => {
+                for block in new_fork {
+                    emitted.put(block.header.block_hash, ());
+                }
+            }
+            Err(e) => {
+                warn!(error = ?e, "skipping undecodable block-stream log entry during rebuild");
+            }
         }
     }
 
@@ -521,7 +456,6 @@ fn rebuild_state(db: &DatabaseProvider) -> (LruCache<H256, ()>, LruCache<H256, (
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures::{StreamExt as _, TryStreamExt as _};
     use irys_database::{
         IrysDatabaseArgs as _, append_block_stream_event, open_or_create_db,
         prune_block_stream_below, tables::IrysTables,
@@ -553,8 +487,14 @@ mod tests {
         serde_json::to_vec(&sample_stream_event()).expect("serialize sample event")
     }
 
-    fn collect_replay(replay: ReplayStream) -> Vec<Arc<StreamFrame>> {
-        futures::executor::block_on(replay.try_collect()).expect("collect replay")
+    fn collect_replay(handle: &BlockStreamHandle, start: u64, end: u64) -> Vec<StreamFrame> {
+        let mut cursor = start;
+        let mut frames = Vec::new();
+        while let Some((next, page)) = handle.replay_page(cursor, end).expect("replay_page") {
+            frames.extend(page);
+            cursor = next;
+        }
+        frames
     }
 
     fn sample_block(height: u64) -> Arc<SealedBlock> {
@@ -663,8 +603,8 @@ mod tests {
     fn events_page_frames_match_sse_replay() {
         let (handle, _tmp) = handle_with_events(3);
         let page = handle.events_page(0, 10).unwrap();
-        let (replay, _live) = handle.subscribe(0).unwrap();
-        let replay = collect_replay(replay);
+        let (start, end, _live) = handle.subscribe(0).unwrap();
+        let replay = collect_replay(&handle, start, end);
         assert_eq!(
             serde_json::to_value(&page.frames).unwrap(),
             serde_json::to_value(&replay).unwrap(),
@@ -677,36 +617,89 @@ mod tests {
         let (handle, _tmp) = handle_with_events(3); // seqs 0,1,2 → logical_len = 3
         // A cursor beyond the tip (only reachable after a reset shrank the log) replays from the floor,
         // so the follower sees below-cursor frames and rewinds — not an empty replay.
-        let (replay, _live) = handle.subscribe(99).unwrap();
-        let replay = collect_replay(replay);
+        let (start, end, _live) = handle.subscribe(99).unwrap();
+        assert_eq!((start, end), (0, 3)); // clamped to the retained floor, not the stale cursor
+        let replay = collect_replay(&handle, start, end);
         assert_eq!(replay.first().map(|f| f.seq), Some(0));
         assert_eq!(replay.len(), 3);
         // Caught up at the tip replays nothing — no re-stream of the whole log.
-        let (replay, _live) = handle.subscribe(3).unwrap();
-        let replay = collect_replay(replay);
-        assert!(replay.is_empty());
+        let (start, end, _live) = handle.subscribe(3).unwrap();
+        assert_eq!((start, end), (3, 3));
+        assert!(collect_replay(&handle, start, end).is_empty());
     }
 
     #[test]
-    fn subscribe_replay_decodes_at_most_one_page_at_a_time() {
-        let event_count = u64::try_from(REPLAY_PAGE).unwrap() + 1;
-        let (handle, _tmp) = handle_with_events(event_count);
-        let (mut replay, _live) = handle.subscribe(0).unwrap();
+    fn subscribe_below_floor_replays_from_floor_while_poll_truncates() {
+        let (handle, _tmp) = handle_with_events(5); // seqs 0..=4 → logical_len = 5
+        handle
+            .db
+            .update_eyre(|tx| prune_block_stream_below(tx, 3))
+            .unwrap(); // floor → 3
 
-        assert!(replay.buffered.is_empty());
-        let first = futures::executor::block_on(replay.next())
-            .expect("first replay item")
-            .expect("decode first replay item");
+        // SSE side: subscribe clamps the below-floor cursor to the floor and replays frames-from-floor.
+        let (start, end, _live) = handle.subscribe(0).unwrap();
+        assert_eq!((start, end), (3, 5));
+        assert_eq!(
+            collect_replay(&handle, start, end)
+                .iter()
+                .map(|f| f.seq)
+                .collect::<Vec<_>>(),
+            vec![3, 4]
+        );
 
-        assert_eq!(first.seq, 0);
-        assert_eq!(replay.buffered.len(), REPLAY_PAGE - 1);
+        // Poll side: the raw below-floor cursor gets an empty, truncated resync page (the I6 asymmetry).
+        let page = handle.events_page(0, 10).unwrap();
+        assert!(page.truncated && page.frames.is_empty());
+        assert_eq!(page.next_seq, 3);
+    }
+
+    #[test]
+    fn replay_page_bounds_by_end_not_logical_len() {
+        let (handle, _tmp) = handle_with_events(3); // logical_len = 3
+        let (start, end, _live) = handle.subscribe(0).unwrap(); // end captured = 3
+        // The log grows after subscribe; the replay must still stop at the captured `end`, never reading
+        // seq 3 or 4 (which belong to the live tail).
+        handle
+            .db
+            .update_eyre(|tx| append_block_stream_event(tx, sample_event()))
+            .unwrap();
+        handle
+            .db
+            .update_eyre(|tx| append_block_stream_event(tx, sample_event()))
+            .unwrap();
+        assert_eq!(
+            collect_replay(&handle, start, end)
+                .iter()
+                .map(|f| f.seq)
+                .collect::<Vec<_>>(),
+            vec![0, 1, 2]
+        );
+        // replay_page reports done exactly at `end`, not at the new tip.
+        assert!(handle.replay_page(end, end).unwrap().is_none());
+    }
+
+    #[test]
+    fn replay_page_aborts_below_advanced_floor() {
+        let (handle, _tmp) = handle_with_events(5); // seqs 0..=4
+        handle
+            .db
+            .update_eyre(|tx| prune_block_stream_below(tx, 3))
+            .unwrap(); // floor → 3
+
+        // A subscriber that had progressed to cursor 1 is now below the advanced floor: replay_page
+        // aborts (None) with the cursor still short of `end` — how the handler tells resync from done.
+        assert!(handle.replay_page(1, 5).unwrap().is_none());
+        // Resuming from the new floor pages normally.
+        let (next, frames) = handle.replay_page(3, 5).unwrap().expect("page from floor");
+        assert_eq!(next, 5);
+        assert_eq!(frames.iter().map(|f| f.seq).collect::<Vec<_>>(), vec![3, 4]);
     }
 
     #[test]
     fn live_subscribers_share_the_same_frame_allocation() {
         let (handle, _tmp) = handle_with_events(0);
-        let (_replay_a, mut live_a) = handle.subscribe(0).unwrap();
-        let (_replay_b, mut live_b) = handle.subscribe(0).unwrap();
+        let (_, _, mut live_a) = handle.subscribe(0).unwrap();
+        let (_, _, mut live_b) = handle.subscribe(0).unwrap();
 
         handle.append_and_fanout(sample_stream_event()).unwrap();
         let frame_a = live_a.blocking_recv().expect("first live frame");
@@ -736,8 +729,8 @@ mod tests {
         handle.close_live_subscribers();
 
         // Replay still delivers the durable suffix up to the last good seq...
-        let (replay, mut live) = handle.subscribe(0).unwrap();
-        assert_eq!(collect_replay(replay).len(), 2);
+        let (start, end, mut live) = handle.subscribe(0).unwrap();
+        assert_eq!(collect_replay(&handle, start, end).len(), 2);
         // ...but no live sender is registered, so the receiver is already closed and the follower's
         // SSE ends after replay instead of hanging on a tail the halted producer will never feed.
         assert!(live.blocking_recv().is_none());
@@ -759,8 +752,8 @@ mod tests {
 
         producer.drain_queued_signals().expect("drain signals");
 
-        let (replay, _live) = handle.subscribe(0).unwrap();
-        let frames = collect_replay(replay);
+        let (start, end, _live) = handle.subscribe(0).unwrap();
+        let frames = collect_replay(&handle, start, end);
         assert_eq!(
             frames.iter().map(|frame| frame.seq).collect::<Vec<_>>(),
             vec![0, 1]

--- a/crates/actors/src/block_stream_service.rs
+++ b/crates/actors/src/block_stream_service.rs
@@ -55,14 +55,27 @@ pub struct BlockStreamHandle {
     /// Live SSE subscribers. The lock is shared with [`Self::append_and_fanout`] so a subscribe's
     /// snapshot+register pair cannot interleave with an append. Bounded senders: a lagging
     /// subscriber is dropped rather than buffered without limit.
-    live: Mutex<Vec<Sender<Arc<StreamFrame>>>>,
+    live: Mutex<LiveSubscribers>,
     db: DatabaseProvider,
+}
+
+/// The live fan-out registry: subscriber senders plus a `closed` flag the producer sets when it
+/// stops appending for good. Once closed, [`BlockStreamHandle::subscribe`] registers no new sender,
+/// so a reconnecting follower's SSE ends cleanly after its replay instead of hanging on a live tail
+/// nothing will ever feed.
+#[derive(Debug)]
+struct LiveSubscribers {
+    senders: Vec<Sender<Arc<StreamFrame>>>,
+    closed: bool,
 }
 
 impl BlockStreamHandle {
     fn new(db: DatabaseProvider) -> Self {
         Self {
-            live: Mutex::new(Vec::new()),
+            live: Mutex::new(LiveSubscribers {
+                senders: Vec::new(),
+                closed: false,
+            }),
             db,
         }
     }
@@ -97,7 +110,12 @@ impl BlockStreamHandle {
             Ok((start, logical_len))
         })?;
         let (tx, rx) = mpsc::channel(SUBSCRIBER_BUFFER);
-        live.push(tx);
+        // After the producer has halted for good, register no new live sender: dropping `tx` here
+        // closes `rx`, so the reconnecting follower's SSE ends cleanly after its replay rather than
+        // hanging on a live tail nothing will ever feed.
+        if !live.closed {
+            live.senders.push(tx);
+        }
         Ok((ReplayStream::new(&self.db, start, end), rx))
     }
 
@@ -165,7 +183,7 @@ impl BlockStreamHandle {
         let frame = Arc::new(StreamFrame { seq, event });
         // Drop subscribers whose receiver is closed or lagging past `SUBSCRIBER_BUFFER`; a dropped
         // follower reconnects and replays from the durable log via `subscribe(from_seq)`.
-        live.retain(|sender| {
+        live.senders.retain(|sender| {
             sender
                 .try_send(Arc::clone(&frame)) // clone: live subscribers share one immutable frame allocation
                 .is_ok()
@@ -182,7 +200,10 @@ impl BlockStreamHandle {
     /// replay from the last durable `seq`. Called when the producer stops appending for good.
     fn close_live_subscribers(&self) {
         match self.live.lock() {
-            Ok(mut live) => live.clear(),
+            Ok(mut live) => {
+                live.closed = true;
+                live.senders.clear();
+            }
             Err(_) => warn!("block-stream fan-out lock poisoned while closing subscribers"),
         }
     }
@@ -707,6 +728,19 @@ mod tests {
             .subscribe(0)
             .expect_err("poisoned lock must be an error");
         assert!(error.to_string().contains("fan-out lock poisoned"));
+    }
+
+    #[test]
+    fn subscribe_after_close_returns_a_closed_live_receiver() {
+        let (handle, _tmp) = handle_with_events(2);
+        handle.close_live_subscribers();
+
+        // Replay still delivers the durable suffix up to the last good seq...
+        let (replay, mut live) = handle.subscribe(0).unwrap();
+        assert_eq!(collect_replay(replay).len(), 2);
+        // ...but no live sender is registered, so the receiver is already closed and the follower's
+        // SSE ends after replay instead of hanging on a tail the halted producer will never feed.
+        assert!(live.blocking_recv().is_none());
     }
 
     #[test]

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -169,6 +169,26 @@ pub struct ReorgEvent {
     pub db: Option<DatabaseProvider>,
 }
 
+/// A per-block signal fed to the block-stream producer over a dedicated unbounded channel.
+///
+/// Emitted from the node's authoritative sites — the `blocks_to_confirm` loop (`observed`), the
+/// reorg construction (`reorged`), and the per-block migration loop (`finalized`) — each carrying
+/// the `Arc<SealedBlock>` already in hand. Unbounded so it cannot drop under backpressure; the
+/// producer turns these into durable, fanned-out `StreamFrame`s.
+#[derive(Debug, Clone)]
+pub enum BlockStreamSignal {
+    /// A block reached canonical confirmation ⇒ `observed`.
+    Confirmed(Arc<SealedBlock>),
+    /// A block migrated to the index ⇒ `finalized`.
+    Finalized(Arc<SealedBlock>),
+    /// A reorg occurred ⇒ one batched `reorged` frame.
+    Reorged {
+        fork_parent: Arc<IrysBlockHeader>,
+        old_fork: Arc<Vec<Arc<SealedBlock>>>,
+        new_fork: Arc<Vec<Arc<SealedBlock>>>,
+    },
+}
+
 /// Event broadcast when a block's state changes in the block tree.
 #[derive(Debug, Clone)]
 pub struct BlockStateUpdated {
@@ -550,7 +570,15 @@ impl BlockTreeServiceInner {
 
     /// Migrates finalized blocks into the block index and DB via `BlockMigrationService`.
     fn migrate_block(&mut self, block: &Arc<IrysBlockHeader>) -> eyre::Result<()> {
-        self.block_migration_service.migrate_blocks(block)
+        let migrated = self.block_migration_service.migrate_blocks(block)?;
+        // One `finalized` signal per migrated block — a single migrate call migrates a batch.
+        for sealed in &migrated {
+            let _ = self
+                .service_senders
+                .block_stream
+                .send(BlockStreamSignal::Finalized(Arc::clone(sealed)));
+        }
+        Ok(())
     }
 
     /// Handles pre-validated blocks received from the validation service.
@@ -1210,6 +1238,16 @@ impl BlockTreeServiceInner {
             // Deep reorg may poison VDF seeds; re-anchor before reorg fans out.
             self.maybe_reanchor_vdf_after_reorg(&arc_block, &reorg_event);
 
+            // Feed the block-stream producer one batched `reorged` signal (cheap Arc clones of the
+            // forks already in hand) before the broadcast send consumes the event.
+            let _ = self
+                .service_senders
+                .block_stream
+                .send(BlockStreamSignal::Reorged {
+                    fork_parent: Arc::clone(&reorg_event.fork_parent),
+                    old_fork: Arc::clone(&reorg_event.old_fork),
+                    new_fork: Arc::clone(&reorg_event.new_fork),
+                });
             if let Err(e) = self.service_senders.reorg_events.send(reorg_event) {
                 error!(
                     "Failed to broadcast reorg event - mempool state may be stale: {:?}",
@@ -1252,6 +1290,12 @@ impl BlockTreeServiceInner {
             // — block confirmation itself is still valid, the mempool just
             // won't be informed of this particular block.
             for sealed_block in &blocks_to_confirm {
+                // Feed the block-stream producer one `observed` signal per confirmed block — the
+                // authoritative per-block confirmation set (includes ancestors on a fork switch).
+                let _ = self
+                    .service_senders
+                    .block_stream
+                    .send(BlockStreamSignal::Confirmed(Arc::clone(sealed_block)));
                 if let Err(e) =
                     self.service_senders
                         .mempool

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -570,8 +570,6 @@ impl BlockTreeServiceInner {
 
     /// Migrates finalized blocks into the block index and DB via `BlockMigrationService`.
     fn migrate_block(&mut self, block: &Arc<IrysBlockHeader>) -> eyre::Result<()> {
-        // Emit one `finalized` signal per block as it is persisted (inside `migrate_blocks`), so a
-        // mid-batch migration failure still signals the blocks that did migrate.
         let block_stream = self.service_senders.block_stream.clone();
         self.block_migration_service
             .migrate_blocks(block, |sealed| {

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -570,14 +570,18 @@ impl BlockTreeServiceInner {
 
     /// Migrates finalized blocks into the block index and DB via `BlockMigrationService`.
     fn migrate_block(&mut self, block: &Arc<IrysBlockHeader>) -> eyre::Result<()> {
-        let migrated = self.block_migration_service.migrate_blocks(block)?;
-        // One `finalized` signal per migrated block — a single migrate call migrates a batch.
-        for sealed in &migrated {
-            let _ = self
-                .service_senders
-                .block_stream
-                .send(BlockStreamSignal::Finalized(Arc::clone(sealed)));
-        }
+        // Emit one `finalized` signal per block as it is persisted (inside `migrate_blocks`), so a
+        // mid-batch migration failure still signals the blocks that did migrate.
+        let block_stream = self.service_senders.block_stream.clone();
+        self.block_migration_service
+            .migrate_blocks(block, |sealed| {
+                if block_stream
+                    .send(BlockStreamSignal::Finalized(Arc::clone(sealed)))
+                    .is_err()
+                {
+                    tracing::debug!("block-stream producer gone; dropping finalized signal");
+                }
+            })?;
         Ok(())
     }
 
@@ -1240,14 +1244,18 @@ impl BlockTreeServiceInner {
 
             // Feed the block-stream producer one batched `reorged` signal (cheap Arc clones of the
             // forks already in hand) before the broadcast send consumes the event.
-            let _ = self
+            if self
                 .service_senders
                 .block_stream
                 .send(BlockStreamSignal::Reorged {
                     fork_parent: Arc::clone(&reorg_event.fork_parent),
                     old_fork: Arc::clone(&reorg_event.old_fork),
                     new_fork: Arc::clone(&reorg_event.new_fork),
-                });
+                })
+                .is_err()
+            {
+                debug!("block-stream producer gone; dropping reorged signal");
+            }
             if let Err(e) = self.service_senders.reorg_events.send(reorg_event) {
                 error!(
                     "Failed to broadcast reorg event - mempool state may be stale: {:?}",
@@ -1292,10 +1300,14 @@ impl BlockTreeServiceInner {
             for sealed_block in &blocks_to_confirm {
                 // Feed the block-stream producer one `observed` signal per confirmed block — the
                 // authoritative per-block confirmation set (includes ancestors on a fork switch).
-                let _ = self
+                if self
                     .service_senders
                     .block_stream
-                    .send(BlockStreamSignal::Confirmed(Arc::clone(sealed_block)));
+                    .send(BlockStreamSignal::Confirmed(Arc::clone(sealed_block)))
+                    .is_err()
+                {
+                    debug!("block-stream producer gone; dropping confirmed signal");
+                }
                 if let Err(e) =
                     self.service_senders
                         .mempool

--- a/crates/actors/src/lib.rs
+++ b/crates/actors/src/lib.rs
@@ -3,6 +3,7 @@ pub(crate) mod block_ancestry;
 pub mod block_discovery;
 pub mod block_migration_service;
 pub mod block_producer;
+pub mod block_stream_service;
 pub mod block_tree_service;
 pub mod block_validation;
 

--- a/crates/actors/src/metrics.rs
+++ b/crates/actors/src/metrics.rs
@@ -107,6 +107,20 @@ pub fn record_reth_fcu_head_height(height: u64) {
     RETH_FCU_HEAD_HEIGHT.record(height, &[]);
 }
 
+static BLOCK_STREAM_HALTED: std::sync::LazyLock<opentelemetry::metrics::Gauge<u64>> =
+    std::sync::LazyLock::new(|| {
+        opentelemetry::global::meter("irys-actors")
+            .u64_gauge("irys.block_stream.halted")
+            .with_description(
+                "1 once the block-stream producer has halted; the follower stream is stale until restart",
+            )
+            .build()
+    });
+
+pub(crate) fn record_block_stream_halted() {
+    BLOCK_STREAM_HALTED.record(1, &[]);
+}
+
 pub(crate) fn record_block_produced() {
     BLOCKS_PRODUCED.add(1, &[]);
 }

--- a/crates/actors/src/services.rs
+++ b/crates/actors/src/services.rs
@@ -4,7 +4,9 @@ use crate::{
     DataSyncServiceMessage, StorageModuleServiceMessage,
     block_discovery::BlockDiscoveryMessage,
     block_producer::BlockProducerCommand,
-    block_tree_service::{BlockStateUpdated, BlockTreeServiceMessage, ReorgEvent},
+    block_tree_service::{
+        BlockStateUpdated, BlockStreamSignal, BlockTreeServiceMessage, ReorgEvent,
+    },
     cache_service::CacheServiceAction,
     chunk_migration_service::ChunkMigrationServiceMessage,
     mempool_service::MempoolServiceMessage,
@@ -108,6 +110,7 @@ pub struct ServiceReceivers {
     pub peer_events: broadcast::Receiver<PeerEvent>,
     pub peer_network: UnboundedReceiver<PeerNetworkServiceMessage>,
     pub block_discovery: UnboundedReceiver<Traced<BlockDiscoveryMessage>>,
+    pub block_stream: UnboundedReceiver<BlockStreamSignal>,
     pub packing: tokio::sync::mpsc::Receiver<PackingRequest>,
 }
 
@@ -137,6 +140,7 @@ pub struct ServiceSendersInner {
     pub peer_events: broadcast::Sender<PeerEvent>,
     pub peer_network: PeerNetworkSender,
     pub block_discovery: UnboundedSender<Traced<BlockDiscoveryMessage>>,
+    pub block_stream: UnboundedSender<BlockStreamSignal>,
     pub mining_bus: MiningBus,
     pub packing_sender: PackingSender,
 }
@@ -173,6 +177,7 @@ impl ServiceSendersInner {
         let (peer_network_sender, peer_network_receiver) = tokio::sync::mpsc::unbounded_channel();
         let (block_discovery_sender, block_discovery_receiver) =
             unbounded_channel::<Traced<BlockDiscoveryMessage>>();
+        let (block_stream_sender, block_stream_receiver) = unbounded_channel::<BlockStreamSignal>();
         let (packing_sender, packing_receiver) = PackingService::channel(5_000);
 
         let mining_bus = MiningBus::new();
@@ -196,6 +201,7 @@ impl ServiceSendersInner {
             peer_events: peer_events_sender,
             peer_network: PeerNetworkSender::new(peer_network_sender),
             block_discovery: block_discovery_sender,
+            block_stream: block_stream_sender,
             mining_bus,
             packing_sender,
         };
@@ -218,6 +224,7 @@ impl ServiceSendersInner {
             peer_events: peer_events_receiver,
             peer_network: peer_network_receiver,
             block_discovery: block_discovery_receiver,
+            block_stream: block_stream_receiver,
             packing: packing_receiver,
         };
         (senders, receivers)

--- a/crates/api-server/Cargo.toml
+++ b/crates/api-server/Cargo.toml
@@ -20,6 +20,7 @@ socket2.workspace = true
 base58.workspace = true
 hex.workspace = true
 tokio.workspace = true
+tokio-stream = "0.1"
 serde_json = { workspace = true, features = ["std", "raw_value"] }
 serde.workspace = true
 actix-web.workspace = true

--- a/crates/api-server/Cargo.toml
+++ b/crates/api-server/Cargo.toml
@@ -20,7 +20,7 @@ socket2.workspace = true
 base58.workspace = true
 hex.workspace = true
 tokio = { workspace = true, features = ["sync"] }
-tokio-stream = "0.1"
+async-stream = "0.3"
 serde_json = { workspace = true, features = ["std", "raw_value"] }
 serde.workspace = true
 actix-web.workspace = true

--- a/crates/api-server/Cargo.toml
+++ b/crates/api-server/Cargo.toml
@@ -19,7 +19,7 @@ awc.workspace = true
 socket2.workspace = true
 base58.workspace = true
 hex.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["sync"] }
 tokio-stream = "0.1"
 serde_json = { workspace = true, features = ["std", "raw_value"] }
 serde.workspace = true

--- a/crates/api-server/src/lib.rs
+++ b/crates/api-server/src/lib.rs
@@ -65,6 +65,9 @@ pub struct ApiState {
     /// Shared with `BlockTreeService` so `/v1/tip` reads the same in-process
     /// canonical-advance / reorg timestamps the OTEL gauges record.
     pub block_tree_lifecycle: Arc<BlockTreeLifecycleTimestamps>,
+    /// Shared handle to the block-stream producer; the `/internal` SSE handlers call
+    /// `subscribe(from_seq)` on it.
+    pub block_stream: Arc<irys_actors::block_stream_service::BlockStreamHandle>,
 }
 
 impl ApiState {
@@ -228,6 +231,7 @@ pub fn run_server(app_state: ApiState, listener: TcpListener) -> Server {
             // not a permanent redirect, so we can redirect to the highest API version
             .route("/", web::get().to(|| async { Redirect::to("/v1/info") }))
             .service(routes())
+            .service(routes::internal::internal_routes())
             .wrap(Cors::permissive())
             .wrap(TracingLogger::default())
             .wrap(metrics::RequestMetrics)

--- a/crates/api-server/src/lib.rs
+++ b/crates/api-server/src/lib.rs
@@ -206,13 +206,16 @@ pub fn run_server(app_state: ApiState, listener: TcpListener) -> Server {
         actix_workers = ?actix_workers,
         "Starting API server"
     );
+    // The `/internal/*` routes are unauthenticated; mount them only when the deployment opts in
+    // (having network-restricted the HTTP bind to a trusted gateway), never by default.
+    let expose_internal_api = app_state.config.node_config.http.expose_internal_api;
     let state = web::Data::new(app_state);
     let mut server = HttpServer::new(move || {
         let span = tracing::info_span!(target: "irys-api-http", "api_server");
         let _guard = span.enter();
 
         let awc_client = awc::Client::new();
-        App::new()
+        let app = App::new()
             .app_data(state.clone())
             .app_data(web::Data::new(awc_client))
             .app_data(
@@ -230,9 +233,13 @@ pub fn run_server(app_state: ApiState, listener: TcpListener) -> Server {
             )
             // not a permanent redirect, so we can redirect to the highest API version
             .route("/", web::get().to(|| async { Redirect::to("/v1/info") }))
-            .service(routes())
-            .service(routes::internal::internal_routes())
-            .wrap(Cors::permissive())
+            .service(routes());
+        let app = if expose_internal_api {
+            app.service(routes::internal::internal_routes())
+        } else {
+            app
+        };
+        app.wrap(Cors::permissive())
             .wrap(TracingLogger::default())
             .wrap(metrics::RequestMetrics)
     })

--- a/crates/api-server/src/routes/internal/mod.rs
+++ b/crates/api-server/src/routes/internal/mod.rs
@@ -18,10 +18,7 @@ use irys_actors::block_tree_service::get_block_header;
 use irys_database::db::IrysDatabaseExt as _;
 use irys_domain::BlockTreeEntry;
 use irys_types::block_stream::{BlockEvent, EventsPage, StreamFrame};
-use irys_types::{
-    DataLedger, DataTransactionHeader, H256, IrysBlockHeader, LedgerChunkOffset,
-    app_state::DatabaseProvider,
-};
+use irys_types::{H256, LedgerChunkOffset};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -49,10 +46,6 @@ async fn blocks_stream(
     state: web::Data<ApiState>,
     query: web::Query<StreamQuery>,
 ) -> Result<HttpResponse, ApiError> {
-    // Atomic handover: subscribe snapshots the immutable replay bound `end` and registers the live sender
-    // under one lock, so the live tail begins at exactly `seq = end` (no gap/dup). `start` is already
-    // clamped to the retained floor for a stale cursor, so paging from it replays frames-from-floor — the
-    // SSE rewind; the poll endpoint passes the raw cursor instead and gets a truncated page.
     let (start, end, mut live) = state
         .block_stream
         .subscribe(query.from_seq)
@@ -156,6 +149,17 @@ async fn blocks_range(
     state: web::Data<ApiState>,
     query: web::Query<RangeQuery>,
 ) -> Result<web::Json<Vec<BlockEvent>>, ApiError> {
+    // An inverted range is a malformed request, not an empty span: answering `200 []` here would
+    // be indistinguishable from a genuinely empty canonical range on the endpoint a follower uses
+    // to reconcile after truncation.
+    if query.from_height > query.to_height {
+        return Err(ApiError::InvalidBlockParameter {
+            parameter: format!(
+                "block range {}..={} is inverted (from_height exceeds to_height)",
+                query.from_height, query.to_height
+            ),
+        });
+    }
     // Inclusive count: the handler resolves `from_height..=to_height`, so a span of N covers N + 1
     // heights. Cap the inclusive count so the documented MAX_BLOCK_RANGE bound is exact.
     let height_count = query
@@ -199,6 +203,11 @@ struct ChunksQuery {
 /// misread the shortfall as the node lacking the data.
 const MAX_CHUNK_SPAN: u64 = 64;
 
+/// Concurrent `/internal/chunks` unpack jobs across all requests. Each job recomputes packing
+/// entropy for up to [`MAX_CHUNK_SPAN`] chunks on the blocking pool, so without admission control
+/// a burst of requests could saturate that pool and starve its other users (DB reads, file I/O).
+static UNPACK_GATE: tokio::sync::Semaphore = tokio::sync::Semaphore::const_new(4);
+
 /// One chunk of `GET /internal/chunks`, unpacked. `bytes` and `proof` serialise as JSON integer
 /// arrays (plain `Vec<u8>`), NOT the node's usual `Base64` strings — the gateway decodes them as
 /// `Vec<u8>`. `proof` is the chunk's `data_path`, which gateway consumers `validate_path` against
@@ -229,18 +238,27 @@ async fn chunks_range(
 ) -> Result<web::Json<Vec<ChunkRead>>, ApiError> {
     let ledger = crate::routes::parse_ledger_id(query.ledger)?;
     let Some((from, to)) = parse_offset_span(&query.offset) else {
-        return Err(ApiError::Custom(format!(
-            "invalid offset span {:?}: expected from-to with from <= to",
-            query.offset
-        )));
+        return Err(ApiError::InvalidBlockParameter {
+            parameter: format!(
+                "offset span {:?} is malformed: expected from-to with from <= to",
+                query.offset
+            ),
+        });
     };
     if to - from >= MAX_CHUNK_SPAN {
-        return Err(ApiError::Custom(format!(
-            "chunk span {from}-{to} exceeds the maximum of {MAX_CHUNK_SPAN} chunks"
-        )));
+        return Err(ApiError::InvalidBlockParameter {
+            parameter: format!(
+                "chunk span {from}-{to} exceeds the maximum of {MAX_CHUNK_SPAN} chunks"
+            ),
+        });
     }
     // Unpacking recomputes packing entropy per chunk (CPU-bound, millions of hash rounds at
-    // mainnet packing strength), so the read loop runs on the blocking pool.
+    // mainnet packing strength), so the read loop runs on the blocking pool, gated by
+    // [`UNPACK_GATE`]. The semaphore is never closed, so acquire cannot fail.
+    let _permit = UNPACK_GATE
+        .acquire()
+        .await
+        .map_err(|e| ApiError::Internal { err: e.to_string() })?;
     let provider = Arc::clone(&state.chunk_provider);
     let chunks = web::block(move || {
         let mut out = Vec::new();
@@ -256,8 +274,6 @@ async fn chunks_range(
                 }),
                 // Not stored at this offset: omit (the short-read contract).
                 Ok(None) => {}
-                // No storage module covers the offset, or the read failed mid-flight. Either way
-                // this node cannot serve the chunk — omit it and let the gateway fail over.
                 Err(e) => {
                     debug!(?ledger, offset, "internal chunk read failed: {e:#}");
                 }
@@ -364,57 +380,32 @@ fn resolve_block_hash(state: &ApiState, block_hash: H256) -> Result<Option<Block
         return Ok(None);
     };
 
-    let db = &state.db;
-    // Fail the read if any ledger's tx headers cannot be fully resolved, rather than returning a
-    // silently truncated block. The closure stashes the first error; the event built alongside it
-    // is discarded when one is present.
-    let mut resolve_err: Option<ApiError> = None;
-    let event = BlockEvent::from_header_and_txs(
-        &header,
-        |ledger| match resolve_ledger_txs(db, &header, ledger) {
-            Ok(txs) => txs,
-            Err(e) => {
-                resolve_err.get_or_insert(e);
-                Vec::new()
+    // One read transaction resolves every ledger's tx headers — a migrated block can carry
+    // hundreds of ids, and a range request resolves up to MAX_BLOCK_RANGE blocks. Fail the read if
+    // any header cannot be fully resolved, rather than returning a silently truncated block: a
+    // dropped tx would shift the computed `tx_start_offset` of every surviving tx in its ledger.
+    let event = state
+        .db
+        .view_eyre(|tx| {
+            let mut resolve_err: Option<eyre::Report> = None;
+            let event = BlockEvent::from_header_and_txs(
+                &header,
+                |ledger| match irys_database::block_ledger_tx_headers(tx, &header, ledger) {
+                    Ok(txs) => txs,
+                    Err(e) => {
+                        resolve_err.get_or_insert(e);
+                        Vec::new()
+                    }
+                },
+                chunk_size,
+            );
+            match resolve_err {
+                Some(e) => Err(e),
+                None => Ok(event),
             }
-        },
-        chunk_size,
-    );
-    if let Some(e) = resolve_err {
-        return Err(e);
-    }
+        })
+        .map_err(|e| ApiError::Internal { err: e.to_string() })?;
     Ok(Some(event))
-}
-
-/// Resolves the ordered transaction headers for one ledger of a migrated block from the DB.
-///
-/// Fails closed: a tx id with no header row (or a DB error) aborts the read rather than yielding a
-/// truncated ledger. A dropped tx would also shift the computed `tx_start_offset` of every
-/// surviving tx in the ledger, so a short block silently misrepresents canonical contents.
-fn resolve_ledger_txs(
-    db: &DatabaseProvider,
-    header: &IrysBlockHeader,
-    ledger: DataLedger,
-) -> Result<Vec<DataTransactionHeader>, ApiError> {
-    let ledger_id = ledger.get_id();
-    let Some(data_ledger) = header
-        .data_ledgers
-        .iter()
-        .find(|dl| dl.ledger_id == ledger_id)
-    else {
-        return Ok(Vec::new());
-    };
-    let mut txs = Vec::with_capacity(data_ledger.tx_ids.0.len());
-    for tx_id in &data_ledger.tx_ids.0 {
-        let header = db
-            .view_eyre(|tx| irys_database::tx_header_by_txid(tx, tx_id))
-            .map_err(|e| ApiError::Internal { err: e.to_string() })?
-            .ok_or_else(|| ApiError::Internal {
-                err: format!("canonical block missing tx header for {tx_id}"),
-            })?;
-        txs.push(header);
-    }
-    Ok(txs)
 }
 
 #[cfg(test)]

--- a/crates/api-server/src/routes/internal/mod.rs
+++ b/crates/api-server/src/routes/internal/mod.rs
@@ -14,9 +14,14 @@ use crate::error::ApiError;
 use actix_web::{HttpResponse, dev::HttpServiceFactory, web};
 use irys_actors::block_tree_service::get_block_header;
 use irys_database::db::IrysDatabaseExt as _;
+use irys_domain::BlockTreeEntry;
 use irys_types::block_stream::{BlockEvent, EventsPage, StreamFrame};
-use irys_types::{DataLedger, DataTransactionHeader, IrysBlockHeader, app_state::DatabaseProvider};
+use irys_types::{
+    DataLedger, DataTransactionHeader, H256, IrysBlockHeader, app_state::DatabaseProvider,
+};
 use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::sync::Arc;
 use tokio_stream::StreamExt as _;
 use tokio_stream::wrappers::ReceiverStream;
 
@@ -45,8 +50,8 @@ async fn blocks_stream(
         .subscribe(query.from_seq)
         .map_err(|e| ApiError::Internal { err: e.to_string() })?;
 
-    let body = tokio_stream::iter(replay)
-        .chain(ReceiverStream::new(live))
+    let body = replay
+        .chain(ReceiverStream::new(live).map(Ok::<_, eyre::Report>))
         .map(frame_to_sse);
 
     Ok(HttpResponse::Ok()
@@ -54,8 +59,10 @@ async fn blocks_stream(
         .streaming(body))
 }
 
-fn frame_to_sse(frame: StreamFrame) -> Result<web::Bytes, actix_web::Error> {
-    let json = serde_json::to_string(&frame).map_err(actix_web::error::ErrorInternalServerError)?;
+fn frame_to_sse(frame: eyre::Result<Arc<StreamFrame>>) -> Result<web::Bytes, actix_web::Error> {
+    let frame = frame.map_err(actix_web::error::ErrorInternalServerError)?;
+    let json = serde_json::to_string(frame.as_ref())
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(web::Bytes::from(format!("data: {json}\n\n")))
 }
 
@@ -105,6 +112,7 @@ struct RangeQuery {
 
 /// Max number of heights one range request may span, to bound the per-request DB work.
 const MAX_BLOCK_RANGE: u64 = 1_000;
+const CANONICAL_SNAPSHOT_ATTEMPTS: usize = 3;
 
 /// `GET /internal/blocks?from_height=&to_height=` — the canonical blocks in `[from, to]`, ascending.
 async fn blocks_range(
@@ -120,13 +128,103 @@ async fn blocks_range(
             ),
         });
     }
-    let mut events = Vec::new();
-    for height in query.from_height..=query.to_height {
-        if let Some(event) = resolve_block_event(&state, height)? {
-            events.push(event);
-        }
+    let snapshot = snapshot_canonical_range(&state, query.from_height, query.to_height)?;
+    let events = snapshot
+        .into_iter()
+        .map(|source| resolve_snapshot_block(&state, source))
+        .collect::<Result<Vec<_>, _>>()?;
+    if !events.windows(2).all(|pair| {
+        pair[0].header.height.checked_add(1) == Some(pair[1].header.height)
+            && pair[1].header.previous_block_hash == pair[0].header.block_hash
+    }) {
+        return Err(ApiError::Internal {
+            err: "canonical block range snapshot is not a contiguous parent-linked chain"
+                .to_string(),
+        });
     }
     Ok(web::Json(events))
+}
+
+enum CanonicalBlockSource {
+    InTree(BlockTreeEntry),
+    Migrated { height: u64, block_hash: H256 },
+}
+
+fn snapshot_canonical_range(
+    state: &ApiState,
+    from_height: u64,
+    to_height: u64,
+) -> Result<Vec<CanonicalBlockSource>, ApiError> {
+    for _ in 0..CANONICAL_SNAPSHOT_ATTEMPTS {
+        let entries = state.block_tree.read().get_canonical_chain().0;
+        let signature: Vec<(u64, H256)> = entries
+            .iter()
+            .map(|entry| (entry.height(), entry.block_hash()))
+            .collect();
+        let mut in_tree: BTreeMap<u64, BlockTreeEntry> = entries
+            .into_iter()
+            .filter(|entry| (from_height..=to_height).contains(&entry.height()))
+            .map(|entry| (entry.height(), entry))
+            .collect();
+        let snapshot = snapshot_with_index(state, from_height, to_height, &mut in_tree)?;
+        let unchanged = state
+            .block_tree
+            .read()
+            .get_canonical_chain()
+            .0
+            .iter()
+            .map(|entry| (entry.height(), entry.block_hash()))
+            .eq(signature.into_iter());
+        if unchanged {
+            return Ok(snapshot);
+        }
+    }
+    Err(ApiError::Internal {
+        err: "canonical chain changed repeatedly while snapshotting block range".to_string(),
+    })
+}
+
+fn snapshot_with_index(
+    state: &ApiState,
+    from_height: u64,
+    to_height: u64,
+    in_tree: &mut BTreeMap<u64, BlockTreeEntry>,
+) -> Result<Vec<CanonicalBlockSource>, ApiError> {
+    state
+        .db
+        .view_eyre(|tx| {
+            let mut snapshot = Vec::new();
+            for height in from_height..=to_height {
+                if let Some(entry) = in_tree.remove(&height) {
+                    snapshot.push(CanonicalBlockSource::InTree(entry));
+                } else if let Some(block_hash) =
+                    irys_database::block_index_hash_by_height(tx, height)?
+                {
+                    snapshot.push(CanonicalBlockSource::Migrated { height, block_hash });
+                }
+            }
+            Ok(snapshot)
+        })
+        .map_err(|e| ApiError::Internal { err: e.to_string() })
+}
+
+fn resolve_snapshot_block(
+    state: &ApiState,
+    source: CanonicalBlockSource,
+) -> Result<BlockEvent, ApiError> {
+    match source {
+        CanonicalBlockSource::InTree(entry) => Ok(BlockEvent::from_sealed(
+            entry.sealed_block(),
+            state.config.consensus.chunk_size,
+        )),
+        CanonicalBlockSource::Migrated { height, block_hash } => {
+            resolve_block_hash(state, block_hash)?.ok_or_else(|| ApiError::Internal {
+                err: format!(
+                    "canonical range snapshot block {block_hash} at height {height} is unavailable"
+                ),
+            })
+        }
+    }
 }
 
 /// Resolves the canonical block at `height` to a `BlockEvent`, or `None` if there is none.
@@ -135,8 +233,6 @@ async fn blocks_range(
 /// `IrysDataTxHeaders`); migrated blocks are rebuilt from the header plus per-tx headers resolved
 /// from the DB via `tx_header_by_txid`.
 fn resolve_block_event(state: &ApiState, height: u64) -> Result<Option<BlockEvent>, ApiError> {
-    let chunk_size = state.config.consensus.chunk_size;
-
     let in_tree = state
         .block_tree
         .read()
@@ -152,6 +248,11 @@ fn resolve_block_event(state: &ApiState, height: u64) -> Result<Option<BlockEven
         },
     };
 
+    resolve_block_hash(state, block_hash)
+}
+
+fn resolve_block_hash(state: &ApiState, block_hash: H256) -> Result<Option<BlockEvent>, ApiError> {
+    let chunk_size = state.config.consensus.chunk_size;
     if let Some(sealed) = state.block_tree.read().get_sealed_block(&block_hash) {
         return Ok(Some(BlockEvent::from_sealed(&sealed, chunk_size)));
     }

--- a/crates/api-server/src/routes/internal/mod.rs
+++ b/crates/api-server/src/routes/internal/mod.rs
@@ -1,8 +1,9 @@
-//! The `/internal/*` HTTP surface: the block-stream SSE endpoint and the canonical block reads.
+//! The `/internal/*` HTTP surface: the block-stream SSE endpoint, the canonical block reads, and
+//! the unpacked chunk-range read.
 //!
-//! These routes serve the gateway block follower. The wire shapes live in
-//! [`irys_types::block_stream`]. `stream` is registered before `{height}` so it is matched as a
-//! literal segment rather than captured as a height.
+//! These routes serve the gateway block follower and its verification pipeline. The block wire
+//! shapes live in [`irys_types::block_stream`]. `stream` is registered before `{height}` so it is
+//! matched as a literal segment rather than captured as a height.
 //!
 //! SECURITY: these endpoints carry no application-layer authentication. They are mounted only when
 //! `http.expose_internal_api` is set (off by default); when enabled they ride the same HTTP listener
@@ -18,11 +19,13 @@ use irys_database::db::IrysDatabaseExt as _;
 use irys_domain::BlockTreeEntry;
 use irys_types::block_stream::{BlockEvent, EventsPage, StreamFrame};
 use irys_types::{
-    DataLedger, DataTransactionHeader, H256, IrysBlockHeader, app_state::DatabaseProvider,
+    DataLedger, DataTransactionHeader, H256, IrysBlockHeader, LedgerChunkOffset,
+    app_state::DatabaseProvider,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::sync::Arc;
+use tracing::debug;
 
 pub fn internal_routes() -> impl HttpServiceFactory {
     web::scope("internal")
@@ -30,6 +33,7 @@ pub fn internal_routes() -> impl HttpServiceFactory {
         .route("/blocks/events", web::get().to(blocks_events))
         .route("/blocks/{height}", web::get().to(block_by_height))
         .route("/blocks", web::get().to(blocks_range))
+        .route("/chunks", web::get().to(chunks_range))
 }
 
 #[derive(Debug, Deserialize)]
@@ -183,6 +187,89 @@ async fn blocks_range(
     Ok(web::Json(events))
 }
 
+#[derive(Debug, Deserialize)]
+struct ChunksQuery {
+    ledger: u32,
+    offset: String,
+}
+
+/// Max chunks one `/internal/chunks` request may span. Sized above the gateway's request sizes —
+/// the relay verifies bodies in 8-chunk fetches and the data service acquires extents of up to
+/// 16 MiB (64 chunks) — because a conforming consumer must never see a capped response: it would
+/// misread the shortfall as the node lacking the data.
+const MAX_CHUNK_SPAN: u64 = 64;
+
+/// One chunk of `GET /internal/chunks`, unpacked. `bytes` and `proof` serialise as JSON integer
+/// arrays (plain `Vec<u8>`), NOT the node's usual `Base64` strings — the gateway decodes them as
+/// `Vec<u8>`. `proof` is the chunk's `data_path`, which gateway consumers `validate_path` against
+/// the transaction's `data_root`.
+#[derive(Debug, Serialize)]
+struct ChunkRead {
+    ledger_id: u32,
+    offset: u64,
+    bytes: Vec<u8>,
+    proof: Vec<u8>,
+}
+
+/// Parses the `offset=from-to` query form into an inclusive span.
+fn parse_offset_span(s: &str) -> Option<(u64, u64)> {
+    let (from, to) = s.split_once('-')?;
+    let from: u64 = from.parse().ok()?;
+    let to: u64 = to.parse().ok()?;
+    (from <= to).then_some((from, to))
+}
+
+/// `GET /internal/chunks?ledger=&offset=from-to` — the stored chunks of one inclusive
+/// absolute-ledger-offset span, unpacked. Chunks the node does not hold are omitted rather than
+/// erred: the gateway reads a shortfall as "this node lacks the range" and fails over to another
+/// node, so absence must stay distinguishable from a malformed request (which 400s).
+async fn chunks_range(
+    state: web::Data<ApiState>,
+    query: web::Query<ChunksQuery>,
+) -> Result<web::Json<Vec<ChunkRead>>, ApiError> {
+    let ledger = crate::routes::parse_ledger_id(query.ledger)?;
+    let Some((from, to)) = parse_offset_span(&query.offset) else {
+        return Err(ApiError::Custom(format!(
+            "invalid offset span {:?}: expected from-to with from <= to",
+            query.offset
+        )));
+    };
+    if to - from >= MAX_CHUNK_SPAN {
+        return Err(ApiError::Custom(format!(
+            "chunk span {from}-{to} exceeds the maximum of {MAX_CHUNK_SPAN} chunks"
+        )));
+    }
+    // Unpacking recomputes packing entropy per chunk (CPU-bound, millions of hash rounds at
+    // mainnet packing strength), so the read loop runs on the blocking pool.
+    let provider = Arc::clone(&state.chunk_provider);
+    let chunks = web::block(move || {
+        let mut out = Vec::new();
+        for offset in from..=to {
+            match provider
+                .get_unpacked_chunk_by_ledger_offset(ledger, LedgerChunkOffset::from(offset))
+            {
+                Ok(Some(unpacked)) => out.push(ChunkRead {
+                    ledger_id: query.ledger,
+                    offset,
+                    bytes: unpacked.bytes.0,
+                    proof: unpacked.data_path.0,
+                }),
+                // Not stored at this offset: omit (the short-read contract).
+                Ok(None) => {}
+                // No storage module covers the offset, or the read failed mid-flight. Either way
+                // this node cannot serve the chunk — omit it and let the gateway fail over.
+                Err(e) => {
+                    debug!(?ledger, offset, "internal chunk read failed: {e:#}");
+                }
+            }
+        }
+        out
+    })
+    .await
+    .map_err(|e| ApiError::Internal { err: e.to_string() })?;
+    Ok(web::Json(chunks))
+}
+
 enum CanonicalBlockSource {
     InTree(BlockTreeEntry),
     Migrated { height: u64, block_hash: H256 },
@@ -328,4 +415,22 @@ fn resolve_ledger_txs(
         txs.push(header);
     }
     Ok(txs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_offset_span;
+
+    #[test]
+    fn offset_span_parses_inclusive_bounds() {
+        assert_eq!(parse_offset_span("0-0"), Some((0, 0)));
+        assert_eq!(parse_offset_span("3-11"), Some((3, 11)));
+    }
+
+    #[test]
+    fn offset_span_rejects_malformed_or_inverted() {
+        for bad in ["", "5", "-", "a-b", "1-2-3", "-4", "4-", "9-3"] {
+            assert_eq!(parse_offset_span(bad), None, "{bad:?}");
+        }
+    }
 }

--- a/crates/api-server/src/routes/internal/mod.rs
+++ b/crates/api-server/src/routes/internal/mod.rs
@@ -3,6 +3,11 @@
 //! These routes serve the gateway block follower. The wire shapes live in
 //! [`irys_types::block_stream`]. `stream` is registered before `{height}` so it is matched as a
 //! literal segment rather than captured as a height.
+//!
+//! SECURITY: these endpoints carry no application-layer authentication and ride the same HTTP
+//! listener as the public API. They expose internal block data and a long-lived SSE stream, so the
+//! deployment MUST restrict `/internal/*` at the network layer (firewall / reverse proxy / bind
+//! address) to the trusted gateway.
 
 use crate::ApiState;
 use crate::error::ApiError;
@@ -13,7 +18,7 @@ use irys_types::block_stream::{BlockEvent, StreamFrame};
 use irys_types::{DataLedger, DataTransactionHeader, IrysBlockHeader, app_state::DatabaseProvider};
 use serde::Deserialize;
 use tokio_stream::StreamExt as _;
-use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_stream::wrappers::ReceiverStream;
 use tracing::warn;
 
 pub fn internal_routes() -> impl HttpServiceFactory {
@@ -41,7 +46,7 @@ async fn blocks_stream(
         .map_err(|e| ApiError::Internal { err: e.to_string() })?;
 
     let body = tokio_stream::iter(replay)
-        .chain(UnboundedReceiverStream::new(live))
+        .chain(ReceiverStream::new(live))
         .map(frame_to_sse);
 
     Ok(HttpResponse::Ok()
@@ -74,11 +79,23 @@ struct RangeQuery {
     to_height: u64,
 }
 
+/// Max number of heights one range request may span, to bound the per-request DB work.
+const MAX_BLOCK_RANGE: u64 = 1_000;
+
 /// `GET /internal/blocks?from_height=&to_height=` — the canonical blocks in `[from, to]`, ascending.
 async fn blocks_range(
     state: web::Data<ApiState>,
     query: web::Query<RangeQuery>,
 ) -> Result<web::Json<Vec<BlockEvent>>, ApiError> {
+    let span = query.to_height.saturating_sub(query.from_height);
+    if span > MAX_BLOCK_RANGE {
+        return Err(ApiError::InvalidBlockParameter {
+            parameter: format!(
+                "block range {}..={} spans {span} heights, exceeding the maximum {MAX_BLOCK_RANGE}",
+                query.from_height, query.to_height
+            ),
+        });
+    }
     let mut events = Vec::new();
     for height in query.from_height..=query.to_height {
         if let Some(event) = resolve_block_event(&state, height)? {

--- a/crates/api-server/src/routes/internal/mod.rs
+++ b/crates/api-server/src/routes/internal/mod.rs
@@ -1,0 +1,156 @@
+//! The `/internal/*` HTTP surface: the block-stream SSE endpoint and the canonical block reads.
+//!
+//! These routes serve the gateway block follower. The wire shapes live in
+//! [`irys_types::block_stream`]. `stream` is registered before `{height}` so it is matched as a
+//! literal segment rather than captured as a height.
+
+use crate::ApiState;
+use crate::error::ApiError;
+use actix_web::{HttpResponse, dev::HttpServiceFactory, web};
+use irys_actors::block_tree_service::get_block_header;
+use irys_database::db::IrysDatabaseExt as _;
+use irys_types::block_stream::{BlockEvent, StreamFrame};
+use irys_types::{DataLedger, DataTransactionHeader, IrysBlockHeader, app_state::DatabaseProvider};
+use serde::Deserialize;
+use tokio_stream::StreamExt as _;
+use tokio_stream::wrappers::UnboundedReceiverStream;
+use tracing::warn;
+
+pub fn internal_routes() -> impl HttpServiceFactory {
+    web::scope("internal")
+        .route("/blocks/stream", web::get().to(blocks_stream))
+        .route("/blocks/{height}", web::get().to(block_by_height))
+        .route("/blocks", web::get().to(blocks_range))
+}
+
+#[derive(Debug, Deserialize)]
+struct StreamQuery {
+    #[serde(default)]
+    from_seq: u64,
+}
+
+/// `GET /internal/blocks/stream?from_seq=` — the SSE stream. Replays the durable suffix from
+/// `from_seq`, then tails live frames, each framed as `data: {json}\n\n`.
+async fn blocks_stream(
+    state: web::Data<ApiState>,
+    query: web::Query<StreamQuery>,
+) -> Result<HttpResponse, ApiError> {
+    let (replay, live) = state
+        .block_stream
+        .subscribe(query.from_seq)
+        .map_err(|e| ApiError::Internal { err: e.to_string() })?;
+
+    let body = tokio_stream::iter(replay)
+        .chain(UnboundedReceiverStream::new(live))
+        .map(frame_to_sse);
+
+    Ok(HttpResponse::Ok()
+        .content_type("text/event-stream")
+        .streaming(body))
+}
+
+fn frame_to_sse(frame: StreamFrame) -> Result<web::Bytes, actix_web::Error> {
+    let json = serde_json::to_string(&frame).map_err(actix_web::error::ErrorInternalServerError)?;
+    Ok(web::Bytes::from(format!("data: {json}\n\n")))
+}
+
+/// `GET /internal/blocks/{height}` — the canonical block at `height` as a `BlockEvent`, or `404`.
+async fn block_by_height(
+    state: web::Data<ApiState>,
+    path: web::Path<u64>,
+) -> Result<web::Json<BlockEvent>, ApiError> {
+    let height = path.into_inner();
+    resolve_block_event(&state, height)?
+        .map(web::Json)
+        .ok_or(ApiError::ErrNoId {
+            id: height.to_string(),
+            err: "no canonical block at height".to_string(),
+        })
+}
+
+#[derive(Debug, Deserialize)]
+struct RangeQuery {
+    from_height: u64,
+    to_height: u64,
+}
+
+/// `GET /internal/blocks?from_height=&to_height=` — the canonical blocks in `[from, to]`, ascending.
+async fn blocks_range(
+    state: web::Data<ApiState>,
+    query: web::Query<RangeQuery>,
+) -> Result<web::Json<Vec<BlockEvent>>, ApiError> {
+    let mut events = Vec::new();
+    for height in query.from_height..=query.to_height {
+        if let Some(event) = resolve_block_event(&state, height)? {
+            events.push(event);
+        }
+    }
+    Ok(web::Json(events))
+}
+
+/// Resolves the canonical block at `height` to a `BlockEvent`, or `None` if there is none.
+///
+/// In-tree blocks are built from the sealed block in hand (recent blocks are not yet persisted to
+/// `IrysDataTxHeaders`); migrated blocks are rebuilt from the header plus per-tx headers resolved
+/// from the DB via `tx_header_by_txid`.
+fn resolve_block_event(state: &ApiState, height: u64) -> Result<Option<BlockEvent>, ApiError> {
+    let chunk_size = state.config.consensus.chunk_size;
+
+    let in_tree = state
+        .block_tree
+        .read()
+        .get_canonical_chain()
+        .0
+        .iter()
+        .find_map(|entry| (entry.height() == height).then(|| entry.block_hash()));
+    let block_hash = match in_tree {
+        Some(hash) => hash,
+        None => match state.block_index.read().get_item(height) {
+            Some(item) => item.block_hash,
+            None => return Ok(None),
+        },
+    };
+
+    if let Some(sealed) = state.block_tree.read().get_sealed_block(&block_hash) {
+        return Ok(Some(BlockEvent::from_sealed(&sealed, chunk_size)));
+    }
+
+    let header = get_block_header(&state.block_tree, &state.db, block_hash, false)
+        .map_err(|e| ApiError::Internal { err: e.to_string() })?;
+    let Some(header) = header else {
+        return Ok(None);
+    };
+
+    let db = &state.db;
+    let event = BlockEvent::from_header_and_txs(
+        &header,
+        |ledger| resolve_ledger_txs(db, &header, ledger),
+        chunk_size,
+    );
+    Ok(Some(event))
+}
+
+/// Resolves the ordered transaction headers for one ledger of a migrated block from the DB.
+fn resolve_ledger_txs(
+    db: &DatabaseProvider,
+    header: &IrysBlockHeader,
+    ledger: DataLedger,
+) -> Vec<DataTransactionHeader> {
+    let ledger_id = ledger.get_id();
+    let Some(data_ledger) = header
+        .data_ledgers
+        .iter()
+        .find(|dl| dl.ledger_id == ledger_id)
+    else {
+        return Vec::new();
+    };
+    let mut txs = Vec::with_capacity(data_ledger.tx_ids.0.len());
+    for tx_id in &data_ledger.tx_ids.0 {
+        match db.view_eyre(|tx| irys_database::tx_header_by_txid(tx, tx_id)) {
+            Ok(Some(header)) => txs.push(header),
+            Ok(None) => {}
+            Err(e) => warn!(?tx_id, error = ?e, "internal read: tx header lookup failed"),
+        }
+    }
+    txs
+}

--- a/crates/api-server/src/routes/internal/mod.rs
+++ b/crates/api-server/src/routes/internal/mod.rs
@@ -14,7 +14,7 @@ use crate::error::ApiError;
 use actix_web::{HttpResponse, dev::HttpServiceFactory, web};
 use irys_actors::block_tree_service::get_block_header;
 use irys_database::db::IrysDatabaseExt as _;
-use irys_types::block_stream::{BlockEvent, StreamFrame};
+use irys_types::block_stream::{BlockEvent, EventsPage, StreamFrame};
 use irys_types::{DataLedger, DataTransactionHeader, IrysBlockHeader, app_state::DatabaseProvider};
 use serde::Deserialize;
 use tokio_stream::StreamExt as _;
@@ -23,6 +23,7 @@ use tokio_stream::wrappers::ReceiverStream;
 pub fn internal_routes() -> impl HttpServiceFactory {
     web::scope("internal")
         .route("/blocks/stream", web::get().to(blocks_stream))
+        .route("/blocks/events", web::get().to(blocks_events))
         .route("/blocks/{height}", web::get().to(block_by_height))
         .route("/blocks", web::get().to(blocks_range))
 }
@@ -56,6 +57,30 @@ async fn blocks_stream(
 fn frame_to_sse(frame: StreamFrame) -> Result<web::Bytes, actix_web::Error> {
     let json = serde_json::to_string(&frame).map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(web::Bytes::from(format!("data: {json}\n\n")))
+}
+
+#[derive(Debug, Deserialize)]
+struct EventsQuery {
+    #[serde(default)]
+    from_seq: u64,
+    limit: Option<u64>,
+}
+
+/// Default page size for `GET /internal/blocks/events` when `limit` is omitted.
+const DEFAULT_EVENTS_PAGE: u64 = 256;
+
+/// `GET /internal/blocks/events?from_seq=&limit=` — a bounded JSON page over the same durable event log
+/// the SSE stream tails (the poll half of the follower contract). The page envelope (`next_seq`,
+/// `has_more`, `truncated`, `lowest_retained_seq`) is built by `events_page` on the block-stream handle.
+async fn blocks_events(
+    state: web::Data<ApiState>,
+    query: web::Query<EventsQuery>,
+) -> Result<web::Json<EventsPage>, ApiError> {
+    let page = state
+        .block_stream
+        .events_page(query.from_seq, query.limit.unwrap_or(DEFAULT_EVENTS_PAGE))
+        .map_err(|e| ApiError::Internal { err: e.to_string() })?;
+    Ok(web::Json(page))
 }
 
 /// `GET /internal/blocks/{height}` — the canonical block at `height` as a `BlockEvent`, or `404`.

--- a/crates/api-server/src/routes/internal/mod.rs
+++ b/crates/api-server/src/routes/internal/mod.rs
@@ -4,10 +4,11 @@
 //! [`irys_types::block_stream`]. `stream` is registered before `{height}` so it is matched as a
 //! literal segment rather than captured as a height.
 //!
-//! SECURITY: these endpoints carry no application-layer authentication and ride the same HTTP
-//! listener as the public API. They expose internal block data and a long-lived SSE stream, so the
-//! deployment MUST restrict `/internal/*` at the network layer (firewall / reverse proxy / bind
-//! address) to the trusted gateway.
+//! SECURITY: these endpoints carry no application-layer authentication. They are mounted only when
+//! `http.expose_internal_api` is set (off by default); when enabled they ride the same HTTP listener
+//! as the public API. They expose internal block data and a long-lived SSE stream, so a deployment
+//! that enables them MUST restrict `/internal/*` at the network layer (firewall / reverse proxy /
+//! bind address) to the trusted gateway.
 
 use crate::ApiState;
 use crate::error::ApiError;

--- a/crates/api-server/src/routes/internal/mod.rs
+++ b/crates/api-server/src/routes/internal/mod.rs
@@ -96,7 +96,13 @@ async fn block_by_height(
     path: web::Path<u64>,
 ) -> Result<web::Json<BlockEvent>, ApiError> {
     let height = path.into_inner();
-    resolve_block_event(&state, height)?
+    // Resolve through the same stabilised snapshot the range path uses (a single-height span), so a
+    // reorg landing mid-read cannot return a block that has just been orphaned.
+    snapshot_canonical_range(&state, height, height)?
+        .into_iter()
+        .next()
+        .map(|source| resolve_snapshot_block(&state, source))
+        .transpose()?
         .map(web::Json)
         .ok_or(ApiError::ErrNoId {
             id: height.to_string(),
@@ -225,30 +231,6 @@ fn resolve_snapshot_block(
             })
         }
     }
-}
-
-/// Resolves the canonical block at `height` to a `BlockEvent`, or `None` if there is none.
-///
-/// In-tree blocks are built from the sealed block in hand (recent blocks are not yet persisted to
-/// `IrysDataTxHeaders`); migrated blocks are rebuilt from the header plus per-tx headers resolved
-/// from the DB via `tx_header_by_txid`.
-fn resolve_block_event(state: &ApiState, height: u64) -> Result<Option<BlockEvent>, ApiError> {
-    let in_tree = state
-        .block_tree
-        .read()
-        .get_canonical_chain()
-        .0
-        .iter()
-        .find_map(|entry| (entry.height() == height).then(|| entry.block_hash()));
-    let block_hash = match in_tree {
-        Some(hash) => hash,
-        None => match state.block_index.read().get_item(height) {
-            Some(item) => item.block_hash,
-            None => return Ok(None),
-        },
-    };
-
-    resolve_block_hash(state, block_hash)
 }
 
 fn resolve_block_hash(state: &ApiState, block_hash: H256) -> Result<Option<BlockEvent>, ApiError> {

--- a/crates/api-server/src/routes/internal/mod.rs
+++ b/crates/api-server/src/routes/internal/mod.rs
@@ -19,7 +19,6 @@ use irys_types::{DataLedger, DataTransactionHeader, IrysBlockHeader, app_state::
 use serde::Deserialize;
 use tokio_stream::StreamExt as _;
 use tokio_stream::wrappers::ReceiverStream;
-use tracing::warn;
 
 pub fn internal_routes() -> impl HttpServiceFactory {
     web::scope("internal")
@@ -139,35 +138,54 @@ fn resolve_block_event(state: &ApiState, height: u64) -> Result<Option<BlockEven
     };
 
     let db = &state.db;
+    // Fail the read if any ledger's tx headers cannot be fully resolved, rather than returning a
+    // silently truncated block. The closure stashes the first error; the event built alongside it
+    // is discarded when one is present.
+    let mut resolve_err: Option<ApiError> = None;
     let event = BlockEvent::from_header_and_txs(
         &header,
-        |ledger| resolve_ledger_txs(db, &header, ledger),
+        |ledger| match resolve_ledger_txs(db, &header, ledger) {
+            Ok(txs) => txs,
+            Err(e) => {
+                resolve_err.get_or_insert(e);
+                Vec::new()
+            }
+        },
         chunk_size,
     );
+    if let Some(e) = resolve_err {
+        return Err(e);
+    }
     Ok(Some(event))
 }
 
 /// Resolves the ordered transaction headers for one ledger of a migrated block from the DB.
+///
+/// Fails closed: a tx id with no header row (or a DB error) aborts the read rather than yielding a
+/// truncated ledger. A dropped tx would also shift the computed `tx_start_offset` of every
+/// surviving tx in the ledger, so a short block silently misrepresents canonical contents.
 fn resolve_ledger_txs(
     db: &DatabaseProvider,
     header: &IrysBlockHeader,
     ledger: DataLedger,
-) -> Vec<DataTransactionHeader> {
+) -> Result<Vec<DataTransactionHeader>, ApiError> {
     let ledger_id = ledger.get_id();
     let Some(data_ledger) = header
         .data_ledgers
         .iter()
         .find(|dl| dl.ledger_id == ledger_id)
     else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
     let mut txs = Vec::with_capacity(data_ledger.tx_ids.0.len());
     for tx_id in &data_ledger.tx_ids.0 {
-        match db.view_eyre(|tx| irys_database::tx_header_by_txid(tx, tx_id)) {
-            Ok(Some(header)) => txs.push(header),
-            Ok(None) => {}
-            Err(e) => warn!(?tx_id, error = ?e, "internal read: tx header lookup failed"),
-        }
+        let header = db
+            .view_eyre(|tx| irys_database::tx_header_by_txid(tx, tx_id))
+            .map_err(|e| ApiError::Internal { err: e.to_string() })?
+            .ok_or_else(|| ApiError::Internal {
+                err: format!("canonical block missing tx header for {tx_id}"),
+            })?;
+        txs.push(header);
     }
-    txs
+    Ok(txs)
 }

--- a/crates/api-server/src/routes/internal/mod.rs
+++ b/crates/api-server/src/routes/internal/mod.rs
@@ -152,11 +152,16 @@ async fn blocks_range(
     state: web::Data<ApiState>,
     query: web::Query<RangeQuery>,
 ) -> Result<web::Json<Vec<BlockEvent>>, ApiError> {
-    let span = query.to_height.saturating_sub(query.from_height);
-    if span > MAX_BLOCK_RANGE {
+    // Inclusive count: the handler resolves `from_height..=to_height`, so a span of N covers N + 1
+    // heights. Cap the inclusive count so the documented MAX_BLOCK_RANGE bound is exact.
+    let height_count = query
+        .to_height
+        .saturating_sub(query.from_height)
+        .saturating_add(1);
+    if height_count > MAX_BLOCK_RANGE {
         return Err(ApiError::InvalidBlockParameter {
             parameter: format!(
-                "block range {}..={} spans {span} heights, exceeding the maximum {MAX_BLOCK_RANGE}",
+                "block range {}..={} spans {height_count} heights, exceeding the maximum {MAX_BLOCK_RANGE}",
                 query.from_height, query.to_height
             ),
         });

--- a/crates/api-server/src/routes/internal/mod.rs
+++ b/crates/api-server/src/routes/internal/mod.rs
@@ -23,8 +23,6 @@ use irys_types::{
 use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use tokio_stream::StreamExt as _;
-use tokio_stream::wrappers::ReceiverStream;
 
 pub fn internal_routes() -> impl HttpServiceFactory {
     web::scope("internal")
@@ -40,30 +38,58 @@ struct StreamQuery {
     from_seq: u64,
 }
 
-/// `GET /internal/blocks/stream?from_seq=` — the SSE stream. Replays the durable suffix from
-/// `from_seq`, then tails live frames, each framed as `data: {json}\n\n`.
+/// `GET /internal/blocks/stream?from_seq=` — the SSE stream. Replays the durable suffix `[start, end)`
+/// captured atomically by `subscribe` (looping the same poll primitive via `replay_page`), then tails the
+/// live frames, each framed as `data: {json}\n\n`.
 async fn blocks_stream(
     state: web::Data<ApiState>,
     query: web::Query<StreamQuery>,
 ) -> Result<HttpResponse, ApiError> {
-    let (replay, live) = state
+    // Atomic handover: subscribe snapshots the immutable replay bound `end` and registers the live sender
+    // under one lock, so the live tail begins at exactly `seq = end` (no gap/dup). `start` is already
+    // clamped to the retained floor for a stale cursor, so paging from it replays frames-from-floor — the
+    // SSE rewind; the poll endpoint passes the raw cursor instead and gets a truncated page.
+    let (start, end, mut live) = state
         .block_stream
         .subscribe(query.from_seq)
         .map_err(|e| ApiError::Internal { err: e.to_string() })?;
-
-    let body = replay
-        .chain(ReceiverStream::new(live).map(Ok::<_, eyre::Report>))
-        .map(frame_to_sse);
+    let handle = Arc::clone(&state.block_stream);
+    let body = async_stream::try_stream! {
+        // Replay the immutable [start, end) snapshot one bounded page at a time. replay_page caps each
+        // page by `end` (not events_page's has_more, which tracks a moving tip), so the live tail begins
+        // exactly at seq=end.
+        let mut cursor = start;
+        while let Some((next, frames)) = handle
+            .replay_page(cursor, end)
+            .map_err(actix_web::error::ErrorInternalServerError)?
+        {
+            for frame in &frames {
+                yield sse_bytes(frame)?;
+            }
+            cursor = next;
+        }
+        if cursor < end {
+            // replay_page returned None before reaching `end`: a prune advanced the floor past the cursor
+            // mid-replay. End the SSE as a clean EOF so the follower reconnects and resyncs — do not fall
+            // through to the live tail (that would push a seq gap onto the wire).
+            return;
+        }
+        // Live tail [end, ..). `recv` yields `None` when the producer halts and drops the sender, ending
+        // the SSE cleanly after replay.
+        while let Some(frame) = live.recv().await {
+            yield sse_bytes(&frame)?;
+        }
+    };
 
     Ok(HttpResponse::Ok()
         .content_type("text/event-stream")
-        .streaming(body))
+        // Explicit error type: try_stream! cannot infer it through actix's generic `.streaming`, which
+        // only bounds `E: Into<BoxError>`.
+        .streaming::<_, actix_web::Error>(body))
 }
 
-fn frame_to_sse(frame: eyre::Result<Arc<StreamFrame>>) -> Result<web::Bytes, actix_web::Error> {
-    let frame = frame.map_err(actix_web::error::ErrorInternalServerError)?;
-    let json = serde_json::to_string(frame.as_ref())
-        .map_err(actix_web::error::ErrorInternalServerError)?;
+fn sse_bytes(frame: &StreamFrame) -> Result<web::Bytes, actix_web::Error> {
+    let json = serde_json::to_string(frame).map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(web::Bytes::from(format!("data: {json}\n\n")))
 }
 

--- a/crates/api-server/src/routes/mod.rs
+++ b/crates/api-server/src/routes/mod.rs
@@ -7,6 +7,7 @@ pub mod commitment;
 pub mod config;
 pub mod get_chunk;
 pub mod index;
+pub mod internal;
 pub mod ledger;
 pub mod mempool;
 pub mod mining;

--- a/crates/chain-tests/Cargo.toml
+++ b/crates/chain-tests/Cargo.toml
@@ -37,7 +37,7 @@ itertools.workspace = true
 reth.workspace = true
 reth-db.workspace = true
 reth-ethereum-primitives.workspace = true
-reqwest = { workspace = true, features = ["json"] }
+reqwest = { workspace = true, features = ["json", "stream"] }
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true

--- a/crates/chain-tests/src/integration/block_stream.rs
+++ b/crates/chain-tests/src/integration/block_stream.rs
@@ -13,13 +13,13 @@ use irys_types::{H256, NodeConfig};
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::sync::mpsc::Receiver;
 
 const TEST_USER_BALANCE_IRYS: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
 
 /// Receives frames until `predicate` matches, or times out.
 async fn next_frame_for(
-    live: &mut UnboundedReceiver<StreamFrame>,
+    live: &mut Receiver<StreamFrame>,
     predicate: impl Fn(&StreamFrame) -> bool,
 ) -> eyre::Result<StreamFrame> {
     loop {
@@ -185,6 +185,15 @@ async fn internal_reads_by_height_and_range() -> eyre::Result<()> {
         .send()
         .await?;
     assert_eq!(resp.status(), 404);
+
+    // range span exceeding the cap: 400, rejected before any per-height work.
+    let resp = client
+        .get(format!(
+            "{address}/internal/blocks?from_height=0&to_height=5000"
+        ))
+        .send()
+        .await?;
+    assert_eq!(resp.status(), 400);
 
     Ok(())
 }

--- a/crates/chain-tests/src/integration/block_stream.rs
+++ b/crates/chain-tests/src/integration/block_stream.rs
@@ -10,7 +10,7 @@ use eyre::OptionExt as _;
 use irys_actors::block_stream_service::BlockStreamHandle;
 use irys_types::block_stream::{StreamEvent, StreamFrame};
 use irys_types::irys::IrysSigner;
-use irys_types::{H256, NodeConfig};
+use irys_types::{Base64, DataLedger, H256, LedgerChunkOffset, NodeConfig, validate_path};
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
@@ -715,5 +715,132 @@ async fn internal_range_after_reorg_is_single_parent_linked_fork() -> eyre::Resu
     );
 
     tokio::join!(genesis_node.stop(), peer_node.stop());
+    Ok(())
+}
+
+/// The `/internal/chunks` contract the gateway's verification pipeline relies on: unpacked bytes
+/// plus the `data_path` proof per stored chunk of an inclusive absolute-offset span, short reads
+/// (not errors) for offsets the node does not hold, and 400s for malformed requests.
+#[test_log::test(tokio::test)]
+async fn internal_chunks_serves_unpacked_proven_range_with_short_reads() -> eyre::Result<()> {
+    let chunk_size = 32_u64;
+    let mut config = NodeConfig::testing().with_consensus(|c| {
+        c.chunk_size = chunk_size;
+        c.num_chunks_in_partition = 10;
+        c.num_chunks_in_recall_range = 2;
+        c.num_partitions_per_slot = 1;
+        c.entropy_packing_iterations = 1_000;
+        c.block_migration_depth = 1;
+    });
+    config.storage.num_writes_before_sync = 1;
+    let signer = IrysSigner::random_signer(&config.consensus_config());
+    config.fund_genesis_accounts(vec![&signer]);
+
+    let node = IrysNodeTest::new_genesis(config).start().await;
+    node.node_ctx
+        .packing_waiter
+        .wait_for_idle(Some(Duration::from_secs(10)))
+        .await?;
+
+    // 2 full chunks + 1 byte: the tail chunk must come back trimmed to the data, not padded to
+    // chunk_size by the unpack.
+    let data: Vec<u8> = (0..(2 * chunk_size + 1)).map(|i| i as u8).collect();
+    let tx = node
+        .post_data_tx(node.get_anchor().await?, data.clone(), &signer)
+        .await;
+    node.wait_for_mempool(tx.header.id, 20).await?;
+    node.upload_chunks(&tx).await?;
+    let inclusion_block = node.mine_block().await?;
+    node.mine_block().await?;
+    node.wait_for_block_in_index_height(inclusion_block.height, 20)
+        .await?;
+    // Sole data tx on the chain, Submit ledger: absolute offsets [0, 3). Wait for the last chunk
+    // to land in a storage module so the range read below is deterministic.
+    node.wait_for_chunk_in_storage(DataLedger::Submit, LedgerChunkOffset::from(2_u64), 30)
+        .await?;
+
+    let address = format!(
+        "http://127.0.0.1:{}",
+        node.node_ctx.config.node_config.http.bind_port
+    );
+    let client = reqwest::Client::new();
+
+    // Mirrors the gateway's decode: bytes/proof as plain u8 arrays. A base64-string regression
+    // fails deserialization here, exactly as it would on the gateway.
+    #[derive(Debug, serde::Deserialize)]
+    struct ChunkRead {
+        ledger_id: u32,
+        offset: u64,
+        bytes: Vec<u8>,
+        proof: Vec<u8>,
+    }
+
+    let submit_id = DataLedger::Submit.get_id();
+    let chunks: Vec<ChunkRead> = client
+        .get(format!(
+            "{address}/internal/chunks?ledger={submit_id}&offset=0-2"
+        ))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert_eq!(chunks.len(), 3, "all three stored chunks are served");
+    for (i, chunk) in chunks.iter().enumerate() {
+        assert_eq!(chunk.ledger_id, submit_id);
+        assert_eq!(chunk.offset, i as u64);
+        let start = i * chunk_size as usize;
+        let end = (start + chunk_size as usize).min(data.len());
+        assert_eq!(
+            chunk.bytes,
+            &data[start..end],
+            "unpacked bytes at offset {i} match the uploaded data"
+        );
+        // The served proof is the stored data_path, byte-identical to the one the signer built,
+        // and it validates against the tx's committed data_root at this chunk's byte position.
+        assert_eq!(chunk.proof, tx.proofs[i].proof, "data_path at offset {i}");
+        validate_path(
+            tx.header.data_root.0,
+            &Base64(chunk.proof.clone()),
+            start as u128,
+        )?;
+    }
+
+    // Short read: a span reaching past the stored data returns only the stored chunks (the
+    // gateway reads the shortfall as "this node lacks the rest" and fails over — never a 4xx).
+    let short: Vec<ChunkRead> = client
+        .get(format!(
+            "{address}/internal/chunks?ledger={submit_id}&offset=0-7"
+        ))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert_eq!(short.len(), 3, "unstored offsets are omitted, not erred");
+    let empty: Vec<ChunkRead> = client
+        .get(format!(
+            "{address}/internal/chunks?ledger={submit_id}&offset=5-7"
+        ))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert!(empty.is_empty(), "a fully unstored span is an empty page");
+
+    // Malformed requests are 400s, distinguishable from absence.
+    for bad in [
+        format!("{address}/internal/chunks?ledger={submit_id}&offset=2-1"),
+        format!("{address}/internal/chunks?ledger={submit_id}&offset=abc"),
+        format!("{address}/internal/chunks?ledger={submit_id}&offset=0-64"),
+        format!("{address}/internal/chunks?ledger=999&offset=0-2"),
+        format!("{address}/internal/chunks?ledger={submit_id}"),
+    ] {
+        let status = client.get(&bad).send().await?.status();
+        assert_eq!(status, 400, "GET {bad} must be a bad request");
+    }
+
+    node.stop().await;
     Ok(())
 }

--- a/crates/chain-tests/src/integration/block_stream.rs
+++ b/crates/chain-tests/src/integration/block_stream.rs
@@ -1,0 +1,328 @@
+//! Integration tests for the node-internal block-stream contract (`/internal/blocks/*`).
+//!
+//! These drive a real node and exercise the producer through the shared `BlockStreamHandle`
+//! (`observed`, `finalized`, `reorged`) and the canonical read endpoints over HTTP.
+
+use crate::utils::IrysNodeTest;
+use alloy_core::primitives::ruint::aliases::U256;
+use alloy_genesis::GenesisAccount;
+use eyre::OptionExt as _;
+use irys_types::block_stream::{StreamEvent, StreamFrame};
+use irys_types::irys::IrysSigner;
+use irys_types::{H256, NodeConfig};
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::mpsc::UnboundedReceiver;
+
+const TEST_USER_BALANCE_IRYS: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
+
+/// Receives frames until `predicate` matches, or times out.
+async fn next_frame_for(
+    live: &mut UnboundedReceiver<StreamFrame>,
+    predicate: impl Fn(&StreamFrame) -> bool,
+) -> eyre::Result<StreamFrame> {
+    loop {
+        let frame = tokio::time::timeout(Duration::from_secs(30), live.recv())
+            .await?
+            .ok_or_eyre("block-stream channel closed")?;
+        if predicate(&frame) {
+            return Ok(frame);
+        }
+    }
+}
+
+#[test_log::test(tokio::test)]
+async fn observed_emitted_with_data_roots_and_replays_without_gap() -> eyre::Result<()> {
+    let mut node = IrysNodeTest::default_async();
+    let user = IrysSigner::random_signer(&node.cfg.consensus_config());
+    node.cfg.consensus.extend_genesis_accounts(vec![(
+        user.address(),
+        GenesisAccount {
+            balance: TEST_USER_BALANCE_IRYS,
+            ..Default::default()
+        },
+    )]);
+    let node = node.start().await;
+    let handle = node.node_ctx.block_stream_handle.clone();
+
+    // Subscribe before producing.
+    let (_replay0, mut live) = handle.subscribe(0)?;
+
+    // Post a data tx and mine; an `observed` frame carrying its data_root must arrive.
+    node.post_publish_data_tx(&user, b"alpha".to_vec()).await?;
+    node.mine_blocks(2).await?;
+
+    let frame = next_frame_for(&mut live, |f| {
+        f.kind() == "observed" && !f.data_roots().is_empty()
+    })
+    .await?;
+    assert_eq!(frame.kind(), "observed");
+    assert!(
+        frame.block_hash().is_some(),
+        "observed frame carries a block_hash"
+    );
+    let seq_with_data = frame.seq;
+
+    // A late subscriber replays history (including that frame at its original seq) with strictly
+    // increasing, gapless seqs — the replay→live handover property.
+    let (replay_late, _live_late) = handle.subscribe(0)?;
+    assert!(
+        replay_late.iter().any(|f| f.seq == seq_with_data),
+        "replay must include the earlier frame at its original seq"
+    );
+    let seqs: Vec<u64> = replay_late.iter().map(|f| f.seq).collect();
+    assert!(
+        seqs.windows(2).all(|w| w[1] == w[0] + 1),
+        "replayed seqs are contiguous and monotonic: {seqs:?}"
+    );
+    // De-dup: no two `observed` frames share a block_hash.
+    let mut observed_hashes: Vec<_> = replay_late
+        .iter()
+        .filter(|f| f.kind() == "observed")
+        .filter_map(StreamFrame::block_hash)
+        .collect();
+    let total = observed_hashes.len();
+    observed_hashes.sort();
+    observed_hashes.dedup();
+    assert_eq!(
+        total,
+        observed_hashes.len(),
+        "observed emitted once per block"
+    );
+
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn finalized_emitted_on_migration() -> eyre::Result<()> {
+    let mut node = IrysNodeTest::default_async();
+    // Finalise quickly: a block migrates once the tip is this many blocks ahead.
+    node.cfg.consensus.get_mut().block_migration_depth = 2;
+    let node = node.start().await;
+    let handle = node.node_ctx.block_stream_handle.clone();
+    let (_replay, mut live) = handle.subscribe(0)?;
+
+    let blk1 = node.mine_block().await?;
+    node.wait_until_height(blk1.height, 10).await?;
+
+    // Advance the tip well past the migration depth so blk1 migrates to the index.
+    node.mine_blocks(3).await?;
+    node.wait_until_block_index_height(blk1.height, 30).await?;
+
+    // A `finalized` frame for blk1 must arrive.
+    let finalized = next_frame_for(&mut live, |f| {
+        f.kind() == "finalized" && f.block_hash() == Some(blk1.block_hash)
+    })
+    .await?;
+    assert_eq!(finalized.kind(), "finalized");
+    assert_eq!(finalized.block_hash(), Some(blk1.block_hash));
+
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn internal_reads_by_height_and_range() -> eyre::Result<()> {
+    let mut node = IrysNodeTest::default_async();
+    let user = IrysSigner::random_signer(&node.cfg.consensus_config());
+    node.cfg.consensus.extend_genesis_accounts(vec![(
+        user.address(),
+        GenesisAccount {
+            balance: TEST_USER_BALANCE_IRYS,
+            ..Default::default()
+        },
+    )]);
+    let node = node.start().await;
+    let address = format!(
+        "http://127.0.0.1:{}",
+        node.node_ctx.config.node_config.http.bind_port
+    );
+    let client = reqwest::Client::new();
+
+    node.post_publish_data_tx(&user, b"gamma".to_vec()).await?;
+    let blk = node.mine_block().await?;
+    node.wait_until_height(blk.height, 10).await?;
+
+    // by-height: returns the canonical BlockEvent, tx count matching the block.
+    let resp = client
+        .get(format!("{address}/internal/blocks/{}", blk.height))
+        .send()
+        .await?;
+    assert_eq!(resp.status(), 200);
+    let event: serde_json::Value = resp.json().await?;
+    assert_eq!(event["header"]["height"].as_u64(), Some(blk.height));
+    let expected_txs: usize = blk.data_ledgers.iter().map(|l| l.tx_ids.0.len()).sum();
+    assert_eq!(
+        event["txs"].as_array().expect("txs array").len(),
+        expected_txs
+    );
+
+    // range: ascending canonical BlockEvents.
+    let resp = client
+        .get(format!(
+            "{address}/internal/blocks?from_height=0&to_height={}",
+            blk.height
+        ))
+        .send()
+        .await?;
+    assert_eq!(resp.status(), 200);
+    let events: serde_json::Value = resp.json().await?;
+    let heights: Vec<u64> = events
+        .as_array()
+        .expect("events array")
+        .iter()
+        .map(|e| e["header"]["height"].as_u64().expect("height"))
+        .collect();
+    assert!(!heights.is_empty());
+    assert!(
+        heights.windows(2).all(|w| w[0] < w[1]),
+        "range is ascending: {heights:?}"
+    );
+
+    // unknown height: 404.
+    let resp = client
+        .get(format!("{address}/internal/blocks/99999"))
+        .send()
+        .await?;
+    assert_eq!(resp.status(), 404);
+
+    Ok(())
+}
+
+/// A fork switch emits exactly one batched `reorged` frame whose `orphaned`/`new_fork`/`fork_parent`
+/// mirror the authoritative `ReorgEvent`, and the winning-fork blocks are conveyed by that frame
+/// alone — never re-emitted as `observed` (the de-dup the producer's ordering guarantee relies on).
+#[test_log::test(tokio::test)]
+async fn reorged_emitted_for_fork_switch_without_duplicate_observed() -> eyre::Result<()> {
+    let seconds_to_wait = 20_usize;
+    // Epoch size 10 (matching the other isolated-fork reorg tests) avoids epoch-boundary races
+    // while the two nodes mine competing forks in isolation.
+    let mut genesis_config = NodeConfig::testing_with_epochs(10);
+    genesis_config.consensus.get_mut().chunk_size = 32;
+
+    let peer_signer = genesis_config.new_random_signer();
+    genesis_config.fund_genesis_accounts(vec![&peer_signer]);
+
+    let genesis_node = IrysNodeTest::new_genesis(genesis_config)
+        .start_and_wait_for_packing("GENESIS", seconds_to_wait)
+        .await;
+    let peer_config = genesis_node.testing_peer_with_signer(&peer_signer);
+    let peer_node = genesis_node
+        .testing_peer_with_assignments_and_name(peer_config, "PEER")
+        .await?;
+
+    // Subscribe to the genesis node's stream before the fork; setup frames are already durable, so
+    // only post-subscribe frames arrive live.
+    let handle = genesis_node.node_ctx.block_stream_handle.clone();
+    let (_replay, mut live) = handle.subscribe(0)?;
+
+    // Isolate both nodes so each builds an independent fork from the same base.
+    genesis_node.gossip_disable();
+    peer_node.gossip_disable();
+    let base_height = genesis_node.get_canonical_chain_height().await;
+
+    // Genesis mines the soon-to-be-orphaned block; the peer mines a strictly longer chain that will
+    // win the fork choice once gossiped.
+    genesis_node.mine_blocks_without_gossip(1).await?;
+    genesis_node
+        .wait_until_height(base_height + 1, seconds_to_wait)
+        .await?;
+    peer_node.mine_blocks_without_gossip(3).await?;
+    peer_node
+        .wait_until_height(base_height + 3, seconds_to_wait)
+        .await?;
+    let peer_block_1 = Arc::new(peer_node.get_block_by_height(base_height + 1).await?);
+    let peer_block_2 = Arc::new(peer_node.get_block_by_height(base_height + 2).await?);
+    let peer_block_3 = Arc::new(peer_node.get_block_by_height(base_height + 3).await?);
+
+    // Arm reorg detection, then re-enable gossip and feed genesis the winning chain in order.
+    let reorg_future = genesis_node.wait_for_reorg(seconds_to_wait);
+    genesis_node.gossip_enable();
+    peer_node.gossip_enable();
+    for block in [&peer_block_1, &peer_block_2, &peer_block_3] {
+        peer_node.gossip_block_to_peers(block)?;
+        genesis_node
+            .wait_for_block(&block.block_hash, seconds_to_wait)
+            .await?;
+    }
+    let reorg_event = reorg_future.await?;
+
+    // Block until the durable `reorged` frame lands (the producer consumes the signal async).
+    let _ = next_frame_for(&mut live, |f| f.kind() == "reorged").await?;
+
+    // Flush the producer past the post-reorg `Confirmed` signals for the winning fork (which must be
+    // de-duped to nothing): mine one fresh canonical block and await ITS `observed`. Receiving a
+    // frame the producer enqueued strictly after those signals proves they were all processed, so a
+    // missing `observed` for a winning block is a real de-dup, not an unflushed queue.
+    let flush = genesis_node.mine_block().await?;
+    let _ = next_frame_for(&mut live, |f| {
+        f.kind() == "observed" && f.block_hash() == Some(flush.block_hash)
+    })
+    .await?;
+
+    // Snapshot the complete durable log and assert the whole-log invariants on it.
+    let (log, _live_snapshot) = handle.subscribe(0)?;
+
+    let reorged: Vec<&StreamFrame> = log.iter().filter(|f| f.kind() == "reorged").collect();
+    assert_eq!(
+        reorged.len(),
+        1,
+        "exactly one reorged frame for one fork switch"
+    );
+
+    let StreamEvent::Reorged {
+        fork_parent,
+        orphaned,
+        new_fork,
+    } = &reorged[0].event
+    else {
+        unreachable!("filtered to reorged frames");
+    };
+
+    // The frame's batch mirrors the authoritative ReorgEvent.
+    assert_eq!(fork_parent.height, reorg_event.fork_parent.height);
+    assert_eq!(fork_parent.block_hash, reorg_event.fork_parent.block_hash);
+    let orphaned_hashes: Vec<H256> = orphaned.iter().map(|b| b.header.block_hash).collect();
+    let old_fork_hashes: Vec<H256> = reorg_event
+        .old_fork
+        .iter()
+        .map(|b| b.header().block_hash)
+        .collect();
+    assert_eq!(
+        orphaned_hashes, old_fork_hashes,
+        "orphaned == old fork, ascending"
+    );
+    let new_fork_hashes: Vec<H256> = new_fork.iter().map(|b| b.header.block_hash).collect();
+    let new_fork_event_hashes: Vec<H256> = reorg_event
+        .new_fork
+        .iter()
+        .map(|b| b.header().block_hash)
+        .collect();
+    assert_eq!(
+        new_fork_hashes, new_fork_event_hashes,
+        "new_fork == winning fork, ascending"
+    );
+
+    // seqs stay contiguous and monotonic across the reorg.
+    let seqs: Vec<u64> = log.iter().map(|f| f.seq).collect();
+    assert!(
+        seqs.windows(2).all(|w| w[1] == w[0] + 1),
+        "seqs contiguous across the reorg: {seqs:?}"
+    );
+
+    // De-dup: no `observed` frame carries a winning-fork hash — those blocks reach the consumer only
+    // via the reorged frame's `new_fork`.
+    let winning: HashSet<H256> = new_fork_hashes.into_iter().collect();
+    let duplicate = log
+        .iter()
+        .filter(|f| f.kind() == "observed")
+        .filter_map(StreamFrame::block_hash)
+        .find(|h| winning.contains(h));
+    assert!(
+        duplicate.is_none(),
+        "winning-fork block must not be re-emitted as observed: {duplicate:?}"
+    );
+
+    tokio::join!(genesis_node.stop(), peer_node.stop());
+    Ok(())
+}

--- a/crates/chain-tests/src/integration/block_stream.rs
+++ b/crates/chain-tests/src/integration/block_stream.rs
@@ -38,6 +38,49 @@ async fn collect_replay(replay: ReplayStream) -> eyre::Result<Vec<Arc<StreamFram
     replay.try_collect().await
 }
 
+/// Reads `count` frames from the real `/internal/blocks/stream?from_seq=` SSE endpoint over HTTP,
+/// decoding each `data: {json}\n\n` event to JSON. The durable replay prefix is gapless and ordered,
+/// so the first `count` frames are stable against any frame appended afterwards.
+async fn read_sse_frames(
+    address: &str,
+    from_seq: u64,
+    count: usize,
+) -> eyre::Result<Vec<serde_json::Value>> {
+    use futures::StreamExt as _;
+
+    if count == 0 {
+        return Ok(Vec::new());
+    }
+    let mut stream = reqwest::Client::new()
+        .get(format!(
+            "{address}/internal/blocks/stream?from_seq={from_seq}"
+        ))
+        .send()
+        .await?
+        .bytes_stream();
+    let mut buf: Vec<u8> = Vec::new();
+    let mut frames = Vec::new();
+    while frames.len() < count {
+        let chunk = tokio::time::timeout(Duration::from_secs(30), stream.next())
+            .await?
+            .ok_or_eyre("SSE stream ended before all frames arrived")??;
+        buf.extend_from_slice(&chunk);
+        // Compact JSON carries no newlines, so each `data: {json}\n\n` event ends at the first `\n\n`.
+        while let Some(end) = buf.windows(2).position(|w| w == b"\n\n") {
+            let raw: Vec<u8> = buf.drain(..end + 2).collect();
+            let event = std::str::from_utf8(&raw)?
+                .strip_prefix("data: ")
+                .and_then(|s| s.strip_suffix("\n\n"))
+                .ok_or_eyre("malformed SSE frame")?;
+            frames.push(serde_json::from_str::<serde_json::Value>(event)?);
+            if frames.len() == count {
+                break;
+            }
+        }
+    }
+    Ok(frames)
+}
+
 #[test_log::test(tokio::test)]
 async fn observed_emitted_with_data_roots_and_replays_without_gap() -> eyre::Result<()> {
     let mut node = IrysNodeTest::default_async();
@@ -477,7 +520,6 @@ async fn internal_events_equal_sse_over_same_range() -> eyre::Result<()> {
         node.node_ctx.config.node_config.http.bind_port
     );
     let client = reqwest::Client::new();
-    let handle = node.node_ctx.block_stream_handle.clone();
 
     // Produce observed + finalized frames: mine, advance past the migration depth, await the index.
     let blk1 = node.mine_block().await?;
@@ -506,18 +548,14 @@ async fn internal_events_equal_sse_over_same_range() -> eyre::Result<()> {
         }
     }
 
-    // SSE side: the durable replay from seq 0 is the whole log. The log is append-only, so comparing the
-    // poll set against the equal-length SSE prefix is stable against any frame appended afterwards.
-    let (sse_frames, _live) = handle.subscribe(0)?;
-    let sse_frames = collect_replay(sse_frames).await?;
-    assert!(
-        sse_frames.len() >= poll_frames.len(),
-        "SSE replay covers at least the polled range"
-    );
+    // SSE side: read the same range from the real `/internal/blocks/stream` endpoint over HTTP, so this
+    // covers route dispatch, `from_seq` handling, and the `data: {json}\n\n` framing — not just the
+    // in-process replay. The durable replay prefix is gapless and ordered, so its first
+    // `poll_frames.len()` frames are exactly the range the poll endpoint returned.
+    let sse_frames = read_sse_frames(&address, 0, poll_frames.len()).await?;
     for (i, poll) in poll_frames.iter().enumerate() {
         assert_eq!(
-            *poll,
-            serde_json::to_value(&sse_frames[i]).expect("serialize sse frame"),
+            *poll, sse_frames[i],
             "poll frame {i} must be byte-identical to the SSE frame"
         );
     }

--- a/crates/chain-tests/src/integration/block_stream.rs
+++ b/crates/chain-tests/src/integration/block_stream.rs
@@ -537,3 +537,140 @@ async fn internal_events_equal_sse_over_same_range() -> eyre::Result<()> {
 
     Ok(())
 }
+
+/// A canonical range request spanning a fork point returns one consistent, parent-linked chain from the
+/// winning fork — never a splice of the orphaned and adopted chains. The endpoint snapshots the canonical
+/// chain, re-verifies it is unchanged across the per-height resolution (retrying), and rejects any result
+/// that is not a contiguous parent-linked chain (`snapshot_canonical_range`). This drives a real 2-node
+/// reorg and asserts that observable contract over HTTP after the switch settles.
+///
+/// Scope: the mid-request race the snapshot guard defends against — a reorg landing between the canonical
+/// reads — cannot be forced deterministically from integration without fault injection, and a timing-based
+/// probe would be flaky. This locks in the single-fork result the guard must always produce post-reorg.
+#[test_log::test(tokio::test)]
+async fn internal_range_after_reorg_is_single_parent_linked_fork() -> eyre::Result<()> {
+    let seconds_to_wait = 20_usize;
+    // Epoch size 10 (matching the other isolated-fork reorg tests) avoids epoch-boundary races while the
+    // two nodes mine competing forks in isolation.
+    let mut genesis_config = NodeConfig::testing_with_epochs(10);
+    genesis_config.consensus.get_mut().chunk_size = 32;
+
+    let peer_signer = genesis_config.new_random_signer();
+    genesis_config.fund_genesis_accounts(vec![&peer_signer]);
+
+    let genesis_node = IrysNodeTest::new_genesis(genesis_config)
+        .start_and_wait_for_packing("GENESIS", seconds_to_wait)
+        .await;
+    let peer_config = genesis_node.testing_peer_with_signer(&peer_signer);
+    let peer_node = genesis_node
+        .testing_peer_with_assignments_and_name(peer_config, "PEER")
+        .await?;
+
+    // Isolate both nodes so each builds an independent fork from the same base.
+    genesis_node.gossip_disable();
+    peer_node.gossip_disable();
+    let base_height = genesis_node.get_canonical_chain_height().await;
+
+    // Genesis mines the soon-to-be-orphaned block; capture it before the reorg replaces it. The peer mines
+    // a strictly longer chain that wins the fork choice once gossiped.
+    genesis_node.mine_blocks_without_gossip(1).await?;
+    genesis_node
+        .wait_until_height(base_height + 1, seconds_to_wait)
+        .await?;
+    let orphan_block = genesis_node.get_block_by_height(base_height + 1).await?;
+
+    peer_node.mine_blocks_without_gossip(3).await?;
+    peer_node
+        .wait_until_height(base_height + 3, seconds_to_wait)
+        .await?;
+    let peer_block_1 = Arc::new(peer_node.get_block_by_height(base_height + 1).await?);
+    let peer_block_2 = Arc::new(peer_node.get_block_by_height(base_height + 2).await?);
+    let peer_block_3 = Arc::new(peer_node.get_block_by_height(base_height + 3).await?);
+    assert_ne!(
+        orphan_block.block_hash, peer_block_1.block_hash,
+        "the orphan and the winning fork must genuinely diverge at the fork height"
+    );
+
+    // Arm reorg detection, then re-enable gossip and feed genesis the winning chain in order.
+    let reorg_future = genesis_node.wait_for_reorg(seconds_to_wait);
+    genesis_node.gossip_enable();
+    peer_node.gossip_enable();
+    for block in [&peer_block_1, &peer_block_2, &peer_block_3] {
+        peer_node.gossip_block_to_peers(block)?;
+        genesis_node
+            .wait_for_block(&block.block_hash, seconds_to_wait)
+            .await?;
+    }
+    let _reorg_event = reorg_future.await?;
+    // The fork choice has switched: the canonical tip is now the winning fork's tip.
+    genesis_node
+        .wait_until_height(base_height + 3, seconds_to_wait)
+        .await?;
+
+    // Request the canonical range spanning the fork point: the common ancestor at `base_height` through the
+    // winning tip at `base_height + 3`, covering the divergence at `base_height + 1`.
+    let address = format!(
+        "http://127.0.0.1:{}",
+        genesis_node.node_ctx.config.node_config.http.bind_port
+    );
+    let client = reqwest::Client::new();
+    let to_height = base_height + 3;
+    let resp = client
+        .get(format!(
+            "{address}/internal/blocks?from_height={base_height}&to_height={to_height}"
+        ))
+        .send()
+        .await?;
+    assert_eq!(resp.status(), 200, "a settled canonical range resolves");
+    let events: serde_json::Value = resp.json().await?;
+    let events = events.as_array().expect("events array");
+
+    // The range is the full contiguous height span, ascending.
+    let heights: Vec<u64> = events
+        .iter()
+        .map(|e| e["header"]["height"].as_u64().expect("height"))
+        .collect();
+    assert_eq!(
+        heights,
+        (base_height..=to_height).collect::<Vec<_>>(),
+        "range is the full contiguous height span: {heights:?}"
+    );
+
+    // Every block links to its predecessor: one parent-linked fork, not a splice of two.
+    for pair in events.windows(2) {
+        assert_eq!(
+            pair[1]["header"]["previous_block_hash"], pair[0]["header"]["block_hash"],
+            "block at height {} must link to its predecessor",
+            pair[1]["header"]["height"]
+        );
+    }
+
+    // Every forked height reflects the winning (adopted) fork — never the orphaned chain.
+    for (height, winner) in [
+        (base_height + 1, &peer_block_1),
+        (base_height + 2, &peer_block_2),
+        (base_height + 3, &peer_block_3),
+    ] {
+        let block = events
+            .iter()
+            .find(|e| e["header"]["height"].as_u64() == Some(height))
+            .expect("block at forked height present");
+        assert_eq!(
+            block["header"]["block_hash"],
+            serde_json::to_value(winner.block_hash)?,
+            "height {height} must reflect the winning fork",
+        );
+    }
+    let at_fork = events
+        .iter()
+        .find(|e| e["header"]["height"].as_u64() == Some(base_height + 1))
+        .expect("block at fork height present");
+    assert_ne!(
+        at_fork["header"]["block_hash"],
+        serde_json::to_value(orphan_block.block_hash)?,
+        "the forked height must never resolve to the orphaned block",
+    );
+
+    tokio::join!(genesis_node.stop(), peer_node.stop());
+    Ok(())
+}

--- a/crates/chain-tests/src/integration/block_stream.rs
+++ b/crates/chain-tests/src/integration/block_stream.rs
@@ -335,3 +335,192 @@ async fn reorged_emitted_for_fork_switch_without_duplicate_observed() -> eyre::R
     tokio::join!(genesis_node.stop(), peer_node.stop());
     Ok(())
 }
+
+/// `GET /internal/blocks/events` pages the same log over HTTP and honours the three cursor regimes:
+/// in-window pagination, the caught-up empty page, and the beyond-tip clamp — plus the error/probe codes.
+#[test_log::test(tokio::test)]
+async fn internal_events_endpoint_pages_and_regimes() -> eyre::Result<()> {
+    let node = IrysNodeTest::default_async().start().await;
+    let address = format!(
+        "http://127.0.0.1:{}",
+        node.node_ctx.config.node_config.http.bind_port
+    );
+    let client = reqwest::Client::new();
+
+    let blk = node.mine_block().await?;
+    node.wait_until_height(blk.height, 10).await?;
+    node.mine_blocks(2).await?;
+    node.wait_until_height(blk.height + 2, 10).await?;
+
+    // Page from 0 with a small limit, following next_seq/has_more to exhaustion.
+    let mut from = 0_u64;
+    let mut seqs = Vec::new();
+    loop {
+        let page: serde_json::Value = client
+            .get(format!(
+                "{address}/internal/blocks/events?from_seq={from}&limit=2"
+            ))
+            .send()
+            .await?
+            .json()
+            .await?;
+        for f in page["frames"].as_array().expect("frames array") {
+            seqs.push(f["seq"].as_u64().expect("seq"));
+        }
+        from = page["next_seq"].as_u64().expect("next_seq");
+        if !page["has_more"].as_bool().expect("has_more") {
+            break;
+        }
+    }
+    // At exhaustion (`has_more=false`), the last `next_seq` is the log's logical length.
+    let logical_len = from;
+    assert_eq!(seqs.first(), Some(&0), "log starts at seq 0");
+    assert!(
+        seqs.windows(2).all(|w| w[1] == w[0] + 1),
+        "contiguous, each seq visited once: {seqs:?}"
+    );
+    assert!(logical_len >= 1);
+
+    // Caught-up (from_seq == logical_len): a normal empty page, not a clamp.
+    let resp = client
+        .get(format!(
+            "{address}/internal/blocks/events?from_seq={logical_len}"
+        ))
+        .send()
+        .await?;
+    assert_eq!(resp.status(), 200);
+    let page: serde_json::Value = resp.json().await?;
+    assert!(page["frames"].as_array().unwrap().is_empty());
+    assert_eq!(page["next_seq"].as_u64(), Some(logical_len));
+    assert_eq!(page["has_more"].as_bool(), Some(false));
+    assert_eq!(page["truncated"].as_bool(), Some(false));
+
+    // Beyond tip (from_seq > logical_len): clamp to floor 0 (log not pruned), truncated false, not empty.
+    let page: serde_json::Value = client
+        .get(format!(
+            "{address}/internal/blocks/events?from_seq={}",
+            logical_len + 5
+        ))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert_eq!(
+        page["frames"].as_array().unwrap().first().unwrap()["seq"].as_u64(),
+        Some(0)
+    );
+    assert_eq!(page["truncated"].as_bool(), Some(false));
+
+    // Over-size limit is clamped, not rejected.
+    assert_eq!(
+        client
+            .get(format!(
+                "{address}/internal/blocks/events?from_seq=0&limit=100000"
+            ))
+            .send()
+            .await?
+            .status(),
+        200
+    );
+
+    // Malformed query → 400.
+    assert_eq!(
+        client
+            .get(format!("{address}/internal/blocks/events?from_seq=abc"))
+            .send()
+            .await?
+            .status(),
+        400
+    );
+
+    // `events` is the literal route, not captured as `{height}`: a valid page shape proves it.
+    let page: serde_json::Value = client
+        .get(format!(
+            "{address}/internal/blocks/events?from_seq=0&limit=1"
+        ))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert!(
+        page["frames"].is_array()
+            && page["next_seq"].is_u64()
+            && page["lowest_retained_seq"].is_u64()
+    );
+
+    Ok(())
+}
+
+/// The poll endpoint and the SSE stream carry byte-identical frames over the same range. Driven with
+/// `observed` + `finalized` frames; `reorged` equivalence follows from the same kind-agnostic
+/// `StreamFrame` serializer (unit-tested via `events_page_frames_match_sse_replay`) and is exercised
+/// end-to-end by `reorged_emitted_for_fork_switch_without_duplicate_observed`.
+#[test_log::test(tokio::test)]
+async fn internal_events_equal_sse_over_same_range() -> eyre::Result<()> {
+    let mut node = IrysNodeTest::default_async();
+    node.cfg.consensus.get_mut().block_migration_depth = 2;
+    let node = node.start().await;
+    let address = format!(
+        "http://127.0.0.1:{}",
+        node.node_ctx.config.node_config.http.bind_port
+    );
+    let client = reqwest::Client::new();
+    let handle = node.node_ctx.block_stream_handle.clone();
+
+    // Produce observed + finalized frames: mine, advance past the migration depth, await the index.
+    let blk1 = node.mine_block().await?;
+    node.wait_until_height(blk1.height, 10).await?;
+    node.mine_blocks(3).await?;
+    node.wait_until_block_index_height(blk1.height, 30).await?;
+
+    // Poll side: page /events from 0 to exhaustion over HTTP.
+    let mut poll_frames: Vec<serde_json::Value> = Vec::new();
+    let mut from = 0_u64;
+    loop {
+        let page: serde_json::Value = client
+            .get(format!(
+                "{address}/internal/blocks/events?from_seq={from}&limit=3"
+            ))
+            .send()
+            .await?
+            .json()
+            .await?;
+        for f in page["frames"].as_array().expect("frames array") {
+            poll_frames.push(f.clone());
+        }
+        from = page["next_seq"].as_u64().expect("next_seq");
+        if !page["has_more"].as_bool().expect("has_more") {
+            break;
+        }
+    }
+
+    // SSE side: the durable replay from seq 0 is the whole log. The log is append-only, so comparing the
+    // poll set against the equal-length SSE prefix is stable against any frame appended afterwards.
+    let (sse_frames, _live) = handle.subscribe(0)?;
+    assert!(
+        sse_frames.len() >= poll_frames.len(),
+        "SSE replay covers at least the polled range"
+    );
+    for (i, poll) in poll_frames.iter().enumerate() {
+        assert_eq!(
+            *poll,
+            serde_json::to_value(&sse_frames[i]).expect("serialize sse frame"),
+            "poll frame {i} must be byte-identical to the SSE frame"
+        );
+    }
+    // The range genuinely exercised both frame kinds.
+    assert!(
+        poll_frames
+            .iter()
+            .any(|f| f["kind"].as_str() == Some("observed")),
+        "expected an observed frame"
+    );
+    assert!(
+        poll_frames
+            .iter()
+            .any(|f| f["kind"].as_str() == Some("finalized")),
+        "expected a finalized frame"
+    );
+
+    Ok(())
+}

--- a/crates/chain-tests/src/integration/block_stream.rs
+++ b/crates/chain-tests/src/integration/block_stream.rs
@@ -7,6 +7,8 @@ use crate::utils::IrysNodeTest;
 use alloy_core::primitives::ruint::aliases::U256;
 use alloy_genesis::GenesisAccount;
 use eyre::OptionExt as _;
+use futures::TryStreamExt as _;
+use irys_actors::block_stream_service::ReplayStream;
 use irys_types::block_stream::{StreamEvent, StreamFrame};
 use irys_types::irys::IrysSigner;
 use irys_types::{H256, NodeConfig};
@@ -19,9 +21,9 @@ const TEST_USER_BALANCE_IRYS: U256 = U256::from_limbs([1_000_000_000_000_000_000
 
 /// Receives frames until `predicate` matches, or times out.
 async fn next_frame_for(
-    live: &mut Receiver<StreamFrame>,
+    live: &mut Receiver<Arc<StreamFrame>>,
     predicate: impl Fn(&StreamFrame) -> bool,
-) -> eyre::Result<StreamFrame> {
+) -> eyre::Result<Arc<StreamFrame>> {
     loop {
         let frame = tokio::time::timeout(Duration::from_secs(30), live.recv())
             .await?
@@ -30,6 +32,10 @@ async fn next_frame_for(
             return Ok(frame);
         }
     }
+}
+
+async fn collect_replay(replay: ReplayStream) -> eyre::Result<Vec<Arc<StreamFrame>>> {
+    replay.try_collect().await
 }
 
 #[test_log::test(tokio::test)]
@@ -67,6 +73,7 @@ async fn observed_emitted_with_data_roots_and_replays_without_gap() -> eyre::Res
     // A late subscriber replays history (including that frame at its original seq) with strictly
     // increasing, gapless seqs — the replay→live handover property.
     let (replay_late, _live_late) = handle.subscribe(0)?;
+    let replay_late = collect_replay(replay_late).await?;
     assert!(
         replay_late.iter().any(|f| f.seq == seq_with_data),
         "replay must include the earlier frame at its original seq"
@@ -80,7 +87,7 @@ async fn observed_emitted_with_data_roots_and_replays_without_gap() -> eyre::Res
     let mut observed_hashes: Vec<_> = replay_late
         .iter()
         .filter(|f| f.kind() == "observed")
-        .filter_map(StreamFrame::block_hash)
+        .filter_map(|frame| frame.block_hash())
         .collect();
     let total = observed_hashes.len();
     observed_hashes.sort();
@@ -271,8 +278,13 @@ async fn reorged_emitted_for_fork_switch_without_duplicate_observed() -> eyre::R
 
     // Snapshot the complete durable log and assert the whole-log invariants on it.
     let (log, _live_snapshot) = handle.subscribe(0)?;
+    let log = collect_replay(log).await?;
 
-    let reorged: Vec<&StreamFrame> = log.iter().filter(|f| f.kind() == "reorged").collect();
+    let reorged: Vec<&StreamFrame> = log
+        .iter()
+        .filter(|f| f.kind() == "reorged")
+        .map(Arc::as_ref)
+        .collect();
     assert_eq!(
         reorged.len(),
         1,
@@ -325,7 +337,7 @@ async fn reorged_emitted_for_fork_switch_without_duplicate_observed() -> eyre::R
     let duplicate = log
         .iter()
         .filter(|f| f.kind() == "observed")
-        .filter_map(StreamFrame::block_hash)
+        .filter_map(|frame| frame.block_hash())
         .find(|h| winning.contains(h));
     assert!(
         duplicate.is_none(),
@@ -497,6 +509,7 @@ async fn internal_events_equal_sse_over_same_range() -> eyre::Result<()> {
     // SSE side: the durable replay from seq 0 is the whole log. The log is append-only, so comparing the
     // poll set against the equal-length SSE prefix is stable against any frame appended afterwards.
     let (sse_frames, _live) = handle.subscribe(0)?;
+    let sse_frames = collect_replay(sse_frames).await?;
     assert!(
         sse_frames.len() >= poll_frames.len(),
         "SSE replay covers at least the polled range"

--- a/crates/chain-tests/src/integration/block_stream.rs
+++ b/crates/chain-tests/src/integration/block_stream.rs
@@ -254,6 +254,16 @@ async fn internal_reads_by_height_and_range() -> eyre::Result<()> {
         .await?;
     assert_eq!(resp.status(), 400);
 
+    // inverted range: 400, never a silently empty 200 (a reconciling follower could not tell it
+    // from a genuinely empty canonical span).
+    let resp = client
+        .get(format!(
+            "{address}/internal/blocks?from_height=3&to_height=1"
+        ))
+        .send()
+        .await?;
+    assert_eq!(resp.status(), 400);
+
     Ok(())
 }
 

--- a/crates/chain-tests/src/integration/block_stream.rs
+++ b/crates/chain-tests/src/integration/block_stream.rs
@@ -7,8 +7,7 @@ use crate::utils::IrysNodeTest;
 use alloy_core::primitives::ruint::aliases::U256;
 use alloy_genesis::GenesisAccount;
 use eyre::OptionExt as _;
-use futures::TryStreamExt as _;
-use irys_actors::block_stream_service::ReplayStream;
+use irys_actors::block_stream_service::BlockStreamHandle;
 use irys_types::block_stream::{StreamEvent, StreamFrame};
 use irys_types::irys::IrysSigner;
 use irys_types::{H256, NodeConfig};
@@ -34,8 +33,18 @@ async fn next_frame_for(
     }
 }
 
-async fn collect_replay(replay: ReplayStream) -> eyre::Result<Vec<Arc<StreamFrame>>> {
-    replay.try_collect().await
+fn collect_replay(
+    handle: &BlockStreamHandle,
+    start: u64,
+    end: u64,
+) -> eyre::Result<Vec<StreamFrame>> {
+    let mut cursor = start;
+    let mut frames = Vec::new();
+    while let Some((next, page)) = handle.replay_page(cursor, end)? {
+        frames.extend(page);
+        cursor = next;
+    }
+    Ok(frames)
 }
 
 /// Reads `count` frames from the real `/internal/blocks/stream?from_seq=` SSE endpoint over HTTP,
@@ -96,7 +105,7 @@ async fn observed_emitted_with_data_roots_and_replays_without_gap() -> eyre::Res
     let handle = node.node_ctx.block_stream_handle.clone();
 
     // Subscribe before producing.
-    let (_replay0, mut live) = handle.subscribe(0)?;
+    let (_, _, mut live) = handle.subscribe(0)?;
 
     // Post a data tx and mine; an `observed` frame carrying its data_root must arrive.
     node.post_publish_data_tx(&user, b"alpha".to_vec()).await?;
@@ -115,8 +124,8 @@ async fn observed_emitted_with_data_roots_and_replays_without_gap() -> eyre::Res
 
     // A late subscriber replays history (including that frame at its original seq) with strictly
     // increasing, gapless seqs — the replay→live handover property.
-    let (replay_late, _live_late) = handle.subscribe(0)?;
-    let replay_late = collect_replay(replay_late).await?;
+    let (start, end, _live_late) = handle.subscribe(0)?;
+    let replay_late = collect_replay(&handle, start, end)?;
     assert!(
         replay_late.iter().any(|f| f.seq == seq_with_data),
         "replay must include the earlier frame at its original seq"
@@ -130,7 +139,7 @@ async fn observed_emitted_with_data_roots_and_replays_without_gap() -> eyre::Res
     let mut observed_hashes: Vec<_> = replay_late
         .iter()
         .filter(|f| f.kind() == "observed")
-        .filter_map(|frame| frame.block_hash())
+        .filter_map(StreamFrame::block_hash)
         .collect();
     let total = observed_hashes.len();
     observed_hashes.sort();
@@ -151,7 +160,7 @@ async fn finalized_emitted_on_migration() -> eyre::Result<()> {
     node.cfg.consensus.get_mut().block_migration_depth = 2;
     let node = node.start().await;
     let handle = node.node_ctx.block_stream_handle.clone();
-    let (_replay, mut live) = handle.subscribe(0)?;
+    let (_, _, mut live) = handle.subscribe(0)?;
 
     let blk1 = node.mine_block().await?;
     node.wait_until_height(blk1.height, 10).await?;
@@ -273,7 +282,7 @@ async fn reorged_emitted_for_fork_switch_without_duplicate_observed() -> eyre::R
     // Subscribe to the genesis node's stream before the fork; setup frames are already durable, so
     // only post-subscribe frames arrive live.
     let handle = genesis_node.node_ctx.block_stream_handle.clone();
-    let (_replay, mut live) = handle.subscribe(0)?;
+    let (_, _, mut live) = handle.subscribe(0)?;
 
     // Isolate both nodes so each builds an independent fork from the same base.
     genesis_node.gossip_disable();
@@ -320,14 +329,10 @@ async fn reorged_emitted_for_fork_switch_without_duplicate_observed() -> eyre::R
     .await?;
 
     // Snapshot the complete durable log and assert the whole-log invariants on it.
-    let (log, _live_snapshot) = handle.subscribe(0)?;
-    let log = collect_replay(log).await?;
+    let (start, end, _live_snapshot) = handle.subscribe(0)?;
+    let log = collect_replay(&handle, start, end)?;
 
-    let reorged: Vec<&StreamFrame> = log
-        .iter()
-        .filter(|f| f.kind() == "reorged")
-        .map(Arc::as_ref)
-        .collect();
+    let reorged: Vec<&StreamFrame> = log.iter().filter(|f| f.kind() == "reorged").collect();
     assert_eq!(
         reorged.len(),
         1,
@@ -380,7 +385,7 @@ async fn reorged_emitted_for_fork_switch_without_duplicate_observed() -> eyre::R
     let duplicate = log
         .iter()
         .filter(|f| f.kind() == "observed")
-        .filter_map(|frame| frame.block_hash())
+        .filter_map(StreamFrame::block_hash)
         .find(|h| winning.contains(h));
     assert!(
         duplicate.is_none(),

--- a/crates/chain-tests/src/integration/mod.rs
+++ b/crates/chain-tests/src/integration/mod.rs
@@ -1,2 +1,3 @@
+mod block_stream;
 mod cache_service;
 mod data_size;

--- a/crates/chain-tests/src/perm_ledger_expiry/mod.rs
+++ b/crates/chain-tests/src/perm_ledger_expiry/mod.rs
@@ -296,14 +296,13 @@ async fn heavy_perm_and_term_expiry_same_epoch() -> eyre::Result<()> {
     // Mine another block to promote tx2 to Publish
     node.mine_block().await?;
 
-    // Verify promotion state before expiry
+    // Verify promotion state before expiry. tx2's promotion lands when the mempool processes the
+    // block's `BlockConfirmed` (behind block production), so wait for it; only then is the
+    // negative tx1 read meaningful.
+    node.wait_for_promotion(&tx2.header.id, 20).await?;
     assert!(
         !node.get_is_promoted(&tx1.header.id).await?,
         "tx1 should NOT be promoted (no chunks uploaded)"
-    );
-    assert!(
-        node.get_is_promoted(&tx2.header.id).await?,
-        "tx2 should be promoted (chunks uploaded)"
     );
 
     // Mine to first epoch boundary to trigger slot allocation (need 2+ slots per ledger)
@@ -833,13 +832,11 @@ async fn slow_heavy_perm_partition_recycle_and_reuse() -> eyre::Result<()> {
     node.wait_for_ingress_proofs_no_mining(vec![tx1.header.id], 20)
         .await?;
 
-    // Mine another block to promote tx1 to Publish
+    // Mine another block to promote tx1 to Publish. The mempool reflects the promotion when it
+    // processes the block's `BlockConfirmed`, which runs behind block production — so wait, don't
+    // assert instantly.
     node.mine_block().await?;
-
-    assert!(
-        node.get_is_promoted(&tx1.header.id).await?,
-        "tx1 should be promoted to Publish before expiry"
-    );
+    node.wait_for_promotion(&tx1.header.id, 20).await?;
     info!("tx1 promoted to Publish");
 
     // Mine to first epoch boundary → triggers slot allocation (need 2+ Publish slots)
@@ -963,11 +960,8 @@ async fn slow_heavy_perm_partition_recycle_and_reuse() -> eyre::Result<()> {
     info!("Reached second epoch boundary at height {}", epoch_height2);
 
     // ========== Phase 4: Verify recycling worked ==========
-    // Verify tx2 is promoted
-    assert!(
-        node.get_is_promoted(&tx2.header.id).await?,
-        "tx2 should be promoted to Publish after expiry"
-    );
+    // Verify tx2 is promoted (same confirm-lag as tx1: wait, don't assert instantly).
+    node.wait_for_promotion(&tx2.header.id, 20).await?;
     info!("tx2 promoted to Publish after recycling");
 
     // Get final snapshot and verify every expired Publish partition was recycled.

--- a/crates/chain-tests/src/utils.rs
+++ b/crates/chain-tests/src/utils.rs
@@ -2352,6 +2352,22 @@ impl IrysNodeTest<IrysNodeCtx> {
         }
     }
 
+    /// Polls [`Self::get_is_promoted`] until the tx reports promoted. The mempool applies a
+    /// block's promotions when it processes `BlockConfirmed`, which runs behind block production —
+    /// an instant read straight after `mine_block` races that update.
+    pub async fn wait_for_promotion(&self, tx_id: &H256, max_seconds: usize) -> eyre::Result<()> {
+        let max_seconds = coverage_adjusted_timeout(max_seconds);
+        for _ in 0..max_seconds {
+            if self.get_is_promoted(tx_id).await? {
+                return Ok(());
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+        Err(eyre::eyre!(
+            "tx {tx_id} not promoted to Publish after {max_seconds}s"
+        ))
+    }
+
     /// read storage tx from mempool (with DB fallback)
     pub async fn get_storage_tx_header_from_mempool(
         &self,

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -108,6 +108,9 @@ pub struct IrysNodeCtx {
     pub mempool_guard: MempoolReadGuard,
     pub vdf_steps_guard: VdfStateReadonly,
     pub service_senders: ServiceSenders,
+    /// Shared handle to the block-stream producer; cloned into [`ApiState`] so the `/internal`
+    /// SSE handlers can call `subscribe(from_seq)`.
+    pub block_stream_handle: Arc<irys_actors::block_stream_service::BlockStreamHandle>,
     pub partition_controllers: Vec<PartitionMiningController>,
     pub packing_waiter: irys_actors::packing_service::PackingIdleWaiter,
     // Shutdown channel — send a ShutdownReason to trigger graceful shutdown of the lifecycle task
@@ -162,6 +165,7 @@ impl IrysNodeCtx {
             started_at: self.started_at,
             mining_address: self.config.node_config.miner_address(),
             block_tree_lifecycle: self.block_tree_lifecycle.clone(),
+            block_stream: self.block_stream_handle.clone(),
         }
     }
 
@@ -1686,6 +1690,16 @@ impl IrysNode {
             runtime_handle.clone(),
         );
 
+        // Start the block-stream producer: consumes the `block_stream` signal feed and exposes the
+        // shared handle the `/internal` SSE handlers call `subscribe(from_seq)` on.
+        let (block_stream_service_handle, block_stream_handle) =
+            irys_actors::block_stream_service::BlockStreamService::spawn_service(
+                receivers.block_stream,
+                irys_db.clone(),
+                config.consensus.chunk_size,
+                runtime_handle.clone(),
+            );
+
         let (oneshot_tx, oneshot_rx) = tokio::sync::oneshot::channel();
         let block_tree_sender = service_senders.block_tree.clone();
         if let Err(e) =
@@ -2011,6 +2025,7 @@ impl IrysNode {
             vdf_steps_guard: vdf_state_readonly,
             mempool_guard: mempool_guard.clone(),
             service_senders: service_senders.clone(),
+            block_stream_handle,
             partition_controllers,
             packing_waiter: packing_handle.waiter(),
             shutdown_sender: tokio::sync::mpsc::channel::<ShutdownReason>(1).0,
@@ -2096,6 +2111,7 @@ impl IrysNode {
 
             // 6. Chain management
             services.push(block_tree_handle);
+            services.push(block_stream_service_handle);
 
             // 7. State management
             services.push(mempool_handle);
@@ -2129,6 +2145,7 @@ impl IrysNode {
                 started_at: irys_node_ctx.started_at,
                 mining_address: irys_node_ctx.config.node_config.miner_address(),
                 block_tree_lifecycle: irys_node_ctx.block_tree_lifecycle.clone(),
+                block_stream: irys_node_ctx.block_stream_handle.clone(),
             },
             http_listener,
         );

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -1209,6 +1209,14 @@ pub fn block_index_latest_height<T: DbTx>(tx: &T) -> eyre::Result<Option<u64>> {
     Ok(cursor.last()?.map(|(height, _)| height))
 }
 
+/// Returns the canonical migrated block hash recorded at `height`.
+pub fn block_index_hash_by_height<T: DbTx>(
+    tx: &T,
+    height: BlockHeight,
+) -> eyre::Result<Option<H256>> {
+    Ok(tx.get::<MigratedBlockHashes>(height)?)
+}
+
 /// Returns the number of blocks stored in the block index.
 pub fn block_index_num_blocks<T: DbTx>(tx: &T) -> eyre::Result<u64> {
     let count = tx.entries::<MigratedBlockHashes>()?;

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -8,8 +8,9 @@ use crate::db_cache::{
 };
 use crate::tables::{
     CachedChunks, CachedChunksIndex, CachedDataRoots, CompactCachedIngressProof,
-    CompactLedgerIndexItem, IngressProofs, IrysBlockHeaders, IrysBlockIndexItems, IrysCommitments,
-    IrysDataTxHeaders, IrysPoAChunks, Metadata, MigratedBlockHashes, PeerListItems,
+    CompactLedgerIndexItem, IngressProofs, IrysBlockHeaders, IrysBlockIndexItems,
+    IrysBlockStreamEvents, IrysCommitments, IrysDataTxHeaders, IrysPoAChunks, Metadata,
+    MigratedBlockHashes, PeerListItems,
 };
 
 use crate::db::IrysDatabaseExt as _;
@@ -1275,6 +1276,54 @@ pub fn database_schema_version<T: DbTx>(tx: &mut T) -> Result<Option<u32>, Datab
     }
 }
 
+/// Appends a block-stream event to the durable log, assigning and returning the next monotonic
+/// `seq`.
+///
+/// The block-stream producer is the sole writer, so reading the last key and incrementing within
+/// the same write transaction is race-free. `seq` keys sort numerically because reth encodes
+/// integer DB keys big-endian (the same property the block-index range scans rely on).
+pub fn append_block_stream_event<T: DbTx + DbTxMut>(tx: &T, value: Vec<u8>) -> eyre::Result<u64> {
+    let next_seq = {
+        let mut cursor = tx.cursor_read::<IrysBlockStreamEvents>()?;
+        cursor.last()?.map_or(0, |(seq, _)| seq + 1)
+    };
+    tx.put::<IrysBlockStreamEvents>(next_seq, value)?;
+    Ok(next_seq)
+}
+
+/// Reads block-stream events with `seq >= from_seq`, ascending — the replay suffix served on
+/// `subscribe(from_seq)`.
+pub fn read_block_stream_from<T: DbTx>(tx: &T, from_seq: u64) -> eyre::Result<Vec<(u64, Vec<u8>)>> {
+    let mut cursor = tx.cursor_read::<IrysBlockStreamEvents>()?;
+    let mut events = Vec::new();
+    for entry in cursor.walk(Some(from_seq))? {
+        events.push(entry?);
+    }
+    Ok(events)
+}
+
+/// Returns the highest `seq` in the block-stream log, or `None` if empty. Lets the producer rebuild
+/// its in-memory de-dup state from just the log tail on startup, without reading the whole log.
+pub fn block_stream_latest_seq<T: DbTx>(tx: &T) -> eyre::Result<Option<u64>> {
+    let mut cursor = tx.cursor_read::<IrysBlockStreamEvents>()?;
+    Ok(cursor.last()?.map(|(seq, _)| seq))
+}
+
+/// Prunes block-stream events with `seq < keep_from_seq` — count-based retention, deleting the
+/// oldest beyond the configured window.
+pub fn prune_block_stream_below<T: DbTxMut>(tx: &T, keep_from_seq: u64) -> eyre::Result<()> {
+    if keep_from_seq == 0 {
+        return Ok(());
+    }
+    let mut cursor = tx.cursor_write::<IrysBlockStreamEvents>()?;
+    let mut range_walker = cursor.walk_range(0..keep_from_seq)?;
+    while let Some(result) = range_walker.next() {
+        result?;
+        range_walker.delete_current()?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{
@@ -1291,6 +1340,59 @@ mod tests {
         tx_header_by_txid,
     };
     use reth_db::mdbx::DatabaseArguments;
+
+    #[test]
+    fn block_stream_log_append_read_prune() -> eyre::Result<()> {
+        use super::{append_block_stream_event, prune_block_stream_below, read_block_stream_from};
+
+        let path = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db = open_or_create_db(
+            path.path(),
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing().unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            db.update_eyre(|tx| append_block_stream_event(tx, b"a".to_vec()))?,
+            0
+        );
+        assert_eq!(
+            db.update_eyre(|tx| append_block_stream_event(tx, b"b".to_vec()))?,
+            1
+        );
+        assert_eq!(
+            db.update_eyre(|tx| append_block_stream_event(tx, b"c".to_vec()))?,
+            2
+        );
+
+        let suffix = db.view_eyre(|tx| read_block_stream_from(tx, 1))?;
+        assert_eq!(suffix, vec![(1, b"b".to_vec()), (2, b"c".to_vec())]);
+
+        // Cross the 0xFF byte boundary to prove numeric (big-endian) key ordering.
+        for _ in 0..260 {
+            db.update_eyre(|tx| append_block_stream_event(tx, b"x".to_vec()))?;
+        }
+        let seqs: Vec<u64> = db
+            .view_eyre(|tx| read_block_stream_from(tx, 0))?
+            .into_iter()
+            .map(|(seq, _)| seq)
+            .collect();
+        assert!(
+            seqs.windows(2).all(|w| w[0] < w[1]),
+            "seq must sort numerically across the byte boundary"
+        );
+        assert_eq!(seqs.last().copied(), Some(262)); // 3 + 260 events ⇒ last seq 262
+
+        db.update_eyre(|tx| prune_block_stream_below(tx, 260))?;
+        let kept: Vec<u64> = db
+            .view_eyre(|tx| read_block_stream_from(tx, 0))?
+            .into_iter()
+            .map(|(seq, _)| seq)
+            .collect();
+        assert_eq!(kept, vec![260, 261, 262]);
+        Ok(())
+    }
 
     #[test]
     fn insert_and_get_tests() -> eyre::Result<()> {

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -1284,6 +1284,33 @@ pub fn database_schema_version<T: DbTx>(tx: &mut T) -> Result<Option<u32>, Datab
     }
 }
 
+/// Resolves the ordered transaction headers of one ledger of a migrated block.
+///
+/// Fails closed: a tx id with no header row aborts the read rather than yielding a truncated
+/// ledger — a dropped tx would shift the derived `tx_start_offset` of every surviving tx, so a
+/// short result silently misrepresents canonical contents.
+pub fn block_ledger_tx_headers<T: DbTx>(
+    tx: &T,
+    header: &IrysBlockHeader,
+    ledger: DataLedger,
+) -> eyre::Result<Vec<DataTransactionHeader>> {
+    let ledger_id = ledger.get_id();
+    let Some(data_ledger) = header
+        .data_ledgers
+        .iter()
+        .find(|dl| dl.ledger_id == ledger_id)
+    else {
+        return Ok(Vec::new());
+    };
+    let mut txs = Vec::with_capacity(data_ledger.tx_ids.0.len());
+    for tx_id in &data_ledger.tx_ids.0 {
+        let header = tx_header_by_txid(tx, tx_id)?
+            .ok_or_else(|| eyre::eyre!("canonical block missing tx header for {tx_id}"))?;
+        txs.push(header);
+    }
+    Ok(txs)
+}
+
 /// Appends a block-stream event to the durable log, assigning and returning the next monotonic
 /// `seq`.
 ///
@@ -1293,14 +1320,19 @@ pub fn database_schema_version<T: DbTx>(tx: &mut T) -> Result<Option<u32>, Datab
 pub fn append_block_stream_event<T: DbTx + DbTxMut>(tx: &T, value: Vec<u8>) -> eyre::Result<u64> {
     let next_seq = {
         let mut cursor = tx.cursor_read::<IrysBlockStreamEvents>()?;
-        cursor.last()?.map_or(0, |(seq, _)| seq + 1)
+        match cursor.last()? {
+            Some((seq, _)) => seq
+                .checked_add(1)
+                .ok_or_else(|| eyre::eyre!("block-stream seq overflow"))?,
+            None => 0,
+        }
     };
     tx.put::<IrysBlockStreamEvents>(next_seq, value)?;
     Ok(next_seq)
 }
 
-/// Reads block-stream events with `seq >= from_seq`, ascending — used by the producer's startup de-dup
-/// state rebuild (`rebuild_state`).
+/// Reads block-stream events with `seq >= from_seq`, ascending and unbounded — callers cap the
+/// span via `from_seq`.
 pub fn read_block_stream_from<T: DbTx>(tx: &T, from_seq: u64) -> eyre::Result<Vec<(u64, Vec<u8>)>> {
     let mut cursor = tx.cursor_read::<IrysBlockStreamEvents>()?;
     let mut events = Vec::new();
@@ -1391,7 +1423,10 @@ mod tests {
 
     #[test]
     fn block_stream_log_append_read_prune() -> eyre::Result<()> {
-        use super::{append_block_stream_event, prune_block_stream_below, read_block_stream_from};
+        use super::{
+            append_block_stream_event, block_stream_lowest_seq, prune_block_stream_below,
+            read_block_stream_from, read_block_stream_range,
+        };
 
         let path = irys_testing_utils::utils::TempDirBuilder::new().build();
         let db = open_or_create_db(
@@ -1400,6 +1435,13 @@ mod tests {
             DatabaseArguments::irys_testing().unwrap(),
         )
         .unwrap();
+
+        // Empty log: no floor, empty bounded range.
+        assert_eq!(db.view_eyre(block_stream_lowest_seq)?, None);
+        assert!(
+            db.view_eyre(|tx| read_block_stream_range(tx, 0, 10))?
+                .is_empty()
+        );
 
         assert_eq!(
             db.update_eyre(|tx| append_block_stream_event(tx, b"a".to_vec()))?,
@@ -1416,6 +1458,19 @@ mod tests {
 
         let suffix = db.view_eyre(|tx| read_block_stream_from(tx, 1))?;
         assert_eq!(suffix, vec![(1, b"b".to_vec()), (2, b"c".to_vec())]);
+        assert_eq!(db.view_eyre(block_stream_lowest_seq)?, Some(0));
+
+        // Bounded range honours both from_seq and limit; limit 0 is an empty probe.
+        let seqs: Vec<u64> = db
+            .view_eyre(|tx| read_block_stream_range(tx, 1, 2))?
+            .into_iter()
+            .map(|(seq, _)| seq)
+            .collect();
+        assert_eq!(seqs, vec![1, 2]);
+        assert!(
+            db.view_eyre(|tx| read_block_stream_range(tx, 0, 0))?
+                .is_empty()
+        );
 
         // Cross the 0xFF byte boundary to prove numeric (big-endian) key ordering.
         for _ in 0..260 {
@@ -1439,54 +1494,7 @@ mod tests {
             .map(|(seq, _)| seq)
             .collect();
         assert_eq!(kept, vec![260, 261, 262]);
-        Ok(())
-    }
-
-    #[test]
-    fn block_stream_lowest_and_range() -> eyre::Result<()> {
-        use super::{
-            append_block_stream_event, block_stream_lowest_seq, prune_block_stream_below,
-            read_block_stream_range,
-        };
-
-        let path = irys_testing_utils::utils::TempDirBuilder::new().build();
-        let db = open_or_create_db(
-            path.path(),
-            IrysTables::ALL,
-            DatabaseArguments::irys_testing().unwrap(),
-        )
-        .unwrap();
-
-        // Empty log: no floor, empty range.
-        assert_eq!(db.view_eyre(block_stream_lowest_seq)?, None);
-        assert!(
-            db.view_eyre(|tx| read_block_stream_range(tx, 0, 10))?
-                .is_empty()
-        );
-
-        for b in [b"a", b"b", b"c", b"d"] {
-            db.update_eyre(|tx| append_block_stream_event(tx, b.to_vec()))?;
-        } // seqs 0..=3
-
-        assert_eq!(db.view_eyre(block_stream_lowest_seq)?, Some(0));
-
-        // Bounded range honours both from_seq and limit.
-        let seqs: Vec<u64> = db
-            .view_eyre(|tx| read_block_stream_range(tx, 1, 2))?
-            .into_iter()
-            .map(|(seq, _)| seq)
-            .collect();
-        assert_eq!(seqs, vec![1, 2]);
-
-        // limit 0 → empty page.
-        assert!(
-            db.view_eyre(|tx| read_block_stream_range(tx, 0, 0))?
-                .is_empty()
-        );
-
-        // Pruning advances the retained floor.
-        db.update_eyre(|tx| prune_block_stream_below(tx, 2))?;
-        assert_eq!(db.view_eyre(block_stream_lowest_seq)?, Some(2));
+        assert_eq!(db.view_eyre(block_stream_lowest_seq)?, Some(260));
         Ok(())
     }
 

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -1302,11 +1302,35 @@ pub fn read_block_stream_from<T: DbTx>(tx: &T, from_seq: u64) -> eyre::Result<Ve
     Ok(events)
 }
 
+/// Reads up to `limit` block-stream events with `seq >= from_seq`, ascending — the bounded page served
+/// on `GET /internal/blocks/events`. Unlike [`read_block_stream_from`], the walk is capped at `limit` so
+/// a large log cannot be drained into a single response.
+pub fn read_block_stream_range<T: DbTx>(
+    tx: &T,
+    from_seq: u64,
+    limit: usize,
+) -> eyre::Result<Vec<(u64, Vec<u8>)>> {
+    let mut cursor = tx.cursor_read::<IrysBlockStreamEvents>()?;
+    let mut events = Vec::new();
+    for entry in cursor.walk(Some(from_seq))?.take(limit) {
+        events.push(entry?);
+    }
+    Ok(events)
+}
+
 /// Returns the highest `seq` in the block-stream log, or `None` if empty. Lets the producer rebuild
 /// its in-memory de-dup state from just the log tail on startup, without reading the whole log.
 pub fn block_stream_latest_seq<T: DbTx>(tx: &T) -> eyre::Result<Option<u64>> {
     let mut cursor = tx.cursor_read::<IrysBlockStreamEvents>()?;
     Ok(cursor.last()?.map(|(seq, _)| seq))
+}
+
+/// Returns the lowest `seq` still retained in the block-stream log (the first key), or `None` if the log
+/// is empty. Count-based pruning advances this floor over time, so a poll cursor below it is a truncation
+/// rather than a contiguous resume point.
+pub fn block_stream_lowest_seq<T: DbTx>(tx: &T) -> eyre::Result<Option<u64>> {
+    let mut cursor = tx.cursor_read::<IrysBlockStreamEvents>()?;
+    Ok(cursor.first()?.map(|(seq, _)| seq))
 }
 
 /// Prunes block-stream events with `seq < keep_from_seq` — count-based retention, deleting the
@@ -1391,6 +1415,54 @@ mod tests {
             .map(|(seq, _)| seq)
             .collect();
         assert_eq!(kept, vec![260, 261, 262]);
+        Ok(())
+    }
+
+    #[test]
+    fn block_stream_lowest_and_range() -> eyre::Result<()> {
+        use super::{
+            append_block_stream_event, block_stream_lowest_seq, prune_block_stream_below,
+            read_block_stream_range,
+        };
+
+        let path = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db = open_or_create_db(
+            path.path(),
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing().unwrap(),
+        )
+        .unwrap();
+
+        // Empty log: no floor, empty range.
+        assert_eq!(db.view_eyre(block_stream_lowest_seq)?, None);
+        assert!(
+            db.view_eyre(|tx| read_block_stream_range(tx, 0, 10))?
+                .is_empty()
+        );
+
+        for b in [b"a", b"b", b"c", b"d"] {
+            db.update_eyre(|tx| append_block_stream_event(tx, b.to_vec()))?;
+        } // seqs 0..=3
+
+        assert_eq!(db.view_eyre(block_stream_lowest_seq)?, Some(0));
+
+        // Bounded range honours both from_seq and limit.
+        let seqs: Vec<u64> = db
+            .view_eyre(|tx| read_block_stream_range(tx, 1, 2))?
+            .into_iter()
+            .map(|(seq, _)| seq)
+            .collect();
+        assert_eq!(seqs, vec![1, 2]);
+
+        // limit 0 → empty page.
+        assert!(
+            db.view_eyre(|tx| read_block_stream_range(tx, 0, 0))?
+                .is_empty()
+        );
+
+        // Pruning advances the retained floor.
+        db.update_eyre(|tx| prune_block_stream_below(tx, 2))?;
+        assert_eq!(db.view_eyre(block_stream_lowest_seq)?, Some(2));
         Ok(())
     }
 

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -1299,8 +1299,8 @@ pub fn append_block_stream_event<T: DbTx + DbTxMut>(tx: &T, value: Vec<u8>) -> e
     Ok(next_seq)
 }
 
-/// Reads block-stream events with `seq >= from_seq`, ascending — the replay suffix served on
-/// `subscribe(from_seq)`.
+/// Reads block-stream events with `seq >= from_seq`, ascending — used by the producer's startup de-dup
+/// state rebuild (`rebuild_state`).
 pub fn read_block_stream_from<T: DbTx>(tx: &T, from_seq: u64) -> eyre::Result<Vec<(u64, Vec<u8>)>> {
     let mut cursor = tx.cursor_read::<IrysBlockStreamEvents>()?;
     let mut events = Vec::new();
@@ -1339,6 +1339,22 @@ pub fn block_stream_latest_seq<T: DbTx>(tx: &T) -> eyre::Result<Option<u64>> {
 pub fn block_stream_lowest_seq<T: DbTx>(tx: &T) -> eyre::Result<Option<u64>> {
     let mut cursor = tx.cursor_read::<IrysBlockStreamEvents>()?;
     Ok(cursor.first()?.map(|(seq, _)| seq))
+}
+
+/// Returns `(lowest_retained_seq, logical_len)` for the block-stream log in one read: the lowest retained
+/// `seq` (the prune floor, `0` if empty) and the current highest retained `seq` plus one (`0` if empty —
+/// no high-watermark is persisted, so a fully emptied log reports `0`). Shared by the SSE `subscribe`
+/// snapshot and the `/events` poll so both derive the cursor window from one read; each clamps that
+/// window differently by design, so only the read is shared, never the clamp.
+pub fn block_stream_log_bounds<T: DbTx>(tx: &T) -> eyre::Result<(u64, u64)> {
+    let lowest = block_stream_lowest_seq(tx)?.unwrap_or(0);
+    let logical_len = match block_stream_latest_seq(tx)? {
+        Some(seq) => seq
+            .checked_add(1)
+            .ok_or_else(|| eyre::eyre!("block-stream seq overflow"))?,
+        None => 0,
+    };
+    Ok((lowest, logical_len))
 }
 
 /// Prunes block-stream events with `seq < keep_from_seq` — count-based retention, deleting the
@@ -1471,6 +1487,32 @@ mod tests {
         // Pruning advances the retained floor.
         db.update_eyre(|tx| prune_block_stream_below(tx, 2))?;
         assert_eq!(db.view_eyre(block_stream_lowest_seq)?, Some(2));
+        Ok(())
+    }
+
+    #[test]
+    fn block_stream_log_bounds_reports_floor_and_logical_len() -> eyre::Result<()> {
+        use super::{append_block_stream_event, block_stream_log_bounds, prune_block_stream_below};
+
+        let path = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db = open_or_create_db(
+            path.path(),
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing().unwrap(),
+        )
+        .unwrap();
+
+        // Empty log: floor 0, logical_len 0.
+        assert_eq!(db.view_eyre(block_stream_log_bounds)?, (0, 0));
+
+        for b in [b"a", b"b", b"c"] {
+            db.update_eyre(|tx| append_block_stream_event(tx, b.to_vec()))?;
+        } // seqs 0..=2 → logical_len 3
+        assert_eq!(db.view_eyre(block_stream_log_bounds)?, (0, 3));
+
+        // Pruning advances the floor; logical_len (highest seq + 1) is unchanged.
+        db.update_eyre(|tx| prune_block_stream_below(tx, 2))?;
+        assert_eq!(db.view_eyre(block_stream_log_bounds)?, (2, 3));
         Ok(())
     }
 

--- a/crates/database/src/snapshot.rs
+++ b/crates/database/src/snapshot.rs
@@ -12,7 +12,8 @@ use std::ffi::CString;
 use std::path::Path;
 
 use crate::tables::{
-    CachedChunks, CachedChunksIndex, CachedDataRoots, IngressProofs, PeerListItems,
+    CachedChunks, CachedChunksIndex, CachedDataRoots, IngressProofs, IrysBlockStreamEvents,
+    PeerListItems,
 };
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -132,6 +133,9 @@ pub fn strip_node_local(env: &DatabaseEnv, include_caches: bool) -> eyre::Result
         .context("opening write tx for snapshot strip")?;
     tx.clear::<PeerListItems>()
         .context("clearing PeerListItems")?;
+    // Node-local follower stream log; never travels in a snapshot.
+    tx.clear::<IrysBlockStreamEvents>()
+        .context("clearing IrysBlockStreamEvents")?;
     if !include_caches {
         tx.clear::<CachedDataRoots>()
             .context("clearing CachedDataRoots")?;
@@ -202,6 +206,18 @@ mod tests {
         count
     }
 
+    fn count_block_stream_events(env: &DatabaseEnv) -> usize {
+        let tx = env.tx().expect("open ro tx");
+        let mut cursor = tx
+            .cursor_read::<IrysBlockStreamEvents>()
+            .expect("open stream cursor");
+        let mut count = 0;
+        while cursor.next().expect("walk stream").is_some() {
+            count += 1;
+        }
+        count
+    }
+
     fn block_present(env: &DatabaseEnv, block_hash: &irys_types::H256) -> bool {
         let tx = env.tx().expect("open ro tx");
         tx.get::<crate::tables::IrysBlockHeaders>(*block_hash)
@@ -225,6 +241,10 @@ mod tests {
         })
         .expect("insert peers")
         .expect("insert peers ok");
+
+        env.update(|tx| crate::append_block_stream_event(tx, b"stream-evt".to_vec()))
+            .expect("append stream event")
+            .expect("append stream event ok");
 
         block.block_hash
     }
@@ -259,6 +279,11 @@ mod tests {
 
         assert_eq!(count_peers(&copy_db), 2, "peers carried into the copy");
         assert!(block_present(&copy_db, &block_hash));
+        assert_eq!(
+            count_block_stream_events(&copy_db),
+            1,
+            "block-stream log carried into the copy"
+        );
 
         strip_node_local(&copy_db, include_caches).expect("strip succeeds");
 
@@ -266,6 +291,11 @@ mod tests {
         assert!(
             block_present(&copy_db, &block_hash),
             "block headers survive strip"
+        );
+        assert_eq!(
+            count_block_stream_events(&copy_db),
+            0,
+            "block-stream log cleared after strip"
         );
 
         assert_eq!(count_peers(&src_db), 2, "source db left untouched");

--- a/crates/database/src/tables.rs
+++ b/crates/database/src/tables.rs
@@ -233,4 +233,12 @@ table Metadata {
     type Key = MetadataKey;
     type Value = Vec<u8>;
 }
+
+/// Append-only log of internal block-stream events, keyed by a monotonic `seq`.
+/// The value is the canonical wire JSON of the event payload (see
+/// `irys_types::block_stream`). Node-local: stripped from snapshots.
+table IrysBlockStreamEvents {
+    type Key = u64;
+    type Value = Vec<u8>;
+}
 }

--- a/crates/domain/src/models/chunk_provider.rs
+++ b/crates/domain/src/models/chunk_provider.rs
@@ -1,6 +1,7 @@
 use eyre::OptionExt as _;
 use irys_types::{
     ChunkFormat, Config, DataLedger, DataRoot, LedgerChunkOffset, PackedChunk, TxChunkOffset,
+    UnpackedChunk,
 };
 use tracing::debug;
 
@@ -33,6 +34,26 @@ impl ChunkProvider {
             get_storage_module_at_offset(&self.storage_modules_guard, ledger, ledger_offset)
                 .ok_or_eyre("No storage module contains this chunk")?;
         module.generate_full_chunk_ledger_offset(ledger_offset)
+    }
+
+    /// Retrieves a chunk from a ledger and unpacks it (entropy recompute + XOR + tail trim).
+    ///
+    /// `Ok(None)` when the offset holds no stored chunk; `Err` when no storage module covers it.
+    pub fn get_unpacked_chunk_by_ledger_offset(
+        &self,
+        ledger: DataLedger,
+        ledger_offset: LedgerChunkOffset,
+    ) -> eyre::Result<Option<UnpackedChunk>> {
+        let Some(packed) = self.get_chunk_by_ledger_offset(ledger, ledger_offset)? else {
+            return Ok(None);
+        };
+        let consensus = &self.config.consensus;
+        Ok(Some(irys_packing::unpack(
+            &packed,
+            consensus.entropy_packing_iterations,
+            consensus.chunk_size as usize,
+            consensus.chain_id,
+        )))
     }
 
     /// Retrieves a chunk by [`DataRoot`]

--- a/crates/types/src/block_stream.rs
+++ b/crates/types/src/block_stream.rs
@@ -68,7 +68,6 @@ pub struct TxMeta {
     pub signer: OwnerId,
     pub data_root: H256,
     pub data_size: u64,
-    /// PR 1450; `0` / zeroed until it lands.
     pub prefix_size: u64,
     pub prefix_hash: H256,
     pub ledger_id: u32,
@@ -183,7 +182,10 @@ impl BlockEvent {
                 tx_ids: dl.tx_ids.0.clone(),
                 total_chunks: dl.total_chunks,
                 required_proof_count: u32::from(dl.required_proof_count.unwrap_or(0)),
-                proof_count: dl.proofs.as_ref().map_or(0, |p| p.0.len() as u32),
+                proof_count: dl
+                    .proofs
+                    .as_ref()
+                    .map_or(0, |p| u32::try_from(p.0.len()).unwrap_or(u32::MAX)),
             });
 
             let Ok(ledger) = DataLedger::try_from(dl.ledger_id) else {
@@ -200,11 +202,11 @@ impl BlockEvent {
                     signer: OwnerId::ethereum(&tx.signer),
                     data_root: tx.data_root,
                     data_size: tx.data_size,
-                    prefix_size: 0,
-                    prefix_hash: H256::zero(),
+                    prefix_size: tx.prefix_size,
+                    prefix_hash: tx.prefix_hash,
                     ledger_id: dl.ledger_id,
                     metadata_format: tx.metadata_format,
-                    tx_position: i as u32,
+                    tx_position: u32::try_from(i).unwrap_or(u32::MAX),
                     tx_start_offset: offsets[i],
                     promoted_height: tx.promoted_height(),
                 });
@@ -216,7 +218,7 @@ impl BlockEvent {
                 height: header.height,
                 block_hash: header.block_hash,
                 previous_block_hash: header.previous_block_hash,
-                timestamp: header.timestamp.as_millis() as u64,
+                timestamp: u64::try_from(header.timestamp.as_millis()).unwrap_or(u64::MAX),
                 miner_address: OwnerId::ethereum(&header.miner_address),
                 data_ledgers,
             },

--- a/crates/types/src/block_stream.rs
+++ b/crates/types/src/block_stream.rs
@@ -9,9 +9,10 @@
 use crate::{DataLedger, DataTransactionHeader, H256, IrysAddress, IrysBlockHeader, SealedBlock};
 use base58::{FromBase58 as _, ToBase58 as _};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::borrow::Cow;
 
 /// One stream frame: a monotonic `seq` flattened beside a `kind`-tagged event.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Serialize)]
 pub struct StreamFrame {
     pub seq: u64,
     #[serde(flatten)]
@@ -21,7 +22,7 @@ pub struct StreamFrame {
 /// A page of [`StreamFrame`]s served by the `GET /internal/blocks/events` poll endpoint, with the cursor
 /// metadata a follower needs to advance: the next `seq` to request, whether more is available now, the
 /// lowest `seq` still retained, and whether the requested cursor fell below that retained floor.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Serialize)]
 pub struct EventsPage {
     pub from_seq: u64,
     pub frames: Vec<StreamFrame>,
@@ -166,7 +167,7 @@ impl BlockEvent {
         let header = block.header();
         let txns = block.transactions();
         Self::build(header, chunk_size, |ledger| {
-            txns.get_ledger_txs(ledger).to_vec()
+            Cow::Borrowed(txns.get_ledger_txs(ledger))
         })
     }
 
@@ -174,16 +175,16 @@ impl BlockEvent {
     /// resolver returns the ordered tx headers for a ledger (e.g. from the DB).
     pub fn from_header_and_txs(
         header: &IrysBlockHeader,
-        ledger_txs: impl FnMut(DataLedger) -> Vec<DataTransactionHeader>,
+        mut ledger_txs: impl FnMut(DataLedger) -> Vec<DataTransactionHeader>,
         chunk_size: u64,
     ) -> Self {
-        Self::build(header, chunk_size, ledger_txs)
+        Self::build(header, chunk_size, |ledger| Cow::Owned(ledger_txs(ledger)))
     }
 
-    fn build(
+    fn build<'a>(
         header: &IrysBlockHeader,
         chunk_size: u64,
-        mut ledger_txs: impl FnMut(DataLedger) -> Vec<DataTransactionHeader>,
+        mut ledger_txs: impl FnMut(DataLedger) -> Cow<'a, [DataTransactionHeader]>,
     ) -> Self {
         let mut data_ledgers = Vec::with_capacity(header.data_ledgers.len());
         let mut txs = Vec::new();
@@ -192,7 +193,7 @@ impl BlockEvent {
             data_ledgers.push(DataLedgerEntry {
                 ledger_id: dl.ledger_id,
                 tx_root: dl.tx_root,
-                tx_ids: dl.tx_ids.0.clone(),
+                tx_ids: dl.tx_ids.0.clone(), // clone: the response owns its serialized tx-id list
                 total_chunks: dl.total_chunks,
                 required_proof_count: u32::from(dl.required_proof_count.unwrap_or(0)),
                 proof_count: dl
@@ -221,7 +222,11 @@ impl BlockEvent {
                     metadata_format: tx.metadata_format,
                     tx_position: u32::try_from(i).unwrap_or(u32::MAX),
                     tx_start_offset: offsets[i],
-                    promoted_height: tx.promoted_height(),
+                    promoted_height: if ledger == DataLedger::Publish {
+                        Some(header.height)
+                    } else {
+                        tx.promoted_height()
+                    },
                 });
             }
         }
@@ -272,6 +277,7 @@ impl StreamFrame {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{DataTransactionLedger, H256List};
 
     fn sample_block_event(h: H256) -> BlockEvent {
         BlockEvent {
@@ -401,5 +407,21 @@ mod tests {
         assert_eq!(start_offsets(3, &[1, 2], 1), vec![0, 1]);
         // rounding up: 3 bytes at chunk_size 2 ⇒ 2 chunks
         assert_eq!(start_offsets(2, &[3], 2), vec![0]);
+    }
+
+    #[test]
+    fn publish_transaction_uses_containing_block_as_promotion_height() {
+        let mut header = IrysBlockHeader::default();
+        header.height = 23;
+        header.data_ledgers = vec![DataTransactionLedger {
+            ledger_id: DataLedger::Publish.into(),
+            tx_ids: H256List(vec![H256::zero()]),
+            ..Default::default()
+        }];
+
+        let event =
+            BlockEvent::from_header_and_txs(&header, |_| vec![DataTransactionHeader::default()], 1);
+
+        assert_eq!(event.txs[0].promoted_height, Some(23));
     }
 }

--- a/crates/types/src/block_stream.rs
+++ b/crates/types/src/block_stream.rs
@@ -18,6 +18,19 @@ pub struct StreamFrame {
     pub event: StreamEvent,
 }
 
+/// A page of [`StreamFrame`]s served by the `GET /internal/blocks/events` poll endpoint, with the cursor
+/// metadata a follower needs to advance: the next `seq` to request, whether more is available now, the
+/// lowest `seq` still retained, and whether the requested cursor fell below that retained floor.
+#[derive(Debug, Clone, Serialize)]
+pub struct EventsPage {
+    pub from_seq: u64,
+    pub frames: Vec<StreamFrame>,
+    pub next_seq: u64,
+    pub has_more: bool,
+    pub lowest_retained_seq: u64,
+    pub truncated: bool,
+}
+
 /// The tagged event payload. `kind` is lowercase; `observed`/`finalized` flatten a [`BlockEvent`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "lowercase")]

--- a/crates/types/src/block_stream.rs
+++ b/crates/types/src/block_stream.rs
@@ -1,0 +1,390 @@
+//! Wire types for the node-internal block-stream contract (`/internal/blocks/*`).
+//!
+//! These are response-only shapes consumed by the gateway block follower. Hash fields serialise as
+//! base58 (the node's default [`H256`] serde); account ids use the gateway's `OwnerId { sig_type,
+//! bytes }` encoding. They are built from data the node already holds — sealed blocks on the stream
+//! paths, header + resolved tx headers on the read paths — and are never derived onto the consensus
+//! types directly.
+
+use crate::{DataLedger, DataTransactionHeader, H256, IrysAddress, IrysBlockHeader, SealedBlock};
+use base58::{FromBase58 as _, ToBase58 as _};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// One stream frame: a monotonic `seq` flattened beside a `kind`-tagged event.
+#[derive(Debug, Clone, Serialize)]
+pub struct StreamFrame {
+    pub seq: u64,
+    #[serde(flatten)]
+    pub event: StreamEvent,
+}
+
+/// The tagged event payload. `kind` is lowercase; `observed`/`finalized` flatten a [`BlockEvent`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum StreamEvent {
+    Observed(BlockEvent),
+    Finalized(BlockEvent),
+    Reorged {
+        fork_parent: BlockRef,
+        /// Orphaned (old-fork) blocks, ascending by height.
+        orphaned: Vec<BlockEvent>,
+        /// Winning (new-fork) blocks, ascending by height.
+        new_fork: Vec<BlockEvent>,
+    },
+}
+
+/// A block header view plus its per-transaction metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockEvent {
+    pub header: BlockHeaderView,
+    pub txs: Vec<TxMeta>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockHeaderView {
+    pub height: u64,
+    pub block_hash: H256,
+    pub previous_block_hash: H256,
+    /// Milliseconds since the Unix epoch.
+    pub timestamp: u64,
+    pub miner_address: OwnerId,
+    pub data_ledgers: Vec<DataLedgerEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DataLedgerEntry {
+    pub ledger_id: u32,
+    pub tx_root: H256,
+    pub tx_ids: Vec<H256>,
+    pub total_chunks: u64,
+    pub required_proof_count: u32,
+    pub proof_count: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TxMeta {
+    pub tx_id: H256,
+    pub anchor: H256,
+    pub signer: OwnerId,
+    pub data_root: H256,
+    pub data_size: u64,
+    /// PR 1450; `0` / zeroed until it lands.
+    pub prefix_size: u64,
+    pub prefix_hash: H256,
+    pub ledger_id: u32,
+    pub metadata_format: u8,
+    /// Index of this tx within its ledger, in block order.
+    pub tx_position: u32,
+    /// Absolute chunk offset of this tx within its ledger.
+    pub tx_start_offset: u64,
+    pub promoted_height: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockRef {
+    pub height: u64,
+    pub block_hash: H256,
+}
+
+/// Gateway `OwnerId` encoding: a signature-scheme discriminant plus the base58 of the 20-byte address.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OwnerId {
+    pub sig_type: u16,
+    #[serde(
+        serialize_with = "serialize_base58",
+        deserialize_with = "deserialize_base58"
+    )]
+    pub bytes: Vec<u8>,
+}
+
+/// Ethereum / secp256k1 discriminant, matching the reference producer's frames.
+const SIG_TYPE_ETHEREUM: u16 = 0;
+
+impl OwnerId {
+    fn ethereum(addr: &IrysAddress) -> Self {
+        Self {
+            sig_type: SIG_TYPE_ETHEREUM,
+            bytes: addr.0.as_slice().to_vec(),
+        }
+    }
+}
+
+fn serialize_base58<S: Serializer>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error> {
+    serializer.serialize_str(&bytes.to_base58())
+}
+
+fn deserialize_base58<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Vec<u8>, D::Error> {
+    use serde::de::Error as _;
+    let encoded = String::deserialize(deserializer)?;
+    encoded
+        .from_base58()
+        .map_err(|e| D::Error::custom(format!("invalid base58: {e:?}")))
+}
+
+/// Chunks occupied by a transaction of `data_size` bytes, rounding up.
+fn ceil_chunks(data_size: u64, chunk_size: u64) -> u64 {
+    if chunk_size == 0 {
+        return 0;
+    }
+    data_size.div_ceil(chunk_size)
+}
+
+/// Absolute per-tx start offsets within a ledger, derived from the ledger's post-block `total_chunks`.
+///
+/// The pre-block cursor is `total_chunks` minus the chunks this block's transactions added, so each
+/// tx's start accumulates from there in block order. This needs only the block in hand — no parent
+/// lookup.
+fn start_offsets(total_chunks: u64, data_sizes: &[u64], chunk_size: u64) -> Vec<u64> {
+    let block_chunks: u64 = data_sizes.iter().map(|&s| ceil_chunks(s, chunk_size)).sum();
+    let mut cursor = total_chunks.saturating_sub(block_chunks);
+    data_sizes
+        .iter()
+        .map(|&s| {
+            let start = cursor;
+            cursor += ceil_chunks(s, chunk_size);
+            start
+        })
+        .collect()
+}
+
+impl BlockEvent {
+    /// Build from a sealed block (stream paths): header view plus a [`TxMeta`] per data transaction,
+    /// in ledger order.
+    pub fn from_sealed(block: &SealedBlock, chunk_size: u64) -> Self {
+        let header = block.header();
+        let txns = block.transactions();
+        Self::build(header, chunk_size, |ledger| {
+            txns.get_ledger_txs(ledger).to_vec()
+        })
+    }
+
+    /// Build from a header and a per-ledger resolver of transaction headers (read paths). The
+    /// resolver returns the ordered tx headers for a ledger (e.g. from the DB).
+    pub fn from_header_and_txs(
+        header: &IrysBlockHeader,
+        ledger_txs: impl FnMut(DataLedger) -> Vec<DataTransactionHeader>,
+        chunk_size: u64,
+    ) -> Self {
+        Self::build(header, chunk_size, ledger_txs)
+    }
+
+    fn build(
+        header: &IrysBlockHeader,
+        chunk_size: u64,
+        mut ledger_txs: impl FnMut(DataLedger) -> Vec<DataTransactionHeader>,
+    ) -> Self {
+        let mut data_ledgers = Vec::with_capacity(header.data_ledgers.len());
+        let mut txs = Vec::new();
+
+        for dl in &header.data_ledgers {
+            data_ledgers.push(DataLedgerEntry {
+                ledger_id: dl.ledger_id,
+                tx_root: dl.tx_root,
+                tx_ids: dl.tx_ids.0.clone(),
+                total_chunks: dl.total_chunks,
+                required_proof_count: u32::from(dl.required_proof_count.unwrap_or(0)),
+                proof_count: dl.proofs.as_ref().map_or(0, |p| p.0.len() as u32),
+            });
+
+            let Ok(ledger) = DataLedger::try_from(dl.ledger_id) else {
+                continue;
+            };
+            let ledger_headers = ledger_txs(ledger);
+            let sizes: Vec<u64> = ledger_headers.iter().map(|t| t.data_size).collect();
+            let offsets = start_offsets(dl.total_chunks, &sizes, chunk_size);
+
+            for (i, tx) in ledger_headers.iter().enumerate() {
+                txs.push(TxMeta {
+                    tx_id: tx.id,
+                    anchor: tx.anchor,
+                    signer: OwnerId::ethereum(&tx.signer),
+                    data_root: tx.data_root,
+                    data_size: tx.data_size,
+                    prefix_size: 0,
+                    prefix_hash: H256::zero(),
+                    ledger_id: dl.ledger_id,
+                    metadata_format: tx.metadata_format,
+                    tx_position: i as u32,
+                    tx_start_offset: offsets[i],
+                    promoted_height: tx.promoted_height(),
+                });
+            }
+        }
+
+        Self {
+            header: BlockHeaderView {
+                height: header.height,
+                block_hash: header.block_hash,
+                previous_block_hash: header.previous_block_hash,
+                timestamp: header.timestamp.as_millis() as u64,
+                miner_address: OwnerId::ethereum(&header.miner_address),
+                data_ledgers,
+            },
+            txs,
+        }
+    }
+}
+
+impl StreamFrame {
+    /// The lowercase frame kind, for routing on the consumer side and in tests.
+    pub fn kind(&self) -> &'static str {
+        match self.event {
+            StreamEvent::Observed(_) => "observed",
+            StreamEvent::Finalized(_) => "finalized",
+            StreamEvent::Reorged { .. } => "reorged",
+        }
+    }
+
+    /// The block hash for `observed`/`finalized` frames; `None` for `reorged`.
+    pub fn block_hash(&self) -> Option<H256> {
+        match &self.event {
+            StreamEvent::Observed(b) | StreamEvent::Finalized(b) => Some(b.header.block_hash),
+            StreamEvent::Reorged { .. } => None,
+        }
+    }
+
+    /// The data_roots carried by an `observed`/`finalized` frame; empty for `reorged`.
+    pub fn data_roots(&self) -> Vec<H256> {
+        match &self.event {
+            StreamEvent::Observed(b) | StreamEvent::Finalized(b) => {
+                b.txs.iter().map(|t| t.data_root).collect()
+            }
+            StreamEvent::Reorged { .. } => Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_block_event(h: H256) -> BlockEvent {
+        BlockEvent {
+            header: BlockHeaderView {
+                height: 8,
+                block_hash: h,
+                previous_block_hash: h,
+                timestamp: 1_718_600_000_000,
+                miner_address: OwnerId {
+                    sig_type: 0,
+                    bytes: vec![1_u8; 20],
+                },
+                data_ledgers: vec![DataLedgerEntry {
+                    ledger_id: 1,
+                    tx_root: h,
+                    tx_ids: vec![h],
+                    total_chunks: 12,
+                    required_proof_count: 1,
+                    proof_count: 0,
+                }],
+            },
+            txs: vec![TxMeta {
+                tx_id: h,
+                anchor: h,
+                signer: OwnerId {
+                    sig_type: 0,
+                    bytes: vec![1_u8; 20],
+                },
+                data_root: h,
+                data_size: 1024,
+                prefix_size: 0,
+                prefix_hash: H256::zero(),
+                ledger_id: 1,
+                metadata_format: 0,
+                tx_position: 0,
+                tx_start_offset: 0,
+                promoted_height: None,
+            }],
+        }
+    }
+
+    #[test]
+    fn observed_frame_serialises_to_contract_json() {
+        let h = H256::from([7_u8; 32]);
+        let frame = StreamFrame {
+            seq: 42,
+            event: StreamEvent::Observed(sample_block_event(h)),
+        };
+        let v: serde_json::Value = serde_json::to_value(&frame).unwrap();
+        assert_eq!(v["seq"], 42);
+        assert_eq!(v["kind"], "observed"); // flattened beside seq, lowercase
+        assert_eq!(
+            v["header"]["block_hash"]
+                .as_str()
+                .unwrap()
+                .from_base58()
+                .unwrap(),
+            vec![7_u8; 32]
+        );
+        assert_eq!(v["header"]["miner_address"]["sig_type"], 0);
+        assert!(v["header"]["miner_address"]["bytes"].is_string());
+        assert_eq!(v["txs"][0]["promoted_height"], serde_json::Value::Null);
+        assert_eq!(
+            v["txs"][0]["data_root"]
+                .as_str()
+                .unwrap()
+                .from_base58()
+                .unwrap(),
+            vec![7_u8; 32]
+        );
+    }
+
+    #[test]
+    fn reorged_frame_has_batch_shape() {
+        let h = H256::from([3_u8; 32]);
+        let frame = StreamFrame {
+            seq: 44,
+            event: StreamEvent::Reorged {
+                fork_parent: BlockRef {
+                    height: 7,
+                    block_hash: h,
+                },
+                orphaned: vec![],
+                new_fork: vec![],
+            },
+        };
+        let v = serde_json::to_value(&frame).unwrap();
+        assert_eq!(v["kind"], "reorged");
+        assert_eq!(v["fork_parent"]["height"], 7);
+        assert!(v["orphaned"].is_array() && v["new_fork"].is_array());
+    }
+
+    #[test]
+    fn event_json_round_trips_for_log_replay() {
+        // The producer stores the StreamEvent JSON and rebuilds a typed frame on replay.
+        let h = H256::from([9_u8; 32]);
+        let event = StreamEvent::Observed(sample_block_event(h));
+        let bytes = serde_json::to_vec(&event).unwrap();
+        let decoded: StreamEvent = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            serde_json::to_value(&event).unwrap(),
+            serde_json::to_value(&decoded).unwrap()
+        );
+        // A frame built from the decoded event serialises with seq + kind at top level.
+        let frame = StreamFrame {
+            seq: 5,
+            event: decoded,
+        };
+        let v = serde_json::to_value(&frame).unwrap();
+        assert_eq!(v["seq"], 5);
+        assert_eq!(v["kind"], "observed");
+        assert_eq!(
+            v["header"]["block_hash"]
+                .as_str()
+                .unwrap()
+                .from_base58()
+                .unwrap(),
+            vec![9_u8; 32]
+        );
+    }
+
+    #[test]
+    fn tx_start_offset_accumulates_from_pre_block_cursor() {
+        // ledger total_chunks = 10; two txs sized 1 and 2 chunks (chunk_size 1) ⇒ pre-block = 7 ⇒ [7, 8]
+        assert_eq!(start_offsets(10, &[1, 2], 1), vec![7, 8]);
+        // genesis: total equals this block's chunks ⇒ starts at 0
+        assert_eq!(start_offsets(3, &[1, 2], 1), vec![0, 1]);
+        // rounding up: 3 bytes at chunk_size 2 ⇒ 2 chunks
+        assert_eq!(start_offsets(2, &[3], 2), vec![0]);
+    }
+}

--- a/crates/types/src/block_stream.rs
+++ b/crates/types/src/block_stream.rs
@@ -129,9 +129,16 @@ fn serialize_base58<S: Serializer>(bytes: &[u8], serializer: S) -> Result<S::Ok,
 fn deserialize_base58<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Vec<u8>, D::Error> {
     use serde::de::Error as _;
     let encoded = String::deserialize(deserializer)?;
-    encoded
+    let bytes = encoded
         .from_base58()
-        .map_err(|e| D::Error::custom(format!("invalid base58: {e:?}")))
+        .map_err(|e| D::Error::custom(format!("invalid base58: {e:?}")))?;
+    if bytes.len() != 20 {
+        return Err(D::Error::custom(format!(
+            "invalid owner address length: expected 20 bytes, got {}",
+            bytes.len()
+        )));
+    }
+    Ok(bytes)
 }
 
 /// Chunks occupied by a transaction of `data_size` bytes, rounding up.

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -1098,6 +1098,8 @@ mod tests {
         expected_config.gossip.bind_ip = Some("127.0.0.1".to_string());
         expected_config.http.public_ip = Some("127.0.0.1".to_string());
         expected_config.http.bind_ip = Some("127.0.0.1".to_string());
+        // TOML omits `expose_internal_api`, so it defaults to `false`; `testing()` sets it `true`.
+        expected_config.http.expose_internal_api = false;
         expected_config.reth.network.public_ip = Some("0.0.0.0".to_string());
         expected_config.reth.network.bind_ip = Some("0.0.0.0".to_string());
         // TOML doesn't include these fields, so they default to production values

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -1098,7 +1098,6 @@ mod tests {
         expected_config.gossip.bind_ip = Some("127.0.0.1".to_string());
         expected_config.http.public_ip = Some("127.0.0.1".to_string());
         expected_config.http.bind_ip = Some("127.0.0.1".to_string());
-        // TOML omits `expose_internal_api`, so it defaults to `false`; `testing()` sets it `true`.
         expected_config.http.expose_internal_api = false;
         expected_config.reth.network.public_ip = Some("0.0.0.0".to_string());
         expected_config.reth.network.bind_ip = Some("0.0.0.0".to_string());

--- a/crates/types/src/config/node.rs
+++ b/crates/types/src/config/node.rs
@@ -642,6 +642,12 @@ pub struct HttpConfig {
     /// Actix worker count. Defaults to half the available system threads.
     #[serde(default = "default_actix_workers")]
     pub actix_workers: usize,
+    /// Whether to mount the node-internal `/internal/*` endpoints (block-stream SSE + canonical
+    /// block reads) on this HTTP listener. Off by default: these routes carry no application-layer
+    /// authentication, so enable them only on a node whose HTTP bind is restricted to a trusted
+    /// gateway at the network layer (firewall / reverse proxy / bind address).
+    #[serde(default)]
+    pub expose_internal_api: bool,
 }
 
 impl_network_config_with_defaults!(HttpConfig);
@@ -1164,6 +1170,8 @@ impl NodeConfig {
                 bind_ip: None,
                 bind_port: 0,
                 actix_workers: default_actix_workers(),
+                // Test nodes bind locally and are trusted, so expose the internal block-follower API.
+                expose_internal_api: true,
             },
             mempool: MempoolNodeConfig {
                 max_pending_pledge_items: 100,
@@ -1348,6 +1356,9 @@ impl NodeConfig {
                 bind_ip: None,
                 bind_port: 8080,
                 actix_workers: default_actix_workers(),
+                // Unauthenticated internal endpoints stay off by default; a gateway deployment opts
+                // in via `expose_internal_api` once its HTTP bind is network-restricted.
+                expose_internal_api: false,
             },
 
             mempool: MempoolNodeConfig {

--- a/crates/types/src/config/node.rs
+++ b/crates/types/src/config/node.rs
@@ -642,10 +642,10 @@ pub struct HttpConfig {
     /// Actix worker count. Defaults to half the available system threads.
     #[serde(default = "default_actix_workers")]
     pub actix_workers: usize,
-    /// Whether to mount the node-internal `/internal/*` endpoints (block-stream SSE + canonical
-    /// block reads) on this HTTP listener. Off by default: these routes carry no application-layer
-    /// authentication, so enable them only on a node whose HTTP bind is restricted to a trusted
-    /// gateway at the network layer (firewall / reverse proxy / bind address).
+    /// Whether to mount the node-internal `/internal/*` endpoints (block-stream SSE, canonical
+    /// block reads, unpacked chunk-range reads) on this HTTP listener. Off by default: these routes
+    /// carry no application-layer authentication, so enable them only on a node whose HTTP bind is
+    /// restricted to a trusted gateway at the network layer (firewall / reverse proxy / bind address).
     #[serde(default)]
     pub expose_internal_api: bool,
 }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -6,6 +6,7 @@ pub mod app_state;
 pub mod arbiter_handle;
 pub mod block;
 pub mod block_production;
+pub mod block_stream;
 pub mod chainspec;
 pub mod chunk;
 pub mod chunked;

--- a/docker/tests/data-sync/configs/irys-1.toml
+++ b/docker/tests/data-sync/configs/irys-1.toml
@@ -97,6 +97,7 @@ block_tree_depth = 50
 num_chunks_in_partition = 60
 num_chunks_in_recall_range = 10
 num_partitions_per_slot = 3
+num_partitions_per_term_ledger_slot = 3
 entropy_packing_iterations = 1000
 safe_minimum_number_of_years = 200
 stake_value = 20000.0

--- a/docker/tests/data-sync/configs/irys-1.toml
+++ b/docker/tests/data-sync/configs/irys-1.toml
@@ -85,6 +85,10 @@ max_commitments_per_address = 20
 
 [vdf]
 parallel_verification_thread_limit = 1
+# Raised from the 15s default: under this cluster's load a node's VDF clock can pause
+# >15s during fast-forward catch-up, tripping the never-mislabel stall panic. Node-local,
+# NOT consensus-hashed. See design/docs/vdf-validation-stall-detection.md
+progress_timeout_secs = 120
 
 [consensus.Custom]
 chain_id = 1270

--- a/docker/tests/data-sync/configs/irys-1.toml
+++ b/docker/tests/data-sync/configs/irys-1.toml
@@ -145,6 +145,10 @@ balance = "0x152cf4e72a974f1c0000"
 [consensus.Custom.reth.alloc.0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC]
 balance = "0x152cf4e72a974f1c0000"
 
+# netwatch data-upload probe signer (key.hex)
+[consensus.Custom.reth.alloc.0x8b2e5fbf97c990dfc06b3c1fe1639a4a694901ee]
+balance = "0x152cf4e72a974f1c0000"
+
 [consensus.Custom.mempool]
 max_data_txs_per_block = 100
 max_commitment_txs_per_block = 100

--- a/docker/tests/data-sync/configs/irys-2.toml
+++ b/docker/tests/data-sync/configs/irys-2.toml
@@ -146,6 +146,10 @@ balance = "0x152cf4e72a974f1c0000"
 [consensus.Custom.reth.alloc.0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC]
 balance = "0x152cf4e72a974f1c0000"
 
+# netwatch data-upload probe signer (key.hex)
+[consensus.Custom.reth.alloc.0x8b2e5fbf97c990dfc06b3c1fe1639a4a694901ee]
+balance = "0x152cf4e72a974f1c0000"
+
 [consensus.Custom.mempool]
 max_data_txs_per_block = 100
 max_commitment_txs_per_block = 100

--- a/docker/tests/data-sync/configs/irys-2.toml
+++ b/docker/tests/data-sync/configs/irys-2.toml
@@ -85,6 +85,10 @@ max_commitments_per_address = 20
 
 [vdf]
 parallel_verification_thread_limit = 8
+# Raised from the 15s default: under this cluster's load a node's VDF clock can pause
+# >15s during fast-forward catch-up, tripping the never-mislabel stall panic. Node-local,
+# NOT consensus-hashed. See design/docs/vdf-validation-stall-detection.md
+progress_timeout_secs = 120
 
 [consensus.Custom]
 expected_genesis_hash = ""
@@ -109,8 +113,8 @@ minimum_term_fee_usd = 0.01
 
 [consensus.Custom.genesis]
 timestamp_millis = 0
-miner_address = "0x951AA3768fE8d51DbC348520b0825C0c1f197277"
-reward_address = "0x951AA3768fE8d51DbC348520b0825C0c1f197277"
+miner_address = "0x10605A299777D44BE5373D120d5479f07860325d"
+reward_address = "0x10605A299777D44BE5373D120d5479f07860325d"
 last_epoch_hash = "11111111111111111111111111111111"
 vdf_seed = "11111111111111111111111111111111"
 genesis_price = 1.0
@@ -159,7 +163,7 @@ min_difficulty_adjustment_factor = "0.25"
 [consensus.Custom.vdf]
 reset_frequency = 2000
 num_checkpoints_in_vdf_step = 25
-max_allowed_vdf_fork_steps = 120000
+max_allowed_vdf_fork_steps = 60000
 sha_1s_difficulty = 100000
 
 [consensus.Custom.block_reward_config]

--- a/docker/tests/data-sync/configs/irys-2.toml
+++ b/docker/tests/data-sync/configs/irys-2.toml
@@ -98,6 +98,7 @@ block_tree_depth = 50
 num_chunks_in_partition = 60
 num_chunks_in_recall_range = 10
 num_partitions_per_slot = 3
+num_partitions_per_term_ledger_slot = 3
 entropy_packing_iterations = 1000
 safe_minimum_number_of_years = 200
 stake_value = 20000.0

--- a/docker/tests/data-sync/configs/irys-3.toml
+++ b/docker/tests/data-sync/configs/irys-3.toml
@@ -85,6 +85,10 @@ max_commitments_per_address = 20
 
 [vdf]
 parallel_verification_thread_limit = 8
+# Raised from the 15s default: under this cluster's load a node's VDF clock can pause
+# >15s during fast-forward catch-up, tripping the never-mislabel stall panic. Node-local,
+# NOT consensus-hashed. See design/docs/vdf-validation-stall-detection.md
+progress_timeout_secs = 120
 
 [consensus.Custom]
 expected_genesis_hash = ""
@@ -109,8 +113,8 @@ minimum_term_fee_usd = 0.01
 
 [consensus.Custom.genesis]
 timestamp_millis = 0
-miner_address = "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
-reward_address = "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
+miner_address = "0x10605A299777D44BE5373D120d5479f07860325d"
+reward_address = "0x10605A299777D44BE5373D120d5479f07860325d"
 last_epoch_hash = "11111111111111111111111111111111"
 vdf_seed = "11111111111111111111111111111111"
 genesis_price = 1.0
@@ -159,7 +163,7 @@ min_difficulty_adjustment_factor = "0.25"
 [consensus.Custom.vdf]
 reset_frequency = 2000
 num_checkpoints_in_vdf_step = 25
-max_allowed_vdf_fork_steps = 120000
+max_allowed_vdf_fork_steps = 60000
 sha_1s_difficulty = 100000
 
 [consensus.Custom.block_reward_config]

--- a/docker/tests/data-sync/configs/irys-3.toml
+++ b/docker/tests/data-sync/configs/irys-3.toml
@@ -146,6 +146,10 @@ balance = "0x152cf4e72a974f1c0000"
 [consensus.Custom.reth.alloc.0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC]
 balance = "0x152cf4e72a974f1c0000"
 
+# netwatch data-upload probe signer (key.hex)
+[consensus.Custom.reth.alloc.0x8b2e5fbf97c990dfc06b3c1fe1639a4a694901ee]
+balance = "0x152cf4e72a974f1c0000"
+
 [consensus.Custom.mempool]
 max_data_txs_per_block = 100
 max_commitment_txs_per_block = 100

--- a/docker/tests/data-sync/configs/irys-3.toml
+++ b/docker/tests/data-sync/configs/irys-3.toml
@@ -98,6 +98,7 @@ block_tree_depth = 50
 num_chunks_in_partition = 60
 num_chunks_in_recall_range = 10
 num_partitions_per_slot = 3
+num_partitions_per_term_ledger_slot = 3
 entropy_packing_iterations = 1000
 safe_minimum_number_of_years = 200
 stake_value = 20000.0

--- a/docker/tests/data-sync/scripts/start_peer_with_auto_restart.sh
+++ b/docker/tests/data-sync/scripts/start_peer_with_auto_restart.sh
@@ -145,7 +145,7 @@ monitor_and_restart() {
 
     # "Stuck" only if >0 and equal
     if [[ "$height" -gt 0 && "$height" -eq "$last_height" ]]; then
-      ((stuck_count++))
+      stuck_count=$((stuck_count + 1))
       log "Stuck at height $height, count: $stuck_count"
 
       if [[ "$stuck_count" -ge "$STUCK_THRESHOLD" ]]; then
@@ -161,7 +161,7 @@ monitor_and_restart() {
 
 restart_node() {
   # Backoff grows with each restart up to a cap
-  ((RESTARTS++))
+  RESTARTS=$((RESTARTS + 1))
   local backoff=$(( RESTART_BACKOFF_BASE ** (RESTARTS-1) ))
   (( backoff > RESTART_BACKOFF_MAX_SEC )) && backoff="$RESTART_BACKOFF_MAX_SEC"
 

--- a/docs/90-services/06-rpc-api.md
+++ b/docs/90-services/06-rpc-api.md
@@ -5,9 +5,10 @@ block-event log two ways — a push stream and an equivalent paged poll — plus
 transports carry the **same** `StreamFrame`s from the **same** seq-keyed log, so a follower may use either
 and reach identical state.
 
-> **Security.** These routes carry no application-layer authentication and ride the same HTTP listener as
-> the public API. The deployment **must** restrict `/internal/*` at the network layer (firewall / reverse
-> proxy / bind address) to the trusted gateway.
+> **Security.** These routes carry no application-layer authentication. They are mounted only when the
+> node sets `http.expose_internal_api` (off by default); when enabled they ride the same HTTP listener as
+> the public API. A deployment that enables them **must** restrict `/internal/*` at the network layer
+> (firewall / reverse proxy / bind address) to the trusted gateway.
 
 ## The event log and its cursor
 
@@ -85,11 +86,11 @@ a `truncated` poll.
 - `200` for any valid `from_seq` / `limit`, including every cursor regime above.
 - `400` only for an unparsable `from_seq` / `limit`, or a range read exceeding `MAX_BLOCK_RANGE`.
 - `5xx` only on a genuine log-read fault.
-- **`404` means the endpoint is not deployed.** Both `/internal` routes are mounted unconditionally — there
-  is no runtime "disabled" mode — so a `404` is the normal not-found served by an older node build that
-  lacks the route. The gateway's transport selector treats `404` / connection-refused as "this transport is
-  unsupported" and falls back accordingly. The endpoints therefore never return `404` for an empty, short,
-  or out-of-range log.
+- **`404` means the endpoint is not available.** The `/internal` routes are mounted only when the node
+  sets `http.expose_internal_api` (off by default); a node with it disabled, or an older build that lacks
+  the route entirely, serves a normal not-found. The gateway's transport selector treats `404` /
+  connection-refused as "this transport is unsupported" and falls back accordingly. When the routes are
+  mounted they never return `404` for an empty, short, or out-of-range log.
 
 ## Limitation: log recreation (reset)
 

--- a/docs/90-services/06-rpc-api.md
+++ b/docs/90-services/06-rpc-api.md
@@ -1,9 +1,9 @@
-# Node-internal block-follower API (`/internal/blocks/*`)
+# Node-internal block-follower API (`/internal/*`)
 
-The `/internal/*` HTTP surface serves the gateway block follower. It exposes the node's durable
-block-event log two ways — a push stream and an equivalent paged poll — plus canonical block reads. Both
-transports carry the **same** `StreamFrame`s from the **same** seq-keyed log, so a follower may use either
-and reach identical state.
+The `/internal/*` HTTP surface serves the gateway block follower and its verification pipeline. It
+exposes the node's durable block-event log two ways — a push stream and an equivalent paged poll — plus
+canonical block reads and an unpacked chunk-range read. Both transports carry the **same** `StreamFrame`s
+from the **same** seq-keyed log, so a follower may use either and reach identical state.
 
 > **Security.** These routes carry no application-layer authentication. They are mounted only when the
 > node sets `http.expose_internal_api` (off by default); when enabled they ride the same HTTP listener as
@@ -81,10 +81,47 @@ SSE stream from `0`.
 These return current canonical state, not transition history; they back a follower's reconciliation after
 a `truncated` poll.
 
+## `GET /internal/chunks?ledger=&offset=from-to`
+
+The stored chunks of one inclusive absolute-ledger-offset span, **unpacked** (packing entropy reversed,
+tail chunk trimmed to the data). This backs the gateway's verification pipeline: the relay reads bodies
+back in 8-chunk windows to verify them against the block's committed `data_root`, and the data service
+acquires extents through the same route.
+
+**Query**
+
+- `ledger` — numeric `DataLedger` id (0 = Publish, 1 = Submit, 10 = OneYear, 20 = ThirtyDay).
+- `offset` — the inclusive span, `from-to`, in absolute ledger chunk offsets (the space `tx_start_offset`
+  in a `StreamFrame`'s `TxMeta` points into). The span is bounded by `MAX_CHUNK_SPAN` (64 chunks); a wider
+  span is `400`.
+
+**Response — `200 application/json`**
+
+```jsonc
+[
+  {
+    "ledger_id": 1,
+    "offset": 42,            // absolute ledger chunk offset
+    "bytes": [7, 0, 255],    // unpacked chunk data, plain integer array (not Base64)
+    "proof": [1, 2, 3]       // the chunk's data_path; validates against the tx's data_root
+  }
+]
+```
+
+`bytes` and `proof` are JSON integer arrays, unlike the `Base64` strings of the public chunk routes — the
+gateway decodes them as raw byte vectors.
+
+**Short reads.** A chunk the node does not hold is omitted from the array; a fully unstored span is `[]`.
+The response is still `200`: the gateway reads a shortfall as "this node lacks the range" and fails over
+to another node, so absence must stay distinguishable from a malformed request. Consumers must therefore
+size requests within `MAX_CHUNK_SPAN`, or a conforming node would answer with a permanently short page.
+
 ## Error and probe conventions
 
-- `200` for any valid `from_seq` / `limit`, including every cursor regime above.
-- `400` only for an unparsable `from_seq` / `limit`, or a range read exceeding `MAX_BLOCK_RANGE`.
+- `200` for any valid `from_seq` / `limit`, including every cursor regime above, and for any well-formed
+  chunk span (however little of it is stored).
+- `400` only for an unparsable `from_seq` / `limit`, a range read exceeding `MAX_BLOCK_RANGE`, or a chunk
+  request that is malformed (bad `ledger`, unparsable or inverted `offset`) or wider than `MAX_CHUNK_SPAN`.
 - `5xx` only on a genuine log-read fault.
 - **`404` means the endpoint is not available.** The `/internal` routes are mounted only when the node
   sets `http.expose_internal_api` (off by default); a node with it disabled, or an older build that lacks

--- a/docs/90-services/06-rpc-api.md
+++ b/docs/90-services/06-rpc-api.md
@@ -127,7 +127,18 @@ size requests within `MAX_CHUNK_SPAN`, or a conforming node would answer with a 
   sets `http.expose_internal_api` (off by default); a node with it disabled, or an older build that lacks
   the route entirely, serves a normal not-found. The gateway's transport selector treats `404` /
   connection-refused as "this transport is unsupported" and falls back accordingly. When the routes are
-  mounted they never return `404` for an empty, short, or out-of-range log.
+  mounted they never return `404` for an empty, short, or out-of-range log. The one exception is
+  `GET /internal/blocks/{height}`, whose `404` also means "no canonical block at that height" — a
+  transport prober must key on the stream/events routes, never on the by-height read.
+
+## Limitation: the crash window
+
+A signal is in-memory between its authoritative site and the producer's durable append, so the log
+is lossless only while the node runs: a crash inside that window loses the frame. For `finalized`
+the durable truth survives in the block index, and the producer reconciles the index tail against
+the log at startup, appending any missing `finalized` frames in height order. A lost `observed` or
+`reorged` frame is not replayed; a follower recovers the resulting state through the canonical
+reads, exactly as it does after a `truncated` poll.
 
 ## Limitation: log recreation (reset)
 

--- a/docs/90-services/06-rpc-api.md
+++ b/docs/90-services/06-rpc-api.md
@@ -1,1 +1,98 @@
- <!-- # RPC interface documentation and methods -->
+# Node-internal block-follower API (`/internal/blocks/*`)
+
+The `/internal/*` HTTP surface serves the gateway block follower. It exposes the node's durable
+block-event log two ways — a push stream and an equivalent paged poll — plus canonical block reads. Both
+transports carry the **same** `StreamFrame`s from the **same** seq-keyed log, so a follower may use either
+and reach identical state.
+
+> **Security.** These routes carry no application-layer authentication and ride the same HTTP listener as
+> the public API. The deployment **must** restrict `/internal/*` at the network layer (firewall / reverse
+> proxy / bind address) to the trusted gateway.
+
+## The event log and its cursor
+
+The node appends `observed` / `finalized` / `reorged` events to a durable, append-only log keyed by a
+monotonic `seq` (the 0-based append index). `seq` never rewinds or repeats within one log lifetime, so it
+is the follower's resume cursor — never height, which repeats across forks.
+
+The log is pruned: once it exceeds `RETENTION_EVENTS` (100,000) the oldest events are deleted (batched, so
+the retained count is ~100k with up to `PRUNE_INTERVAL` overshoot). Two quantities therefore matter:
+
+- **`logical_len`** — the highest `seq` ever appended, plus one. This is *not* the retained row count;
+  after pruning they differ.
+- **`lowest_retained_seq`** — the lowest `seq` still held (the prune floor). It advances over time.
+
+## `GET /internal/blocks/stream?from_seq=`
+
+A Server-Sent Events stream. Replays the durable suffix from `from_seq`, then tails live frames, each
+framed as `data: {json}\n\n`. A lagging subscriber is dropped and reconnects with `from_seq` to replay
+from the log. The connection does not close on its own; a reader stops at a chosen `seq`.
+
+## `GET /internal/blocks/events?from_seq=&limit=`
+
+The poll half: a bounded JSON page over the same log, for consumers that cannot hold a stream open. It
+registers no live subscriber and reads in a single transaction.
+
+**Query**
+
+- `from_seq` — inclusive resume cursor; default `0`.
+- `limit` — page size; default `256`, clamped to `MAX_PAGE` (1024). Over-size is clamped, not rejected.
+  `limit=0` is a valid zero-frame probe.
+
+**Response — `200 application/json`**
+
+```jsonc
+{
+  "from_seq": 100,              // echoed
+  "frames": [ /* StreamFrame, ascending seq, contiguous from the page's start */ ],
+  "next_seq": 164,              // start + frames.len(); the next poll's from_seq
+  "has_more": true,             // next_seq < logical_len
+  "lowest_retained_seq": 0,     // prune floor (0 if unpruned)
+  "truncated": false            // true iff from_seq < lowest_retained_seq
+}
+```
+
+**Cursor regimes** (all `200`):
+
+| `from_seq` vs the window | behaviour | `truncated` |
+| --- | --- | --- |
+| in-window / at-tip (`lowest_retained_seq..=logical_len`) | page from `from_seq`; `from_seq == logical_len` is a normal empty page (caught up) | `false` |
+| below the floor (`< lowest_retained_seq`) | page from `lowest_retained_seq`; the requested span was pruned | `true` |
+| beyond the tip (`> logical_len`) | clamp to `lowest_retained_seq` (`0` on a fresh log) | `false` |
+
+A `truncated` page tells the follower its requested span is gone; it re-bootstraps current state (the
+reads below) and resumes streaming from `lowest_retained_seq`. The endpoint never silently returns a page
+whose first `seq` exceeds `from_seq` without `truncated`.
+
+**Equivalence.** For every in-window `seq`, the frame `/events` returns equals the frame the SSE stream
+would push for that `seq`; concatenating poll pages from `from_seq=0` yields the identical sequence as the
+SSE stream from `0`.
+
+## Canonical reads
+
+- `GET /internal/blocks/{height}` — the canonical block at `height` as a `BlockEvent`, or `404`.
+- `GET /internal/blocks?from_height=&to_height=` — the canonical blocks in `[from, to]`, ascending. The
+  span is bounded by `MAX_BLOCK_RANGE` (1000); a larger span is `400`.
+
+These return current canonical state, not transition history; they back a follower's reconciliation after
+a `truncated` poll.
+
+## Error and probe conventions
+
+- `200` for any valid `from_seq` / `limit`, including every cursor regime above.
+- `400` only for an unparsable `from_seq` / `limit`, or a range read exceeding `MAX_BLOCK_RANGE`.
+- `5xx` only on a genuine log-read fault.
+- **`404` means the endpoint is not deployed.** Both `/internal` routes are mounted unconditionally — there
+  is no runtime "disabled" mode — so a `404` is the normal not-found served by an older node build that
+  lacks the route. The gateway's transport selector treats `404` / connection-refused as "this transport is
+  unsupported" and falls back accordingly. The endpoints therefore never return `404` for an empty, short,
+  or out-of-range log.
+
+## Limitation: log recreation (reset)
+
+`seq` is node-local and not stable across a log recreation. The log is stripped from snapshots, so a
+snapshot restore or DB wipe restarts it at `seq 0` while block headers survive. The beyond-tip clamp gives
+only *partial* reset detection (it fires only when the follower's cursor exceeds the new, shorter log's
+tip), and low-`seq` frames do not by themselves recover lost history. Robust handling needs a
+generation/epoch identifier — a `(stream_id, seq)` cursor across both transports — which is a planned
+follow-up. For now a node reset requires an operator-coordinated follower re-bootstrap.

--- a/docs/90-services/06-rpc-api.md
+++ b/docs/90-services/06-rpc-api.md
@@ -26,7 +26,9 @@ the retained count is ~100k with up to `PRUNE_INTERVAL` overshoot). Two quantiti
 
 A Server-Sent Events stream. Replays the durable suffix from `from_seq`, then tails live frames, each
 framed as `data: {json}\n\n`. A lagging subscriber is dropped and reconnects with `from_seq` to replay
-from the log. The connection does not close on its own; a reader stops at a chosen `seq`.
+from the log. The connection does not close on its own; a reader stops at a chosen `seq`. A cursor past
+the tip (`from_seq > logical_len`, only after a reset) replays from the retained floor — the same
+beyond-tip clamp as the poll endpoint — so the follower sees below-`seq` frames and rewinds.
 
 ## `GET /internal/blocks/events?from_seq=&limit=`
 

--- a/docs/90-services/06-rpc-api.md
+++ b/docs/90-services/06-rpc-api.md
@@ -57,12 +57,13 @@ registers no live subscriber and reads in a single transaction.
 | `from_seq` vs the window | behaviour | `truncated` |
 | --- | --- | --- |
 | in-window / at-tip (`lowest_retained_seq..=logical_len`) | page from `from_seq`; `from_seq == logical_len` is a normal empty page (caught up) | `false` |
-| below the floor (`< lowest_retained_seq`) | page from `lowest_retained_seq`; the requested span was pruned | `true` |
+| below the floor (`< lowest_retained_seq`) | empty page; `next_seq` is the floor the follower resyncs forward to; the requested span was pruned | `true` |
 | beyond the tip (`> logical_len`) | clamp to `lowest_retained_seq` (`0` on a fresh log) | `false` |
 
-A `truncated` page tells the follower its requested span is gone; it re-bootstraps current state (the
-reads below) and resumes streaming from `lowest_retained_seq`. The endpoint never silently returns a page
-whose first `seq` exceeds `from_seq` without `truncated`.
+A `truncated` page is a resync signal: it carries no frames, and `next_seq` is the floor
+(`lowest_retained_seq`). The follower discards any frames, force-resets its cursor forward to `next_seq`,
+re-bootstraps current state (the reads below) up to the floor, and resumes streaming from there. The
+endpoint never silently returns a page whose first `seq` exceeds `from_seq` without `truncated`.
 
 **Equivalence.** For every in-window `seq`, the frame `/events` returns equals the frame the SSE stream
 would push for that `seq`; concatenating poll pages from `from_seq=0` yields the identical sequence as the


### PR DESCRIPTION
**Describe the changes**
**Before**: Node had no interface for an external follower to observe block lifecycle (confirm/finalise/reorg), read canonical blocks, or resume after downtime.
  **After**: Adds /internal/* — SSE stream of durable, replayable observed/finalized/reorged frames plus by-height/range reads, backed by a single producer over a seq-keyed log.


**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an internal block-follower API with a durable, monotonic event stream via SSE (`/internal/blocks/stream`) plus a paginated events endpoint (`/internal/blocks/events`) with replay and pruning-aware cursor behavior.
  * Added internal canonical block reads by height and height range (`/internal/blocks/{height}`, `/internal/blocks?from_height=&to_height=`).
  * Internal endpoints are now conditionally exposed via `http.expose_internal_api`.
* **Bug Fixes**
  * Improved ordering of finalized/migrated and reorg/confirmed signaling in the event stream.
* **Tests**
  * Added end-to-end coverage for SSE/poll equivalence, pagination clamping, replay behavior, and reorg invariants.
* **Documentation**
  * Expanded internal endpoint documentation with cursor semantics and response conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->