### PR TITLE
feat(backport): pin genesis EVM state root (genesis_evm_state) + init-state fail-fast guard

### DIFF
--- a/crates/api-server/src/routes/supply.rs
+++ b/crates/api-server/src/routes/supply.rs
@@ -69,13 +69,11 @@ fn calculate_supply(state: &ApiState) -> Result<SupplyResponse> {
 
     let config = &state.config.consensus;
 
-    let genesis_supply: U256 = config
-        .reth
-        .alloc
-        .values()
-        .fold(U256::zero(), |acc, account| {
+    let genesis_supply: U256 = config.reth.alloc().map_or(U256::zero(), |alloc| {
+        alloc.values().fold(U256::zero(), |acc, account| {
             acc + U256::from_le_bytes(account.balance.to_le_bytes())
-        });
+        })
+    });
 
     // Use actual supply if available, otherwise fall back to estimated
     let (emitted_amount, calculation_method) = if let Some(supply_state) = &state.supply_state {

--- a/crates/chain-tests/src/api/supply_endpoint.rs
+++ b/crates/chain-tests/src/api/supply_endpoint.rs
@@ -103,16 +103,17 @@ fn validate_supply_invariants(
         "Total supply should equal genesis + emitted"
     );
 
-    let expected_genesis: U256 = ctx
-        .node_ctx
-        .config
-        .consensus
-        .reth
-        .alloc
-        .values()
-        .fold(U256::zero(), |acc, account| {
-            acc + U256::from_le_bytes(account.balance.to_le_bytes())
-        });
+    let expected_genesis: U256 =
+        ctx.node_ctx
+            .config
+            .consensus
+            .reth
+            .alloc()
+            .map_or(U256::zero(), |alloc| {
+                alloc.values().fold(U256::zero(), |acc, account| {
+                    acc + U256::from_le_bytes(account.balance.to_le_bytes())
+                })
+            });
     eyre::ensure!(
         amounts.genesis == expected_genesis,
         "Genesis supply should match config"

--- a/crates/chain-tests/src/startup/genesis.rs
+++ b/crates/chain-tests/src/startup/genesis.rs
@@ -73,9 +73,10 @@ async fn test_genesis_state_dump_and_restore() -> eyre::Result<()> {
     // wipe the reth folder
     remove_dir_all(reth_data_dir)?;
 
-    // init genesis with the saved state
-    // this function has existing checks to make sure the state_root is correct
-    // between the captured state and the actual computed state root
+    // init genesis with the saved state. init-state derives the genesis state root
+    // from the dump itself, so it succeeds without anything pinned in config — `cs`
+    // here is the running node's alloc-based spec. Pinning the dumped state root via
+    // `consensus.reth.genesis_evm_state` is a boot-time config concern, not init-state's.
     init_state(config, cs.clone(), dump_path, reth::tasks::Runtime::test()).await?;
 
     Ok(())

--- a/crates/config/templates/testnet_config.toml
+++ b/crates/config/templates/testnet_config.toml
@@ -119,10 +119,10 @@ genesis_price = 1.0
 [consensus.Custom.reth]
 gas_limit = 30000000
 
-[consensus.Custom.reth.alloc.0x64f1a2829e0e698c18e7792d6e74f67d89aa0a32]
+[consensus.Custom.reth.genesis_evm_state.alloc.0x64f1a2829e0e698c18e7792d6e74f67d89aa0a32]
 balance = "0x152cf4e72a974f1c0000"
 
-[consensus.Custom.reth.alloc.0xa93225cbf141438629f1bd906a31a1c5401ce924]
+[consensus.Custom.reth.genesis_evm_state.alloc.0xa93225cbf141438629f1bd906a31a1c5401ce924]
 balance = "0x152cf4e72a974f1c0000"
 
 [consensus.Custom.mempool]

--- a/crates/reth-node-bridge/src/genesis.rs
+++ b/crates/reth-node-bridge/src/genesis.rs
@@ -2,6 +2,7 @@ use clap::Parser as _;
 use irys_reth::IrysEthereumNode;
 use irys_types::NodeConfig;
 use reth::chainspec::EthereumChainSpecParser;
+use reth::primitives::SealedHeader;
 use reth_chainspec::ChainSpec;
 use reth_cli_commands::init_state::InitStateCommand;
 use std::{
@@ -58,8 +59,14 @@ pub async fn init_state(
     ]);
 
     let mut chainspec = chainspec.deref().clone();
-    // override the state root, null out the genesis allocation
-    chainspec.genesis_header.set_state_root(expected_state_root);
+    // Override the state root and null out the genesis allocation. Re-seal the
+    // header from the patched value rather than calling `set_state_root` on the
+    // already-sealed header: `set_state_root` mutates the inner header but leaves
+    // `SealedHeader`'s cached block hash stale, so reth would persist a genesis
+    // hash that disagrees with the stored header's state root.
+    let mut genesis_header = chainspec.genesis_header.clone_header();
+    genesis_header.state_root = expected_state_root;
+    chainspec.genesis_header = SealedHeader::seal_slow(genesis_header);
     chainspec.genesis.alloc = BTreeMap::new();
 
     cmd.env.chain = Arc::new(chainspec);
@@ -70,15 +77,17 @@ pub async fn init_state(
     Ok(())
 }
 
-/// Whether `reth_data_dir` already holds an initialized reth database.
+/// Whether `reth_data_dir` already holds an initialized (or partially initialized)
+/// reth database.
 ///
-/// reth writes its mdbx environment to `<datadir>/db/mdbx.dat`; its presence means
-/// a genesis block has already been written. `init-state` will not overwrite an
-/// existing genesis, so callers must refuse to re-initialize over it (otherwise the
-/// stale genesis silently survives and only surfaces as a genesis-hash mismatch at
-/// boot).
+/// reth will not overwrite an existing genesis, so callers must refuse to
+/// re-initialize over one (otherwise the stale genesis silently survives and only
+/// surfaces as a genesis-hash mismatch at boot). This mirrors reth's own emptiness
+/// check (`is_database_empty`): any entry under `<datadir>/db` counts as
+/// initialized. Checking only `mdbx.dat` would miss a partially-initialized datadir,
+/// since reth writes `db/database.version` before the mdbx environment.
 fn reth_db_is_initialized(reth_data_dir: &Path) -> bool {
-    reth_data_dir.join("db").join("mdbx.dat").exists()
+    std::fs::read_dir(reth_data_dir.join("db")).is_ok_and(|mut entries| entries.next().is_some())
 }
 
 #[cfg(test)]
@@ -87,17 +96,22 @@ mod tests {
     use irys_testing_utils::utils::TempDirBuilder;
 
     #[test]
-    fn reth_db_initialization_is_detected_by_mdbx_file() {
+    fn reth_db_initialization_is_detected_by_nonempty_db_dir() {
         let tmp = TempDirBuilder::new().build();
         let reth_dir = tmp.path();
 
         // Empty datadir: not initialized.
         assert!(!reth_db_is_initialized(reth_dir));
 
-        // `db/` exists but the mdbx env hasn't been written yet: still not initialized.
+        // `db/` exists but is empty: still not initialized.
         let db = reth_dir.join("db");
         std::fs::create_dir_all(&db).unwrap();
         assert!(!reth_db_is_initialized(reth_dir));
+
+        // reth writes `database.version` before the mdbx env; a partially
+        // initialized datadir already counts as initialized.
+        std::fs::write(db.join("database.version"), b"2").unwrap();
+        assert!(reth_db_is_initialized(reth_dir));
 
         // mdbx env present: initialized.
         std::fs::write(db.join("mdbx.dat"), b"").unwrap();

--- a/crates/reth-node-bridge/src/genesis.rs
+++ b/crates/reth-node-bridge/src/genesis.rs
@@ -9,7 +9,7 @@ use std::{
     fs::File,
     io::{BufRead as _, BufReader},
     ops::Deref as _,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::Arc,
 };
 
@@ -26,12 +26,28 @@ pub async fn init_state(
     state_path: PathBuf,
     runtime: reth::tasks::Runtime,
 ) -> eyre::Result<()> {
+    // Refuse to re-initialize over an existing reth database: reth will not overwrite
+    // an existing genesis, so a stale datadir silently keeps the old genesis and the
+    // mismatch only surfaces at boot ("genesis hash in storage does not match the
+    // specified chainspec"). Fail fast with actionable guidance instead.
+    let reth_data_dir = config.reth_data_dir();
+    eyre::ensure!(
+        !reth_db_is_initialized(&reth_data_dir),
+        "reth data directory `{}` already contains an initialized database; init-state will not \
+         overwrite its genesis, so a stale genesis would surface as a genesis-hash mismatch at \
+         boot. Wipe it first (e.g. `rm -rf {}`) and re-run init-state.",
+        reth_data_dir.display(),
+        reth_data_dir.display(),
+    );
+
     // read the expected state root from the file
     let state_dump = File::open(&state_path)?;
     let mut reader = BufReader::new(state_dump);
     let mut line = String::new();
     reader.read_line(&mut line)?;
 
+    // init-state derives the genesis state root from the dump itself; pinning it for
+    // boot is a config concern (`consensus.reth.genesis_evm_state`), not init-state's.
     let expected_state_root = serde_json::from_str::<StateRoot>(&line)?.root;
 
     let mut cmd = InitStateCommand::<EthereumChainSpecParser>::parse_from([
@@ -52,4 +68,39 @@ pub async fn init_state(
     cmd.execute::<IrysEthereumNode>(runtime).await?;
 
     Ok(())
+}
+
+/// Whether `reth_data_dir` already holds an initialized reth database.
+///
+/// reth writes its mdbx environment to `<datadir>/db/mdbx.dat`; its presence means
+/// a genesis block has already been written. `init-state` will not overwrite an
+/// existing genesis, so callers must refuse to re-initialize over it (otherwise the
+/// stale genesis silently survives and only surfaces as a genesis-hash mismatch at
+/// boot).
+fn reth_db_is_initialized(reth_data_dir: &Path) -> bool {
+    reth_data_dir.join("db").join("mdbx.dat").exists()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::reth_db_is_initialized;
+    use irys_testing_utils::utils::TempDirBuilder;
+
+    #[test]
+    fn reth_db_initialization_is_detected_by_mdbx_file() {
+        let tmp = TempDirBuilder::new().build();
+        let reth_dir = tmp.path();
+
+        // Empty datadir: not initialized.
+        assert!(!reth_db_is_initialized(reth_dir));
+
+        // `db/` exists but the mdbx env hasn't been written yet: still not initialized.
+        let db = reth_dir.join("db");
+        std::fs::create_dir_all(&db).unwrap();
+        assert!(!reth_db_is_initialized(reth_dir));
+
+        // mdbx env present: initialized.
+        std::fs::write(db.join("mdbx.dat"), b"").unwrap();
+        assert!(reth_db_is_initialized(reth_dir));
+    }
 }

--- a/crates/tooling/multiversion-tests/src/data_tx.rs
+++ b/crates/tooling/multiversion-tests/src/data_tx.rs
@@ -15,8 +15,8 @@ use std::time::Duration;
 use tokio::time::{Instant, sleep};
 
 /// Pre-funded test signing key. Its address (`0x64f1a282…`) is in
-/// `consensus.Custom.reth.alloc` for both OLD and NEW testing configs, so we
-/// can pay the term + perm fees on every test cluster without setup.
+/// `consensus.Custom.reth.genesis_evm_state.alloc` for both OLD and NEW testing
+/// configs, so we can pay the term + perm fees on every test cluster without setup.
 pub const DEV_PRIVATE_KEY_HEX: &str =
     "db793353b633df950842415065f769699541160845d73db902eadee6bc5042d0";
 

--- a/crates/types/src/canonical.rs
+++ b/crates/types/src/canonical.rs
@@ -857,7 +857,9 @@ mod tests {
     #[test]
     fn hashmap_keys_use_camel_case() {
         let v = to_canonical(&ConsensusConfig::testnet()).unwrap();
-        assert!(v["reth"]["alloc"].is_object());
+        // `alloc` is now nested under the `genesis_evm_state` enum (camelCased to
+        // `genesisEvmState`); its map keys (addresses) must survive canonicalization.
+        assert!(v["reth"]["genesisEvmState"]["alloc"].is_object());
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/types/src/chainspec.rs
+++ b/crates/types/src/chainspec.rs
@@ -16,7 +16,7 @@ use reth_chainspec::{
 };
 use reth_primitives_traits::SealedHeader;
 
-use crate::config::consensus::IrysRethConfig;
+use crate::config::consensus::{GenesisEvmState, IrysRethConfig};
 use crate::hardfork_config::IrysHardforkConfig;
 
 hardfork!(
@@ -135,6 +135,14 @@ pub fn irys_chain_spec(
     // Build hardfork schedule from Irys hardfork config
     let chain_hardforks = IrysChainHardforks::new(hardforks);
 
+    // Genesis EVM state is specified either inline (`alloc`) or by a pinned
+    // state root (loaded out-of-band via `init-state`). These are mutually
+    // exclusive by construction (see `GenesisEvmState`).
+    let (alloc, pinned_state_root) = match &reth_config.genesis_evm_state {
+        GenesisEvmState::Alloc(alloc) => (alloc.clone(), None),
+        GenesisEvmState::StateRoot(root) => (Default::default(), Some(*root)),
+    };
+
     // Construct Genesis internally with sensible defaults
     // All Ethereum hardfork fields default to None (we manage hardforks separately)
     let genesis = Genesis {
@@ -144,7 +152,7 @@ pub fn irys_chain_spec(
             ..Default::default()
         },
         gas_limit: reth_config.gas_limit,
-        alloc: reth_config.alloc.clone(),
+        alloc,
         timestamp,
         nonce: 0,
         difficulty: U256::ZERO,
@@ -159,7 +167,13 @@ pub fn irys_chain_spec(
         parent_hash: None,
     };
 
-    let genesis_header = make_genesis_header(&genesis, &chain_hardforks.inner);
+    let mut genesis_header = make_genesis_header(&genesis, &chain_hardforks.inner);
+    // When the genesis state is supplied out-of-band via `init-state`, the dumped
+    // state root is pinned here so that init-state, the genesis node, and peers
+    // all reconstruct the identical genesis header (and thus genesis block hash).
+    if let Some(state_root) = pinned_state_root {
+        genesis_header.state_root = state_root;
+    }
     let header_hash = genesis_header.hash_slow();
 
     let chainspec = ChainSpec {
@@ -177,4 +191,56 @@ pub fn irys_chain_spec(
     };
 
     Ok(Arc::new(chainspec))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::irys_chain_spec;
+    use crate::config::consensus::{ConsensusConfig, GenesisEvmState, IrysRethConfig};
+    use alloy_primitives::B256;
+    use std::collections::BTreeMap;
+
+    /// A pinned `GenesisEvmState::StateRoot` (e.g. an `init-state` dump root)
+    /// must be reflected in the genesis header so a booting node reconstructs
+    /// the same genesis block that `init-state` wrote — instead of re-deriving
+    /// the root from an inline `alloc`.
+    #[test]
+    fn pinned_genesis_state_root_overrides_header_root() {
+        let consensus = ConsensusConfig::testing();
+        let hardforks = consensus.hardforks.clone();
+        let gas_limit = consensus.reth.gas_limit;
+
+        // Baseline: empty inline alloc -> empty-state-trie genesis root.
+        let inline = IrysRethConfig {
+            gas_limit,
+            genesis_evm_state: GenesisEvmState::Alloc(BTreeMap::new()),
+        };
+        let inline_spec = irys_chain_spec(1, &inline, &hardforks, 0).unwrap();
+
+        // Pin a state root that differs from the empty-trie root.
+        let pinned = B256::repeat_byte(0xAB);
+        let pinned_cfg = IrysRethConfig {
+            gas_limit,
+            genesis_evm_state: GenesisEvmState::StateRoot(pinned),
+        };
+        let pinned_spec = irys_chain_spec(1, &pinned_cfg, &hardforks, 0).unwrap();
+
+        assert_eq!(pinned_spec.genesis_header.state_root, pinned);
+        assert_ne!(pinned_spec.genesis_hash(), inline_spec.genesis_hash());
+    }
+
+    /// Operators configure a state-preserving reset by pinning the dumped root
+    /// in TOML, so the `StateRoot` variant must round-trip through the config.
+    #[test]
+    fn state_root_variant_toml_roundtrip() {
+        let toml = "\
+gas_limit = 30000000
+
+[genesis_evm_state]
+state_root = \"0x1111111111111111111111111111111111111111111111111111111111111111\"
+";
+        let cfg: IrysRethConfig = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.genesis_state_root(), Some(B256::repeat_byte(0x11)));
+        assert!(cfg.alloc().is_none());
+    }
 }

--- a/crates/types/src/config/consensus.rs
+++ b/crates/types/src/config/consensus.rs
@@ -1275,7 +1275,7 @@ mod tests {
     #[test]
     fn test_consensus_hash_regression() {
         let config = ConsensusConfig::testing();
-        let expected_hash = H256::from_base58("CZCM35BPbUpiw9i7e3TEZWZcV3g8iYRE1tEqwCCzsTpz");
+        let expected_hash = H256::from_base58("6v2x1bjvaqtoVaQ52dc4J6DR7hMhCebwa178P9TU5isQ");
         assert_eq!(
             config.keccak256_hash(),
             expected_hash,

--- a/crates/types/src/config/consensus.rs
+++ b/crates/types/src/config/consensus.rs
@@ -13,7 +13,7 @@ use crate::{UnixTimestamp, serde_utils, unix_timestamp_string_serde};
 use alloy_core::hex::FromHex as _;
 use alloy_eips::eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M;
 use alloy_genesis::GenesisAccount;
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{Address, B256, U256};
 use eyre::Result;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
@@ -243,6 +243,31 @@ pub struct BlockRewardConfig {
     pub half_life_secs: u64,
 }
 
+/// Specifies the genesis EVM state.
+///
+/// `Alloc` and `StateRoot` are mutually exclusive *by construction*: a network's
+/// genesis EVM state is described **either** by an inline account allocation
+/// **or** by a pinned state root — never both.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GenesisEvmState {
+    /// Inline account allocations (address -> balance/code/storage). Use when
+    /// the genesis state is small enough to embed directly in config.
+    Alloc(BTreeMap<Address, GenesisAccount>),
+    /// Pinned genesis EVM state root. Use when the genesis state is loaded
+    /// out-of-band via `init-state` from a state dump (too large for `alloc`).
+    /// The dumped root must be a pinned consensus value so that every node — the
+    /// one that ran `init-state`, the genesis node, and peers — reconstructs the
+    /// identical genesis header instead of re-deriving the root from `alloc`.
+    StateRoot(B256),
+}
+
+impl Default for GenesisEvmState {
+    fn default() -> Self {
+        Self::Alloc(BTreeMap::new())
+    }
+}
+
 /// # Reth Configuration
 ///
 /// Minimal configuration needed for reth integration.
@@ -254,9 +279,10 @@ pub struct IrysRethConfig {
     #[serde(default = "default_gas_limit")]
     pub gas_limit: u64,
 
-    /// Initial account allocations (address -> balance/code/storage)
+    /// How the genesis EVM state is specified — inline `alloc` or a pinned state
+    /// root. Defaults to an empty inline allocation.
     #[serde(default)]
-    pub alloc: BTreeMap<Address, GenesisAccount>,
+    pub genesis_evm_state: GenesisEvmState,
 }
 
 fn default_gas_limit() -> u64 {
@@ -264,12 +290,43 @@ fn default_gas_limit() -> u64 {
 }
 
 impl IrysRethConfig {
+    /// The inline genesis allocation, or `None` when the genesis state is pinned
+    /// via a state root.
+    pub fn alloc(&self) -> Option<&BTreeMap<Address, GenesisAccount>> {
+        match &self.genesis_evm_state {
+            GenesisEvmState::Alloc(alloc) => Some(alloc),
+            GenesisEvmState::StateRoot(_) => None,
+        }
+    }
+
+    /// The pinned genesis EVM state root, or `None` when the genesis state is
+    /// specified inline via `alloc`.
+    pub fn genesis_state_root(&self) -> Option<B256> {
+        match &self.genesis_evm_state {
+            GenesisEvmState::StateRoot(root) => Some(*root),
+            GenesisEvmState::Alloc(_) => None,
+        }
+    }
+
+    /// Mutable access to the inline genesis allocation.
+    ///
+    /// Panics if the genesis state is pinned via a state root, since inline
+    /// allocations and a pinned state root are mutually exclusive.
+    pub fn alloc_mut(&mut self) -> &mut BTreeMap<Address, GenesisAccount> {
+        match &mut self.genesis_evm_state {
+            GenesisEvmState::Alloc(alloc) => alloc,
+            GenesisEvmState::StateRoot(_) => {
+                panic!("cannot mutate `alloc`: genesis state is pinned via a state root")
+            }
+        }
+    }
+
     /// Extend the genesis allocations with additional accounts
     pub fn extend_accounts(
         &mut self,
         accounts: impl IntoIterator<Item = (Address, GenesisAccount)>,
     ) {
-        self.alloc.extend(accounts);
+        self.alloc_mut().extend(accounts);
     }
 }
 
@@ -613,7 +670,7 @@ impl ConsensusConfig {
             // Reth config
             reth: IrysRethConfig {
                 gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
-                alloc: {
+                genesis_evm_state: GenesisEvmState::Alloc({
                     let mut map = BTreeMap::new();
                     map.insert(
                         Address::from_slice(
@@ -629,7 +686,7 @@ impl ConsensusConfig {
                         },
                     );
                     map
-                },
+                }),
             },
             genesis: GenesisConfig {
                 // The timestamp in milliseconds used for the genesis block
@@ -829,7 +886,7 @@ impl ConsensusConfig {
             },
             reth: IrysRethConfig {
                 gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
-                alloc: {
+                genesis_evm_state: GenesisEvmState::Alloc({
                     let mut map = BTreeMap::new();
                     map.insert(
                         Address::from_slice(
@@ -854,7 +911,7 @@ impl ConsensusConfig {
                         },
                     );
                     map
-                },
+                }),
             },
             block_reward_config: BlockRewardConfig {
                 inflation_cap: Amount::token(rust_decimal::Decimal::from(INFLATION_CAP)).unwrap(),
@@ -967,7 +1024,7 @@ impl ConsensusConfig {
             },
             reth: IrysRethConfig {
                 gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
-                alloc: BTreeMap::new(),
+                genesis_evm_state: GenesisEvmState::Alloc(BTreeMap::new()),
             },
             block_reward_config: BlockRewardConfig {
                 inflation_cap: Amount::token(rust_decimal::Decimal::from(INFLATION_CAP)).unwrap(),

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -734,10 +734,10 @@ mod tests {
         [reth]
         gas_limit = 30000000
 
-        [reth.alloc.0x64f1a2829e0e698c18e7792d6e74f67d89aa0a32]
+        [reth.genesis_evm_state.alloc.0x64f1a2829e0e698c18e7792d6e74f67d89aa0a32]
         balance = "0x152cf4e72a974f1c0000"
 
-        [reth.alloc.0xa93225cbf141438629f1bd906a31a1c5401ce924]
+        [reth.genesis_evm_state.alloc.0xa93225cbf141438629f1bd906a31a1c5401ce924]
         balance = "0x152cf4e72a974f1c0000"
 
         [mempool]

--- a/crates/types/src/version.rs
+++ b/crates/types/src/version.rs
@@ -1094,7 +1094,7 @@ mod tests {
         };
         config
             .reth
-            .alloc
+            .alloc_mut()
             .insert(genesis_signer.address().into(), genesis_account);
 
         // Fixed private key for the peer handshake (different from genesis)


### PR DESCRIPTION
## Summary

Backport of the genesis-EVM-state fixes from `release/testnet/3.x` (upstream `eab0064fe`, `5ce0d25b0`), plus two correctness/CI fixes surfaced by review.

A network whose genesis EVM state is loaded out-of-band via `init-state` (state too large to inline in `alloc`) must reconstruct the identical genesis block on every node. Boot previously derived the genesis state root from `reth.alloc`, so it diverged from the dump-derived root `init-state` wrote, and reth aborted at startup with a genesis-hash mismatch.

### Backported changes
- **`genesis_evm_state` config:** replaces `IrysRethConfig.alloc` with `GenesisEvmState { Alloc(map) | StateRoot(B256) }` — inline allocation or a pinned state root, mutually exclusive by construction. `irys_chain_spec` applies the pinned root (and clears alloc), so a node configured with `genesis_evm_state.state_root` reconstructs the same genesis the dump produced and boots cleanly.
- **`init-state` fail-fast guard:** refuses to run over an already-initialized reth datadir (reth will not overwrite an existing genesis), bailing with guidance to wipe.

### Review fixes added on this branch
- **Re-seal genesis header in `init_state`:** `set_state_root` on the sealed header left the cached block hash stale, which could persist a genesis hash that disagrees with the stored header. Now re-seals from the patched value (`clone_header` → `seal_slow`).
- **Broaden the db-init guard:** `reth_db_is_initialized` now treats any entry under `<datadir>/db` as initialized (mirrors reth's `is_database_empty`), closing a `database.version`-only false negative.
- **Fix CI:** updated the `test_consensus_hash_regression` expected hash, which changed because the config serialization changed (`reth.alloc` → `reth.genesis_evm_state.alloc`).

### ⚠️ Operator-facing config migration
`IrysRethConfig` uses `deny_unknown_fields`, so existing configs must migrate `reth.alloc.*` → `reth.genesis_evm_state.alloc.*` (or the new `state_root` form). Old configs fail to parse at boot (loud, not silent). The `consensus_config_hash` also changes, so cross-version handshakes log a mismatch (they do **not** reject) — treat this as a coordinated-upgrade boundary.

### Test plan
- `cargo test -p irys-types --lib consensus_hash` (5 pass) and `chainspec::tests` (2 pass)
- `cargo test -p irys-reth-node-bridge --lib genesis::tests` (guard test passes)
- `cargo test -p irys-chain-tests test_genesis_state_dump_and_restore` (exercises the `init_state` re-seal end-to-end; passes)
- `cargo fmt` + `cargo clippy --tests` clean on touched crates

### Note for maintainers
The re-seal and guard tweak are ahead of the canonical `release/testnet/3.x`; forward them there so the branches don't drift. That branch also still pins the old consensus-hash regression value and is likely red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for pinned genesis state roots as an alternative to inline genesis allocations.
  * Updated genesis configuration to use `genesis_evm_state` for EVM state (with alloc or pinned root).
  * Added faster detection of already-initialized databases to avoid using stale genesis.

* **Bug Fixes**
  * Improved genesis supply calculations to handle missing allocation data safely.
  * Ensured the genesis header uses the pinned state root when configured.

* **Documentation**
  * Updated genesis-related docs and test configuration fixtures to match the new `genesis_evm_state` structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->