### PR TITLE
fix(multiversion-tests): clamp data tx prefix_size to data_size

### DIFF
--- a/crates/tooling/multiversion-tests/src/data_tx.rs
+++ b/crates/tooling/multiversion-tests/src/data_tx.rs
@@ -181,7 +181,10 @@ pub async fn submit_data_tx(
         tx.header.metadata_format = 1;
     }
     if !tx_build.keep_default.iter().any(|f| f == "prefix_size") {
-        tx.header.prefix_size = 64;
+        // Clamp to data_size: consensus rejects prefix_size > data_size
+        // (prefix_hash commits to the first prefix_size data bytes), and the
+        // test payloads here are all smaller than this 64-byte sentinel.
+        tx.header.prefix_size = data_size.min(64);
     }
     let tx = signer
         .sign_transaction(tx)


### PR DESCRIPTION
## Problem

The `master` Multiversion Tests job is failing deterministically — all 8 tests (3 e2e + 5 upgrade) reject the harness's data transactions at `/v1/tx` with:

```
400: Data transaction <id> has prefix_size greater than data_size
```

(e.g. [run 27723769463](https://github.com/Irys-xyz/irys/actions/runs/27723769463/job/82015273800))

## Root cause

Two recently-merged consensus PRs collided:

- **#1450** added the `prefix_size` field and a harness override that force-sets `tx.header.prefix_size = 64` on every data tx (`data_tx.rs`), to exercise a non-trivial `Compact` round-trip encoding across versions.
- **#1451** added the consensus rule rejecting `prefix_size > data_size` (`prefix_hash` commits to the first `prefix_size` data bytes, so a longer prefix is structurally impossible).

Every multiversion test payload is smaller than 64 bytes (38–54), so the hardcoded sentinel now exceeds `data_size` and the node correctly rejects it. The node behavior is intended; this is purely a stale test-harness sentinel that #1451 didn't update.

## Fix

Clamp the sentinel to `data_size.min(64)`. It still produces a non-default value (payloads are ≥38 bytes, so the round-trip check stays meaningful) while respecting the `prefix_size <= data_size` invariant.

## Validation

Full suite, reproducing the CI command shape (old = master sha in a worktree, new = `CURRENT`):

```
test result: ok. 8 passed; 0 failed; 0 ignored; finished in 846.33s
```

All data txs now promote instead of being rejected at ingress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of prefix size validation in test data transactions to properly clamp values when test payloads are smaller than the default threshold, ensuring compliance with consensus limits while maintaining existing configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->