### PR TITLE
fix(consensus): prevent Submit-expiry vs promotion double-pay + ingress-proof cache delete

### DIFF
--- a/.github/workflows/conventional-pr.yaml
+++ b/.github/workflows/conventional-pr.yaml
@@ -3,8 +3,8 @@ name: Ensure Conventional Commit message
 on: pull_request
 
 permissions:
-  # contents:read lets the action check out the repository; pull-requests:read lets
-  # it query the PR title and description to enforce the conventional-commit format.
+  # contents:read grants read-only repository access; pull-requests:read lets the
+  # action query the PR title and description to enforce the conventional-commit format.
   contents: read
   pull-requests: read
 

--- a/.github/workflows/conventional-pr.yaml
+++ b/.github/workflows/conventional-pr.yaml
@@ -3,6 +3,8 @@ name: Ensure Conventional Commit message
 on: pull_request
 
 permissions:
+  # contents:read lets the action check out the repository; pull-requests:read lets
+  # it query the PR title and description to enforce the conventional-commit format.
   contents: read
   pull-requests: read
 

--- a/crates/actors/Cargo.toml
+++ b/crates/actors/Cargo.toml
@@ -54,6 +54,7 @@ thiserror.workspace = true
 irys-types = { workspace = true, features = ["test-utils"] }
 irys-config = { workspace = true, features = ["test-utils"] }
 irys-database = { workspace = true, features = ["test-utils"] }
+irys-storage = { workspace = true, features = ["test-utils"] }
 irys-api-client = { workspace = true, features = ["test-utils"] }
 irys-domain = { workspace = true, features = ["test-utils"] }
 test-log.workspace = true

--- a/crates/actors/src/block_discovery.rs
+++ b/crates/actors/src/block_discovery.rs
@@ -534,6 +534,22 @@ impl BlockDiscoveryServiceInner {
         // get any remaining valid_ingress_anchor_block hashes from the block index
         // we do not need the full block headers, so we use the block index
         {
+            // NC-0042 / #1405: the deepest by-hash ancestor we reached above
+            // (`parent_block`, at `bt_finished_height`) is on THIS block's chain.
+            // Push its hash BY-HASH — it sits ABOVE the index handoff below, so it
+            // must NOT be taken from the (reorg-mutable) block index, which is only
+            // branch-invariant below the reorg floor. Everything strictly deeper is
+            // read from the index, anchored to this by-hash boundary by the handoff
+            // check at `last_bt_safe_parent_height`: a matching hash there makes the
+            // whole linear index suffix branch-correct (or the assertion fires). This
+            // preserves the inclusive `[min_ingress_proof_anchor_height,
+            // bt_finished_height]` anchor window (matching the mempool) while
+            // resolving the boundary branch-correctly instead of from the local
+            // canonical index.
+            if bt_finished_height >= min_ingress_proof_anchor_height {
+                valid_ingress_anchor_blocks.push(parent_block.block_hash);
+            }
+
             // how many blocks do we need the block index to get to `min_ingress_proof_anchor_height`?
             let remaining = bt_finished_height.saturating_sub(min_ingress_proof_anchor_height);
             debug!(
@@ -548,8 +564,11 @@ impl BlockDiscoveryServiceInner {
             // this is the last block header we got from the above loop
             // we use this to ensure that
             let last_bt_safe_parent_height = parent_block.height.checked_sub(1);
-            // IMPORTANT: this MUST be inclusive! matching mempool `validate_ingress_proof_anchor_for_inclusion` behaviour
-            for height in min_ingress_proof_anchor_height..=bt_finished_height {
+            // EXCLUSIVE of `bt_finished_height`: that boundary is supplied by-hash
+            // above (the index entry there is above the handoff and unverified). The
+            // top of this range is `last_bt_safe_parent_height`, where the handoff
+            // check ties the index to the by-hash chain.
+            for height in min_ingress_proof_anchor_height..bt_finished_height {
                 // these block index assertions should always be true, which is why we panic (we enforce that the block tree must at least go to the boundary for migration in Config::validate)
                 let block_index_item =
                     block_index

--- a/crates/actors/src/block_discovery.rs
+++ b/crates/actors/src/block_discovery.rs
@@ -534,7 +534,7 @@ impl BlockDiscoveryServiceInner {
         // get any remaining valid_ingress_anchor_block hashes from the block index
         // we do not need the full block headers, so we use the block index
         {
-            // NC-0042 / #1405: the deepest by-hash ancestor we reached above
+            // NC-0042: the deepest by-hash ancestor we reached above
             // (`parent_block`, at `bt_finished_height`) is on THIS block's chain.
             // Push its hash BY-HASH — it sits ABOVE the index handoff below, so it
             // must NOT be taken from the (reorg-mutable) block index, which is only

--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -1672,28 +1672,13 @@ pub trait BlockProdStrategy {
         prev_block_header: &IrysBlockHeader,
         block_timestamp: UnixTimestampMs,
     ) -> Result<MempoolTxs, crate::tx_selector::TxSelectorError> {
-        // NC-0042 §4b: compute the set of Submit-ledger txs whose storage has
-        // expired as of the block we're about to produce, from the same expired
-        // -partition → block → tx walk that schedules perm_fee refunds. The tx
-        // selector drops any publish candidate in this set so the producer never
-        // both promotes and refunds the same tx (panic) or promotes a tx that was
-        // refunded in an earlier block (silent cross-block double-pay).
-        let next_block_height = prev_block_header.height + 1;
-        let (parent_epoch_snapshot, _) = self
-            .fetch_parent_snapshots(prev_block_header)
-            .map_err(crate::tx_selector::TxSelectorError::Other)?;
-        let expired_submit_tx_ids = ledger_expiry::expired_submit_tx_ids(
-            &parent_epoch_snapshot,
-            next_block_height,
-            &self.inner().config,
-            self.inner().block_index.clone(),
-            &self.inner().block_tree_guard,
-            &self.inner().mempool_guard,
-            &self.inner().db,
-        )
-        .await
-        .map_err(crate::tx_selector::TxSelectorError::Other)?;
-
+        // NC-0042 §4b: the tx selector drops any publish candidate whose Submit
+        // -ledger storage has expired as of the block we're about to produce
+        // (per candidate, via `ledger_expiry::is_submit_storage_expired`), so the
+        // producer never both promotes and refunds the same tx (panic) or
+        // promotes a tx that was refunded in an earlier block (silent cross-block
+        // double-pay). It resolves that from `block_index` + the parent epoch
+        // snapshot — the same inputs the refund walk uses.
         let ctx = crate::tx_selector::TxSelectionContext {
             block_tree: &self.inner().block_tree_guard,
             db: &self.inner().db,
@@ -1701,7 +1686,8 @@ pub trait BlockProdStrategy {
             config: &self.inner().config,
             mempool_state: self.inner().mempool_guard.atomic_state(),
             chunk_ingress_state: &self.inner().chunk_ingress_state,
-            expired_submit_tx_ids: &expired_submit_tx_ids,
+            block_index: &self.inner().block_index,
+            mempool_guard: &self.inner().mempool_guard,
         };
         crate::tx_selector::select_best_txs(
             prev_block_header.block_hash,
@@ -1879,6 +1865,7 @@ pub trait BlockProdStrategy {
 
         let mut result = ledger_expiry::calculate_expired_ledger_fees(
             parent_epoch_snapshot,
+            prev_block_header,
             block_height,
             DataLedger::Submit,
             &self.inner().config,
@@ -1908,6 +1895,7 @@ pub trait BlockProdStrategy {
             ] {
                 let delta = ledger_expiry::calculate_expired_ledger_fees(
                     parent_epoch_snapshot,
+                    prev_block_header,
                     block_height,
                     ledger,
                     &self.inner().config,

--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -1674,8 +1674,8 @@ pub trait BlockProdStrategy {
     ) -> Result<MempoolTxs, crate::tx_selector::TxSelectorError> {
         // NC-0042 §4b: the tx selector drops any publish candidate whose Submit
         // -ledger storage has expired as of the block we're about to produce
-        // (per candidate, via `ledger_expiry::is_submit_storage_expired`), so the
-        // producer never both promotes and refunds the same tx (panic) or
+        // (`expired_submit_range` once, then `submit_tx_expired` per candidate), so
+        // the producer never both promotes and refunds the same tx (panic) or
         // promotes a tx that was refunded in an earlier block (silent cross-block
         // double-pay). It resolves that from `block_index` + the parent epoch
         // snapshot — the same inputs the refund walk uses.

--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -1114,8 +1114,9 @@ pub trait BlockProdStrategy {
             &mempool_bundle.publish_txs.txs,
             self.inner().config.consensus.chunk_size,
         );
-        let publish_total_chunks =
-            prev_block_header.data_ledgers[DataLedger::Publish].total_chunks + publish_chunks_added;
+        let publish_total_chunks = prev_block_header.data_ledgers[DataLedger::Publish]
+            .total_chunks
+            .saturating_add(publish_chunks_added);
         let opt_proofs = mempool_bundle.publish_txs.proofs.clone();
 
         // Difficulty adjustment logic
@@ -1184,8 +1185,9 @@ pub trait BlockProdStrategy {
         }
         let chunk_size = self.inner().config.consensus.chunk_size;
         let submit_chunks_added = calculate_chunks_added(&mempool_bundle.submit_txs, chunk_size);
-        let submit_total_chunks =
-            prev_block_header.data_ledgers[DataLedger::Submit].total_chunks + submit_chunks_added;
+        let submit_total_chunks = prev_block_header.data_ledgers[DataLedger::Submit]
+            .total_chunks
+            .saturating_add(submit_chunks_added);
 
         let cascade_active = self
             .inner()
@@ -1294,7 +1296,7 @@ pub trait BlockProdStrategy {
                         .find(|l| l.ledger_id == DataLedger::OneYear as u32)
                         .map(|l| l.total_chunks)
                         .unwrap_or(0)
-                        + one_year_chunks_added;
+                        .saturating_add(one_year_chunks_added);
 
                     let thirty_day_chunks_added =
                         calculate_chunks_added(&mempool_bundle.thirty_day_txs, chunk_size);
@@ -1304,7 +1306,7 @@ pub trait BlockProdStrategy {
                         .find(|l| l.ledger_id == DataLedger::ThirtyDay as u32)
                         .map(|l| l.total_chunks)
                         .unwrap_or(0)
-                        + thirty_day_chunks_added;
+                        .saturating_add(thirty_day_chunks_added);
 
                     ledgers.push(DataTransactionLedger {
                         ledger_id: DataLedger::OneYear.into(),
@@ -1841,79 +1843,53 @@ pub trait BlockProdStrategy {
         mempool_txs: &MempoolTxs,
     ) -> eyre::Result<LedgerExpiryBalanceDelta> {
         let chunk_size = self.inner().config.consensus.chunk_size;
-        // Gate for the write-window exclusion: the Cascade status of THIS block
-        // (its own timestamp — the value `perform_epoch_tasks` reads to gate the
-        // `touch_active_ledger_slots` that rescues these slots). Must not use the
-        // parent-snapshot helper below: at the activation epoch the parent still
-        // predates activation, which would disable the exclusion while the touch
-        // already runs — settling a slot that did not recycle.
+        // Cascade status of THIS block (its own timestamp — the value
+        // `perform_epoch_tasks` reads to gate the `touch_active_ledger_slots` that
+        // rescues slots written this epoch). Gates the write-window exclusion, and
+        // must NOT be the parent-snapshot helper `is_cascade_active_for_epoch`
+        // below, which lags by an epoch at the activation boundary.
         let cascade_active_for_block = self
             .inner()
             .config
             .consensus
             .hardforks
             .is_cascade_active_at(block_timestamp.to_secs());
-        // `ledger`'s cumulative total_chunks at the block being produced =
-        // parent total + chunks added by this block's selected txs. This is the
-        // exact value that lands in the block header (see produce_block_*), and
-        // the validator reads it straight from the header — so both sides agree.
-        // It lets the fee calc exclude slots written this epoch (rescued by the
-        // last_height touch) from the expiring set.
-        let new_total = |ledger: DataLedger, txs: &[DataTransactionHeader]| -> u64 {
-            prev_block_header.ledger_total_chunks(ledger) + calculate_chunks_added(txs, chunk_size)
-        };
-
-        let mut result = ledger_expiry::calculate_expired_ledger_fees(
-            parent_epoch_snapshot,
-            prev_block_header,
-            block_height,
-            DataLedger::Submit,
-            &self.inner().config,
-            self.inner().block_index.clone(),
-            &self.inner().block_tree_guard,
-            &self.inner().mempool_guard,
-            &self.inner().db,
-            true, // expect txs to be promoted — return perm fee refund if not
-            new_total(DataLedger::Submit, &mempool_txs.submit_tx),
-            cascade_active_for_block,
-        )
-        .in_current_span()
-        .await?;
-
-        // When Cascade is active, also process OneYear and ThirtyDay term ledgers.
-        // These are term-only (no promotion), so expect_txs_to_be_promoted = false.
-        let cascade_active = self
+        let cascade_active_for_epoch = self
             .inner()
             .config
             .consensus
             .hardforks
             .is_cascade_active_for_epoch(parent_epoch_snapshot);
-        if cascade_active {
-            for (ledger, txs) in [
-                (DataLedger::OneYear, &mempool_txs.one_year_tx),
-                (DataLedger::ThirtyDay, &mempool_txs.thirty_day_tx),
-            ] {
-                let delta = ledger_expiry::calculate_expired_ledger_fees(
-                    parent_epoch_snapshot,
-                    prev_block_header,
-                    block_height,
-                    ledger,
-                    &self.inner().config,
-                    self.inner().block_index.clone(),
-                    &self.inner().block_tree_guard,
-                    &self.inner().mempool_guard,
-                    &self.inner().db,
-                    false, // no promotion for these ledgers
-                    new_total(ledger, txs),
-                    cascade_active_for_block,
-                )
-                .in_current_span()
-                .await?;
-                result.merge(delta);
-            }
-        }
 
-        Ok(result)
+        // The producer's per-ledger `total_chunks` at this block = parent total +
+        // chunks added by this block's selected txs. This is the exact value that
+        // lands in the block header (see produce_block_*), so the validator — which
+        // reads it from that header — settles the identical expiring set.
+        ledger_expiry::calculate_all_expired_ledger_fees(
+            parent_epoch_snapshot,
+            prev_block_header,
+            block_height,
+            &self.inner().config,
+            &self.inner().block_index,
+            &self.inner().block_tree_guard,
+            &self.inner().mempool_guard,
+            &self.inner().db,
+            cascade_active_for_block,
+            cascade_active_for_epoch,
+            |ledger| {
+                let txs: &[DataTransactionHeader] = match ledger {
+                    DataLedger::Submit => &mempool_txs.submit_tx,
+                    DataLedger::OneYear => &mempool_txs.one_year_tx,
+                    DataLedger::ThirtyDay => &mempool_txs.thirty_day_tx,
+                    _ => &[],
+                };
+                prev_block_header
+                    .ledger_total_chunks(ledger)
+                    .saturating_add(calculate_chunks_added(txs, chunk_size))
+            },
+        )
+        .in_current_span()
+        .await
     }
 }
 
@@ -2027,8 +2003,8 @@ pub async fn current_timestamp(prev_block_header: &IrysBlockHeader) -> UnixTimes
 /// # Returns
 /// Total number of chunks needed, including padding for partial chunks
 pub fn calculate_chunks_added(txs: &[DataTransactionHeader], chunk_size: u64) -> u64 {
-    let bytes_added = txs.iter().fold(0, |acc, tx| {
-        acc + tx.data_size.div_ceil(chunk_size) * chunk_size
+    let bytes_added = txs.iter().fold(0_u64, |acc, tx| {
+        acc.saturating_add(tx.data_size.div_ceil(chunk_size).saturating_mul(chunk_size))
     });
 
     bytes_added / chunk_size

--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -1672,6 +1672,28 @@ pub trait BlockProdStrategy {
         prev_block_header: &IrysBlockHeader,
         block_timestamp: UnixTimestampMs,
     ) -> Result<MempoolTxs, crate::tx_selector::TxSelectorError> {
+        // NC-0042 §4b: compute the set of Submit-ledger txs whose storage has
+        // expired as of the block we're about to produce, from the same expired
+        // -partition → block → tx walk that schedules perm_fee refunds. The tx
+        // selector drops any publish candidate in this set so the producer never
+        // both promotes and refunds the same tx (panic) or promotes a tx that was
+        // refunded in an earlier block (silent cross-block double-pay).
+        let next_block_height = prev_block_header.height + 1;
+        let (parent_epoch_snapshot, _) = self
+            .fetch_parent_snapshots(prev_block_header)
+            .map_err(crate::tx_selector::TxSelectorError::Other)?;
+        let expired_submit_tx_ids = ledger_expiry::expired_submit_tx_ids(
+            &parent_epoch_snapshot,
+            next_block_height,
+            &self.inner().config,
+            self.inner().block_index.clone(),
+            &self.inner().block_tree_guard,
+            &self.inner().mempool_guard,
+            &self.inner().db,
+        )
+        .await
+        .map_err(crate::tx_selector::TxSelectorError::Other)?;
+
         let ctx = crate::tx_selector::TxSelectionContext {
             block_tree: &self.inner().block_tree_guard,
             db: &self.inner().db,
@@ -1679,6 +1701,7 @@ pub trait BlockProdStrategy {
             config: &self.inner().config,
             mempool_state: self.inner().mempool_guard.atomic_state(),
             chunk_ingress_state: &self.inner().chunk_ingress_state,
+            expired_submit_tx_ids: &expired_submit_tx_ids,
         };
         crate::tx_selector::select_best_txs(
             prev_block_header.block_hash,

--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -165,7 +165,6 @@ pub async fn calculate_expired_ledger_fees(
         block_range,
         ledger_type,
         config,
-        &block_index,
         block_tree_guard,
         mempool_guard,
         db,
@@ -222,7 +221,6 @@ async fn collect_tx_to_miners_from_range(
     block_range: BlockRange,
     ledger_type: DataLedger,
     config: &Config,
-    block_index: &BlockIndex,
     block_tree_guard: &BlockTreeReadGuard,
     mempool_guard: &MempoolReadGuard,
     db: &DatabaseProvider,
@@ -235,6 +233,10 @@ async fn collect_tx_to_miners_from_range(
         same_block
     );
 
+    // Per-tx attribution is keyed on the slot containing each tx's START offset
+    // (NC-0042 R4), so every block — boundary or middle — is processed against the
+    // same un-merged `slot_miners` map rather than a per-block miner union.
+    let slot_miners = &block_range.slot_miners;
     let earliest_miners;
     let latest_miners;
 
@@ -246,12 +248,11 @@ async fn collect_tx_to_miners_from_range(
         let miners = process_boundary_block(
             &block_range.min_block,
             block_range.min_block.block_hash,
-            Arc::clone(&block_range.min_block_miners),
             true, // is_earliest
             true, // is_latest — sole boundary block (min == max), so trim BOTH ends
             ledger_type,
             config,
-            block_index,
+            slot_miners,
             block_tree_guard,
             mempool_guard,
             db,
@@ -265,12 +266,11 @@ async fn collect_tx_to_miners_from_range(
         let e_miners = process_boundary_block(
             &block_range.min_block,
             block_range.min_block.block_hash,
-            Arc::clone(&block_range.min_block_miners),
             true,  // is_earliest — min block trims only the start
             false, // is_latest
             ledger_type,
             config,
-            block_index,
+            slot_miners,
             block_tree_guard,
             mempool_guard,
             db,
@@ -280,12 +280,11 @@ async fn collect_tx_to_miners_from_range(
         let l_miners = process_boundary_block(
             &block_range.max_block,
             block_range.max_block.block_hash,
-            Arc::clone(&block_range.max_block_miners),
             false, // is_earliest
             true,  // is_latest — max block trims only the end
             ledger_type,
             config,
-            block_index,
+            slot_miners,
             block_tree_guard,
             mempool_guard,
             db,
@@ -296,9 +295,21 @@ async fn collect_tx_to_miners_from_range(
         latest_miners = l_miners;
     }
 
-    // Process middle blocks
-    let middle_miners =
-        process_middle_blocks(block_range.middle_blocks, ledger_type, block_tree_guard, db).await?;
+    // Middle (fully-interior) blocks: no trim (they lie entirely within the
+    // expired range), but still attributed per-slot by tx start offset — a middle
+    // block can straddle a slot boundary too. The boundary blocks share the same
+    // global range, so reuse it for the (unused) trim arguments.
+    let middle_miners = process_middle_blocks(
+        &block_range.middle_blocks,
+        block_range.min_block.chunk_range,
+        ledger_type,
+        config,
+        slot_miners,
+        block_tree_guard,
+        mempool_guard,
+        db,
+    )
+    .await?;
 
     tracing::info!(
         "Collected transactions: earliest={}, latest={}, middle={}",
@@ -386,7 +397,6 @@ pub async fn expired_submit_tx_ids(
         block_range,
         DataLedger::Submit,
         config,
-        &block_index,
         block_tree_guard,
         mempool_guard,
         db,
@@ -779,8 +789,12 @@ fn assert_canonical_via_mbh(db: &DatabaseProvider, hash: H256, height: u64) -> e
 /// Branch-correct resolution of the canonical block that introduced chunk
 /// `offset` in `ledger`, as a pure function of the block's **own parent
 /// ancestry** (`parent_hash`) — never the node's canonical tip or migration-
-/// lagged index frontier (NC-0042 R1). Returns `(height, block_hash, block_total)`
-/// where `block_total` is that block's cumulative `ledger` total.
+/// lagged index frontier (NC-0042 R1). Returns `(height, block_hash, base,
+/// block_total)` where `base` is the cumulative `ledger` total *before* the block
+/// (its start offset) and `block_total` is the cumulative total *through* it.
+/// `base` is resolved from the same branch-correct ancestry as the block itself,
+/// so a boundary block's start offset never falls back to the migrated-only index
+/// (NC-0042 R1: that fallback errored on an un-migrated boundary predecessor).
 ///
 /// Fast path: offsets below the migrated index tip resolve via the index binary
 /// search (finalized ⇒ branch-invariant, O(log n)). Slow path: offsets in the
@@ -799,7 +813,7 @@ fn resolve_ledger_offset_to_block(
     block_tree_guard: &BlockTreeReadGuard,
     block_index: &BlockIndex,
     db: &DatabaseProvider,
-) -> eyre::Result<(BlockHeight, H256, u64)> {
+) -> eyre::Result<(BlockHeight, H256, u64, u64)> {
     // Fast path: finalized/migrated region — binary search is branch-invariant.
     let index_tip_total = block_index
         .get_latest_item()
@@ -810,6 +824,7 @@ fn resolve_ledger_offset_to_block(
         return Ok((
             height,
             item.block_hash,
+            migrated_predecessor_total(block_index, ledger, height),
             ledger_total_of_index_item(&item, ledger),
         ));
     }
@@ -836,7 +851,7 @@ fn resolve_ledger_offset_to_block(
                 )?
         };
         if (prev_total..total).contains(&offset) {
-            return Ok((header.height, cursor, total));
+            return Ok((header.height, cursor, prev_total, total));
         }
         cursor = header.previous_block_hash;
     }
@@ -847,8 +862,30 @@ fn resolve_ledger_offset_to_block(
     Ok((
         height,
         item.block_hash,
+        migrated_predecessor_total(block_index, ledger, height),
         ledger_total_of_index_item(&item, ledger),
     ))
+}
+
+/// Cumulative `ledger` total *before* a migrated block at `height` (its base
+/// offset): the predecessor's indexed total, or `0` at genesis. Sound only for
+/// **migrated** heights — then `height - 1` is itself migrated (below the reorg
+/// floor, branch-invariant), so the index read is exact. Used by
+/// [`resolve_ledger_offset_to_block`]'s index fast paths; the un-migrated tail
+/// instead carries `prev_total` straight from the by-hash ancestry walk.
+fn migrated_predecessor_total(
+    block_index: &BlockIndex,
+    ledger: DataLedger,
+    height: BlockHeight,
+) -> u64 {
+    if height == 0 {
+        0
+    } else {
+        block_index
+            .get_item(height - 1)
+            .map(|i| ledger_total_of_index_item(&i, ledger))
+            .unwrap_or(0)
+    }
 }
 
 /// Reconstructs `target`'s Submit-ledger **start chunk offset**: the cumulative
@@ -992,7 +1029,13 @@ fn find_block_range(
     block_tree_guard: &BlockTreeReadGuard,
     db: &DatabaseProvider,
 ) -> eyre::Result<Option<BlockRange>> {
-    let mut blocks_with_expired_ledgers = BTreeMap::new();
+    // Per-block branch-correct base offset (hash → base). Miner attribution is
+    // per-slot (`slot_miners` below), NOT per-block: a block straddling two
+    // expired slots with different miners must split the txs by their start
+    // offset, not pay every tx to the union of both slots' miners (NC-0042 R4).
+    let mut block_bases: BTreeMap<H256, u64> = BTreeMap::new();
+    // Slot index → its miners (un-merged), for per-tx attribution by start offset.
+    let mut slot_miners: BTreeMap<SlotIndex, Arc<Vec<IrysAddress>>> = BTreeMap::new();
 
     // Bound the expired chunk range by the *parent header's* recorded ledger size
     // only — a pure function of the block being built/validated, identical on every
@@ -1010,8 +1053,8 @@ fn find_block_range(
 
     // Track min and max blocks as we iterate. Keyed by hash (not block-index item)
     // so un-migrated tail blocks — which have no index entry yet — are representable.
-    let mut min_height: Option<(BlockHeight, H256)> = None;
-    let mut max_height: Option<(BlockHeight, H256)> = None;
+    let mut min_height: Option<(BlockHeight, H256, u64)> = None;
+    let mut max_height: Option<(BlockHeight, H256, u64)> = None;
     // The boundary trim must span the UNION of all expired slots, not one slot's
     // range. When several expired slots share a block (small partitions), trimming
     // to a single slot's range would drop the others — under-refunding / halving
@@ -1021,6 +1064,9 @@ fn find_block_range(
     let mut global_end: Option<u64> = None;
 
     for (slot_index, miners) in expired_slots {
+        // Per-slot miners (un-merged) — the attribution source keyed by tx start
+        // offset's slot, instead of a per-block union (NC-0042 R4).
+        slot_miners.insert(slot_index, Arc::new(miners));
         let chunk_range = slot_index.compute_chunk_range(
             config.consensus.num_chunks_in_partition,
             max_chunk_offset_across_all_partitions,
@@ -1033,7 +1079,7 @@ fn find_block_range(
         while chunk_offset < *chunk_range.end() {
             // Branch-correct: resolve the offset against the parent's own ancestry
             // (tree-then-index, C1-gated), not the migrated-only index.
-            let (height, block_hash, block_total) = resolve_ledger_offset_to_block(
+            let (height, block_hash, block_base, block_total) = resolve_ledger_offset_to_block(
                 chunk_offset,
                 parent_block_hash,
                 ledger_type,
@@ -1042,26 +1088,24 @@ fn find_block_range(
                 db,
             )?;
 
-            // Update min_height if this is the first block or a lower height
-            if min_height.as_ref().is_none_or(|(h, _)| height < *h) {
-                min_height = Some((height, block_hash));
+            // Update min_height if this is the first block or a lower height.
+            // Carry the block's branch-correct base (start offset) so boundary
+            // trimming reads it from the parent ancestry, never re-deriving it
+            // from the migrated-only index (NC-0042 R1 — the un-migrated boundary
+            // predecessor errored / could diverge there).
+            if min_height.as_ref().is_none_or(|(h, _, _)| height < *h) {
+                min_height = Some((height, block_hash, block_base));
             }
 
             // Update max_height if this is the first block or a higher height
-            if max_height.as_ref().is_none_or(|(h, _)| height > *h) {
-                max_height = Some((height, block_hash));
+            if max_height.as_ref().is_none_or(|(h, _, _)| height > *h) {
+                max_height = Some((height, block_hash, block_base));
             }
 
-            // If the block already exists, merge the miners
-            blocks_with_expired_ledgers
-                .entry(block_hash)
-                .and_modify(|existing_miners: &mut Arc<Vec<IrysAddress>>| {
-                    // Merge the new miners with existing ones
-                    let mut combined = (**existing_miners).clone();
-                    combined.extend(miners.clone());
-                    *existing_miners = Arc::new(combined);
-                })
-                .or_insert_with(|| Arc::new(miners.clone()));
+            // Record the block's branch-correct base offset (the same for every
+            // offset that resolves to it). Miners are NOT merged here — each tx is
+            // attributed to its own start-offset slot in `slot_miners` (NC-0042 R4).
+            block_bases.entry(block_hash).or_insert(block_base);
 
             // Advance to the first chunk of the NEXT block. `block_total` is the
             // exclusive end of this block's chunks (offsets `[base, block_total)`),
@@ -1081,9 +1125,9 @@ fn find_block_range(
     }
 
     // Extract min and max block data - these must exist if we have expired slots
-    let (min_height, min_hash) =
+    let (min_height, min_hash, min_base) =
         min_height.expect("min_height must be populated after iterating expired slots");
-    let (max_height, max_hash) =
+    let (max_height, max_hash, max_base) =
         max_height.expect("max_height must be populated after iterating expired slots");
 
     // Both boundary blocks trim against the full expired span [global_start,
@@ -1098,51 +1142,28 @@ fn find_block_range(
     let min_block = BoundaryBlock {
         height: min_height,
         block_hash: min_hash,
+        base: min_base,
         chunk_range: global_range,
     };
 
     let max_block = BoundaryBlock {
         height: max_height,
         block_hash: max_hash,
+        base: max_base,
         chunk_range: global_range,
     };
 
-    // Get miners for boundary blocks before removing them
-    let min_block_miners = blocks_with_expired_ledgers
-        .remove(&min_block.block_hash)
-        .unwrap_or_else(|| Arc::new(vec![]));
-
-    let max_block_miners = blocks_with_expired_ledgers
-        .remove(&max_block.block_hash)
-        .unwrap_or_else(|| Arc::new(vec![]));
+    // The boundaries are processed explicitly; drop them so `block_bases` holds
+    // only the fully-interior ("middle") blocks.
+    block_bases.remove(&min_block.block_hash);
+    block_bases.remove(&max_block.block_hash);
 
     Ok(Some(BlockRange {
         min_block,
         max_block,
-        min_block_miners,
-        max_block_miners,
-        middle_blocks: blocks_with_expired_ledgers,
+        middle_blocks: block_bases,
+        slot_miners,
     }))
-}
-
-/// Helper to get the previous block's max chunk offset
-fn get_previous_max_offset(
-    block_index_guard: &BlockIndex,
-    block_height: BlockHeight,
-    ledger_type: DataLedger,
-) -> eyre::Result<LedgerChunkOffset> {
-    if block_height == 0 {
-        Ok(LedgerChunkOffset::from(0))
-    } else {
-        let prev_height = block_height - 1;
-        Ok(LedgerChunkOffset::from(
-            block_index_guard
-                .get_item(prev_height)
-                .ok_or_eyre("previous block must exist")?
-                .ledgers[ledger_type]
-                .total_chunks,
-        ))
-    }
 }
 
 /// Processes transactions from a boundary block (first or last).
@@ -1155,12 +1176,11 @@ fn get_previous_max_offset(
 async fn process_boundary_block(
     boundary: &BoundaryBlock,
     block_hash: H256,
-    miners: Arc<Vec<IrysAddress>>,
     is_earliest: bool,
     is_latest: bool,
     ledger_type: DataLedger,
     config: &Config,
-    block_index: &BlockIndex,
+    slot_miners: &BTreeMap<SlotIndex, Arc<Vec<IrysAddress>>>,
     block_tree_guard: &BlockTreeReadGuard,
     mempool_guard: &MempoolReadGuard,
     db: &DatabaseProvider,
@@ -1179,8 +1199,13 @@ async fn process_boundary_block(
     let ledger_data_txs =
         get_data_tx_in_parallel(ledger_tx_ids.to_vec(), mempool_guard, db).await?;
 
-    // Get the previous block's max offset
-    let prev_max_offset = get_previous_max_offset(block_index, boundary.height, ledger_type)?;
+    // The boundary block's branch-correct start offset, carried from
+    // `find_block_range`'s parent-ancestry resolution. NOT re-derived from the
+    // migrated-only block index: that read errored when the boundary block's
+    // predecessor was in the un-migrated tail, and could return the canonical
+    // (wrong-branch) total on a side fork — re-introducing the R1 index-lag
+    // divergence in the refund/fee walk (NC-0042).
+    let prev_max_offset = LedgerChunkOffset::from(boundary.base);
 
     // Filter transactions based on chunk positions
     let filtered_txs = filter_transactions_by_chunk_range(
@@ -1190,7 +1215,8 @@ async fn process_boundary_block(
         is_earliest,
         is_latest,
         config.consensus.chunk_size,
-        miners,
+        config.consensus.num_chunks_in_partition,
+        slot_miners,
     );
 
     Ok(filtered_txs)
@@ -1233,7 +1259,8 @@ fn filter_transactions_by_chunk_range(
     is_earliest: bool,
     is_latest: bool,
     chunk_size: u64,
-    miners: Arc<Vec<IrysAddress>>,
+    num_chunks_in_partition: u64,
+    slot_miners: &BTreeMap<SlotIndex, Arc<Vec<IrysAddress>>>,
 ) -> BTreeMap<IrysTransactionId, Arc<Vec<IrysAddress>>> {
     let mut current_offset = prev_max_offset;
     let mut tx_to_miners = BTreeMap::new();
@@ -1247,67 +1274,104 @@ fn filter_transactions_by_chunk_range(
         *partition_range.end()
     );
 
-    if !miners.is_empty() {
-        for (idx, tx) in transactions.iter().enumerate() {
-            let chunks = tx.data_size.div_ceil(chunk_size);
-            let tx_start = current_offset;
-            let tx_end = current_offset + chunks;
+    for (idx, tx) in transactions.iter().enumerate() {
+        let chunks = tx.data_size.div_ceil(chunk_size);
+        let tx_start = current_offset;
+        let tx_end = current_offset + chunks;
 
-            tracing::debug!(
-                "Tx {}: id={}, data_size={}, chunks={}, tx_start={}, tx_end={}",
-                idx,
-                tx.id,
-                tx.data_size,
-                chunks,
-                *tx_start,
-                *tx_end
-            );
+        tracing::debug!(
+            "Tx {}: id={}, data_size={}, chunks={}, tx_start={}, tx_end={}",
+            idx,
+            tx.id,
+            tx.data_size,
+            chunks,
+            *tx_start,
+            *tx_end
+        );
 
-            // Start trim (earliest boundary): skip transactions that start before
-            // the partition; we only include transactions starting within it.
-            if is_earliest && tx_start < partition_range.start() {
-                tracing::debug!("  Skipping (starts before partition)");
-                current_offset = tx_end;
-                continue;
-            }
-            // End trim (latest boundary): stop at the first transaction that starts
-            // at or after the partition end (one starting exactly at the end belongs
-            // to the next partition). Independent of the start trim so a sole block
-            // (min == max) applies both.
-            if is_latest && tx_start >= partition_range.end() {
-                tracing::debug!("  Breaking (starts at or after partition end)");
-                break;
-            }
-
-            // Include this transaction
-            tracing::debug!("  Including transaction");
-            tx_to_miners.insert(tx.id, Arc::clone(&miners));
+        // Start trim (earliest boundary): skip transactions that start before
+        // the partition; we only include transactions starting within it.
+        if is_earliest && tx_start < partition_range.start() {
+            tracing::debug!("  Skipping (starts before partition)");
             current_offset = tx_end;
+            continue;
         }
+        // End trim (latest boundary): stop at the first transaction that starts
+        // at or after the partition end (one starting exactly at the end belongs
+        // to the next partition). Independent of the start trim so a sole block
+        // (min == max) applies both.
+        if is_latest && tx_start >= partition_range.end() {
+            tracing::debug!("  Breaking (starts at or after partition end)");
+            break;
+        }
+
+        // Per-slot attribution: the slot containing this tx's START offset owns it
+        // (the module's ownership rule). NOT a per-block miner union — that
+        // cross-paid adjacent expired slots owned by different miners when they
+        // shared a block (NC-0042 R4). Expired slots tile [global_start,
+        // global_end) contiguously, so an in-range tx always maps to a present
+        // slot; the `None` arm is a defensive guard, not an expected path.
+        if num_chunks_in_partition != 0 {
+            let slot = SlotIndex::new(*tx_start / num_chunks_in_partition);
+            match slot_miners.get(&slot) {
+                Some(miners) => {
+                    tracing::debug!("  Including transaction (slot {})", slot.0);
+                    tx_to_miners.insert(tx.id, Arc::clone(miners));
+                }
+                None => tracing::warn!(
+                    tx.id = ?tx.id,
+                    slot = slot.0,
+                    "tx start offset maps to a non-expired slot; skipping (unexpected)"
+                ),
+            }
+        }
+        current_offset = tx_end;
     }
 
     tracing::info!("Filtered to {} transactions", tx_to_miners.len());
     tx_to_miners
 }
 
-/// Processes all middle blocks (non-boundary blocks)
+/// Processes all middle (fully-interior) blocks. Unlike the boundaries these need
+/// no trim — every tx lies within the expired range — but they DO need per-slot
+/// attribution: a middle block can straddle a slot boundary, so each tx is paid to
+/// the miners of the slot containing its start offset, computed from the block's
+/// branch-correct base offset (NC-0042 R4 — previously every middle-block tx was
+/// paid to the per-block miner union).
 async fn process_middle_blocks(
-    middle_blocks: BTreeMap<H256, Arc<Vec<IrysAddress>>>,
+    middle_blocks: &BTreeMap<H256, u64>,
+    global_range: LedgerChunkRange,
     ledger_type: DataLedger,
+    config: &Config,
+    slot_miners: &BTreeMap<SlotIndex, Arc<Vec<IrysAddress>>>,
     block_tree_guard: &BlockTreeReadGuard,
+    mempool_guard: &MempoolReadGuard,
     db: &DatabaseProvider,
 ) -> eyre::Result<BTreeMap<IrysTransactionId, Arc<Vec<IrysAddress>>>> {
     let mut tx_to_miners = BTreeMap::new();
 
-    for (block_hash, miners) in middle_blocks {
-        let block = get_block_by_hash(block_hash, block_tree_guard, db).await?;
+    for (block_hash, base) in middle_blocks {
+        let block = get_block_by_hash(*block_hash, block_tree_guard, db).await?;
         let ledger_tx_ids = block
             .get_data_ledger_tx_ids_ordered(ledger_type)
             .ok_or_eyre(format!("{:?} ledger is required", ledger_type))?;
+        let ledger_data_txs =
+            get_data_tx_in_parallel(ledger_tx_ids.to_vec(), mempool_guard, db).await?;
 
-        for tx_id in ledger_tx_ids.iter() {
-            tx_to_miners.insert(*tx_id, Arc::clone(&miners));
-        }
+        // No trim (`is_earliest = is_latest = false`): a middle block lies entirely
+        // within the expired range. `global_range` is passed only for logging
+        // parity. Each tx is attributed by the slot containing its start offset.
+        let filtered = filter_transactions_by_chunk_range(
+            ledger_data_txs,
+            LedgerChunkOffset::from(*base),
+            global_range,
+            false,
+            false,
+            config.consensus.chunk_size,
+            config.consensus.num_chunks_in_partition,
+            slot_miners,
+        );
+        tx_to_miners.extend(filtered);
     }
 
     Ok(tx_to_miners)
@@ -1457,6 +1521,11 @@ impl SlotIndex {
 struct BoundaryBlock {
     height: BlockHeight,
     block_hash: H256,
+    /// The block's branch-correct Submit start offset (cumulative chunks *before*
+    /// it), resolved from the parent ancestry in [`find_block_range`]. Used as the
+    /// boundary trim's starting `current_offset` instead of an index lookup, so a
+    /// boundary block in the un-migrated tail is handled correctly (NC-0042 R1).
+    base: u64,
     chunk_range: LedgerChunkRange,
 }
 
@@ -1464,9 +1533,17 @@ struct BoundaryBlock {
 struct BlockRange {
     min_block: BoundaryBlock,
     max_block: BoundaryBlock,
-    min_block_miners: Arc<Vec<IrysAddress>>,
-    max_block_miners: Arc<Vec<IrysAddress>>,
-    middle_blocks: BTreeMap<H256, Arc<Vec<IrysAddress>>>,
+    /// Fully-interior blocks (strictly between the boundaries): hash → branch-
+    /// correct base offset. Attributed per-slot by tx start offset just like the
+    /// boundary blocks, so a middle block straddling a slot boundary splits
+    /// correctly across miners.
+    middle_blocks: BTreeMap<H256, u64>,
+    /// Slot index → the miners that stored it (un-merged). A tx is attributed to
+    /// the miners of the slot containing its START offset — the module's ownership
+    /// rule. Keeping this per-slot (not a per-block union) is what stops adjacent
+    /// expired slots owned by different miners from cross-paying when they share a
+    /// block (NC-0042 R4).
+    slot_miners: BTreeMap<SlotIndex, Arc<Vec<IrysAddress>>>,
 }
 
 #[cfg(test)]
@@ -2049,8 +2126,15 @@ mod tests {
     /// block must be the tree block at height 4. Pre-R1 the range was capped at
     /// the index tip → max block height 2, silently dropping the tail's
     /// refunds/miner payouts (an epoch-block accounting + determinism gap).
-    #[test]
-    fn find_block_range_resolves_unmigrated_tail() -> eyre::Result<()> {
+    ///
+    /// Also covers the R1 boundary-base fix: the resolved boundary blocks must
+    /// carry their branch-correct start offset (`base`), and the downstream
+    /// `collect_tx_to_miners_from_range` walk must succeed on an un-migrated
+    /// boundary block. Pre-fix the boundary base was re-derived from
+    /// `block_index.get_item(height - 1)`, which returned `None` for the
+    /// un-migrated height 3 and errored "previous block must exist".
+    #[tokio::test]
+    async fn find_block_range_resolves_unmigrated_tail() -> eyre::Result<()> {
         use irys_database::{IrysDatabaseArgs as _, open_or_create_db, tables::IrysTables};
         use irys_domain::{
             BlockTree, BlockTreeReadGuard, CommitmentSnapshot, EpochSnapshot, dummy_ema_snapshot,
@@ -2130,7 +2214,9 @@ mod tests {
         for (height, submit_total) in [0_u64, 8, 14].into_iter().enumerate() {
             block_index.push_item(
                 &BlockIndexItem {
-                    block_hash: H256::random(),
+                    // Migrated index agrees with the tree on block hashes (as in
+                    // reality), so the boundary walk can fetch the fast-path block.
+                    block_hash: headers[height].block_hash,
                     num_ledgers: 2,
                     ledgers: vec![
                         irys_types::LedgerIndexItem {
@@ -2177,6 +2263,224 @@ mod tests {
         assert_eq!(
             range.max_block.block_hash, tree_tail_hash,
             "the max boundary block must be the tree block, not an indexed one"
+        );
+
+        // R1 boundary-base fix: each boundary block carries its branch-correct
+        // start offset, resolved from the parent ancestry. min_block (height 2)
+        // base = Submit total through height 1 = 8 (present in the index);
+        // max_block (height 4) base = total through height 3 = 18, which is PAST
+        // the migrated index tip (14) and is obtainable ONLY from the tree walk.
+        assert_eq!(
+            range.min_block.base, 8,
+            "min_block base = Submit total through height 1"
+        );
+        assert_eq!(
+            range.max_block.base, 18,
+            "max_block base = Submit total through the un-migrated height 3 — \
+             tree-only; pre-R1 the index lookup of height 3 errored"
+        );
+
+        // End-to-end: the boundary/middle walk must succeed on the un-migrated
+        // max boundary block. Pre-fix this errored with "previous block must
+        // exist" because the boundary base was read from the migrated-only index.
+        // (Fixture blocks carry no Submit tx_ids, so the result is empty — the
+        // point is that resolution completes without error.)
+        let tx_to_miners = collect_tx_to_miners_from_range(
+            range,
+            DataLedger::Submit,
+            &config,
+            &guard,
+            &MempoolReadGuard::stub(),
+            &db,
+        )
+        .await?;
+        assert!(
+            tx_to_miners.is_empty(),
+            "fixture blocks carry no Submit tx_ids, so no txs are attributed"
+        );
+
+        Ok(())
+    }
+
+    /// NC-0042 R4: when two expired slots owned by DIFFERENT miners share one
+    /// block (a block straddling the slot boundary), each tx must be attributed
+    /// to the miners of the slot containing its **start offset** — the module's
+    /// ownership rule — NOT the union of both slots' miners. Pre-fix
+    /// `find_block_range` merged miners per block, so every tx in the straddle
+    /// block was paid to both miner sets (mis-distributed term fees + a wrong
+    /// reward rolling-hash). Deterministic across nodes (not a fork), but a real
+    /// fee-accounting bug invisible to the single-miner heavy fixtures.
+    #[tokio::test]
+    async fn collect_attributes_each_tx_to_its_start_offset_slot_miners() -> eyre::Result<()> {
+        use irys_database::{
+            IrysDatabaseArgs as _, insert_tx_header, open_or_create_db, tables::IrysTables,
+        };
+        use irys_domain::{
+            BlockTree, BlockTreeReadGuard, CommitmentSnapshot, EpochSnapshot, dummy_ema_snapshot,
+        };
+        use irys_testing_utils::IrysBlockHeaderTestExt as _;
+        use irys_types::{BlockTransactions, DataTransactionHeaderV1, H256List, SealedBlock};
+        use reth_db::mdbx::DatabaseArguments;
+        use std::sync::RwLock;
+
+        // chunk_size = 1 ⇒ data_size N occupies N chunks. Partition = 4 chunks, so
+        // slot 0 = [0,4), slot 1 = [4,8). A single block (height 1) holds all 8
+        // chunks, straddling the slot-0/slot-1 boundary.
+        let mut node_config = irys_types::NodeConfig::testing();
+        {
+            let c = node_config.consensus.get_mut();
+            c.chunk_size = 1;
+            c.num_chunks_in_partition = 4;
+        }
+        let config = Config::new_with_random_peer_id(node_config);
+
+        // Four 2-chunk txs: tx0 [0,2) + tx1 [2,4) start in slot 0; tx2 [4,6) +
+        // tx3 [6,8) start in slot 1.
+        let mk_tx = |id_byte: u8| -> DataTransactionHeader {
+            let mut id = [0_u8; 32];
+            id[0] = id_byte;
+            DataTransactionHeader::V1(irys_types::DataTransactionHeaderV1WithMetadata {
+                tx: DataTransactionHeaderV1 {
+                    id: H256::from(id),
+                    data_size: 2,
+                    ..Default::default()
+                },
+                metadata: irys_types::DataTransactionMetadata::new(),
+            })
+        };
+        let txs = [mk_tx(1), mk_tx(2), mk_tx(3), mk_tx(4)];
+        let tx_ids: Vec<H256> = txs.iter().map(|t| t.id).collect();
+
+        fn submit_header(height: u64, total_chunks: u64, tx_ids: Vec<H256>) -> IrysBlockHeader {
+            let mut h = IrysBlockHeader::new_mock_header();
+            h.height = height;
+            h.data_ledgers = vec![irys_types::DataTransactionLedger {
+                ledger_id: DataLedger::Submit as u32,
+                tx_root: H256::zero(),
+                tx_ids: H256List(tx_ids),
+                total_chunks,
+                expires: None,
+                proofs: None,
+                required_proof_count: None,
+            }];
+            h
+        }
+        // Tree: genesis (Submit total 0) → block 1 (Submit total 8, the 4 txs).
+        let mut genesis = submit_header(0, 0, vec![]);
+        genesis.cumulative_diff = 0.into();
+        genesis.test_sign();
+        let mut block1 = submit_header(1, 8, tx_ids.clone());
+        block1.previous_block_hash = genesis.block_hash;
+        block1.cumulative_diff = 1.into();
+        block1.test_sign();
+        let block1_hash = block1.block_hash;
+        let guard = {
+            let mut tree = BlockTree::new(&genesis, irys_types::ConsensusConfig::testing());
+            tree.mark_tip(&genesis.block_hash).unwrap();
+            let sealed = Arc::new(SealedBlock::new_unchecked(
+                Arc::new(block1.clone()),
+                BlockTransactions::default(),
+            ));
+            tree.add_block(
+                &sealed,
+                Arc::new(CommitmentSnapshot::default()),
+                Arc::new(EpochSnapshot::default()),
+                dummy_ema_snapshot(),
+            )?;
+            BlockTreeReadGuard::new(Arc::new(RwLock::new(tree)))
+        };
+
+        // DB: seeded tx headers + a migrated index agreeing with the tree.
+        let temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db_env = open_or_create_db(
+            &temp_dir,
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        let db = DatabaseProvider(Arc::new(db_env));
+        db.update_eyre(|wtx| {
+            for t in &txs {
+                insert_tx_header(wtx, t)?;
+            }
+            Ok(())
+        })?;
+        let block_index = BlockIndex::new_for_testing(db.clone());
+        for (height, (hash, submit_total)) in [(genesis.block_hash, 0_u64), (block1_hash, 8)]
+            .into_iter()
+            .enumerate()
+        {
+            block_index.push_item(
+                &BlockIndexItem {
+                    block_hash: hash,
+                    num_ledgers: 2,
+                    ledgers: vec![
+                        irys_types::LedgerIndexItem {
+                            total_chunks: 0,
+                            tx_root: H256::random(),
+                            ledger: DataLedger::Publish,
+                        },
+                        irys_types::LedgerIndexItem {
+                            total_chunks: submit_total,
+                            tx_root: H256::random(),
+                            ledger: DataLedger::Submit,
+                        },
+                    ],
+                },
+                height as u64,
+            )?;
+        }
+
+        // Slot 0 stored by miner A, slot 1 by miner B; both expired this epoch.
+        let miner_a = IrysAddress::repeat_byte(0xAA);
+        let miner_b = IrysAddress::repeat_byte(0xBB);
+        let mut expired = BTreeMap::new();
+        expired.insert(SlotIndex::new(0), vec![miner_a]);
+        expired.insert(SlotIndex::new(1), vec![miner_b]);
+
+        let range = find_block_range(
+            expired,
+            &config,
+            &block_index,
+            DataLedger::Submit,
+            8, // parent_total
+            block1_hash,
+            &guard,
+            &db,
+        )?
+        .expect("expired slots hold data");
+
+        let tx_to_miners = collect_tx_to_miners_from_range(
+            range,
+            DataLedger::Submit,
+            &config,
+            &guard,
+            &MempoolReadGuard::stub(),
+            &db,
+        )
+        .await?;
+
+        // Each tx is attributed to ONLY the miners of its start-offset slot.
+        // Pre-fix every tx in the straddle block was attributed to [A, B].
+        let miners_of = |id: &H256| tx_to_miners.get(id).map(|m| m.to_vec());
+        assert_eq!(
+            miners_of(&tx_ids[0]),
+            Some(vec![miner_a]),
+            "tx0 (offset 0, slot 0) → miner A only"
+        );
+        assert_eq!(
+            miners_of(&tx_ids[1]),
+            Some(vec![miner_a]),
+            "tx1 (offset 2, slot 0) → miner A only"
+        );
+        assert_eq!(
+            miners_of(&tx_ids[2]),
+            Some(vec![miner_b]),
+            "tx2 (offset 4, slot 1) → miner B only"
+        );
+        assert_eq!(
+            miners_of(&tx_ids[3]),
+            Some(vec![miner_b]),
+            "tx3 (offset 6, slot 1) → miner B only"
         );
 
         Ok(())

--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -147,95 +147,21 @@ pub async fn calculate_expired_ledger_fees(
         }
     };
 
-    // Step 3: Process boundary blocks
-    let same_block = block_range.min_block.item.block_hash == block_range.max_block.item.block_hash;
-    tracing::info!(
-        "Processing boundary blocks: min_block height={}, max_block height={}, same_block={}",
-        block_range.min_block.height,
-        block_range.max_block.height,
-        same_block
-    );
-
-    let earliest_miners;
-    let latest_miners;
-
-    if same_block {
-        // When min and max are the same block, process it only once to avoid double-counting
-        // Process as earliest block (will include all transactions in the partition range)
-        let miners = process_boundary_block(
-            &block_range.min_block,
-            block_range.min_block.item.block_hash,
-            Arc::clone(&block_range.min_block_miners),
-            true, // is_earliest
-            ledger_type,
-            config,
-            &block_index,
-            block_tree_guard,
-            mempool_guard,
-            db,
-        )
-        .await?;
-
-        earliest_miners = miners;
-        latest_miners = BTreeMap::new();
-    } else {
-        // Different blocks - process both boundaries
-        let e_miners = process_boundary_block(
-            &block_range.min_block,
-            block_range.min_block.item.block_hash,
-            Arc::clone(&block_range.min_block_miners),
-            true, // is_earliest
-            ledger_type,
-            config,
-            &block_index,
-            block_tree_guard,
-            mempool_guard,
-            db,
-        )
-        .await?;
-
-        let l_miners = process_boundary_block(
-            &block_range.max_block,
-            block_range.max_block.item.block_hash,
-            Arc::clone(&block_range.max_block_miners),
-            false, // is_earliest
-            ledger_type,
-            config,
-            &block_index,
-            block_tree_guard,
-            mempool_guard,
-            db,
-        )
-        .await?;
-
-        earliest_miners = e_miners;
-        latest_miners = l_miners;
-    }
-
-    // Step 4: Process middle blocks
-    let middle_miners =
-        process_middle_blocks(block_range.middle_blocks, ledger_type, block_tree_guard, db).await?;
-
-    // Step 5: Combine all transactions
-    let mut all_tx_ids = Vec::new();
-    all_tx_ids.extend(earliest_miners.keys());
-    all_tx_ids.extend(latest_miners.keys());
-    all_tx_ids.extend(middle_miners.keys());
-
-    tracing::info!(
-        "Collected transactions: earliest={}, latest={}, middle={}, total={}",
-        earliest_miners.len(),
-        latest_miners.len(),
-        middle_miners.len(),
-        all_tx_ids.len()
-    );
-
-    let mut tx_to_miners = BTreeMap::new();
-    tx_to_miners.extend(earliest_miners);
-    tx_to_miners.extend(latest_miners);
-    tx_to_miners.extend(middle_miners);
+    // Steps 3-5: Process boundary + middle blocks → tx → miners
+    let tx_to_miners = collect_tx_to_miners_from_range(
+        block_range,
+        ledger_type,
+        config,
+        &block_index,
+        block_tree_guard,
+        mempool_guard,
+        db,
+    )
+    .await?;
 
     // Step 6: Fetch transactions
+    let mut all_tx_ids = Vec::new();
+    all_tx_ids.extend(tx_to_miners.keys());
     let mut transactions = get_data_tx_in_parallel(all_tx_ids, mempool_guard, db).await?;
     transactions.sort_by(irys_types::DataTransactionHeader::compare_tx);
 
@@ -270,6 +196,170 @@ pub async fn calculate_expired_ledger_fees(
     );
 
     Ok(fees)
+}
+
+/// Boundary + middle block processing (algorithm steps 3-5): maps every tx in the
+/// expired chunk ranges to the miners who stored it.
+///
+/// Shared by [`calculate_expired_ledger_fees`] (fee/refund distribution) and
+/// [`expired_submit_tx_ids`] (NC-0042 non-promotability set) so the two cannot
+/// disagree about which txs an expired slot contains — the structural flaw the
+/// cycle-math approximation introduced (see NC-0042 §4b).
+async fn collect_tx_to_miners_from_range(
+    block_range: BlockRange,
+    ledger_type: DataLedger,
+    config: &Config,
+    block_index: &BlockIndex,
+    block_tree_guard: &BlockTreeReadGuard,
+    mempool_guard: &MempoolReadGuard,
+    db: &DatabaseProvider,
+) -> eyre::Result<BTreeMap<IrysTransactionId, Arc<Vec<IrysAddress>>>> {
+    let same_block = block_range.min_block.item.block_hash == block_range.max_block.item.block_hash;
+    tracing::info!(
+        "Processing boundary blocks: min_block height={}, max_block height={}, same_block={}",
+        block_range.min_block.height,
+        block_range.max_block.height,
+        same_block
+    );
+
+    let earliest_miners;
+    let latest_miners;
+
+    if same_block {
+        // When min and max are the same block, process it only once to avoid double-counting
+        // Process as earliest block (will include all transactions in the partition range)
+        let miners = process_boundary_block(
+            &block_range.min_block,
+            block_range.min_block.item.block_hash,
+            Arc::clone(&block_range.min_block_miners),
+            true, // is_earliest
+            ledger_type,
+            config,
+            block_index,
+            block_tree_guard,
+            mempool_guard,
+            db,
+        )
+        .await?;
+
+        earliest_miners = miners;
+        latest_miners = BTreeMap::new();
+    } else {
+        // Different blocks - process both boundaries
+        let e_miners = process_boundary_block(
+            &block_range.min_block,
+            block_range.min_block.item.block_hash,
+            Arc::clone(&block_range.min_block_miners),
+            true, // is_earliest
+            ledger_type,
+            config,
+            block_index,
+            block_tree_guard,
+            mempool_guard,
+            db,
+        )
+        .await?;
+
+        let l_miners = process_boundary_block(
+            &block_range.max_block,
+            block_range.max_block.item.block_hash,
+            Arc::clone(&block_range.max_block_miners),
+            false, // is_earliest
+            ledger_type,
+            config,
+            block_index,
+            block_tree_guard,
+            mempool_guard,
+            db,
+        )
+        .await?;
+
+        earliest_miners = e_miners;
+        latest_miners = l_miners;
+    }
+
+    // Process middle blocks
+    let middle_miners =
+        process_middle_blocks(block_range.middle_blocks, ledger_type, block_tree_guard, db).await?;
+
+    tracing::info!(
+        "Collected transactions: earliest={}, latest={}, middle={}",
+        earliest_miners.len(),
+        latest_miners.len(),
+        middle_miners.len(),
+    );
+
+    let mut tx_to_miners = BTreeMap::new();
+    tx_to_miners.extend(earliest_miners);
+    tx_to_miners.extend(latest_miners);
+    tx_to_miners.extend(middle_miners);
+
+    Ok(tx_to_miners)
+}
+
+/// NC-0042 §4b/§4c: the set of Submit-ledger transaction ids whose storage has
+/// **expired as of `block_height`** — i.e. the txs that are (or will be at the
+/// next epoch) perm-fee-refunded and therefore must never be promoted.
+///
+/// This is the authoritative non-promotability predicate shared by the producer
+/// filter (`tx_selector::get_publish_txs_and_proofs`) and the validator check
+/// (`block_validation`). It is derived from the *same* expired-partition →
+/// block → tx walk that `calculate_expired_ledger_fees` uses for refunds, so the
+/// "is this tx refunded?" and "may this tx be promoted?" decisions cannot
+/// diverge.
+///
+/// Unlike the refund pipeline (which keys on *newly* expiring slots, acting once
+/// per slot), this keys on [`EpochSnapshot::get_all_expired_term_slot_indexes`]
+/// (inclusive of slots that expired at an earlier epoch), so a tx remains
+/// non-promotable for every block at-or-after its slot's expiry — covering both
+/// the same-block (epoch) collision and the cross-block double-pay.
+///
+/// Miners are irrelevant here (no fee attribution), so a sentinel miner is used
+/// purely to satisfy the boundary-filter's non-empty-miners requirement; the
+/// returned value is the tx-id set only.
+#[tracing::instrument(skip_all, fields(block.height = block_height))]
+pub async fn expired_submit_tx_ids(
+    parent_epoch_snapshot: &EpochSnapshot,
+    block_height: u64,
+    config: &Config,
+    block_index: BlockIndex,
+    block_tree_guard: &BlockTreeReadGuard,
+    mempool_guard: &MempoolReadGuard,
+    db: &DatabaseProvider,
+) -> eyre::Result<std::collections::BTreeSet<IrysTransactionId>> {
+    let slot_indexes =
+        parent_epoch_snapshot.get_all_expired_term_slot_indexes(DataLedger::Submit, block_height);
+    if slot_indexes.is_empty() {
+        return Ok(std::collections::BTreeSet::new());
+    }
+
+    // Sentinel miner: `find_block_range` / `filter_transactions_by_chunk_range`
+    // require a non-empty miner list to include a slot's txs, but we only need the
+    // tx ids here. The address value is never read (we take `.keys()`).
+    let expired_slots: BTreeMap<SlotIndex, Vec<IrysAddress>> = slot_indexes
+        .into_iter()
+        .map(|i| (SlotIndex::new(i as u64), vec![IrysAddress::ZERO]))
+        .collect();
+
+    let block_range =
+        match find_block_range(expired_slots, config, &block_index, DataLedger::Submit)? {
+            Some(br) => br,
+            // No chunks were ever uploaded into the expired slot ranges.
+            None => return Ok(std::collections::BTreeSet::new()),
+        };
+
+    let tx_to_miners = collect_tx_to_miners_from_range(
+        block_range,
+        DataLedger::Submit,
+        config,
+        &block_index,
+        block_tree_guard,
+        mempool_guard,
+        db,
+    )
+    .await?;
+
+    Ok(tx_to_miners.into_keys().collect())
 }
 
 /// Fetches a block header from block tree or database

--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -622,7 +622,12 @@ pub fn expired_submit_range(
         eyre::bail!("num_chunks_in_partition must be non-zero for Submit-expiry range math");
     }
     let parent_total = parent_block_header.ledger_total_chunks(DataLedger::Submit);
-    let range_end = (max_expired_slot as u64 + 1)
+    // `max_expired_slot` is a slot index (usize); the checked conversion documents
+    // the invariant and `saturating_add` keeps the lone `+1` from wrapping.
+    let max_expired_slot = u64::try_from(max_expired_slot)
+        .map_err(|_| eyre::eyre!("expired Submit slot index does not fit in u64"))?;
+    let range_end = max_expired_slot
+        .saturating_add(1)
         .saturating_mul(p)
         .min(parent_total);
     if range_end == 0 {

--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -1732,6 +1732,75 @@ mod tests {
         );
     }
 
+    /// NC-0042 R4 amount-attribution: when distinct miners own different expired
+    /// slots (hence different txs), each miner's reward must be exactly the
+    /// treasury slice of ITS slot's txs — never cross-credited to the other
+    /// miner. The straddle MAPPING (tx start offset → slot → miner) is proven by
+    /// `collect_attributes_each_tx_to_its_start_offset_slot_miners`; this composes
+    /// that mapping with `aggregate_balance_deltas` to confirm the resulting
+    /// per-miner reward AMOUNTS. (A full multi-node produced-block variant that
+    /// decodes the on-chain reward shadow-txs is a reasonable follow-up — the
+    /// refund harness is single-miner and cannot place two miners' slots in one
+    /// boundary block without partition-assignment control it does not expose.)
+    #[test]
+    fn aggregate_attributes_each_slots_fee_to_its_own_miner() {
+        let node_config = irys_types::NodeConfig::testing();
+        let config = Config::new_with_random_peer_id(node_config);
+
+        let miner_a = IrysAddress::repeat_byte(0xAA);
+        let miner_b = IrysAddress::repeat_byte(0xBB);
+
+        // tx0,tx1 stored by miner A (slot 0); tx2,tx3 by miner B (slot 1) — the
+        // outcome of the per-slot start-offset attribution on a straddle block.
+        let mk = |id_byte: u8, term_fee: u64| -> DataTransactionHeader {
+            DataTransactionHeader::V1(irys_types::DataTransactionHeaderV1WithMetadata {
+                tx: DataTransactionHeaderV1 {
+                    id: H256::from([id_byte; 32]),
+                    term_fee: U256::from(term_fee).into(),
+                    data_size: 100,
+                    ..Default::default()
+                },
+                metadata: irys_types::DataTransactionMetadata::new(),
+            })
+        };
+        let txs = [mk(1, 1000), mk(2, 2000), mk(3, 4000), mk(4, 8000)];
+
+        let mut tx_to_miners = BTreeMap::new();
+        tx_to_miners.insert(txs[0].id, Arc::new(vec![miner_a]));
+        tx_to_miners.insert(txs[1].id, Arc::new(vec![miner_a]));
+        tx_to_miners.insert(txs[2].id, Arc::new(vec![miner_b]));
+        tx_to_miners.insert(txs[3].id, Arc::new(vec![miner_b]));
+
+        let epoch_snapshot = EpochSnapshot::default();
+        let result =
+            aggregate_balance_deltas(txs.to_vec(), &tx_to_miners, &epoch_snapshot, &config, false)
+                .unwrap();
+
+        // Single miner per tx ⇒ that miner gets the whole treasury slice. Compute
+        // it via TermFeeCharges so the assertion tracks the real fee model.
+        let treasury = |term_fee: u64| -> U256 {
+            TermFeeCharges::new(U256::from(term_fee).into(), &config.consensus)
+                .unwrap()
+                .distribution_on_expiry(&[IrysAddress::ZERO])
+                .unwrap()[0]
+        };
+        assert_eq!(
+            result.reward_balance_increment.get(&miner_a).unwrap().0,
+            treasury(1000).saturating_add(treasury(2000)),
+            "miner A receives exactly slot-0 txs' treasury slices"
+        );
+        assert_eq!(
+            result.reward_balance_increment.get(&miner_b).unwrap().0,
+            treasury(4000).saturating_add(treasury(8000)),
+            "miner B receives exactly slot-1 txs' treasury slices"
+        );
+        assert_eq!(
+            result.reward_balance_increment.len(),
+            2,
+            "exactly the two slot owners are credited — no cross-crediting"
+        );
+    }
+
     #[test]
     fn test_ledger_expiry_balance_delta_merge_combines_rewards() {
         use crate::shadow_tx_generator::RollingHash;

--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -147,7 +147,7 @@ pub async fn calculate_expired_ledger_fees(
         config,
         &block_index,
         ledger_type,
-        parent_ledger_total_chunks(parent_block_header, ledger_type),
+        parent_block_header.ledger_total_chunks(ledger_type),
         parent_block_header.block_hash,
         block_tree_guard,
         db,
@@ -236,60 +236,23 @@ async fn collect_tx_to_miners_from_range(
     // (NC-0042 R4), so every block — boundary or middle — is processed against the
     // same un-merged `slot_miners` map rather than a per-block miner union.
     let slot_miners = &block_range.slot_miners;
-    let earliest_miners;
-    let latest_miners;
 
-    if same_block {
-        // When min and max are the same block, process it once as BOTH the earliest
-        // and latest boundary so both ends of the expired range are trimmed. (Trimming
-        // only the start — the old behavior — over-included the next slot's txs, which
-        // diverged from the exact per-candidate promotion filter; see NC-0042 §4b.)
-        let miners = process_boundary_block(
-            &block_range.min_block,
-            true, // is_earliest
-            true, // is_latest — sole boundary block (min == max), so trim BOTH ends
-            ledger_type,
-            config,
-            slot_miners,
-            block_tree_guard,
-            mempool_guard,
-            db,
-        )
-        .await?;
-
-        earliest_miners = miners;
-        latest_miners = BTreeMap::new();
-    } else {
-        // Different blocks - process both boundaries
-        let e_miners = process_boundary_block(
-            &block_range.min_block,
-            true,  // is_earliest — min block trims only the start
-            false, // is_latest
-            ledger_type,
-            config,
-            slot_miners,
-            block_tree_guard,
-            mempool_guard,
-            db,
-        )
-        .await?;
-
-        let l_miners = process_boundary_block(
-            &block_range.max_block,
-            false, // is_earliest
-            true,  // is_latest — max block trims only the end
-            ledger_type,
-            config,
-            slot_miners,
-            block_tree_guard,
-            mempool_guard,
-            db,
-        )
-        .await?;
-
-        earliest_miners = e_miners;
-        latest_miners = l_miners;
-    }
+    // Process the earliest boundary. For the sole-block case (min == max), process
+    // it as BOTH earliest and latest so both ends of the expired range are trimmed.
+    // (Trimming only the start — the old behavior — over-included the next slot's
+    // txs, which diverged from the exact per-candidate promotion filter; NC-0042 §4b.)
+    let earliest_miners = process_boundary_block(
+        &block_range.min_block,
+        true,       // is_earliest
+        same_block, // is_latest only when this is also the sole (max) block
+        ledger_type,
+        config,
+        slot_miners,
+        block_tree_guard,
+        mempool_guard,
+        db,
+    )
+    .await?;
 
     // Middle (fully-interior) blocks: no trim (they lie entirely within the
     // expired range), but still attributed per-slot by tx start offset — a middle
@@ -307,24 +270,51 @@ async fn collect_tx_to_miners_from_range(
     )
     .await?;
 
-    tracing::info!(
-        "Collected transactions: earliest={}, latest={}, middle={}",
-        earliest_miners.len(),
-        latest_miners.len(),
-        middle_miners.len(),
-    );
-
     let mut tx_to_miners = BTreeMap::new();
     tx_to_miners.extend(earliest_miners);
-    tx_to_miners.extend(latest_miners);
+
+    // Different blocks: process the latest boundary separately and extend.
+    if !same_block {
+        let latest_miners = process_boundary_block(
+            &block_range.max_block,
+            false, // is_earliest
+            true,  // is_latest — max block trims only the end
+            ledger_type,
+            config,
+            slot_miners,
+            block_tree_guard,
+            mempool_guard,
+            db,
+        )
+        .await?;
+        tracing::info!(
+            "Collected transactions: earliest={}, latest={}, middle={}",
+            tx_to_miners.len(),
+            latest_miners.len(),
+            middle_miners.len(),
+        );
+        tx_to_miners.extend(latest_miners);
+    } else {
+        tracing::info!(
+            "Collected transactions: earliest={}, middle={}",
+            tx_to_miners.len(),
+            middle_miners.len(),
+        );
+    }
+
     tx_to_miners.extend(middle_miners);
 
     Ok(tx_to_miners)
 }
 
 /// NC-0042 §4b/§4c: the set of Submit-ledger transaction ids whose storage has
-/// **expired as of `block_height`** — i.e. the txs that are (or will be at the
-/// next epoch) perm-fee-refunded and therefore must never be promoted.
+/// **expired as of `block_height`** — i.e. txs whose Submit storage is already
+/// expired at this block height, so they are perm-fee-refunded (now or at the
+/// next epoch settlement) and therefore must never be promoted.
+///
+/// Near-expiry is not disqualifying by itself: a tx may still be promoted even
+/// if its lowest slot is close to expiry, because its storage can span later
+/// slots and remains promotable until it has actually expired.
 ///
 /// It is derived from the *same* expired-partition → block → tx walk that
 /// `calculate_expired_ledger_fees` uses for refunds, so the "is this tx
@@ -386,7 +376,7 @@ pub async fn expired_submit_tx_ids(
         config,
         &block_index,
         DataLedger::Submit,
-        parent_ledger_total_chunks(parent_block_header, DataLedger::Submit),
+        parent_block_header.ledger_total_chunks(DataLedger::Submit),
         parent_block_header.block_hash,
         block_tree_guard,
         db,
@@ -524,7 +514,7 @@ pub fn expired_submit_range(
     // header (not this node's block-index tip) is what makes the verdict
     // branch-deterministic.
     let p = config.consensus.num_chunks_in_partition;
-    let parent_total = parent_ledger_total_chunks(parent_block_header, DataLedger::Submit);
+    let parent_total = parent_block_header.ledger_total_chunks(DataLedger::Submit);
     let range_end = (max_expired_slot as u64 + 1)
         .saturating_mul(p)
         .min(parent_total);
@@ -543,9 +533,10 @@ pub fn expired_submit_range(
 /// `txid`'s Submit storage expired as of `range.block_height`?
 ///
 /// Branch-correct: `txid`'s Submit inclusion is resolved from the block's **own
-/// parent ancestry** (migrated inclusions via `canonical_submit_height`, which is
-/// finalized and branch-invariant; un-migrated inclusions via a by-hash parent
-/// walk — never the node's canonical tip or migration-lagged index). The verdict
+/// parent ancestry** (migrated inclusions via `canonical_submit_height`, branch-
+/// invariant for the already-expired inclusions this acts on — below the reorg
+/// floor; see `resolve_submit_inclusion`; un-migrated inclusions via a by-hash
+/// parent walk — never the node's canonical tip or migration-lagged index). The verdict
 /// is then a pure offset comparison: expired iff the candidate's Submit start
 /// offset is `< range_end`. A candidate with no resolvable Submit inclusion on
 /// this branch yields `false`.
@@ -616,9 +607,15 @@ struct SubmitInclusion {
 /// Resolves `txid`'s Submit inclusion along the **block's own parent ancestry**
 /// (`range.parent_block_hash`) — never the node's canonical tip.
 ///
-/// Fast path: `canonical_submit_height` resolves migrated inclusions in O(1).
-/// Migrated blocks are below the reorg floor, hence finalized and shared by every
-/// branch, so the height is authoritative and branch-invariant.
+/// Fast path: `canonical_submit_height` resolves migrated inclusions in O(1)
+/// from the canonical index / `MigratedBlockHashes`. Migrated rows are only
+/// branch-invariant BELOW the reorg floor — since #1405 a deep reorg can rewrite
+/// them up to `block_tree_depth` deep. This is safe HERE because
+/// `submit_tx_expired` only acts on *expired* Submit slots, and `Config::validate`
+/// requires a slot's lifetime (`submit_ledger_epoch_length * num_blocks_in_epoch`)
+/// to exceed `block_tree_depth`, so any expired tx's inclusion sits below the
+/// reorg floor and the height is authoritative on every branch. (See the
+/// fork-awareness note above `canonical_metadata_height` in `database.rs`.)
 ///
 /// Slow path (only when the inclusion is un-migrated, i.e. the fast path returns
 /// `None`): walk the parent chain by hash up to `tx_anchor_expiry_depth` blocks
@@ -637,8 +634,9 @@ fn resolve_submit_inclusion(
     block_tree_guard: &BlockTreeReadGuard,
     db: &DatabaseProvider,
 ) -> eyre::Result<Option<SubmitInclusion>> {
-    // Fast path: migrated inclusion (finalized, branch-invariant). Capped at the
-    // parent — Submit inclusion is strictly before the block being evaluated.
+    // Fast path: migrated inclusion (branch-invariant below the reorg floor, where
+    // the slot-lifetime invariant keeps expired txs — see the doc above). Capped at
+    // the parent — Submit inclusion is strictly before the block being evaluated.
     let max_height = range.block_height.saturating_sub(1);
     if let Some(h) = db.view_eyre(|tx| canonical_submit_height(tx, &txid, max_height))? {
         let item = block_index
@@ -651,7 +649,10 @@ fn resolve_submit_inclusion(
             block_index
                 .get_item(h - 1)
                 .map(|i| submit_total_of_index_item(&i))
-                .unwrap_or(0)
+                .ok_or_eyre(
+                    "migrated predecessor must be indexed \
+                     (below the reorg floor → finalized)",
+                )?
         };
         return Ok(Some(SubmitInclusion {
             block_hash: item.block_hash,
@@ -674,7 +675,7 @@ fn resolve_submit_inclusion(
             tree.get_block(hash).map(|header| WalkBlock {
                 height: header.height,
                 prev_hash: header.previous_block_hash,
-                submit_total: parent_ledger_total_chunks(header, DataLedger::Submit),
+                submit_total: header.ledger_total_chunks(DataLedger::Submit),
                 includes_txid: block_includes_submit_tx(header, &txid),
             })
         },
@@ -739,12 +740,7 @@ fn walk_submit_inclusion(
                 // Predecessor below the tree window → canonical index, C1-gated.
                 let prev_height = block.height - 1;
                 if !is_canonical_at(block.prev_hash, prev_height)? {
-                    eyre::bail!(
-                        "Submit-expiry walk reached a non-canonical ancestor at height \
-                         {prev_height} (supplied {}) — off the validated block's branch \
-                         (C1 guard)",
-                        block.prev_hash
-                    );
+                    return Err(c1_non_canonical_ancestor_err(prev_height, block.prev_hash));
                 }
                 index_submit_total_at(prev_height).ok_or_eyre(
                     "Submit-expiry walk: predecessor below block_tree window must be \
@@ -793,6 +789,17 @@ fn is_canonical_at(db: &DatabaseProvider, hash: H256, height: u64) -> eyre::Resu
     Ok(canonical == Some(hash))
 }
 
+/// Unified C1 side-fork error: the expiry walk reached a block that is not the
+/// canonical block at `height` — i.e. it descended onto a side-fork ancestor off
+/// the validated block's own branch. Shared by the pure walk
+/// (`walk_submit_inclusion`) and [`assert_canonical_via_mbh`].
+fn c1_non_canonical_ancestor_err(height: u64, hash: H256) -> eyre::Report {
+    eyre::eyre!(
+        "expiry walk reached a non-canonical ancestor at height {height} \
+         (supplied {hash}) — off the validated block's branch (C1 guard)"
+    )
+}
+
 /// C1 side-fork guard: confirm `hash` is the canonical block at `height` per
 /// `MigratedBlockHashes` before trusting a height-keyed (canonical-only) index
 /// lookup for it. Without this, a walk that descended onto a side-fork ancestor
@@ -800,10 +807,7 @@ fn is_canonical_at(db: &DatabaseProvider, hash: H256, height: u64) -> eyre::Resu
 /// the wrong block.
 fn assert_canonical_via_mbh(db: &DatabaseProvider, hash: H256, height: u64) -> eyre::Result<()> {
     if !is_canonical_at(db, hash, height)? {
-        eyre::bail!(
-            "expiry walk reached a non-canonical ancestor at height {height} \
-             (supplied {hash}) — off the validated block's branch (C1 guard)"
-        );
+        return Err(c1_non_canonical_ancestor_err(height, hash));
     }
     Ok(())
 }
@@ -824,10 +828,13 @@ fn assert_canonical_via_mbh(db: &DatabaseProvider, hash: H256, height: u64) -> e
 /// + `previous_block_hash`); a predecessor below the block-tree window is read
 /// from the index only after the `MigratedBlockHashes` C1 check confirms it is
 /// canonical at that height. No `get_canonical_chain` or height→hash tree lookup
-/// is ever used for the forky region. The fast/slow split is itself branch-safe:
-/// both paths return the same block (a migrated offset's block is finalized and
-/// shared by every branch; an un-migrated offset's block is on the parent's own
-/// chain).
+/// is ever used for the forky region. The fast/slow split is branch-safe for the
+/// offsets this is called with: callers only resolve *expired* partitions, which
+/// the slot-lifetime > `block_tree_depth` config invariant keeps below the reorg
+/// floor, so a migrated offset's block is finalized and shared by every branch
+/// (migrated rows above the floor are reorg-mutable since #1405, but expired
+/// offsets never reach there); an un-migrated offset's block is on the parent's
+/// own chain.
 fn resolve_ledger_offset_to_block(
     offset: u64,
     parent_hash: H256,
@@ -836,7 +843,9 @@ fn resolve_ledger_offset_to_block(
     block_index: &BlockIndex,
     db: &DatabaseProvider,
 ) -> eyre::Result<(BlockHeight, H256, u64, u64)> {
-    // Fast path: finalized/migrated region — binary search is branch-invariant.
+    // Fast path: migrated region (index binary search). Branch-invariant for the
+    // expired offsets this is called with — kept below the reorg floor by the
+    // slot-lifetime > block_tree_depth config invariant; see the doc above.
     let index_tip_total = block_index
         .get_latest_item()
         .map(|item| ledger_total_of_index_item(&item, ledger))
@@ -846,7 +855,7 @@ fn resolve_ledger_offset_to_block(
         return Ok((
             height,
             item.block_hash,
-            migrated_predecessor_total(block_index, ledger, height),
+            migrated_predecessor_total(block_index, ledger, height)?,
             ledger_total_of_index_item(&item, ledger),
         ));
     }
@@ -855,11 +864,11 @@ fn resolve_ledger_offset_to_block(
     let tree = block_tree_guard.read();
     let mut cursor = parent_hash;
     while let Some(header) = tree.get_block(&cursor) {
-        let total = parent_ledger_total_chunks(header, ledger);
+        let total = header.ledger_total_chunks(ledger);
         let prev_total = if header.height == 0 {
             0
         } else if let Some(prev) = tree.get_block(&header.previous_block_hash) {
-            parent_ledger_total_chunks(prev, ledger)
+            prev.ledger_total_chunks(ledger)
         } else {
             // Predecessor below the tree window → canonical index, C1-gated.
             let prev_height = header.height - 1;
@@ -884,7 +893,7 @@ fn resolve_ledger_offset_to_block(
     Ok((
         height,
         item.block_hash,
-        migrated_predecessor_total(block_index, ledger, height),
+        migrated_predecessor_total(block_index, ledger, height)?,
         ledger_total_of_index_item(&item, ledger),
     ))
 }
@@ -899,14 +908,20 @@ fn migrated_predecessor_total(
     block_index: &BlockIndex,
     ledger: DataLedger,
     height: BlockHeight,
-) -> u64 {
+) -> eyre::Result<u64> {
     if height == 0 {
-        0
+        Ok(0)
     } else {
         block_index
             .get_item(height - 1)
             .map(|i| ledger_total_of_index_item(&i, ledger))
-            .unwrap_or(0)
+            .ok_or_else(|| {
+                eyre::eyre!(
+                    "migrated predecessor at height {} must be indexed \
+                     (below the reorg floor → finalized)",
+                    height - 1
+                )
+            })
     }
 }
 
@@ -1024,20 +1039,6 @@ fn collect_expired_partitions(
     }
 
     Ok(expired_ledger_slot_indexes)
-}
-
-/// The parent block header's recorded total chunk count for `ledger`. Headers
-/// carry per-ledger totals, so this is a pure function of the parent block —
-/// unlike the node's block-index tip, which moves as the chain grows. `0` when
-/// the ledger is absent from the header (e.g. pre-Cascade blocks without
-/// OneYear/ThirtyDay entries).
-fn parent_ledger_total_chunks(parent_block_header: &IrysBlockHeader, ledger: DataLedger) -> u64 {
-    parent_block_header
-        .data_ledgers
-        .iter()
-        .find(|dl| dl.ledger_id == ledger as u32)
-        .map(|dl| dl.total_chunks)
-        .unwrap_or(0)
 }
 
 /// Finds all blocks containing data in the expired chunk ranges
@@ -1292,6 +1293,12 @@ fn filter_transactions_by_chunk_range(
     if chunk_size == 0 {
         eyre::bail!("chunk_size must be non-zero for ledger-expiry chunk math");
     }
+    // `*tx_start / num_chunks_in_partition` below would panic or yield all-slot-0
+    // on a zero divisor. Guard loudly so a misconfigured partition size fails
+    // deterministically rather than silently misattributing every tx to slot 0.
+    if num_chunks_in_partition == 0 {
+        eyre::bail!("num_chunks_in_partition must be non-zero for ledger-expiry chunk math");
+    }
 
     let mut current_offset = prev_max_offset;
     let mut tx_to_miners = BTreeMap::new();
@@ -1345,22 +1352,20 @@ fn filter_transactions_by_chunk_range(
         // refund walk has diverged from the per-candidate promotion filter
         // (`submit_tx_expired`) — fail loud rather than silently under-refund,
         // which in consensus code would strand a refund and break Pipeline A ≡ B.
-        if num_chunks_in_partition != 0 {
-            let slot = SlotIndex::new(*tx_start / num_chunks_in_partition);
-            match slot_miners.get(&slot) {
-                Some(miners) => {
-                    tracing::debug!("  Including transaction (slot {})", slot.0);
-                    tx_to_miners.insert(tx.id, Arc::clone(miners));
-                }
-                None => eyre::bail!(
-                    "tx {} start offset {} maps to non-expired slot {} \
-                     (expired slots must tile the range contiguously) — refund \
-                     walk diverged from the promotion filter (NC-0042)",
-                    tx.id,
-                    *tx_start,
-                    slot.0,
-                ),
+        let slot = SlotIndex::new(*tx_start / num_chunks_in_partition);
+        match slot_miners.get(&slot) {
+            Some(miners) => {
+                tracing::debug!("  Including transaction (slot {})", slot.0);
+                tx_to_miners.insert(tx.id, Arc::clone(miners));
             }
+            None => eyre::bail!(
+                "tx {} start offset {} maps to non-expired slot {} \
+                 (expired slots must tile the range contiguously) — refund \
+                 walk diverged from the promotion filter (NC-0042)",
+                tx.id,
+                *tx_start,
+                slot.0,
+            ),
         }
         current_offset = tx_end;
     }
@@ -2967,6 +2972,118 @@ mod tests {
         assert!(
             err.to_string().contains("non-expired slot"),
             "expected the NC-0042 fail-loud message, got: {err}"
+        );
+    }
+
+    /// P2-5: `filter_transactions_by_chunk_range` must bail when `chunk_size == 0`
+    /// rather than panicking. Mirrors the existing `chunk_size == 0` guard in
+    /// `submit_tx_start_offset` and the `num_chunks_in_partition == 0` guard added
+    /// alongside it.
+    #[test]
+    fn filter_transactions_by_chunk_range_bails_on_zero_chunk_size() {
+        let tx = DataTransactionHeader::V1(irys_types::DataTransactionHeaderV1WithMetadata {
+            tx: DataTransactionHeaderV1 {
+                id: H256::random(),
+                data_size: 100,
+                ..Default::default()
+            },
+            metadata: irys_types::DataTransactionMetadata::new(),
+        });
+        let mut slot_miners: BTreeMap<SlotIndex, Arc<Vec<IrysAddress>>> = BTreeMap::new();
+        slot_miners.insert(SlotIndex::new(0), Arc::new(vec![IrysAddress::ZERO]));
+        let err = filter_transactions_by_chunk_range(
+            vec![tx],
+            LedgerChunkOffset::from(0_u64),
+            LedgerChunkRange(ledger_chunk_offset_ii!(0, 100)),
+            false, // is_earliest
+            false, // is_latest
+            0,     // chunk_size = 0 → must bail
+            10,    // num_chunks_in_partition
+            &slot_miners,
+        )
+        .expect_err("chunk_size == 0 must fail loud");
+        assert!(
+            err.to_string().contains("chunk_size"),
+            "expected the chunk_size guard message, got: {err}"
+        );
+    }
+
+    /// P1-3: `expired_submit_range` must bail when the expired Submit slot set is a
+    /// non-contiguous prefix (e.g. `{0, 2}` with slot 1 unwritten/excluded). The
+    /// contiguity invariant underpins the `[0, range_end)` promotion filter; a hole
+    /// would cause the filter to over-approximate real expired txs (NC-0042).
+    #[test]
+    fn expired_submit_range_bails_on_non_prefix_expired_set() {
+        use irys_domain::{CommitmentState, PartitionAssignments};
+        use irys_types::{Config, NodeConfig};
+
+        // Default config: num_blocks_in_epoch=100, submit_ledger_epoch_length=5,
+        // num_chunks_in_partition=10. min_blocks = 5 * 100 = 500.
+        let node_config = NodeConfig::testing();
+        let config = Config::new_with_random_peer_id(node_config);
+
+        let mut epoch = EpochSnapshot {
+            ledgers: irys_database::Ledgers::new(&config.consensus, false),
+            partition_assignments: PartitionAssignments::new(),
+            all_active_partitions: Vec::new(),
+            unassigned_partitions: Vec::new(),
+            storage_submodules_config: None,
+            config: config.clone(),
+            commitment_state: CommitmentState::default(),
+            epoch_block: IrysBlockHeader::default(),
+            previous_epoch_block: None,
+            expired_partition_infos: None,
+            epoch_height: 0,
+        };
+
+        // Allocate 4 Submit slots at height 1 (last_height=1 for all).
+        // Slot 3 is the never-expiring last slot.
+        epoch.ledgers[DataLedger::Submit].allocate_slots(4, 1);
+
+        // Touch slots 0 and 2 only (chunks [0,10) and [20,30)); slot 1 stays
+        // unwritten. With cascade_active=true, unwritten slots are excluded from
+        // expiry, so slot 1 is never returned as expired.
+        let chunks_per_slot = config.consensus.num_chunks_in_partition;
+        epoch.ledgers.touch_filled_slots(
+            DataLedger::Submit,
+            0,
+            chunks_per_slot,
+            chunks_per_slot,
+            1,
+            true,
+        );
+        epoch.ledgers.touch_filled_slots(
+            DataLedger::Submit,
+            2 * chunks_per_slot,
+            3 * chunks_per_slot,
+            chunks_per_slot,
+            1,
+            true,
+        );
+
+        // block_height = min_blocks + 50 → expiry_height = 50. Slots 0 and 2 have
+        // last_height=1 ≤ 50, so they expire. Slot 1 is unwritten (excluded by
+        // cascade). Slot 3 is the last slot (never expires). Result: {0, 2} — a hole.
+        let ep = &config.consensus.epoch;
+        let min_blocks = ep.submit_ledger_epoch_length * ep.num_blocks_in_epoch;
+        let block_height = min_blocks + 50;
+
+        // Sanity: fixture produces the non-prefix set before asserting the guard.
+        assert_eq!(
+            epoch.get_all_expired_term_slot_indexes(DataLedger::Submit, block_height, true),
+            vec![0, 2],
+            "fixture must produce the non-prefix expired set {{0, 2}}"
+        );
+
+        // Parent header just needs a Submit total that covers at least slot 2's data.
+        let mut parent = IrysBlockHeader::new_mock_header();
+        parent.data_ledgers[DataLedger::Submit].total_chunks = 3 * chunks_per_slot;
+
+        let err = expired_submit_range(block_height, &epoch, &parent, &config, true)
+            .expect_err("a non-prefix expired set must fail loud, not over-approximate");
+        assert!(
+            err.to_string().contains("not a contiguous prefix"),
+            "expected the NC-0042 contiguity guard message, got: {err}"
         );
     }
 }

--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -851,13 +851,7 @@ fn resolve_ledger_offset_to_block(
         .map(|item| ledger_total_of_index_item(&item, ledger))
         .unwrap_or(0);
     if offset < index_tip_total {
-        let (height, item) = block_index.get_block_index_item(ledger, offset)?;
-        return Ok((
-            height,
-            item.block_hash,
-            migrated_predecessor_total(block_index, ledger, height)?,
-            ledger_total_of_index_item(&item, ledger),
-        ));
+        return resolve_offset_via_index(block_index, ledger, offset);
     }
 
     // Slow path: un-migrated tail — walk the parent ancestry by hash.
@@ -889,40 +883,42 @@ fn resolve_ledger_offset_to_block(
 
     // Walked off the retained tree window without matching → the offset is below
     // it, hence finalized/migrated; resolve from the index (branch-invariant).
-    let (height, item) = block_index.get_block_index_item(ledger, offset)?;
-    Ok((
-        height,
-        item.block_hash,
-        migrated_predecessor_total(block_index, ledger, height)?,
-        ledger_total_of_index_item(&item, ledger),
-    ))
+    resolve_offset_via_index(block_index, ledger, offset)
 }
 
-/// Cumulative `ledger` total *before* a migrated block at `height` (its base
-/// offset): the predecessor's indexed total, or `0` at genesis. Sound only for
-/// **migrated** heights — then `height - 1` is itself migrated (below the reorg
-/// floor, branch-invariant), so the index read is exact. Used by
-/// [`resolve_ledger_offset_to_block`]'s index fast paths; the un-migrated tail
-/// instead carries `prev_total` straight from the by-hash ancestry walk.
-fn migrated_predecessor_total(
+/// Resolve `offset` to its introducing block via the **finalized block index**,
+/// returning `(height, block_hash, base, total)`.
+///
+/// Uses [`BlockIndex::get_block_bounds`] (anchored at the latest indexed height),
+/// NOT [`BlockIndex::get_block_index_item`]. The two binary-search the same index
+/// but diverge on a probed block whose entry for `ledger` is absent:
+/// `get_block_index_item` errors, while `get_block_bounds` treats it as
+/// `total_chunks = 0` and keeps searching. That tolerance is required for ledgers
+/// introduced after genesis — `OneYear`/`ThirtyDay` at a **mid-chain Cascade
+/// activation**: a pre-activation block carries only `Publish`+`Submit`, so once
+/// a term slot ages into the migrated index and expires, the strict variant would
+/// error the instant the search probes a pre-activation height, bubbling out of
+/// both the producer and validator epoch-block expiry walk → a deterministic
+/// chain stall. Only called for offsets below the migrated index tip (finalized ⇒
+/// branch-invariant), so anchoring at the latest indexed height is branch-safe.
+/// `base` (the predecessor's total) comes straight from the bounds, which compute
+/// it the same way the old `migrated_predecessor_total` did (0 at genesis or when
+/// the predecessor predates the ledger's introduction).
+fn resolve_offset_via_index(
     block_index: &BlockIndex,
     ledger: DataLedger,
-    height: BlockHeight,
-) -> eyre::Result<u64> {
-    if height == 0 {
-        Ok(0)
-    } else {
-        block_index
-            .get_item(height - 1)
-            .map(|i| ledger_total_of_index_item(&i, ledger))
-            .ok_or_else(|| {
-                eyre::eyre!(
-                    "migrated predecessor at height {} must be indexed \
-                     (below the reorg floor → finalized)",
-                    height - 1
-                )
-            })
-    }
+    offset: u64,
+) -> eyre::Result<(BlockHeight, H256, u64, u64)> {
+    let bounds = block_index.get_block_bounds(ledger, LedgerChunkOffset::from(offset))?;
+    let item = block_index
+        .get_item(bounds.height)
+        .ok_or_eyre("block bounds height absent from block index")?;
+    Ok((
+        bounds.height,
+        item.block_hash,
+        bounds.start_chunk_offset,
+        bounds.end_chunk_offset,
+    ))
 }
 
 /// Reconstructs `target`'s Submit-ledger **start chunk offset**: the cumulative
@@ -2226,6 +2222,139 @@ mod tests {
         )?
         .expect("expired slot 0 holds data");
         assert_eq!(range.max_block.height, 3);
+
+        Ok(())
+    }
+
+    /// NC-0042 (mid-chain Cascade): `find_block_range` must resolve an expired
+    /// OneYear/ThirtyDay chunk offset even though the block index contains
+    /// PRE-activation items that carry only Publish+Submit (no term-ledger entry).
+    ///
+    /// Regression: `resolve_ledger_offset_to_block`'s index fast path used
+    /// `get_block_index_item`, whose binary search errors ("Ledger OneYear not
+    /// found in block at height N") the instant it probes a pre-activation
+    /// 2-ledger block. On a network where Cascade activates mid-chain, once a
+    /// OneYear/ThirtyDay slot ages into the migrated index and expires, that error
+    /// bubbles out of BOTH the producer and the validator epoch-block expiry path
+    /// → a deterministic chain stall. The tolerant `get_block_bounds` treats a
+    /// probed block lacking the ledger as `total_chunks = 0`, so resolution
+    /// converges on the introducing block instead of erroring.
+    #[test]
+    fn find_block_range_resolves_term_ledger_offset_across_preactivation_index() -> eyre::Result<()>
+    {
+        use irys_database::{IrysDatabaseArgs as _, open_or_create_db, tables::IrysTables};
+        use irys_domain::{BlockTree, BlockTreeReadGuard};
+        use irys_testing_utils::IrysBlockHeaderTestExt as _;
+        use reth_db::mdbx::DatabaseArguments;
+        use std::sync::RwLock;
+
+        let mut node_config = irys_types::NodeConfig::testing();
+        node_config.consensus.get_mut().num_chunks_in_partition = 10;
+        let config = Config::new_with_random_peer_id(node_config);
+
+        let temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db_env = open_or_create_db(
+            &temp_dir,
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        let db = DatabaseProvider(Arc::new(db_env));
+        let block_index = BlockIndex::new_for_testing(db.clone());
+
+        // Heights 0-2: PRE-Cascade — only Publish + Submit, no OneYear entry.
+        for (height, submit_total) in [0_u64, 5, 8].into_iter().enumerate() {
+            block_index.push_item(
+                &BlockIndexItem {
+                    block_hash: H256::random(),
+                    num_ledgers: 2,
+                    ledgers: vec![
+                        irys_types::LedgerIndexItem {
+                            total_chunks: 0,
+                            tx_root: H256::random(),
+                            ledger: DataLedger::Publish,
+                        },
+                        irys_types::LedgerIndexItem {
+                            total_chunks: submit_total,
+                            tx_root: H256::random(),
+                            ledger: DataLedger::Submit,
+                        },
+                    ],
+                },
+                height as u64,
+            )?;
+        }
+        // Heights 3-5: POST-Cascade — OneYear introduced, cumulative totals 5,12,18.
+        for (idx, one_year_total) in [5_u64, 12, 18].into_iter().enumerate() {
+            block_index.push_item(
+                &BlockIndexItem {
+                    block_hash: H256::random(),
+                    num_ledgers: 4,
+                    ledgers: vec![
+                        irys_types::LedgerIndexItem {
+                            total_chunks: 0,
+                            tx_root: H256::random(),
+                            ledger: DataLedger::Publish,
+                        },
+                        irys_types::LedgerIndexItem {
+                            total_chunks: 8,
+                            tx_root: H256::random(),
+                            ledger: DataLedger::Submit,
+                        },
+                        irys_types::LedgerIndexItem {
+                            total_chunks: one_year_total,
+                            tx_root: H256::random(),
+                            ledger: DataLedger::OneYear,
+                        },
+                        irys_types::LedgerIndexItem {
+                            total_chunks: 0,
+                            tx_root: H256::random(),
+                            ledger: DataLedger::ThirtyDay,
+                        },
+                    ],
+                },
+                3 + idx as u64,
+            )?;
+        }
+
+        // Expired OneYear slot 0 ([0,10)). Offset 0 < the index-tip OneYear total
+        // (18), so resolution takes the index fast path, whose binary search over
+        // heights [0,5] probes pre-activation height 2 (which has no OneYear entry).
+        let mut expired = BTreeMap::new();
+        expired.insert(SlotIndex::new(0), vec![IrysAddress::ZERO]);
+
+        // All resolved offsets lie below the migrated tip, so the tree/parent are
+        // unused (same setup as `find_block_range_bounds_by_parent_not_index_tip`).
+        let mut genesis = IrysBlockHeader::new_mock_header();
+        genesis.height = 0;
+        genesis.cumulative_diff = 0.into();
+        genesis.test_sign();
+        let guard = BlockTreeReadGuard::new(Arc::new(RwLock::new(BlockTree::new(
+            &genesis,
+            irys_types::ConsensusConfig::testing(),
+        ))));
+        let parent_hash = genesis.block_hash;
+
+        let range = find_block_range(
+            expired,
+            &config,
+            &block_index,
+            DataLedger::OneYear,
+            18, // parent's OneYear total
+            parent_hash,
+            &guard,
+            &db,
+        )?
+        .expect("expired OneYear slot 0 holds data");
+
+        // OneYear slot 0 ([0,10)) spans height 3 (totals 0->5) and height 4 (5->12).
+        assert_eq!(
+            range.min_block.height, 3,
+            "OneYear chunk 0 first appears at height 3"
+        );
+        assert_eq!(
+            range.max_block.height, 4,
+            "OneYear chunk 9 lands at height 4"
+        );
 
         Ok(())
     }

--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -360,8 +360,15 @@ pub async fn expired_submit_tx_ids(
     mempool_guard: &MempoolReadGuard,
     db: &DatabaseProvider,
 ) -> eyre::Result<std::collections::BTreeSet<IrysTransactionId>> {
-    let slot_indexes =
-        parent_epoch_snapshot.get_all_expired_term_slot_indexes(DataLedger::Submit, block_height);
+    let cascade_active = config
+        .consensus
+        .hardforks
+        .is_cascade_active_at(parent_epoch_snapshot.epoch_block.timestamp_secs());
+    let slot_indexes = parent_epoch_snapshot.get_all_expired_term_slot_indexes(
+        DataLedger::Submit,
+        block_height,
+        cascade_active,
+    );
     if slot_indexes.is_empty() {
         return Ok(std::collections::BTreeSet::new());
     }
@@ -423,11 +430,16 @@ pub async fn is_submit_storage_expired(
     mempool_guard: &MempoolReadGuard,
     db: &DatabaseProvider,
 ) -> eyre::Result<bool> {
+    let cascade_active = config
+        .consensus
+        .hardforks
+        .is_cascade_active_at(parent_epoch_snapshot.epoch_block.timestamp_secs());
     let Some(range) = expired_submit_range(
         block_height,
         parent_epoch_snapshot,
         parent_block_header,
         config,
+        cascade_active,
     )?
     else {
         return Ok(false);
@@ -469,34 +481,31 @@ pub struct ExpiredSubmitRange {
 /// a pure function of the block's own parent, identical on every node regardless
 /// of that node's migration-lagged block-index tip (NC-0042 F2). The branch-
 /// correct mapping from a candidate's inclusion to a chunk offset happens later,
-/// per candidate, in [`submit_tx_expired`].
+/// per candidate, in [`submit_tx_expired`]. `cascade_active` MUST be the
+/// Cascade status of the block being produced/validated; pre-Cascade replay
+/// keeps the old allocation-anchored unwritten-slot expiry behavior.
 pub fn expired_submit_range(
     block_height: u64,
     parent_epoch_snapshot: &EpochSnapshot,
     parent_block_header: &IrysBlockHeader,
     config: &Config,
+    cascade_active: bool,
 ) -> eyre::Result<Option<ExpiredSubmitRange>> {
-    // The expired Submit slots (also handles "not enough blocks elapsed → empty").
-    let slot_indexes =
-        parent_epoch_snapshot.get_all_expired_term_slot_indexes(DataLedger::Submit, block_height);
+    let slot_indexes = parent_epoch_snapshot.get_all_expired_term_slot_indexes(
+        DataLedger::Submit,
+        block_height,
+        cascade_active,
+    );
     let Some(&max_expired_slot) = slot_indexes.iter().max() else {
         return Ok(None);
     };
 
-    // NC-0042 contiguity guard. The `[0, range_end)` collapse below is correct only
-    // if the expired slots are a prefix `{0..=max}`. In normal operation they are:
-    // chunk offsets are cumulative and slots fill sequentially, so `last_height` is
-    // non-decreasing in slot index, and empty pre-allocated slots sit at the top
-    // where the never-expire-the-last-slot rule trims them. A hole (an empty,
-    // non-last slot aged out by its allocation height beneath a still-live lower
-    // slot) would make the prefix over-approximate — deterministically rejecting
-    // valid promotions AND diverging from the slot-exact refund walk
-    // (`collect_expired_partitions`, which only settles slots that actually hold
-    // partitions). The set is a pure function of canonical state, so failing loud
-    // here fails identically on every node (no fork) instead of silently diverging
-    // — same philosophy as the `filter_transactions_by_chunk_range` guard below.
-    // `slot_indexes` is ascending and distinct (`get_all_expired_slot_indexes`
-    // iterates slots in order), so "value at position i equals i" ⇔ prefix-from-0.
+    // Expired Submit slots must be a prefix of the written data. Unwritten
+    // preallocated slots never expire, and Submit data is append-only, so once a
+    // higher slot has written data, later writes cannot return to keep a lower
+    // slot live while that higher written slot expires. If this guard ever fires,
+    // the promotion filter would over-approximate real expired txs and must fail
+    // loud rather than silently diverge.
     if let Some((i, &slot)) = slot_indexes
         .iter()
         .enumerate()
@@ -2705,59 +2714,226 @@ mod tests {
         Ok(())
     }
 
-    /// NC-0042 contiguity guard: `expired_submit_range` collapses the expired
-    /// Submit slots to a single `[0, range_end)` prefix, which is only correct if
-    /// the slots are `{0..=max}`. A hole (an empty, non-last slot aged out by its
-    /// allocation height beneath a still-live lower slot) would over-approximate
-    /// — deterministically rejecting valid promotions AND diverging from the
-    /// slot-exact refund walk. The verdict is a pure function of canonical state,
-    /// so it must fail loud (identically on every node) rather than silently.
-    #[test]
-    fn expired_submit_range_bails_on_non_prefix_expired_set() {
-        fn submit_header_total(total_chunks: u64) -> IrysBlockHeader {
+    /// Canonical P0 repro turned regression: normal epoch-slot allocation
+    /// preallocates future Submit slots, but those unwritten slots must never
+    /// expire. Only slot 0 should expire here; slot 1 remains live because it
+    /// was refreshed by a later write, and slots 2/3 remain live because they
+    /// never held canonical data at all.
+    #[tokio::test]
+    async fn submit_expiry_skips_canonical_unwritten_slots() -> eyre::Result<()> {
+        use irys_database::{
+            IrysDatabaseArgs as _, insert_block_header, insert_tx_header, open_or_create_db,
+            set_data_tx_included_height, tables::IrysTables,
+        };
+        use irys_domain::{
+            BlockIndex, BlockTree, BlockTreeReadGuard, CommitmentState, PartitionAssignments,
+        };
+        use irys_testing_utils::{IrysBlockHeaderTestExt as _, utils::TempDirBuilder};
+        use irys_types::{
+            Config, ConsensusConfig, DataTransactionHeaderV1, DataTransactionHeaderV1WithMetadata,
+            DataTransactionMetadata, H256List, LedgerIndexItem, NodeConfig, UnixTimestamp,
+            app_state::DatabaseProvider, hardfork_config::Cascade,
+        };
+        use reth_db::{mdbx::DatabaseArguments, transaction::DbTxMut as _};
+        use std::sync::{Arc, RwLock};
+
+        fn config_with_cascade() -> Config {
+            let mut node_config = NodeConfig::testing();
+            let consensus = node_config.consensus.get_mut();
+            consensus.chunk_size = 1;
+            consensus.num_chunks_in_partition = 10;
+            consensus.hardforks.cascade = Some(Cascade {
+                activation_timestamp: UnixTimestamp::from_secs(0),
+                one_year_epoch_length: 365,
+                thirty_day_epoch_length: 30,
+                annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
+            });
+            Config::new_with_random_peer_id(node_config)
+        }
+
+        fn submit_epoch_header(height: u64, total_chunks: u64) -> IrysBlockHeader {
             let mut h = IrysBlockHeader::new_mock_header();
-            h.data_ledgers = vec![irys_types::DataTransactionLedger {
-                ledger_id: DataLedger::Submit as u32,
-                tx_root: H256::zero(),
-                tx_ids: irys_types::H256List(vec![]),
-                total_chunks,
-                expires: None,
-                proofs: None,
-                required_proof_count: None,
-            }];
+            h.height = height;
+            h.timestamp = irys_types::UnixTimestampMs::from_millis((height as u128) * 1000);
+            h.data_ledgers[DataLedger::Submit].total_chunks = total_chunks;
+            h.data_ledgers[DataLedger::Submit].tx_ids = H256List::new();
             h
         }
 
-        // Build the hole topology in real ledger state: 4 Submit slots allocated
-        // at height 1, then only slot 1 touched (chunks [12,18) with a 10-chunk
-        // partition) → last_height [1, 100, 1, 1]. At an expiry height in (1, 100)
-        // slots 0 and 2 expire while slot 1 stays live; slot 3 is the never-
-        // expiring last slot. So `get_all_expired_term_slot_indexes` returns the
-        // non-prefix set {0, 2}.
-        let mut epoch = EpochSnapshot::default();
-        epoch.ledgers[DataLedger::Submit].allocate_slots(4, 1);
-        epoch
-            .ledgers
-            .touch_filled_slots(DataLedger::Submit, 12, 18, 10, 100);
+        fn submit_chain_header(
+            height: u64,
+            total_chunks: u64,
+            tx_ids: Vec<H256>,
+        ) -> IrysBlockHeader {
+            let mut h = IrysBlockHeader::new_mock_header();
+            h.height = height;
+            h.data_ledgers[DataLedger::Submit].total_chunks = total_chunks;
+            h.data_ledgers[DataLedger::Submit].tx_ids = H256List(tx_ids);
+            h
+        }
 
-        let ep = &epoch.config.consensus.epoch;
-        let min_blocks = ep.submit_ledger_epoch_length * ep.num_blocks_in_epoch;
-        let block_height = min_blocks + 50; // expiry_height = 50 ∈ (1, 100)
+        let config = config_with_cascade();
 
-        // Sanity: the fixture really is a hole before we assert the guard fires.
+        let num_blocks_in_epoch = config.consensus.epoch.num_blocks_in_epoch;
+        let blocks_per_cycle =
+            config.consensus.epoch.submit_ledger_epoch_length * num_blocks_in_epoch;
+        let epoch1_height = num_blocks_in_epoch;
+        let epoch2_height = 2 * num_blocks_in_epoch;
+        let expiry_epoch_height = blocks_per_cycle + num_blocks_in_epoch;
+        let probe_height = expiry_epoch_height + 1;
+
+        // Canonical epoch evolution:
+        //   h=0      : genesis allocates slot 0
+        //   h=N      : total_chunks jumps to 18, so slots 0/1 receive data and
+        //              several future slots are preallocated but untouched
+        //   h=2N     : total_chunks advances only to 19, refreshing slot 1 alone
+        //   h=3N..6N : no new data, so the touched/stale heights persist
+        // At h=6N+1, slot 0 has expired, slot 1 is still live, and untouched
+        // preallocated slots 2/3 must remain unexpired.
+        let mut epoch = EpochSnapshot {
+            ledgers: irys_database::Ledgers::new(&config.consensus, false),
+            partition_assignments: PartitionAssignments::new(),
+            all_active_partitions: Vec::new(),
+            unassigned_partitions: Vec::new(),
+            storage_submodules_config: None,
+            config: config.clone(),
+            commitment_state: CommitmentState::default(),
+            epoch_block: IrysBlockHeader::default(),
+            previous_epoch_block: None,
+            expired_partition_infos: None,
+            epoch_height: 0,
+        };
+        let mut epoch0 = submit_epoch_header(0, 0);
+        epoch0.test_sign();
+        epoch.perform_epoch_tasks(&None, &epoch0, vec![])?;
+        let mut epoch1 = submit_epoch_header(epoch1_height, 18);
+        epoch1.test_sign();
+        epoch.perform_epoch_tasks(&Some(epoch0.clone()), &epoch1, vec![])?;
+        let mut epoch2 = submit_epoch_header(epoch2_height, 19);
+        epoch2.test_sign();
+        epoch.perform_epoch_tasks(&Some(epoch1.clone()), &epoch2, vec![])?;
+        let mut prev_epoch = epoch2.clone();
+        for height in
+            (3 * num_blocks_in_epoch..=expiry_epoch_height).step_by(num_blocks_in_epoch as usize)
+        {
+            let mut next_epoch = submit_epoch_header(height, 19);
+            next_epoch.test_sign();
+            epoch.perform_epoch_tasks(&Some(prev_epoch.clone()), &next_epoch, vec![])?;
+            prev_epoch = next_epoch;
+        }
+
         assert_eq!(
-            epoch.get_all_expired_term_slot_indexes(DataLedger::Submit, block_height),
-            vec![0, 2],
-            "fixture must produce the non-prefix expired set {{0, 2}}"
+            epoch.get_all_expired_term_slot_indexes(DataLedger::Submit, probe_height, true),
+            vec![0],
+            "canonical epoch processing must skip unwritten preallocated Submit slots"
         );
 
-        let parent = submit_header_total(25); // data through slot 2 (3 × 10 chunks)
-        let err = expired_submit_range(block_height, &epoch, &parent, &epoch.config)
-            .expect_err("a non-prefix expired set must fail loud, not over-approximate");
+        let tx_slot_0 = DataTransactionHeader::V1(DataTransactionHeaderV1WithMetadata {
+            tx: DataTransactionHeaderV1 {
+                id: H256::random(),
+                data_size: 10, // chunks [0,10) -> slot 0
+                ..Default::default()
+            },
+            metadata: DataTransactionMetadata::new(),
+        });
+        let tx_slot_1 = DataTransactionHeader::V1(DataTransactionHeaderV1WithMetadata {
+            tx: DataTransactionHeaderV1 {
+                id: H256::random(),
+                data_size: 9, // chunks [10,19) -> slot 1
+                ..Default::default()
+            },
+            metadata: DataTransactionMetadata::new(),
+        });
+
+        let mut inclusion_genesis = submit_chain_header(0, 0, vec![]);
+        inclusion_genesis.cumulative_diff = 0.into();
+        inclusion_genesis.test_sign();
+        let mut inclusion_block = submit_chain_header(1, 19, vec![tx_slot_0.id, tx_slot_1.id]);
+        inclusion_block.previous_block_hash = inclusion_genesis.block_hash;
+        inclusion_block.cumulative_diff = 1.into();
+        inclusion_block.test_sign();
+
+        let temp_dir = TempDirBuilder::new().build();
+        let db_env = open_or_create_db(
+            &temp_dir,
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        let db = DatabaseProvider(Arc::new(db_env));
+        db.update_eyre(|wtx| {
+            insert_tx_header(wtx, &tx_slot_0)?;
+            insert_tx_header(wtx, &tx_slot_1)?;
+            set_data_tx_included_height(wtx, &tx_slot_0.id, 1)?;
+            set_data_tx_included_height(wtx, &tx_slot_1.id, 1)?;
+            insert_block_header(wtx, &inclusion_genesis)?;
+            insert_block_header(wtx, &inclusion_block)?;
+            wtx.put::<irys_database::tables::MigratedBlockHashes>(0, inclusion_genesis.block_hash)?;
+            wtx.put::<irys_database::tables::MigratedBlockHashes>(1, inclusion_block.block_hash)?;
+            Ok(())
+        })?;
+
+        let block_index = BlockIndex::new_for_testing(db.clone());
+        for (height, (hash, submit_total)) in [
+            (inclusion_genesis.block_hash, 0_u64),
+            (inclusion_block.block_hash, 19_u64),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            block_index.push_item(
+                &BlockIndexItem {
+                    block_hash: hash,
+                    num_ledgers: 2,
+                    ledgers: vec![
+                        LedgerIndexItem {
+                            total_chunks: 0,
+                            tx_root: H256::random(),
+                            ledger: DataLedger::Publish,
+                        },
+                        LedgerIndexItem {
+                            total_chunks: submit_total,
+                            tx_root: H256::random(),
+                            ledger: DataLedger::Submit,
+                        },
+                    ],
+                },
+                height as u64,
+            )?;
+        }
+
+        let tree = BlockTree::new(&inclusion_genesis, ConsensusConfig::testing());
+        let guard = BlockTreeReadGuard::new(Arc::new(RwLock::new(tree)));
+
+        let range = expired_submit_range(probe_height, &epoch, &prev_epoch, &config, true)?
+            .expect("expired Submit slots must produce a range");
         assert!(
-            err.to_string().contains("not a contiguous prefix"),
-            "expected the NC-0042 contiguity guard message, got: {err}"
+            submit_tx_expired(
+                tx_slot_0.id,
+                &range,
+                &config,
+                &block_index,
+                &guard,
+                &MempoolReadGuard::stub(),
+                &db,
+            )
+            .await?,
+            "slot-0 tx must be expired"
         );
+        assert!(
+            !submit_tx_expired(
+                tx_slot_1.id,
+                &range,
+                &config,
+                &block_index,
+                &guard,
+                &MempoolReadGuard::stub(),
+                &db,
+            )
+            .await?,
+            "slot-1 tx must stay live even though later empty slots also expired"
+        );
+
+        Ok(())
     }
 
     /// NC-0042 fail-loud (commit c300d7ec2): a tx whose start offset maps to a

--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -483,6 +483,32 @@ pub fn expired_submit_range(
         return Ok(None);
     };
 
+    // NC-0042 contiguity guard. The `[0, range_end)` collapse below is correct only
+    // if the expired slots are a prefix `{0..=max}`. In normal operation they are:
+    // chunk offsets are cumulative and slots fill sequentially, so `last_height` is
+    // non-decreasing in slot index, and empty pre-allocated slots sit at the top
+    // where the never-expire-the-last-slot rule trims them. A hole (an empty,
+    // non-last slot aged out by its allocation height beneath a still-live lower
+    // slot) would make the prefix over-approximate — deterministically rejecting
+    // valid promotions AND diverging from the slot-exact refund walk
+    // (`collect_expired_partitions`, which only settles slots that actually hold
+    // partitions). The set is a pure function of canonical state, so failing loud
+    // here fails identically on every node (no fork) instead of silently diverging
+    // — same philosophy as the `filter_transactions_by_chunk_range` guard below.
+    // `slot_indexes` is ascending and distinct (`get_all_expired_slot_indexes`
+    // iterates slots in order), so "value at position i equals i" ⇔ prefix-from-0.
+    if let Some((i, &slot)) = slot_indexes
+        .iter()
+        .enumerate()
+        .find(|&(i, &slot)| slot != i)
+    {
+        eyre::bail!(
+            "expired Submit slot set {slot_indexes:?} is not a contiguous prefix from 0 \
+             (slot {slot} at position {i}) — the [0, range_end) promotion-filter \
+             assumption is violated; refusing to over-approximate (NC-0042)"
+        );
+    }
+
     // End of the expired chunk range = end of the highest expired slot, clamped
     // to data actually written *as of the parent*. Expired slots form a prefix
     // from slot 0, so the range is `[0, range_end)`. Bounding by the parent
@@ -2600,5 +2626,94 @@ mod tests {
         assert_eq!(submit_span_verdict(inc.base, inc.total, 5), Some(false));
 
         Ok(())
+    }
+
+    /// NC-0042 contiguity guard: `expired_submit_range` collapses the expired
+    /// Submit slots to a single `[0, range_end)` prefix, which is only correct if
+    /// the slots are `{0..=max}`. A hole (an empty, non-last slot aged out by its
+    /// allocation height beneath a still-live lower slot) would over-approximate
+    /// — deterministically rejecting valid promotions AND diverging from the
+    /// slot-exact refund walk. The verdict is a pure function of canonical state,
+    /// so it must fail loud (identically on every node) rather than silently.
+    #[test]
+    fn expired_submit_range_bails_on_non_prefix_expired_set() {
+        fn submit_header_total(total_chunks: u64) -> IrysBlockHeader {
+            let mut h = IrysBlockHeader::new_mock_header();
+            h.data_ledgers = vec![irys_types::DataTransactionLedger {
+                ledger_id: DataLedger::Submit as u32,
+                tx_root: H256::zero(),
+                tx_ids: irys_types::H256List(vec![]),
+                total_chunks,
+                expires: None,
+                proofs: None,
+                required_proof_count: None,
+            }];
+            h
+        }
+
+        // Build the hole topology in real ledger state: 4 Submit slots allocated
+        // at height 1, then only slot 1 touched (chunks [12,18) with a 10-chunk
+        // partition) → last_height [1, 100, 1, 1]. At an expiry height in (1, 100)
+        // slots 0 and 2 expire while slot 1 stays live; slot 3 is the never-
+        // expiring last slot. So `get_all_expired_term_slot_indexes` returns the
+        // non-prefix set {0, 2}.
+        let mut epoch = EpochSnapshot::default();
+        epoch.ledgers[DataLedger::Submit].allocate_slots(4, 1);
+        epoch
+            .ledgers
+            .touch_filled_slots(DataLedger::Submit, 12, 18, 10, 100);
+
+        let ep = &epoch.config.consensus.epoch;
+        let min_blocks = ep.submit_ledger_epoch_length * ep.num_blocks_in_epoch;
+        let block_height = min_blocks + 50; // expiry_height = 50 ∈ (1, 100)
+
+        // Sanity: the fixture really is a hole before we assert the guard fires.
+        assert_eq!(
+            epoch.get_all_expired_term_slot_indexes(DataLedger::Submit, block_height),
+            vec![0, 2],
+            "fixture must produce the non-prefix expired set {{0, 2}}"
+        );
+
+        let parent = submit_header_total(25); // data through slot 2 (3 × 10 chunks)
+        let err = expired_submit_range(block_height, &epoch, &parent, &epoch.config)
+            .expect_err("a non-prefix expired set must fail loud, not over-approximate");
+        assert!(
+            err.to_string().contains("not a contiguous prefix"),
+            "expected the NC-0042 contiguity guard message, got: {err}"
+        );
+    }
+
+    /// NC-0042 fail-loud (commit c300d7ec2): a tx whose start offset maps to a
+    /// slot absent from `slot_miners` (a non-expired slot) must `Err`, not be
+    /// silently dropped — a silent under-refund would strand a refund and break
+    /// Pipeline A ≡ B if the contiguity invariant ever broke.
+    #[test]
+    fn filter_transactions_by_chunk_range_bails_on_non_expired_slot() {
+        let tx = DataTransactionHeader::V1(irys_types::DataTransactionHeaderV1WithMetadata {
+            tx: DataTransactionHeaderV1 {
+                id: H256::random(),
+                data_size: 5,
+                ..Default::default()
+            },
+            metadata: irys_types::DataTransactionMetadata::new(),
+        });
+        // tx starts at offset 0 → slot 0, but `slot_miners` is empty: no expired
+        // slot covers it. Middle-block flags (no trim) so it is not skipped first.
+        let slot_miners: BTreeMap<SlotIndex, Arc<Vec<IrysAddress>>> = BTreeMap::new();
+        let err = filter_transactions_by_chunk_range(
+            vec![tx],
+            LedgerChunkOffset::from(0_u64),
+            LedgerChunkRange(ledger_chunk_offset_ii!(0, 100)),
+            false, // is_earliest — no start trim
+            false, // is_latest — no end trim
+            1,     // chunk_size
+            10,    // num_chunks_in_partition
+            &slot_miners,
+        )
+        .expect_err("a tx mapping to a non-expired slot must fail loud");
+        assert!(
+            err.to_string().contains("non-expired slot"),
+            "expected the NC-0042 fail-loud message, got: {err}"
+        );
     }
 }

--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -345,15 +345,17 @@ pub async fn expired_submit_tx_ids(
     parent_block_header: &IrysBlockHeader,
     block_height: u64,
     config: &Config,
+    // Cascade status of the block being produced/validated (its OWN timestamp),
+    // NOT the parent epoch snapshot's. Must mirror exactly what production passes
+    // to `expired_submit_range`, so this differential-test oracle stays faithful
+    // at the activation epoch boundary (NC-0042) — previously this derived it from
+    // `parent_epoch_snapshot.epoch_block.timestamp_secs()`, which lags the block.
+    cascade_active: bool,
     block_index: BlockIndex,
     block_tree_guard: &BlockTreeReadGuard,
     mempool_guard: &MempoolReadGuard,
     db: &DatabaseProvider,
 ) -> eyre::Result<std::collections::BTreeSet<IrysTransactionId>> {
-    let cascade_active = config
-        .consensus
-        .hardforks
-        .is_cascade_active_at(parent_epoch_snapshot.epoch_block.timestamp_secs());
     let slot_indexes = parent_epoch_snapshot.get_all_expired_term_slot_indexes(
         DataLedger::Submit,
         block_height,
@@ -415,15 +417,13 @@ pub async fn is_submit_storage_expired(
     parent_epoch_snapshot: &EpochSnapshot,
     parent_block_header: &IrysBlockHeader,
     config: &Config,
+    // The block-under-test's own Cascade status — see `expired_submit_tx_ids`.
+    cascade_active: bool,
     block_index: &BlockIndex,
     block_tree_guard: &BlockTreeReadGuard,
     mempool_guard: &MempoolReadGuard,
     db: &DatabaseProvider,
 ) -> eyre::Result<bool> {
-    let cascade_active = config
-        .consensus
-        .hardforks
-        .is_cascade_active_at(parent_epoch_snapshot.epoch_block.timestamp_secs());
     let Some(range) = expired_submit_range(
         block_height,
         parent_epoch_snapshot,
@@ -514,6 +514,15 @@ pub fn expired_submit_range(
     // header (not this node's block-index tip) is what makes the verdict
     // branch-deterministic.
     let p = config.consensus.num_chunks_in_partition;
+    // Fail loud on a zero partition size rather than silently disabling the
+    // §4b/§4c filter: with `p == 0`, `range_end` would collapse to 0 and this
+    // function would return `Ok(None)` (no candidate filtered), while the refund
+    // walk (`filter_transactions_by_chunk_range`) bails — an asymmetric silent
+    // bypass. `Config::validate` also rejects `p == 0`; this guards any path that
+    // bypassed validation (NC-0042).
+    if p == 0 {
+        eyre::bail!("num_chunks_in_partition must be non-zero for Submit-expiry range math");
+    }
     let parent_total = parent_block_header.ledger_total_chunks(DataLedger::Submit);
     let range_end = (max_expired_slot as u64 + 1)
         .saturating_mul(p)
@@ -1311,7 +1320,9 @@ fn filter_transactions_by_chunk_range(
     for (idx, tx) in transactions.iter().enumerate() {
         let chunks = tx.data_size.div_ceil(chunk_size);
         let tx_start = current_offset;
-        let tx_end = current_offset + chunks;
+        // saturating: a malformed/huge data_size must not wrap the cumulative
+        // offset in release builds (the comparisons below would then misclassify).
+        let tx_end = LedgerChunkOffset::from((*current_offset).saturating_add(chunks));
 
         tracing::debug!(
             "Tx {}: id={}, data_size={}, chunks={}, tx_start={}, tx_end={}",
@@ -1547,7 +1558,8 @@ impl SlotIndex {
         chunks_per_partition: u64,
         max_offset: LedgerChunkOffset,
     ) -> LedgerChunkRange {
-        let start = LedgerChunkOffset::from(self.0 * chunks_per_partition).min(max_offset);
+        let start =
+            LedgerChunkOffset::from(self.0.saturating_mul(chunks_per_partition)).min(max_offset);
         let end = start + chunks_per_partition;
         let end = end.min(max_offset);
         LedgerChunkRange(ledger_chunk_offset_ii!(start, end))
@@ -3065,6 +3077,31 @@ mod tests {
             )
             .await?,
             "slot-1 tx must stay live even though later empty slots also expired"
+        );
+
+        // Walk-oracle parity + the new `cascade_active` parameter: the (now
+        // parameterized) `expired_submit_tx_ids` walk must return EXACTLY the
+        // per-candidate–expired set — only the slot-0 tx — when passed the block's
+        // own Cascade status. Previously the oracle derived Cascade from the parent
+        // epoch snapshot's timestamp, which lags the block and was wrong at the
+        // activation boundary; full mid-chain activation is covered end-to-end by
+        // the `cascade_term_expiry` chain-tests.
+        let oracle = expired_submit_tx_ids(
+            &epoch,
+            &prev_epoch,
+            probe_height,
+            &config,
+            true, // the block-under-test's own Cascade status (activation at genesis here)
+            block_index.clone(),
+            &guard,
+            &MempoolReadGuard::stub(),
+            &db,
+        )
+        .await?;
+        assert_eq!(
+            oracle,
+            std::collections::BTreeSet::from([tx_slot_0.id]),
+            "walk oracle must equal the per-candidate verdicts (slot-0 expired, slot-1 live)"
         );
 
         Ok(())

--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -716,7 +716,7 @@ struct SubmitInclusion {
 ///
 /// Fast path: `canonical_submit_height` resolves migrated inclusions in O(1)
 /// from the canonical index / `MigratedBlockHashes`. Migrated rows are only
-/// branch-invariant BELOW the reorg floor — since #1405 a deep reorg can rewrite
+/// branch-invariant BELOW the reorg floor — a deep reorg can rewrite
 /// them up to `block_tree_depth` deep. This is safe HERE because
 /// `submit_tx_expired` only acts on *expired* Submit slots, and `Config::validate`
 /// requires a slot's lifetime (`submit_ledger_epoch_length * num_blocks_in_epoch`)
@@ -1044,7 +1044,7 @@ fn assert_canonical_via_mbh(db: &DatabaseProvider, hash: H256, height: u64) -> e
 /// offsets this is called with: callers only resolve *expired* partitions, which
 /// the slot-lifetime > `block_tree_depth` config invariant keeps below the reorg
 /// floor, so a migrated offset's block is finalized and shared by every branch
-/// (migrated rows above the floor are reorg-mutable since #1405, but expired
+/// (migrated rows above the floor are reorg-mutable, but expired
 /// offsets never reach there); an un-migrated offset's block is on the parent's
 /// own chain.
 fn resolve_ledger_offset_to_block(
@@ -3351,9 +3351,9 @@ mod tests {
     /// bases refund suppression on the branch-resolved `promoted_on_branch` set,
     /// NOT on the fetched header's node-local `promoted_height`. A tx whose header
     /// still carries a (branch-variant) `promoted_height = Some` from local mempool
-    /// state must STILL be refunded when it is absent from the branch set — the
-    /// exact divergence the pre-fix `data_tx.promoted_height().is_none()` check
-    /// produced. (On the pre-fix code this asserts fails: no refund is emitted.)
+    /// state must STILL be refunded when it is absent from the branch set. Gating
+    /// the refund on the header's node-local `promoted_height` instead of the
+    /// branch-resolved set would wrongly suppress it — exactly what this guards.
     #[test]
     fn aggregate_refunds_use_branch_set_not_node_local_promoted_height() {
         let config = Config::new_with_random_peer_id(irys_types::NodeConfig::testing());

--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -61,7 +61,7 @@ use crate::block_discovery::get_data_tx_in_parallel;
 use crate::mempool_guard::MempoolReadGuard;
 use crate::shadow_tx_generator::RollingHash;
 use eyre::{OptionExt as _, eyre};
-use irys_database::{block_header_by_hash, db::IrysDatabaseExt as _};
+use irys_database::{block_header_by_hash, canonical_submit_height, db::IrysDatabaseExt as _};
 use irys_domain::{BlockIndex, BlockTreeReadGuard, EpochSnapshot};
 use irys_types::{
     BlockHeight, BlockIndexItem, Config, DataLedger, DataTransactionHeader, H256, IrysAddress,
@@ -86,6 +86,7 @@ use std::sync::Arc;
 #[tracing::instrument(skip_all, fields(block.height = block_height, ledger.type = ?ledger_type))]
 pub async fn calculate_expired_ledger_fees(
     parent_epoch_snapshot: &EpochSnapshot,
+    parent_block_header: &IrysBlockHeader,
     block_height: u64,
     ledger_type: DataLedger,
     config: &Config,
@@ -138,7 +139,13 @@ pub async fn calculate_expired_ledger_fees(
     }
 
     // Step 2: Find block ranges
-    let block_range = match find_block_range(expired_slots, config, &block_index, ledger_type)? {
+    let block_range = match find_block_range(
+        expired_slots,
+        config,
+        &block_index,
+        ledger_type,
+        parent_ledger_total_chunks(parent_block_header, ledger_type),
+    )? {
         Some(br) => br,
         None => {
             // Check to see if there were no chunks uploaded to this ledger slot!
@@ -301,12 +308,9 @@ async fn collect_tx_to_miners_from_range(
 /// **expired as of `block_height`** — i.e. the txs that are (or will be at the
 /// next epoch) perm-fee-refunded and therefore must never be promoted.
 ///
-/// This is the authoritative non-promotability predicate shared by the producer
-/// filter (`tx_selector::get_publish_txs_and_proofs`) and the validator check
-/// (`block_validation`). It is derived from the *same* expired-partition →
-/// block → tx walk that `calculate_expired_ledger_fees` uses for refunds, so the
-/// "is this tx refunded?" and "may this tx be promoted?" decisions cannot
-/// diverge.
+/// It is derived from the *same* expired-partition → block → tx walk that
+/// `calculate_expired_ledger_fees` uses for refunds, so the "is this tx
+/// refunded?" and "may this tx be promoted?" decisions cannot diverge.
 ///
 /// Unlike the refund pipeline (which keys on *newly* expiring slots, acting once
 /// per slot), this keys on [`EpochSnapshot::get_all_expired_term_slot_indexes`]
@@ -317,9 +321,20 @@ async fn collect_tx_to_miners_from_range(
 /// Miners are irrelevant here (no fee attribution), so a sentinel miner is used
 /// purely to satisfy the boundary-filter's non-empty-miners requirement; the
 /// returned value is the tx-id set only.
+///
+/// # Retained as a test-only oracle
+///
+/// Production no longer materializes this whole-history set on every block — it
+/// was O(expired-partition history) per produced/validated block. The producer
+/// filter and validator check now use the per-candidate `is_submit_storage_expired`
+/// (O(candidate txs) per block). This walk is kept as the **differential-test
+/// oracle**: a tx is in this set iff `is_submit_storage_expired` returns `true`
+/// for it, and that equivalence is asserted against real chain state.
+#[cfg(any(test, feature = "test-utils"))]
 #[tracing::instrument(skip_all, fields(block.height = block_height))]
 pub async fn expired_submit_tx_ids(
     parent_epoch_snapshot: &EpochSnapshot,
+    parent_block_header: &IrysBlockHeader,
     block_height: u64,
     config: &Config,
     block_index: BlockIndex,
@@ -341,12 +356,17 @@ pub async fn expired_submit_tx_ids(
         .map(|i| (SlotIndex::new(i as u64), vec![IrysAddress::ZERO]))
         .collect();
 
-    let block_range =
-        match find_block_range(expired_slots, config, &block_index, DataLedger::Submit)? {
-            Some(br) => br,
-            // No chunks were ever uploaded into the expired slot ranges.
-            None => return Ok(std::collections::BTreeSet::new()),
-        };
+    let block_range = match find_block_range(
+        expired_slots,
+        config,
+        &block_index,
+        DataLedger::Submit,
+        parent_ledger_total_chunks(parent_block_header, DataLedger::Submit),
+    )? {
+        Some(br) => br,
+        // No chunks were ever uploaded into the expired slot ranges.
+        None => return Ok(std::collections::BTreeSet::new()),
+    };
 
     let tx_to_miners = collect_tx_to_miners_from_range(
         block_range,
@@ -360,6 +380,270 @@ pub async fn expired_submit_tx_ids(
     .await?;
 
     Ok(tx_to_miners.into_keys().collect())
+}
+
+/// NC-0042 §4b/§4c per-candidate non-promotability predicate: returns whether
+/// `txid`'s Submit-ledger storage has expired as of `block_height` (the block
+/// being produced/validated).
+///
+/// This is the O(candidate-tx) replacement for the O(expired-partition-history)
+/// `expired_submit_tx_ids` set: instead of walking every expired partition on
+/// every block, it resolves only *this* tx's Submit inclusion block and tests it
+/// against the expired chunk range.
+///
+/// ## Equivalence (differential-tested)
+///
+/// It reproduces, for a single candidate, exactly what `expired_submit_tx_ids`
+/// computes for the whole set. The expired slots are a contiguous prefix
+/// starting at slot 0 (slot `last_height` is the allocation height, monotonic in
+/// slot index), so the expired chunk range is `[0, range_end)` spanning blocks
+/// `[min_block, max_block]`. A candidate's inclusion block is then tested with
+/// the *same boundary rules* the walk applies:
+/// - block before/after that range → not expired;
+/// - an earliest or middle block of the range, or the whole range packed into a
+///   single block (`min_block == max_block`, only reachable with tiny test
+///   partitions) → expired (the walk includes every tx of those blocks);
+/// - the latest block of a multi-block range → expired iff the tx's start chunk
+///   offset is before `range_end` (the walk trims here).
+///
+/// ## Metadata dependency (vs. the metadata-free walk)
+///
+/// This resolves the tx's Submit inclusion height from local `included_height`
+/// metadata (`canonical_submit_height`), whereas the walk derives everything
+/// from canonical block contents. The dependency is sound for the candidates we
+/// check: they are unpromoted at check time (so the Publish-migration
+/// `included_height` overwrite has not happened), and the height comes from the
+/// node's own canonical chain, never the peer's block. A `None` resolution
+/// yields `false` (a tx with no canonical Submit inclusion cannot have expired
+/// Submit storage).
+#[tracing::instrument(level = "debug", skip_all, fields(tx.id = %txid, block.height = block_height))]
+pub async fn is_submit_storage_expired(
+    txid: IrysTransactionId,
+    block_height: u64,
+    parent_epoch_snapshot: &EpochSnapshot,
+    parent_block_header: &IrysBlockHeader,
+    config: &Config,
+    block_index: &BlockIndex,
+    block_tree_guard: &BlockTreeReadGuard,
+    mempool_guard: &MempoolReadGuard,
+    db: &DatabaseProvider,
+) -> eyre::Result<bool> {
+    let Some(range) = expired_submit_range(
+        block_height,
+        parent_epoch_snapshot,
+        parent_block_header,
+        config,
+        block_index,
+    )?
+    else {
+        return Ok(false);
+    };
+    submit_tx_expired(
+        txid,
+        None,
+        &range,
+        config,
+        block_index,
+        block_tree_guard,
+        mempool_guard,
+        db,
+    )
+    .await
+}
+
+/// Block-level inputs for the §4b/§4c Submit-expiry check, computed **once per
+/// block** and reused across every publish candidate via [`submit_tx_expired`].
+///
+/// Scanning the expired-slot set and the two `block_index` boundary lookups do
+/// not depend on the candidate, so hoisting them here keeps the per-candidate
+/// cost to a single `canonical_submit_height` read — plus, only on the latest
+/// boundary block of a multi-block range, one inclusion-block walk.
+#[derive(Debug, Clone, Copy)]
+pub struct ExpiredSubmitRange {
+    /// The block being produced/validated (caps the canonical Submit lookup).
+    block_height: u64,
+    /// Block span of the expired chunk range `[0, range_end)`.
+    min_block_height: u64,
+    max_block_height: u64,
+    /// Exclusive end of the expired chunk range, clamped to data actually written.
+    range_end: u64,
+    /// Hash of `max_block_height`'s block — the only block whose per-tx offsets
+    /// a candidate check might need to reconstruct.
+    max_block_hash: H256,
+}
+
+/// Computes the [`ExpiredSubmitRange`] for `block_height`, or `None` if no Submit
+/// storage has expired as of this block (nothing to filter). The equivalence
+/// argument with the `expired_submit_tx_ids` walk is documented on
+/// [`is_submit_storage_expired`].
+pub fn expired_submit_range(
+    block_height: u64,
+    parent_epoch_snapshot: &EpochSnapshot,
+    parent_block_header: &IrysBlockHeader,
+    config: &Config,
+    block_index: &BlockIndex,
+) -> eyre::Result<Option<ExpiredSubmitRange>> {
+    // The expired Submit slots — the exact set `expired_submit_tx_ids` keys on
+    // (also handles the "not enough blocks elapsed → empty" case).
+    let slot_indexes =
+        parent_epoch_snapshot.get_all_expired_term_slot_indexes(DataLedger::Submit, block_height);
+    let Some(&max_expired_slot) = slot_indexes.iter().max() else {
+        return Ok(None);
+    };
+
+    // End of the expired chunk range = end of the highest expired slot, clamped
+    // to the data actually written (mirrors `find_block_range`'s
+    // `compute_chunk_range` — same min(parent header total, index total) bound,
+    // see the comment there for why both terms are needed). Expired slots are a
+    // prefix from slot 0, so the range starts at 0 and the walk's earliest-block
+    // skip never fires.
+    let p = config.consensus.num_chunks_in_partition;
+    let max_offset = block_index
+        .get_latest_item()
+        .map(|item| item.ledgers[DataLedger::Submit].total_chunks)
+        .unwrap_or(0)
+        .min(parent_ledger_total_chunks(
+            parent_block_header,
+            DataLedger::Submit,
+        ));
+    let range_end = (max_expired_slot as u64 + 1)
+        .saturating_mul(p)
+        .min(max_offset);
+    if range_end == 0 {
+        return Ok(None);
+    }
+
+    // Block range holding the expired chunks.
+    let (min_block_height, _) = block_index.get_block_index_item(DataLedger::Submit, 0)?;
+    let (max_block_height, max_block_item) =
+        block_index.get_block_index_item(DataLedger::Submit, range_end - 1)?;
+
+    Ok(Some(ExpiredSubmitRange {
+        block_height,
+        min_block_height,
+        max_block_height,
+        range_end,
+        max_block_hash: max_block_item.block_hash,
+    }))
+}
+
+/// Per-candidate verdict against a precomputed [`ExpiredSubmitRange`]: is
+/// `txid`'s Submit storage expired as of `range.block_height`?
+///
+/// `submit_height` lets a caller that already resolved the candidate's canonical
+/// Submit inclusion height (e.g. the tx selector's prior-Submit check) pass it in
+/// to avoid a duplicate `canonical_submit_height` read; pass `None` to resolve it
+/// here. A `None` resolution (no canonical Submit inclusion) yields `false`.
+#[tracing::instrument(level = "debug", skip_all, fields(tx.id = %txid))]
+pub async fn submit_tx_expired(
+    txid: IrysTransactionId,
+    submit_height: Option<u64>,
+    range: &ExpiredSubmitRange,
+    config: &Config,
+    block_index: &BlockIndex,
+    block_tree_guard: &BlockTreeReadGuard,
+    mempool_guard: &MempoolReadGuard,
+    db: &DatabaseProvider,
+) -> eyre::Result<bool> {
+    // Submit inclusion is strictly before this block, so cap the lookup at the parent.
+    let submit_height = match submit_height {
+        Some(h) => h,
+        None => {
+            let max_height = range.block_height.saturating_sub(1);
+            match db.view_eyre(|tx| canonical_submit_height(tx, &txid, max_height))? {
+                Some(h) => h,
+                None => return Ok(false),
+            }
+        }
+    };
+
+    // The verdict depends on the candidate's exact start offset only on the
+    // latest boundary of a multi-block range (the only place the walk trims).
+    // Everywhere else the inclusion-block height alone decides, so skip the
+    // inclusion-block fetch.
+    let needs_start_offset =
+        range.min_block_height != range.max_block_height && submit_height == range.max_block_height;
+    let start_offset = if needs_start_offset {
+        // Reconstruct the candidate's Submit start offset from its inclusion
+        // block (== the max boundary block here). `get_data_tx_in_parallel`
+        // preserves input order — the same helper the walk uses, so the
+        // reconstructed offsets match.
+        let base_chunks = get_previous_max_offset(block_index, submit_height, DataLedger::Submit)?;
+        let block = get_block_by_hash(range.max_block_hash, block_tree_guard, db).await?;
+        let ordered_ids = block
+            .get_data_ledger_tx_ids_ordered(DataLedger::Submit)
+            .ok_or_eyre("Submit ledger required for the expiry inclusion block")?;
+        let headers = get_data_tx_in_parallel(ordered_ids.to_vec(), mempool_guard, db).await?;
+        let ordered: Vec<(IrysTransactionId, u64)> =
+            headers.iter().map(|h| (h.id, h.data_size)).collect();
+        submit_tx_start_offset(txid, &ordered, *base_chunks, config.consensus.chunk_size)
+    } else {
+        None
+    };
+
+    Ok(submit_tx_in_expired_range(
+        submit_height,
+        range.min_block_height,
+        range.max_block_height,
+        range.range_end,
+        start_offset,
+    ))
+}
+
+/// Pure boundary decision for [`is_submit_storage_expired`]: given the expired
+/// chunk range's block span `[min_block_height, max_block_height]` and its
+/// `range_end` offset, decides whether a candidate whose Submit inclusion is
+/// block `submit_height` is in the set — mirroring `find_block_range` /
+/// `filter_transactions_by_chunk_range`.
+///
+/// `start_offset` (the candidate's Submit start chunk offset) is consulted only
+/// on the latest boundary of a multi-block range — the one place the walk trims
+/// — so callers may pass `None` in every other case. The expired range always
+/// begins at slot 0, so the earliest-block skip never applies.
+fn submit_tx_in_expired_range(
+    submit_height: u64,
+    min_block_height: u64,
+    max_block_height: u64,
+    range_end: u64,
+    start_offset: Option<u64>,
+) -> bool {
+    // Inclusion block outside the expired block span.
+    if submit_height < min_block_height || submit_height > max_block_height {
+        return false;
+    }
+    // Whole range packed into one block (`same_block`, only reachable with tiny
+    // test partitions), or an earliest/middle block → the walk includes every tx
+    // of these blocks.
+    if min_block_height == max_block_height || submit_height < max_block_height {
+        return true;
+    }
+    // Latest boundary of a multi-block range → the walk trims at `range_end`.
+    start_offset.is_some_and(|offset| offset < range_end)
+}
+
+/// Reconstructs `target`'s Submit-ledger **start chunk offset**: the cumulative
+/// chunk offset at the end of the previous block (`base_chunks`) plus the chunks
+/// of every Submit tx ordered before `target` in its inclusion block — exactly
+/// as `filter_transactions_by_chunk_range` accumulates `current_offset`.
+/// `block_submit_txs` is that block's Submit txs as `(tx_id, data_size)` in
+/// on-chain order. `None` if `target` is not in the block.
+fn submit_tx_start_offset(
+    target: IrysTransactionId,
+    block_submit_txs: &[(IrysTransactionId, u64)],
+    base_chunks: u64,
+    chunk_size: u64,
+) -> Option<u64> {
+    if chunk_size == 0 {
+        return None;
+    }
+    let mut offset = base_chunks;
+    for (id, data_size) in block_submit_txs {
+        if *id == target {
+            return Some(offset);
+        }
+        offset = offset.saturating_add(data_size.div_ceil(chunk_size));
+    }
+    None
 }
 
 /// Fetches a block header from block tree or database
@@ -453,21 +737,55 @@ fn collect_expired_partitions(
     Ok(expired_ledger_slot_indexes)
 }
 
+/// The parent block header's recorded total chunk count for `ledger`. Headers
+/// carry per-ledger totals, so this is a pure function of the parent block —
+/// unlike the node's block-index tip, which moves as the chain grows. `0` when
+/// the ledger is absent from the header (e.g. pre-Cascade blocks without
+/// OneYear/ThirtyDay entries).
+fn parent_ledger_total_chunks(parent_block_header: &IrysBlockHeader, ledger: DataLedger) -> u64 {
+    parent_block_header
+        .data_ledgers
+        .iter()
+        .find(|dl| dl.ledger_id == ledger as u32)
+        .map(|dl| dl.total_chunks)
+        .unwrap_or(0)
+}
+
 /// Finds all blocks containing data in the expired chunk ranges
 fn find_block_range(
     expired_slots: BTreeMap<SlotIndex, Vec<IrysAddress>>,
     config: &Config,
     block_index: &BlockIndex,
     ledger_type: DataLedger,
+    parent_total_chunks: u64,
 ) -> eyre::Result<Option<BlockRange>> {
     let mut blocks_with_expired_ledgers = BTreeMap::new();
 
-    // Ensure that we don't start reading a partition that's only partially populated
+    // Ensure that we don't start reading a partition that's only partially populated.
+    //
+    // Bounded by min(parent_total_chunks, index total):
+    // - `parent_total_chunks` (the parent header's recorded ledger size) makes the
+    //   result a function of the block being built/validated, not of this node's
+    //   current tip — a validator replaying an old block (sync) must not see data
+    //   that landed *after* that block in a partially-filled expired slot.
+    // - the block-index total caps lookups to migrated blocks (the index lags the
+    //   tip by `block_migration_depth`, so offsets beyond it are unresolvable).
+    // At the live tip the index term binds (index ≤ parent — unchanged behavior);
+    // during historical validation the parent term binds (deterministic verdict).
+    // Residual: expired-range chunks inside the not-yet-migrated tail are invisible
+    // until migration catches up to the parent, so verdicts there can still differ
+    // across nodes for up to `block_migration_depth` blocks. Only reachable when a
+    // partially-filled expired slot is still receiving data (allocation runs ahead
+    // of fill — see `calculate_additional_slots`); resolving it would require
+    // walking unmigrated tree blocks by chunk offset, which the index can't do.
     let last_item = block_index
         .get_latest_item()
         .expect("expected block index to contain at least one item");
-    let max_chunk_offset_across_all_partitions =
-        LedgerChunkOffset::from(last_item.ledgers[ledger_type].total_chunks);
+    let max_chunk_offset_across_all_partitions = LedgerChunkOffset::from(
+        last_item.ledgers[ledger_type]
+            .total_chunks
+            .min(parent_total_chunks),
+    );
 
     // Track min and max blocks as we iterate
     let mut min_height: Option<(BlockHeight, BlockIndexItem, LedgerChunkRange)> = None;
@@ -1108,5 +1426,188 @@ mod tests {
         delta1.merge(delta2);
         assert!(delta1.reward_balance_increment.is_empty());
         assert!(delta1.user_perm_fee_refunds.is_empty());
+    }
+
+    // --- NC-0042 §4b/§4c per-candidate pure cores. The full DB-backed
+    //     equivalence vs. the `expired_submit_tx_ids` walk oracle is asserted in
+    //     chain-tests; these pin the offset math and boundary rules directly. ---
+
+    // `submit_tx_start_offset`: chunk_size = 1 ⇒ data_size == chunk count unless
+    // noted.
+
+    #[test]
+    fn start_offset_sums_preceding_txs_from_base() {
+        let a = H256::random();
+        let b = H256::random();
+        // base 8: A occupies chunks [8,10), so B starts at chunk 10.
+        let block = [(a, 2), (b, 5)];
+        assert_eq!(submit_tx_start_offset(a, &block, 8, 1), Some(8));
+        assert_eq!(submit_tx_start_offset(b, &block, 8, 1), Some(10));
+    }
+
+    #[test]
+    fn start_offset_rounds_each_tx_up_to_whole_chunks() {
+        // chunk_size 10: A data_size 15 → 2 chunks (div_ceil), so B starts at 2.
+        let a = H256::random();
+        let b = H256::random();
+        assert_eq!(
+            submit_tx_start_offset(b, &[(a, 15), (b, 5)], 0, 10),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn start_offset_none_when_target_absent_or_chunk_size_zero() {
+        let absent = H256::random();
+        assert_eq!(
+            submit_tx_start_offset(absent, &[(H256::random(), 3)], 0, 1),
+            None
+        );
+        let a = H256::random();
+        assert_eq!(submit_tx_start_offset(a, &[(a, 3)], 0, 0), None);
+    }
+
+    // `submit_tx_in_expired_range`: expired chunk range ends at `range_end`,
+    // spanning blocks `[min, max]`.
+
+    #[test]
+    fn block_after_expired_range_is_not_expired() {
+        // Recent tx (block 9) past the expired span [2,5] → not expired.
+        assert!(!submit_tx_in_expired_range(9, 2, 5, 100, None));
+    }
+
+    #[test]
+    fn block_before_expired_range_is_not_expired() {
+        assert!(!submit_tx_in_expired_range(1, 2, 5, 100, None));
+    }
+
+    #[test]
+    fn same_block_range_includes_every_tx_of_that_block() {
+        // Whole expired range packed into one block (min == max), as in tiny
+        // test partitions: every tx of that block is in the set, regardless of
+        // start offset — this is the walk's `same_block` over-inclusion.
+        assert!(submit_tx_in_expired_range(3, 3, 3, 10, None));
+    }
+
+    #[test]
+    fn earliest_and_middle_blocks_are_fully_included() {
+        // Multi-block range [2,6]: earliest (2) and middle (4) blocks include
+        // every tx without consulting the start offset.
+        assert!(submit_tx_in_expired_range(2, 2, 6, 1000, None));
+        assert!(submit_tx_in_expired_range(4, 2, 6, 1000, None));
+    }
+
+    #[test]
+    fn latest_block_of_multiblock_range_trims_at_range_end() {
+        // The production path: a partition spans many blocks, so the highest
+        // expired slot's data ends mid-block. On that latest block the walk keeps
+        // only txs whose start offset is before range_end.
+        assert!(
+            submit_tx_in_expired_range(6, 2, 6, 1000, Some(999)),
+            "tx starting before range_end is expired"
+        );
+        assert!(
+            !submit_tx_in_expired_range(6, 2, 6, 1000, Some(1000)),
+            "tx starting at/after range_end is in the next (unexpired) slot"
+        );
+        // Defensive: a tx not found in its inclusion block (None) is not expired.
+        assert!(!submit_tx_in_expired_range(6, 2, 6, 1000, None));
+    }
+
+    /// NC-0042 determinism regression: `find_block_range` must bound the
+    /// expired chunk range by the *parent block's* recorded ledger size, not
+    /// this node's block-index tip. With a partially-filled expired slot, a
+    /// tip-based bound sweeps in chunks that landed *after* the validated
+    /// block's parent, so the verdict would change with when a node evaluates
+    /// it (live vs. catching up) — a consensus divergence.
+    #[test]
+    fn find_block_range_bounds_by_parent_not_index_tip() -> eyre::Result<()> {
+        use irys_database::{IrysDatabaseArgs as _, open_or_create_db, tables::IrysTables};
+        use reth_db::mdbx::DatabaseArguments;
+
+        let mut node_config = irys_types::NodeConfig::testing();
+        node_config.consensus.get_mut().num_chunks_in_partition = 10;
+        let config = Config::new_with_random_peer_id(node_config);
+
+        // Index of 5 blocks with Submit totals 0,4,7,12,15. Slot 0 covers
+        // chunks [0,10). At height 2 (the "parent") slot 0 is only 7/10 full;
+        // heights 3-4 grew the index past the slot boundary into slot 1.
+        let temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db_env = open_or_create_db(
+            &temp_dir,
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        let db = DatabaseProvider(Arc::new(db_env));
+        let block_index = BlockIndex::new_for_testing(db);
+        for (height, submit_total) in [0_u64, 4, 7, 12, 15].into_iter().enumerate() {
+            block_index.push_item(
+                &BlockIndexItem {
+                    block_hash: H256::random(),
+                    num_ledgers: 2,
+                    ledgers: vec![
+                        irys_types::LedgerIndexItem {
+                            total_chunks: 0,
+                            tx_root: H256::random(),
+                            ledger: DataLedger::Publish,
+                        },
+                        irys_types::LedgerIndexItem {
+                            total_chunks: submit_total,
+                            tx_root: H256::random(),
+                            ledger: DataLedger::Submit,
+                        },
+                    ],
+                },
+                height as u64,
+            )?;
+        }
+        let expired_slot_0 = || {
+            let mut m = BTreeMap::new();
+            m.insert(SlotIndex::new(0), vec![IrysAddress::ZERO]);
+            m
+        };
+
+        // Parent at height 2 (total 7): the range must stop at the block
+        // holding chunk 6 (height 2), even though the index tip (total 15)
+        // covers slot 0's full [0,10) range.
+        let range = find_block_range(
+            expired_slot_0(),
+            &config,
+            &block_index,
+            DataLedger::Submit,
+            7,
+        )?
+        .expect("expired slot 0 holds data");
+        assert_eq!(range.min_block.height, 1, "chunk 0 lands at height 1");
+        assert_eq!(
+            range.max_block.height, 2,
+            "parent-bounded range must exclude chunks written after the parent"
+        );
+
+        // Parent == tip: identical to the old tip-based bound (slot 0 truncated
+        // at the partition end 10 → chunk 9 lands at height 3).
+        let range = find_block_range(
+            expired_slot_0(),
+            &config,
+            &block_index,
+            DataLedger::Submit,
+            15,
+        )?
+        .expect("expired slot 0 holds data");
+        assert_eq!(range.max_block.height, 3);
+
+        // Parent ahead of the migrated index (unmigrated tail): the index term
+        // caps lookups — no out-of-range error, same blocks as parent == tip.
+        let range = find_block_range(
+            expired_slot_0(),
+            &config,
+            &block_index,
+            DataLedger::Submit,
+            20,
+        )?
+        .expect("expired slot 0 holds data");
+        assert_eq!(range.max_block.height, 3);
+
+        Ok(())
     }
 }

--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -172,8 +172,7 @@ pub async fn calculate_expired_ledger_fees(
     .await?;
 
     // Step 6: Fetch transactions
-    let mut all_tx_ids = Vec::new();
-    all_tx_ids.extend(tx_to_miners.keys());
+    let all_tx_ids: Vec<_> = tx_to_miners.keys().copied().collect();
     let mut transactions = get_data_tx_in_parallel(all_tx_ids, mempool_guard, db).await?;
     transactions.sort_by(irys_types::DataTransactionHeader::compare_tx);
 
@@ -247,7 +246,6 @@ async fn collect_tx_to_miners_from_range(
         // diverged from the exact per-candidate promotion filter; see NC-0042 §4b.)
         let miners = process_boundary_block(
             &block_range.min_block,
-            block_range.min_block.block_hash,
             true, // is_earliest
             true, // is_latest — sole boundary block (min == max), so trim BOTH ends
             ledger_type,
@@ -265,7 +263,6 @@ async fn collect_tx_to_miners_from_range(
         // Different blocks - process both boundaries
         let e_miners = process_boundary_block(
             &block_range.min_block,
-            block_range.min_block.block_hash,
             true,  // is_earliest — min block trims only the start
             false, // is_latest
             ledger_type,
@@ -279,7 +276,6 @@ async fn collect_tx_to_miners_from_range(
 
         let l_miners = process_boundary_block(
             &block_range.max_block,
-            block_range.max_block.block_hash,
             false, // is_earliest
             true,  // is_latest — max block trims only the end
             ledger_type,
@@ -406,23 +402,15 @@ pub async fn expired_submit_tx_ids(
     Ok(tx_to_miners.into_keys().collect())
 }
 
-/// NC-0042 §4b/§4c per-candidate non-promotability predicate: returns whether
-/// `txid`'s Submit-ledger storage has expired as of `block_height` (the block
-/// being produced/validated).
+/// Test-only convenience that combines [`expired_submit_range`] (computed once)
+/// with [`submit_tx_expired`] (per candidate) into a single per-`txid` verdict.
 ///
-/// The verdict is an exact offset comparison: `txid` is expired iff its Submit
-/// **start chunk offset** is `< range_end`, where `[0, range_end)` is the expired
-/// chunk prefix bounded by the parent header's recorded Submit total (see
-/// [`expired_submit_range`]).
-///
-/// Branch-deterministic by construction: both `range_end` and the candidate's
-/// Submit inclusion are resolved from the block's **own parent ancestry**, never
-/// this node's canonical tip or its migration-lagged block-index frontier, so
-/// every node reaches the same verdict (NC-0042 F2). See
-/// [`resolve_submit_inclusion`] for the migrated (fast, via
-/// `canonical_submit_height`) vs un-migrated (by-hash parent walk) resolution. A
-/// candidate with no resolvable Submit inclusion on this branch yields `false`
-/// (it cannot have expired Submit storage).
+/// Production does NOT call this: both the producer (`tx_selector`) and the
+/// validator (`block_validation`) hoist `expired_submit_range` out of their
+/// candidate loops and call `submit_tx_expired` directly. The branch-determinism
+/// rationale lives on those two functions. Kept here as the differential-test
+/// counterpart to the [`expired_submit_tx_ids`] walk oracle.
+#[cfg(any(test, feature = "test-utils"))]
 #[tracing::instrument(level = "debug", skip_all, fields(tx.id = %txid, block.height = block_height))]
 pub async fn is_submit_storage_expired(
     txid: IrysTransactionId,
@@ -651,7 +639,7 @@ fn resolve_submit_inclusion(
             tree.get_block(hash).map(|header| WalkBlock {
                 height: header.height,
                 prev_hash: header.previous_block_hash,
-                submit_total: submit_total_of_header(header),
+                submit_total: parent_ledger_total_chunks(header, DataLedger::Submit),
                 includes_txid: block_includes_submit_tx(header, &txid),
             })
         },
@@ -660,13 +648,9 @@ fn resolve_submit_inclusion(
                 .get_item(height)
                 .map(|item| submit_total_of_index_item(&item))
         },
-        |hash, height| {
-            // C1 gate input: is `hash` the canonical block at `height` per
-            // `MigratedBlockHashes`? (`block_tree_depth > block_migration_depth`
-            // guarantees a predecessor below the tree window is indexed.)
-            let canonical = db.view_eyre(|tx| Ok(tx.get::<MigratedBlockHashes>(height)?))?;
-            Ok(canonical == Some(hash))
-        },
+        // C1 gate input: is `hash` the canonical block at `height` per
+        // `MigratedBlockHashes`? (shared with `assert_canonical_via_mbh`.)
+        |hash, height| is_canonical_at(db, hash, height),
     )?;
     Ok(resolved.map(|(block_hash, base, total)| SubmitInclusion {
         block_hash,
@@ -740,12 +724,6 @@ fn walk_submit_inclusion(
     Ok(None)
 }
 
-/// Cumulative Submit chunk total recorded in a block header (`0` if the Submit
-/// ledger is absent — pre-Submit / inactive).
-fn submit_total_of_header(header: &IrysBlockHeader) -> u64 {
-    parent_ledger_total_chunks(header, DataLedger::Submit)
-}
-
 /// Whether `header`'s Submit ledger includes `txid` (per-block `tx_ids`).
 fn block_includes_submit_tx(header: &IrysBlockHeader, txid: &IrysTransactionId) -> bool {
     header
@@ -770,14 +748,23 @@ fn ledger_total_of_index_item(item: &BlockIndexItem, ledger: DataLedger) -> u64 
         .unwrap_or(0)
 }
 
+/// Is `hash` the canonical block at `height` per `MigratedBlockHashes`? The
+/// single C1 read, shared by the pure walk (`walk_submit_inclusion`, via a
+/// closure) and `assert_canonical_via_mbh`. (`block_tree_depth >
+/// block_migration_depth` guarantees a predecessor below the tree window is
+/// indexed, so `false` here means a genuinely non-canonical ancestor.)
+fn is_canonical_at(db: &DatabaseProvider, hash: H256, height: u64) -> eyre::Result<bool> {
+    let canonical = db.view_eyre(|tx| Ok(tx.get::<MigratedBlockHashes>(height)?))?;
+    Ok(canonical == Some(hash))
+}
+
 /// C1 side-fork guard: confirm `hash` is the canonical block at `height` per
 /// `MigratedBlockHashes` before trusting a height-keyed (canonical-only) index
 /// lookup for it. Without this, a walk that descended onto a side-fork ancestor
 /// below the block-tree window would attribute the canonical block's chunks to
 /// the wrong block.
 fn assert_canonical_via_mbh(db: &DatabaseProvider, hash: H256, height: u64) -> eyre::Result<()> {
-    let canonical = db.view_eyre(|tx| Ok(tx.get::<MigratedBlockHashes>(height)?))?;
-    if canonical != Some(hash) {
+    if !is_canonical_at(db, hash, height)? {
         eyre::bail!(
             "expiry walk reached a non-canonical ancestor at height {height} \
              (supplied {hash}) — off the validated block's branch (C1 guard)"
@@ -1175,7 +1162,6 @@ fn find_block_range(
 /// 3. Applies filtering based on whether it's the earliest or latest block
 async fn process_boundary_block(
     boundary: &BoundaryBlock,
-    block_hash: H256,
     is_earliest: bool,
     is_latest: bool,
     ledger_type: DataLedger,
@@ -1186,7 +1172,7 @@ async fn process_boundary_block(
     db: &DatabaseProvider,
 ) -> eyre::Result<BTreeMap<IrysTransactionId, Arc<Vec<IrysAddress>>>> {
     // Get the block and its transactions
-    let block = get_block_by_hash(block_hash, block_tree_guard, db).await?;
+    let block = get_block_by_hash(boundary.block_hash, block_tree_guard, db).await?;
     let ledger_tx_ids = block
         .get_data_ledger_tx_ids_ordered(ledger_type)
         .ok_or_eyre(format!(

--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -62,17 +62,17 @@ use crate::mempool_guard::MempoolReadGuard;
 use crate::shadow_tx_generator::RollingHash;
 use eyre::{OptionExt as _, eyre};
 use irys_database::{
-    block_header_by_hash, canonical_submit_height, db::IrysDatabaseExt as _,
-    reth_db::transaction::DbTx as _, tables::MigratedBlockHashes,
+    block_header_by_hash, canonical_promoted_height, canonical_submit_height,
+    db::IrysDatabaseExt as _, reth_db::transaction::DbTx as _, tables::MigratedBlockHashes,
 };
-use irys_domain::{BlockIndex, BlockTreeReadGuard, EpochSnapshot};
+use irys_domain::{BlockIndex, BlockTree, BlockTreeReadGuard, EpochSnapshot};
 use irys_types::{
     BlockHeight, BlockIndexItem, Config, DataLedger, DataTransactionHeader, H256, IrysAddress,
     IrysBlockHeader, IrysTransactionId, LedgerChunkOffset, LedgerChunkRange, U256,
     app_state::DatabaseProvider, fee_distribution::TermFeeCharges, ledger_chunk_offset_ii,
 };
 use nodit::{InclusiveInterval as _, interval::ii};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 /// Calculates the aggregated fees owed to miners when data ledgers expire.
@@ -173,8 +173,36 @@ pub async fn calculate_expired_ledger_fees(
 
     // Step 6: Fetch transactions
     let all_tx_ids: Vec<_> = tx_to_miners.keys().copied().collect();
-    let mut transactions = get_data_tx_in_parallel(all_tx_ids, mempool_guard, db).await?;
-    transactions.sort_by(irys_types::DataTransactionHeader::compare_tx);
+
+    // NC-0042 P0: resolve which of these txs were promoted **on this block's own
+    // branch** before computing refunds. The refund-suppression decision must
+    // never read `DataTransactionHeader::promoted_height` from the fetched header
+    // — `get_data_tx_in_parallel` prefers the node-local mempool copy, where
+    // `promoted_height` is set at block confirmation within the reorg window
+    // (`mempool_service::apply_block_confirmed_updates`) and is therefore
+    // branch-variant: two forks contesting the slot-expiry boundary would
+    // disagree about whether a tx was promoted → divergent refund sets →
+    // consensus fork. `resolve_promoted_on_branch` answers purely from the
+    // block's parent ancestry (by-hash), mirroring `resolve_submit_inclusion`.
+    // Only the Submit ledger refunds (`expect_txs_to_be_promoted`); for term
+    // ledgers the walk is skipped entirely.
+    let promoted_on_branch = if expect_txs_to_be_promoted {
+        resolve_promoted_on_branch(
+            &all_tx_ids,
+            parent_block_header.block_hash,
+            block_height,
+            config,
+            block_tree_guard,
+            db,
+        )?
+    } else {
+        BTreeSet::new()
+    };
+
+    // No sort here: `aggregate_balance_deltas` sorts by `compare_tx` (it owns the
+    // "refunds sorted by tx_id" determinism invariant), so a sort at this site is
+    // redundant.
+    let transactions = get_data_tx_in_parallel(all_tx_ids, mempool_guard, db).await?;
 
     // Step 7: Calculate fees
     tracing::debug!(
@@ -193,6 +221,7 @@ pub async fn calculate_expired_ledger_fees(
         parent_epoch_snapshot,
         config,
         expect_txs_to_be_promoted,
+        &promoted_on_branch,
     )?;
 
     let total_fees = fees
@@ -207,6 +236,75 @@ pub async fn calculate_expired_ledger_fees(
     );
 
     Ok(fees)
+}
+
+/// Producer/validator-shared orchestration of [`calculate_expired_ledger_fees`]
+/// across the expiring data ledgers: always the Submit ledger (promotion expected
+/// → perm-fee refunds for unpromoted txs), plus — only when Cascade is active for
+/// the epoch — the OneYear and ThirtyDay term ledgers (no promotion). Returns the
+/// merged delta.
+///
+/// This is the single home for the three-call pattern so producer↔validator parity
+/// is **mechanical, not hand-maintained**: both sides pass the same
+/// `cascade_active_for_block` (the block's OWN timestamp — gates the write-window
+/// exclusion to match `touch_active_ledger_slots`, and must NOT be the
+/// epoch-lagging `is_cascade_active_for_epoch`) and `cascade_active_for_epoch`
+/// (gates whether the term ledgers settle at all). The ONLY legitimate difference —
+/// each ledger's cumulative `total_chunks` at this block — is supplied by
+/// `new_total_chunks`: the producer computes `parent + chunks_added`, the validator
+/// reads it straight from the header it is validating.
+pub async fn calculate_all_expired_ledger_fees(
+    parent_epoch_snapshot: &EpochSnapshot,
+    parent_block_header: &IrysBlockHeader,
+    block_height: u64,
+    config: &Config,
+    block_index: &BlockIndex,
+    block_tree_guard: &BlockTreeReadGuard,
+    mempool_guard: &MempoolReadGuard,
+    db: &DatabaseProvider,
+    cascade_active_for_block: bool,
+    cascade_active_for_epoch: bool,
+    new_total_chunks: impl Fn(DataLedger) -> u64,
+) -> eyre::Result<LedgerExpiryBalanceDelta> {
+    let mut result = calculate_expired_ledger_fees(
+        parent_epoch_snapshot,
+        parent_block_header,
+        block_height,
+        DataLedger::Submit,
+        config,
+        block_index.clone(),
+        block_tree_guard,
+        mempool_guard,
+        db,
+        true, // Submit: expect promotion — refund the perm fee for unpromoted txs
+        new_total_chunks(DataLedger::Submit),
+        cascade_active_for_block,
+    )
+    .await?;
+
+    // Term ledgers (no promotion) only settle once Cascade is active for the epoch.
+    if cascade_active_for_epoch {
+        for ledger in [DataLedger::OneYear, DataLedger::ThirtyDay] {
+            let delta = calculate_expired_ledger_fees(
+                parent_epoch_snapshot,
+                parent_block_header,
+                block_height,
+                ledger,
+                config,
+                block_index.clone(),
+                block_tree_guard,
+                mempool_guard,
+                db,
+                false, // term ledgers: no promotion expected
+                new_total_chunks(ledger),
+                cascade_active_for_block,
+            )
+            .await?;
+            result.merge(delta);
+        }
+    }
+
+    Ok(result)
 }
 
 /// Boundary + middle block processing (algorithm steps 3-5): maps every tx in the
@@ -651,13 +749,13 @@ fn resolve_submit_inclusion(
         let item = block_index
             .get_item(h)
             .ok_or_eyre("canonical_submit_height returned a height absent from the block index")?;
-        let total = submit_total_of_index_item(&item);
+        let total = ledger_total_of_index_item(&item, DataLedger::Submit);
         let base = if h == 0 {
             0
         } else {
             block_index
                 .get_item(h - 1)
-                .map(|i| submit_total_of_index_item(&i))
+                .map(|i| ledger_total_of_index_item(&i, DataLedger::Submit))
                 .ok_or_eyre(
                     "migrated predecessor must be indexed \
                      (below the reorg floor → finalized)",
@@ -685,13 +783,13 @@ fn resolve_submit_inclusion(
                 height: header.height,
                 prev_hash: header.previous_block_hash,
                 submit_total: header.ledger_total_chunks(DataLedger::Submit),
-                includes_txid: block_includes_submit_tx(header, &txid),
+                includes_txid: block_includes_ledger_tx(header, DataLedger::Submit, &txid),
             })
         },
         |height| {
             block_index
                 .get_item(height)
-                .map(|item| submit_total_of_index_item(&item))
+                .map(|item| ledger_total_of_index_item(&item, DataLedger::Submit))
         },
         // C1 gate input: is `hash` the canonical block at `height` per
         // `MigratedBlockHashes`? (shared with `assert_canonical_via_mbh`.)
@@ -764,18 +862,123 @@ fn walk_submit_inclusion(
     Ok(None)
 }
 
-/// Whether `header`'s Submit ledger includes `txid` (per-block `tx_ids`).
-fn block_includes_submit_tx(header: &IrysBlockHeader, txid: &IrysTransactionId) -> bool {
+/// Whether `header` includes `txid` in `ledger`'s per-block `tx_ids`.
+///
+/// For `Submit` this is plain membership. For `Publish` it is the **branch-correct
+/// promotion signal**: a tx's promotion is recorded by adding its id to the
+/// promoting block's Publish ledger (`mempool_service` derives the mempool
+/// `promoted_height` from exactly this set), so Publish membership on a branch is
+/// the branch-correct "was this tx promoted here?" answer.
+fn block_includes_ledger_tx(
+    header: &IrysBlockHeader,
+    ledger: DataLedger,
+    txid: &IrysTransactionId,
+) -> bool {
     header
-        .data_ledgers
-        .iter()
-        .find(|l| l.ledger_id == DataLedger::Submit as u32)
-        .is_some_and(|l| l.tx_ids.0.contains(txid))
+        .get_data_ledger_tx_ids_ordered(ledger)
+        .is_some_and(|ids| ids.contains(txid))
 }
 
-/// Cumulative Submit chunk total from a migrated block-index item.
-fn submit_total_of_index_item(item: &BlockIndexItem) -> u64 {
-    ledger_total_of_index_item(item, DataLedger::Submit)
+/// Branch-correct set of `candidate_txids` that were **promoted on the
+/// block-being-settled's own branch** — the refund-suppression analogue of
+/// [`resolve_submit_inclusion`] and the fix for the NC-0042 P0 consensus-fork
+/// vector.
+///
+/// The fetched [`DataTransactionHeader::promoted_height`] is node-local mempool
+/// state: it is set at block confirmation *within the reorg window*
+/// (`mempool_service::apply_block_confirmed_updates`) and cleared only on reorg,
+/// so it is **branch-variant**. Gating a perm-fee refund on it lets two forks
+/// contesting a slot-expiry boundary compute different refund sets — a divergent
+/// shadow-tx/treasury set → consensus fork. The answer here is instead a pure
+/// function of the block's **own parent ancestry** (`parent_block_hash`), never
+/// the node's canonical tip or live mempool.
+///
+/// Primary path — branch walk: from `parent_block_hash`, walk the parent chain
+/// **by hash** (retained tree first, DB fallback for tree-evicted headers — as in
+/// the validator's `get_previous_tx_inclusions`) over the full reorg window
+/// ([`prior_inclusion_walk_depth`] = `max(tx_anchor_expiry_depth,
+/// block_tree_depth)`), marking any candidate found in a block's Publish ledger
+/// as promoted. Walking the entire reorg window guarantees every branch-variant
+/// (recent) promotion is resolved here by-hash on this block's own branch.
+///
+/// Finalized fallback — [`canonical_promoted_height`]: for candidates NOT found
+/// by the walk, consult the MBH-verified canonical promotion height, capped
+/// strictly **below the walked window**. Below the reorg floor
+/// `MigratedBlockHashes` is branch-invariant (see `canonical_metadata_height` in
+/// `irys_database`), so an old finalized promotion (one made long before expiry,
+/// outside the reorg window) resolves identically on every node/branch.
+fn resolve_promoted_on_branch(
+    candidate_txids: &[IrysTransactionId],
+    parent_block_hash: H256,
+    block_height: u64,
+    config: &Config,
+    block_tree_guard: &BlockTreeReadGuard,
+    db: &DatabaseProvider,
+) -> eyre::Result<BTreeSet<IrysTransactionId>> {
+    let walk_depth = crate::block_validation::prior_inclusion_walk_depth(config);
+    let walk_min_height = block_height.saturating_sub(walk_depth);
+
+    let mut remaining: BTreeSet<IrysTransactionId> = candidate_txids.iter().copied().collect();
+    let mut promoted: BTreeSet<IrysTransactionId> = BTreeSet::new();
+
+    // Primary path: by-hash parent walk over the reorg window. `height` is
+    // tracked explicitly (ancestry is contiguous: each parent is height-1) so the
+    // loop only ever attempts to resolve ancestors that are *within* the window —
+    // an in-window ancestor missing from BOTH the tree and the DB is a local
+    // inconsistency and fails loud (classified NodeFault upstream), never a silent
+    // under-suppression that could diverge from a healthy node.
+    {
+        let tree = block_tree_guard.read();
+        let mut cursor = parent_block_hash;
+        let mut height = block_height.saturating_sub(1); // parent height
+        while !remaining.is_empty() && height >= walk_min_height {
+            // Resolve the ancestor header by hash (tree first, DB fallback). An
+            // in-window ancestor missing from BOTH is a local inconsistency → fail
+            // loud (NodeFault upstream), never a silent under-suppression.
+            let header = block_header_from_tree_then_db(&tree, db, &cursor)?.ok_or_else(|| {
+                eyre!(
+                    "expiry promotion walk: ancestor {cursor} at height {height} \
+                     (within the reorg window) is missing from both the block tree \
+                     and the DB"
+                )
+            })?;
+            debug_assert_eq!(
+                header.height, height,
+                "expiry promotion walk descended onto a non-contiguous ancestor"
+            );
+            remaining.retain(|txid| {
+                if block_includes_ledger_tx(&header, DataLedger::Publish, txid) {
+                    promoted.insert(*txid);
+                    false
+                } else {
+                    true
+                }
+            });
+            if height == 0 {
+                break; // genesis has no parent
+            }
+            cursor = header.previous_block_hash;
+            height -= 1;
+        }
+    }
+
+    // Finalized fallback: a promotion older than the walked window is below the
+    // reorg floor, where MBH (and thus `canonical_promoted_height`) is
+    // branch-invariant. Cap strictly below the window so a reorg-mutable height
+    // can never be trusted here — the walk already covered that band by hash.
+    if !remaining.is_empty() {
+        let max_height = walk_min_height.saturating_sub(1);
+        db.view_eyre(|tx| {
+            for txid in &remaining {
+                if canonical_promoted_height(tx, txid, max_height)?.is_some() {
+                    promoted.insert(*txid);
+                }
+            }
+            Ok(())
+        })?;
+    }
+
+    Ok(promoted)
 }
 
 /// Cumulative chunk total for `ledger` from a migrated block-index item
@@ -955,19 +1158,33 @@ fn submit_tx_start_offset(
     None
 }
 
-/// Fetches a block header from block tree or database
+/// Resolve a block header BY HASH against an **already-held** tree read guard,
+/// falling back to the DB for headers evicted from the retained tree window. The
+/// single home for the "tree-first, DB-fallback, by-hash" resolution the
+/// fork-ancestry walks share — takes the held `&BlockTree` so a caller can hold the
+/// guard across an entire walk (no per-step re-lock). `None` ⇒ the hash is in
+/// neither the tree nor the DB.
+fn block_header_from_tree_then_db(
+    tree: &BlockTree,
+    db: &DatabaseProvider,
+    hash: &H256,
+) -> eyre::Result<Option<IrysBlockHeader>> {
+    if let Some(header) = tree.get_block(hash) {
+        return Ok(Some(header.clone()));
+    }
+    db.view_eyre(|tx| block_header_by_hash(tx, hash, false))
+}
+
+/// Fetches a block header from the block tree or database, acquiring the read guard
+/// for a single lookup. For walks that hold the guard across many lookups, call
+/// [`block_header_from_tree_then_db`] directly with the held guard.
 #[tracing::instrument(level = "trace", skip_all, fields(block.hash = %block_hash))]
 async fn get_block_by_hash(
     block_hash: H256,
     block_tree_guard: &BlockTreeReadGuard,
     db: &DatabaseProvider,
 ) -> eyre::Result<IrysBlockHeader> {
-    // Check block tree first
-    if let Some(header) = block_tree_guard.read().get_block(&block_hash).cloned() {
-        return Ok(header);
-    }
-    // Fallback to database
-    db.view_eyre(|tx| block_header_by_hash(tx, &block_hash, false))?
+    block_header_from_tree_then_db(&block_tree_guard.read(), db, &block_hash)?
         .ok_or_eyre("block not found in db")
 }
 
@@ -1467,12 +1684,18 @@ impl LedgerExpiryBalanceDelta {
 /// - `epoch_snapshot`: Used to resolve miner addresses to reward addresses at payout time
 /// - `config`: Node configuration
 /// - `expect_txs_to_be_promoted`: Whether transactions are expected to be promoted
+/// - `promoted_on_branch`: tx ids that were promoted on the block-being-settled's
+///   own branch (resolved branch-correctly by [`resolve_promoted_on_branch`]). A
+///   perm-fee refund is suppressed iff the tx is in this set. Pre-computed (rather
+///   than read from `DataTransactionHeader::promoted_height`) because the fetched
+///   header's `promoted_height` is node-local mempool state and branch-variant.
 fn aggregate_balance_deltas(
     mut transactions: Vec<DataTransactionHeader>,
     tx_to_miners: &BTreeMap<IrysTransactionId, Arc<Vec<IrysAddress>>>,
     epoch_snapshot: &EpochSnapshot,
     config: &Config,
     expect_txs_to_be_promoted: bool,
+    promoted_on_branch: &BTreeSet<IrysTransactionId>,
 ) -> eyre::Result<LedgerExpiryBalanceDelta> {
     let mut balance_delta = LedgerExpiryBalanceDelta::default();
     transactions.sort_by(irys_types::DataTransactionHeader::compare_tx); // This ensures refunds will be sorted by tx_id
@@ -1518,9 +1741,13 @@ fn aggregate_balance_deltas(
             continue;
         }
 
-        // process refunds of perm fee if the tx was not promoted
+        // process refunds of perm fee if the tx was not promoted **on this
+        // branch**. Promotion is resolved branch-correctly upstream
+        // (`resolve_promoted_on_branch`); we must NOT consult
+        // `data_tx.promoted_height()` here — it is node-local mempool state and
+        // would fork the refund set across competing branches (NC-0042 P0).
         {
-            if data_tx.promoted_height().is_none() {
+            if !promoted_on_branch.contains(&data_tx.id) {
                 // Only process refund if perm_fee exists (should always be present if tx is expected to be promoted)
                 let perm_fee = data_tx
                     .perm_fee
@@ -1534,8 +1761,7 @@ fn aggregate_balance_deltas(
             } else {
                 tracing::debug!(
                     tx.id = ?data_tx.id,
-                    tx.promoted_height = ?data_tx.promoted_height(),
-                    "Tx was promoted, no refund needed",
+                    "Tx was promoted on this branch, no refund needed",
                 );
             }
         }
@@ -1560,7 +1786,10 @@ impl SlotIndex {
     ) -> LedgerChunkRange {
         let start =
             LedgerChunkOffset::from(self.0.saturating_mul(chunks_per_partition)).min(max_offset);
-        let end = start + chunks_per_partition;
+        // saturating_add for parity with the saturating_mul above; the following
+        // .min(max_offset) clamps to real on-chain totals, so saturation can never
+        // change a reachable result (overflow needs totals near u64::MAX).
+        let end = LedgerChunkOffset::from((*start).saturating_add(chunks_per_partition));
         let end = end.min(max_offset);
         LedgerChunkRange(ledger_chunk_offset_ii!(start, end))
     }
@@ -1655,6 +1884,7 @@ mod tests {
             &epoch_snapshot,
             &config,
             false,
+            &BTreeSet::new(),
         )
         .unwrap();
 
@@ -1742,9 +1972,15 @@ mod tests {
         let mut tx_to_miners = BTreeMap::new();
         tx_to_miners.insert(tx1.id, Arc::new(vec![miner1, miner2, miner3]));
 
-        let result =
-            aggregate_balance_deltas(vec![tx1], &tx_to_miners, &epoch_snapshot, &config, false)
-                .unwrap();
+        let result = aggregate_balance_deltas(
+            vec![tx1],
+            &tx_to_miners,
+            &epoch_snapshot,
+            &config,
+            false,
+            &BTreeSet::new(),
+        )
+        .unwrap();
 
         // 2850 split 3 ways = 950 each; pool gets 2x (1900), miner3 gets 1x (950)
         assert_eq!(result.reward_balance_increment.len(), 2);
@@ -1802,9 +2038,15 @@ mod tests {
         tx_to_miners.insert(txs[3].id, Arc::new(vec![miner_b]));
 
         let epoch_snapshot = EpochSnapshot::default();
-        let result =
-            aggregate_balance_deltas(txs.to_vec(), &tx_to_miners, &epoch_snapshot, &config, false)
-                .unwrap();
+        let result = aggregate_balance_deltas(
+            txs.to_vec(),
+            &tx_to_miners,
+            &epoch_snapshot,
+            &config,
+            false,
+            &BTreeSet::new(),
+        )
+        .unwrap();
 
         // Single miner per tx ⇒ that miner gets the whole treasury slice. Compute
         // it via TermFeeCharges so the assertion tracks the real fee model.
@@ -2858,6 +3100,302 @@ mod tests {
         assert_eq!(submit_span_verdict(inc.base, inc.total, 5), Some(false));
 
         Ok(())
+    }
+
+    /// NC-0042 P0 (consensus-fork fix): the perm-fee refund suppression must read
+    /// promotion from the block's OWN branch, never node-local mempool/DB state.
+    /// This proves [`resolve_promoted_on_branch`] answers purely from
+    /// `parent_block_hash` ancestry — the SAME txid resolves as promoted when
+    /// walking the fork that promoted it and as un-promoted when walking the fork
+    /// that did not, so two honest producers on competing branches compute
+    /// matching (branch-determined) refund sets regardless of any local hint.
+    #[test]
+    fn resolve_promoted_on_branch_reads_only_the_blocks_own_branch() -> eyre::Result<()> {
+        use irys_database::{IrysDatabaseArgs as _, open_or_create_db, tables::IrysTables};
+        use irys_domain::{
+            BlockTree, BlockTreeReadGuard, CommitmentSnapshot, EpochSnapshot, dummy_ema_snapshot,
+        };
+        use irys_testing_utils::IrysBlockHeaderTestExt as _;
+        use irys_types::{BlockTransactions, SealedBlock};
+        use reth_db::mdbx::DatabaseArguments;
+        use std::sync::RwLock;
+
+        // A header carrying `publish_tx_ids` in its Publish ledger (the promotion
+        // signal `block_includes_publish_tx` reads) plus an empty Submit ledger.
+        fn with_publish(height: u64, publish_tx_ids: Vec<H256>) -> IrysBlockHeader {
+            let ledger = |id: DataLedger, tx_ids: Vec<H256>| irys_types::DataTransactionLedger {
+                ledger_id: id as u32,
+                tx_root: H256::zero(),
+                tx_ids: irys_types::H256List(tx_ids),
+                total_chunks: 0,
+                expires: None,
+                proofs: None,
+                required_proof_count: None,
+            };
+            let mut h = IrysBlockHeader::new_mock_header();
+            h.height = height;
+            h.data_ledgers = vec![
+                ledger(DataLedger::Publish, publish_tx_ids),
+                ledger(DataLedger::Submit, vec![]),
+            ];
+            h
+        }
+
+        let target = H256::random();
+
+        // genesis h0 → h1, then a fork at h2: `promoted` includes `target` in its
+        // Publish ledger, `bare` does not. A settlement block at height 3 walks
+        // back from whichever h2 is its parent.
+        let mut genesis = with_publish(0, vec![]);
+        let mut h1 = with_publish(1, vec![]);
+        let mut h2_promoted = with_publish(2, vec![target]);
+        let mut h2_bare = with_publish(2, vec![]);
+
+        let guard = {
+            genesis.cumulative_diff = 0.into();
+            genesis.test_sign();
+            let mut tree = BlockTree::new(&genesis, irys_types::ConsensusConfig::testing());
+            tree.mark_tip(&genesis.block_hash).unwrap();
+
+            h1.previous_block_hash = genesis.block_hash;
+            h1.cumulative_diff = 1.into();
+            h1.test_sign();
+
+            h2_promoted.previous_block_hash = h1.block_hash;
+            h2_promoted.cumulative_diff = 2.into();
+            h2_promoted.test_sign();
+
+            // Distinct cumulative_diff so the sibling is a genuine second child of
+            // h1, not a duplicate. We never mark either h2 as tip — the walk is
+            // driven by the explicit `parent_block_hash`, not fork choice.
+            h2_bare.previous_block_hash = h1.block_hash;
+            h2_bare.cumulative_diff = 3.into();
+            h2_bare.test_sign();
+
+            for h in [&h1, &h2_promoted, &h2_bare] {
+                let sealed = Arc::new(SealedBlock::new_unchecked(
+                    Arc::new(h.clone()),
+                    BlockTransactions::default(),
+                ));
+                tree.add_block(
+                    &sealed,
+                    Arc::new(CommitmentSnapshot::default()),
+                    Arc::new(EpochSnapshot::default()),
+                    dummy_ema_snapshot(),
+                )?;
+            }
+            BlockTreeReadGuard::new(Arc::new(RwLock::new(tree)))
+        };
+
+        // Empty db ⇒ the finalized `canonical_promoted_height` fallback finds
+        // nothing; the by-hash branch walk is the sole decider.
+        let temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db_env = open_or_create_db(
+            &temp_dir,
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        let db = DatabaseProvider(Arc::new(db_env));
+        let config = Config::new_with_random_peer_id(irys_types::NodeConfig::testing());
+
+        // Walking the promoting fork → `target` IS promoted (refund suppressed).
+        let on_promoted =
+            resolve_promoted_on_branch(&[target], h2_promoted.block_hash, 3, &config, &guard, &db)?;
+        assert!(
+            on_promoted.contains(&target),
+            "target IS promoted on the fork whose ancestry includes the Publish inclusion"
+        );
+
+        // Walking the bare fork → `target` is NOT promoted (refund emitted), even
+        // though a sibling branch (and any node-local hint) promoted it.
+        let on_bare =
+            resolve_promoted_on_branch(&[target], h2_bare.block_hash, 3, &config, &guard, &db)?;
+        assert!(
+            on_bare.is_empty(),
+            "target is NOT promoted on the fork whose ancestry never included it"
+        );
+
+        Ok(())
+    }
+
+    /// NC-0042 P0 — the exact trap, as a reintroduction guard. The original bug
+    /// gated the refund on a **node-local** promotion signal. The most tempting
+    /// wrong "fix" is to keep using the node-local `IrysDataTxMetadata`
+    /// `promoted_height` hint via a by-height lookup — which is branch-invariant
+    /// only BELOW the reorg floor. This pins that: with a stale `promoted_height`
+    /// hint planted in the DB **inside the reorg window** (and `MigratedBlockHashes`
+    /// agreeing, so a naive `canonical_promoted_height(parent_height)` WOULD report
+    /// it promoted), `resolve_promoted_on_branch` must STILL report the tx as
+    /// un-promoted because the block's own branch never carried it in a Publish
+    /// ledger. Any regression to a fast-path-first by-height lookup, or a finalized
+    /// fallback whose cap reaches into the reorg window, fails this test.
+    #[test]
+    fn resolve_promoted_on_branch_ignores_in_window_node_local_hint() -> eyre::Result<()> {
+        use irys_database::{
+            IrysDatabaseArgs as _, canonical_promoted_height, insert_tx_header, open_or_create_db,
+            set_data_tx_included_height, set_data_tx_promoted_height, tables::IrysTables,
+            tables::MigratedBlockHashes,
+        };
+        use irys_domain::{BlockTree, BlockTreeReadGuard};
+        use irys_testing_utils::IrysBlockHeaderTestExt as _;
+        use irys_types::{
+            BlockTransactions, DataTransactionHeaderV1, DataTransactionHeaderV1WithMetadata,
+            DataTransactionMetadata, SealedBlock,
+        };
+        use reth_db::{mdbx::DatabaseArguments, transaction::DbTxMut as _};
+        use std::sync::RwLock;
+
+        // Submit-only headers ⇒ `target` is NEVER in a Publish ledger on this
+        // branch, so the branch walk must conclude "not promoted".
+        fn submit_only(height: u64) -> IrysBlockHeader {
+            let mut h = IrysBlockHeader::new_mock_header();
+            h.height = height;
+            h.data_ledgers = vec![irys_types::DataTransactionLedger {
+                ledger_id: DataLedger::Submit as u32,
+                tx_root: H256::zero(),
+                tx_ids: irys_types::H256List(vec![]),
+                total_chunks: 0,
+                expires: None,
+                proofs: None,
+                required_proof_count: None,
+            }];
+            h
+        }
+
+        let target = H256::random();
+
+        // Linear chain genesis h0 → h1 → h2. A settlement block at height 3 walks
+        // back from h2.
+        let mut headers = [submit_only(0), submit_only(1), submit_only(2)];
+        let guard = {
+            let mut iter = headers.iter_mut();
+            let genesis = iter.next().unwrap();
+            genesis.cumulative_diff = 0.into();
+            genesis.test_sign();
+            let mut prev = genesis.block_hash;
+            let mut tree = BlockTree::new(genesis, irys_types::ConsensusConfig::testing());
+            tree.mark_tip(&prev).unwrap();
+            for h in iter {
+                h.previous_block_hash = prev;
+                h.cumulative_diff = h.height.into();
+                h.test_sign();
+                prev = h.block_hash;
+                let sealed = Arc::new(SealedBlock::new_unchecked(
+                    Arc::new(h.clone()),
+                    BlockTransactions::default(),
+                ));
+                tree.add_block(
+                    &sealed,
+                    Arc::new(irys_domain::CommitmentSnapshot::default()),
+                    Arc::new(EpochSnapshot::default()),
+                    irys_domain::dummy_ema_snapshot(),
+                )?;
+            }
+            BlockTreeReadGuard::new(Arc::new(RwLock::new(tree)))
+        };
+
+        let temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db_env = open_or_create_db(
+            &temp_dir,
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        let db = DatabaseProvider(Arc::new(db_env));
+
+        // Plant the stale node-local promotion hint at height 1 (inside the reorg
+        // window for the block at height 3) with MBH agreeing — exactly the
+        // node-local state the old code read and the new code must ignore.
+        let target_header = DataTransactionHeader::V1(DataTransactionHeaderV1WithMetadata {
+            tx: DataTransactionHeaderV1 {
+                id: target,
+                ..Default::default()
+            },
+            metadata: DataTransactionMetadata::new(),
+        });
+        db.update_eyre(|wtx| {
+            insert_tx_header(wtx, &target_header)?;
+            // included_height is a precondition for promoted_height; the inclusion
+            // sits below the reorg floor (slot-lifetime invariant) so its exact
+            // value is immaterial here.
+            set_data_tx_included_height(wtx, &target, 1)?;
+            set_data_tx_promoted_height(wtx, &target, 1)?;
+            wtx.put::<MigratedBlockHashes>(1, headers[1].block_hash)?;
+            Ok(())
+        })?;
+
+        let config = Config::new_with_random_peer_id(irys_types::NodeConfig::testing());
+
+        // The trap is live: a naive by-height lookup at the parent height WOULD
+        // report `target` promoted (hint 1 ≤ 2 and MBH[1] is set).
+        let naive = db.view_eyre(|tx| canonical_promoted_height(tx, &target, 2))?;
+        assert_eq!(
+            naive,
+            Some(1),
+            "precondition: the stale in-window hint would fool a parent-height lookup"
+        );
+
+        // The branch-correct resolver ignores it: `target` is not in any Publish
+        // ledger on h2's ancestry, and the finalized fallback is capped below the
+        // walked reorg window.
+        let promoted =
+            resolve_promoted_on_branch(&[target], headers[2].block_hash, 3, &config, &guard, &db)?;
+        assert!(
+            promoted.is_empty(),
+            "resolver must ignore the node-local in-window promoted_height hint"
+        );
+
+        Ok(())
+    }
+
+    /// NC-0042 P0 regression guard at the settlement layer: `aggregate_balance_deltas`
+    /// bases refund suppression on the branch-resolved `promoted_on_branch` set,
+    /// NOT on the fetched header's node-local `promoted_height`. A tx whose header
+    /// still carries a (branch-variant) `promoted_height = Some` from local mempool
+    /// state must STILL be refunded when it is absent from the branch set — the
+    /// exact divergence the pre-fix `data_tx.promoted_height().is_none()` check
+    /// produced. (On the pre-fix code this asserts fails: no refund is emitted.)
+    #[test]
+    fn aggregate_refunds_use_branch_set_not_node_local_promoted_height() {
+        let config = Config::new_with_random_peer_id(irys_types::NodeConfig::testing());
+
+        let signer = IrysAddress::random();
+        let mut tx = DataTransactionHeader::V1(irys_types::DataTransactionHeaderV1WithMetadata {
+            tx: DataTransactionHeaderV1 {
+                id: H256::random(),
+                term_fee: U256::from(1000).into(),
+                perm_fee: Some(irys_types::BoundedFee::from(777_u64)),
+                signer,
+                data_size: 100,
+                ..Default::default()
+            },
+            metadata: irys_types::DataTransactionMetadata::new(),
+        });
+        // Stale, branch-variant node-local promotion state on the fetched header.
+        tx.set_promoted_height(Some(5));
+
+        let miner = IrysAddress::random();
+        let mut tx_to_miners = BTreeMap::new();
+        tx_to_miners.insert(tx.id, Arc::new(vec![miner]));
+
+        let epoch_snapshot = EpochSnapshot::default();
+
+        // Branch-resolved set is EMPTY ⇒ tx was NOT promoted on this branch ⇒ refund,
+        // regardless of the header's `promoted_height = Some(5)`.
+        let result = aggregate_balance_deltas(
+            vec![tx.clone()],
+            &tx_to_miners,
+            &epoch_snapshot,
+            &config,
+            true, // expect_txs_to_be_promoted (Submit ledger)
+            &BTreeSet::new(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            result.user_perm_fee_refunds,
+            vec![(tx.id, irys_types::BoundedFee::from(777_u64).get(), signer)],
+            "refund must follow the branch set despite header promoted_height = Some"
+        );
     }
 
     /// Canonical P0 repro turned regression: normal epoch-slot allocation

--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -61,7 +61,10 @@ use crate::block_discovery::get_data_tx_in_parallel;
 use crate::mempool_guard::MempoolReadGuard;
 use crate::shadow_tx_generator::RollingHash;
 use eyre::{OptionExt as _, eyre};
-use irys_database::{block_header_by_hash, canonical_submit_height, db::IrysDatabaseExt as _};
+use irys_database::{
+    block_header_by_hash, canonical_submit_height, db::IrysDatabaseExt as _,
+    reth_db::transaction::DbTx as _, tables::MigratedBlockHashes,
+};
 use irys_domain::{BlockIndex, BlockTreeReadGuard, EpochSnapshot};
 use irys_types::{
     BlockHeight, BlockIndexItem, Config, DataLedger, DataTransactionHeader, H256, IrysAddress,
@@ -145,6 +148,9 @@ pub async fn calculate_expired_ledger_fees(
         &block_index,
         ledger_type,
         parent_ledger_total_chunks(parent_block_header, ledger_type),
+        parent_block_header.block_hash,
+        block_tree_guard,
+        db,
     )? {
         Some(br) => br,
         None => {
@@ -221,7 +227,7 @@ async fn collect_tx_to_miners_from_range(
     mempool_guard: &MempoolReadGuard,
     db: &DatabaseProvider,
 ) -> eyre::Result<BTreeMap<IrysTransactionId, Arc<Vec<IrysAddress>>>> {
-    let same_block = block_range.min_block.item.block_hash == block_range.max_block.item.block_hash;
+    let same_block = block_range.min_block.block_hash == block_range.max_block.block_hash;
     tracing::info!(
         "Processing boundary blocks: min_block height={}, max_block height={}, same_block={}",
         block_range.min_block.height,
@@ -233,13 +239,16 @@ async fn collect_tx_to_miners_from_range(
     let latest_miners;
 
     if same_block {
-        // When min and max are the same block, process it only once to avoid double-counting
-        // Process as earliest block (will include all transactions in the partition range)
+        // When min and max are the same block, process it once as BOTH the earliest
+        // and latest boundary so both ends of the expired range are trimmed. (Trimming
+        // only the start — the old behavior — over-included the next slot's txs, which
+        // diverged from the exact per-candidate promotion filter; see NC-0042 §4b.)
         let miners = process_boundary_block(
             &block_range.min_block,
-            block_range.min_block.item.block_hash,
+            block_range.min_block.block_hash,
             Arc::clone(&block_range.min_block_miners),
             true, // is_earliest
+            true, // is_latest — sole boundary block (min == max), so trim BOTH ends
             ledger_type,
             config,
             block_index,
@@ -255,9 +264,10 @@ async fn collect_tx_to_miners_from_range(
         // Different blocks - process both boundaries
         let e_miners = process_boundary_block(
             &block_range.min_block,
-            block_range.min_block.item.block_hash,
+            block_range.min_block.block_hash,
             Arc::clone(&block_range.min_block_miners),
-            true, // is_earliest
+            true,  // is_earliest — min block trims only the start
+            false, // is_latest
             ledger_type,
             config,
             block_index,
@@ -269,9 +279,10 @@ async fn collect_tx_to_miners_from_range(
 
         let l_miners = process_boundary_block(
             &block_range.max_block,
-            block_range.max_block.item.block_hash,
+            block_range.max_block.block_hash,
             Arc::clone(&block_range.max_block_miners),
             false, // is_earliest
+            true,  // is_latest — max block trims only the end
             ledger_type,
             config,
             block_index,
@@ -362,6 +373,9 @@ pub async fn expired_submit_tx_ids(
         &block_index,
         DataLedger::Submit,
         parent_ledger_total_chunks(parent_block_header, DataLedger::Submit),
+        parent_block_header.block_hash,
+        block_tree_guard,
+        db,
     )? {
         Some(br) => br,
         // No chunks were ever uploaded into the expired slot ranges.
@@ -386,36 +400,19 @@ pub async fn expired_submit_tx_ids(
 /// `txid`'s Submit-ledger storage has expired as of `block_height` (the block
 /// being produced/validated).
 ///
-/// This is the O(candidate-tx) replacement for the O(expired-partition-history)
-/// `expired_submit_tx_ids` set: instead of walking every expired partition on
-/// every block, it resolves only *this* tx's Submit inclusion block and tests it
-/// against the expired chunk range.
+/// The verdict is an exact offset comparison: `txid` is expired iff its Submit
+/// **start chunk offset** is `< range_end`, where `[0, range_end)` is the expired
+/// chunk prefix bounded by the parent header's recorded Submit total (see
+/// [`expired_submit_range`]).
 ///
-/// ## Equivalence (differential-tested)
-///
-/// It reproduces, for a single candidate, exactly what `expired_submit_tx_ids`
-/// computes for the whole set. The expired slots are a contiguous prefix
-/// starting at slot 0 (slot `last_height` is the allocation height, monotonic in
-/// slot index), so the expired chunk range is `[0, range_end)` spanning blocks
-/// `[min_block, max_block]`. A candidate's inclusion block is then tested with
-/// the *same boundary rules* the walk applies:
-/// - block before/after that range → not expired;
-/// - an earliest or middle block of the range, or the whole range packed into a
-///   single block (`min_block == max_block`, only reachable with tiny test
-///   partitions) → expired (the walk includes every tx of those blocks);
-/// - the latest block of a multi-block range → expired iff the tx's start chunk
-///   offset is before `range_end` (the walk trims here).
-///
-/// ## Metadata dependency (vs. the metadata-free walk)
-///
-/// This resolves the tx's Submit inclusion height from local `included_height`
-/// metadata (`canonical_submit_height`), whereas the walk derives everything
-/// from canonical block contents. The dependency is sound for the candidates we
-/// check: they are unpromoted at check time (so the Publish-migration
-/// `included_height` overwrite has not happened), and the height comes from the
-/// node's own canonical chain, never the peer's block. A `None` resolution
-/// yields `false` (a tx with no canonical Submit inclusion cannot have expired
-/// Submit storage).
+/// Branch-deterministic by construction: both `range_end` and the candidate's
+/// Submit inclusion are resolved from the block's **own parent ancestry**, never
+/// this node's canonical tip or its migration-lagged block-index frontier, so
+/// every node reaches the same verdict (NC-0042 F2). See
+/// [`resolve_submit_inclusion`] for the migrated (fast, via
+/// `canonical_submit_height`) vs un-migrated (by-hash parent walk) resolution. A
+/// candidate with no resolvable Submit inclusion on this branch yields `false`
+/// (it cannot have expired Submit storage).
 #[tracing::instrument(level = "debug", skip_all, fields(tx.id = %txid, block.height = block_height))]
 pub async fn is_submit_storage_expired(
     txid: IrysTransactionId,
@@ -433,14 +430,12 @@ pub async fn is_submit_storage_expired(
         parent_epoch_snapshot,
         parent_block_header,
         config,
-        block_index,
     )?
     else {
         return Ok(false);
     };
     submit_tx_expired(
         txid,
-        None,
         &range,
         config,
         block_index,
@@ -451,40 +446,39 @@ pub async fn is_submit_storage_expired(
     .await
 }
 
-/// Block-level inputs for the §4b/§4c Submit-expiry check, computed **once per
-/// block** and reused across every publish candidate via [`submit_tx_expired`].
+/// Block-level inputs for the §4b/§4c Submit-expiry check, computed once per
+/// block and reused across every publish candidate via [`submit_tx_expired`].
 ///
-/// Scanning the expired-slot set and the two `block_index` boundary lookups do
-/// not depend on the candidate, so hoisting them here keeps the per-candidate
-/// cost to a single `canonical_submit_height` read — plus, only on the latest
-/// boundary block of a multi-block range, one inclusion-block walk.
+/// Every field is a pure function of the block's **own parent** — never this
+/// node's canonical tip or migration-lagged block index — so the verdict is
+/// identical across nodes (NC-0042 F2 branch-determinism).
 #[derive(Debug, Clone, Copy)]
 pub struct ExpiredSubmitRange {
     /// The block being produced/validated (caps the canonical Submit lookup).
     block_height: u64,
-    /// Block span of the expired chunk range `[0, range_end)`.
-    min_block_height: u64,
-    max_block_height: u64,
-    /// Exclusive end of the expired chunk range, clamped to data actually written.
+    /// Exclusive end of the expired chunk range `[0, range_end)`, bounded by the
+    /// parent header's recorded Submit total.
     range_end: u64,
-    /// Hash of `max_block_height`'s block — the only block whose per-tx offsets
-    /// a candidate check might need to reconstruct.
-    max_block_hash: H256,
+    /// The block's own parent hash — root of the branch-correct ancestry walk
+    /// used to resolve a candidate's Submit inclusion. Never the node's tip.
+    parent_block_hash: H256,
 }
 
 /// Computes the [`ExpiredSubmitRange`] for `block_height`, or `None` if no Submit
-/// storage has expired as of this block (nothing to filter). The equivalence
-/// argument with the `expired_submit_tx_ids` walk is documented on
-/// [`is_submit_storage_expired`].
+/// storage has expired as of this block (nothing to filter).
+///
+/// `range_end` is bounded by the **parent header's** recorded Submit total only —
+/// a pure function of the block's own parent, identical on every node regardless
+/// of that node's migration-lagged block-index tip (NC-0042 F2). The branch-
+/// correct mapping from a candidate's inclusion to a chunk offset happens later,
+/// per candidate, in [`submit_tx_expired`].
 pub fn expired_submit_range(
     block_height: u64,
     parent_epoch_snapshot: &EpochSnapshot,
     parent_block_header: &IrysBlockHeader,
     config: &Config,
-    block_index: &BlockIndex,
 ) -> eyre::Result<Option<ExpiredSubmitRange>> {
-    // The expired Submit slots — the exact set `expired_submit_tx_ids` keys on
-    // (also handles the "not enough blocks elapsed → empty" case).
+    // The expired Submit slots (also handles "not enough blocks elapsed → empty").
     let slot_indexes =
         parent_epoch_snapshot.get_all_expired_term_slot_indexes(DataLedger::Submit, block_height);
     let Some(&max_expired_slot) = slot_indexes.iter().max() else {
@@ -492,52 +486,39 @@ pub fn expired_submit_range(
     };
 
     // End of the expired chunk range = end of the highest expired slot, clamped
-    // to the data actually written (mirrors `find_block_range`'s
-    // `compute_chunk_range` — same min(parent header total, index total) bound,
-    // see the comment there for why both terms are needed). Expired slots are a
-    // prefix from slot 0, so the range starts at 0 and the walk's earliest-block
-    // skip never fires.
+    // to data actually written *as of the parent*. Expired slots form a prefix
+    // from slot 0, so the range is `[0, range_end)`. Bounding by the parent
+    // header (not this node's block-index tip) is what makes the verdict
+    // branch-deterministic.
     let p = config.consensus.num_chunks_in_partition;
-    let max_offset = block_index
-        .get_latest_item()
-        .map(|item| item.ledgers[DataLedger::Submit].total_chunks)
-        .unwrap_or(0)
-        .min(parent_ledger_total_chunks(
-            parent_block_header,
-            DataLedger::Submit,
-        ));
+    let parent_total = parent_ledger_total_chunks(parent_block_header, DataLedger::Submit);
     let range_end = (max_expired_slot as u64 + 1)
         .saturating_mul(p)
-        .min(max_offset);
+        .min(parent_total);
     if range_end == 0 {
         return Ok(None);
     }
 
-    // Block range holding the expired chunks.
-    let (min_block_height, _) = block_index.get_block_index_item(DataLedger::Submit, 0)?;
-    let (max_block_height, max_block_item) =
-        block_index.get_block_index_item(DataLedger::Submit, range_end - 1)?;
-
     Ok(Some(ExpiredSubmitRange {
         block_height,
-        min_block_height,
-        max_block_height,
         range_end,
-        max_block_hash: max_block_item.block_hash,
+        parent_block_hash: parent_block_header.block_hash,
     }))
 }
 
 /// Per-candidate verdict against a precomputed [`ExpiredSubmitRange`]: is
 /// `txid`'s Submit storage expired as of `range.block_height`?
 ///
-/// `submit_height` lets a caller that already resolved the candidate's canonical
-/// Submit inclusion height (e.g. the tx selector's prior-Submit check) pass it in
-/// to avoid a duplicate `canonical_submit_height` read; pass `None` to resolve it
-/// here. A `None` resolution (no canonical Submit inclusion) yields `false`.
+/// Branch-correct: `txid`'s Submit inclusion is resolved from the block's **own
+/// parent ancestry** (migrated inclusions via `canonical_submit_height`, which is
+/// finalized and branch-invariant; un-migrated inclusions via a by-hash parent
+/// walk — never the node's canonical tip or migration-lagged index). The verdict
+/// is then a pure offset comparison: expired iff the candidate's Submit start
+/// offset is `< range_end`. A candidate with no resolvable Submit inclusion on
+/// this branch yields `false`.
 #[tracing::instrument(level = "debug", skip_all, fields(tx.id = %txid))]
 pub async fn submit_tx_expired(
     txid: IrysTransactionId,
-    submit_height: Option<u64>,
     range: &ExpiredSubmitRange,
     config: &Config,
     block_index: &BlockIndex,
@@ -545,80 +526,329 @@ pub async fn submit_tx_expired(
     mempool_guard: &MempoolReadGuard,
     db: &DatabaseProvider,
 ) -> eyre::Result<bool> {
-    // Submit inclusion is strictly before this block, so cap the lookup at the parent.
-    let submit_height = match submit_height {
-        Some(h) => h,
+    let Some(inc) =
+        resolve_submit_inclusion(txid, range, config, block_index, block_tree_guard, db)?
+    else {
+        // No Submit inclusion resolvable on this branch → cannot have expired.
+        return Ok(false);
+    };
+
+    // Offset verdict against the expired range `[0, range_end)`. The block span
+    // decides outright unless `range_end` falls strictly inside the inclusion
+    // block, in which case the candidate's exact start offset settles it.
+    match submit_span_verdict(inc.base, inc.total, range.range_end) {
+        Some(verdict) => Ok(verdict),
         None => {
-            let max_height = range.block_height.saturating_sub(1);
-            match db.view_eyre(|tx| canonical_submit_height(tx, &txid, max_height))? {
-                Some(h) => h,
-                None => return Ok(false),
-            }
+            let block = get_block_by_hash(inc.block_hash, block_tree_guard, db).await?;
+            let ordered_ids = block
+                .get_data_ledger_tx_ids_ordered(DataLedger::Submit)
+                .ok_or_eyre("Submit ledger required for the expiry inclusion block")?;
+            let headers = get_data_tx_in_parallel(ordered_ids.to_vec(), mempool_guard, db).await?;
+            let ordered: Vec<(IrysTransactionId, u64)> =
+                headers.iter().map(|h| (h.id, h.data_size)).collect();
+            let start_offset =
+                submit_tx_start_offset(txid, &ordered, inc.base, config.consensus.chunk_size);
+            Ok(start_offset.is_some_and(|offset| offset < range.range_end))
         }
-    };
-
-    // The verdict depends on the candidate's exact start offset only on the
-    // latest boundary of a multi-block range (the only place the walk trims).
-    // Everywhere else the inclusion-block height alone decides, so skip the
-    // inclusion-block fetch.
-    let needs_start_offset =
-        range.min_block_height != range.max_block_height && submit_height == range.max_block_height;
-    let start_offset = if needs_start_offset {
-        // Reconstruct the candidate's Submit start offset from its inclusion
-        // block (== the max boundary block here). `get_data_tx_in_parallel`
-        // preserves input order — the same helper the walk uses, so the
-        // reconstructed offsets match.
-        let base_chunks = get_previous_max_offset(block_index, submit_height, DataLedger::Submit)?;
-        let block = get_block_by_hash(range.max_block_hash, block_tree_guard, db).await?;
-        let ordered_ids = block
-            .get_data_ledger_tx_ids_ordered(DataLedger::Submit)
-            .ok_or_eyre("Submit ledger required for the expiry inclusion block")?;
-        let headers = get_data_tx_in_parallel(ordered_ids.to_vec(), mempool_guard, db).await?;
-        let ordered: Vec<(IrysTransactionId, u64)> =
-            headers.iter().map(|h| (h.id, h.data_size)).collect();
-        submit_tx_start_offset(txid, &ordered, *base_chunks, config.consensus.chunk_size)
-    } else {
-        None
-    };
-
-    Ok(submit_tx_in_expired_range(
-        submit_height,
-        range.min_block_height,
-        range.max_block_height,
-        range.range_end,
-        start_offset,
-    ))
+    }
 }
 
-/// Pure boundary decision for [`is_submit_storage_expired`]: given the expired
-/// chunk range's block span `[min_block_height, max_block_height]` and its
-/// `range_end` offset, decides whether a candidate whose Submit inclusion is
-/// block `submit_height` is in the set — mirroring `find_block_range` /
-/// `filter_transactions_by_chunk_range`.
+/// Pure block-span decision: given an inclusion block's `[base, total)` Submit
+/// chunk span and the expired range end, is the candidate expired?
+/// `Some(true)`  → the whole block lies before `range_end`.
+/// `Some(false)` → the block starts at/after `range_end`.
+/// `None`        → `range_end` falls strictly inside the block; the caller must
+///                  consult the candidate's exact start offset.
+fn submit_span_verdict(base: u64, total: u64, range_end: u64) -> Option<bool> {
+    if total <= range_end {
+        Some(true)
+    } else if base >= range_end {
+        Some(false)
+    } else {
+        None
+    }
+}
+
+/// A candidate's branch-correct Submit inclusion: the block that introduced it
+/// into the Submit ledger, with the cumulative chunk offsets bracketing it.
+struct SubmitInclusion {
+    /// Hash of the inclusion block.
+    block_hash: H256,
+    /// Cumulative Submit chunks *before* the inclusion block (its start offset).
+    base: u64,
+    /// Cumulative Submit chunks *through* the inclusion block.
+    total: u64,
+}
+
+/// Resolves `txid`'s Submit inclusion along the **block's own parent ancestry**
+/// (`range.parent_block_hash`) — never the node's canonical tip.
 ///
-/// `start_offset` (the candidate's Submit start chunk offset) is consulted only
-/// on the latest boundary of a multi-block range — the one place the walk trims
-/// — so callers may pass `None` in every other case. The expired range always
-/// begins at slot 0, so the earliest-block skip never applies.
-fn submit_tx_in_expired_range(
-    submit_height: u64,
-    min_block_height: u64,
-    max_block_height: u64,
-    range_end: u64,
-    start_offset: Option<u64>,
-) -> bool {
-    // Inclusion block outside the expired block span.
-    if submit_height < min_block_height || submit_height > max_block_height {
-        return false;
+/// Fast path: `canonical_submit_height` resolves migrated inclusions in O(1).
+/// Migrated blocks are below the reorg floor, hence finalized and shared by every
+/// branch, so the height is authoritative and branch-invariant.
+///
+/// Slow path (only when the inclusion is un-migrated, i.e. the fast path returns
+/// `None`): walk the parent chain by hash up to `tx_anchor_expiry_depth` blocks
+/// (config-asserted `>= block_migration_depth`, so the walk covers the entire
+/// un-migrated window) looking for `txid` in each block's Submit `tx_ids`. The
+/// inclusion block's predecessor total comes from the tree, or — if the
+/// predecessor is below the tree window — from the canonical index, gated by
+/// `MigratedBlockHashes` so a side-fork ancestor can never be mistaken for the
+/// canonical block at that height (the C1 guard). No `get_canonical_chain` or
+/// height→hash tree lookup is ever used.
+fn resolve_submit_inclusion(
+    txid: IrysTransactionId,
+    range: &ExpiredSubmitRange,
+    config: &Config,
+    block_index: &BlockIndex,
+    block_tree_guard: &BlockTreeReadGuard,
+    db: &DatabaseProvider,
+) -> eyre::Result<Option<SubmitInclusion>> {
+    // Fast path: migrated inclusion (finalized, branch-invariant). Capped at the
+    // parent — Submit inclusion is strictly before the block being evaluated.
+    let max_height = range.block_height.saturating_sub(1);
+    if let Some(h) = db.view_eyre(|tx| canonical_submit_height(tx, &txid, max_height))? {
+        let item = block_index
+            .get_item(h)
+            .ok_or_eyre("canonical_submit_height returned a height absent from the block index")?;
+        let total = submit_total_of_index_item(&item);
+        let base = if h == 0 {
+            0
+        } else {
+            block_index
+                .get_item(h - 1)
+                .map(|i| submit_total_of_index_item(&i))
+                .unwrap_or(0)
+        };
+        return Ok(Some(SubmitInclusion {
+            block_hash: item.block_hash,
+            base,
+            total,
+        }));
     }
-    // Whole range packed into one block (`same_block`, only reachable with tiny
-    // test partitions), or an earliest/middle block → the walk includes every tx
-    // of these blocks.
-    if min_block_height == max_block_height || submit_height < max_block_height {
-        return true;
+
+    // Slow path: un-migrated inclusion — walk the parent ancestry by hash. The
+    // walk logic lives in the pure `walk_submit_inclusion` so the branch-
+    // correctness rules (by-hash traversal, C1 side-fork guard) are unit-testable
+    // with in-memory maps; here we back it with the live tree, the block index,
+    // and `MigratedBlockHashes`.
+    let max_walk = config.consensus.mempool.tx_anchor_expiry_depth as u64;
+    let tree = block_tree_guard.read();
+    let resolved = walk_submit_inclusion(
+        range.parent_block_hash,
+        max_walk,
+        |hash| {
+            tree.get_block(hash).map(|header| WalkBlock {
+                height: header.height,
+                prev_hash: header.previous_block_hash,
+                submit_total: submit_total_of_header(header),
+                includes_txid: block_includes_submit_tx(header, &txid),
+            })
+        },
+        |height| {
+            block_index
+                .get_item(height)
+                .map(|item| submit_total_of_index_item(&item))
+        },
+        |hash, height| {
+            // C1 gate input: is `hash` the canonical block at `height` per
+            // `MigratedBlockHashes`? (`block_tree_depth > block_migration_depth`
+            // guarantees a predecessor below the tree window is indexed.)
+            let canonical = db.view_eyre(|tx| Ok(tx.get::<MigratedBlockHashes>(height)?))?;
+            Ok(canonical == Some(hash))
+        },
+    )?;
+    Ok(resolved.map(|(block_hash, base, total)| SubmitInclusion {
+        block_hash,
+        base,
+        total,
+    }))
+}
+
+/// Dependency-free view of a block needed by [`walk_submit_inclusion`].
+#[derive(Clone, Copy)]
+struct WalkBlock {
+    height: u64,
+    prev_hash: H256,
+    /// Cumulative Submit chunks through this block.
+    submit_total: u64,
+    /// Whether this block's Submit ledger includes the candidate txid.
+    includes_txid: bool,
+}
+
+/// Pure branch-correct ancestry walk — the testable core of
+/// [`resolve_submit_inclusion`]'s slow path. Walks the parent chain **by hash**
+/// from `parent_hash` (never the node's canonical tip) for at most `max_walk`
+/// steps, looking for the block that includes the candidate. When found, the
+/// predecessor's cumulative Submit total (the inclusion's `base` offset) comes
+/// from the tree if present, otherwise from the canonical index — but only after
+/// `is_canonical_at` confirms the predecessor hash is the canonical block at that
+/// height (the **C1 side-fork guard**, so a side-fork ancestor's chunks are never
+/// misattributed; `block_tree_depth > block_migration_depth` guarantees such a
+/// predecessor is indexed). Returns `(block_hash, base, total)`.
+fn walk_submit_inclusion(
+    parent_hash: H256,
+    max_walk: u64,
+    header_by_hash: impl Fn(&H256) -> Option<WalkBlock>,
+    index_submit_total_at: impl Fn(u64) -> Option<u64>,
+    is_canonical_at: impl Fn(H256, u64) -> eyre::Result<bool>,
+) -> eyre::Result<Option<(H256, u64, u64)>> {
+    let mut cursor = parent_hash;
+    let mut steps = 0_u64;
+    while steps <= max_walk {
+        let Some(block) = header_by_hash(&cursor) else {
+            break; // fell out of the retained tree window
+        };
+        if block.includes_txid {
+            let total = block.submit_total;
+            // Predecessor total, branch-correct.
+            let base = if block.height == 0 {
+                0
+            } else if let Some(prev) = header_by_hash(&block.prev_hash) {
+                prev.submit_total
+            } else {
+                // Predecessor below the tree window → canonical index, C1-gated.
+                let prev_height = block.height - 1;
+                if !is_canonical_at(block.prev_hash, prev_height)? {
+                    eyre::bail!(
+                        "Submit-expiry walk reached a non-canonical ancestor at height \
+                         {prev_height} (supplied {}) — off the validated block's branch \
+                         (C1 guard)",
+                        block.prev_hash
+                    );
+                }
+                index_submit_total_at(prev_height).ok_or_eyre(
+                    "Submit-expiry walk: predecessor below block_tree window must be \
+                     indexed (block_tree_depth > block_migration_depth)",
+                )?
+            };
+            return Ok(Some((cursor, base, total)));
+        }
+        cursor = block.prev_hash;
+        steps += 1;
     }
-    // Latest boundary of a multi-block range → the walk trims at `range_end`.
-    start_offset.is_some_and(|offset| offset < range_end)
+    Ok(None)
+}
+
+/// Cumulative Submit chunk total recorded in a block header (`0` if the Submit
+/// ledger is absent — pre-Submit / inactive).
+fn submit_total_of_header(header: &IrysBlockHeader) -> u64 {
+    parent_ledger_total_chunks(header, DataLedger::Submit)
+}
+
+/// Whether `header`'s Submit ledger includes `txid` (per-block `tx_ids`).
+fn block_includes_submit_tx(header: &IrysBlockHeader, txid: &IrysTransactionId) -> bool {
+    header
+        .data_ledgers
+        .iter()
+        .find(|l| l.ledger_id == DataLedger::Submit as u32)
+        .is_some_and(|l| l.tx_ids.0.contains(txid))
+}
+
+/// Cumulative Submit chunk total from a migrated block-index item.
+fn submit_total_of_index_item(item: &BlockIndexItem) -> u64 {
+    ledger_total_of_index_item(item, DataLedger::Submit)
+}
+
+/// Cumulative chunk total for `ledger` from a migrated block-index item
+/// (`0` if the ledger is absent — pre-Cascade / inactive).
+fn ledger_total_of_index_item(item: &BlockIndexItem, ledger: DataLedger) -> u64 {
+    item.ledgers
+        .iter()
+        .find(|l| l.ledger == ledger)
+        .map(|l| l.total_chunks)
+        .unwrap_or(0)
+}
+
+/// C1 side-fork guard: confirm `hash` is the canonical block at `height` per
+/// `MigratedBlockHashes` before trusting a height-keyed (canonical-only) index
+/// lookup for it. Without this, a walk that descended onto a side-fork ancestor
+/// below the block-tree window would attribute the canonical block's chunks to
+/// the wrong block.
+fn assert_canonical_via_mbh(db: &DatabaseProvider, hash: H256, height: u64) -> eyre::Result<()> {
+    let canonical = db.view_eyre(|tx| Ok(tx.get::<MigratedBlockHashes>(height)?))?;
+    if canonical != Some(hash) {
+        eyre::bail!(
+            "expiry walk reached a non-canonical ancestor at height {height} \
+             (supplied {hash}) — off the validated block's branch (C1 guard)"
+        );
+    }
+    Ok(())
+}
+
+/// Branch-correct resolution of the canonical block that introduced chunk
+/// `offset` in `ledger`, as a pure function of the block's **own parent
+/// ancestry** (`parent_hash`) — never the node's canonical tip or migration-
+/// lagged index frontier (NC-0042 R1). Returns `(height, block_hash, block_total)`
+/// where `block_total` is that block's cumulative `ledger` total.
+///
+/// Fast path: offsets below the migrated index tip resolve via the index binary
+/// search (finalized ⇒ branch-invariant, O(log n)). Slow path: offsets in the
+/// un-migrated tail are resolved by walking the parent chain BY HASH (`get_block`
+/// + `previous_block_hash`); a predecessor below the block-tree window is read
+/// from the index only after the `MigratedBlockHashes` C1 check confirms it is
+/// canonical at that height. No `get_canonical_chain` or height→hash tree lookup
+/// is ever used for the forky region. The fast/slow split is itself branch-safe:
+/// both paths return the same block (a migrated offset's block is finalized and
+/// shared by every branch; an un-migrated offset's block is on the parent's own
+/// chain).
+fn resolve_ledger_offset_to_block(
+    offset: u64,
+    parent_hash: H256,
+    ledger: DataLedger,
+    block_tree_guard: &BlockTreeReadGuard,
+    block_index: &BlockIndex,
+    db: &DatabaseProvider,
+) -> eyre::Result<(BlockHeight, H256, u64)> {
+    // Fast path: finalized/migrated region — binary search is branch-invariant.
+    let index_tip_total = block_index
+        .get_latest_item()
+        .map(|item| ledger_total_of_index_item(&item, ledger))
+        .unwrap_or(0);
+    if offset < index_tip_total {
+        let (height, item) = block_index.get_block_index_item(ledger, offset)?;
+        return Ok((
+            height,
+            item.block_hash,
+            ledger_total_of_index_item(&item, ledger),
+        ));
+    }
+
+    // Slow path: un-migrated tail — walk the parent ancestry by hash.
+    let tree = block_tree_guard.read();
+    let mut cursor = parent_hash;
+    while let Some(header) = tree.get_block(&cursor) {
+        let total = parent_ledger_total_chunks(header, ledger);
+        let prev_total = if header.height == 0 {
+            0
+        } else if let Some(prev) = tree.get_block(&header.previous_block_hash) {
+            parent_ledger_total_chunks(prev, ledger)
+        } else {
+            // Predecessor below the tree window → canonical index, C1-gated.
+            let prev_height = header.height - 1;
+            assert_canonical_via_mbh(db, header.previous_block_hash, prev_height)?;
+            block_index
+                .get_item(prev_height)
+                .map(|i| ledger_total_of_index_item(&i, ledger))
+                .ok_or_eyre(
+                    "expiry walk: predecessor below block_tree window must be indexed \
+                     (block_tree_depth > block_migration_depth)",
+                )?
+        };
+        if (prev_total..total).contains(&offset) {
+            return Ok((header.height, cursor, total));
+        }
+        cursor = header.previous_block_hash;
+    }
+
+    // Walked off the retained tree window without matching → the offset is below
+    // it, hence finalized/migrated; resolve from the index (branch-invariant).
+    let (height, item) = block_index.get_block_index_item(ledger, offset)?;
+    Ok((
+        height,
+        item.block_hash,
+        ledger_total_of_index_item(&item, ledger),
+    ))
 }
 
 /// Reconstructs `target`'s Submit-ledger **start chunk offset**: the cumulative
@@ -758,63 +988,73 @@ fn find_block_range(
     block_index: &BlockIndex,
     ledger_type: DataLedger,
     parent_total_chunks: u64,
+    parent_block_hash: H256,
+    block_tree_guard: &BlockTreeReadGuard,
+    db: &DatabaseProvider,
 ) -> eyre::Result<Option<BlockRange>> {
     let mut blocks_with_expired_ledgers = BTreeMap::new();
 
-    // Ensure that we don't start reading a partition that's only partially populated.
+    // Bound the expired chunk range by the *parent header's* recorded ledger size
+    // only — a pure function of the block being built/validated, identical on every
+    // node regardless of that node's migration-lagged index tip (NC-0042 R1). Each
+    // offset is then mapped to its block branch-correctly via
+    // `resolve_ledger_offset_to_block` (parent-ancestry walk by hash for the
+    // un-migrated tail, finalized index below it, C1-gated), so the whole
+    // enumeration is a pure function of the parent's canonical ancestry.
     //
-    // Bounded by min(parent_total_chunks, index total):
-    // - `parent_total_chunks` (the parent header's recorded ledger size) makes the
-    //   result a function of the block being built/validated, not of this node's
-    //   current tip — a validator replaying an old block (sync) must not see data
-    //   that landed *after* that block in a partially-filled expired slot.
-    // - the block-index total caps lookups to migrated blocks (the index lags the
-    //   tip by `block_migration_depth`, so offsets beyond it are unresolvable).
-    // At the live tip the index term binds (index ≤ parent — unchanged behavior);
-    // during historical validation the parent term binds (deterministic verdict).
-    // Residual: expired-range chunks inside the not-yet-migrated tail are invisible
-    // until migration catches up to the parent, so verdicts there can still differ
-    // across nodes for up to `block_migration_depth` blocks. Only reachable when a
-    // partially-filled expired slot is still receiving data (allocation runs ahead
-    // of fill — see `calculate_additional_slots`); resolving it would require
-    // walking unmigrated tree blocks by chunk offset, which the index can't do.
-    let last_item = block_index
-        .get_latest_item()
-        .expect("expected block index to contain at least one item");
-    let max_chunk_offset_across_all_partitions = LedgerChunkOffset::from(
-        last_item.ledgers[ledger_type]
-            .total_chunks
-            .min(parent_total_chunks),
-    );
+    // Previously this clamped to `min(index_tip, parent)` and resolved via the
+    // migrated-only index, leaving expired chunks in the un-migrated tail invisible
+    // — an epoch-block consensus-fork vector AND a stranded-refund accounting gap
+    // (the now-exact §4b filter drops a tail tx that this walk never refunded).
+    let max_chunk_offset_across_all_partitions = LedgerChunkOffset::from(parent_total_chunks);
 
-    // Track min and max blocks as we iterate
-    let mut min_height: Option<(BlockHeight, BlockIndexItem, LedgerChunkRange)> = None;
-    let mut max_height: Option<(BlockHeight, BlockIndexItem, LedgerChunkRange)> = None;
+    // Track min and max blocks as we iterate. Keyed by hash (not block-index item)
+    // so un-migrated tail blocks — which have no index entry yet — are representable.
+    let mut min_height: Option<(BlockHeight, H256)> = None;
+    let mut max_height: Option<(BlockHeight, H256)> = None;
+    // The boundary trim must span the UNION of all expired slots, not one slot's
+    // range. When several expired slots share a block (small partitions), trimming
+    // to a single slot's range would drop the others — under-refunding / halving
+    // fee distribution (NC-0042). Expired slots are a contiguous prefix from slot
+    // 0, so the union is `[lowest start, highest end)`.
+    let mut global_start: Option<u64> = None;
+    let mut global_end: Option<u64> = None;
 
     for (slot_index, miners) in expired_slots {
         let chunk_range = slot_index.compute_chunk_range(
             config.consensus.num_chunks_in_partition,
             max_chunk_offset_across_all_partitions,
         );
+        global_start =
+            Some(global_start.map_or(*chunk_range.start(), |s| s.min(*chunk_range.start())));
+        global_end = Some(global_end.map_or(*chunk_range.end(), |e| e.max(*chunk_range.end())));
 
         let mut chunk_offset = *chunk_range.start();
         while chunk_offset < *chunk_range.end() {
-            let (height, block_index_item) =
-                block_index.get_block_index_item(ledger_type, chunk_offset)?;
+            // Branch-correct: resolve the offset against the parent's own ancestry
+            // (tree-then-index, C1-gated), not the migrated-only index.
+            let (height, block_hash, block_total) = resolve_ledger_offset_to_block(
+                chunk_offset,
+                parent_block_hash,
+                ledger_type,
+                block_tree_guard,
+                block_index,
+                db,
+            )?;
 
             // Update min_height if this is the first block or a lower height
-            if min_height.as_ref().is_none_or(|(h, _, _)| height < *h) {
-                min_height = Some((height, block_index_item.clone(), chunk_range));
+            if min_height.as_ref().is_none_or(|(h, _)| height < *h) {
+                min_height = Some((height, block_hash));
             }
 
             // Update max_height if this is the first block or a higher height
-            if max_height.as_ref().is_none_or(|(h, _, _)| height > *h) {
-                max_height = Some((height, block_index_item.clone(), chunk_range));
+            if max_height.as_ref().is_none_or(|(h, _)| height > *h) {
+                max_height = Some((height, block_hash));
             }
 
             // If the block already exists, merge the miners
             blocks_with_expired_ledgers
-                .entry(block_index_item.block_hash)
+                .entry(block_hash)
                 .and_modify(|existing_miners: &mut Arc<Vec<IrysAddress>>| {
                     // Merge the new miners with existing ones
                     let mut combined = (**existing_miners).clone();
@@ -823,10 +1063,14 @@ fn find_block_range(
                 })
                 .or_insert_with(|| Arc::new(miners.clone()));
 
-            // Skip to the next chunk after this block ends.
-            // We do this by going to the very end of the current blocks max chunk offset
-            chunk_offset =
-                (block_index_item.ledgers[ledger_type].total_chunks + 1).min(*chunk_range.end());
+            // Advance to the first chunk of the NEXT block. `block_total` is the
+            // exclusive end of this block's chunks (offsets `[base, block_total)`),
+            // so it is exactly the next block's first offset. The old `+ 1` here
+            // skipped that boundary chunk, so a block whose first chunk landed on a
+            // slot boundary was never resolved — silently dropping its expired txs
+            // from the refund/fee walk (NC-0042). `block_total > chunk_offset`
+            // always (the offset lies within this block), so progress is guaranteed.
+            chunk_offset = block_total.min(*chunk_range.end());
         }
     }
 
@@ -837,30 +1081,39 @@ fn find_block_range(
     }
 
     // Extract min and max block data - these must exist if we have expired slots
-    let (min_height, min_item, min_range) =
+    let (min_height, min_hash) =
         min_height.expect("min_height must be populated after iterating expired slots");
-    let (max_height, max_item, max_range) =
+    let (max_height, max_hash) =
         max_height.expect("max_height must be populated after iterating expired slots");
 
+    // Both boundary blocks trim against the full expired span [global_start,
+    // global_end): the earliest skips txs starting before it, the latest breaks at
+    // its end, and a sole block (min == max) does both. Using the union — not a
+    // single slot's range — is what keeps a block holding several expired slots
+    // from being trimmed down to one (the multi-slot under-count bug).
+    let global_range = LedgerChunkRange(ledger_chunk_offset_ii!(
+        global_start.expect("global_start populated when expired slots exist"),
+        global_end.expect("global_end populated when expired slots exist")
+    ));
     let min_block = BoundaryBlock {
         height: min_height,
-        item: min_item,
-        chunk_range: min_range,
+        block_hash: min_hash,
+        chunk_range: global_range,
     };
 
     let max_block = BoundaryBlock {
         height: max_height,
-        item: max_item,
-        chunk_range: max_range,
+        block_hash: max_hash,
+        chunk_range: global_range,
     };
 
     // Get miners for boundary blocks before removing them
     let min_block_miners = blocks_with_expired_ledgers
-        .remove(&min_block.item.block_hash)
+        .remove(&min_block.block_hash)
         .unwrap_or_else(|| Arc::new(vec![]));
 
     let max_block_miners = blocks_with_expired_ledgers
-        .remove(&max_block.item.block_hash)
+        .remove(&max_block.block_hash)
         .unwrap_or_else(|| Arc::new(vec![]));
 
     Ok(Some(BlockRange {
@@ -904,6 +1157,7 @@ async fn process_boundary_block(
     block_hash: H256,
     miners: Arc<Vec<IrysAddress>>,
     is_earliest: bool,
+    is_latest: bool,
     ledger_type: DataLedger,
     config: &Config,
     block_index: &BlockIndex,
@@ -934,6 +1188,7 @@ async fn process_boundary_block(
         prev_max_offset,
         boundary.chunk_range,
         is_earliest,
+        is_latest,
         config.consensus.chunk_size,
         miners,
     );
@@ -948,10 +1203,17 @@ async fn process_boundary_block(
 ///
 /// # Boundary Handling
 ///
-/// - **Earliest block**: Skips transactions that start before the partition boundary,
-///   only including transactions fully contained within the partition
-/// - **Latest block**: Includes all transactions that start within the partition,
-///   even if they extend beyond the partition end
+/// The two trims are independent so the **sole** boundary block (the whole
+/// expired range packed into one block, `min == max`) can apply both at once:
+/// - **Start trim** (`is_earliest`): skips transactions that start before the
+///   partition boundary.
+/// - **End trim** (`is_latest`): stops at the first transaction starting at or
+///   after the partition end.
+///
+/// A multi-block range sets exactly one (`min` block → start trim, `max` block →
+/// end trim). A sole block sets **both** — omitting the end trim there would
+/// over-include the next slot's txs (NC-0042 §4b: keeps Pipeline B's refund set
+/// exact, matching the per-candidate promotion filter `submit_tx_expired`).
 ///
 /// # Returns
 ///
@@ -961,13 +1223,15 @@ async fn process_boundary_block(
     chunk.partition_start = %partition_range.start(),
     chunk.partition_end = %partition_range.end(),
     tx.count = transactions.len(),
-    boundary.is_earliest = is_earliest
+    boundary.is_earliest = is_earliest,
+    boundary.is_latest = is_latest
 ))]
 fn filter_transactions_by_chunk_range(
     transactions: Vec<DataTransactionHeader>,
     prev_max_offset: LedgerChunkOffset,
     partition_range: LedgerChunkRange,
     is_earliest: bool,
+    is_latest: bool,
     chunk_size: u64,
     miners: Arc<Vec<IrysAddress>>,
 ) -> BTreeMap<IrysTransactionId, Arc<Vec<IrysAddress>>> {
@@ -999,21 +1263,20 @@ fn filter_transactions_by_chunk_range(
                 *tx_end
             );
 
-            if is_earliest {
-                // For earliest block: skip transactions that start before the partition
-                // We only include transactions fully contained within the partition
-                if tx_start < partition_range.start() {
-                    tracing::debug!("  Skipping (starts before partition)");
-                    current_offset = tx_end;
-                    continue;
-                }
-            } else {
-                // For latest block: stop when we reach a transaction that starts at or after the partition end
-                // We use >= because a transaction starting exactly at the end belongs to the next partition
-                if tx_start >= partition_range.end() {
-                    tracing::debug!("  Breaking (starts at or after partition end)");
-                    break;
-                }
+            // Start trim (earliest boundary): skip transactions that start before
+            // the partition; we only include transactions starting within it.
+            if is_earliest && tx_start < partition_range.start() {
+                tracing::debug!("  Skipping (starts before partition)");
+                current_offset = tx_end;
+                continue;
+            }
+            // End trim (latest boundary): stop at the first transaction that starts
+            // at or after the partition end (one starting exactly at the end belongs
+            // to the next partition). Independent of the start trim so a sole block
+            // (min == max) applies both.
+            if is_latest && tx_start >= partition_range.end() {
+                tracing::debug!("  Breaking (starts at or after partition end)");
+                break;
             }
 
             // Include this transaction
@@ -1193,7 +1456,7 @@ impl SlotIndex {
 #[derive(Debug, Clone)]
 struct BoundaryBlock {
     height: BlockHeight,
-    item: BlockIndexItem,
+    block_hash: H256,
     chunk_range: LedgerChunkRange,
 }
 
@@ -1467,51 +1730,191 @@ mod tests {
         assert_eq!(submit_tx_start_offset(a, &[(a, 3)], 0, 0), None);
     }
 
-    // `submit_tx_in_expired_range`: expired chunk range ends at `range_end`,
-    // spanning blocks `[min, max]`.
+    // `submit_span_verdict`: the pure offset decision over an inclusion block's
+    // `[base, total)` Submit chunk span against the expired `range_end`. The
+    // verdict is an exact offset comparison — no block-span over-inclusion (this
+    // is the F4 fix vs. the old `submit_tx_in_expired_range` block-membership).
 
     #[test]
-    fn block_after_expired_range_is_not_expired() {
-        // Recent tx (block 9) past the expired span [2,5] → not expired.
-        assert!(!submit_tx_in_expired_range(9, 2, 5, 100, None));
+    fn span_verdict_block_wholly_before_range_end_is_expired() {
+        // Inclusion block occupies [4, 9); range_end 10 ⇒ whole block expired.
+        assert_eq!(submit_span_verdict(4, 9, 10), Some(true));
+        // Exactly touching: total == range_end ⇒ still wholly before.
+        assert_eq!(submit_span_verdict(4, 10, 10), Some(true));
     }
 
     #[test]
-    fn block_before_expired_range_is_not_expired() {
-        assert!(!submit_tx_in_expired_range(1, 2, 5, 100, None));
+    fn span_verdict_block_at_or_after_range_end_is_not_expired() {
+        // Inclusion block starts at the boundary ⇒ not expired.
+        assert_eq!(submit_span_verdict(10, 14, 10), Some(false));
+        // Entirely past the boundary.
+        assert_eq!(submit_span_verdict(20, 25, 10), Some(false));
     }
 
     #[test]
-    fn same_block_range_includes_every_tx_of_that_block() {
-        // Whole expired range packed into one block (min == max), as in tiny
-        // test partitions: every tx of that block is in the set, regardless of
-        // start offset — this is the walk's `same_block` over-inclusion.
-        assert!(submit_tx_in_expired_range(3, 3, 3, 10, None));
+    fn span_verdict_straddle_requires_exact_offset() {
+        // range_end 10 falls strictly inside [8, 12) ⇒ caller must consult the
+        // candidate's exact start offset (no over-inclusion of the whole block).
+        assert_eq!(submit_span_verdict(8, 12, 10), None);
+    }
+
+    // `walk_submit_inclusion`: the pure, branch-correct ancestry walk that backs
+    // `resolve_submit_inclusion`'s slow path (un-migrated Submit inclusions). The
+    // NC-0042 F2 (ii) fix and the C1 side-fork guard live here; these exercise
+    // them with in-memory maps (no BlockTree/BlockIndex/db fixtures).
+
+    /// Build a `header_by_hash` map from `(hash, height, prev, submit_total,
+    /// includes_txid)` rows.
+    fn walk_tree(
+        rows: &[(H256, u64, H256, u64, bool)],
+    ) -> std::collections::HashMap<H256, WalkBlock> {
+        rows.iter()
+            .map(|&(hash, height, prev_hash, submit_total, includes_txid)| {
+                (
+                    hash,
+                    WalkBlock {
+                        height,
+                        prev_hash,
+                        submit_total,
+                        includes_txid,
+                    },
+                )
+            })
+            .collect()
+    }
+
+    fn unreachable_index(_height: u64) -> Option<u64> {
+        panic!("index lookup must not be called when the predecessor is in-tree / unneeded")
+    }
+    fn unreachable_canonical(_hash: H256, _height: u64) -> eyre::Result<bool> {
+        panic!("C1 canonical check must not be called when the predecessor is in-tree / unneeded")
     }
 
     #[test]
-    fn earliest_and_middle_blocks_are_fully_included() {
-        // Multi-block range [2,6]: earliest (2) and middle (4) blocks include
-        // every tx without consulting the start offset.
-        assert!(submit_tx_in_expired_range(2, 2, 6, 1000, None));
-        assert!(submit_tx_in_expired_range(4, 2, 6, 1000, None));
+    fn walk_finds_tx_with_in_tree_predecessor() {
+        // h2(parent, not incl) → h1(incl, prev h0) → h0(genesis). base from the
+        // in-tree predecessor h0's total; index/canonical never consulted.
+        let h0 = H256::random();
+        let h1 = H256::random();
+        let h2 = H256::random();
+        let tree = walk_tree(&[
+            (h2, 2, h1, 20, false),
+            (h1, 1, h0, 15, true),
+            (h0, 0, H256::zero(), 8, false),
+        ]);
+        let got = walk_submit_inclusion(
+            h2,
+            100,
+            |h| tree.get(h).copied(),
+            unreachable_index,
+            unreachable_canonical,
+        )
+        .unwrap();
+        assert_eq!(got, Some((h1, 8, 15)));
     }
 
     #[test]
-    fn latest_block_of_multiblock_range_trims_at_range_end() {
-        // The production path: a partition spans many blocks, so the highest
-        // expired slot's data ends mid-block. On that latest block the walk keeps
-        // only txs whose start offset is before range_end.
+    fn walk_tree_bottom_predecessor_uses_canonical_index() {
+        // Inclusion block is the bottom of the retained tree; its predecessor is
+        // below the window → base via the canonical index, gated by the C1 check.
+        let h_bottom = H256::random();
+        let h_below = H256::random();
+        let tree = walk_tree(&[(h_bottom, 5, h_below, 30, true)]);
+        let got = walk_submit_inclusion(
+            h_bottom,
+            100,
+            |h| tree.get(h).copied(),
+            |height| (height == 4).then_some(25),
+            |hash, height| Ok(hash == h_below && height == 4), // C1 passes
+        )
+        .unwrap();
+        assert_eq!(got, Some((h_bottom, 25, 30)));
+    }
+
+    #[test]
+    fn walk_c1_guard_rejects_non_canonical_predecessor() {
+        // KEY branch-correctness test: predecessor below the window is NOT the
+        // canonical block at its height (a side-fork ancestor) → C1 guard fires,
+        // the walk errors rather than misattributing the canonical block's chunks.
+        let h_bottom = H256::random();
+        let h_below = H256::random();
+        let tree = walk_tree(&[(h_bottom, 5, h_below, 30, true)]);
+        let err = walk_submit_inclusion(
+            h_bottom,
+            100,
+            |h| tree.get(h).copied(),
+            |_| Some(25),
+            |_, _| Ok(false), // C1: supplied hash is not canonical at that height
+        )
+        .unwrap_err();
         assert!(
-            submit_tx_in_expired_range(6, 2, 6, 1000, Some(999)),
-            "tx starting before range_end is expired"
+            err.to_string().contains("non-canonical ancestor"),
+            "expected the C1 guard message, got: {err}"
         );
-        assert!(
-            !submit_tx_in_expired_range(6, 2, 6, 1000, Some(1000)),
-            "tx starting at/after range_end is in the next (unexpired) slot"
-        );
-        // Defensive: a tx not found in its inclusion block (None) is not expired.
-        assert!(!submit_tx_in_expired_range(6, 2, 6, 1000, None));
+    }
+
+    #[test]
+    fn walk_returns_none_when_tx_absent() {
+        // No block in the window includes the tx; the walk runs off the bottom
+        // (predecessor of genesis absent from the map) → None.
+        let h0 = H256::random();
+        let h1 = H256::random();
+        let h2 = H256::random();
+        let tree = walk_tree(&[
+            (h2, 2, h1, 20, false),
+            (h1, 1, h0, 15, false),
+            (h0, 0, H256::zero(), 8, false),
+        ]);
+        let got = walk_submit_inclusion(
+            h2,
+            100,
+            |h| tree.get(h).copied(),
+            unreachable_index,
+            unreachable_canonical,
+        )
+        .unwrap();
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn walk_genesis_inclusion_has_zero_base() {
+        // Inclusion at height 0 ⇒ base is 0 with no predecessor lookup at all.
+        let h0 = H256::random();
+        let tree = walk_tree(&[(h0, 0, H256::zero(), 5, true)]);
+        let got = walk_submit_inclusion(
+            h0,
+            100,
+            |h| tree.get(h).copied(),
+            unreachable_index,
+            unreachable_canonical,
+        )
+        .unwrap();
+        assert_eq!(got, Some((h0, 0, 5)));
+    }
+
+    #[test]
+    fn walk_stops_at_max_walk_depth() {
+        // The including block sits at depth 2, but max_walk=1 bounds the walk to
+        // depths {0,1}, so it is never reached → None (the anchor-expiry bound).
+        let h0 = H256::random();
+        let h1 = H256::random();
+        let h2 = H256::random();
+        let h3 = H256::random();
+        let tree = walk_tree(&[
+            (h3, 3, h2, 30, false),
+            (h2, 2, h1, 20, false),
+            (h1, 1, h0, 15, true), // depth 2 from h3 — beyond max_walk
+            (h0, 0, H256::zero(), 8, false),
+        ]);
+        let got = walk_submit_inclusion(
+            h3,
+            1,
+            |h| tree.get(h).copied(),
+            unreachable_index,
+            unreachable_canonical,
+        )
+        .unwrap();
+        assert_eq!(got, None);
     }
 
     /// NC-0042 determinism regression: `find_block_range` must bound the
@@ -1523,7 +1926,10 @@ mod tests {
     #[test]
     fn find_block_range_bounds_by_parent_not_index_tip() -> eyre::Result<()> {
         use irys_database::{IrysDatabaseArgs as _, open_or_create_db, tables::IrysTables};
+        use irys_domain::{BlockTree, BlockTreeReadGuard};
+        use irys_testing_utils::IrysBlockHeaderTestExt as _;
         use reth_db::mdbx::DatabaseArguments;
+        use std::sync::RwLock;
 
         let mut node_config = irys_types::NodeConfig::testing();
         node_config.consensus.get_mut().num_chunks_in_partition = 10;
@@ -1539,7 +1945,7 @@ mod tests {
             DatabaseArguments::irys_testing()?,
         )?;
         let db = DatabaseProvider(Arc::new(db_env));
-        let block_index = BlockIndex::new_for_testing(db);
+        let block_index = BlockIndex::new_for_testing(db.clone());
         for (height, submit_total) in [0_u64, 4, 7, 12, 15].into_iter().enumerate() {
             block_index.push_item(
                 &BlockIndexItem {
@@ -1567,6 +1973,21 @@ mod tests {
             m
         };
 
+        // All three cases below resolve offsets that lie BELOW the migrated index
+        // tip (total 15), so they exercise `find_block_range`'s fast path: the block
+        // tree is never walked and `parent_hash` is unused. A genesis-only tree and
+        // an arbitrary parent hash satisfy the signature. The slow/un-migrated-tail
+        // path is covered by `find_block_range_resolves_unmigrated_tail`.
+        let mut genesis = IrysBlockHeader::new_mock_header();
+        genesis.height = 0;
+        genesis.cumulative_diff = 0.into();
+        genesis.test_sign();
+        let guard = BlockTreeReadGuard::new(Arc::new(RwLock::new(BlockTree::new(
+            &genesis,
+            irys_types::ConsensusConfig::testing(),
+        ))));
+        let parent_hash = genesis.block_hash;
+
         // Parent at height 2 (total 7): the range must stop at the block
         // holding chunk 6 (height 2), even though the index tip (total 15)
         // covers slot 0's full [0,10) range.
@@ -1576,6 +1997,9 @@ mod tests {
             &block_index,
             DataLedger::Submit,
             7,
+            parent_hash,
+            &guard,
+            &db,
         )?
         .expect("expired slot 0 holds data");
         assert_eq!(range.min_block.height, 1, "chunk 0 lands at height 1");
@@ -1592,21 +2016,290 @@ mod tests {
             &block_index,
             DataLedger::Submit,
             15,
+            parent_hash,
+            &guard,
+            &db,
         )?
         .expect("expired slot 0 holds data");
         assert_eq!(range.max_block.height, 3);
 
-        // Parent ahead of the migrated index (unmigrated tail): the index term
-        // caps lookups — no out-of-range error, same blocks as parent == tip.
+        // Parent total ahead of the migrated index, but slot 0's data ([0,10)) is
+        // fully migrated, so resolution stays on the fast path — same blocks as
+        // parent == tip, no out-of-range error.
         let range = find_block_range(
             expired_slot_0(),
             &config,
             &block_index,
             DataLedger::Submit,
             20,
+            parent_hash,
+            &guard,
+            &db,
         )?
         .expect("expired slot 0 holds data");
         assert_eq!(range.max_block.height, 3);
+
+        Ok(())
+    }
+
+    /// NC-0042 R1: `find_block_range` must resolve expired chunks in the
+    /// **un-migrated tail** from the parent's block tree, not truncate at the
+    /// migrated block-index tip. Slot 1 (`[10,20)`) extends past the index tip
+    /// (Submit total 14) into tree-only blocks (heights 3,4); the range's max
+    /// block must be the tree block at height 4. Pre-R1 the range was capped at
+    /// the index tip → max block height 2, silently dropping the tail's
+    /// refunds/miner payouts (an epoch-block accounting + determinism gap).
+    #[test]
+    fn find_block_range_resolves_unmigrated_tail() -> eyre::Result<()> {
+        use irys_database::{IrysDatabaseArgs as _, open_or_create_db, tables::IrysTables};
+        use irys_domain::{
+            BlockTree, BlockTreeReadGuard, CommitmentSnapshot, EpochSnapshot, dummy_ema_snapshot,
+        };
+        use irys_testing_utils::IrysBlockHeaderTestExt as _;
+        use irys_types::{BlockTransactions, SealedBlock};
+        use reth_db::mdbx::DatabaseArguments;
+        use std::sync::RwLock;
+
+        let mut node_config = irys_types::NodeConfig::testing();
+        node_config.consensus.get_mut().num_chunks_in_partition = 10;
+        let config = Config::new_with_random_peer_id(node_config);
+
+        // A Submit header with a cumulative chunk total at `height`.
+        fn with_submit(height: u64, total_chunks: u64) -> IrysBlockHeader {
+            let mut h = IrysBlockHeader::new_mock_header();
+            h.height = height;
+            h.data_ledgers = vec![irys_types::DataTransactionLedger {
+                ledger_id: DataLedger::Submit as u32,
+                tx_root: H256::zero(),
+                tx_ids: irys_types::H256List(vec![]),
+                total_chunks,
+                expires: None,
+                proofs: None,
+                required_proof_count: None,
+            }];
+            h
+        }
+
+        // Tree holds heights 0..=4 with cumulative Submit totals 0,8,14,18,22, so
+        // block h introduced chunks [total(h-1), total(h)). The migrated index
+        // holds only 0..=2 (tip total 14); heights 3,4 are the un-migrated tail,
+        // present ONLY in the tree.
+        let mut headers: Vec<IrysBlockHeader> = [0_u64, 8, 14, 18, 22]
+            .into_iter()
+            .enumerate()
+            .map(|(h, t)| with_submit(h as u64, t))
+            .collect();
+        let guard = {
+            let mut iter = headers.iter_mut();
+            let genesis = iter.next().unwrap();
+            genesis.cumulative_diff = 0.into();
+            genesis.test_sign();
+            let mut prev = genesis.block_hash;
+            let mut tree = BlockTree::new(genesis, irys_types::ConsensusConfig::testing());
+            tree.mark_tip(&prev).unwrap();
+            for h in iter {
+                h.previous_block_hash = prev;
+                h.cumulative_diff = h.height.into();
+                h.test_sign();
+                prev = h.block_hash;
+                let sealed = Arc::new(SealedBlock::new_unchecked(
+                    Arc::new(h.clone()),
+                    BlockTransactions::default(),
+                ));
+                tree.add_block(
+                    &sealed,
+                    Arc::new(CommitmentSnapshot::default()),
+                    Arc::new(EpochSnapshot::default()),
+                    dummy_ema_snapshot(),
+                )?;
+            }
+            BlockTreeReadGuard::new(Arc::new(RwLock::new(tree)))
+        };
+        let parent_hash = headers[4].block_hash; // height 4 = tip = the parent
+        let tree_tail_hash = headers[4].block_hash;
+
+        // Migrated index: heights 0..=2 only (Submit totals 0,8,14).
+        let temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db_env = open_or_create_db(
+            &temp_dir,
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        let db = DatabaseProvider(Arc::new(db_env));
+        let block_index = BlockIndex::new_for_testing(db.clone());
+        for (height, submit_total) in [0_u64, 8, 14].into_iter().enumerate() {
+            block_index.push_item(
+                &BlockIndexItem {
+                    block_hash: H256::random(),
+                    num_ledgers: 2,
+                    ledgers: vec![
+                        irys_types::LedgerIndexItem {
+                            total_chunks: 0,
+                            tx_root: H256::random(),
+                            ledger: DataLedger::Publish,
+                        },
+                        irys_types::LedgerIndexItem {
+                            total_chunks: submit_total,
+                            tx_root: H256::random(),
+                            ledger: DataLedger::Submit,
+                        },
+                    ],
+                },
+                height as u64,
+            )?;
+        }
+
+        // Expire slot 1 = chunks [10,20); parent's Submit total is 22.
+        let mut expired = BTreeMap::new();
+        expired.insert(SlotIndex::new(1), vec![IrysAddress::ZERO]);
+        let range = find_block_range(
+            expired,
+            &config,
+            &block_index,
+            DataLedger::Submit,
+            22, // parent_total — slot 1's tail (chunks 14-19) is past the index tip 14
+            parent_hash,
+            &guard,
+            &db,
+        )?
+        .expect("expired slot 1 holds data");
+
+        // chunk 10 (fast path, index) → height 2; chunk 19 (slow path, tree) →
+        // the un-migrated tree block at height 4 — proving the tail was resolved.
+        assert_eq!(
+            range.min_block.height, 2,
+            "slot 1 starts at chunk 10, which lives in height 2"
+        );
+        assert_eq!(
+            range.max_block.height, 4,
+            "slot 1's tail must resolve to the un-migrated tree block (pre-R1 this was capped at 2)"
+        );
+        assert_eq!(
+            range.max_block.block_hash, tree_tail_hash,
+            "the max boundary block must be the tree block, not an indexed one"
+        );
+
+        Ok(())
+    }
+
+    /// NC-0042 F2 (ii) — real-fixture coverage of `resolve_submit_inclusion`'s
+    /// SLOW path against an actual `BlockTree`: a candidate whose Submit inclusion
+    /// is in the un-migrated tree (absent from the migrated index /
+    /// `MigratedBlockHashes`, so `canonical_submit_height` returns `None`) must
+    /// still be resolved — by the branch-correct by-hash parent walk — with the
+    /// correct `(base, total)` offsets. This is the path the chain-test
+    /// (`block_migration_depth = 1`) never reaches; fast-path resolution of a
+    /// migrated inclusion is covered end-to-end by
+    /// `chain-tests/.../promote_after_submit_expiry.rs`. (The below-tree-window
+    /// predecessor + C1 side-fork rejection are covered by the `walk_*` unit
+    /// tests, which need no heavy tree fixture.)
+    #[test]
+    fn resolve_submit_inclusion_slow_path_walks_untracked_tree() -> eyre::Result<()> {
+        use irys_database::{IrysDatabaseArgs as _, open_or_create_db, tables::IrysTables};
+        use irys_domain::{
+            BlockTree, BlockTreeReadGuard, CommitmentSnapshot, EpochSnapshot, dummy_ema_snapshot,
+        };
+        use irys_testing_utils::IrysBlockHeaderTestExt as _;
+        use irys_types::{BlockTransactions, SealedBlock};
+        use reth_db::mdbx::DatabaseArguments;
+        use std::sync::RwLock;
+
+        // A header with one Submit ledger entry: cumulative chunk total + tx_ids.
+        fn with_submit(height: u64, total_chunks: u64, tx_ids: Vec<H256>) -> IrysBlockHeader {
+            let mut h = IrysBlockHeader::new_mock_header();
+            h.height = height;
+            h.data_ledgers = vec![irys_types::DataTransactionLedger {
+                ledger_id: DataLedger::Submit as u32,
+                tx_root: H256::zero(),
+                tx_ids: irys_types::H256List(tx_ids),
+                total_chunks,
+                expires: None,
+                proofs: None,
+                required_proof_count: None,
+            }];
+            h
+        }
+
+        let target = H256::random();
+        // Cumulative Submit totals h0=5, h1=12, h2=20. The target lands in h1, so
+        // its inclusion spans Submit chunks [5, 12): base 5, total 12.
+        let mut headers = [
+            with_submit(0, 5, vec![]),
+            with_submit(1, 12, vec![target]),
+            with_submit(2, 20, vec![]),
+        ];
+
+        // Build a real BlockTree from the headers. The shared `genesis_tree`
+        // helper can't be used here: it seals every block with the *checked*
+        // `SealedBlock::new`, which rejects h1 (it declares `target` in its Submit
+        // ledger but has an empty body). `SealedBlock::new_unchecked` (test-only)
+        // skips that body check; genesis (empty ledgers) still seals via
+        // `BlockTree::new`.
+        let guard = {
+            let mut iter = headers.iter_mut();
+            let genesis = iter.next().unwrap();
+            genesis.cumulative_diff = 0.into();
+            genesis.test_sign();
+            let mut prev = genesis.block_hash;
+            let mut tree = BlockTree::new(genesis, irys_types::ConsensusConfig::testing());
+            tree.mark_tip(&prev).unwrap();
+            for h in iter {
+                h.previous_block_hash = prev;
+                h.cumulative_diff = h.height.into();
+                h.test_sign();
+                prev = h.block_hash;
+                let sealed = Arc::new(SealedBlock::new_unchecked(
+                    Arc::new(h.clone()),
+                    BlockTransactions::default(),
+                ));
+                tree.add_block(
+                    &sealed,
+                    Arc::new(CommitmentSnapshot::default()),
+                    Arc::new(EpochSnapshot::default()),
+                    dummy_ema_snapshot(),
+                )?;
+            }
+            BlockTreeReadGuard::new(Arc::new(RwLock::new(tree)))
+        };
+        let inclusion_hash = headers[1].block_hash; // h1
+        let parent_hash = headers[2].block_hash; // h2 = tip = parent of block @ height 3
+
+        // Empty db ⇒ canonical_submit_height returns None ⇒ the SLOW path runs.
+        let temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db_env = open_or_create_db(
+            &temp_dir,
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        let db = DatabaseProvider(Arc::new(db_env));
+        let block_index = BlockIndex::new_for_testing(db.clone());
+        let config = Config::new_with_random_peer_id(irys_types::NodeConfig::testing());
+
+        let range = ExpiredSubmitRange {
+            block_height: 3,
+            range_end: 12,
+            parent_block_hash: parent_hash,
+        };
+
+        let inc = resolve_submit_inclusion(target, &range, &config, &block_index, &guard, &db)?
+            .expect("slow path must resolve the un-migrated Submit inclusion");
+        assert_eq!(
+            inc.block_hash, inclusion_hash,
+            "resolved the wrong inclusion block"
+        );
+        assert_eq!(
+            inc.base, 5,
+            "base = predecessor (h0) cumulative Submit total"
+        );
+        assert_eq!(
+            inc.total, 12,
+            "total = inclusion block (h1) cumulative Submit total"
+        );
+
+        // End-to-end verdict via the pure span decision (no body load needed):
+        // range_end 12 ⇒ block [5,12) wholly before ⇒ expired; range_end 5 ⇒ not.
+        assert_eq!(submit_span_verdict(inc.base, inc.total, 12), Some(true));
+        assert_eq!(submit_span_verdict(inc.base, inc.total, 5), Some(false));
 
         Ok(())
     }

--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -1276,6 +1276,14 @@ fn filter_transactions_by_chunk_range(
     num_chunks_in_partition: u64,
     slot_miners: &BTreeMap<SlotIndex, Arc<Vec<IrysAddress>>>,
 ) -> eyre::Result<BTreeMap<IrysTransactionId, Arc<Vec<IrysAddress>>>> {
+    // `data_size.div_ceil(chunk_size)` below panics on a zero divisor. `chunk_size`
+    // is a genesis-fixed consensus constant (never 0 in a real config), but guard
+    // it loudly and deterministically rather than risk a producer/validator panic —
+    // matching the `chunk_size == 0` guard in `submit_tx_start_offset`.
+    if chunk_size == 0 {
+        eyre::bail!("chunk_size must be non-zero for ledger-expiry chunk math");
+    }
+
     let mut current_offset = prev_max_offset;
     let mut tx_to_miners = BTreeMap::new();
 

--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -1217,7 +1217,7 @@ async fn process_boundary_block(
         config.consensus.chunk_size,
         config.consensus.num_chunks_in_partition,
         slot_miners,
-    );
+    )?;
 
     Ok(filtered_txs)
 }
@@ -1243,7 +1243,9 @@ async fn process_boundary_block(
 ///
 /// # Returns
 ///
-/// mapping of tx ID to miners who stored it
+/// Mapping of tx ID to the miners who stored it. Fails loud (`Err`) if an
+/// in-range tx maps to a non-expired slot — an unreachable state that would mean
+/// the refund walk diverged from the per-candidate promotion filter (NC-0042).
 #[tracing::instrument(level = "trace", skip_all, fields(
     chunk.prev_max_offset = %prev_max_offset,
     chunk.partition_start = %partition_range.start(),
@@ -1261,7 +1263,7 @@ fn filter_transactions_by_chunk_range(
     chunk_size: u64,
     num_chunks_in_partition: u64,
     slot_miners: &BTreeMap<SlotIndex, Arc<Vec<IrysAddress>>>,
-) -> BTreeMap<IrysTransactionId, Arc<Vec<IrysAddress>>> {
+) -> eyre::Result<BTreeMap<IrysTransactionId, Arc<Vec<IrysAddress>>>> {
     let mut current_offset = prev_max_offset;
     let mut tx_to_miners = BTreeMap::new();
 
@@ -1310,7 +1312,10 @@ fn filter_transactions_by_chunk_range(
         // cross-paid adjacent expired slots owned by different miners when they
         // shared a block (NC-0042 R4). Expired slots tile [global_start,
         // global_end) contiguously, so an in-range tx always maps to a present
-        // slot; the `None` arm is a defensive guard, not an expected path.
+        // slot. The `None` arm is therefore unreachable; if it ever fires the
+        // refund walk has diverged from the per-candidate promotion filter
+        // (`submit_tx_expired`) — fail loud rather than silently under-refund,
+        // which in consensus code would strand a refund and break Pipeline A ≡ B.
         if num_chunks_in_partition != 0 {
             let slot = SlotIndex::new(*tx_start / num_chunks_in_partition);
             match slot_miners.get(&slot) {
@@ -1318,10 +1323,13 @@ fn filter_transactions_by_chunk_range(
                     tracing::debug!("  Including transaction (slot {})", slot.0);
                     tx_to_miners.insert(tx.id, Arc::clone(miners));
                 }
-                None => tracing::warn!(
-                    tx.id = ?tx.id,
-                    slot = slot.0,
-                    "tx start offset maps to a non-expired slot; skipping (unexpected)"
+                None => eyre::bail!(
+                    "tx {} start offset {} maps to non-expired slot {} \
+                     (expired slots must tile the range contiguously) — refund \
+                     walk diverged from the promotion filter (NC-0042)",
+                    tx.id,
+                    *tx_start,
+                    slot.0,
                 ),
             }
         }
@@ -1329,7 +1337,7 @@ fn filter_transactions_by_chunk_range(
     }
 
     tracing::info!("Filtered to {} transactions", tx_to_miners.len());
-    tx_to_miners
+    Ok(tx_to_miners)
 }
 
 /// Processes all middle (fully-interior) blocks. Unlike the boundaries these need
@@ -1370,7 +1378,7 @@ async fn process_middle_blocks(
             config.consensus.chunk_size,
             config.consensus.num_chunks_in_partition,
             slot_miners,
-        );
+        )?;
         tx_to_miners.extend(filtered);
     }
 

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -4531,53 +4531,30 @@ async fn generate_expected_shadow_transactions(
             .consensus
             .hardforks
             .is_cascade_active_at(block.timestamp_secs());
-        let mut result = ledger_expiry::calculate_expired_ledger_fees(
-            &parent_epoch_snapshot,
-            &prev_block,
-            block.height,
-            DataLedger::Submit,
-            config,
-            block_index.clone(),
-            block_tree_guard,
-            mempool_guard,
-            db,
-            true, // expect txs to be promoted — return perm fee refund if not
-            block.ledger_total_chunks(DataLedger::Submit),
-            cascade_active_for_block,
-        )
-        .in_current_span()
-        .await
-        .map_err(node_fault)?;
-
-        // When Cascade is active, also process OneYear and ThirtyDay term ledgers.
-        let cascade_active = config
+        let cascade_active_for_epoch = config
             .consensus
             .hardforks
             .is_cascade_active_for_epoch(&parent_epoch_snapshot);
-        if cascade_active {
-            for ledger in [DataLedger::OneYear, DataLedger::ThirtyDay] {
-                let delta = ledger_expiry::calculate_expired_ledger_fees(
-                    &parent_epoch_snapshot,
-                    &prev_block,
-                    block.height,
-                    ledger,
-                    config,
-                    block_index.clone(),
-                    block_tree_guard,
-                    mempool_guard,
-                    db,
-                    false, // no promotion for these ledgers
-                    block.ledger_total_chunks(ledger),
-                    cascade_active_for_block,
-                )
-                .in_current_span()
-                .await
-                .map_err(node_fault)?;
-                result.merge(delta);
-            }
-        }
-
-        result
+        // Each ledger's cumulative `total_chunks` is read straight from the header
+        // being validated — the producer computed the identical value, so both
+        // settle the same expiring set. Shared with the producer so the
+        // Submit + Cascade-gated term-ledger settlement cannot drift between sides.
+        ledger_expiry::calculate_all_expired_ledger_fees(
+            &parent_epoch_snapshot,
+            &prev_block,
+            block.height,
+            config,
+            &block_index,
+            block_tree_guard,
+            mempool_guard,
+            db,
+            cascade_active_for_block,
+            cascade_active_for_epoch,
+            |ledger| block.ledger_total_chunks(ledger),
+        )
+        .in_current_span()
+        .await
+        .map_err(node_fault)?
     } else {
         ledger_expiry::LedgerExpiryBalanceDelta::default()
     };
@@ -4631,6 +4608,23 @@ async fn generate_expected_shadow_transactions(
     // slot expired at an *earlier* epoch (cross-block double-pay, devnet 39962)
     // are both in the set. A tx whose Submit inclusion is in this very block
     // (same-block Submit→Publish) is not — its slot can't have expired yet.
+    //
+    // CLEAN-CUTOVER DECISION (NC-0042 P1, deliberate — confirmed off-chain): this
+    // rejection — and the refund/fee-algorithm changes it interlocks with (the
+    // per-slot miner attribution, sole-block dual-trim, and dropped +1 chunk-advance
+    // in `ledger_expiry`) — are NOT Cascade-gated. Only the *slot-set selection*
+    // (the write-window exclusion in `get_expiring_partition_info`) is. So a node
+    // replaying history from genesis applies these rules to PRE-Cascade blocks too
+    // (`expired_submit_range` still returns allocation-anchored expired slots when
+    // `cascade_active=false`). We accept this because no persistent (mainnet /
+    // non-resettable-testnet) pre-softfork data-tx history exists that could trip it
+    // — the only blocks it would newly reject are exactly the buggy
+    // already-expired-promotion blocks this fix exists to forbid, which must not
+    // exist on any chain we replay. If that assumption is ever falsified, gate this
+    // block and the refund-algorithm changes behind
+    // `is_cascade_active_at(block.timestamp_secs())` so pre-activation replay
+    // reproduces old behavior bit-for-bit. Pinned by the mixed-mode test
+    // `slow_heavy_cascade_midchain_submit_expiry_refunds_across_activation`.
     {
         // The expired-Submit range is the same for every publish tx in this block,
         // so resolve it once and reuse it per-candidate. Locally derived (parent
@@ -6099,7 +6093,7 @@ enum TxInclusionState {
 /// production (so the reorg window is the binding term there); `max` keeps this
 /// correct for test configs that set a tiny `block_tree_depth` without lowering
 /// `tx_anchor_expiry_depth`. See the [`get_previous_tx_inclusions`] docblock.
-fn prior_inclusion_walk_depth(config: &Config) -> u64 {
+pub(crate) fn prior_inclusion_walk_depth(config: &Config) -> u64 {
     u64::from(config.consensus.mempool.tx_anchor_expiry_depth)
         .max(config.consensus.block_tree_depth)
 }

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -4603,21 +4603,54 @@ async fn generate_expected_shadow_transactions(
         Vec::new()
     };
 
-    // Deterministic block-invariant: peer-attributable. See
-    // `ShadowTransactionInvalid` doc — a tx in the publish ledger that also
-    // has a perm_fee refund scheduled is a structural inconsistency in the
-    // peer's block (promoted txs must not receive refunds). Routed here
-    // (rather than only inside `ShadowTxGenerator::new`) so violations
-    // surface as consensus rejection rather than soft-internal
-    // `ShadowTxNodeFault` for invariant violations. The constructor keeps an identical guard
-    // as defence-in-depth for non-validation callers.
-    for tx in &publish_ledger_with_txs.txs {
-        for (refund_tx_id, _, _) in &expired_ledger_fees.user_perm_fee_refunds {
-            if tx.id == *refund_tx_id {
+    // NC-0042: peer-attributable consensus rule — no Publish-ledger tx may have
+    // its Submit-ledger storage already expired as of this block.
+    //   == block.height  →  same-block epoch collision (Bug A, devnet 39960)
+    //   <  block.height  →  cross-block silent double-pay (devnet 39962 — every
+    //                       validator accepted it pre-fix)
+    //
+    // Producer-side: `tx_selector::get_publish_txs_and_proofs` already filters
+    // out expired candidates (using this same set) so an honest producer never
+    // emits such a block. This check is the peer-attributable rejection when a
+    // malicious or buggy peer's block does.
+    //
+    // Defence-in-depth: `ShadowTxGenerator::new` (shadow_tx_generator.rs:258)
+    // still guards the same-block case for any non-validation construction path
+    // (tests, future callers). The rule here is canonical; the constructor guard
+    // is defence-in-depth only.
+    //
+    // The expired set is derived from the *same* expired-partition → block → tx walk
+    // that schedules `user_perm_fee_refunds`, so "is this tx refunded?" and "may
+    // this tx be promoted?" cannot diverge (the structural flaw the earlier
+    // cycle-math approximation introduced — see NC-0042 §4b).
+    //
+    // This is a strict superset of the old same-block guard: a tx whose Submit
+    // slot expires *at* this block (same-block epoch collision) and a tx whose
+    // slot expired at an *earlier* epoch (cross-block double-pay, devnet 39962)
+    // are both in the set. A tx whose Submit inclusion is in this very block
+    // (same-block Submit→Publish) is not — its slot can't have expired yet.
+    {
+        let expired_submit_tx_ids = ledger_expiry::expired_submit_tx_ids(
+            &parent_epoch_snapshot,
+            block.height,
+            config,
+            block_index.clone(),
+            block_tree_guard,
+            mempool_guard,
+            db,
+        )
+        .await
+        // Locally derived (parent epoch snapshot, our block_index/mempool/DB);
+        // a failure here is a hard node-local fault, not a peer statement.
+        .map_err(|e| node_fault(format!("NC-0042 expiry check: {e}")))?;
+
+        for tx in &publish_ledger_with_txs.txs {
+            if expired_submit_tx_ids.contains(&tx.id) {
                 return Err(consensus(format!(
-                    "Transaction {} is in publish ledger but also has a perm_fee refund scheduled. \
-                     Promoted transactions should not receive refunds.",
-                    tx.id
+                    "Transaction {} is in the publish ledger but its Submit-ledger \
+                     storage has already expired as of block {} (it is/was perm_fee \
+                     refunded; promoted txs must not be refunded). See NC-0042.",
+                    tx.id, block.height,
                 )));
             }
         }

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -4641,7 +4641,6 @@ async fn generate_expected_shadow_transactions(
             &parent_epoch_snapshot,
             &prev_block,
             config,
-            &block_index,
         )
         .map_err(|e| node_fault(format!("NC-0042 expiry check: {e}")))?;
         if let Some(range) = &expired_range {
@@ -4649,7 +4648,6 @@ async fn generate_expected_shadow_transactions(
                 // Per-candidate form of the (refund-pipeline-shared) expired-tx set.
                 let expired = ledger_expiry::submit_tx_expired(
                     tx.id,
-                    None,
                     range,
                     config,
                     &block_index,

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -4636,11 +4636,16 @@ async fn generate_expected_shadow_transactions(
         // so resolve it once and reuse it per-candidate. Locally derived (parent
         // epoch snapshot, our block_index/mempool/DB); a failure here is a hard
         // node-local fault, not a peer statement. `None` → nothing expired.
+        let cascade_active_for_block = config
+            .consensus
+            .hardforks
+            .is_cascade_active_at(block.timestamp_secs());
         let expired_range = ledger_expiry::expired_submit_range(
             block.height,
             &parent_epoch_snapshot,
             &prev_block,
             config,
+            cascade_active_for_block,
         )
         .map_err(|e| node_fault(format!("NC-0042 expiry check: {e}")))?;
         if let Some(range) = &expired_range {

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -5391,19 +5391,13 @@ pub async fn data_txs_are_valid(
         );
     }
 
-    // Step 3: Check past inclusions only for non-promoted txs.
-    //
-    // Walk depth is `tx_anchor_expiry_depth`: anchor-expiry semantics
-    // bound any legitimate prior inclusion of `block`'s txs to within
-    // this window of `block`, regardless of how deep reorgs go (see the
-    // docblock on `get_previous_tx_inclusions` for the derivation).
-    // Deeper reorg support changes which chain the block tree buffers,
-    // not where on `block`'s chain a tx with a given anchor can have
-    // been included.
+    // Step 3: Check past inclusions only for non-promoted txs. The walk must cover
+    // both the duplicate-anchor window and the reorg window — see
+    // `prior_inclusion_walk_depth` and the `get_previous_tx_inclusions` docblock.
     get_previous_tx_inclusions(
         &mut txs_to_check,
         block,
-        config.consensus.mempool.tx_anchor_expiry_depth as u64,
+        prior_inclusion_walk_depth(config),
         service_senders,
         db,
     )
@@ -5423,53 +5417,34 @@ pub async fn data_txs_are_valid(
             TxInclusionState::Searching { ledger_current } => {
                 match ledger_current {
                     DataLedger::Publish => {
-                        // Past Submit inclusion was not in the historical scan
-                        // window — fall back to the fork-aware canonical-
-                        // height getters in `irys_database`.
+                        // Prior Submit/promotion was deeper than the by-hash
+                        // inclusion walk above — which now covers the full reorg
+                        // window (max(tx_anchor_expiry_depth, block_tree_depth)).
+                        // So any inclusion reaching this fallback is BELOW the
+                        // reorg floor: finalized, hence branch-invariant, so the
+                        // by-height canonical-height getters in `irys_database`
+                        // (metadata hint + `MigratedBlockHashes`) resolve it
+                        // identically on every node/branch. (Before the walk was
+                        // widened, this arm could run inside the reorg-mutable
+                        // `(tip - block_tree_depth, tip - block_migration_depth]`
+                        // band and fork — widening the walk to the reorg window is
+                        // exactly what makes this fallback safe post-#1405; see the
+                        // `get_previous_tx_inclusions` docblock.)
                         //
                         // `canonical_submit_height` is sufficient evidence of
                         // prior Submit: the structural pre-pass guarantees
                         // `tx.ledger_id == Publish`, and term ledgers reject
-                        // `ledger_id == Publish`, so the only term ledger
-                        // that could have produced an `included_height` is
-                        // Submit.  An MDBX I/O failure is a local fault that
-                        // we surface as `BlockBoundsLookupError` (classified
-                        // as `NodeFault`, so the caller aborts rather than
-                        // peer-attributing the local DB error).
+                        // `ledger_id == Publish`, so the only term ledger that
+                        // could have produced an `included_height` is Submit. An
+                        // MDBX I/O failure is a local fault surfaced as
+                        // `BlockBoundsLookupError` (classified `NodeFault`, so the
+                        // caller aborts rather than peer-attributing the DB error).
                         //
-                        // Defense-in-depth `canonical_promoted_height`
-                        // rejection.  Under the current invariants this is
-                        // effectively unreachable for legitimate prior
-                        // promotions: anchor expiry forces any legitimate
-                        // prior Publish of a tx in `block` to lie within
-                        // `tx_anchor_expiry_depth` of `block` (see
-                        // `get_previous_tx_inclusions`'s derivation), so the
-                        // parent walk above would have surfaced it as
-                        // `Found { historical: Publish, current: Publish }`
-                        // before we reach `Searching`.  The check is kept
-                        // as a safety net against a future bug that lets a
-                        // prior promotion escape the walk.
-                        //
-                        // FORK-AWARENESS CAVEAT (reorg-readiness): the
-                        // rejection's `block_hash` is taken from
-                        // `MigratedBlockHashes[promoted_height]`, which today
-                        // is fork-invariant past `block_migration_depth`
-                        // (deeper reorgs are aborted, so migrated rows are
-                        // irreversibly canonical from every chain's
-                        // perspective).  When deeper reorgs land, MBH past
-                        // migration_depth becomes a LOCAL-canonical view
-                        // that can disagree with `block`'s chain — this
-                        // check would then report `PublishTxAlreadyIncluded`
-                        // for a tx that isn't actually promoted on
-                        // `block`'s chain.
-                        // The same invariant change breaks
-                        // `canonical_promoted_height` / `canonical_submit_height`:
-                        // their "MBH-verified ⇒ canonical" contracts rely on
-                        // `block_migration_depth` being the absolute reorg
-                        // ceiling.  Audit this arm and those helpers (and
-                        // every site that consumes them, e.g. tx_selector's
-                        // prior-Submit fallback) together when changing
-                        // that invariant.
+                        // The `canonical_promoted_height` rejection below is
+                        // defense-in-depth: a prior promotion within the reorg
+                        // window is already surfaced as `Found` by the walk, so
+                        // only a finalized prior promotion reaches here — where MBH
+                        // is branch-invariant.
                         let parent_height = block.height.saturating_sub(1);
 
                         let submit_lookup =
@@ -6110,45 +6085,60 @@ enum TxInclusionState {
     },
 }
 
+/// Walk depth for the prevalidation prior-inclusion scan
+/// ([`get_previous_tx_inclusions`]). It must cover BOTH:
+///   - the **duplicate-anchor window** (`tx_anchor_expiry_depth`): a re-inclusion
+///     of the same tx_id reuses the same anchor, which expires within this window;
+///   - the **reorg window** (`block_tree_depth`): a promotion's prior Submit is
+///     bounded by `ingress_proof_anchor_expiry_depth` (NOT the tx anchor), so an
+///     inclusion inside the reorg window must be resolved branch-correctly by-hash
+///     here rather than via the by-height index/MBH fallback, which is only
+///     branch-invariant below the reorg floor (#1405).
+///
+/// `Config::validate` enforces `tx_anchor_expiry_depth <= block_tree_depth` in
+/// production (so the reorg window is the binding term there); `max` keeps this
+/// correct for test configs that set a tiny `block_tree_depth` without lowering
+/// `tx_anchor_expiry_depth`. See the [`get_previous_tx_inclusions`] docblock.
+fn prior_inclusion_walk_depth(config: &Config) -> u64 {
+    (config.consensus.mempool.tx_anchor_expiry_depth as u64).max(config.consensus.block_tree_depth)
+}
+
 /// Walks `block_under_validation`'s ancestors via the block tree (DB fallback
 /// for tree-evicted headers), updating each entry in `tx_ids` with the
 /// inclusion state found on this chain.
 ///
 /// **Fork-awareness contract.**  This walk is the validator's fork-aware
-/// source for prior inclusions of `block_under_validation`'s txs.  It is
-/// both *sufficient* and *tight*: every legitimate prior inclusion of any
-/// tx in `block_under_validation` necessarily lies within
-/// `tx_anchor_expiry_depth` blocks of `block_under_validation`, and no
-/// legitimate prior inclusion can lie outside it.
+/// (by-hash) source for prior inclusions of `block_under_validation`'s txs.
+/// `walk_depth` must be `max(tx_anchor_expiry_depth, block_tree_depth)`,
+/// covering two distinct requirements:
 ///
-/// **Derivation of the bound.**  For any tx in `block_under_validation`
-/// with signed anchor `A`:
-///   * `block_under_validation.height ≤ A + tx_anchor_expiry_depth` —
-///     `block_under_validation` itself must include the tx with an
-///     unexpired anchor.
-///   * Any prior canonical inclusion `I` of that tx has the *same* `A`
-///     (the tx_id is derived from the signed payload, which includes the
-///     anchor — re-anchoring produces a different tx_id), and must also
-///     satisfy `I ≤ A + tx_anchor_expiry_depth`.
-///   * Combined: `I ∈ [block_under_validation.height − tx_anchor_expiry_depth,
-///     block_under_validation.height − 1]`.
+/// 1. **Duplicate detection — needs `tx_anchor_expiry_depth`.**  For any tx in
+///    `block_under_validation` with signed anchor `A`: a re-inclusion `I` has the
+///    *same* `A` (the tx_id is derived from the signed payload incl. the anchor —
+///    re-anchoring yields a different tx_id) so `I ≤ A + tx_anchor_expiry_depth`,
+///    while `block_under_validation.height ≤ A + tx_anchor_expiry_depth`. Hence any
+///    duplicate lies within `tx_anchor_expiry_depth` of `block_under_validation`.
+///    (`I ≥ 1` is implicit: `build_unsigned_irys_genesis_block` gives height 0
+///    empty `tx_ids` for every data ledger, so the loop short-circuits at
+///    `block.1 == 0` without inspecting genesis.)
 ///
-/// Note that `I ≥ 1` is implicit: `build_unsigned_irys_genesis_block`
-/// constructs height 0 with `tx_ids = H256List::new()` for every data ledger,
-/// so no tx can have a prior inclusion at genesis.  The loop below relies on
-/// that fact to short-circuit at `block.1 == 0` without inspecting genesis.
+/// 2. **Branch-correctness — needs `block_tree_depth` (the reorg window).**  A
+///    *promotion*'s prior Submit is NOT bounded by `tx_anchor_expiry_depth`: a
+///    promoted (Publish) tx re-validates only its ingress-proof anchors
+///    (`ingress_proof_anchor_expiry_depth`, typically far larger), NOT its data-tx
+///    anchor (see `block_discovery`'s anchor checks). So the prior Submit can lie
+///    up to `ingress_proof_anchor_expiry_depth` back. Any such inclusion that falls
+///    inside the reorg window MUST be resolved here by-hash on
+///    `block_under_validation`'s own ancestry; resolving it via the by-height
+///    index/MBH shortcut (the `Searching { ledger_current: Publish }` arm in
+///    `data_txs_are_valid`) is only branch-invariant BELOW the reorg floor, which
+///    deep reorgs (#1405) moved from `block_migration_depth` to `block_tree_depth`.
+///    Walking the full reorg window guarantees that fallback is reached only for
+///    *finalized* inclusions, where node-canonical == every branch.
 ///
-/// So `walk_depth = tx_anchor_expiry_depth` covers exactly the reachable
-/// range of any prior inclusion `block_under_validation` could have.
-/// Walking deeper does no harm but is wasted work; walking shallower
-/// (e.g. `block_migration_depth`) would leave a legitimate-inclusion
-/// window uncovered and would force the DB fallback to bear correctness
-/// responsibility it isn't structurally equipped for (see the
-/// `Searching { ledger_current: Publish }` arm in `data_txs_are_valid`).
-///
-/// The bound is independent of reorg depth: deeper reorgs change which
-/// chain `block_tree` buffers but not where on `block_under_validation`'s
-/// chain a tx with a given anchor can have been included.
+/// (Config invariant `tx_anchor_expiry_depth ≤ block_tree_depth` makes #2 the
+/// binding term in production; `max(...)` keeps the walk correct for test configs
+/// that set a tiny `block_tree_depth` without lowering `tx_anchor_expiry_depth`.)
 #[tracing::instrument(level = "trace", skip_all, fields(block.hash = ?block_under_validation.block_hash))]
 async fn get_previous_tx_inclusions(
     tx_ids: &mut HashMap<H256, (&DataTransactionHeader, TxInclusionState)>,
@@ -6581,6 +6571,128 @@ mod tests {
         Ok(())
     }
 
+    /// REGRESSION (RISK-2 / #1405 deep-reorg walk depth): `get_previous_tx_inclusions`
+    /// must resolve a promotion's prior Submit branch-correctly by-hash for the whole
+    /// reorg window — not just `tx_anchor_expiry_depth`. A Publish candidate C at
+    /// height 5 promotes tx T whose prior Submit sits at height 1 (depth 4) — inside
+    /// the band (tx_anchor_expiry_depth=2, block_tree_depth=8]. With the new walk depth
+    /// (`max` = 8) the by-hash walk reaches the Submit and marks it `Found`; with the
+    /// old depth (2) the walk misses it and T stays `Searching`, which in
+    /// `data_txs_are_valid` would fall to the by-height MBH fallback — branch-incorrect
+    /// during a deep reorg (a node off C's branch would wrongly reject C). The
+    /// ancestors live only in the DB (resolved via the by-hash DB fallback, since the
+    /// tree guard is empty); T's `included_height` is intentionally NOT recorded, so
+    /// the by-height fallback could not save the old shallow walk.
+    #[tokio::test]
+    async fn get_previous_tx_inclusions_finds_prior_submit_in_reorg_window_band() -> eyre::Result<()>
+    {
+        use irys_database::{
+            IrysDatabaseArgs as _, open_or_create_db,
+            tables::{IrysBlockHeaders, IrysTables},
+        };
+        use irys_testing_utils::IrysBlockHeaderTestExt as _;
+        use reth_db::mdbx::DatabaseArguments;
+        use reth_db::transaction::DbTxMut as _;
+
+        let tmp = TempDirBuilder::new().build();
+        let env = open_or_create_db(
+            tmp.path(),
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        let db = DatabaseProvider(Arc::new(env));
+
+        let tx_id = H256::random();
+
+        // genesis(0) -> b1(1, Submit=[T]) -> b2(2) -> b3(3) -> b4(4) -> C(5, Publish=[T])
+        let mk = |height: u64, prev: H256, cdiff: u64| -> IrysBlockHeader {
+            let mut h = IrysBlockHeader::new_mock_header();
+            h.height = height;
+            h.previous_block_hash = prev;
+            h.cumulative_diff = U256::from(cdiff);
+            h
+        };
+
+        let mut genesis = mk(0, H256::zero(), 0);
+        genesis.test_sign();
+        let mut b1 = mk(1, genesis.block_hash, 1);
+        b1.data_ledgers[DataLedger::Submit as usize].tx_ids = H256List(vec![tx_id]);
+        b1.test_sign();
+        let mut b2 = mk(2, b1.block_hash, 2);
+        b2.test_sign();
+        let mut b3 = mk(3, b2.block_hash, 3);
+        b3.test_sign();
+        let mut b4 = mk(4, b3.block_hash, 4);
+        b4.test_sign();
+        let mut c = mk(5, b4.block_hash, 5);
+        c.data_ledgers[DataLedger::Publish as usize].tx_ids = H256List(vec![tx_id]);
+        c.test_sign();
+
+        db.update(|tx| -> eyre::Result<()> {
+            for h in [&genesis, &b1, &b2, &b3, &b4, &c] {
+                tx.put::<IrysBlockHeaders>(h.block_hash, h.clone().into())?;
+            }
+            Ok(())
+        })??;
+
+        // Empty tree guard: the walk falls through to the by-hash DB lookup.
+        let consensus = ConsensusConfig::testing();
+        let block_tree_guard = dummy_block_tree_guard(&consensus);
+        let (service_senders, mut receivers) = crate::test_helpers::build_test_service_senders();
+        let guard_for_responder = block_tree_guard.clone();
+        tokio::spawn(async move {
+            while let Some(msg) = receivers.block_tree.recv().await {
+                if let BlockTreeServiceMessage::GetBlockTreeReadGuard { response } = msg.inner {
+                    let _ = response.send(guard_for_responder.clone());
+                }
+            }
+        });
+
+        let tx_header = DataTransactionHeader::default();
+        let searching = || {
+            HashMap::from([(
+                tx_id,
+                (
+                    &tx_header,
+                    TxInclusionState::Searching {
+                        ledger_current: DataLedger::Publish,
+                    },
+                ),
+            )])
+        };
+
+        // New walk depth (max(tx_anchor=2, block_tree=8) = 8): finds the prior Submit.
+        let mut states = searching();
+        get_previous_tx_inclusions(&mut states, &c, 8, &service_senders, &db).await?;
+        assert!(
+            matches!(
+                states.get(&tx_id).map(|(_, s)| s),
+                Some(TxInclusionState::Found {
+                    ledger_current: (DataLedger::Publish, cur),
+                    ledger_historical: (DataLedger::Submit, hist),
+                }) if *cur == c.block_hash && *hist == b1.block_hash
+            ),
+            "new walk depth must find the prior Submit by-hash, got {:?}",
+            states.get(&tx_id).map(|(_, s)| s),
+        );
+
+        // Old walk depth (tx_anchor_expiry_depth = 2 < depth 4): misses it.
+        let mut states_old = searching();
+        get_previous_tx_inclusions(&mut states_old, &c, 2, &service_senders, &db).await?;
+        assert!(
+            matches!(
+                states_old.get(&tx_id).map(|(_, s)| s),
+                Some(TxInclusionState::Searching {
+                    ledger_current: DataLedger::Publish,
+                })
+            ),
+            "old shallow walk must miss the prior Submit (regression marker), got {:?}",
+            states_old.get(&tx_id).map(|(_, s)| s),
+        );
+
+        Ok(())
+    }
+
     #[test]
     fn same_ledger_in_two_historical_blocks_is_marked_duplicate() -> eyre::Result<()> {
         let tx_id = H256::from_slice(&[8; 32]);
@@ -6619,6 +6731,35 @@ mod tests {
         ));
 
         Ok(())
+    }
+
+    /// Pins the RISK-2 walk-depth derivation: the prevalidation prior-inclusion
+    /// walk must cover `max(tx_anchor_expiry_depth, block_tree_depth)` so a
+    /// promotion's prior Submit inside the reorg window is resolved by-hash (not
+    /// via the branch-incorrect by-height fallback). A revert to just
+    /// `tx_anchor_expiry_depth` (or to `min`) fails this test.
+    #[test]
+    fn prior_inclusion_walk_depth_covers_both_windows() {
+        // Test-mode config, so the production `tx_anchor_expiry_depth <=
+        // block_tree_depth` validator guard does not constrain the
+        // tx_anchor > block_tree case below.
+        fn config_with_depths(tx_anchor: u8, block_tree: u64) -> Config {
+            let mut node_config = NodeConfig::testing();
+            {
+                let c = node_config.consensus.get_mut();
+                c.mempool.tx_anchor_expiry_depth = tx_anchor;
+                c.block_tree_depth = block_tree;
+            }
+            Config::new_with_random_peer_id(node_config)
+        }
+
+        // Production-shaped: the reorg window (block_tree_depth) is the binding term.
+        assert_eq!(prior_inclusion_walk_depth(&config_with_depths(20, 50)), 50);
+        // Degenerate (tx_anchor > tree): the duplicate-anchor window binds — `max`
+        // (not `min`/just-tree) is required so every reachable duplicate is walked.
+        assert_eq!(prior_inclusion_walk_depth(&config_with_depths(60, 50)), 60);
+        // Equal: either reading is correct.
+        assert_eq!(prior_inclusion_walk_depth(&config_with_depths(50, 50)), 50);
     }
 
     pub(super) struct TestContext {

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -6100,7 +6100,8 @@ enum TxInclusionState {
 /// correct for test configs that set a tiny `block_tree_depth` without lowering
 /// `tx_anchor_expiry_depth`. See the [`get_previous_tx_inclusions`] docblock.
 fn prior_inclusion_walk_depth(config: &Config) -> u64 {
-    (config.consensus.mempool.tx_anchor_expiry_depth as u64).max(config.consensus.block_tree_depth)
+    u64::from(config.consensus.mempool.tx_anchor_expiry_depth)
+        .max(config.consensus.block_tree_depth)
 }
 
 /// Walks `block_under_validation`'s ancestors via the block tree (DB fallback

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -4584,9 +4584,8 @@ async fn generate_expected_shadow_transactions(
 
     // NC-0042: peer-attributable consensus rule — no Publish-ledger tx may have
     // its Submit-ledger storage already expired as of this block.
-    //   == block.height  →  same-block epoch collision (Bug A, devnet 39960)
-    //   <  block.height  →  cross-block silent double-pay (devnet 39962 — every
-    //                       validator accepted it pre-fix)
+    //   == block.height  →  same-block epoch collision
+    //   <  block.height  →  cross-block silent double-pay
     //
     // Producer-side: `tx_selector::get_publish_txs_and_proofs` already filters
     // out expired candidates (using this same set) so an honest producer never
@@ -4605,7 +4604,7 @@ async fn generate_expected_shadow_transactions(
     //
     // This is a strict superset of the old same-block guard: a tx whose Submit
     // slot expires *at* this block (same-block epoch collision) and a tx whose
-    // slot expired at an *earlier* epoch (cross-block double-pay, devnet 39962)
+    // slot expired at an *earlier* epoch (cross-block double-pay)
     // are both in the set. A tx whose Submit inclusion is in this very block
     // (same-block Submit→Publish) is not — its slot can't have expired yet.
     //
@@ -5422,7 +5421,7 @@ pub async fn data_txs_are_valid(
                         // widened, this arm could run inside the reorg-mutable
                         // `(tip - block_tree_depth, tip - block_migration_depth]`
                         // band and fork — widening the walk to the reorg window is
-                        // exactly what makes this fallback safe post-#1405; see the
+                        // exactly what makes this fallback safe; see the
                         // `get_previous_tx_inclusions` docblock.)
                         //
                         // `canonical_submit_height` is sufficient evidence of
@@ -6087,7 +6086,7 @@ enum TxInclusionState {
 ///     bounded by `ingress_proof_anchor_expiry_depth` (NOT the tx anchor), so an
 ///     inclusion inside the reorg window must be resolved branch-correctly by-hash
 ///     here rather than via the by-height index/MBH fallback, which is only
-///     branch-invariant below the reorg floor (#1405).
+///     branch-invariant below the reorg floor.
 ///
 /// `Config::validate` enforces `tx_anchor_expiry_depth <= block_tree_depth` in
 /// production (so the reorg window is the binding term there); `max` keeps this
@@ -6127,7 +6126,7 @@ pub(crate) fn prior_inclusion_walk_depth(config: &Config) -> u64 {
 ///    `block_under_validation`'s own ancestry; resolving it via the by-height
 ///    index/MBH shortcut (the `Searching { ledger_current: Publish }` arm in
 ///    `data_txs_are_valid`) is only branch-invariant BELOW the reorg floor, which
-///    deep reorgs (#1405) moved from `block_migration_depth` to `block_tree_depth`.
+///    deep reorgs moved from `block_migration_depth` to `block_tree_depth`.
 ///    Walking the full reorg window guarantees that fallback is reached only for
 ///    *finalized* inclusions, where node-canonical == every branch.
 ///
@@ -6566,7 +6565,7 @@ mod tests {
         Ok(())
     }
 
-    /// REGRESSION (RISK-2 / #1405 deep-reorg walk depth): `get_previous_tx_inclusions`
+    /// REGRESSION (deep-reorg walk depth): `get_previous_tx_inclusions`
     /// must resolve a promotion's prior Submit branch-correctly by-hash for the whole
     /// reorg window — not just `tx_anchor_expiry_depth`. A Publish candidate C at
     /// height 5 promotes tx T whose prior Submit sits at height 1 (depth 4) — inside
@@ -6728,7 +6727,7 @@ mod tests {
         Ok(())
     }
 
-    /// Pins the RISK-2 walk-depth derivation: the prevalidation prior-inclusion
+    /// Pins the walk-depth derivation: the prevalidation prior-inclusion
     /// walk must cover `max(tx_anchor_expiry_depth, block_tree_depth)` so a
     /// promotion's prior Submit inside the reorg window is resolved by-hash (not
     /// via the branch-incorrect by-height fallback). A revert to just

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -4597,10 +4597,21 @@ async fn generate_expected_shadow_transactions(
     // (tests, future callers). The rule here is canonical; the constructor guard
     // is defence-in-depth only.
     //
-    // The expired set is derived from the *same* expired-partition → block → tx walk
-    // that schedules `user_perm_fee_refunds`, so "is this tx refunded?" and "may
-    // this tx be promoted?" cannot diverge (the structural flaw the earlier
-    // cycle-math approximation introduced — see NC-0042 §4b).
+    // `submit_tx_expired` keys off `get_all_expired_term_slot_indexes` — the
+    // *inclusive* all-expired Submit slot set. That is a strict SUPERSET of the set
+    // the refund pipeline settles (`get_expiring_partition_info`, which additionally
+    // drops slots `written_this_epoch`). The containment is the load-bearing
+    // property: a refunded tx is always in this blocked set, so "refunded" ⇒ "not
+    // promotable" and the double-pay this fix forbids (refund + permanent storage)
+    // cannot occur. The converse is intentionally NOT exact — a slot rescued from
+    // refund by the write-window exclusion (it received Submit data this epoch) is
+    // still treated as expired here, because the promotion path reads the *parent*
+    // epoch snapshot (pre-`touch_active_ledger_slots`) and cannot see the current
+    // epoch's write. That is conservative (never a double-pay) and self-healing:
+    // once the epoch `touch` bumps the slot's `last_height` it leaves the blocked
+    // set for the rest of the epoch, so at worst a promotion is delayed one block at
+    // the epoch boundary. Replaces the earlier cycle-math approximation — see
+    // NC-0042 §4b.
     //
     // This is a strict superset of the old same-block guard: a tx whose Submit
     // slot expires *at* this block (same-block epoch collision) and a tx whose
@@ -4643,7 +4654,8 @@ async fn generate_expected_shadow_transactions(
         .map_err(|e| node_fault(format!("NC-0042 expiry check: {e}")))?;
         if let Some(range) = &expired_range {
             for tx in &publish_ledger_with_txs.txs {
-                // Per-candidate form of the (refund-pipeline-shared) expired-tx set.
+                // Per-candidate form of the inclusive all-expired Submit set (a
+                // superset of the refund set; see the §4b/§4c note above).
                 let expired = ledger_expiry::submit_tx_expired(
                     tx.id,
                     range,

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -4533,6 +4533,7 @@ async fn generate_expected_shadow_transactions(
             .is_cascade_active_at(block.timestamp_secs());
         let mut result = ledger_expiry::calculate_expired_ledger_fees(
             &parent_epoch_snapshot,
+            &prev_block,
             block.height,
             DataLedger::Submit,
             config,
@@ -4557,6 +4558,7 @@ async fn generate_expected_shadow_transactions(
             for ledger in [DataLedger::OneYear, DataLedger::ThirtyDay] {
                 let delta = ledger_expiry::calculate_expired_ledger_fees(
                     &parent_epoch_snapshot,
+                    &prev_block,
                     block.height,
                     ledger,
                     config,
@@ -4630,28 +4632,41 @@ async fn generate_expected_shadow_transactions(
     // are both in the set. A tx whose Submit inclusion is in this very block
     // (same-block Submit→Publish) is not — its slot can't have expired yet.
     {
-        let expired_submit_tx_ids = ledger_expiry::expired_submit_tx_ids(
-            &parent_epoch_snapshot,
+        // The expired-Submit range is the same for every publish tx in this block,
+        // so resolve it once and reuse it per-candidate. Locally derived (parent
+        // epoch snapshot, our block_index/mempool/DB); a failure here is a hard
+        // node-local fault, not a peer statement. `None` → nothing expired.
+        let expired_range = ledger_expiry::expired_submit_range(
             block.height,
+            &parent_epoch_snapshot,
+            &prev_block,
             config,
-            block_index.clone(),
-            block_tree_guard,
-            mempool_guard,
-            db,
+            &block_index,
         )
-        .await
-        // Locally derived (parent epoch snapshot, our block_index/mempool/DB);
-        // a failure here is a hard node-local fault, not a peer statement.
         .map_err(|e| node_fault(format!("NC-0042 expiry check: {e}")))?;
-
-        for tx in &publish_ledger_with_txs.txs {
-            if expired_submit_tx_ids.contains(&tx.id) {
-                return Err(consensus(format!(
-                    "Transaction {} is in the publish ledger but its Submit-ledger \
-                     storage has already expired as of block {} (it is/was perm_fee \
-                     refunded; promoted txs must not be refunded). See NC-0042.",
-                    tx.id, block.height,
-                )));
+        if let Some(range) = &expired_range {
+            for tx in &publish_ledger_with_txs.txs {
+                // Per-candidate form of the (refund-pipeline-shared) expired-tx set.
+                let expired = ledger_expiry::submit_tx_expired(
+                    tx.id,
+                    None,
+                    range,
+                    config,
+                    &block_index,
+                    block_tree_guard,
+                    mempool_guard,
+                    db,
+                )
+                .await
+                .map_err(|e| node_fault(format!("NC-0042 expiry check: {e}")))?;
+                if expired {
+                    return Err(consensus(format!(
+                        "Transaction {} is in the publish ledger but its Submit-ledger \
+                         storage has already expired as of block {} (it is/was perm_fee \
+                         refunded; promoted txs must not be refunded). See NC-0042.",
+                        tx.id, block.height,
+                    )));
+                }
             }
         }
     }

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -3482,7 +3482,7 @@ fn load_owning_tx_for_poa(
                     if is_poa_owning_leaf(cursor, h.data_size, tx_leaf_min_byte_range) {
                         return Some(h.clone());
                     }
-                    cursor += h.data_size as u128;
+                    cursor += u128::from(h.data_size);
                     None
                 })
         })

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -945,12 +945,17 @@ impl InnerCacheTask {
                     ingress_proof.data_root = ?proof.data_root,
                     "Skipping reanchoring of ingress proof due to REGENERATE_PROOFS = false"
                 );
-                if let Err(e) = ChunkIngressServiceInner::remove_ingress_proof_by_signer(
-                    &self.db,
-                    proof.data_root,
-                    local_addr,
-                ) {
-                    warn!(ingress_proof.data_root = ?proof, "Failed to remove ingress proof: {e}");
+                // Content-checked delete, same TOCTOU guard as the `to_delete`
+                // loop: only remove the local proof if it is still the one we
+                // scanned, so a proof refreshed since the scan is preserved.
+                let scanned = CompactCachedIngressProof(CachedIngressProof {
+                    address: local_addr,
+                    proof: proof.clone(),
+                });
+                if let Err(e) = self.db.update_eyre(|rw_tx| {
+                    delete_ingress_proof_if_unchanged(rw_tx, proof.data_root, scanned)
+                }) {
+                    warn!(ingress_proof.data_root = ?proof.data_root, "Failed to remove ingress proof: {e}");
                 }
             }
         }
@@ -977,11 +982,16 @@ impl InnerCacheTask {
                     ingress_proof.data_root = ?proof.data_root,
                     "Regeneration disabled, removing ingress proof for data root"
                 );
-                if let Err(e) = ChunkIngressServiceInner::remove_ingress_proof_by_signer(
-                    &self.db,
-                    proof.data_root,
-                    local_addr,
-                ) {
+                // Content-checked delete, same TOCTOU guard as the `to_delete`
+                // loop: only remove the local proof if it is still the one we
+                // scanned, so a proof refreshed since the scan is preserved.
+                let scanned = CompactCachedIngressProof(CachedIngressProof {
+                    address: local_addr,
+                    proof: proof.clone(),
+                });
+                if let Err(e) = self.db.update_eyre(|rw_tx| {
+                    delete_ingress_proof_if_unchanged(rw_tx, proof.data_root, scanned)
+                }) {
                     warn!(ingress_proof.data_root = ?proof.data_root, "Failed to remove ingress proof: {e}");
                 }
             }

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -884,6 +884,15 @@ impl InnerCacheTask {
             }
         }
 
+        // Release the scan's read transaction (and its walker/cursor) before the
+        // per-proof write-tx loop below. Holding a long-lived reader open across
+        // up to MAX_PROOF_CHECKS_PER_RUN short write txns would pin the MVCC
+        // snapshot and hold back MDBX free-page reclamation; nothing past the scan
+        // reads from `tx` (the delete/reanchor/regen loops open their own txns).
+        drop(walker);
+        drop(cursor);
+        drop(tx);
+
         // Delete expired proofs — per-signer to avoid wiping other signers' rows on the same
         // data_root. Content-aware delete closes the TOCTOU window: a fresh proof stored
         // between the scan and this delete will not match the scanned value and is preserved.

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -1366,7 +1366,7 @@ mod tests {
     //
     // Real prod ingress goes through `cache_data_root_with_expiry`, which sets
     // `expiry_height` to `anchor + tx_anchor_expiry_depth`.  Direct callers of
-    // `cache_data_root(_, _, None)` (this fixture, pre-fix code paths) leave
+    // `cache_data_root(_, _, None)` (this fixture) leave
     // `expiry_height = None`.  We set it manually here to mirror what the
     // mempool ingress path produces, so the test exercises the realistic
     // "unconfirmed entry with expiry in the future" state rather than the

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -16,7 +16,7 @@ use irys_domain::{BlockIndexReadGuard, BlockTreeReadGuard, EpochSnapshot};
 use irys_types::ingress::CachedIngressProof;
 use irys_types::v2::GossipBroadcastMessageV2;
 use irys_types::{
-    Config, DataLedger, DataRoot, DatabaseProvider, GIGABYTE, H256, IngressProof,
+    Config, DataLedger, DataRoot, DatabaseProvider, GIGABYTE, H256, IngressProof, IrysAddress,
     LedgerChunkOffset, SendTraced as _, TokioServiceHandle, Traced, UnixTimestamp,
 };
 use reth::tasks::shutdown::Shutdown;
@@ -799,7 +799,7 @@ impl InnerCacheTask {
         // TODO: we can randomise the start of the cursor by providing a random key. MDBX will seek to the neareset key if it doesn't exist.
         // we might want to do this to prevent scanning over just the first `MAX_PROOF_CHECKS_PER_RUN` valid entries.
         let mut walker = cursor.walk(None)?;
-        let mut to_delete: Vec<DataRoot> = Vec::new();
+        let mut to_delete: Vec<(DataRoot, IrysAddress)> = Vec::new();
         let mut to_reanchor: Vec<IngressProof> = Vec::new();
         let mut to_regen: Vec<IngressProof> = Vec::new();
         let mut processed = 0_usize;
@@ -827,7 +827,7 @@ impl InnerCacheTask {
             // Associated txids
             let Some(cached_data_root) = cached_data_root_by_data_root(&tx, data_root)? else {
                 debug!(ingress_proof.data_root = ?data_root, "Proof has no cached data root; marking for deletion");
-                to_delete.push(data_root);
+                to_delete.push((data_root, address));
                 continue;
             };
 
@@ -855,7 +855,7 @@ impl InnerCacheTask {
 
             if at_capacity {
                 // Unpromoted + expired + at capacity: delete
-                to_delete.push(data_root);
+                to_delete.push((data_root, address));
                 debug!(ingress_proof.data_root = ?data_root, cache.at_capacity = true, "Marking expired proof for deletion (at capacity)");
             } else if is_locally_produced && any_unpromoted {
                 match check_result.regeneration_action {
@@ -876,15 +876,17 @@ impl InnerCacheTask {
                 }
             } else {
                 // Not local + expired: delete
-                to_delete.push(data_root);
+                to_delete.push((data_root, address));
                 debug!(ingress_proof.data_root = ?data_root, cache.at_capacity = false, "Marking expired proof for deletion (promoted)");
             }
         }
 
-        // Delete expired proofs using a proper removal function
+        // Delete expired proofs — per-signer to avoid wiping other signers' rows on the same data_root
         if !to_delete.is_empty() {
-            for root in to_delete.iter() {
-                if let Err(e) = ChunkIngressServiceInner::remove_ingress_proof(&self.db, *root) {
+            for (root, addr) in to_delete.iter() {
+                if let Err(e) =
+                    ChunkIngressServiceInner::remove_ingress_proof_by_signer(&self.db, *root, *addr)
+                {
                     warn!(ingress_proof.data_root = ?root, "Failed to remove ingress proof: {e}");
                 }
             }
@@ -917,9 +919,11 @@ impl InnerCacheTask {
                     ingress_proof.data_root = ?proof.data_root,
                     "Skipping reanchoring of ingress proof due to REGENERATE_PROOFS = false"
                 );
-                if let Err(e) =
-                    ChunkIngressServiceInner::remove_ingress_proof(&self.db, proof.data_root)
-                {
+                if let Err(e) = ChunkIngressServiceInner::remove_ingress_proof_by_signer(
+                    &self.db,
+                    proof.data_root,
+                    local_addr,
+                ) {
                     warn!(ingress_proof.data_root = ?proof, "Failed to remove ingress proof: {e}");
                 }
             }
@@ -947,9 +951,11 @@ impl InnerCacheTask {
                     ingress_proof.data_root = ?proof.data_root,
                     "Regeneration disabled, removing ingress proof for data root"
                 );
-                if let Err(e) =
-                    ChunkIngressServiceInner::remove_ingress_proof(&self.db, proof.data_root)
-                {
+                if let Err(e) = ChunkIngressServiceInner::remove_ingress_proof_by_signer(
+                    &self.db,
+                    proof.data_root,
+                    local_addr,
+                ) {
                     warn!(ingress_proof.data_root = ?proof.data_root, "Failed to remove ingress proof: {e}");
                 }
             }
@@ -2433,6 +2439,142 @@ mod tests {
             assert!(
                 cached.block_set.contains(&good_hash),
                 "good block hash should remain"
+            );
+            Ok(())
+        })??;
+
+        Ok(())
+    }
+
+    /// Regression: `prune_ingress_proofs` must delete only the expired signer's
+    /// row, not all proofs for the same `data_root`.
+    ///
+    /// Sets up three distinct-signer proofs for one `data_root`:
+    /// - `signer_a` / `signer_b`: valid anchors (genesis block hash) → not expired
+    /// - `signer_c` (not local): invalid anchor (random unknown hash) → expired
+    ///
+    /// After one pass of `prune_ingress_proofs` the expired proof must be gone
+    /// and the two valid ones must still be present.
+    #[tokio::test]
+    async fn prune_ingress_proofs_preserves_valid_distinct_signer_proofs() -> eyre::Result<()> {
+        let node_config = NodeConfig::testing();
+        let config = Config::new_with_random_peer_id(node_config);
+        let _temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db_env = open_or_create_db(
+            &_temp_dir,
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        let db = DatabaseProvider(Arc::new(db_env));
+
+        // A shared data_root for all three proofs.
+        let data_root = H256::random();
+        // A txid that will live in the CDR's txid_set and remain unpromoted.
+        let txid = H256::random();
+
+        // Three distinct signer addresses.
+        let addr_a = IrysAddress::random();
+        let addr_b = IrysAddress::random();
+        let addr_c = IrysAddress::random(); // this one will have an expired proof
+
+        // Build the genesis block; its hash is a valid anchor.
+        let genesis_block = new_mock_signed_header();
+        let valid_anchor = genesis_block.block_hash;
+        // A random hash not in the block tree → InvalidAnchor → expired.
+        let invalid_anchor = H256::random();
+
+        // Persist CDR + unpromoted tx header + three ingress-proof rows.
+        db.update(|wtx| -> eyre::Result<()> {
+            // CachedDataRoot with one pending txid (any_unpromoted = true).
+            let cdr = CachedDataRoot {
+                data_size: 64,
+                data_size_confirmed: false,
+                txid_set: vec![txid],
+                block_set: vec![],
+                expiry_height: None,
+                cached_at: irys_types::UnixTimestamp::now()?,
+            };
+            wtx.put::<CachedDataRoots>(data_root, cdr)?;
+
+            // Tx header for the pending txid; promoted_height = None (default).
+            let tx_header = DataTransactionHeader::V1(DataTransactionHeaderV1WithMetadata {
+                tx: DataTransactionHeaderV1 {
+                    id: txid,
+                    data_root,
+                    data_size: 64,
+                    ..Default::default()
+                },
+                metadata: DataTransactionMetadata::new(),
+            });
+            database::insert_tx_header(wtx, &tx_header)?;
+
+            // Two valid proofs (known anchor → not expired).
+            let make_proof = |anchor: H256| {
+                let mut p = IngressProof::default();
+                p.data_root = data_root;
+                p.anchor = anchor;
+                p
+            };
+            irys_database::store_external_ingress_proof_checked(
+                wtx,
+                &make_proof(valid_anchor),
+                addr_a,
+            )?;
+            irys_database::store_external_ingress_proof_checked(
+                wtx,
+                &make_proof(valid_anchor),
+                addr_b,
+            )?;
+            // One expired proof (unknown anchor).
+            irys_database::store_external_ingress_proof_checked(
+                wtx,
+                &make_proof(invalid_anchor),
+                addr_c,
+            )?;
+
+            Ok(())
+        })??;
+
+        // Sanity: three proofs inserted.
+        let initial_count = db.view_eyre(|rtx| {
+            Ok(irys_database::ingress_proofs_by_data_root(rtx, data_root)?.len())
+        })?;
+        assert_eq!(initial_count, 3, "expected 3 proofs before pruning");
+
+        let block_tree = BlockTree::new(&genesis_block, config.consensus.clone());
+        let block_tree_guard =
+            irys_domain::BlockTreeReadGuard::new(Arc::new(RwLock::new(block_tree)));
+        let block_index = BlockIndex::new_for_testing(db.clone());
+        let block_index_guard =
+            irys_domain::block_index_guard::BlockIndexReadGuard::new(block_index);
+
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let service_task = InnerCacheTask {
+            db: db.clone(),
+            block_tree_guard,
+            block_index_guard,
+            config,
+            gossip_broadcast: tokio::sync::mpsc::unbounded_channel().0,
+            ingress_proof_generation_state: IngressProofGenerationState::new(),
+            cache_sender: tx,
+        };
+
+        service_task.prune_ingress_proofs()?;
+
+        db.view(|rtx| -> eyre::Result<()> {
+            let remaining = irys_database::ingress_proofs_by_data_root(rtx, data_root)?;
+            assert_eq!(
+                remaining.len(),
+                2,
+                "two valid proofs must survive; got {}",
+                remaining.len()
+            );
+            let addrs: Vec<IrysAddress> = remaining.iter().map(|(_, c)| c.address).collect();
+            assert!(addrs.contains(&addr_a), "proof for addr_a must survive");
+            assert!(addrs.contains(&addr_b), "proof for addr_b must survive");
+            assert!(
+                !addrs.contains(&addr_c),
+                "expired proof for addr_c must be deleted"
             );
             Ok(())
         })??;

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -2747,4 +2747,158 @@ mod tests {
 
         Ok(())
     }
+
+    /// `prune_ingress_proofs` must handle ≥2 expired signers for the same data_root in
+    /// one pass: both their rows must be deleted while the surviving signer's row is kept.
+    ///
+    /// Setup — three distinct remote signers for one `data_root`:
+    /// - `addr_a`: valid anchor (genesis block hash) → NOT expired → must survive
+    /// - `addr_b`: invalid anchor (random unknown hash) → expired → must be deleted
+    /// - `addr_c`: invalid anchor (different random hash) → expired → must be deleted
+    ///
+    /// After one pass of `prune_ingress_proofs`:
+    /// - addr_b and addr_c proofs are gone
+    /// - addr_a proof is still present
+    #[tokio::test]
+    async fn prune_ingress_proofs_deletes_two_expired_signers_preserves_one() -> eyre::Result<()> {
+        let node_config = NodeConfig::testing();
+        let config = Config::new_with_random_peer_id(node_config);
+        let _temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db_env = open_or_create_db(
+            &_temp_dir,
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        let db = DatabaseProvider(Arc::new(db_env));
+
+        // Shared data_root for all three proofs.
+        let data_root = H256::random();
+        // A txid present in the CDR's txid_set; promoted_height = None → any_unpromoted = true.
+        let txid = H256::random();
+
+        // Three distinct remote signer addresses (none is the local node's address).
+        let addr_a = IrysAddress::random();
+        let addr_b = IrysAddress::random();
+        let addr_c = IrysAddress::random();
+
+        // Genesis block provides the valid anchor.
+        let genesis_block = new_mock_signed_header();
+        let valid_anchor = genesis_block.block_hash;
+        // Two distinct unknown hashes → both proofs expired.
+        let expired_anchor_b = H256::random();
+        let expired_anchor_c = H256::random();
+
+        db.update(|wtx| -> eyre::Result<()> {
+            // CDR with one pending (unpromoted) txid.
+            let cdr = CachedDataRoot {
+                data_size: 64,
+                data_size_confirmed: false,
+                txid_set: vec![txid],
+                block_set: vec![],
+                expiry_height: None,
+                cached_at: irys_types::UnixTimestamp::now()?,
+            };
+            wtx.put::<CachedDataRoots>(data_root, cdr)?;
+
+            // Unpromoted tx header (promoted_height = None by default).
+            let tx_header = DataTransactionHeader::V1(DataTransactionHeaderV1WithMetadata {
+                tx: DataTransactionHeaderV1 {
+                    id: txid,
+                    data_root,
+                    data_size: 64,
+                    ..Default::default()
+                },
+                metadata: DataTransactionMetadata::new(),
+            });
+            database::insert_tx_header(wtx, &tx_header)?;
+
+            let make_proof = |anchor: H256| {
+                let mut p = IngressProof::default();
+                p.data_root = data_root;
+                p.anchor = anchor;
+                p
+            };
+
+            // addr_a: valid anchor → not expired → survives.
+            irys_database::store_external_ingress_proof_checked(
+                wtx,
+                &make_proof(valid_anchor),
+                addr_a,
+            )?;
+            // addr_b and addr_c: expired anchors → will be pruned.
+            irys_database::store_external_ingress_proof_checked(
+                wtx,
+                &make_proof(expired_anchor_b),
+                addr_b,
+            )?;
+            irys_database::store_external_ingress_proof_checked(
+                wtx,
+                &make_proof(expired_anchor_c),
+                addr_c,
+            )?;
+
+            Ok(())
+        })??;
+
+        // Sanity: three proofs inserted.
+        let initial_count = db.view_eyre(|rtx| {
+            Ok(irys_database::ingress_proofs_by_data_root(rtx, data_root)?.len())
+        })?;
+        assert_eq!(initial_count, 3, "expected 3 proofs before pruning");
+
+        let block_tree = BlockTree::new(&genesis_block, config.consensus.clone());
+        let block_tree_guard =
+            irys_domain::BlockTreeReadGuard::new(Arc::new(RwLock::new(block_tree)));
+        let block_index = BlockIndex::new_for_testing(db.clone());
+        let block_index_guard =
+            irys_domain::block_index_guard::BlockIndexReadGuard::new(block_index);
+
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let service_task = InnerCacheTask {
+            db: db.clone(),
+            block_tree_guard,
+            block_index_guard,
+            config,
+            gossip_broadcast: tokio::sync::mpsc::unbounded_channel().0,
+            ingress_proof_generation_state: IngressProofGenerationState::new(),
+            cache_sender: tx,
+        };
+
+        service_task.prune_ingress_proofs()?;
+
+        db.view(|rtx| -> eyre::Result<()> {
+            // Exactly one proof must remain — addr_a's.
+            let remaining = irys_database::ingress_proofs_by_data_root(rtx, data_root)?;
+            assert_eq!(
+                remaining.len(),
+                1,
+                "only addr_a's proof should survive; got {}",
+                remaining.len()
+            );
+            assert_eq!(
+                remaining[0].1.address, addr_a,
+                "surviving proof must belong to addr_a"
+            );
+
+            // Per-key checks using ingress_proof_by_data_root_address.
+            assert!(
+                irys_database::ingress_proof_by_data_root_address(rtx, data_root, addr_a)?
+                    .is_some(),
+                "addr_a proof must survive"
+            );
+            assert!(
+                irys_database::ingress_proof_by_data_root_address(rtx, data_root, addr_b)?
+                    .is_none(),
+                "addr_b expired proof must be deleted"
+            );
+            assert!(
+                irys_database::ingress_proof_by_data_root_address(rtx, data_root, addr_c)?
+                    .is_none(),
+                "addr_c expired proof must be deleted"
+            );
+            Ok(())
+        })??;
+
+        Ok(())
+    }
 }

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -5,18 +5,18 @@ use crate::chunk_ingress_service::ingress_proofs::{
 use crate::metrics;
 use irys_database::{
     cached_data_root_by_data_root, delete_cached_chunks_by_data_root_older_than,
-    get_data_tx_metadata, tx_header_by_txid,
+    delete_ingress_proof_if_unchanged, get_data_tx_metadata, tx_header_by_txid,
 };
 use irys_database::{
     db::IrysDatabaseExt as _,
     delete_cached_chunks_by_data_root, get_cache_size,
-    tables::{CachedChunks, CachedDataRoots, IngressProofs},
+    tables::{CachedChunks, CachedDataRoots, CompactCachedIngressProof, IngressProofs},
 };
 use irys_domain::{BlockIndexReadGuard, BlockTreeReadGuard, EpochSnapshot};
 use irys_types::ingress::CachedIngressProof;
 use irys_types::v2::GossipBroadcastMessageV2;
 use irys_types::{
-    Config, DataLedger, DataRoot, DatabaseProvider, GIGABYTE, H256, IngressProof, IrysAddress,
+    Config, DataLedger, DataRoot, DatabaseProvider, GIGABYTE, H256, IngressProof,
     LedgerChunkOffset, SendTraced as _, TokioServiceHandle, Traced, UnixTimestamp,
 };
 use reth::tasks::shutdown::Shutdown;
@@ -799,7 +799,10 @@ impl InnerCacheTask {
         // TODO: we can randomise the start of the cursor by providing a random key. MDBX will seek to the neareset key if it doesn't exist.
         // we might want to do this to prevent scanning over just the first `MAX_PROOF_CHECKS_PER_RUN` valid entries.
         let mut walker = cursor.walk(None)?;
-        let mut to_delete: Vec<(DataRoot, IrysAddress)> = Vec::new();
+        // Carries the full proof content so the delete phase can compare before deleting
+        // (closes the TOCTOU window: a fresh proof stored between the scan and the delete
+        // will not match the scanned content and will be preserved).
+        let mut to_delete: Vec<(DataRoot, CompactCachedIngressProof)> = Vec::new();
         let mut to_reanchor: Vec<IngressProof> = Vec::new();
         let mut to_regen: Vec<IngressProof> = Vec::new();
         let mut processed = 0_usize;
@@ -822,12 +825,12 @@ impl InnerCacheTask {
                 break;
             }
             processed += 1;
-            let CachedIngressProof { address, proof } = compact.0;
+            let CachedIngressProof { address, proof } = compact.0.clone();
 
             // Associated txids
             let Some(cached_data_root) = cached_data_root_by_data_root(&tx, data_root)? else {
                 debug!(ingress_proof.data_root = ?data_root, "Proof has no cached data root; marking for deletion");
-                to_delete.push((data_root, address));
+                to_delete.push((data_root, compact));
                 continue;
             };
 
@@ -855,7 +858,7 @@ impl InnerCacheTask {
 
             if at_capacity {
                 // Unpromoted + expired + at capacity: delete
-                to_delete.push((data_root, address));
+                to_delete.push((data_root, compact));
                 debug!(ingress_proof.data_root = ?data_root, cache.at_capacity = true, "Marking expired proof for deletion (at capacity)");
             } else if is_locally_produced && any_unpromoted {
                 match check_result.regeneration_action {
@@ -876,24 +879,38 @@ impl InnerCacheTask {
                 }
             } else {
                 // Not local + expired: delete
-                to_delete.push((data_root, address));
-                debug!(ingress_proof.data_root = ?data_root, cache.at_capacity = false, "Marking expired proof for deletion (promoted)");
+                to_delete.push((data_root, compact));
+                debug!(ingress_proof.data_root = ?data_root, cache.at_capacity = false, "Marking expired proof for deletion (remote or fully-promoted)");
             }
         }
 
-        // Delete expired proofs — per-signer to avoid wiping other signers' rows on the same data_root
+        // Delete expired proofs — per-signer to avoid wiping other signers' rows on the same
+        // data_root. Content-aware delete closes the TOCTOU window: a fresh proof stored
+        // between the scan and this delete will not match the scanned value and is preserved.
         if !to_delete.is_empty() {
-            for (root, addr) in to_delete.iter() {
-                if let Err(e) =
-                    ChunkIngressServiceInner::remove_ingress_proof_by_signer(&self.db, *root, *addr)
-                {
-                    warn!(ingress_proof.data_root = ?root, "Failed to remove ingress proof: {e}");
+            let mut deleted_count = 0_usize;
+            for (root, scanned) in to_delete.iter() {
+                match self.db.update_eyre(|rw_tx| {
+                    delete_ingress_proof_if_unchanged(rw_tx, *root, scanned.clone())
+                }) {
+                    Ok(true) => deleted_count += 1,
+                    Ok(false) => {
+                        debug!(
+                            ingress_proof.data_root = ?root,
+                            "Skipping stale delete: proof was refreshed since scan"
+                        );
+                    }
+                    Err(e) => {
+                        warn!(ingress_proof.data_root = ?root, "Failed to remove ingress proof: {e}");
+                    }
                 }
             }
-            info!(
-                proofs.deleted = to_delete.len(),
-                "Deleted expired ingress proofs"
-            );
+            if deleted_count > 0 {
+                info!(
+                    proofs.deleted = deleted_count,
+                    "Deleted expired ingress proofs"
+                );
+            }
         }
 
         // Regenerate local expired proofs (only when under capacity)
@@ -1318,8 +1335,8 @@ mod tests {
     use irys_testing_utils::{initialize_tracing, new_mock_signed_header};
     use irys_types::{
         Base64, Config, DataTransactionHeader, DataTransactionHeaderV1,
-        DataTransactionHeaderV1WithMetadata, DataTransactionMetadata, NodeConfig, TxChunkOffset,
-        UnpackedChunk, app_state::DatabaseProvider,
+        DataTransactionHeaderV1WithMetadata, DataTransactionMetadata, IrysAddress, NodeConfig,
+        TxChunkOffset, UnpackedChunk, app_state::DatabaseProvider,
     };
     use reth_db::cursor::DbDupCursorRO as _;
     use reth_db::mdbx::DatabaseArguments;

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -2617,4 +2617,134 @@ mod tests {
 
         Ok(())
     }
+
+    /// Regression: when the cache is at capacity, a locally-produced expired
+    /// proof with unpromoted txs must be deleted (not regenerated), and the
+    /// content-checked delete path (`delete_ingress_proof_if_unchanged`) must
+    /// be used so a concurrently-refreshed proof is preserved.
+    ///
+    /// Setup:
+    /// - `max_cache_size_bytes = 0` → `at_capacity = true` (0 >= 0)
+    /// - Local proof (config's signer address) for a data_root that has one
+    ///   unpromoted tx; anchor = random hash → expired
+    /// - Sibling proof (distinct address) for the same data_root; anchor =
+    ///   genesis block hash → NOT expired → must survive
+    ///
+    /// After one pass of `prune_ingress_proofs`:
+    /// - local (expired + at-capacity) proof is deleted
+    /// - sibling (valid anchor) proof is preserved
+    #[tokio::test]
+    async fn prune_ingress_proofs_at_capacity_deletes_local_proof() -> eyre::Result<()> {
+        let mut node_config = NodeConfig::testing();
+        // Force at_capacity = true: chunk_cache_size (0) >= 0.
+        node_config.cache.max_cache_size_bytes = 0;
+        let config = Config::new_with_random_peer_id(node_config);
+        let _temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db_env = open_or_create_db(
+            &_temp_dir,
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        let db = DatabaseProvider(Arc::new(db_env));
+
+        let data_root = H256::random();
+        let txid = H256::random();
+
+        // Address of the local signer (derived from NodeConfig::testing()'s fixed key).
+        let local_addr = config.irys_signer().address();
+        // A different address for the sibling proof.
+        let sibling_addr = IrysAddress::random();
+
+        // Build the genesis block; its hash is a valid anchor (not expired).
+        let genesis_block = new_mock_signed_header();
+        let valid_anchor = genesis_block.block_hash;
+        // Unknown anchor → expired.
+        let expired_anchor = H256::random();
+
+        db.update(|wtx| -> eyre::Result<()> {
+            // CachedDataRoot with one pending (unpromoted) txid.
+            let cdr = irys_database::db_cache::CachedDataRoot {
+                data_size: 64,
+                data_size_confirmed: false,
+                txid_set: vec![txid],
+                block_set: vec![],
+                expiry_height: None,
+                cached_at: irys_types::UnixTimestamp::now()?,
+            };
+            wtx.put::<CachedDataRoots>(data_root, cdr)?;
+
+            // Unpromoted tx header (promoted_height = None by default).
+            let tx_header = DataTransactionHeader::V1(DataTransactionHeaderV1WithMetadata {
+                tx: DataTransactionHeaderV1 {
+                    id: txid,
+                    data_root,
+                    data_size: 64,
+                    ..Default::default()
+                },
+                metadata: DataTransactionMetadata::new(),
+            });
+            database::insert_tx_header(wtx, &tx_header)?;
+
+            // Local proof with expired anchor → at-capacity branch deletes it.
+            let mut local_proof = IngressProof::default();
+            local_proof.data_root = data_root;
+            local_proof.anchor = expired_anchor;
+            irys_database::store_external_ingress_proof_checked(wtx, &local_proof, local_addr)?;
+
+            // Sibling proof with valid anchor → not expired → survives.
+            let mut sibling_proof = IngressProof::default();
+            sibling_proof.data_root = data_root;
+            sibling_proof.anchor = valid_anchor;
+            irys_database::store_external_ingress_proof_checked(wtx, &sibling_proof, sibling_addr)?;
+
+            Ok(())
+        })??;
+
+        let initial_count = db.view_eyre(|rtx| {
+            Ok(irys_database::ingress_proofs_by_data_root(rtx, data_root)?.len())
+        })?;
+        assert_eq!(initial_count, 2, "expected 2 proofs before pruning");
+
+        let block_tree = BlockTree::new(&genesis_block, config.consensus.clone());
+        let block_tree_guard =
+            irys_domain::BlockTreeReadGuard::new(Arc::new(RwLock::new(block_tree)));
+        let block_index = BlockIndex::new_for_testing(db.clone());
+        let block_index_guard =
+            irys_domain::block_index_guard::BlockIndexReadGuard::new(block_index);
+
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let service_task = InnerCacheTask {
+            db: db.clone(),
+            block_tree_guard,
+            block_index_guard,
+            config,
+            gossip_broadcast: tokio::sync::mpsc::unbounded_channel().0,
+            ingress_proof_generation_state: IngressProofGenerationState::new(),
+            cache_sender: tx,
+        };
+
+        service_task.prune_ingress_proofs()?;
+
+        db.view(|rtx| -> eyre::Result<()> {
+            let remaining = irys_database::ingress_proofs_by_data_root(rtx, data_root)?;
+            assert_eq!(
+                remaining.len(),
+                1,
+                "only the sibling proof should survive; got {}",
+                remaining.len()
+            );
+            let addr = remaining[0].1.address;
+            assert_eq!(
+                addr, sibling_addr,
+                "surviving proof must be the sibling (valid anchor)"
+            );
+            assert_ne!(
+                addr, local_addr,
+                "local expired proof must have been deleted at capacity"
+            );
+            Ok(())
+        })??;
+
+        Ok(())
+    }
 }

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -801,8 +801,11 @@ impl InnerCacheTask {
         let mut walker = cursor.walk(None)?;
         // Carries the full proof content so the delete phase can compare before deleting
         // (closes the TOCTOU window: a fresh proof stored between the scan and the delete
-        // will not match the scanned content and will be preserved).
-        let mut to_delete: Vec<(DataRoot, CompactCachedIngressProof)> = Vec::new();
+        // will not match the scanned content and will be preserved). The bool flags an
+        // orphan deletion (no `CachedDataRoots` entry at scan time); for those the delete
+        // phase also re-checks the root is still absent, so a root re-cached between scan
+        // and delete keeps its proof.
+        let mut to_delete: Vec<(DataRoot, CompactCachedIngressProof, bool)> = Vec::new();
         let mut to_reanchor: Vec<IngressProof> = Vec::new();
         let mut to_regen: Vec<IngressProof> = Vec::new();
         let mut processed = 0_usize;
@@ -830,7 +833,7 @@ impl InnerCacheTask {
             // Associated txids
             let Some(cached_data_root) = cached_data_root_by_data_root(&tx, data_root)? else {
                 debug!(ingress_proof.data_root = ?data_root, "Proof has no cached data root; marking for deletion");
-                to_delete.push((data_root, compact));
+                to_delete.push((data_root, compact, true));
                 continue;
             };
 
@@ -858,7 +861,7 @@ impl InnerCacheTask {
 
             if at_capacity {
                 // Unpromoted + expired + at capacity: delete
-                to_delete.push((data_root, compact));
+                to_delete.push((data_root, compact, false));
                 debug!(ingress_proof.data_root = ?data_root, cache.at_capacity = true, "Marking expired proof for deletion (at capacity)");
             } else if is_locally_produced && any_unpromoted {
                 match check_result.regeneration_action {
@@ -879,7 +882,7 @@ impl InnerCacheTask {
                 }
             } else {
                 // Not local + expired: delete
-                to_delete.push((data_root, compact));
+                to_delete.push((data_root, compact, false));
                 debug!(ingress_proof.data_root = ?data_root, cache.at_capacity = false, "Marking expired proof for deletion (remote or fully-promoted)");
             }
         }
@@ -898,15 +901,21 @@ impl InnerCacheTask {
         // between the scan and this delete will not match the scanned value and is preserved.
         if !to_delete.is_empty() {
             let mut deleted_count = 0_usize;
-            for (root, scanned) in to_delete.iter() {
+            for (root, scanned, is_orphan) in to_delete.iter() {
                 match self.db.update_eyre(|rw_tx| {
+                    // Orphan deletions were scheduled because the data root had no
+                    // `CachedDataRoots` entry at scan time. Re-check inside the write tx:
+                    // if the root was re-cached since the scan, keep its proof.
+                    if *is_orphan && cached_data_root_by_data_root(rw_tx, *root)?.is_some() {
+                        return Ok(false);
+                    }
                     delete_ingress_proof_if_unchanged(rw_tx, *root, scanned.clone())
                 }) {
                     Ok(true) => deleted_count += 1,
                     Ok(false) => {
                         debug!(
                             ingress_proof.data_root = ?root,
-                            "Skipping stale delete: proof was refreshed since scan"
+                            "Skipping stale delete: proof was refreshed or data root re-cached since scan"
                         );
                     }
                     Err(e) => {

--- a/crates/actors/src/chunk_ingress_service/ingress_proofs.rs
+++ b/crates/actors/src/chunk_ingress_service/ingress_proofs.rs
@@ -5,12 +5,13 @@ use irys_database::reth_db::transaction::DbTx as _;
 use irys_database::{
     cached_data_root_by_data_root, db_cache::data_size_to_chunk_count, tables::CachedChunksIndex,
 };
-use irys_database::{delete_ingress_proof, store_ingress_proof};
+use irys_database::{delete_ingress_proof_by_signer, store_ingress_proof};
 use irys_domain::BlockTreeReadGuard;
 use irys_types::irys::IrysSigner;
 use irys_types::v2::GossipBroadcastMessageV2;
 use irys_types::{
-    BlockHash, Config, DataRoot, DatabaseProvider, H256, IngressProof, SendTraced as _, Traced,
+    BlockHash, Config, DataRoot, DatabaseProvider, H256, IngressProof, IrysAddress,
+    SendTraced as _, Traced,
 };
 use reth_db::DatabaseError;
 use tracing::{debug, error, warn};
@@ -183,13 +184,16 @@ impl ChunkIngressServiceInner {
         }
     }
 
-    pub(crate) fn remove_ingress_proof(
+    /// Removes only the ingress proof belonging to `address` for the given
+    /// `data_root`, leaving proofs from other signers intact.
+    pub(crate) fn remove_ingress_proof_by_signer(
         irys_db: &DatabaseProvider,
         data_root: DataRoot,
+        address: IrysAddress,
     ) -> Result<(), IngressProofError> {
         irys_db
             .update_scoped(|rw_tx| -> Result<(), DatabaseError> {
-                delete_ingress_proof(rw_tx, data_root)
+                delete_ingress_proof_by_signer(rw_tx, data_root, address)
                     .map_err(|report| DatabaseError::Other(report.to_string()))?;
                 Ok(())
             })

--- a/crates/actors/src/chunk_ingress_service/ingress_proofs.rs
+++ b/crates/actors/src/chunk_ingress_service/ingress_proofs.rs
@@ -2,16 +2,15 @@ use super::ChunkIngressServiceInner;
 use crate::cache_service::{CacheServiceAction, CacheServiceSender};
 use irys_database::db::{IrysDatabaseExt as _, IrysDupCursorExt as _};
 use irys_database::reth_db::transaction::DbTx as _;
+use irys_database::store_ingress_proof;
 use irys_database::{
     cached_data_root_by_data_root, db_cache::data_size_to_chunk_count, tables::CachedChunksIndex,
 };
-use irys_database::{delete_ingress_proof_by_signer, store_ingress_proof};
 use irys_domain::BlockTreeReadGuard;
 use irys_types::irys::IrysSigner;
 use irys_types::v2::GossipBroadcastMessageV2;
 use irys_types::{
-    BlockHash, Config, DataRoot, DatabaseProvider, H256, IngressProof, IrysAddress,
-    SendTraced as _, Traced,
+    BlockHash, Config, DataRoot, DatabaseProvider, H256, IngressProof, SendTraced as _, Traced,
 };
 use reth_db::DatabaseError;
 use tracing::{debug, error, warn};
@@ -182,25 +181,6 @@ impl ChunkIngressServiceInner {
         } else {
             Ok(())
         }
-    }
-
-    /// Removes only the ingress proof belonging to `address` for the given
-    /// `data_root`, leaving proofs from other signers intact.
-    pub(crate) fn remove_ingress_proof_by_signer(
-        irys_db: &DatabaseProvider,
-        data_root: DataRoot,
-        address: IrysAddress,
-    ) -> Result<(), IngressProofError> {
-        irys_db
-            .update_scoped(|rw_tx| -> Result<(), DatabaseError> {
-                delete_ingress_proof_by_signer(rw_tx, data_root, address)
-                    .map_err(|report| DatabaseError::Other(report.to_string()))?;
-                Ok(())
-            })
-            .map_err(|db_err| IngressProofError::DatabaseError(db_err.to_string()))?
-            .map_err(|db_err| IngressProofError::DatabaseError(db_err.to_string()))?;
-
-        Ok(())
     }
 
     pub(crate) fn is_ingress_proof_expired_static(

--- a/crates/actors/src/shadow_tx_generator.rs
+++ b/crates/actors/src/shadow_tx_generator.rs
@@ -246,15 +246,20 @@ impl<'a> ShadowTxGenerator<'a> {
     ) -> Result<Self> {
         // Defence-in-depth: no publish-ledger tx may also have a perm_fee
         // refund scheduled (promoted transactions must not receive refunds).
-        // The canonical check lives at the validation call site
-        // (`generate_expected_shadow_transactions` in `block_validation.rs`)
-        // so violations surface as `ValidationError::ShadowTransactionInvalid`
-        // (peer-attributable consensus rejection) rather than soft
-        // `ShadowTxNodeFault`. This in-constructor guard covers any
-        // other construction path (tests, future callers) so the invariant
-        // can't be silently bypassed. If this arm ever fires from production
-        // validation, the call-site check failed to run — fix the call site,
-        // don't relax this guard.
+        //
+        // The canonical validator check now lives at `generate_expected_shadow_transactions`
+        // in `block_validation.rs` (NC-0042 §4c). It rejects any publish-ledger tx
+        // whose Submit-ledger storage has expired as of the block, using the same
+        // expired-partition → tx set that schedules the refunds
+        // (`ledger_expiry::expired_submit_tx_ids`). That covers both the same-block
+        // (`==`) and cross-block (`<`) double-pay cases and subsumes this guard's
+        // `==`-only same-block detection. Violations there surface as
+        // `ValidationError::ShadowTransactionInvalid` (peer-attributable rejection).
+        //
+        // This in-constructor guard is defence-in-depth for non-validation
+        // construction paths (tests, future callers).  If it fires from a
+        // production validation path, the call-site check failed to run —
+        // fix the call site, don't relax this guard.
         for tx in &publish_ledger.txs {
             for (refund_tx_id, _, _) in &ledger_expiry_balance_delta.user_perm_fee_refunds {
                 if tx.id == *refund_tx_id {

--- a/crates/actors/src/shadow_tx_generator.rs
+++ b/crates/actors/src/shadow_tx_generator.rs
@@ -249,13 +249,18 @@ impl<'a> ShadowTxGenerator<'a> {
         //
         // The canonical validator check now lives at `generate_expected_shadow_transactions`
         // in `block_validation.rs` (NC-0042 §4c). It rejects any publish-ledger tx
-        // whose Submit-ledger storage has expired as of the block, using the same
-        // expired-partition → tx set that schedules the refunds (resolved
-        // per-candidate via `ledger_expiry::expired_submit_range` +
-        // `submit_tx_expired`). That covers both the same-block
-        // (`==`) and cross-block (`<`) double-pay cases and subsumes this guard's
-        // `==`-only same-block detection. Violations there surface as
-        // `ValidationError::ShadowTransactionInvalid` (peer-attributable rejection).
+        // whose Submit-ledger storage has expired as of the block, keyed on the
+        // *inclusive* all-expired Submit slot set (resolved per-candidate via
+        // `ledger_expiry::expired_submit_range` + `submit_tx_expired`). That set is a
+        // strict SUPERSET of the set the refund pipeline schedules — under Cascade the
+        // refund pipeline additionally drops slots written this epoch, which §4c still
+        // treats as expired. The containment is the load-bearing property: a refunded
+        // tx is always in this blocked set, so "refunded" ⇒ "non-promotable" and the
+        // double-pay cannot occur (the over-blocking is conservative and self-heals).
+        // The check covers both the same-block (`==`) and cross-block (`<`) double-pay
+        // cases and subsumes this guard's `==`-only same-block detection. Violations
+        // there surface as `ValidationError::ShadowTransactionInvalid`
+        // (peer-attributable rejection).
         //
         // This in-constructor guard is defence-in-depth for non-validation
         // construction paths (tests, future callers).  If it fires from a

--- a/crates/actors/src/shadow_tx_generator.rs
+++ b/crates/actors/src/shadow_tx_generator.rs
@@ -250,8 +250,9 @@ impl<'a> ShadowTxGenerator<'a> {
         // The canonical validator check now lives at `generate_expected_shadow_transactions`
         // in `block_validation.rs` (NC-0042 §4c). It rejects any publish-ledger tx
         // whose Submit-ledger storage has expired as of the block, using the same
-        // expired-partition → tx set that schedules the refunds
-        // (`ledger_expiry::expired_submit_tx_ids`). That covers both the same-block
+        // expired-partition → tx set that schedules the refunds (resolved
+        // per-candidate via `ledger_expiry::expired_submit_range` +
+        // `submit_tx_expired`). That covers both the same-block
         // (`==`) and cross-block (`<`) double-pay cases and subsumes this guard's
         // `==`-only same-block detection. Violations there surface as
         // `ValidationError::ShadowTransactionInvalid` (peer-attributable rejection).

--- a/crates/actors/src/tx_selector/mod.rs
+++ b/crates/actors/src/tx_selector/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod helpers;
 use crate::block_discovery::{TxLookupResult, get_data_tx_in_parallel_inner};
 use crate::block_validation::get_assigned_ingress_proofs;
 use crate::chunk_ingress_service::{ChunkIngressServiceInner, ChunkIngressState};
+use crate::mempool_guard::MempoolReadGuard;
 use crate::mempool_service::{AtomicMempoolState, MempoolTxs, validate_commitment_transaction};
 use crate::shadow_tx_generator::PublishLedgerWithTxs;
 use eyre::{OptionExt as _, eyre};
@@ -15,7 +16,7 @@ use irys_database::{
     tx_header_by_txid,
 };
 use irys_domain::{
-    BlockTreeEntry, BlockTreeReadGuard, CommitmentSnapshotStatus, EpochSnapshot,
+    BlockIndex, BlockTreeEntry, BlockTreeReadGuard, CommitmentSnapshotStatus, EpochSnapshot,
     HardforkConfigExt as _,
 };
 use irys_reth_node_bridge::IrysRethNodeAdapter;
@@ -77,13 +78,12 @@ pub struct TxSelectionContext<'a> {
     pub config: &'a Config,
     pub mempool_state: &'a AtomicMempoolState,
     pub chunk_ingress_state: &'a ChunkIngressState,
-    /// Submit-ledger tx ids whose storage has expired as of the block being
-    /// produced (NC-0042 §4b). Such txs are perm-fee-refunded by the expiry
-    /// pipeline and must not be promoted; `get_publish_txs_and_proofs` drops any
-    /// publish candidate in this set. Computed by the producer via
-    /// `ledger_expiry::expired_submit_tx_ids` from the same walk that schedules
-    /// the refunds, so the two cannot diverge. Empty for non-producer callers.
-    pub expired_submit_tx_ids: &'a std::collections::BTreeSet<H256>,
+    /// Canonical block index — the NC-0042 §4b publish-candidate filter uses it
+    /// to resolve each candidate's Submit inclusion block.
+    pub block_index: &'a BlockIndex,
+    /// Mempool guard — used by the §4b filter to read the inclusion block's
+    /// Submit-ledger tx headers (same lookup path as the expiry walk).
+    pub mempool_guard: &'a MempoolReadGuard,
 }
 
 /// Main entry point: selects the best transactions from the mempool for block production.
@@ -776,6 +776,13 @@ async fn get_publish_txs_and_proofs(
     let mut publish_proofs: Vec<IngressProof> = Vec::new();
     // IMPORTANT: must be valid for THE HEIGHT WE ARE ABOUT TO PRODUCE
     let next_block_height = current_height + 1;
+    // Parent of the block we're producing (`select_best_txs` truncates the
+    // canonical chain at the parent, so it is the last entry). Bounds the §4b
+    // expiry check to data as of the parent rather than this node's moving tip.
+    let parent_block_header = canonical
+        .last()
+        .ok_or_eyre("canonical chain must contain the parent block")?
+        .header();
 
     // only max anchor age is constrained for ingress proofs
     let min_ingress_proof_anchor_height = next_block_height.saturating_sub(
@@ -890,6 +897,18 @@ async fn get_publish_txs_and_proofs(
             acc
         });
 
+        // NC-0042 §4b: the expired-Submit range is the same for every candidate,
+        // so compute it once here and reuse it per-candidate via `submit_tx_expired`
+        // (which then costs at most one canonical Submit-height read each). `None`
+        // means nothing has expired as of this block → no candidate is filtered.
+        let expired_submit_range = crate::block_producer::ledger_expiry::expired_submit_range(
+            next_block_height,
+            epoch_snapshot,
+            parent_block_header,
+            ctx.config,
+            ctx.block_index,
+        )?;
+
         for tx_header in &tx_headers {
             debug!(
                 "Processing publish candidate tx {} {:#?}",
@@ -912,14 +931,19 @@ async fn get_publish_txs_and_proofs(
             // ledgers (OneYear / ThirtyDay) reject `ledger_id == Publish` at
             // structural validation, so a `Some` from the canonical DB index
             // is sufficient evidence of prior Submit.
-            if !submit_txs_from_canonical.contains(&tx_header.id) {
+            //
+            // Capture the resolved height (DB-fallback path only) so the §4b
+            // expiry check below can reuse it instead of looking it up again.
+            // Live-tree candidates hit the HashSet — their height is resolved
+            // lazily inside `submit_tx_expired` (a recent tx can't have expired).
+            let submit_height: Option<u64> = if submit_txs_from_canonical.contains(&tx_header.id) {
+                None
+            } else {
                 match ctx
                     .db
                     .view_eyre(|tx| canonical_submit_height(tx, &tx_header.id, current_height))
                 {
-                    Ok(Some(_)) => {
-                        // canonical Submit inclusion past the live-tree window
-                    }
+                    Ok(Some(h)) => Some(h),
                     Ok(None) => {
                         warn!(
                             tx.id = ?tx_header.id,
@@ -946,17 +970,28 @@ async fn get_publish_txs_and_proofs(
                         continue;
                     }
                 }
-            }
+            };
 
             // NC-0042 §4b: drop publish candidates whose Submit-ledger storage has
-            // expired as of the block we're producing. `ctx.expired_submit_tx_ids`
-            // is computed by the producer from the *same* expired-partition → block
-            // → tx walk that schedules `user_perm_fee_refunds` (Pipeline B,
-            // `ledger_expiry::expired_submit_tx_ids`), so "is this tx refunded?" and
-            // "may this tx be promoted?" cannot diverge. A tx in this set is (or
-            // will be, at the next epoch) perm-fee-refunded; promoting it would be a
+            // expired as of the block we're producing. `submit_tx_expired` is the
+            // per-candidate form of the expired-tx set that the refund pipeline
+            // (Pipeline B) acts on, so "is this tx refunded?" and "may this tx be
+            // promoted?" cannot diverge. A tx that is expired here is (or will be,
+            // at the next epoch) perm-fee-refunded; promoting it would be a
             // same-block or cross-block double-pay.
-            if ctx.expired_submit_tx_ids.contains(&tx_header.id) {
+            if let Some(range) = &expired_submit_range
+                && crate::block_producer::ledger_expiry::submit_tx_expired(
+                    tx_header.id,
+                    submit_height,
+                    range,
+                    ctx.config,
+                    ctx.block_index,
+                    ctx.block_tree,
+                    ctx.mempool_guard,
+                    ctx.db,
+                )
+                .await?
+            {
                 warn!(
                     tx.id = ?tx_header.id,
                     tx.data_root = ?tx_header.data_root,

--- a/crates/actors/src/tx_selector/mod.rs
+++ b/crates/actors/src/tx_selector/mod.rs
@@ -906,7 +906,6 @@ async fn get_publish_txs_and_proofs(
             epoch_snapshot,
             parent_block_header,
             ctx.config,
-            ctx.block_index,
         )?;
 
         for tx_header in &tx_headers {
@@ -932,18 +931,16 @@ async fn get_publish_txs_and_proofs(
             // structural validation, so a `Some` from the canonical DB index
             // is sufficient evidence of prior Submit.
             //
-            // Capture the resolved height (DB-fallback path only) so the §4b
-            // expiry check below can reuse it instead of looking it up again.
-            // Live-tree candidates hit the HashSet — their height is resolved
-            // lazily inside `submit_tx_expired` (a recent tx can't have expired).
-            let submit_height: Option<u64> = if submit_txs_from_canonical.contains(&tx_header.id) {
-                None
-            } else {
+            // Prior-Submit gate: live-tree candidates are in the canonical fold;
+            // others must have a canonical (migrated) Submit inclusion. The §4b
+            // expiry check below resolves the inclusion itself (branch-correct),
+            // so we only need the gate's continue-on-missing side effect here.
+            if !submit_txs_from_canonical.contains(&tx_header.id) {
                 match ctx
                     .db
                     .view_eyre(|tx| canonical_submit_height(tx, &tx_header.id, current_height))
                 {
-                    Ok(Some(h)) => Some(h),
+                    Ok(Some(_)) => {}
                     Ok(None) => {
                         warn!(
                             tx.id = ?tx_header.id,
@@ -970,7 +967,7 @@ async fn get_publish_txs_and_proofs(
                         continue;
                     }
                 }
-            };
+            }
 
             // NC-0042 §4b: drop publish candidates whose Submit-ledger storage has
             // expired as of the block we're producing. `submit_tx_expired` is the
@@ -982,7 +979,6 @@ async fn get_publish_txs_and_proofs(
             if let Some(range) = &expired_submit_range
                 && crate::block_producer::ledger_expiry::submit_tx_expired(
                     tx_header.id,
-                    submit_height,
                     range,
                     ctx.config,
                     ctx.block_index,

--- a/crates/actors/src/tx_selector/mod.rs
+++ b/crates/actors/src/tx_selector/mod.rs
@@ -77,6 +77,13 @@ pub struct TxSelectionContext<'a> {
     pub config: &'a Config,
     pub mempool_state: &'a AtomicMempoolState,
     pub chunk_ingress_state: &'a ChunkIngressState,
+    /// Submit-ledger tx ids whose storage has expired as of the block being
+    /// produced (NC-0042 §4b). Such txs are perm-fee-refunded by the expiry
+    /// pipeline and must not be promoted; `get_publish_txs_and_proofs` drops any
+    /// publish candidate in this set. Computed by the producer via
+    /// `ledger_expiry::expired_submit_tx_ids` from the same walk that schedules
+    /// the refunds, so the two cannot diverge. Empty for non-producer callers.
+    pub expired_submit_tx_ids: &'a std::collections::BTreeSet<H256>,
 }
 
 /// Main entry point: selects the best transactions from the mempool for block production.
@@ -875,10 +882,9 @@ async fn get_publish_txs_and_proofs(
         // `Validated` entry can leak its Submit tx_ids here, making the
         // fast-path say "already submitted" for a tx whose Submit inclusion is
         // about to be rolled back. The producer then skips the DB fallback
-        // (line ~893) and includes the tx as a publish candidate; peer
-        // validators catch any genuine double-publish via Vector B's
-        // canonical-DB check, so the worst case is a rejected block (no
-        // consensus impact, producer pays the cost).
+        // and includes the tx as a publish candidate; peer validators catch any
+        // genuine double-publish via Vector B's canonical-DB check, so the worst
+        // case is a rejected block (no consensus impact, producer pays the cost).
         let submit_txs_from_canonical = canonical.iter().fold(HashSet::new(), |mut acc, v| {
             acc.extend(v.header().data_ledgers[DataLedger::Submit].tx_ids.0.clone());
             acc
@@ -940,6 +946,24 @@ async fn get_publish_txs_and_proofs(
                         continue;
                     }
                 }
+            }
+
+            // NC-0042 §4b: drop publish candidates whose Submit-ledger storage has
+            // expired as of the block we're producing. `ctx.expired_submit_tx_ids`
+            // is computed by the producer from the *same* expired-partition → block
+            // → tx walk that schedules `user_perm_fee_refunds` (Pipeline B,
+            // `ledger_expiry::expired_submit_tx_ids`), so "is this tx refunded?" and
+            // "may this tx be promoted?" cannot diverge. A tx in this set is (or
+            // will be, at the next epoch) perm-fee-refunded; promoting it would be a
+            // same-block or cross-block double-pay.
+            if ctx.expired_submit_tx_ids.contains(&tx_header.id) {
+                warn!(
+                    tx.id = ?tx_header.id,
+                    tx.data_root = ?tx_header.data_root,
+                    next_block_height,
+                    "Submit-ledger storage expired; tx is non-promotable (would conflict with perm_fee refund) — see NC-0042",
+                );
+                continue;
             }
 
             // If it's not promoted, validate the proofs

--- a/crates/actors/src/tx_selector/mod.rs
+++ b/crates/actors/src/tx_selector/mod.rs
@@ -901,11 +901,17 @@ async fn get_publish_txs_and_proofs(
         // so compute it once here and reuse it per-candidate via `submit_tx_expired`
         // (which then costs at most one canonical Submit-height read each). `None`
         // means nothing has expired as of this block → no candidate is filtered.
+        let cascade_active_for_block = ctx
+            .config
+            .consensus
+            .hardforks
+            .is_cascade_active_at(current_timestamp);
         let expired_submit_range = crate::block_producer::ledger_expiry::expired_submit_range(
             next_block_height,
             epoch_snapshot,
             parent_block_header,
             ctx.config,
+            cascade_active_for_block,
         )?;
 
         for tx_header in &tx_headers {

--- a/crates/actors/src/tx_selector/mod.rs
+++ b/crates/actors/src/tx_selector/mod.rs
@@ -571,8 +571,13 @@ pub async fn select_best_txs(
                     continue;
                 }
 
-                // Term-only ledgers must not carry a perm_fee
-                if tx.perm_fee.is_some_and(|f| f > BoundedFee::zero()) {
+                // Term-only ledgers must not carry a perm_fee AT ALL. The validator
+                // (`block_validation` term-ledger prevalidation) and mempool ingress
+                // (`data_txs.rs`) both reject any `perm_fee.is_some()`, so a `Some(0)`
+                // accepted here would make the producer build a block every peer
+                // rejects (producer-more-permissive-than-validator). Match `is_some()`
+                // so the producer can never select such a tx. (NC-0042)
+                if tx.perm_fee.is_some() {
                     debug!(
                         tx.id = ?tx.id,
                         tx.ledger = ?ledger,

--- a/crates/chain-tests/src/multi_node/api_ingress_validation.rs
+++ b/crates/chain-tests/src/multi_node/api_ingress_validation.rs
@@ -544,6 +544,37 @@ async fn heavy_cascade_mempool_ingress_boundary_for_term_ledgers() -> eyre::Resu
         ),
     }
 
+    // Post-Cascade: OneYear with perm_fee = Some(0) must ALSO be rejected at ingress
+    // (NC-0042 M2). The ingress guard is `perm_fee.is_some()`, so a zero perm_fee is
+    // rejected here and can never reach the producer's tx selector — closing the
+    // producer-more-permissive-than-validator gap where the selector formerly only
+    // skipped `perm_fee > 0`.
+    let one_year_zero_perm_tx = signer.create_transaction_with_fees(
+        data.clone(),
+        ctx.get_anchor().await?,
+        DataLedger::OneYear,
+        one_year_price.term_fee.into(),
+        Some(BoundedFee::zero()),
+    )?;
+    let one_year_zero_perm_tx = signer.sign_transaction(one_year_zero_perm_tx)?;
+    match ctx
+        .ingest_data_tx(one_year_zero_perm_tx.header.clone())
+        .await
+    {
+        Err(AddTxError::TxIngress(TxIngressError::FundMisalignment(msg))) => {
+            assert!(
+                msg.contains("must not have a perm_fee"),
+                "Expected perm_fee rejection message for perm_fee=Some(0), got: {}",
+                msg
+            );
+        }
+        Ok(_) => panic!("Expected OneYear tx with perm_fee=Some(0) to be rejected"),
+        Err(e) => panic!(
+            "Expected FundMisalignment for OneYear tx with perm_fee=Some(0), got: {:?}",
+            e
+        ),
+    }
+
     // Post-Cascade: OneYear with insufficient term_fee should fail
     assert!(
         one_year_price.term_fee > irys_types::U256::from(0),

--- a/crates/chain-tests/src/promotion/stale_txid_in_cached_data_root.rs
+++ b/crates/chain-tests/src/promotion/stale_txid_in_cached_data_root.rs
@@ -137,6 +137,11 @@ async fn stale_txid_in_cached_data_root_blocks_block_production() -> eyre::Resul
     let config = genesis_node.node_ctx.config.clone();
     let mempool_guard = genesis_node.node_ctx.mempool_guard.clone();
     let chunk_ingress_state = genesis_node.node_ctx.chunk_ingress_state.clone();
+    let block_index = genesis_node
+        .node_ctx
+        .block_producer_inner
+        .block_index
+        .clone();
     let parent_hash = parent.block_hash;
     let parent_timestamp = {
         let tree = block_tree.read();
@@ -148,7 +153,6 @@ async fn stale_txid_in_cached_data_root_blocks_block_production() -> eyre::Resul
     let result = tokio::task::spawn(async move {
         // This test exercises stale-txid handling in the publish-candidate path,
         // not Submit-ledger expiry, so no tx is expired here.
-        let expired_submit_tx_ids = std::collections::BTreeSet::new();
         let ctx = irys_actors::tx_selector::TxSelectionContext {
             block_tree: &block_tree,
             db: &db,
@@ -156,7 +160,8 @@ async fn stale_txid_in_cached_data_root_blocks_block_production() -> eyre::Resul
             config: &config,
             mempool_state: mempool_guard.atomic_state(),
             chunk_ingress_state: &chunk_ingress_state,
-            expired_submit_tx_ids: &expired_submit_tx_ids,
+            block_index: &block_index,
+            mempool_guard: &mempool_guard,
         };
         irys_actors::tx_selector::select_best_txs(
             parent_hash,

--- a/crates/chain-tests/src/promotion/stale_txid_in_cached_data_root.rs
+++ b/crates/chain-tests/src/promotion/stale_txid_in_cached_data_root.rs
@@ -146,6 +146,9 @@ async fn stale_txid_in_cached_data_root_blocks_block_production() -> eyre::Resul
     };
 
     let result = tokio::task::spawn(async move {
+        // This test exercises stale-txid handling in the publish-candidate path,
+        // not Submit-ledger expiry, so no tx is expired here.
+        let expired_submit_tx_ids = std::collections::BTreeSet::new();
         let ctx = irys_actors::tx_selector::TxSelectionContext {
             block_tree: &block_tree,
             db: &db,
@@ -153,6 +156,7 @@ async fn stale_txid_in_cached_data_root_blocks_block_production() -> eyre::Resul
             config: &config,
             mempool_state: mempool_guard.atomic_state(),
             chunk_ingress_state: &chunk_ingress_state,
+            expired_submit_tx_ids: &expired_submit_tx_ids,
         };
         irys_actors::tx_selector::select_best_txs(
             parent_hash,

--- a/crates/chain-tests/src/term_ledger_expiry/mod.rs
+++ b/crates/chain-tests/src/term_ledger_expiry/mod.rs
@@ -1,4 +1,5 @@
 mod perm_refund;
+mod perm_refund_multi_miner;
 
 use crate::utils::IrysNodeTest;
 use alloy_core::primitives::B256;

--- a/crates/chain-tests/src/term_ledger_expiry/mod.rs
+++ b/crates/chain-tests/src/term_ledger_expiry/mod.rs
@@ -102,9 +102,9 @@ async fn heavy_ledger_expiry_multiple_txs_per_block() -> eyre::Result<()> {
         txs_per_block: 2,
         data_size_per_tx: 32, // 1 chunk per tx
         // Two Submit slots expire (slot 0 = chunks [0,5) = tx0-4, slot 1 = [5,10)
-        // = tx5,tx6) → all 7 txs, each once. (Was 5: the pre-fix walk truncated the
-        // expired range at the migration-lagged block-index tip, silently dropping
-        // slot 1's not-yet-migrated tail txs — the NC-0042 R1 determinism bug.)
+        // = tx5,tx6) → all 7 txs, each once: the walk must include slot 1's
+        // not-yet-migrated tail txs rather than truncating at the migration-lagged
+        // block-index tip (NC-0042 R1).
         expected_expired_tx_count: 7,
     })
     .await
@@ -191,9 +191,8 @@ async fn heavy_ledger_expiry_multiple_partitions_expire() -> eyre::Result<()> {
         data_size_per_tx: 64, // 2 chunks per tx to span boundaries
         // Slots 0,1,2 expire (chunk range [0,9)). By the "owned by the partition
         // its start offset falls in" rule, that's tx0-4 (starts 0,2,4,6,8 < 9) —
-        // 5 txs, each once. (Was 6: the pre-fix walk double-counted boundary-block
-        // txs across per-slot events, which equal fees made indistinguishable from
-        // 6 unique txs — see NC-0042 refund-pipeline fix.)
+        // 5 txs, each once — boundary-block txs are attributed to a single slot
+        // by start offset, not double-counted across per-slot events (NC-0042).
         expected_expired_tx_count: 5,
     })
     .await

--- a/crates/chain-tests/src/term_ledger_expiry/mod.rs
+++ b/crates/chain-tests/src/term_ledger_expiry/mod.rs
@@ -99,8 +99,12 @@ async fn heavy_ledger_expiry_multiple_txs_per_block() -> eyre::Result<()> {
         num_blocks_in_epoch: 3,
         num_transactions: 7,
         txs_per_block: 2,
-        data_size_per_tx: 32,         // 1 chunk per tx
-        expected_expired_tx_count: 5, // first slot expires
+        data_size_per_tx: 32, // 1 chunk per tx
+        // Two Submit slots expire (slot 0 = chunks [0,5) = tx0-4, slot 1 = [5,10)
+        // = tx5,tx6) → all 7 txs, each once. (Was 5: the pre-fix walk truncated the
+        // expired range at the migration-lagged block-index tip, silently dropping
+        // slot 1's not-yet-migrated tail txs — the NC-0042 R1 determinism bug.)
+        expected_expired_tx_count: 7,
     })
     .await
 }
@@ -183,8 +187,13 @@ async fn heavy_ledger_expiry_multiple_partitions_expire() -> eyre::Result<()> {
         num_blocks_in_epoch: 3,        // Changed to 3 blocks per epoch
         num_transactions: 10,          // 10 txs that span boundaries
         txs_per_block: 4,
-        data_size_per_tx: 64,         // 2 chunks per tx to span boundaries
-        expected_expired_tx_count: 6, // First 6 txs expire (slots 0-2)
+        data_size_per_tx: 64, // 2 chunks per tx to span boundaries
+        // Slots 0,1,2 expire (chunk range [0,9)). By the "owned by the partition
+        // its start offset falls in" rule, that's tx0-4 (starts 0,2,4,6,8 < 9) —
+        // 5 txs, each once. (Was 6: the pre-fix walk double-counted boundary-block
+        // txs across per-slot events, which equal fees made indistinguishable from
+        // 6 unique txs — see NC-0042 refund-pipeline fix.)
+        expected_expired_tx_count: 5,
     })
     .await
 }

--- a/crates/chain-tests/src/term_ledger_expiry/perm_refund.rs
+++ b/crates/chain-tests/src/term_ledger_expiry/perm_refund.rs
@@ -83,7 +83,7 @@ async fn heavy_perm_fee_refund_for_unpromoted_tx() -> eyre::Result<()> {
         block1
             .get_data_ledger_tx_ids()
             .get(&DataLedger::Submit)
-            .is_some_and(|s| s.contains(&tx1.header.id)),
+            .is_some_and(|s| s.len() == 1 && s[0] == tx1.header.id),
         "tx1 (unpromoted) should be alone in slot 0 at block 1"
     );
 

--- a/crates/chain-tests/src/term_ledger_expiry/perm_refund.rs
+++ b/crates/chain-tests/src/term_ledger_expiry/perm_refund.rs
@@ -56,10 +56,19 @@ async fn heavy_perm_fee_refund_for_unpromoted_tx() -> eyre::Result<()> {
     let anchor = node.get_block_by_height(0).await?.block_hash;
 
     // ==================== ACTION ====================
-    // Post two transactions with permanent fees
     info!("Posting transactions from both users");
 
-    // User1: Transaction that will NOT be promoted (no chunks uploaded)
+    // User1: an UNPROMOTED tx. Mine it ALONE first so it deterministically owns the
+    // lowest chunk offsets (slot 0 — the slot this test expires).
+    //
+    // Why this matters: a block's on-chain tx order is set by `compare_tx`, NOT post
+    // order, so co-locating both txs in one block left which one landed in slot 0 to
+    // chance. The per-tx expiry refund attributes a tx to the partition its START
+    // offset falls in (see the ledger_expiry module doc), so if the *promoted* tx had
+    // sorted into slot 0, the unpromoted tx would sit in a non-expiring slot and get
+    // no refund. The earlier over-inclusive refund walk swept the whole boundary block
+    // and masked this; the NC-0042 fix makes attribution exact, so placement must be
+    // deterministic.
     let tx1 = node
         .post_data_tx(anchor, vec![1_u8; DATA_SIZE], &user1_signer)
         .await;
@@ -69,8 +78,16 @@ async fn heavy_perm_fee_refund_for_unpromoted_tx() -> eyre::Result<()> {
         .expect("Transaction should have perm_fee");
     node.wait_for_mempool(tx1.header.id, 10).await?;
     debug!("tx1: id={}, perm_fee={}", tx1.header.id, tx1_perm_fee);
+    let block1 = node.mine_block().await?;
+    assert!(
+        block1
+            .get_data_ledger_tx_ids()
+            .get(&DataLedger::Submit)
+            .is_some_and(|s| s.contains(&tx1.header.id)),
+        "tx1 (unpromoted) should be alone in slot 0 at block 1"
+    );
 
-    // User2: Transaction that WILL be promoted (chunks uploaded)
+    // User2: a tx that WILL be promoted, mined in the next block (higher slots).
     let tx2 = node
         .post_data_tx(anchor, vec![2_u8; DATA_SIZE], &user2_signer)
         .await;
@@ -80,18 +97,7 @@ async fn heavy_perm_fee_refund_for_unpromoted_tx() -> eyre::Result<()> {
         .expect("Transaction should have perm_fee");
     node.wait_for_mempool(tx2.header.id, 10).await?;
     debug!("tx2: id={}, perm_fee={}", tx2.header.id, tx2_perm_fee);
-
-    // Mine block to include both transactions in Submit ledger
-    info!("Mining block to include transactions");
-    let block1 = node.mine_block().await?;
-    let tx_ids = block1.get_data_ledger_tx_ids();
-    let submit_txs = tx_ids
-        .get(&DataLedger::Submit)
-        .expect("Submit ledger should have transactions");
-    assert!(
-        submit_txs.contains(&tx1.header.id) && submit_txs.contains(&tx2.header.id),
-        "Both transactions should be in Submit ledger"
-    );
+    node.mine_block().await?;
 
     // Upload chunks for tx2 to trigger promotion
     info!("Promoting tx2 by uploading chunks");

--- a/crates/chain-tests/src/term_ledger_expiry/perm_refund.rs
+++ b/crates/chain-tests/src/term_ledger_expiry/perm_refund.rs
@@ -97,7 +97,19 @@ async fn heavy_perm_fee_refund_for_unpromoted_tx() -> eyre::Result<()> {
         .expect("Transaction should have perm_fee");
     node.wait_for_mempool(tx2.header.id, 10).await?;
     debug!("tx2: id={}, perm_fee={}", tx2.header.id, tx2_perm_fee);
-    node.mine_block().await?;
+    let block2 = node.mine_block().await?;
+
+    // tx2 must be in the second Submit block so it occupies a higher slot than tx1
+    // (confirmed-alone-in-slot-1). This is load-bearing: the per-tx expiry
+    // attribution keys on start-offset slot, so a mis-placed tx2 would make the
+    // wrong tx expire and silently invert the refund expectations.
+    assert!(
+        block2
+            .get_data_ledger_tx_ids()
+            .get(&DataLedger::Submit)
+            .is_some_and(|ids| ids.contains(&tx2.header.id)),
+        "tx2 (to-be-promoted) must appear in the second Submit block"
+    );
 
     // Upload chunks for tx2 to trigger promotion
     info!("Promoting tx2 by uploading chunks");

--- a/crates/chain-tests/src/term_ledger_expiry/perm_refund_multi_miner.rs
+++ b/crates/chain-tests/src/term_ledger_expiry/perm_refund_multi_miner.rs
@@ -179,7 +179,7 @@ async fn slow_heavy_per_miner_expiry_reward_attribution_two_miners() -> eyre::Re
     while posted < PEER_PLEDGE_COUNT {
         let batch = PLEDGE_BATCH.min(PEER_PLEDGE_COUNT - posted);
         for _ in 0..batch {
-            node.post_pledge_commitment_with_signer(&peer_signer).await;
+            let _pledge = node.post_pledge_commitment_with_signer(&peer_signer).await;
         }
         posted += batch;
         node.mine_block().await?;

--- a/crates/chain-tests/src/term_ledger_expiry/perm_refund_multi_miner.rs
+++ b/crates/chain-tests/src/term_ledger_expiry/perm_refund_multi_miner.rs
@@ -1,0 +1,371 @@
+//! NC-0042 R4 produced-block coverage: per-miner expiry-reward AMOUNT attribution
+//! across TWO DISTINCT miners settled in ONE boundary block.
+//!
+//! ## The gap this closes
+//!
+//! When two DISTINCT miners each own a different expired Submit slot that settle
+//! in the same boundary block, each miner's `TermFeeReward` must be exactly its
+//! own slot's treasury slice — never cross-credited to the other miner. Before
+//! this test that invariant was verified ONLY by in-memory unit tests
+//! (`aggregate_attributes_each_slots_fee_to_its_own_miner` and
+//! `collect_attributes_each_tx_to_its_start_offset_slot_miners` in
+//! `crates/actors/src/block_producer/ledger_expiry.rs`). No PRODUCED-block test
+//! decoded the on-chain reward shadow-txs and checked each of two distinct miners
+//! gets exactly its slice — the existing produced-block refund test
+//! (`term_ledger_expiry/perm_refund.rs`) is single-miner (genesis mines every
+//! partition). This test exercises the full produce → encode → decode path with
+//! two distinct miners owning two distinct expired Submit slots.
+//!
+//! ## Why the assignment is OBSERVED, not hardcoded
+//!
+//! Submit-slot → miner assignment runs through `process_slot_needs`
+//! (`epoch_snapshot.rs`): each newly-allocated slot draws a capacity partition
+//! (hence its owning miner) from a `SimpleRNG` seeded on the epoch block's
+//! `last_epoch_hash` — a live block hash (VDF/solution/timestamp dependent) that
+//! a test cannot fix. With `num_partitions_per_slot = 1` the per-slot
+//! no-duplicate-miner rule never constrains assignment ACROSS slots, so which
+//! specific miner owns slot k is genuinely non-deterministic per run. Therefore
+//! this test does NOT hardcode "miner A owns slot k"; it READS the actual owner of
+//! each recycled Submit slot from the expiry block's epoch snapshot
+//! (`expired_partition_infos`, which pairs each recycled partition_hash with its
+//! slot_index) and asserts each observed owner's on-chain reward equals exactly the
+//! treasury slices of the txs in the slots that owner holds.
+//!
+//! ## How ≥2 distinct miners is made reliable (not flaky)
+//!
+//! Two ingredients keep the two-miner property exercised on essentially every run:
+//! 1. The genesis miner deterministically owns Submit slot 0 (its pre-existing
+//!    bootstrap partition), which the first data tx fills.
+//! 2. Cascade is activated from genesis so the Submit-ledger last-write "touch"
+//!    runs: every slot WRITTEN in the fill epoch (slot 0 included) has its
+//!    `last_height` refreshed to that epoch, so ALL the data slots — genesis's slot
+//!    0 and the heavily-pledged peer's later slots — expire TOGETHER in one
+//!    boundary block. Without the touch, slot 0 keeps its genesis allocation height
+//!    and recycles at an earlier boundary than the later-written slots, splitting
+//!    the settlement across blocks.
+//! The peer is given many pledges so it wins the non-zero slots. The test still
+//! FAILS LOUD (does not pass vacuously) if the random assignment ever collapses
+//! every recycled slot onto a single miner.
+//!
+//! ## Residual gap
+//!
+//! A bit-exact deterministic "miner A owns slot 0, miner B owns slot 1" mapping is
+//! impossible without making the consensus RNG seed injectable in test builds (a
+//! consensus-path / system-contract change, deliberately not done here). This test
+//! instead proves the on-chain AMOUNTS are correctly partitioned among whatever
+//! distinct miners the protocol assigned — which is exactly the cross-crediting
+//! property under test.
+
+use crate::utils::IrysNodeTest;
+use alloy_genesis::GenesisAccount;
+use irys_config::submodules::StorageSubmodulesConfig;
+use irys_reth_node_bridge::irys_reth::shadow_tx::{ShadowTransaction, TransactionPacket};
+use irys_types::{
+    DataLedger, IrysAddress, NodeConfig, U256, UnixTimestamp, fee_distribution::TermFeeCharges,
+    hardfork_config::Cascade, irys::IrysSigner,
+};
+use reth::rpc::types::TransactionTrait as _;
+use std::collections::BTreeMap;
+use tracing::info;
+
+#[test_log::test(tokio::test)]
+async fn slow_heavy_per_miner_expiry_reward_attribution_two_miners() -> eyre::Result<()> {
+    // ==================== CONFIG ====================
+    const CHUNK_SIZE: u64 = 32;
+    const NUM_CHUNKS_IN_PARTITION: u64 = 5; // 1 partition = 1 slot = 160 bytes
+    const SUBMIT_LEDGER_EPOCH_LENGTH: u64 = 1; // expires after 1 epoch
+    // Large enough that all NUM_SLOTS data txs (one alone per block) fit inside a
+    // SINGLE epoch, so every data slot is allocated at the same epoch boundary and
+    // therefore expires together in one boundary block.
+    const BLOCKS_PER_EPOCH: u64 = 8;
+    // One tx fills exactly one partition → one Submit slot. Each tx, mined alone,
+    // deterministically occupies the next slot by start offset (tx k → slot k). The
+    // LAST slot never expires (protocol rule), so to get several EXPIRING slots
+    // split across two miners we create a handful of slots and only assert over the
+    // ones that actually recycle.
+    const PARTITION_BYTES: usize = (CHUNK_SIZE * NUM_CHUNKS_IN_PARTITION) as usize;
+    const NUM_SLOTS: usize = 5;
+    // A generous peer pledge count makes it overwhelmingly likely the
+    // randomly-seeded slot assignment hands at least one of the new slots (1, 2) to
+    // the peer rather than the genesis miner: with the genesis miner holding only a
+    // small spare-capacity pool, P(every new slot lands on genesis) shrinks roughly
+    // like (genesis_spare / (genesis_spare + N))^(new slots). The peer is never
+    // started as a node, so its pledges add no packing cost here — they only
+    // populate the genesis node's epoch commitment state.
+    const PEER_PLEDGE_COUNT: usize = 16;
+    // Pledges queue behind the stake until it is mined and must not overflow the
+    // mempool's pending-pledge buffer; drain by mining after each batch.
+    const PLEDGE_BATCH: usize = 4;
+    // The peer must afford one stake (20_000 IRYS) plus PEER_PLEDGE_COUNT pledges
+    // (~950 IRYS each). The data-posting user only needs enough for a few data
+    // txs. Fund both generously.
+    const USER_BALANCE: u128 = 1_000_000_000_000_000_000_000; // 1_000 IRYS
+    const PEER_BALANCE: u128 = 1_000_000_000_000_000_000_000_000; // 1_000_000 IRYS
+
+    let mut config = NodeConfig::testing();
+    config.consensus.get_mut().block_migration_depth = 1;
+    config.consensus.get_mut().num_chunks_in_recall_range = 1;
+    config.consensus.get_mut().chunk_size = CHUNK_SIZE;
+    config.consensus.get_mut().num_chunks_in_partition = NUM_CHUNKS_IN_PARTITION;
+    config.consensus.get_mut().epoch.submit_ledger_epoch_length = SUBMIT_LEDGER_EPOCH_LENGTH;
+    config.consensus.get_mut().epoch.num_blocks_in_epoch = BLOCKS_PER_EPOCH;
+    // Activate Cascade from genesis so the Submit-ledger last-write "touch" runs:
+    // every slot WRITTEN in the data epoch (including the genesis-owned slot 0) gets
+    // its `last_height` refreshed to that epoch, so all the data slots expire
+    // TOGETHER in one boundary block. Without the touch, slot 0 keeps its genesis
+    // allocation height (0) and expires at an earlier boundary than the
+    // later-written slots, splitting the settlement across multiple blocks.
+    config.consensus.get_mut().hardforks.cascade = Some(Cascade {
+        activation_timestamp: UnixTimestamp::from_secs(0),
+        one_year_epoch_length: 1000,
+        thirty_day_epoch_length: 1000,
+        annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
+    });
+
+    let consensus_config = config.consensus_config();
+
+    // The data poster (a regular user) and the peer miner's signer. The peer's
+    // signer must be funded at genesis so its stake + pledge commitments are
+    // affordable.
+    let user_signer = IrysSigner::random_signer(&consensus_config);
+    let peer_signer = IrysSigner::random_signer(&consensus_config);
+    config.consensus.extend_genesis_accounts(vec![
+        (
+            user_signer.address(),
+            GenesisAccount {
+                balance: U256::from(USER_BALANCE).into(),
+                ..Default::default()
+            },
+        ),
+        (
+            peer_signer.address(),
+            GenesisAccount {
+                balance: U256::from(PEER_BALANCE).into(),
+                ..Default::default()
+            },
+        ),
+    ]);
+
+    // ==================== START GENESIS + PEER ====================
+    // Cascade adds OneYear/ThirtyDay ledgers; pre-configure extra storage submodules
+    // so there are enough partitions for all four data ledgers.
+    let test_node = IrysNodeTest::new_genesis(config.clone());
+    StorageSubmodulesConfig::load_for_test(test_node.cfg.base_directory.clone(), 5)?;
+    let node = test_node
+        .start_and_wait_for_packing("perm_refund_two_miners", 30)
+        .await;
+    let genesis_address = node.node_ctx.config.node_config.miner_address();
+    let peer_address = peer_signer.address();
+    assert_ne!(
+        genesis_address, peer_address,
+        "genesis and peer must be distinct miners"
+    );
+
+    // Stake + pledge the peer (commitments posted to the genesis node; the genesis
+    // node is the only mining node — the peer just needs partition assignments so
+    // the epoch can hand it Submit slots). Many pledges make peer-ownership of a
+    // new slot overwhelmingly likely. Stake first and mine it in, then post pledges
+    // in batches mining between them so the mempool's pending-pledge buffer never
+    // overflows (a flood of un-mined pledges returns 503 MempoolFull).
+    node.post_stake_commitment_with_signer(&peer_signer).await?;
+    node.mine_block().await?;
+    let mut posted = 0;
+    while posted < PEER_PLEDGE_COUNT {
+        let batch = PLEDGE_BATCH.min(PEER_PLEDGE_COUNT - posted);
+        for _ in 0..batch {
+            node.post_pledge_commitment_with_signer(&peer_signer).await;
+        }
+        posted += batch;
+        node.mine_block().await?;
+    }
+
+    // Mine an epoch so the peer's pledges become assigned capacity partitions,
+    // available for the upcoming Submit-slot allocation.
+    node.mine_until_next_epoch().await?;
+    let peer_assignments = node.get_partition_assignments(peer_address);
+    assert!(
+        !peer_assignments.is_empty(),
+        "peer should have capacity partition assignments after its pledges are processed"
+    );
+    info!(
+        "peer has {} partition assignments after pledge epoch",
+        peer_assignments.len()
+    );
+
+    // ==================== FILL SLOTS ====================
+    // Post one partition-sized tx per block, each mined alone, so each tx
+    // deterministically occupies the next Submit slot (start offset technique from
+    // perm_refund.rs). Track each tx's term_fee → its slot index.
+    info!(
+        "Posting {} partition-filling txs (one per block)",
+        NUM_SLOTS
+    );
+    let mut slot_term_fees: Vec<U256> = Vec::with_capacity(NUM_SLOTS);
+    for slot in 0..NUM_SLOTS {
+        let anchor = node.get_anchor().await?;
+        let data = vec![(slot as u8).wrapping_add(1); PARTITION_BYTES];
+        let tx = node.post_data_tx(anchor, data, &user_signer).await;
+        node.wait_for_mempool(tx.header.id, 10).await?;
+        let block = node.mine_block().await?;
+        let submit = block
+            .get_data_ledger_tx_ids()
+            .get(&DataLedger::Submit)
+            .cloned()
+            .unwrap_or_default();
+        assert!(
+            submit.len() == 1 && submit[0] == tx.header.id,
+            "tx for slot {} must be alone in its block (got {:?})",
+            slot,
+            submit
+        );
+        slot_term_fees.push(tx.header.term_fee.into());
+        info!(
+            "slot {}: tx={}, term_fee={}",
+            slot, tx.header.id, slot_term_fees[slot]
+        );
+    }
+
+    // ==================== MINE TO EXPIRY + COLLECT REWARDS ====================
+    // The Submit slots holding this data all share one last-write height (the
+    // Cascade touch refreshed them in the fill epoch), so they expire TOGETHER in a
+    // single boundary block. Mine epoch-by-epoch, scanning each newly-mined range
+    // for the first block whose EVM body carries TermFeeReward shadow-txs (the
+    // expiry settlement), and stop as soon as it is found — pinning to that single
+    // boundary and avoiding overshoot.
+    let mut scanned_height = node.get_canonical_chain_height().await;
+    let mut expiry_block_height = None;
+    let mut on_chain_rewards: BTreeMap<IrysAddress, U256> = BTreeMap::new();
+    // submit_ledger_epoch_length epochs to expiry, plus a couple of epochs of
+    // headroom for boundary alignment.
+    let max_epochs = SUBMIT_LEDGER_EPOCH_LENGTH + 3;
+    'outer: for _ in 0..max_epochs {
+        node.mine_until_next_epoch().await?;
+        let h = node.get_canonical_chain_height().await;
+        for height in (scanned_height + 1)..=h {
+            let block = node.get_block_by_height(height).await?;
+            let evm = node.wait_for_evm_block(block.evm_block_hash, 30).await?;
+            let mut block_rewards: BTreeMap<IrysAddress, U256> = BTreeMap::new();
+            for tx in &evm.body.transactions {
+                let mut input = tx.input().as_ref();
+                let Ok(shadow) = ShadowTransaction::decode(&mut input) else {
+                    continue;
+                };
+                if let Some(TransactionPacket::TermFeeReward(reward)) = shadow.as_v1() {
+                    let target_addr = IrysAddress::from(reward.target);
+                    let amount = U256::from_le_bytes(reward.amount.to_le_bytes());
+                    let entry = block_rewards.entry(target_addr).or_insert(U256::zero());
+                    *entry = entry.saturating_add(amount);
+                }
+            }
+            if !block_rewards.is_empty() {
+                expiry_block_height = Some(height);
+                on_chain_rewards = block_rewards;
+                break 'outer;
+            }
+        }
+        scanned_height = h;
+    }
+    let expiry_block_height =
+        expiry_block_height.expect("an expiry boundary block emitting TermFeeReward must exist");
+    info!(
+        "expiry boundary block at height {} with rewards {:?}",
+        expiry_block_height, on_chain_rewards
+    );
+
+    // ==================== RESOLVE EXPIRED SLOT OWNERS ====================
+    // The set of slots that actually recycled this boundary is recorded on the
+    // EXPIRY block's epoch snapshot as `expired_partition_infos` — each entry pairs
+    // a recycled partition_hash with the slot_index it left. The owner is resolved
+    // from that same partition's assignment (the recycled partition keeps its
+    // miner_address). The slot_index equals the start-offset slot of the data tx
+    // mined into it (tx k → slot k), so `slot_term_fees[slot]` is that slot's fee.
+    let expiry_block = node.get_block_by_height(expiry_block_height).await?;
+    let mut expired_slot_owners: BTreeMap<usize, IrysAddress> = BTreeMap::new();
+    {
+        let tree = node.node_ctx.block_tree_guard.read();
+        let snapshot = tree
+            .get_epoch_snapshot(&expiry_block.block_hash)
+            .expect("expiry-block epoch snapshot must exist");
+        let expired = snapshot.expired_partition_infos.clone().unwrap_or_default();
+        for info_entry in expired.iter().filter(|p| p.ledger_id == DataLedger::Submit) {
+            let slot_index = info_entry.slot_index;
+            // Only the slots holding one of our partition-filling data txs.
+            if slot_index >= NUM_SLOTS {
+                continue;
+            }
+            let owner = snapshot
+                .get_data_partition_assignment(info_entry.partition_hash)
+                .expect("recycled partition must retain its assignment")
+                .miner_address;
+            expired_slot_owners.insert(slot_index, owner);
+            info!("expired slot {} owned by miner {}", slot_index, owner);
+        }
+    }
+    assert!(
+        !expired_slot_owners.is_empty(),
+        "no Submit slots holding our data recycled at the boundary — test setup \
+         failed to age expiring (non-last) slots"
+    );
+
+    // FAIL LOUD if the random assignment collapsed every expired slot onto one
+    // miner — the cross-crediting property is only exercised with ≥2 distinct
+    // owners. The heavily-pledged peer makes this collapse astronomically unlikely.
+    let distinct_owners: std::collections::BTreeSet<_> =
+        expired_slot_owners.values().copied().collect();
+    assert!(
+        distinct_owners.len() >= 2,
+        "expired Submit slots collapsed onto a single miner ({:?}); the two-miner \
+         cross-crediting property was not exercised. Expired slot owners: {:?}",
+        distinct_owners,
+        expired_slot_owners
+    );
+
+    // ==================== EXPECTED PER-MINER REWARD ====================
+    // Each single-miner slot's whole term_fee_treasury goes to that slot's owner
+    // (distribution_on_expiry over a one-element miner list). Sum per owner over the
+    // slots that owner holds among the expired set.
+    let mut expected_rewards: BTreeMap<IrysAddress, U256> = BTreeMap::new();
+    for (&slot_index, &owner) in &expired_slot_owners {
+        let treasury = TermFeeCharges::new(slot_term_fees[slot_index].into(), &consensus_config)?
+            .distribution_on_expiry(&[owner])?[0];
+        let entry = expected_rewards.entry(owner).or_insert(U256::zero());
+        *entry = entry.saturating_add(treasury);
+    }
+
+    // ==================== ASSERT: NO CROSS-CREDITING ====================
+    // Each owner's on-chain TermFeeReward total must equal exactly the sum of the
+    // treasury slices of the slots IT owns — neither miner receives any part of
+    // the other's slot.
+    for (owner, expected) in &expected_rewards {
+        let got = on_chain_rewards.get(owner).copied().unwrap_or(U256::zero());
+        assert_eq!(
+            got, *expected,
+            "miner {} on-chain expiry reward ({}) must equal exactly its own slots' \
+             treasury slices ({}) — no cross-crediting from the other miner's slot",
+            owner, got, expected
+        );
+    }
+
+    // And no recipient outside the expected owner set received an expiry reward in
+    // this block (catches a stray credit to a third party / the wrong miner).
+    for (recipient, amount) in &on_chain_rewards {
+        if *amount == U256::zero() {
+            continue;
+        }
+        assert!(
+            expected_rewards.contains_key(recipient),
+            "unexpected TermFeeReward recipient {} (amount {}) in the expiry block — \
+             only the expired slots' owners should be credited",
+            recipient,
+            amount
+        );
+    }
+
+    info!(
+        "two-miner expiry reward attribution verified: {:?}",
+        expected_rewards
+    );
+
+    node.stop().await;
+    Ok(())
+}

--- a/crates/chain-tests/src/term_ledger_expiry/perm_refund_multi_miner.rs
+++ b/crates/chain-tests/src/term_ledger_expiry/perm_refund_multi_miner.rs
@@ -109,6 +109,12 @@ async fn slow_heavy_per_miner_expiry_reward_attribution_two_miners() -> eyre::Re
     config.consensus.get_mut().num_chunks_in_partition = NUM_CHUNKS_IN_PARTITION;
     config.consensus.get_mut().epoch.submit_ledger_epoch_length = SUBMIT_LEDGER_EPOCH_LENGTH;
     config.consensus.get_mut().epoch.num_blocks_in_epoch = BLOCKS_PER_EPOCH;
+    // Pin to 1 so each expired slot maps to exactly one miner — required for the
+    // per-miner attribution assertions below (one partition = one owner per slot).
+    config
+        .consensus
+        .get_mut()
+        .num_partitions_per_term_ledger_slot = 1;
     // Activate Cascade from genesis so the Submit-ledger last-write "touch" runs:
     // every slot WRITTEN in the data epoch (including the genesis-owned slot 0) gets
     // its `last_height` refreshed to that epoch, so all the data slots expire

--- a/crates/chain-tests/src/utils.rs
+++ b/crates/chain-tests/src/utils.rs
@@ -2153,6 +2153,32 @@ impl IrysNodeTest<IrysNodeCtx> {
                 .timestamp_secs();
             irys_types::UnixTimestamp::from_secs(parent_secs.as_secs() + 1)
         };
+        // Mirror production (block_producer::fetch_best_mempool_txs): compute the
+        // set of Submit-ledger txs whose storage has expired as of the block being
+        // produced, so the publish-candidate expiry filter (NC-0042 §4b) behaves
+        // here exactly as in the real producer.
+        let (parent_height, parent_epoch_snapshot) = {
+            let tree = self.node_ctx.block_tree_guard.read();
+            let height = tree
+                .get_block(&parent_block_hash)
+                .expect("parent block should exist in block tree")
+                .height;
+            let snapshot = tree
+                .get_epoch_snapshot(&parent_block_hash)
+                .expect("parent epoch snapshot should exist");
+            (height, snapshot)
+        };
+        let expired_submit_tx_ids =
+            irys_actors::block_producer::ledger_expiry::expired_submit_tx_ids(
+                &parent_epoch_snapshot,
+                parent_height + 1,
+                &self.node_ctx.config,
+                self.node_ctx.block_producer_inner.block_index.clone(),
+                &self.node_ctx.block_tree_guard,
+                &self.node_ctx.mempool_guard,
+                &self.node_ctx.db,
+            )
+            .await?;
         let ctx = irys_actors::tx_selector::TxSelectionContext {
             block_tree: &self.node_ctx.block_tree_guard,
             db: &self.node_ctx.db,
@@ -2160,6 +2186,7 @@ impl IrysNodeTest<IrysNodeCtx> {
             config: &self.node_ctx.config,
             mempool_state: self.node_ctx.mempool_guard.atomic_state(),
             chunk_ingress_state: &self.node_ctx.chunk_ingress_state,
+            expired_submit_tx_ids: &expired_submit_tx_ids,
         };
         irys_actors::tx_selector::select_best_txs(parent_block_hash, new_block_timestamp, &ctx)
             .await

--- a/crates/chain-tests/src/utils.rs
+++ b/crates/chain-tests/src/utils.rs
@@ -206,7 +206,7 @@ pub async fn capacity_chunk_solution(
             sleep(Duration::from_millis(200)).await;
             tries += 1;
         }
-        // Never advance past the latest AVAILABLE VDF step. When the #1449 confirmation gate parks
+        // Never advance past the latest AVAILABLE VDF step. When the confirmation gate parks
         // the VDF at a reset boundary, `global_step` stops here; targeting the un-produced boundary
         // step would make `get_steps` fail. Mining a solution at an available step still produces a
         // block, which advances the confirmed step so the gate releases for the next block (exactly

--- a/crates/chain-tests/src/utils.rs
+++ b/crates/chain-tests/src/utils.rs
@@ -2153,32 +2153,9 @@ impl IrysNodeTest<IrysNodeCtx> {
                 .timestamp_secs();
             irys_types::UnixTimestamp::from_secs(parent_secs.as_secs() + 1)
         };
-        // Mirror production (block_producer::fetch_best_mempool_txs): compute the
-        // set of Submit-ledger txs whose storage has expired as of the block being
-        // produced, so the publish-candidate expiry filter (NC-0042 §4b) behaves
-        // here exactly as in the real producer.
-        let (parent_height, parent_epoch_snapshot) = {
-            let tree = self.node_ctx.block_tree_guard.read();
-            let height = tree
-                .get_block(&parent_block_hash)
-                .expect("parent block should exist in block tree")
-                .height;
-            let snapshot = tree
-                .get_epoch_snapshot(&parent_block_hash)
-                .expect("parent epoch snapshot should exist");
-            (height, snapshot)
-        };
-        let expired_submit_tx_ids =
-            irys_actors::block_producer::ledger_expiry::expired_submit_tx_ids(
-                &parent_epoch_snapshot,
-                parent_height + 1,
-                &self.node_ctx.config,
-                self.node_ctx.block_producer_inner.block_index.clone(),
-                &self.node_ctx.block_tree_guard,
-                &self.node_ctx.mempool_guard,
-                &self.node_ctx.db,
-            )
-            .await?;
+        // Mirror production (block_producer::fetch_best_mempool_txs): the publish
+        // -candidate expiry filter (NC-0042 §4b) resolves expiry per candidate
+        // from the block index + parent epoch snapshot inside the tx selector.
         let ctx = irys_actors::tx_selector::TxSelectionContext {
             block_tree: &self.node_ctx.block_tree_guard,
             db: &self.node_ctx.db,
@@ -2186,7 +2163,8 @@ impl IrysNodeTest<IrysNodeCtx> {
             config: &self.node_ctx.config,
             mempool_state: self.node_ctx.mempool_guard.atomic_state(),
             chunk_ingress_state: &self.node_ctx.chunk_ingress_state,
-            expired_submit_tx_ids: &expired_submit_tx_ids,
+            block_index: &self.node_ctx.block_producer_inner.block_index,
+            mempool_guard: &self.node_ctx.mempool_guard,
         };
         irys_actors::tx_selector::select_best_txs(parent_block_hash, new_block_timestamp, &ctx)
             .await

--- a/crates/chain-tests/src/validation/cascade_submit_expiry_promotion.rs
+++ b/crates/chain-tests/src/validation/cascade_submit_expiry_promotion.rs
@@ -1,0 +1,443 @@
+// NC-0042 §4b/§4c end-to-end coverage with the Cascade hardfork ACTIVE.
+//
+// The shared §4b/§4c tests (`publish_after_submit_expiry_filtered.rs` and
+// `promote_after_submit_expiry.rs`) both run with Cascade OFF (pinned in
+// `submit_expiry_two_node_setup`). Post-Cascade the Submit-ledger expiry
+// semantics change — written-slot tracking and last-write anchoring (see
+// `cascade_term_expiry.rs`) — and the §4b filter set becomes a strict SUPERSET
+// of the refund set (a slot rescued by a late write at its expiry epoch is
+// excluded from refunds but still governs promotability). This test pins the
+// §4b/§4c rule end-to-end on that post-Cascade path.
+//
+// What this test proves end-to-end, with Cascade active from genesis:
+//   §4b (honest producer): the honest producer mines past the Submit slot's
+//     expiry without panicking, and does NOT promote the expired tx. The slot's
+//     unpromoted txs are perm-fee-refunded by Pipeline B — so the expired tx is
+//     refunded but not promoted (no double-pay).
+//   §4c (validator): a hand-built `EvilPublishStrategy` block that promotes the
+//     already-expired Submit tx (with a valid ingress proof, so it fails ONLY on
+//     the expiry rule) is REJECTED by a validating node with
+//     `ShadowTransactionInvalid` carrying the NC-0042 marker.
+//
+// Directional, NOT exact-equality: under Cascade the §4b filter set is a
+// superset of the refund set, so this test deliberately does NOT assert
+// `refunded == expired`. It asserts the invariants that actually matter:
+//   - the expired tx is non-promotable (the per-candidate verdict says expired),
+//   - a block promoting it is rejected (§4c),
+//   - it is not BOTH promoted AND refunded in the honest expiry block (§4b /
+//     no double-pay).
+//
+// Setup (mirrors the post-Cascade Submit-expiry aging in `cascade_term_expiry`'s
+// `heavy_cascade_rescued_slot_defers_reward_and_refund`, combined with the
+// overflow-to-force-a-2nd-slot trick from the pre-Cascade §4b/§4c tests):
+//   - num_blocks_in_epoch = 2, submit_ledger_epoch_length = 2 -> Submit slot
+//     expiry window = 4 blocks.
+//   - tiny partitions (num_chunks_in_partition = 10, chunk_size = 32) + posting
+//     >10 single-chunk txs overflows partition 0, forcing a 2nd Submit slot so
+//     genesis slot 0 is non-last and can actually expire.
+//   - Cascade active from genesis (activation_timestamp = 0).
+//   - 5 storage submodules so all 4 Cascade ledgers (Publish/Submit/OneYear/
+//     ThirtyDay) plus the overflow 2nd Submit slot have partitions.
+//
+// We drive the txs through the real Submit flow (no DB seeding of
+// MigratedBlockHashes — that collides with the chain's real migration writes and
+// crashes BlockTreeService, per the notes in the pre-Cascade tests).
+
+use crate::utils::{IrysNodeTest, assert_validation_error, solution_context};
+use crate::validation::send_block_and_read_state;
+use irys_actors::block_validation::ValidationError;
+use irys_actors::{
+    BlockProdStrategy, BlockProducerInner, ProductionStrategy, async_trait,
+    block_producer::ledger_expiry::LedgerExpiryBalanceDelta,
+    shadow_tx_generator::PublishLedgerWithTxs,
+};
+use irys_config::submodules::StorageSubmodulesConfig;
+use irys_domain::BlockTreeReadGuard;
+use irys_reth_node_bridge::irys_reth::shadow_tx::{ShadowTransaction, TransactionPacket};
+use irys_types::ingress::generate_ingress_proof;
+use irys_types::{
+    DataLedger, DataTransactionHeader, H256, IngressProofsList, IrysBlockHeader, NodeConfig,
+    UnixTimestamp, UnixTimestampMs, hardfork_config::Cascade,
+};
+use reth::rpc::types::TransactionTrait as _;
+use std::collections::BTreeSet;
+
+#[test_log::test(tokio::test)]
+async fn heavy_cascade_block_promoting_already_expired_submit_tx_gets_rejected() -> eyre::Result<()>
+{
+    /// Forces an already-expired Submit tx into the Publish ledger, with a valid
+    /// ingress proof so the block fails validation *only* on the §4c expiry rule
+    /// (not on a missing/invalid proof). No refund is scheduled in the bundle, so
+    /// the in-constructor defence-in-depth guard does not fire during production —
+    /// the block is built and must be caught at validation time.
+    struct EvilPublishStrategy {
+        prod: ProductionStrategy,
+        expired_tx: DataTransactionHeader,
+        proofs: IngressProofsList,
+        block_tree_guard: BlockTreeReadGuard,
+    }
+
+    #[async_trait::async_trait]
+    impl BlockProdStrategy for EvilPublishStrategy {
+        fn inner(&self) -> &BlockProducerInner {
+            &self.prod.inner
+        }
+
+        async fn get_mempool_txs(
+            &self,
+            _prev_block_header: &IrysBlockHeader,
+            _block_timestamp: UnixTimestampMs,
+        ) -> Result<
+            irys_actors::block_producer::MempoolTxsBundle,
+            irys_actors::tx_selector::TxSelectorError,
+        > {
+            Ok(irys_actors::block_producer::MempoolTxsBundle {
+                commitment_txs: vec![],
+                commitment_txs_to_bill: vec![],
+                submit_txs: vec![],
+                one_year_txs: vec![],
+                thirty_day_txs: vec![],
+                publish_txs: PublishLedgerWithTxs {
+                    txs: vec![self.expired_tx.clone()],
+                    proofs: Some(self.proofs.clone()),
+                },
+                aggregated_miner_fees: LedgerExpiryBalanceDelta::default(),
+                commitment_refund_events: vec![],
+                unstake_refund_events: vec![],
+                epoch_snapshot: self.block_tree_guard.read().canonical_epoch_snapshot(),
+            })
+        }
+    }
+
+    // --- 1. Config: Cascade ACTIVE from genesis + Submit-expiry aging params ---
+    let num_blocks_in_epoch: u64 = 2;
+    let submit_ledger_epoch_length: u64 = 2;
+    let chunk_size: u64 = 32;
+    let num_chunks_in_partition: u64 = 10;
+    // Post-Cascade Submit-slot expiry window, measured from the slot's LAST write
+    // (not its allocation) — unlike the pre-Cascade tests where this equals the
+    // absolute expiry height.
+    let expiry_window = num_blocks_in_epoch * submit_ledger_epoch_length; // = 4
+    let one_year_epoch_length: u64 = 8;
+    let thirty_day_epoch_length: u64 = 2;
+    let seconds_to_wait = 40_usize;
+
+    let mut genesis_config = NodeConfig::testing_with_epochs(num_blocks_in_epoch as usize);
+    {
+        let c = genesis_config.consensus.get_mut();
+        c.chunk_size = chunk_size;
+        c.num_chunks_in_partition = num_chunks_in_partition;
+        c.block_migration_depth = 1;
+        c.epoch.submit_ledger_epoch_length = submit_ledger_epoch_length;
+        // One ingress proof from the genesis signer makes a tx promotable.
+        c.hardforks.frontier.number_of_ingress_proofs_total = 1;
+        // Cascade active from genesis -> post-Cascade written-slot / last-write
+        // Submit-expiry semantics for the whole run.
+        c.hardforks.cascade = Some(Cascade {
+            activation_timestamp: UnixTimestamp::from_secs(0),
+            one_year_epoch_length,
+            thirty_day_epoch_length,
+            annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
+        });
+    }
+
+    let user_signer = genesis_config.new_random_signer();
+    genesis_config.fund_genesis_accounts(vec![&user_signer]);
+
+    // 5 storage submodules: 4 Cascade ledgers (Publish/Submit/OneYear/ThirtyDay)
+    // plus headroom for the overflow 2nd Submit slot need partition assignments.
+    let genesis_node = IrysNodeTest::new_genesis(genesis_config.clone());
+    StorageSubmodulesConfig::load_for_test(genesis_node.cfg.base_directory.clone(), 5)?;
+    let genesis_node = genesis_node
+        .start_and_wait_for_packing("GENESIS", seconds_to_wait)
+        .await;
+    let peer_node = {
+        let peer_config = genesis_node.testing_peer_with_signer(&user_signer);
+        IrysNodeTest::new(peer_config).start_with_name("PEER").await
+    };
+
+    // --- 2. Post >10 single-chunk txs to overflow partition 0, forcing a 2nd
+    //         Submit slot so genesis slot 0 is non-last and can expire. ---
+    let num_txs = (num_chunks_in_partition + 2) as usize;
+    let anchor = genesis_node.get_anchor().await?;
+    let mut txs = Vec::with_capacity(num_txs);
+    for i in 0..num_txs {
+        let data = vec![100 + i as u8; chunk_size as usize];
+        let tx = genesis_node.post_data_tx(anchor, data, &user_signer).await;
+        genesis_node
+            .wait_for_mempool(tx.header.id, seconds_to_wait)
+            .await?;
+        txs.push(tx);
+    }
+    let data_block = genesis_node.mine_block().await?;
+
+    // Sanity: all posted txs landed in the Submit ledger at the data block.
+    let submit_ids: BTreeSet<_> = data_block
+        .get_data_ledger_tx_ids()
+        .get(&DataLedger::Submit)
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .collect();
+    assert_eq!(
+        submit_ids.len(),
+        num_txs,
+        "all posted txs should land in the Submit ledger at the data block"
+    );
+
+    // --- 3. Mine to the next epoch boundary so the capacity overflow allocates a
+    //         2nd Submit slot (genesis slot 0 becomes non-last) and the Cascade
+    //         last-write touch stamps slot 0's `last_height` at the epoch that
+    //         processes its writes. ---
+    let next_epoch_boundary = |h: u64| -> u64 {
+        if h.is_multiple_of(num_blocks_in_epoch) {
+            h
+        } else {
+            h + (num_blocks_in_epoch - (h % num_blocks_in_epoch))
+        }
+    };
+    let alloc_epoch = next_epoch_boundary(data_block.height + 1);
+    while genesis_node.get_canonical_chain_height().await < alloc_epoch {
+        genesis_node.mine_block().await?;
+    }
+
+    // Read slot 0's last-write height + the slot count from the alloc-epoch
+    // snapshot. Under Cascade, Submit slot 0 expires at `last_height + window`
+    // (last-write anchored), NOT at the allocation-anchored cycle height.
+    let alloc_block = genesis_node.get_block_by_height(alloc_epoch).await?;
+    let (slot0_last_height, submit_slot_count) = {
+        let tree = genesis_node.node_ctx.block_tree_guard.read();
+        let snapshot = tree
+            .get_epoch_snapshot(&alloc_block.block_hash)
+            .expect("epoch snapshot at the allocation epoch");
+        let slots = snapshot.ledgers.get_slots(DataLedger::Submit);
+        (slots[0].last_height, slots.len())
+    };
+    assert!(
+        submit_slot_count >= 2,
+        "capacity overflow must have allocated a 2nd Submit slot so slot 0 is non-last \
+         (got {submit_slot_count} slots)"
+    );
+
+    // Submit slot 0 expires (post-Cascade) at the first epoch boundary at or after
+    // `last_height + window`. Pipeline B refunds slot-0's unpromoted txs at that
+    // epoch and the honest producer drops them from promotion (§4b). The loop
+    // terminating proves the producer did NOT panic.
+    let expiry_height = next_epoch_boundary(slot0_last_height + expiry_window);
+    assert_eq!(
+        expiry_height % num_blocks_in_epoch,
+        0,
+        "expiry must coincide with an epoch boundary so the refund pipeline runs"
+    );
+    let height_before_loop = genesis_node.get_canonical_chain_height().await;
+    while genesis_node.get_canonical_chain_height().await < expiry_height {
+        genesis_node.mine_block().await?;
+    }
+    assert!(
+        genesis_node.get_canonical_chain_height().await > height_before_loop,
+        "chain must advance past the expiry epoch (§4b filter must not stall the producer)"
+    );
+
+    // --- 4. §4b directional property: the honest expiry block must NOT promote
+    //         any expired tx, and the expired txs must be perm-fee-refunded (so an
+    //         expired tx is refunded but not promoted — no double-pay). ---
+    let expiry_block = genesis_node.get_block_by_height(expiry_height).await?;
+    let publish_ids: BTreeSet<_> = expiry_block
+        .get_data_ledger_tx_ids()
+        .get(&DataLedger::Publish)
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .collect();
+
+    // The expired Submit tx-id set the producer used at the expiry epoch (derived
+    // from the expiry block's PARENT snapshot, post-Cascade gate).
+    let expiry_parent_block = genesis_node.get_block_by_height(expiry_height - 1).await?;
+    assert_eq!(
+        expiry_parent_block.block_hash, expiry_block.previous_block_hash,
+        "parent header must be the expiry block's parent"
+    );
+    let expiry_parent_snapshot = genesis_node
+        .node_ctx
+        .block_tree_guard
+        .read()
+        .get_epoch_snapshot(&expiry_block.previous_block_hash)
+        .expect("epoch snapshot for the expiry block's parent");
+    let expired_set = irys_actors::block_producer::ledger_expiry::expired_submit_tx_ids(
+        &expiry_parent_snapshot,
+        &expiry_parent_block,
+        expiry_height,
+        &genesis_node.node_ctx.config,
+        genesis_node
+            .node_ctx
+            .block_producer_inner
+            .block_index
+            .clone(),
+        &genesis_node.node_ctx.block_tree_guard,
+        &genesis_node.node_ctx.mempool_guard,
+        &genesis_node.node_ctx.db,
+    )
+    .await?;
+    assert!(
+        !expired_set.is_empty(),
+        "the genesis Submit slot must have expired at this epoch under Cascade"
+    );
+    // §4b: none of the expired txs may be promoted at the honest expiry block.
+    for expired_tx_id in &expired_set {
+        assert!(
+            !publish_ids.contains(expired_tx_id),
+            "expired Submit tx {expired_tx_id} must NOT be promoted (NC-0042 §4b, Cascade)"
+        );
+    }
+
+    // No double-pay: at least one expired tx was perm-fee-refunded in the honest
+    // expiry block, and that refunded tx is NOT in the Publish ledger. (Directional
+    // — under Cascade the refund set may be a strict subset of `expired_set`, so we
+    // do not assert exact equality.)
+    let user_addr = user_signer.address().to_alloy_address();
+    let evm_block = genesis_node
+        .wait_for_evm_block(expiry_block.evm_block_hash, seconds_to_wait)
+        .await?;
+    let refunded_tx_ids: BTreeSet<H256> = evm_block
+        .body
+        .transactions
+        .into_iter()
+        .filter(|tx| tx.input().len() >= 4)
+        .filter_map(|tx| {
+            let shadow_tx = ShadowTransaction::decode(&mut tx.input().as_ref()).ok()?;
+            let packet = shadow_tx.as_v1()?;
+            match packet {
+                TransactionPacket::PermFeeRefund(refund) if refund.target == user_addr => {
+                    Some(H256(refund.irys_ref.into()))
+                }
+                _ => None,
+            }
+        })
+        .collect();
+    assert!(
+        !refunded_tx_ids.is_empty(),
+        "at least one expired Submit tx must be perm-fee-refunded at the expiry epoch \
+         (else the §4b/no-double-pay check is vacuous)"
+    );
+    for refunded in &refunded_tx_ids {
+        assert!(
+            expired_set.contains(refunded),
+            "every refunded tx must be in the expired set (refund ⊆ expired under Cascade)"
+        );
+        assert!(
+            !publish_ids.contains(refunded),
+            "a perm-fee-refunded tx {refunded} must NOT also be promoted (no double-pay, §4b)"
+        );
+    }
+
+    // --- 5. §4c: build an evil block at E+1 that promotes an already-expired tx
+    //         and confirm a validator rejects it with the NC-0042 error. ---
+    let evil_height = expiry_height + 1; // E+1: cross-block, not the epoch block
+    let evil_parent_block = genesis_node.get_block_by_height(expiry_height).await?;
+    let tip_hash = evil_parent_block.block_hash;
+    let tip_snapshot = genesis_node
+        .node_ctx
+        .block_tree_guard
+        .read()
+        .get_epoch_snapshot(&tip_hash)
+        .expect("epoch snapshot for the current tip");
+
+    // Pick a target tx that the per-candidate (§4c) predicate marks expired at the
+    // evil block's height, under the Cascade gate.
+    let mut target: Option<&irys_types::DataTransaction> = None;
+    for tx in &txs {
+        let per_candidate = irys_actors::block_producer::ledger_expiry::is_submit_storage_expired(
+            tx.header.id,
+            evil_height,
+            &tip_snapshot,
+            &evil_parent_block,
+            &genesis_node.node_ctx.config,
+            &genesis_node.node_ctx.block_producer_inner.block_index,
+            &genesis_node.node_ctx.block_tree_guard,
+            &genesis_node.node_ctx.mempool_guard,
+            &genesis_node.node_ctx.db,
+        )
+        .await?;
+        if per_candidate {
+            target = Some(tx);
+            break;
+        }
+    }
+    let target = target.expect(
+        "at least one posted tx must be expired by the per-candidate (§4c) verdict under Cascade",
+    );
+    let expired_tx = target.header.clone();
+
+    // Build a valid ingress proof for the expired tx (genesis signer is staked) so
+    // the evil block fails ONLY on the §4c expiry rule.
+    let genesis_signer = genesis_config.signer();
+    let proof_anchor = genesis_node.get_anchor().await?;
+    let chunks: Vec<Vec<u8>> = vec![target.data.clone().unwrap_or_default().into()];
+    let proof = generate_ingress_proof(
+        &genesis_signer,
+        expired_tx.data_root,
+        chunks.iter().map(|c| Ok(c.as_slice())),
+        genesis_config.consensus_config().chain_id,
+        proof_anchor,
+    )?;
+
+    let evil_strategy = EvilPublishStrategy {
+        expired_tx: expired_tx.clone(),
+        proofs: IngressProofsList(vec![proof]),
+        prod: ProductionStrategy {
+            inner: genesis_node.node_ctx.block_producer_inner.clone(),
+        },
+        block_tree_guard: genesis_node.node_ctx.block_tree_guard.clone(),
+    };
+    let (block, _adj, _payload) = evil_strategy
+        .fully_produce_new_block_without_gossip(&solution_context(&genesis_node.node_ctx).await?)
+        .await?
+        .expect("evil block should be produced (the guard fires at validation, not production)");
+
+    assert_eq!(block.header().height, evil_height, "evil block at E+1");
+    assert!(
+        block.header().data_ledgers[DataLedger::Publish]
+            .tx_ids
+            .contains(&expired_tx.id),
+        "evil block must promote the expired tx"
+    );
+
+    // The §4c rejection message includes "NC-0042" — match on that to ensure the
+    // block is rejected for the right reason, not an unrelated shadow-tx error.
+    let is_nc_0042_expiry_rejection = |e: &ValidationError| match e {
+        ValidationError::ShadowTransactionInvalid(msg) => msg.contains("NC-0042"),
+        _ => false,
+    };
+
+    // Genesis must reject it.
+    let genesis_outcome =
+        send_block_and_read_state(&genesis_node.node_ctx, block.clone(), false).await?;
+    assert_validation_error(
+        genesis_outcome,
+        is_nc_0042_expiry_rejection,
+        "Genesis must reject a Cascade block promoting an already-expired Submit tx (NC-0042 §4c)",
+    );
+
+    // Peer must have the parent chain up to expiry_height before validating E+1.
+    peer_node
+        .wait_until_height(expiry_height, seconds_to_wait)
+        .await?;
+    let peer_outcome = send_block_and_read_state(&peer_node.node_ctx, block.clone(), false).await?;
+    assert_validation_error(
+        peer_outcome,
+        is_nc_0042_expiry_rejection,
+        "Peer must reject a Cascade block promoting an already-expired Submit tx (NC-0042 §4c)",
+    );
+
+    // Neither node should have committed the evil block to the EVM layer.
+    genesis_node
+        .assert_evm_block_absent(block.header().evm_block_hash, 2)
+        .await?;
+    peer_node
+        .assert_evm_block_absent(block.header().evm_block_hash, 2)
+        .await?;
+
+    peer_node.stop().await;
+    genesis_node.stop().await;
+    Ok(())
+}

--- a/crates/chain-tests/src/validation/cascade_submit_expiry_promotion.rs
+++ b/crates/chain-tests/src/validation/cascade_submit_expiry_promotion.rs
@@ -56,7 +56,7 @@ use irys_domain::BlockTreeReadGuard;
 use irys_reth_node_bridge::irys_reth::shadow_tx::{ShadowTransaction, TransactionPacket};
 use irys_types::ingress::generate_ingress_proof;
 use irys_types::{
-    DataLedger, DataTransactionHeader, H256, IngressProofsList, IrysBlockHeader, NodeConfig,
+    DataLedger, DataTransactionHeader, H256, IngressProofsList, IrysBlockHeader, NodeConfig, U256,
     UnixTimestamp, UnixTimestampMs, hardfork_config::Cascade,
 };
 use reth::rpc::types::TransactionTrait as _;
@@ -308,7 +308,7 @@ async fn heavy_cascade_block_promoting_already_expired_submit_tx_gets_rejected()
     let evm_block = genesis_node
         .wait_for_evm_block(expiry_block.evm_block_hash, seconds_to_wait)
         .await?;
-    let refunded_tx_id_list: Vec<H256> = evm_block
+    let refunded_list: Vec<(H256, U256)> = evm_block
         .body
         .transactions
         .into_iter()
@@ -318,19 +318,19 @@ async fn heavy_cascade_block_promoting_already_expired_submit_tx_gets_rejected()
             let packet = shadow_tx.as_v1()?;
             match packet {
                 TransactionPacket::PermFeeRefund(refund) if refund.target == user_addr => {
-                    Some(H256(refund.irys_ref.into()))
+                    Some((H256(refund.irys_ref.into()), U256::from(refund.amount)))
                 }
                 _ => None,
             }
         })
         .collect();
-    let refunded_tx_ids: BTreeSet<H256> = refunded_tx_id_list.iter().copied().collect();
+    let refunded_tx_ids: BTreeSet<H256> = refunded_list.iter().map(|(id, _)| *id).collect();
     // Multiplicity guard (NC-0042): a duplicate PermFeeRefund for the same tx — an
     // over-refund / double-pay — would be silently collapsed by the set and slip
     // past the exact-equality check below. Assert the raw on-chain refund list has
     // no duplicates before deduping.
     assert_eq!(
-        refunded_tx_id_list.len(),
+        refunded_list.len(),
         refunded_tx_ids.len(),
         "on-chain perm-fee refunds must contain no duplicate tx (no over-refund) — NC-0042"
     );
@@ -339,7 +339,7 @@ async fn heavy_cascade_block_promoting_already_expired_submit_tx_gets_rejected()
         "at least one expired Submit tx must be perm-fee-refunded at the expiry epoch \
          (else the §4b/no-double-pay check is vacuous)"
     );
-    for refunded in &refunded_tx_ids {
+    for (refunded, _) in &refunded_list {
         assert!(
             expired_set.contains(refunded),
             "every refunded tx must be in the expired set (refund ⊆ expired under Cascade)"
@@ -379,14 +379,19 @@ async fn heavy_cascade_block_promoting_already_expired_submit_tx_gets_rejected()
             cascade_active_for_block,
         )
         .await?;
-    let expected_refund_ids: BTreeSet<H256> = pipeline_b_refunds
+    // Assert both id-set equality AND per-id refund amounts match Pipeline B (no
+    // under-/over-refund and no wrong-amount shadow tx).
+    let mut on_chain_id_amounts: Vec<(H256, U256)> = refunded_list.clone();
+    on_chain_id_amounts.sort_by_key(|(id, _)| *id);
+    let mut expected_id_amounts: Vec<(H256, U256)> = pipeline_b_refunds
         .user_perm_fee_refunds
         .iter()
-        .map(|(id, _, _)| *id)
+        .map(|(id, amount, _)| (*id, *amount))
         .collect();
+    expected_id_amounts.sort_by_key(|(id, _)| *id);
     assert_eq!(
-        refunded_tx_ids, expected_refund_ids,
-        "on-chain perm-fee refunds must EXACTLY equal Pipeline B's refund set (no \
+        on_chain_id_amounts, expected_id_amounts,
+        "on-chain perm-fee refunds must EXACTLY equal Pipeline B's refund set and amounts (no \
          under- or over-refund) — NC-0042 M5"
     );
 

--- a/crates/chain-tests/src/validation/cascade_submit_expiry_promotion.rs
+++ b/crates/chain-tests/src/validation/cascade_submit_expiry_promotion.rs
@@ -263,11 +263,21 @@ async fn heavy_cascade_block_promoting_already_expired_submit_tx_gets_rejected()
         .read()
         .get_epoch_snapshot(&expiry_block.previous_block_hash)
         .expect("epoch snapshot for the expiry block's parent");
+    // The expiry block's own Cascade status — exactly what production passes to
+    // `expired_submit_range` / `calculate_expired_ledger_fees`; compute once and
+    // reuse for the oracle and the Pipeline B recompute below.
+    let cascade_active_for_block = genesis_node
+        .node_ctx
+        .config
+        .consensus
+        .hardforks
+        .is_cascade_active_at(expiry_block.timestamp_secs());
     let expired_set = irys_actors::block_producer::ledger_expiry::expired_submit_tx_ids(
         &expiry_parent_snapshot,
         &expiry_parent_block,
         expiry_height,
         &genesis_node.node_ctx.config,
+        cascade_active_for_block,
         genesis_node
             .node_ctx
             .block_producer_inner
@@ -298,7 +308,7 @@ async fn heavy_cascade_block_promoting_already_expired_submit_tx_gets_rejected()
     let evm_block = genesis_node
         .wait_for_evm_block(expiry_block.evm_block_hash, seconds_to_wait)
         .await?;
-    let refunded_tx_ids: BTreeSet<H256> = evm_block
+    let refunded_tx_id_list: Vec<H256> = evm_block
         .body
         .transactions
         .into_iter()
@@ -314,6 +324,16 @@ async fn heavy_cascade_block_promoting_already_expired_submit_tx_gets_rejected()
             }
         })
         .collect();
+    let refunded_tx_ids: BTreeSet<H256> = refunded_tx_id_list.iter().copied().collect();
+    // Multiplicity guard (NC-0042): a duplicate PermFeeRefund for the same tx — an
+    // over-refund / double-pay — would be silently collapsed by the set and slip
+    // past the exact-equality check below. Assert the raw on-chain refund list has
+    // no duplicates before deduping.
+    assert_eq!(
+        refunded_tx_id_list.len(),
+        refunded_tx_ids.len(),
+        "on-chain perm-fee refunds must contain no duplicate tx (no over-refund) — NC-0042"
+    );
     assert!(
         !refunded_tx_ids.is_empty(),
         "at least one expired Submit tx must be perm-fee-refunded at the expiry epoch \
@@ -339,12 +359,6 @@ async fn heavy_cascade_block_promoting_already_expired_submit_tx_gets_rejected()
     // exclusion correctly drops any slot rescued by a last-write touch this epoch).
     // This is the Cascade analog of the pre-Cascade `refunded == expired` equality
     // (`publish_after_submit_expiry_filtered.rs`), made rescue/promotion-aware.
-    let cascade_active_for_block = genesis_node
-        .node_ctx
-        .config
-        .consensus
-        .hardforks
-        .is_cascade_active_at(expiry_block.timestamp_secs());
     let pipeline_b_refunds =
         irys_actors::block_producer::ledger_expiry::calculate_expired_ledger_fees(
             &expiry_parent_snapshot,
@@ -390,6 +404,12 @@ async fn heavy_cascade_block_promoting_already_expired_submit_tx_gets_rejected()
 
     // Pick a target tx that the per-candidate (§4c) predicate marks expired at the
     // evil block's height, under the Cascade gate.
+    let evil_cascade_active = genesis_node
+        .node_ctx
+        .config
+        .consensus
+        .hardforks
+        .is_cascade_active_at(evil_parent_block.timestamp_secs());
     let mut target: Option<&irys_types::DataTransaction> = None;
     for tx in &txs {
         let per_candidate = irys_actors::block_producer::ledger_expiry::is_submit_storage_expired(
@@ -398,6 +418,7 @@ async fn heavy_cascade_block_promoting_already_expired_submit_tx_gets_rejected()
             &tip_snapshot,
             &evil_parent_block,
             &genesis_node.node_ctx.config,
+            evil_cascade_active,
             &genesis_node.node_ctx.block_producer_inner.block_index,
             &genesis_node.node_ctx.block_tree_guard,
             &genesis_node.node_ctx.mempool_guard,

--- a/crates/chain-tests/src/validation/cascade_submit_expiry_promotion.rs
+++ b/crates/chain-tests/src/validation/cascade_submit_expiry_promotion.rs
@@ -444,7 +444,10 @@ async fn heavy_cascade_block_promoting_already_expired_submit_tx_gets_rejected()
     // the evil block fails ONLY on the §4c expiry rule.
     let genesis_signer = genesis_config.signer();
     let proof_anchor = genesis_node.get_anchor().await?;
-    let chunks: Vec<Vec<u8>> = vec![target.data.clone().unwrap_or_default().into()];
+    let target_data = target.data.clone().expect(
+        "posted tx payload must be retained to build the ingress proof (fixture invariant)",
+    );
+    let chunks: Vec<Vec<u8>> = vec![target_data.into()];
     let proof = generate_ingress_proof(
         &genesis_signer,
         expired_tx.data_root,

--- a/crates/chain-tests/src/validation/cascade_submit_expiry_promotion.rs
+++ b/crates/chain-tests/src/validation/cascade_submit_expiry_promotion.rs
@@ -330,6 +330,52 @@ async fn heavy_cascade_block_promoting_already_expired_submit_tx_gets_rejected()
         );
     }
 
+    // Exact no-UNDER-refund guard (NC-0042 M5). The `⊆` check above tolerates an
+    // expired, unpromoted, unrescued tx silently failing to be refunded. Pin it down:
+    // the on-chain refunds must EXACTLY equal the set the expiry refund pipeline
+    // (Pipeline B) computes for this block. Recompute Pipeline B from the SAME
+    // branch-correct inputs the producer used (parent snapshot + parent header + this
+    // block's own Cascade gate + this block's Submit total — the write-window
+    // exclusion correctly drops any slot rescued by a last-write touch this epoch).
+    // This is the Cascade analog of the pre-Cascade `refunded == expired` equality
+    // (`publish_after_submit_expiry_filtered.rs`), made rescue/promotion-aware.
+    let cascade_active_for_block = genesis_node
+        .node_ctx
+        .config
+        .consensus
+        .hardforks
+        .is_cascade_active_at(expiry_block.timestamp_secs());
+    let pipeline_b_refunds =
+        irys_actors::block_producer::ledger_expiry::calculate_expired_ledger_fees(
+            &expiry_parent_snapshot,
+            &expiry_parent_block,
+            expiry_height,
+            DataLedger::Submit,
+            &genesis_node.node_ctx.config,
+            genesis_node
+                .node_ctx
+                .block_producer_inner
+                .block_index
+                .clone(),
+            &genesis_node.node_ctx.block_tree_guard,
+            &genesis_node.node_ctx.mempool_guard,
+            &genesis_node.node_ctx.db,
+            true, // expect txs to be promoted -> compute perm-fee refunds for the unpromoted
+            expiry_block.ledger_total_chunks(DataLedger::Submit),
+            cascade_active_for_block,
+        )
+        .await?;
+    let expected_refund_ids: BTreeSet<H256> = pipeline_b_refunds
+        .user_perm_fee_refunds
+        .iter()
+        .map(|(id, _, _)| *id)
+        .collect();
+    assert_eq!(
+        refunded_tx_ids, expected_refund_ids,
+        "on-chain perm-fee refunds must EXACTLY equal Pipeline B's refund set (no \
+         under- or over-refund) — NC-0042 M5"
+    );
+
     // --- 5. §4c: build an evil block at E+1 that promotes an already-expired tx
     //         and confirm a validator rejects it with the NC-0042 error. ---
     let evil_height = expiry_height + 1; // E+1: cross-block, not the epoch block

--- a/crates/chain-tests/src/validation/cascade_term_expiry.rs
+++ b/crates/chain-tests/src/validation/cascade_term_expiry.rs
@@ -1464,3 +1464,130 @@ async fn slow_heavy_cascade_midchain_thirty_day_expiry_resolves_through_index() 
     node.stop().await;
     Ok(())
 }
+
+/// NC-0042 P1 (clean-cutover, mixed-mode): a Submit tx **included before Cascade
+/// activation** must be correctly perm-fee-refunded when its slot **expires after
+/// activation**, and the chain must progress past that expiry epoch without a
+/// §4c-induced halt. The §4c rejection + the refund/fee algorithm are
+/// intentionally NOT Cascade-gated (see the CLEAN-CUTOVER note above the §4c block
+/// in `block_validation`), so this exercises them across the pre→post activation
+/// boundary — the coverage the all-pre-Cascade (`perm_refund`) and no-expiry
+/// midchain (`..._submit_last_height_transition`) tests each leave open.
+///
+/// A single unpromoted 16-chunk tx (512B / 32B) spans slots 0..3 with a 4-chunk
+/// partition, so slot 0 is non-last (expirable) and the tx is attributed to it.
+/// We activate Cascade mid-chain BEFORE slot 0's expiry, then mine until the
+/// refund shadow-tx appears — the expiry height is found data-driven because the
+/// allocation→fill anchoring transition at activation can shift it.
+#[test_log::test(tokio::test)]
+async fn slow_heavy_cascade_midchain_submit_expiry_refunds_across_activation() -> eyre::Result<()> {
+    let num_blocks_in_epoch = 2_u64;
+    let submit_ledger_epoch_length = 2_u64;
+    let one_year_epoch_length = 8_u64;
+    let thirty_day_epoch_length = 2_u64;
+    let chunk_size = 32_u64;
+    // Small partition so one 16-chunk tx spans several slots ⇒ slot 0 is non-last.
+    let num_chunks_in_partition = 4_u64;
+    let data_size = 512_usize;
+
+    let mut config = NodeConfig::testing().with_consensus(|c| {
+        c.block_migration_depth = 1;
+        c.epoch.num_blocks_in_epoch = num_blocks_in_epoch;
+        c.epoch.submit_ledger_epoch_length = submit_ledger_epoch_length;
+        c.chunk_size = chunk_size;
+        c.num_chunks_in_partition = num_chunks_in_partition;
+        // Cascade intentionally NOT configured yet — activated mid-chain below.
+    });
+
+    let user = config.new_random_signer();
+    let user_addr = user.address();
+    config.fund_genesis_accounts(vec![&user]);
+
+    let test_node = IrysNodeTest::new_genesis(config);
+    StorageSubmodulesConfig::load_for_test(test_node.cfg.base_directory.clone(), 8)?;
+    let node = test_node
+        .start_and_wait_for_packing("midchain_expiry", 30)
+        .await;
+
+    // === Pre-Cascade: include one UNPROMOTED Submit tx (no chunks uploaded → never
+    // promoted → refundable). Its 16 chunks span slots 0..3, so slot 0 is non-last
+    // and will expire; the tx is attributed to slot 0 by its start offset. ===
+    let anchor = node.get_block_by_height(0).await?.block_hash;
+    let tx = node
+        .post_data_tx(anchor, vec![1_u8; data_size], &user)
+        .await;
+    let tx_perm_fee = tx.header.perm_fee.expect("data tx must carry a perm_fee");
+    node.wait_for_mempool(tx.header.id, 20).await?;
+    node.mine_block().await?;
+    // One epoch so the slot allocation settles while still pre-Cascade.
+    node.mine_until_next_epoch().await?;
+    let pre_activation_height = node.get_canonical_chain_height().await;
+
+    // === Activate Cascade mid-chain: stop → set activation = now+1 → restart. The
+    // +1s keeps activation strictly after every pre-restart block's (second-granular)
+    // timestamp, so historical blocks stay pre-activation and only newly mined blocks
+    // are cascade-active — deterministic, no wall-clock race. ===
+    let mut stopped = node.stop().await;
+    let activation_timestamp = UnixTimestamp::now()
+        .expect("system time after unix epoch")
+        .as_secs()
+        + 1;
+    stopped.cfg.consensus.get_mut().hardforks.cascade = Some(Cascade {
+        activation_timestamp: UnixTimestamp::from_secs(activation_timestamp),
+        one_year_epoch_length,
+        thirty_day_epoch_length,
+        annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
+    });
+    let node = stopped.start().await;
+
+    // === Mine post-activation until slot 0 expires and `tx` is refunded. The
+    // expiry epoch is detected data-driven (scan each epoch block's shadow txs for
+    // a PermFeeRefund to the user) rather than hard-coded, since the anchoring
+    // transition can move it. ===
+    let mut refund_amount = U256::from(0);
+    let mut refund_height = 0_u64;
+    const MAX_EPOCHS: usize = 16;
+    'mine: for _ in 0..MAX_EPOCHS {
+        let (_, height) = node.mine_until_next_epoch().await?;
+        let block = node.get_block_by_height(height).await?;
+        let evm_block = node.wait_for_evm_block(block.evm_block_hash, 20).await?;
+        for evm_tx in evm_block.body.transactions {
+            if evm_tx.input().len() < 4 {
+                continue;
+            }
+            let Ok(shadow_tx) = ShadowTransaction::decode(&mut evm_tx.input().as_ref()) else {
+                continue;
+            };
+            let Some(TransactionPacket::PermFeeRefund(refund)) = shadow_tx.as_v1() else {
+                continue;
+            };
+            if refund.target == user_addr.to_alloy_address() {
+                refund_amount = U256::from_le_bytes(refund.amount.to_le_bytes());
+                refund_height = height;
+                break 'mine;
+            }
+        }
+    }
+
+    // The refund settled AFTER activation (mixed-mode: pre-Cascade inclusion,
+    // post-activation expiry) — the §4c/refund path ran cascade-active over a
+    // pre-activation tx and did not halt.
+    assert!(
+        refund_height > pre_activation_height,
+        "refund must settle after Cascade activation (refund_height={refund_height}, \
+         pre_activation_height={pre_activation_height})"
+    );
+    assert_eq!(
+        refund_amount, tx_perm_fee,
+        "pre-Cascade-included unpromoted tx must be refunded its full perm_fee at the \
+         post-activation expiry"
+    );
+    // Chain kept progressing past the expiry epoch (no §4c-induced stall).
+    assert!(
+        node.get_canonical_chain_height().await >= refund_height,
+        "chain must progress past the post-activation expiry epoch"
+    );
+
+    node.stop().await;
+    Ok(())
+}

--- a/crates/chain-tests/src/validation/cascade_term_expiry.rs
+++ b/crates/chain-tests/src/validation/cascade_term_expiry.rs
@@ -1363,6 +1363,13 @@ async fn slow_heavy_cascade_midchain_thirty_day_expiry_resolves_through_index() 
     }
 
     // === Activate Cascade mid-chain (stop -> set activation = now+1 -> restart) ===
+    // Wall-clock dependency: +1s ensures activation is strictly after all
+    // pre-restart blocks (their timestamps are <= now(); `cascade_at` activates on
+    // inclusive >=, so now() alone could collide with the tip's second and wrongly
+    // mark a historical epoch cascade-active during replay). The subsequent
+    // `2 * num_blocks_in_epoch` mining loop gives ample real-time margin (each
+    // mined block advances the clock by at least 1 s) to cross the activation
+    // timestamp before any expiry work is done — so this is tolerated, not a race.
     let mut stopped = node.stop().await;
     let activation_timestamp = UnixTimestamp::now()
         .expect("system time after unix epoch")

--- a/crates/chain-tests/src/validation/cascade_term_expiry.rs
+++ b/crates/chain-tests/src/validation/cascade_term_expiry.rs
@@ -1295,3 +1295,165 @@ async fn heavy_cascade_publish_last_write_expiry() -> eyre::Result<()> {
     node.stop().await;
     Ok(())
 }
+
+/// P1 regression (mid-chain Cascade + indexed term-ledger expiry): settling a
+/// ThirtyDay slot that expires AFTER the data has migrated into the block index
+/// must not stall the chain when Cascade was activated mid-chain.
+///
+/// The expiry-fee walk (`block_producer::ledger_expiry::resolve_ledger_offset_to_block`)
+/// resolves each expired chunk offset against the finalized block index. On a
+/// mid-chain activation the pre-activation blocks carry only Publish+Submit — no
+/// ThirtyDay entry — so the index binary search probes a block with no entry for
+/// the ledger. The buggy version used `BlockIndex::get_block_index_item`, which
+/// errors ("Ledger ThirtyDay not found in block at height N") on that probe; the
+/// error bubbles out of BOTH the producer and the validator epoch-block expiry
+/// path, so the expiry epoch can neither be produced nor accepted → the chain
+/// halts. The fix uses the tolerant `get_block_bounds`, which treats a missing
+/// entry as `total_chunks = 0` and keeps searching.
+///
+/// Why the existing term-expiry tests miss it: they activate Cascade at genesis
+/// (`activation_timestamp = 0`), so every block carries all four ledgers and the
+/// index never holds a ThirtyDay-less item. This test activates mid-chain and
+/// keeps the pre-activation phase the majority of the chain, so the binary
+/// search's first probe (`latest_height / 2`) lands on a pre-activation block.
+/// `block_migration_depth = 1` guarantees the ThirtyDay data is in the index
+/// (not the un-migrated tree tail, whose resolution path is unaffected) by the
+/// time it expires.
+#[test_log::test(tokio::test)]
+async fn slow_heavy_cascade_midchain_thirty_day_expiry_resolves_through_index() -> eyre::Result<()>
+{
+    let num_blocks_in_epoch = 2_u64;
+    let one_year_epoch_length = 8_u64;
+    let thirty_day_epoch_length = 2_u64; // expires 2×2 = 4 blocks after last write
+    let expiry_window = thirty_day_epoch_length * num_blocks_in_epoch; // 4
+    let chunk_size = 32_u64;
+    let num_chunks_in_partition = 10_u64;
+
+    let mut config = NodeConfig::testing().with_consensus(|c| {
+        c.block_migration_depth = 1;
+        c.epoch.num_blocks_in_epoch = num_blocks_in_epoch;
+        c.chunk_size = chunk_size;
+        c.num_chunks_in_partition = num_chunks_in_partition;
+        // Cascade intentionally NOT configured yet — activated mid-chain below so
+        // the pre-activation blocks carry only Publish+Submit (the regression).
+    });
+
+    let signer = config.new_random_signer();
+    config.fund_genesis_accounts(vec![&signer]);
+
+    let test_node = IrysNodeTest::new_genesis(config);
+    StorageSubmodulesConfig::load_for_test(test_node.cfg.base_directory.clone(), 5)?;
+    let node = test_node.start_and_wait_for_packing("test", 30).await;
+
+    let next_epoch_boundary = |h: u64| -> u64 {
+        if h.is_multiple_of(num_blocks_in_epoch) {
+            h
+        } else {
+            h + (num_blocks_in_epoch - (h % num_blocks_in_epoch))
+        }
+    };
+
+    // === Pre-activation phase: keep it the MAJORITY of the chain ===
+    // The index binary search's first probe is `latest_height / 2`; making the
+    // pre-activation span exceed half the chain at expiry guarantees that probe
+    // hits a pre-activation (ThirtyDay-less) block — the exact trigger.
+    let pre_activation_target = 16_u64;
+    while node.get_canonical_chain_height().await < pre_activation_target {
+        node.mine_block().await?;
+    }
+
+    // === Activate Cascade mid-chain (stop -> set activation = now+1 -> restart) ===
+    let mut stopped = node.stop().await;
+    let activation_timestamp = UnixTimestamp::now()
+        .expect("system time after unix epoch")
+        .as_secs()
+        + 1;
+    stopped.cfg.consensus.get_mut().hardforks.cascade = Some(Cascade {
+        activation_timestamp: UnixTimestamp::from_secs(activation_timestamp),
+        one_year_epoch_length,
+        thirty_day_epoch_length,
+        annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
+    });
+    let node = stopped.start().await;
+
+    // Mine a couple of cascade-active epochs so activate_cascade runs and the
+    // OneYear/ThirtyDay ledgers come into existence.
+    for _ in 0..(2 * num_blocks_in_epoch) {
+        node.mine_block().await?;
+    }
+
+    // === Post-activation: write 12 chunks of ThirtyDay data ===
+    // 4 txs × 3 chunks = 12 chunks → slot 0 (0-9) fills and slot 1 (10-11) starts,
+    // so slot 0 is non-last and therefore eligible to expire.
+    for i in 0_u8..4 {
+        let mut tx_data = vec![9_u8; 96]; // 96 / 32 = 3 chunks
+        tx_data[0] = i;
+        let price = node.get_data_price(DataLedger::ThirtyDay, 96).await?;
+        let tx = signer.create_transaction_with_fees(
+            tx_data,
+            node.get_anchor().await?,
+            DataLedger::ThirtyDay,
+            BoundedFee::new(price.term_fee),
+            None,
+        )?;
+        let tx = signer.sign_transaction(tx)?;
+        node.ingest_data_tx(tx.header.clone()).await?;
+        node.wait_for_mempool(tx.header.id, 30).await?;
+    }
+    let write_height = node.mine_block().await?.height;
+    let write_epoch = next_epoch_boundary(write_height);
+    while node.get_canonical_chain_height().await < write_epoch {
+        node.mine_block().await?;
+    }
+
+    // Sanity: the ThirtyDay ledger now holds data across ≥2 slots, so slot 0 is
+    // non-last and the data is in the migrated index (depth = 1).
+    {
+        let block = node.get_block_by_height(write_epoch).await?;
+        let tree = node.node_ctx.block_tree_guard.read();
+        let snapshot = tree
+            .get_epoch_snapshot(&block.block_hash)
+            .expect("epoch snapshot should exist");
+        let slots = snapshot.ledgers.get_slots(DataLedger::ThirtyDay);
+        assert!(
+            slots.len() >= 2 && !slots[0].is_expired,
+            "ThirtyDay slot 0 must be non-last and not yet expired (slots={}, slot0_expired={})",
+            slots.len(),
+            slots.first().map(|s| s.is_expired).unwrap_or(false),
+        );
+    }
+
+    // === Mine through the expiry epoch ===
+    // At `write_epoch + expiry_window` the producer settles ThirtyDay slot 0,
+    // walking `find_block_range(ThirtyDay)` → `resolve_ledger_offset_to_block`
+    // → the index binary search that probes a pre-activation block. Without the
+    // fix `mine_block` errors here ("Ledger ThirtyDay not found …") and the chain
+    // cannot advance past this epoch.
+    let expiry_epoch = write_epoch + expiry_window;
+    while node.get_canonical_chain_height().await < expiry_epoch {
+        node.mine_block().await?;
+    }
+
+    assert!(
+        node.get_canonical_chain_height().await >= expiry_epoch,
+        "chain must advance through the ThirtyDay expiry epoch without stalling"
+    );
+
+    // Settlement actually ran: slot 0 recycled (is_expired) at the expiry epoch.
+    {
+        let block = node.get_block_by_height(expiry_epoch).await?;
+        let tree = node.node_ctx.block_tree_guard.read();
+        let snapshot = tree
+            .get_epoch_snapshot(&block.block_hash)
+            .expect("epoch snapshot should exist");
+        let slots = snapshot.ledgers.get_slots(DataLedger::ThirtyDay);
+        assert!(
+            slots[0].is_expired,
+            "ThirtyDay slot 0 must be expired/recycled at the expiry epoch (proves the \
+             indexed expiry-fee walk completed)"
+        );
+    }
+
+    node.stop().await;
+    Ok(())
+}

--- a/crates/chain-tests/src/validation/cascade_term_expiry.rs
+++ b/crates/chain-tests/src/validation/cascade_term_expiry.rs
@@ -593,16 +593,20 @@ async fn slow_heavy_cascade_midchain_activation_submit_last_height_transition() 
         "pre-activation: touch gated off, slot 0 keeps its genesis last_height"
     );
 
-    // === Activate Cascade mid-chain via stop -> set activation = now -> restart ===
-    let mut stopped = node.stop().await;
-    // +1s so activation is STRICTLY after every pre-restart block: their
-    // timestamps are all <= now() (second-granular), and `cascade_at` activates
-    // on inclusive equality (>=), so `now()` alone could collide with the tip's
-    // second and wrongly mark a historical epoch cascade-active during replay.
-    let activation_timestamp = UnixTimestamp::now()
-        .expect("system time after unix epoch")
+    // === Activate Cascade mid-chain via stop -> set activation = tip+1 -> restart ===
+    // Anchor activation to the chain tip's timestamp, NOT wall-clock: tip + 1s is
+    // strictly after every pre-restart block (`cascade_at` activates on inclusive >=),
+    // so historical blocks stay pre-activation and only newly-mined blocks are
+    // cascade-active. Chain-derived, so it's immune to a backward CLOCK_REALTIME lurch
+    // that could make `now()` land at/before the tip (see block_producer::current_timestamp).
+    let tip_height = node.get_canonical_chain_height().await;
+    let activation_timestamp = node
+        .get_block_by_height(tip_height)
+        .await?
+        .timestamp_secs()
         .as_secs()
         + 1;
+    let mut stopped = node.stop().await;
     stopped.cfg.consensus.get_mut().hardforks.cascade = Some(Cascade {
         activation_timestamp: UnixTimestamp::from_secs(activation_timestamp),
         one_year_epoch_length,
@@ -1362,19 +1366,20 @@ async fn slow_heavy_cascade_midchain_thirty_day_expiry_resolves_through_index() 
         node.mine_block().await?;
     }
 
-    // === Activate Cascade mid-chain (stop -> set activation = now+1 -> restart) ===
-    // Wall-clock dependency: +1s ensures activation is strictly after all
-    // pre-restart blocks (their timestamps are <= now(); `cascade_at` activates on
-    // inclusive >=, so now() alone could collide with the tip's second and wrongly
-    // mark a historical epoch cascade-active during replay). The subsequent
-    // `2 * num_blocks_in_epoch` mining loop gives ample real-time margin (each
-    // mined block advances the clock by at least 1 s) to cross the activation
-    // timestamp before any expiry work is done — so this is tolerated, not a race.
-    let mut stopped = node.stop().await;
-    let activation_timestamp = UnixTimestamp::now()
-        .expect("system time after unix epoch")
+    // === Activate Cascade mid-chain (stop -> set activation = tip+1 -> restart) ===
+    // Anchor activation to the chain tip's timestamp, NOT wall-clock: tip + 1s is
+    // strictly after every pre-restart block (`cascade_at` activates on inclusive >=),
+    // so historical blocks stay pre-activation and only newly-mined blocks are
+    // cascade-active. Chain-derived, so it's immune to a backward CLOCK_REALTIME lurch
+    // that could make `now()` land at/before the tip (see block_producer::current_timestamp).
+    let tip_height = node.get_canonical_chain_height().await;
+    let activation_timestamp = node
+        .get_block_by_height(tip_height)
+        .await?
+        .timestamp_secs()
         .as_secs()
         + 1;
+    let mut stopped = node.stop().await;
     stopped.cfg.consensus.get_mut().hardforks.cascade = Some(Cascade {
         activation_timestamp: UnixTimestamp::from_secs(activation_timestamp),
         one_year_epoch_length,
@@ -1523,15 +1528,19 @@ async fn slow_heavy_cascade_midchain_submit_expiry_refunds_across_activation() -
     node.mine_until_next_epoch().await?;
     let pre_activation_height = node.get_canonical_chain_height().await;
 
-    // === Activate Cascade mid-chain: stop → set activation = now+1 → restart. The
-    // +1s keeps activation strictly after every pre-restart block's (second-granular)
-    // timestamp, so historical blocks stay pre-activation and only newly mined blocks
-    // are cascade-active — deterministic, no wall-clock race. ===
-    let mut stopped = node.stop().await;
-    let activation_timestamp = UnixTimestamp::now()
-        .expect("system time after unix epoch")
+    // === Activate Cascade mid-chain: stop → set activation = tip+1 → restart. Anchor
+    // to the chain tip's timestamp (NOT wall-clock): tip + 1s is strictly after every
+    // pre-restart block (`cascade_at` activates on inclusive >=), so historical blocks
+    // stay pre-activation and only newly mined blocks are cascade-active — deterministic
+    // and immune to a backward CLOCK_REALTIME lurch (see block_producer::current_timestamp). ===
+    let tip_height = node.get_canonical_chain_height().await;
+    let activation_timestamp = node
+        .get_block_by_height(tip_height)
+        .await?
+        .timestamp_secs()
         .as_secs()
         + 1;
+    let mut stopped = node.stop().await;
     stopped.cfg.consensus.get_mut().hardforks.cascade = Some(Cascade {
         activation_timestamp: UnixTimestamp::from_secs(activation_timestamp),
         one_year_epoch_length,

--- a/crates/chain-tests/src/validation/data_tx_pricing.rs
+++ b/crates/chain-tests/src/validation/data_tx_pricing.rs
@@ -11,12 +11,13 @@ use irys_actors::{
 };
 use irys_domain::{BlockTreeReadGuard, ChainState};
 use irys_types::IngressProofsList;
+use irys_types::hardfork_config::Cascade;
 use irys_types::storage_pricing::{
     Amount, calculate_perm_fee_from_config, calculate_term_fee_from_config,
 };
 use irys_types::{
-    Config, DataLedger, DataTransactionHeader, IrysBlockHeader, NodeConfig, OracleConfig, U256,
-    UnixTimestamp,
+    BoundedFee, Config, DataLedger, DataTransactionHeader, IrysBlockHeader, NodeConfig,
+    OracleConfig, U256, UnixTimestamp,
 };
 use rust_decimal_macros::dec;
 use std::sync::Arc;
@@ -821,6 +822,153 @@ async fn same_block_promoted_tx_with_ema_price_change_gets_rejected() -> eyre::R
             )
         },
         "block with insufficient perm_fee should be rejected",
+    );
+
+    genesis_node.stop().await;
+    Ok(())
+}
+
+/// Verify the block validator rejects a block whose OneYear (term-ledger) transaction
+/// carries a `perm_fee = Some(0)`.
+///
+/// The rejection site is the structural pre-pass in `data_txs_are_valid` (block_validation.rs):
+///
+///   ```text
+///   for tx in one_year_txs {
+///       ...
+///       if tx.perm_fee.is_some() {
+///           return Err(PreValidationError::TermLedgerTxHasPermFee { tx_id: tx.id });
+///       }
+///   }
+///   ```
+///
+/// Normal API ingress / the mempool reject such a tx before it reaches block production, so
+/// coverage requires injecting it directly via an evil `BlockProdStrategy` that overrides
+/// `get_mempool_txs` — bypassing ingress entirely.  The term_fee is set to the API-quoted
+/// value so the block would otherwise be valid, ensuring the sole rejection cause is the
+/// forbidden `perm_fee` field presence.
+#[test_log::test(tokio::test)]
+async fn heavy_block_term_ledger_tx_with_perm_fee_gets_rejected() -> eyre::Result<()> {
+    struct EvilBlockProdStrategy {
+        pub prod: ProductionStrategy,
+        pub malicious_tx: DataTransactionHeader,
+    }
+
+    #[async_trait::async_trait]
+    impl BlockProdStrategy for EvilBlockProdStrategy {
+        fn inner(&self) -> &BlockProducerInner {
+            &self.prod.inner
+        }
+
+        async fn get_mempool_txs(
+            &self,
+            _prev_block_header: &IrysBlockHeader,
+            _block_timestamp: irys_types::UnixTimestampMs,
+        ) -> Result<
+            irys_actors::block_producer::MempoolTxsBundle,
+            irys_actors::tx_selector::TxSelectorError,
+        > {
+            Ok(irys_actors::block_producer::MempoolTxsBundle {
+                commitment_txs: vec![],
+                commitment_txs_to_bill: vec![],
+                submit_txs: vec![],
+                one_year_txs: vec![self.malicious_tx.clone()],
+                thirty_day_txs: vec![],
+                publish_txs: PublishLedgerWithTxs {
+                    txs: vec![],
+                    proofs: None,
+                },
+                aggregated_miner_fees: LedgerExpiryBalanceDelta::default(),
+                commitment_refund_events: vec![],
+                unstake_refund_events: vec![],
+                epoch_snapshot: irys_domain::dummy_epoch_snapshot(),
+            })
+        }
+    }
+
+    let seconds_to_wait = 20;
+    let mut genesis_config = NodeConfig::testing();
+    genesis_config.consensus.get_mut().chunk_size = 32;
+    // Activate Cascade from genesis so OneYear/ThirtyDay ledgers are live.
+    genesis_config.consensus.get_mut().hardforks.cascade = Some(Cascade {
+        activation_timestamp: UnixTimestamp::from_secs(0),
+        one_year_epoch_length: 365,
+        thirty_day_epoch_length: 30,
+        annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
+    });
+
+    let test_signer = genesis_config.new_random_signer();
+    genesis_config.fund_genesis_accounts(vec![&test_signer]);
+    let genesis_node = IrysNodeTest::new_genesis(genesis_config.clone())
+        .start_and_wait_for_packing("GENESIS", seconds_to_wait)
+        .await;
+    genesis_node.mine_block().await?;
+
+    // Build a OneYear tx with a valid term_fee but perm_fee = Some(0).
+    // The valid term_fee ensures the block would be accepted but for the perm_fee presence.
+    let data = vec![42_u8; 1024];
+    let data_size = data.len() as u64;
+    let price_info = genesis_node
+        .get_data_price(DataLedger::OneYear, data_size)
+        .await?;
+
+    let mut malicious_tx = test_signer.create_transaction_with_fees(
+        data,
+        genesis_node.get_anchor().await?,
+        DataLedger::OneYear,
+        price_info.term_fee.into(), // valid term_fee
+        None,
+    )?;
+    // Force perm_fee = Some(0): term-ledger txs must have perm_fee = None.
+    malicious_tx.header.perm_fee = Some(BoundedFee::zero());
+    let malicious_tx = test_signer.sign_transaction(malicious_tx)?;
+
+    let genesis_block_prod = &genesis_node.node_ctx.block_producer_inner;
+    let block_prod_strategy = EvilBlockProdStrategy {
+        malicious_tx: malicious_tx.header.clone(),
+        prod: ProductionStrategy {
+            inner: Arc::new(BlockProducerInner {
+                config: Config::new_with_random_peer_id(
+                    genesis_node.node_ctx.config.node_config.clone(),
+                ),
+                db: genesis_block_prod.db.clone(),
+                block_discovery: genesis_block_prod.block_discovery.clone(),
+                mining_broadcaster: genesis_block_prod.mining_broadcaster.clone(),
+                service_senders: genesis_block_prod.service_senders.clone(),
+                reward_curve: genesis_block_prod.reward_curve.clone(),
+                vdf_steps_guard: genesis_block_prod.vdf_steps_guard.clone(),
+                block_tree_guard: genesis_block_prod.block_tree_guard.clone(),
+                mempool_guard: genesis_block_prod.mempool_guard.clone(),
+                price_oracle: genesis_block_prod.price_oracle.clone(),
+                reth_payload_builder: genesis_block_prod.reth_payload_builder.clone(),
+                reth_provider: genesis_block_prod.reth_provider.clone(),
+                consensus_engine_handle: genesis_block_prod.consensus_engine_handle.clone(),
+                block_index: genesis_block_prod.block_index.clone(),
+                reth_node_adapter: genesis_block_prod.reth_node_adapter.clone(),
+                chunk_ingress_state: genesis_block_prod.chunk_ingress_state.clone(),
+            }),
+        },
+    };
+
+    let (block, _adjustment_stats, _eth_payload) = block_prod_strategy
+        .fully_produce_new_block_without_gossip(&solution_context(&genesis_node.node_ctx).await?)
+        .await?
+        .unwrap();
+
+    // OneYear txs don't go through the mempool gossip path, so no gossip needed.
+    let outcome =
+        send_block_and_read_state(&genesis_node.node_ctx, Arc::clone(&block), false).await?;
+    // The structural pre-pass in `data_txs_are_valid` fires before any fee arithmetic:
+    //   `if tx.perm_fee.is_some() { return Err(TermLedgerTxHasPermFee { .. }) }`
+    assert_validation_error(
+        outcome,
+        |e| {
+            matches!(
+                e,
+                ValidationError::PreValidation(PreValidationError::TermLedgerTxHasPermFee { .. })
+            )
+        },
+        "block with OneYear tx carrying perm_fee=Some(0) must be rejected with TermLedgerTxHasPermFee",
     );
 
     genesis_node.stop().await;

--- a/crates/chain-tests/src/validation/mod.rs
+++ b/crates/chain-tests/src/validation/mod.rs
@@ -135,6 +135,14 @@ pub(super) async fn submit_expiry_two_node_setup(
     }
     genesis_node.mine_block().await?;
 
+    // Wait for the peer to sync to the genesis node's canonical height before
+    // returning — downstream tests that exercise the validator path on peer_node
+    // race if we hand back an unsynced peer.
+    let genesis_height = genesis_node.get_canonical_chain_height().await;
+    peer_node
+        .wait_until_height(genesis_height, seconds_to_wait)
+        .await?;
+
     Ok(ExpiryTestSetup {
         genesis_config,
         genesis_node,

--- a/crates/chain-tests/src/validation/mod.rs
+++ b/crates/chain-tests/src/validation/mod.rs
@@ -36,11 +36,94 @@ use irys_actors::{
 };
 use irys_chain::IrysNodeCtx;
 use irys_types::{
-    BlockBody, CommitmentTransaction, DataTransactionHeader, DataTransactionHeaderV1, H256,
-    H256List, IrysBlockHeader, IrysTransactionCommon as _, NodeConfig, SealedBlock,
-    SystemTransactionLedger,
+    BlockBody, CommitmentTransaction, DataTransaction, DataTransactionHeader,
+    DataTransactionHeaderV1, H256, H256List, IrysBlockHeader, IrysTransactionCommon as _,
+    NodeConfig, SealedBlock, SystemTransactionLedger,
 };
 use irys_types::{DataLedger, SendTraced as _, SystemLedger};
+
+/// Shared test-setup result used by both the §4b producer test and the §4c
+/// validator test. Both tests require the same config, two-node topology, and
+/// initial data-tx posting step; only what they do *after* the data block differs.
+pub(super) struct ExpiryTestSetup {
+    pub genesis_config: NodeConfig,
+    pub genesis_node: IrysNodeTest<IrysNodeCtx>,
+    pub peer_node: IrysNodeTest<IrysNodeCtx>,
+    /// The txs posted to the Submit ledger (each with embedded data bytes).
+    pub txs: Vec<DataTransaction>,
+    /// The signer used to post the data txs and to fund the genesis accounts.
+    pub user_signer: irys_types::irys::IrysSigner,
+    /// `num_blocks_in_epoch * submit_ledger_epoch_length` — the height at which
+    /// the genesis Submit slot expires and the expiry epoch block is produced.
+    pub blocks_per_cycle: u64,
+    /// Number of blocks per epoch (= 5 in both tests).
+    pub num_blocks_in_epoch: u64,
+    pub seconds_to_wait: usize,
+}
+
+/// Builds the common two-node expiry setup used by both §4b and §4c tests:
+///   - config: 5-block epochs, 2-epoch Submit ledger, 32-byte chunks, 10-chunk partitions
+///   - starts genesis + peer nodes
+///   - posts `num_chunks_in_partition + 2` single-chunk data txs to overflow one partition
+///     (forces a 2nd Submit slot so the genesis slot is non-last and can expire)
+///   - mines the first data block so the txs land in the Submit ledger
+///
+/// Both tests diverge after this point.
+pub(super) async fn submit_expiry_two_node_setup() -> eyre::Result<ExpiryTestSetup> {
+    let num_blocks_in_epoch: usize = 5;
+    let submit_ledger_epoch_length: u64 = 2;
+    let chunk_size: u64 = 32;
+    let num_chunks_in_partition: u64 = 10;
+    let blocks_per_cycle = num_blocks_in_epoch as u64 * submit_ledger_epoch_length;
+    let seconds_to_wait = 40_usize;
+
+    let mut genesis_config = NodeConfig::testing_with_epochs(num_blocks_in_epoch);
+    {
+        let c = genesis_config.consensus.get_mut();
+        c.chunk_size = chunk_size;
+        c.num_chunks_in_partition = num_chunks_in_partition;
+        c.block_migration_depth = 1;
+        c.epoch.submit_ledger_epoch_length = submit_ledger_epoch_length;
+        // One ingress proof from the genesis signer makes a tx promotable — keeps
+        // both tests single-node on the promotion side.
+        c.hardforks.frontier.number_of_ingress_proofs_total = 1;
+    }
+
+    let user_signer = genesis_config.new_random_signer();
+    genesis_config.fund_genesis_accounts(vec![&user_signer]);
+
+    let genesis_node = IrysNodeTest::new_genesis(genesis_config.clone())
+        .start_and_wait_for_packing("GENESIS", seconds_to_wait)
+        .await;
+    let peer_config = genesis_node.testing_peer_with_signer(&user_signer);
+    let peer_node = IrysNodeTest::new(peer_config).start_with_name("PEER").await;
+
+    // Post enough single-chunk txs to overflow one partition (forces a 2nd Submit slot
+    // so genesis slot 0 is non-last and expires at blocks_per_cycle).
+    let num_txs = (num_chunks_in_partition + 2) as usize;
+    let anchor = genesis_node.get_anchor().await?;
+    let mut txs = Vec::with_capacity(num_txs);
+    for i in 0..num_txs {
+        let data = vec![100 + i as u8; chunk_size as usize];
+        let tx = genesis_node.post_data_tx(anchor, data, &user_signer).await;
+        genesis_node
+            .wait_for_mempool(tx.header.id, seconds_to_wait)
+            .await?;
+        txs.push(tx);
+    }
+    genesis_node.mine_block().await?;
+
+    Ok(ExpiryTestSetup {
+        genesis_config,
+        genesis_node,
+        peer_node,
+        txs,
+        user_signer,
+        blocks_per_cycle,
+        num_blocks_in_epoch: num_blocks_in_epoch as u64,
+        seconds_to_wait,
+    })
+}
 
 // Helper function to send a block directly to the block tree service for validation
 pub(crate) async fn send_block_to_block_tree(

--- a/crates/chain-tests/src/validation/mod.rs
+++ b/crates/chain-tests/src/validation/mod.rs
@@ -2,6 +2,7 @@ mod anchor_canonical_reorg;
 mod blobs_rejected;
 mod cascade_block_rejection;
 mod cascade_ledger_shape;
+mod cascade_submit_expiry_promotion;
 mod cascade_term_balance;
 mod cascade_term_expiry;
 mod data_tx_pricing;
@@ -87,6 +88,17 @@ pub(super) async fn submit_expiry_two_node_setup() -> eyre::Result<ExpiryTestSet
         // One ingress proof from the genesis signer makes a tx promotable — keeps
         // both tests single-node on the promotion side.
         c.hardforks.frontier.number_of_ingress_proofs_total = 1;
+        // Pin Cascade OFF. This is the precondition for the `refunded == expired`
+        // EXACT-equality assertion in `publish_after_submit_expiry_filtered.rs`:
+        // pre-Cascade, Pipeline A's §4b drop set and Pipeline B's refund set are
+        // identical. Under Cascade the §4b filter set is a strict SUPERSET of the
+        // refund set (written-slot / last-write anchoring excludes rescued slots
+        // from refunds but not from the promotion filter), so the exact equality
+        // no longer holds. `ConsensusConfig::testing()` already defaults this to
+        // None, but we pin it explicitly so a default change can't silently break
+        // that assertion. The Cascade-active §4b/§4c path is covered separately by
+        // `cascade_submit_expiry_promotion.rs`.
+        c.hardforks.cascade = None;
     }
 
     let user_signer = genesis_config.new_random_signer();

--- a/crates/chain-tests/src/validation/mod.rs
+++ b/crates/chain-tests/src/validation/mod.rs
@@ -12,6 +12,8 @@ mod ledger_expiry_with_unstake;
 mod mempool_gossip_shape;
 mod mempool_ingress_proof_dedup;
 mod poa_cases;
+mod promote_after_submit_expiry;
+mod publish_after_submit_expiry_filtered;
 mod same_block_promotion;
 mod unpledge_partition;
 mod unstake_edge_cases;

--- a/crates/chain-tests/src/validation/mod.rs
+++ b/crates/chain-tests/src/validation/mod.rs
@@ -15,7 +15,9 @@ mod mempool_ingress_proof_dedup;
 mod poa_cases;
 mod promote_after_submit_expiry;
 mod publish_after_submit_expiry_filtered;
+mod reorg_submit_expiry;
 mod same_block_promotion;
+mod slow_path_submit_expiry;
 mod unpledge_partition;
 mod unstake_edge_cases;
 
@@ -70,7 +72,15 @@ pub(super) struct ExpiryTestSetup {
 ///   - mines the first data block so the txs land in the Submit ledger
 ///
 /// Both tests diverge after this point.
-pub(super) async fn submit_expiry_two_node_setup() -> eyre::Result<ExpiryTestSetup> {
+///
+/// `block_migration_depth` is a parameter so the slow-path test
+/// (`slow_path_submit_expiry.rs`) can set it high enough that an expired tx's
+/// Submit inclusion is still UN-migrated at the verdict block, forcing
+/// `resolve_submit_inclusion`'s by-hash slow path. The §4b/§4c tests pass `1`
+/// (immediate migration → fast path).
+pub(super) async fn submit_expiry_two_node_setup(
+    block_migration_depth: u32,
+) -> eyre::Result<ExpiryTestSetup> {
     let num_blocks_in_epoch: usize = 5;
     let submit_ledger_epoch_length: u64 = 2;
     let chunk_size: u64 = 32;
@@ -83,7 +93,7 @@ pub(super) async fn submit_expiry_two_node_setup() -> eyre::Result<ExpiryTestSet
         let c = genesis_config.consensus.get_mut();
         c.chunk_size = chunk_size;
         c.num_chunks_in_partition = num_chunks_in_partition;
-        c.block_migration_depth = 1;
+        c.block_migration_depth = block_migration_depth;
         c.epoch.submit_ledger_epoch_length = submit_ledger_epoch_length;
         // One ingress proof from the genesis signer makes a tx promotable — keeps
         // both tests single-node on the promotion side.

--- a/crates/chain-tests/src/validation/promote_after_submit_expiry.rs
+++ b/crates/chain-tests/src/validation/promote_after_submit_expiry.rs
@@ -1,7 +1,7 @@
 // NC-0042 §4c validator consensus rule: a block that promotes a tx whose
 // Submit-ledger storage has already expired must be rejected with
 // `ShadowTransactionInvalid` — even when the expiry happened in an *earlier*
-// block (the cross-block silent double-pay, devnet 39960/39962).
+// block (the cross-block silent double-pay).
 //
 // Scenario (real flow, no DB seeding):
 //   1. Drive enough data txs through the Submit ledger to force a 2nd slot, so

--- a/crates/chain-tests/src/validation/promote_after_submit_expiry.rs
+++ b/crates/chain-tests/src/validation/promote_after_submit_expiry.rs
@@ -132,10 +132,9 @@ async fn heavy_block_promoting_already_expired_submit_tx_gets_rejected() -> eyre
     // --- 4. Pick a target tx and confirm it is genuinely expired at the NEXT
     //         (cross-block) height we'll produce the evil block at. ---
     let evil_height = expiry_height + 1; // E+1: cross-block, not the epoch block
-    let tip_hash = genesis_node
-        .get_block_by_height(expiry_height)
-        .await?
-        .block_hash;
+    // The current tip is the parent of the evil block we'll produce at E+1.
+    let evil_parent_block = genesis_node.get_block_by_height(expiry_height).await?;
+    let tip_hash = evil_parent_block.block_hash;
     // Bind the snapshot in its own scope so the block-tree read guard is dropped
     // before the await below (held-guard-across-await is a clippy deny).
     let tip_snapshot = genesis_node
@@ -146,6 +145,7 @@ async fn heavy_block_promoting_already_expired_submit_tx_gets_rejected() -> eyre
         .expect("epoch snapshot for the current tip");
     let expired_set = irys_actors::block_producer::ledger_expiry::expired_submit_tx_ids(
         &tip_snapshot,
+        &evil_parent_block,
         evil_height,
         &genesis_node.node_ctx.config,
         genesis_node
@@ -158,6 +158,32 @@ async fn heavy_block_promoting_already_expired_submit_tx_gets_rejected() -> eyre
         &genesis_node.node_ctx.db,
     )
     .await?;
+
+    // Differential check (the equivalence the inversion relies on): the
+    // per-candidate predicate that the producer filter and validator check now
+    // use must agree with the `expired_submit_tx_ids` walk oracle — in both
+    // directions — for every posted Submit tx, against real chain state.
+    for tx in &txs {
+        let per_candidate = irys_actors::block_producer::ledger_expiry::is_submit_storage_expired(
+            tx.header.id,
+            evil_height,
+            &tip_snapshot,
+            &evil_parent_block,
+            &genesis_node.node_ctx.config,
+            &genesis_node.node_ctx.block_producer_inner.block_index,
+            &genesis_node.node_ctx.block_tree_guard,
+            &genesis_node.node_ctx.mempool_guard,
+            &genesis_node.node_ctx.db,
+        )
+        .await?;
+        assert_eq!(
+            per_candidate,
+            expired_set.contains(&tx.header.id),
+            "is_submit_storage_expired must match the expired_submit_tx_ids walk oracle for tx {}",
+            tx.header.id,
+        );
+    }
+
     let target = txs
         .iter()
         .find(|tx| expired_set.contains(&tx.header.id))

--- a/crates/chain-tests/src/validation/promote_after_submit_expiry.rs
+++ b/crates/chain-tests/src/validation/promote_after_submit_expiry.rs
@@ -187,7 +187,10 @@ async fn heavy_block_promoting_already_expired_submit_tx_gets_rejected() -> eyre
     //         staked) so the evil block fails ONLY on the §4c expiry rule. ---
     let genesis_signer = genesis_config.signer();
     let proof_anchor = genesis_node.get_anchor().await?;
-    let chunks: Vec<Vec<u8>> = vec![target.data.clone().unwrap_or_default().into()];
+    let target_data = target.data.clone().expect(
+        "posted tx payload must be retained to build the ingress proof (fixture invariant)",
+    );
+    let chunks: Vec<Vec<u8>> = vec![target_data.into()];
     let proof = generate_ingress_proof(
         &genesis_signer,
         expired_tx.data_root,

--- a/crates/chain-tests/src/validation/promote_after_submit_expiry.rs
+++ b/crates/chain-tests/src/validation/promote_after_submit_expiry.rs
@@ -1,0 +1,221 @@
+// NC-0042 §4c validator consensus rule: a block that promotes a tx whose
+// Submit-ledger storage has already expired must be rejected with
+// `ShadowTransactionInvalid` — even when the expiry happened in an *earlier*
+// block (the cross-block silent double-pay, devnet 39960/39962).
+//
+// Scenario (real flow, no DB seeding):
+//   1. Drive enough data txs through the Submit ledger to force a 2nd slot, so
+//      the genesis slot genuinely expires (per-slot expiry; the last slot is
+//      never expired — see `publish_after_submit_expiry_filtered.rs`).
+//   2. Mine honestly to the expiry epoch. The honest producer drops those txs
+//      from promotion (§4b) and perm-fee-refunds them (Pipeline B).
+//   3. AFTER expiry, an `EvilPublishStrategy` produces a block that promotes one
+//      of the already-expired+refunded txs anyway (the malicious/buggy peer).
+//   4. Both the genesis node and a peer must REJECT that block with
+//      `ShadowTransactionInvalid`. Before §4c this block was accepted by every
+//      validator (no check covered the cross-block case) → permanent double-pay.
+//
+// The earlier version of this test hand-inserted `MigratedBlockHashes` rows;
+// that collides with the real chain's migration writes and crashes
+// BlockTreeService. We drive the tx through the real Submit flow instead.
+
+use crate::utils::{IrysNodeTest, assert_validation_error, solution_context};
+use crate::validation::send_block_and_read_state;
+use irys_actors::block_validation::ValidationError;
+use irys_actors::{
+    BlockProdStrategy, BlockProducerInner, ProductionStrategy, async_trait,
+    block_producer::ledger_expiry::LedgerExpiryBalanceDelta,
+    shadow_tx_generator::PublishLedgerWithTxs,
+};
+use irys_domain::BlockTreeReadGuard;
+use irys_types::ingress::generate_ingress_proof;
+use irys_types::{
+    DataLedger, DataTransactionHeader, IngressProofsList, IrysBlockHeader, NodeConfig,
+    UnixTimestampMs,
+};
+
+#[test_log::test(tokio::test)]
+async fn heavy_block_promoting_already_expired_submit_tx_gets_rejected() -> eyre::Result<()> {
+    /// Forces an already-expired Submit tx into the Publish ledger, with a valid
+    /// ingress proof so the block fails validation *only* on the §4c expiry rule
+    /// (not on a missing/invalid proof). No refund is scheduled in the bundle, so
+    /// the in-constructor defence-in-depth guard does not fire during production —
+    /// the block is built and must be caught at validation time.
+    struct EvilPublishStrategy {
+        prod: ProductionStrategy,
+        expired_tx: DataTransactionHeader,
+        proofs: IngressProofsList,
+        block_tree_guard: BlockTreeReadGuard,
+    }
+
+    #[async_trait::async_trait]
+    impl BlockProdStrategy for EvilPublishStrategy {
+        fn inner(&self) -> &BlockProducerInner {
+            &self.prod.inner
+        }
+
+        async fn get_mempool_txs(
+            &self,
+            _prev_block_header: &IrysBlockHeader,
+            _block_timestamp: UnixTimestampMs,
+        ) -> Result<
+            irys_actors::block_producer::MempoolTxsBundle,
+            irys_actors::tx_selector::TxSelectorError,
+        > {
+            Ok(irys_actors::block_producer::MempoolTxsBundle {
+                commitment_txs: vec![],
+                commitment_txs_to_bill: vec![],
+                submit_txs: vec![],
+                one_year_txs: vec![],
+                thirty_day_txs: vec![],
+                publish_txs: PublishLedgerWithTxs {
+                    txs: vec![self.expired_tx.clone()],
+                    proofs: Some(self.proofs.clone()),
+                },
+                aggregated_miner_fees: LedgerExpiryBalanceDelta::default(),
+                commitment_refund_events: vec![],
+                unstake_refund_events: vec![],
+                epoch_snapshot: self.block_tree_guard.read().canonical_epoch_snapshot(),
+            })
+        }
+    }
+
+    // --- 1. Config (mirrors the expiry setup of the §4b producer test) ---
+    let num_blocks_in_epoch: usize = 5;
+    let submit_ledger_epoch_length: u64 = 2;
+    let chunk_size: u64 = 32;
+    let num_chunks_in_partition: u64 = 10;
+    let blocks_per_cycle = num_blocks_in_epoch as u64 * submit_ledger_epoch_length;
+    let seconds_to_wait = 40;
+
+    let mut genesis_config = NodeConfig::testing_with_epochs(num_blocks_in_epoch);
+    {
+        let c = genesis_config.consensus.get_mut();
+        c.chunk_size = chunk_size;
+        c.num_chunks_in_partition = num_chunks_in_partition;
+        c.block_migration_depth = 1;
+        c.epoch.submit_ledger_epoch_length = submit_ledger_epoch_length;
+        c.hardforks.frontier.number_of_ingress_proofs_total = 1;
+    }
+
+    let user_signer = genesis_config.new_random_signer();
+    genesis_config.fund_genesis_accounts(vec![&user_signer]);
+
+    let genesis_node = IrysNodeTest::new_genesis(genesis_config.clone())
+        .start_and_wait_for_packing("GENESIS", seconds_to_wait)
+        .await;
+    let peer_config = genesis_node.testing_peer_with_signer(&user_signer);
+    let peer_node = IrysNodeTest::new(peer_config).start_with_name("PEER").await;
+
+    // --- 2. Post enough single-chunk data txs to overflow one partition (forces a
+    //         2nd Submit slot so the genesis slot 0 is non-last and expires). ---
+    let num_txs = (num_chunks_in_partition + 2) as usize;
+    let anchor = genesis_node.get_anchor().await?;
+    let mut txs = Vec::with_capacity(num_txs);
+    for i in 0..num_txs {
+        let data = vec![100 + i as u8; chunk_size as usize];
+        let tx = genesis_node.post_data_tx(anchor, data, &user_signer).await;
+        genesis_node
+            .wait_for_mempool(tx.header.id, seconds_to_wait)
+            .await?;
+        txs.push(tx);
+    }
+    genesis_node.mine_block().await?;
+
+    // --- 3. Mine honestly to the expiry epoch. Pipeline B refunds the slot-0 txs
+    //         here and the honest producer drops them from promotion (§4b). ---
+    let expiry_height = blocks_per_cycle; // = 10
+    while genesis_node.get_canonical_chain_height().await < expiry_height {
+        genesis_node.mine_block().await?;
+    }
+
+    // --- 4. Pick a target tx and confirm it is genuinely expired at the NEXT
+    //         (cross-block) height we'll produce the evil block at. ---
+    let evil_height = expiry_height + 1; // E+1: cross-block, not the epoch block
+    let tip_hash = genesis_node
+        .get_block_by_height(expiry_height)
+        .await?
+        .block_hash;
+    // Bind the snapshot in its own scope so the block-tree read guard is dropped
+    // before the await below (held-guard-across-await is a clippy deny).
+    let tip_snapshot = genesis_node
+        .node_ctx
+        .block_tree_guard
+        .read()
+        .get_epoch_snapshot(&tip_hash)
+        .expect("epoch snapshot for the current tip");
+    let expired_set = irys_actors::block_producer::ledger_expiry::expired_submit_tx_ids(
+        &tip_snapshot,
+        evil_height,
+        &genesis_node.node_ctx.config,
+        genesis_node
+            .node_ctx
+            .block_producer_inner
+            .block_index
+            .clone(),
+        &genesis_node.node_ctx.block_tree_guard,
+        &genesis_node.node_ctx.mempool_guard,
+        &genesis_node.node_ctx.db,
+    )
+    .await?;
+    let target = txs
+        .iter()
+        .find(|tx| expired_set.contains(&tx.header.id))
+        .expect("at least one posted tx must have expired by the cross-block height");
+    let expired_tx = target.header.clone();
+
+    // --- 5. Build a valid ingress proof for the expired tx (genesis signer is
+    //         staked) so the evil block fails ONLY on the §4c expiry rule. ---
+    let genesis_signer = genesis_config.signer();
+    let proof_anchor = genesis_node.get_anchor().await?;
+    let chunks: Vec<Vec<u8>> = vec![target.data.clone().unwrap_or_default().into()];
+    let proof = generate_ingress_proof(
+        &genesis_signer,
+        expired_tx.data_root,
+        chunks.iter().map(|c| Ok(c.as_slice())),
+        genesis_config.consensus_config().chain_id,
+        proof_anchor,
+    )?;
+
+    // --- 6. Evil producer builds a block at E+1 that promotes the expired tx ---
+    let evil_strategy = EvilPublishStrategy {
+        expired_tx: expired_tx.clone(),
+        proofs: IngressProofsList(vec![proof]),
+        prod: ProductionStrategy {
+            inner: genesis_node.node_ctx.block_producer_inner.clone(),
+        },
+        block_tree_guard: genesis_node.node_ctx.block_tree_guard.clone(),
+    };
+    let (block, _adj, _payload) = evil_strategy
+        .fully_produce_new_block_without_gossip(&solution_context(&genesis_node.node_ctx).await?)
+        .await?
+        .expect("evil block should be produced (the guard fires at validation, not production)");
+
+    assert_eq!(block.header().height, evil_height, "evil block at E+1");
+    assert!(
+        block.header().data_ledgers[DataLedger::Publish]
+            .tx_ids
+            .contains(&expired_tx.id),
+        "evil block must promote the expired tx"
+    );
+
+    // --- 7. Both nodes must reject it with ShadowTransactionInvalid (§4c) ---
+    let genesis_outcome =
+        send_block_and_read_state(&genesis_node.node_ctx, block.clone(), false).await?;
+    assert_validation_error(
+        genesis_outcome,
+        |e| matches!(e, ValidationError::ShadowTransactionInvalid(_)),
+        "Genesis must reject a block promoting an already-expired Submit tx (NC-0042 §4c)",
+    );
+
+    let peer_outcome = send_block_and_read_state(&peer_node.node_ctx, block.clone(), false).await?;
+    assert_validation_error(
+        peer_outcome,
+        |e| matches!(e, ValidationError::ShadowTransactionInvalid(_)),
+        "Peer must reject a block promoting an already-expired Submit tx (NC-0042 §4c)",
+    );
+
+    peer_node.stop().await;
+    genesis_node.stop().await;
+    Ok(())
+}

--- a/crates/chain-tests/src/validation/promote_after_submit_expiry.rs
+++ b/crates/chain-tests/src/validation/promote_after_submit_expiry.rs
@@ -19,8 +19,8 @@
 // that collides with the real chain's migration writes and crashes
 // BlockTreeService. We drive the tx through the real Submit flow instead.
 
-use crate::utils::{IrysNodeTest, assert_validation_error, solution_context};
-use crate::validation::send_block_and_read_state;
+use crate::utils::{assert_validation_error, solution_context};
+use crate::validation::{send_block_and_read_state, submit_expiry_two_node_setup};
 use irys_actors::block_validation::ValidationError;
 use irys_actors::{
     BlockProdStrategy, BlockProducerInner, ProductionStrategy, async_trait,
@@ -30,8 +30,7 @@ use irys_actors::{
 use irys_domain::BlockTreeReadGuard;
 use irys_types::ingress::generate_ingress_proof;
 use irys_types::{
-    DataLedger, DataTransactionHeader, IngressProofsList, IrysBlockHeader, NodeConfig,
-    UnixTimestampMs,
+    DataLedger, DataTransactionHeader, IngressProofsList, IrysBlockHeader, UnixTimestampMs,
 };
 
 #[test_log::test(tokio::test)]
@@ -80,54 +79,29 @@ async fn heavy_block_promoting_already_expired_submit_tx_gets_rejected() -> eyre
         }
     }
 
-    // --- 1. Config (mirrors the expiry setup of the §4b producer test) ---
-    let num_blocks_in_epoch: usize = 5;
-    let submit_ledger_epoch_length: u64 = 2;
-    let chunk_size: u64 = 32;
-    let num_chunks_in_partition: u64 = 10;
-    let blocks_per_cycle = num_blocks_in_epoch as u64 * submit_ledger_epoch_length;
-    let seconds_to_wait = 40;
-
-    let mut genesis_config = NodeConfig::testing_with_epochs(num_blocks_in_epoch);
-    {
-        let c = genesis_config.consensus.get_mut();
-        c.chunk_size = chunk_size;
-        c.num_chunks_in_partition = num_chunks_in_partition;
-        c.block_migration_depth = 1;
-        c.epoch.submit_ledger_epoch_length = submit_ledger_epoch_length;
-        c.hardforks.frontier.number_of_ingress_proofs_total = 1;
-    }
-
-    let user_signer = genesis_config.new_random_signer();
-    genesis_config.fund_genesis_accounts(vec![&user_signer]);
-
-    let genesis_node = IrysNodeTest::new_genesis(genesis_config.clone())
-        .start_and_wait_for_packing("GENESIS", seconds_to_wait)
-        .await;
-    let peer_config = genesis_node.testing_peer_with_signer(&user_signer);
-    let peer_node = IrysNodeTest::new(peer_config).start_with_name("PEER").await;
-
-    // --- 2. Post enough single-chunk data txs to overflow one partition (forces a
-    //         2nd Submit slot so the genesis slot 0 is non-last and expires). ---
-    let num_txs = (num_chunks_in_partition + 2) as usize;
-    let anchor = genesis_node.get_anchor().await?;
-    let mut txs = Vec::with_capacity(num_txs);
-    for i in 0..num_txs {
-        let data = vec![100 + i as u8; chunk_size as usize];
-        let tx = genesis_node.post_data_tx(anchor, data, &user_signer).await;
-        genesis_node
-            .wait_for_mempool(tx.header.id, seconds_to_wait)
-            .await?;
-        txs.push(tx);
-    }
-    genesis_node.mine_block().await?;
+    // --- 1 + 2. Shared config + two-node startup + overflow data posting ---
+    let setup = submit_expiry_two_node_setup().await?;
+    let genesis_config = setup.genesis_config;
+    let genesis_node = setup.genesis_node;
+    let peer_node = setup.peer_node;
+    let txs = setup.txs;
+    let blocks_per_cycle = setup.blocks_per_cycle;
+    let seconds_to_wait = setup.seconds_to_wait;
 
     // --- 3. Mine honestly to the expiry epoch. Pipeline B refunds the slot-0 txs
     //         here and the honest producer drops them from promotion (§4b). ---
     let expiry_height = blocks_per_cycle; // = 10
+    let height_before_loop = genesis_node.get_canonical_chain_height().await;
     while genesis_node.get_canonical_chain_height().await < expiry_height {
         genesis_node.mine_block().await?;
     }
+    // If the §4b producer filter were absent, the producer would panic at the
+    // expiry epoch block and the chain would stall — the loop would never
+    // terminate. Assert that height advanced so a stall fails fast instead.
+    assert!(
+        genesis_node.get_canonical_chain_height().await > height_before_loop,
+        "chain must have advanced past the expiry epoch (§4b filter must not have stalled the producer)"
+    );
 
     // --- 4. Pick a target tx and confirm it is genuinely expired at the NEXT
     //         (cross-block) height we'll produce the evil block at. ---
@@ -159,10 +133,15 @@ async fn heavy_block_promoting_already_expired_submit_tx_gets_rejected() -> eyre
     )
     .await?;
 
-    // Differential check (the equivalence the inversion relies on): the
-    // per-candidate predicate that the producer filter and validator check now
-    // use must agree with the `expired_submit_tx_ids` walk oracle — in both
-    // directions — for every posted Submit tx, against real chain state.
+    // Differential check: the per-candidate predicate the producer filter and
+    // validator check use (`is_submit_storage_expired`) must agree EXACTLY with the
+    // `expired_submit_tx_ids` walk oracle for every posted tx. Both are now exact
+    // offset comparisons — the refund walk's `same_block` over-inclusion (which this
+    // single-block layout hits) was closed alongside the per-candidate filter
+    // (NC-0042 §4b / R2), so the oracle no longer over-includes whole blocks. We
+    // still drive the evil block off the per-candidate verdict, which is what §4c
+    // enforces.
+    let mut per_candidate_expired = Vec::new();
     for tx in &txs {
         let per_candidate = irys_actors::block_producer::ledger_expiry::is_submit_storage_expired(
             tx.header.id,
@@ -179,15 +158,19 @@ async fn heavy_block_promoting_already_expired_submit_tx_gets_rejected() -> eyre
         assert_eq!(
             per_candidate,
             expired_set.contains(&tx.header.id),
-            "is_submit_storage_expired must match the expired_submit_tx_ids walk oracle for tx {}",
+            "is_submit_storage_expired must agree exactly with the expired_submit_tx_ids \
+             walk oracle for tx {} (both are exact offset comparisons — NC-0042 §4b/R2)",
             tx.header.id,
         );
+        if per_candidate {
+            per_candidate_expired.push(tx);
+        }
     }
 
-    let target = txs
-        .iter()
-        .find(|tx| expired_set.contains(&tx.header.id))
-        .expect("at least one posted tx must have expired by the cross-block height");
+    let target = per_candidate_expired
+        .first()
+        .copied()
+        .expect("at least one posted tx must be expired by the per-candidate (§4c) verdict");
     let expired_tx = target.header.clone();
 
     // --- 5. Build a valid ingress proof for the expired tx (genesis signer is
@@ -225,21 +208,42 @@ async fn heavy_block_promoting_already_expired_submit_tx_gets_rejected() -> eyre
         "evil block must promote the expired tx"
     );
 
+    // The §4c rejection message includes "See NC-0042." — match on that to ensure
+    // the block is rejected for the right reason and not an unrelated shadow-tx error.
+    let is_nc_0042_expiry_rejection = |e: &ValidationError| match e {
+        ValidationError::ShadowTransactionInvalid(msg) => msg.contains("NC-0042"),
+        _ => false,
+    };
+
     // --- 7. Both nodes must reject it with ShadowTransactionInvalid (§4c) ---
     let genesis_outcome =
         send_block_and_read_state(&genesis_node.node_ctx, block.clone(), false).await?;
     assert_validation_error(
         genesis_outcome,
-        |e| matches!(e, ValidationError::ShadowTransactionInvalid(_)),
+        is_nc_0042_expiry_rejection,
         "Genesis must reject a block promoting an already-expired Submit tx (NC-0042 §4c)",
     );
+
+    // Peer must have the parent chain up to expiry_height before we send it the E+1 block;
+    // otherwise it rejects for ParentBlockMissing rather than ShadowTransactionInvalid.
+    peer_node
+        .wait_until_height(expiry_height, seconds_to_wait)
+        .await?;
 
     let peer_outcome = send_block_and_read_state(&peer_node.node_ctx, block.clone(), false).await?;
     assert_validation_error(
         peer_outcome,
-        |e| matches!(e, ValidationError::ShadowTransactionInvalid(_)),
+        is_nc_0042_expiry_rejection,
         "Peer must reject a block promoting an already-expired Submit tx (NC-0042 §4c)",
     );
+
+    // Neither node should have committed the evil block to the EVM layer.
+    genesis_node
+        .assert_evm_block_absent(block.header().evm_block_hash, 2)
+        .await?;
+    peer_node
+        .assert_evm_block_absent(block.header().evm_block_hash, 2)
+        .await?;
 
     peer_node.stop().await;
     genesis_node.stop().await;

--- a/crates/chain-tests/src/validation/promote_after_submit_expiry.rs
+++ b/crates/chain-tests/src/validation/promote_after_submit_expiry.rs
@@ -117,11 +117,20 @@ async fn heavy_block_promoting_already_expired_submit_tx_gets_rejected() -> eyre
         .read()
         .get_epoch_snapshot(&tip_hash)
         .expect("epoch snapshot for the current tip");
+    // The block-under-test's own Cascade status — exactly what production passes
+    // to `expired_submit_range`; compute once and reuse for both oracle helpers.
+    let evil_cascade_active = genesis_node
+        .node_ctx
+        .config
+        .consensus
+        .hardforks
+        .is_cascade_active_at(evil_parent_block.timestamp_secs());
     let expired_set = irys_actors::block_producer::ledger_expiry::expired_submit_tx_ids(
         &tip_snapshot,
         &evil_parent_block,
         evil_height,
         &genesis_node.node_ctx.config,
+        evil_cascade_active,
         genesis_node
             .node_ctx
             .block_producer_inner
@@ -149,6 +158,7 @@ async fn heavy_block_promoting_already_expired_submit_tx_gets_rejected() -> eyre
             &tip_snapshot,
             &evil_parent_block,
             &genesis_node.node_ctx.config,
+            evil_cascade_active,
             &genesis_node.node_ctx.block_producer_inner.block_index,
             &genesis_node.node_ctx.block_tree_guard,
             &genesis_node.node_ctx.mempool_guard,

--- a/crates/chain-tests/src/validation/publish_after_submit_expiry_filtered.rs
+++ b/crates/chain-tests/src/validation/publish_after_submit_expiry_filtered.rs
@@ -121,7 +121,12 @@ async fn heavy_producer_drops_publish_candidate_whose_submit_storage_expired() -
     let chain_id = genesis_config.consensus_config().chain_id;
     let proof_anchor = genesis_node.get_anchor().await?;
     for tx in &txs {
-        let chunks: Vec<Vec<u8>> = vec![tx.data.clone().unwrap_or_default().into()];
+        let chunks: Vec<Vec<u8>> = vec![
+            tx.data
+                .clone()
+                .expect("posted tx must carry data bytes")
+                .into(),
+        ];
         let proof = generate_ingress_proof(
             &genesis_signer,
             tx.header.data_root,

--- a/crates/chain-tests/src/validation/publish_after_submit_expiry_filtered.rs
+++ b/crates/chain-tests/src/validation/publish_after_submit_expiry_filtered.rs
@@ -212,11 +212,18 @@ async fn heavy_producer_drops_publish_candidate_whose_submit_storage_expired() -
         expiry_parent_block.block_hash, expiry_block.previous_block_hash,
         "parent header must be the expiry block's parent"
     );
+    let expiry_cascade_active = genesis_node
+        .node_ctx
+        .config
+        .consensus
+        .hardforks
+        .is_cascade_active_at(expiry_parent_block.timestamp_secs());
     let expired_set = irys_actors::block_producer::ledger_expiry::expired_submit_tx_ids(
         &expiry_parent_snapshot,
         &expiry_parent_block,
         expiry_height,
         &genesis_node.node_ctx.config,
+        expiry_cascade_active,
         genesis_node
             .node_ctx
             .block_producer_inner

--- a/crates/chain-tests/src/validation/publish_after_submit_expiry_filtered.rs
+++ b/crates/chain-tests/src/validation/publish_after_submit_expiry_filtered.rs
@@ -65,7 +65,7 @@ use tracing::info;
 async fn heavy_producer_drops_publish_candidate_whose_submit_storage_expired() -> eyre::Result<()> {
     // --- 1 + 2 + 3. Shared config + two-node startup + overflow data posting ---
     // (See submit_expiry_two_node_setup for the parameter rationale.)
-    let setup = submit_expiry_two_node_setup().await?;
+    let setup = submit_expiry_two_node_setup(1).await?;
     let genesis_config = setup.genesis_config;
     let genesis_node = setup.genesis_node;
     let peer_node = setup.peer_node;

--- a/crates/chain-tests/src/validation/publish_after_submit_expiry_filtered.rs
+++ b/crates/chain-tests/src/validation/publish_after_submit_expiry_filtered.rs
@@ -229,8 +229,14 @@ async fn heavy_producer_drops_publish_candidate_whose_submit_storage_expired() -
         .read()
         .get_epoch_snapshot(&expiry_block.previous_block_hash)
         .expect("epoch snapshot for the expiry block's parent");
+    let expiry_parent_block = genesis_node.get_block_by_height(expiry_height - 1).await?;
+    assert_eq!(
+        expiry_parent_block.block_hash, expiry_block.previous_block_hash,
+        "parent header must be the expiry block's parent"
+    );
     let expired_set = irys_actors::block_producer::ledger_expiry::expired_submit_tx_ids(
         &expiry_parent_snapshot,
+        &expiry_parent_block,
         expiry_height,
         &genesis_node.node_ctx.config,
         genesis_node

--- a/crates/chain-tests/src/validation/publish_after_submit_expiry_filtered.rs
+++ b/crates/chain-tests/src/validation/publish_after_submit_expiry_filtered.rs
@@ -1,0 +1,280 @@
+// NC-0042 §4b heavy chain-test: the honest producer must not promote a tx whose
+// Submit-ledger storage has expired — even when that tx is otherwise promotable
+// in the very block its slot expires.
+//
+// Background:
+//   Two independent pipelines run when producing an epoch block:
+//     A) tx_selector::get_publish_txs_and_proofs — picks promotable txs.
+//     B) block_producer::calculate_expired_ledger_fees — schedules
+//        `user_perm_fee_refunds` for unpromoted Submit-ledger txs whose slot
+//        is expiring at this epoch.
+//   Before NC-0042 §4b, if the same tx X was promotable AND its Submit slot was
+//   expiring at this block, both pipelines selected X and `ShadowTxGenerator::new`
+//   panicked the producer with `BlockProductionError::Irrecoverable`
+//   (the defence-in-depth guard at `shadow_tx_generator.rs:258`).
+//   The fix drops any publish candidate that is in the *same* expired-Submit-tx
+//   set the refund pipeline acts on (`ledger_expiry::expired_submit_tx_ids`), so
+//   "is this tx refunded?" and "may this tx be promoted?" cannot diverge.
+//
+// What this test proves end-to-end:
+//   1. The producer does NOT panic when forced into the scenario.
+//   2. It produces the expiry-epoch block successfully.
+//   3. No tx is BOTH perm-fee-refunded AND promoted in that block (the core
+//      NC-0042 invariant: refunded ⇒ not promoted).
+//   4. At least one tx really was both promotable and expiring (so the filter
+//      actually fired — the test is not vacuous).
+//   5. A peer node validates and accepts the block.
+//
+// Design notes (read before changing):
+//
+// - Submit-ledger expiry is a per-SLOT property, not per-tx cycle math. A slot
+//   expires at `last_height + blocks_per_cycle`, EXCEPT the last/newest slot is
+//   never expired. The genesis slot (slot 0) therefore only expires once a
+//   second slot exists. So we must force a 2nd Submit slot: with a tiny partition
+//   (`num_chunks_in_partition = 10`) we post >10 single-chunk txs, which trips
+//   capacity-based slot allocation at the next epoch. This mirrors the proven
+//   expiry setup in `ledger_expiry_with_unstake.rs`.
+//
+// - `number_of_ingress_proofs_total = 1` (testing default) so a single proof from
+//   the genesis signer makes a tx promotable — turning this into a single-node
+//   test. Lowering it doesn't change the invariant under test (A2 keys on the
+//   expired-partition set, independent of how many proofs accumulated).
+//
+// - To force the timing collision (promotable AND expiring in the SAME block) we
+//   drive the txs through the real Submit flow, then withhold the ingress proofs
+//   until one block before the expiry epoch and inject them directly into the
+//   local IngressProofs DB. Generating proofs directly (rather than via the
+//   chunk-ingress service) makes the timing deterministic.
+//
+// - The earlier `promote_after_submit_expiry.rs` attempt hand-inserted
+//   `MigratedBlockHashes` rows; that collides with the real chain's migration
+//   writes at the same height and crashes BlockTreeService. DO NOT do that —
+//   drive the txs through the real flow.
+
+use crate::utils::IrysNodeTest;
+use irys_database::{db::IrysDatabaseExt as _, store_external_ingress_proof_checked};
+use irys_reth_node_bridge::irys_reth::shadow_tx::{ShadowTransaction, TransactionPacket};
+use irys_types::{DataLedger, NodeConfig, ingress::generate_ingress_proof};
+use reth::rpc::types::TransactionTrait as _;
+use std::collections::BTreeSet;
+use tracing::info;
+
+#[test_log::test(tokio::test)]
+async fn heavy_producer_drops_publish_candidate_whose_submit_storage_expired() -> eyre::Result<()> {
+    // --- 1. Config: small cycle + tiny partition so the genesis Submit slot
+    //         expires (a 2nd slot gets allocated once we overflow the partition).
+    // num_blocks_in_epoch = 5, submit_ledger_epoch_length = 2 → blocks_per_cycle = 10.
+    let num_blocks_in_epoch: usize = 5;
+    let submit_ledger_epoch_length: u64 = 2;
+    let chunk_size: u64 = 32;
+    let num_chunks_in_partition: u64 = 10;
+    let blocks_per_cycle = num_blocks_in_epoch as u64 * submit_ledger_epoch_length;
+    let seconds_to_wait = 40;
+
+    let mut genesis_config = NodeConfig::testing_with_epochs(num_blocks_in_epoch);
+    {
+        let c = genesis_config.consensus.get_mut();
+        c.chunk_size = chunk_size;
+        c.num_chunks_in_partition = num_chunks_in_partition;
+        c.block_migration_depth = 1;
+        c.epoch.submit_ledger_epoch_length = submit_ledger_epoch_length;
+        // testing() already defaults to 1, but make the assumption explicit.
+        c.hardforks.frontier.number_of_ingress_proofs_total = 1;
+    }
+
+    let user_signer = genesis_config.new_random_signer();
+    genesis_config.fund_genesis_accounts(vec![&user_signer]);
+
+    // --- 2. Start genesis + peer ---
+    let genesis_node = IrysNodeTest::new_genesis(genesis_config.clone())
+        .start_and_wait_for_packing("GENESIS", seconds_to_wait)
+        .await;
+    let peer_config = genesis_node.testing_peer_with_signer(&user_signer);
+    let peer_node = IrysNodeTest::new(peer_config).start_with_name("PEER").await;
+
+    // --- 3. Post enough single-chunk data txs to overflow one partition,
+    //         forcing a 2nd Submit slot (so the genesis slot 0 is non-last and
+    //         can expire). Each tx carries a perm_fee (create_publish_transaction),
+    //         so every unpromoted one is perm-fee-refundable at expiry. ---
+    let num_txs = (num_chunks_in_partition + 2) as usize; // 12 chunks > 10 capacity
+    let anchor = genesis_node.get_anchor().await?;
+    let mut txs = Vec::with_capacity(num_txs);
+    for i in 0..num_txs {
+        let data = vec![100 + i as u8; chunk_size as usize];
+        let tx = genesis_node.post_data_tx(anchor, data, &user_signer).await;
+        genesis_node
+            .wait_for_mempool(tx.header.id, seconds_to_wait)
+            .await?;
+        txs.push(tx);
+    }
+    let data_block = genesis_node.mine_block().await?;
+    let submit_ids: BTreeSet<_> = data_block
+        .get_data_ledger_tx_ids()
+        .get(&DataLedger::Submit)
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .collect();
+    assert_eq!(
+        submit_ids.len(),
+        num_txs,
+        "all posted txs should land in the Submit ledger at the data block"
+    );
+
+    // --- 4. Advance to one block before the genesis slot's expiry epoch.
+    //         Slot 0 was allocated at genesis (height 0); it expires at
+    //         blocks_per_cycle, by which point the capacity overflow has caused a
+    //         2nd slot to be allocated (so slot 0 is non-last and does expire). ---
+    let expiry_height = blocks_per_cycle; // = 10
+    assert_eq!(
+        expiry_height % num_blocks_in_epoch as u64,
+        0,
+        "expiry must coincide with an epoch boundary so the refund pipeline runs"
+    );
+    while genesis_node.get_canonical_chain_height().await < expiry_height - 1 {
+        genesis_node.mine_block().await?;
+    }
+    let height_before = genesis_node.get_canonical_chain_height().await;
+    assert_eq!(
+        height_before,
+        expiry_height - 1,
+        "must be exactly one block before the expiry epoch boundary"
+    );
+
+    // --- 5. Inject an ingress proof for EVERY data tx (from the staked genesis
+    //         signer) so each becomes a publish candidate. We do NOT mine in
+    //         between — the very next block is the expiry epoch block. ---
+    let genesis_signer = genesis_config.signer();
+    let chain_id = genesis_config.consensus_config().chain_id;
+    let proof_anchor = genesis_node.get_anchor().await?;
+    for tx in &txs {
+        let chunks: Vec<Vec<u8>> = vec![tx.data.clone().unwrap_or_default().into()];
+        let proof = generate_ingress_proof(
+            &genesis_signer,
+            tx.header.data_root,
+            chunks.iter().map(|c| Ok(c.as_slice())),
+            chain_id,
+            proof_anchor,
+        )?;
+        genesis_node.node_ctx.db.update_eyre(|rw_tx| {
+            store_external_ingress_proof_checked(rw_tx, &proof, genesis_signer.address())?;
+            Ok(())
+        })?;
+    }
+
+    // --- 6. Produce the expiry epoch block with the honest producer ---
+    // Without the §4b fix, the slot-0 txs are simultaneously selected for
+    // promotion (Pipeline A) and perm-fee-refunded (Pipeline B), and
+    // `ShadowTxGenerator::new` panics the producer with `Irrecoverable`.
+    let expiry_block = genesis_node.mine_block().await?;
+    assert_eq!(
+        expiry_block.height, expiry_height,
+        "mined block must be the expiry epoch block"
+    );
+
+    // --- 7. Core invariant: no tx is both promoted and perm-fee-refunded ---
+    let publish_ids: BTreeSet<_> = expiry_block
+        .get_data_ledger_tx_ids()
+        .get(&DataLedger::Publish)
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .collect();
+
+    // Decode the EVM payload to find which txs were perm-fee-refunded.
+    let evm_block = genesis_node
+        .wait_for_evm_block(expiry_block.evm_block_hash, seconds_to_wait)
+        .await?;
+    let user_addr = user_signer.address().to_alloy_address();
+    let refund_count = evm_block
+        .body
+        .transactions
+        .into_iter()
+        .filter(|tx| tx.input().len() >= 4)
+        .filter_map(|tx| {
+            let shadow_tx = ShadowTransaction::decode(&mut tx.input().as_ref()).ok()?;
+            let packet = shadow_tx.as_v1()?;
+            match packet {
+                TransactionPacket::PermFeeRefund(refund) if refund.target == user_addr => Some(()),
+                _ => None,
+            }
+        })
+        .count();
+
+    info!(
+        refund_count,
+        publish_count = publish_ids.len(),
+        "expiry block produced without panic"
+    );
+
+    // The filter must actually have fired. We injected a valid ingress proof for
+    // EVERY tx, so every tx is a promotable publish candidate; the only reason any
+    // is absent from the Publish ledger is the §4b expiry drop. Refund_count > 0
+    // proves expired candidates existed and were diverted to a refund rather than
+    // promoted (verified out-of-band: the producer logs N "non-promotable" drops).
+    assert!(
+        refund_count > 0,
+        "at least one expired tx must be perm-fee-refunded (else the test is vacuous)"
+    );
+
+    // The NC-0042 invariant: a refunded tx must never also be promoted. We assert
+    // it via the expired set the producer used — none of those txs may appear in
+    // the Publish ledger.
+    // Use the SAME parent epoch snapshot the producer used (parent of the expiry
+    // block), which has all the slots allocated by this epoch — not the data
+    // block's snapshot, which only had the genesis slot.
+    let expiry_parent_snapshot = genesis_node
+        .node_ctx
+        .block_tree_guard
+        .read()
+        .get_epoch_snapshot(&expiry_block.previous_block_hash)
+        .expect("epoch snapshot for the expiry block's parent");
+    let expired_set = irys_actors::block_producer::ledger_expiry::expired_submit_tx_ids(
+        &expiry_parent_snapshot,
+        expiry_height,
+        &genesis_node.node_ctx.config,
+        genesis_node
+            .node_ctx
+            .block_producer_inner
+            .block_index
+            .clone(),
+        &genesis_node.node_ctx.block_tree_guard,
+        &genesis_node.node_ctx.mempool_guard,
+        &genesis_node.node_ctx.db,
+    )
+    .await?;
+    assert!(
+        !expired_set.is_empty(),
+        "the genesis Submit slot must have expired at this epoch"
+    );
+    for expired_tx_id in &expired_set {
+        assert!(
+            !publish_ids.contains(expired_tx_id),
+            "expired Submit tx {expired_tx_id} must NOT be promoted (NC-0042 §4b)"
+        );
+    }
+
+    // No-divergence property: every tx the producer dropped from promotion is
+    // exactly a tx the refund pipeline acted on. All txs are from `user_signer`,
+    // so the count of `PermFeeRefund`s to that address must equal the expired set.
+    assert_eq!(
+        refund_count,
+        expired_set.len(),
+        "A2's dropped (expired) set must match Pipeline B's refund set exactly — \
+         the two must not diverge (NC-0042 §4b)"
+    );
+
+    // --- 8. Peer must accept the block (it is a valid canonical block) ---
+    peer_node
+        .wait_until_height(expiry_height, seconds_to_wait)
+        .await?;
+    let peer_block = peer_node.get_block_by_height(expiry_height).await?;
+    assert_eq!(
+        peer_block.block_hash, expiry_block.block_hash,
+        "peer must converge on the same block at the expiry height"
+    );
+
+    peer_node.stop().await;
+    genesis_node.stop().await;
+    Ok(())
+}

--- a/crates/chain-tests/src/validation/publish_after_submit_expiry_filtered.rs
+++ b/crates/chain-tests/src/validation/publish_after_submit_expiry_filtered.rs
@@ -12,9 +12,11 @@
 //   expiring at this block, both pipelines selected X and `ShadowTxGenerator::new`
 //   panicked the producer with `BlockProductionError::Irrecoverable`
 //   (the defence-in-depth guard at `shadow_tx_generator.rs:258`).
-//   The fix drops any publish candidate that is in the *same* expired-Submit-tx
-//   set the refund pipeline acts on (`ledger_expiry::expired_submit_tx_ids`), so
-//   "is this tx refunded?" and "may this tx be promoted?" cannot diverge.
+//   The fix is a per-candidate predicate in `tx_selector::get_publish_txs_and_proofs`
+//   that calls `ledger_expiry::is_submit_storage_expired` for each publish candidate.
+//   Any candidate whose Submit storage has expired is dropped before it can reach
+//   the `ShadowTxGenerator`, so "is this tx refunded?" and "is this tx promoted?"
+//   cannot both be true for the same tx.
 //
 // What this test proves end-to-end:
 //   1. The producer does NOT panic when forced into the scenario.
@@ -51,63 +53,34 @@
 //   writes at the same height and crashes BlockTreeService. DO NOT do that —
 //   drive the txs through the real flow.
 
-use crate::utils::IrysNodeTest;
+use crate::validation::submit_expiry_two_node_setup;
 use irys_database::{db::IrysDatabaseExt as _, store_external_ingress_proof_checked};
 use irys_reth_node_bridge::irys_reth::shadow_tx::{ShadowTransaction, TransactionPacket};
-use irys_types::{DataLedger, NodeConfig, ingress::generate_ingress_proof};
+use irys_types::{DataLedger, H256, ingress::generate_ingress_proof};
 use reth::rpc::types::TransactionTrait as _;
 use std::collections::BTreeSet;
 use tracing::info;
 
 #[test_log::test(tokio::test)]
 async fn heavy_producer_drops_publish_candidate_whose_submit_storage_expired() -> eyre::Result<()> {
-    // --- 1. Config: small cycle + tiny partition so the genesis Submit slot
-    //         expires (a 2nd slot gets allocated once we overflow the partition).
-    // num_blocks_in_epoch = 5, submit_ledger_epoch_length = 2 → blocks_per_cycle = 10.
-    let num_blocks_in_epoch: usize = 5;
-    let submit_ledger_epoch_length: u64 = 2;
-    let chunk_size: u64 = 32;
-    let num_chunks_in_partition: u64 = 10;
-    let blocks_per_cycle = num_blocks_in_epoch as u64 * submit_ledger_epoch_length;
-    let seconds_to_wait = 40;
+    // --- 1 + 2 + 3. Shared config + two-node startup + overflow data posting ---
+    // (See submit_expiry_two_node_setup for the parameter rationale.)
+    let setup = submit_expiry_two_node_setup().await?;
+    let genesis_config = setup.genesis_config;
+    let genesis_node = setup.genesis_node;
+    let peer_node = setup.peer_node;
+    let txs = setup.txs;
+    let user_signer = setup.user_signer;
+    let blocks_per_cycle = setup.blocks_per_cycle;
+    let num_blocks_in_epoch = setup.num_blocks_in_epoch;
+    let seconds_to_wait = setup.seconds_to_wait;
 
-    let mut genesis_config = NodeConfig::testing_with_epochs(num_blocks_in_epoch);
-    {
-        let c = genesis_config.consensus.get_mut();
-        c.chunk_size = chunk_size;
-        c.num_chunks_in_partition = num_chunks_in_partition;
-        c.block_migration_depth = 1;
-        c.epoch.submit_ledger_epoch_length = submit_ledger_epoch_length;
-        // testing() already defaults to 1, but make the assumption explicit.
-        c.hardforks.frontier.number_of_ingress_proofs_total = 1;
-    }
-
-    let user_signer = genesis_config.new_random_signer();
-    genesis_config.fund_genesis_accounts(vec![&user_signer]);
-
-    // --- 2. Start genesis + peer ---
-    let genesis_node = IrysNodeTest::new_genesis(genesis_config.clone())
-        .start_and_wait_for_packing("GENESIS", seconds_to_wait)
-        .await;
-    let peer_config = genesis_node.testing_peer_with_signer(&user_signer);
-    let peer_node = IrysNodeTest::new(peer_config).start_with_name("PEER").await;
-
-    // --- 3. Post enough single-chunk data txs to overflow one partition,
-    //         forcing a 2nd Submit slot (so the genesis slot 0 is non-last and
-    //         can expire). Each tx carries a perm_fee (create_publish_transaction),
-    //         so every unpromoted one is perm-fee-refundable at expiry. ---
-    let num_txs = (num_chunks_in_partition + 2) as usize; // 12 chunks > 10 capacity
-    let anchor = genesis_node.get_anchor().await?;
-    let mut txs = Vec::with_capacity(num_txs);
-    for i in 0..num_txs {
-        let data = vec![100 + i as u8; chunk_size as usize];
-        let tx = genesis_node.post_data_tx(anchor, data, &user_signer).await;
-        genesis_node
-            .wait_for_mempool(tx.header.id, seconds_to_wait)
-            .await?;
-        txs.push(tx);
-    }
-    let data_block = genesis_node.mine_block().await?;
+    // Verify all posted txs landed in the Submit ledger.
+    // The data block was already mined by submit_expiry_two_node_setup.
+    let data_block = genesis_node
+        .get_block_by_height(genesis_node.get_canonical_chain_height().await)
+        .await?;
+    let num_txs = txs.len();
     let submit_ids: BTreeSet<_> = data_block
         .get_data_ledger_tx_ids()
         .get(&DataLedger::Submit)
@@ -182,11 +155,13 @@ async fn heavy_producer_drops_publish_candidate_whose_submit_storage_expired() -
         .collect();
 
     // Decode the EVM payload to find which txs were perm-fee-refunded.
+    // `BalanceIncrement::irys_ref` carries the CL tx_id, enabling identity-based
+    // comparison against the expired set rather than a count-only check.
     let evm_block = genesis_node
         .wait_for_evm_block(expiry_block.evm_block_hash, seconds_to_wait)
         .await?;
     let user_addr = user_signer.address().to_alloy_address();
-    let refund_count = evm_block
+    let refunded_tx_ids: BTreeSet<H256> = evm_block
         .body
         .transactions
         .into_iter()
@@ -195,14 +170,17 @@ async fn heavy_producer_drops_publish_candidate_whose_submit_storage_expired() -
             let shadow_tx = ShadowTransaction::decode(&mut tx.input().as_ref()).ok()?;
             let packet = shadow_tx.as_v1()?;
             match packet {
-                TransactionPacket::PermFeeRefund(refund) if refund.target == user_addr => Some(()),
+                TransactionPacket::PermFeeRefund(refund) if refund.target == user_addr => {
+                    // irys_ref is the CL tx_id encoded as FixedBytes<32>
+                    Some(H256(refund.irys_ref.into()))
+                }
                 _ => None,
             }
         })
-        .count();
+        .collect();
 
     info!(
-        refund_count,
+        refund_count = refunded_tx_ids.len(),
         publish_count = publish_ids.len(),
         "expiry block produced without panic"
     );
@@ -213,7 +191,7 @@ async fn heavy_producer_drops_publish_candidate_whose_submit_storage_expired() -
     // proves expired candidates existed and were diverted to a refund rather than
     // promoted (verified out-of-band: the producer logs N "non-promotable" drops).
     assert!(
-        refund_count > 0,
+        !refunded_tx_ids.is_empty(),
         "at least one expired tx must be perm-fee-refunded (else the test is vacuous)"
     );
 
@@ -260,14 +238,12 @@ async fn heavy_producer_drops_publish_candidate_whose_submit_storage_expired() -
         );
     }
 
-    // No-divergence property: every tx the producer dropped from promotion is
-    // exactly a tx the refund pipeline acted on. All txs are from `user_signer`,
-    // so the count of `PermFeeRefund`s to that address must equal the expired set.
+    // No-divergence (identity): the set of txs the refund pipeline acted on must
+    // equal the expired set the producer used — the two must not diverge (NC-0042 §4b).
     assert_eq!(
-        refund_count,
-        expired_set.len(),
-        "A2's dropped (expired) set must match Pipeline B's refund set exactly — \
-         the two must not diverge (NC-0042 §4b)"
+        refunded_tx_ids, expired_set,
+        "refunded tx-id set must equal the expired set exactly — \
+         Pipeline A's drop list and Pipeline B's refund list must not diverge (NC-0042 §4b)"
     );
 
     // --- 8. Peer must accept the block (it is a valid canonical block) ---

--- a/crates/chain-tests/src/validation/reorg_submit_expiry.rs
+++ b/crates/chain-tests/src/validation/reorg_submit_expiry.rs
@@ -177,7 +177,7 @@ async fn heavy_reorg_across_submit_expiry_epoch_settles_on_winning_branch() -> e
     let evm_block = genesis_node
         .wait_for_evm_block(expiry_block.evm_block_hash, seconds_to_wait)
         .await?;
-    let refunded: BTreeSet<H256> = evm_block
+    let refunded_list: Vec<H256> = evm_block
         .body
         .transactions
         .into_iter()
@@ -192,6 +192,14 @@ async fn heavy_reorg_across_submit_expiry_epoch_settles_on_winning_branch() -> e
             }
         })
         .collect();
+    let refunded: BTreeSet<H256> = refunded_list.iter().copied().collect();
+    // Multiplicity guard: a duplicate PermFeeRefund would be silently collapsed by
+    // the set and slip past the exact-equality check below (over-refund / double-pay).
+    assert_eq!(
+        refunded_list.len(),
+        refunded.len(),
+        "no over-refund: each expired tx refunded exactly once"
+    );
     assert!(
         !refunded.is_empty(),
         "the winning branch's expiry block must perm-fee-refund the expired slot-0 Submit txs \

--- a/crates/chain-tests/src/validation/reorg_submit_expiry.rs
+++ b/crates/chain-tests/src/validation/reorg_submit_expiry.rs
@@ -19,8 +19,9 @@
 //!       canonical tip across the expiry epoch onto the winning branch.
 
 use crate::utils::IrysNodeTest;
+use irys_actors::block_producer::ledger_expiry::calculate_expired_ledger_fees;
 use irys_reth_node_bridge::irys_reth::shadow_tx::{ShadowTransaction, TransactionPacket};
-use irys_types::{H256, NodeConfig};
+use irys_types::{DataLedger, H256, NodeConfig};
 use reth::rpc::types::TransactionTrait as _;
 use std::collections::BTreeSet;
 use std::sync::Arc;
@@ -85,7 +86,7 @@ async fn heavy_reorg_across_submit_expiry_epoch_settles_on_winning_branch() -> e
             .await?;
         txs.push(tx);
     }
-    let posted_ids: BTreeSet<H256> = txs.iter().map(|t| t.header.id).collect();
+    let _posted_ids: BTreeSet<H256> = txs.iter().map(|t| t.header.id).collect();
 
     // h1 (data + commitments), h2 (epoch: 2nd Submit slot + peer partitions).
     genesis_node.mine_block().await?;
@@ -196,9 +197,58 @@ async fn heavy_reorg_across_submit_expiry_epoch_settles_on_winning_branch() -> e
         "the winning branch's expiry block must perm-fee-refund the expired slot-0 Submit txs \
          (branch-correct settlement must survive the reorg across the expiry epoch)"
     );
+
+    // Exact equality against Pipeline B: recompute what the refund pipeline would
+    // produce for this block and assert the on-chain set matches it exactly — a
+    // partial or missing refund fails the test.
+    let expiry_parent_block = genesis_node
+        .get_block_by_height(blocks_per_cycle - 1)
+        .await?;
+    let expiry_parent_snapshot = genesis_node
+        .node_ctx
+        .block_tree_guard
+        .read()
+        .get_epoch_snapshot(&expiry_block.previous_block_hash)
+        .expect("epoch snapshot for the expiry block's parent");
+    // Cascade is OFF (hardforks.cascade = None above), so cascade_active_for_block is false.
+    let cascade_active_for_block = genesis_node
+        .node_ctx
+        .config
+        .consensus
+        .hardforks
+        .is_cascade_active_at(expiry_block.timestamp_secs());
+    let pipeline_b = calculate_expired_ledger_fees(
+        &expiry_parent_snapshot,
+        &expiry_parent_block,
+        blocks_per_cycle,
+        DataLedger::Submit,
+        &genesis_node.node_ctx.config,
+        genesis_node
+            .node_ctx
+            .block_producer_inner
+            .block_index
+            .clone(),
+        &genesis_node.node_ctx.block_tree_guard,
+        &genesis_node.node_ctx.mempool_guard,
+        &genesis_node.node_ctx.db,
+        true,
+        expiry_block.ledger_total_chunks(DataLedger::Submit),
+        cascade_active_for_block,
+    )
+    .await?;
+    let expected_refunds: BTreeSet<H256> = pipeline_b
+        .user_perm_fee_refunds
+        .iter()
+        .map(|(id, _, _)| *id)
+        .collect();
     assert!(
-        refunded.is_subset(&posted_ids),
-        "every refund must correspond to a posted Submit tx (got {refunded:?})"
+        !expected_refunds.is_empty(),
+        "fixture must produce refunds (non-vacuous)"
+    );
+    assert_eq!(
+        refunded, expected_refunds,
+        "winning branch's on-chain refunds must EXACTLY equal Pipeline B's refund set \
+         (branch-correct settlement across the reorg)"
     );
 
     peer2_node.stop().await;

--- a/crates/chain-tests/src/validation/reorg_submit_expiry.rs
+++ b/crates/chain-tests/src/validation/reorg_submit_expiry.rs
@@ -1,0 +1,208 @@
+//! NC-0042 M4: a reorg whose canonical tip moves ACROSS the Submit-ledger expiry
+//! epoch must settle expiry branch-correctly on the WINNING branch.
+//!
+//! The `slot_lifetime > block_tree_depth` config invariant keeps every expired
+//! tx's Submit inclusion BELOW the reorg floor, so a reorg cannot rewrite an
+//! expired inclusion. What this test pins is the integration behaviour the unit
+//! tests (C1 guard, by-hash walk) cannot: a node whose canonical tip sat on the
+//! LOSING fork validates and adopts the WINNING fork's expiry-epoch block —
+//! recomputing the perm-fee-refund settlement against the winning branch's own
+//! ancestry — without stalling, and the resulting canonical expiry block carries
+//! the refunds for the expired slot-0 txs.
+//!
+//! Layout (num_blocks_in_epoch = 2, submit_ledger_epoch_length = 2 ⇒ slot 0
+//! expires at height 4):
+//!   h1: overflow Submit data + peer stake/pledge commitments (common ancestor)
+//!   h2: epoch — 2nd Submit slot allocated (slot 0 becomes non-last); peers packed
+//!   h3: FORK — peer1 and peer2 each mine a competing block (no gossip)
+//!   h4: extend the fork genesis did NOT choose → heavier → reorg moves the
+//!       canonical tip across the expiry epoch onto the winning branch.
+
+use crate::utils::IrysNodeTest;
+use irys_reth_node_bridge::irys_reth::shadow_tx::{ShadowTransaction, TransactionPacket};
+use irys_types::{H256, NodeConfig};
+use reth::rpc::types::TransactionTrait as _;
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use tracing::debug;
+
+#[test_log::test(tokio::test)]
+async fn heavy_reorg_across_submit_expiry_epoch_settles_on_winning_branch() -> eyre::Result<()> {
+    let num_blocks_in_epoch: usize = 2;
+    let submit_ledger_epoch_length: u64 = 2;
+    let blocks_per_cycle = num_blocks_in_epoch as u64 * submit_ledger_epoch_length; // 4 (expiry height)
+    let chunk_size: u64 = 32;
+    let num_chunks_in_partition: u64 = 10;
+    let seconds_to_wait = 40_usize;
+
+    let mut genesis_config = NodeConfig::testing_with_epochs(num_blocks_in_epoch);
+    {
+        let c = genesis_config.consensus.get_mut();
+        c.chunk_size = chunk_size;
+        c.num_chunks_in_partition = num_chunks_in_partition;
+        c.block_migration_depth = 1;
+        c.epoch.submit_ledger_epoch_length = submit_ledger_epoch_length;
+        // One ingress proof makes a tx promotable; keeps the promotion side simple.
+        c.hardforks.frontier.number_of_ingress_proofs_total = 1;
+        // Cascade OFF: allocation-anchored Submit expiry at exactly blocks_per_cycle.
+        c.hardforks.cascade = None;
+    }
+
+    let peer1_signer = genesis_config.new_random_signer();
+    let peer2_signer = genesis_config.new_random_signer();
+    let user_signer = genesis_config.new_random_signer();
+    genesis_config.fund_genesis_accounts(vec![&peer1_signer, &peer2_signer, &user_signer]);
+
+    let genesis_node = IrysNodeTest::new_genesis(genesis_config.clone())
+        .start_and_wait_for_packing("GENESIS", seconds_to_wait)
+        .await;
+    let peer1_node = IrysNodeTest::new(genesis_node.testing_peer_with_signer(&peer1_signer))
+        .start_with_name("PEER1")
+        .await;
+    let peer2_node = IrysNodeTest::new(genesis_node.testing_peer_with_signer(&peer2_signer))
+        .start_with_name("PEER2")
+        .await;
+
+    // Stake + pledge both peers so they get partition assignments at the epoch.
+    let p1_stake = peer1_node.post_stake_commitment(None).await?;
+    let p1_pledge = peer1_node.post_pledge_commitment(None).await?;
+    let p2_stake = peer2_node.post_stake_commitment(None).await?;
+    let p2_pledge = peer2_node.post_pledge_commitment(None).await?;
+    for id in [p1_stake.id(), p1_pledge.id(), p2_stake.id(), p2_pledge.id()] {
+        genesis_node.wait_for_mempool(id, seconds_to_wait).await?;
+    }
+
+    // Overflow data txs into the genesis Submit slot (forces a 2nd slot so slot 0
+    // is non-last and can expire). These land in the common ancestor (h1).
+    let num_txs = (num_chunks_in_partition + 2) as usize;
+    let anchor = genesis_node.get_anchor().await?;
+    let mut txs = Vec::with_capacity(num_txs);
+    for i in 0..num_txs {
+        let data = vec![100 + i as u8; chunk_size as usize];
+        let tx = genesis_node.post_data_tx(anchor, data, &user_signer).await;
+        genesis_node
+            .wait_for_mempool(tx.header.id, seconds_to_wait)
+            .await?;
+        txs.push(tx);
+    }
+    let posted_ids: BTreeSet<H256> = txs.iter().map(|t| t.header.id).collect();
+
+    // h1 (data + commitments), h2 (epoch: 2nd Submit slot + peer partitions).
+    genesis_node.mine_block().await?;
+    genesis_node.mine_block().await?;
+    genesis_node
+        .wait_for_block_at_height(2, seconds_to_wait)
+        .await?;
+    genesis_node
+        .wait_until_block_index_height(1, seconds_to_wait)
+        .await?;
+    peer1_node
+        .wait_until_block_index_height(1, seconds_to_wait)
+        .await?;
+    peer2_node
+        .wait_until_block_index_height(1, seconds_to_wait)
+        .await?;
+    peer1_node.wait_for_packing(seconds_to_wait).await;
+    peer2_node.wait_for_packing(seconds_to_wait).await;
+
+    // FORK at h2: each peer mines its own h3 without gossip.
+    let (r1, r2) = tokio::join!(
+        peer1_node.mine_blocks_without_gossip(1),
+        peer2_node.mine_blocks_without_gossip(1),
+    );
+    r1?;
+    r2?;
+    peer1_node
+        .wait_for_block_at_height(3, seconds_to_wait)
+        .await?;
+    peer2_node
+        .wait_for_block_at_height(3, seconds_to_wait)
+        .await?;
+
+    let peer1_b3 = Arc::new(peer1_node.get_block_by_height(3).await?);
+    let peer2_b3 = Arc::new(peer2_node.get_block_by_height(3).await?);
+    peer1_node.gossip_block_to_peers(&peer1_b3)?;
+    peer2_node.gossip_block_to_peers(&peer2_b3)?;
+    peer1_node
+        .wait_for_block(&peer2_b3.block_hash, seconds_to_wait)
+        .await?;
+    peer2_node
+        .wait_for_block(&peer1_b3.block_hash, seconds_to_wait)
+        .await?;
+    genesis_node
+        .wait_for_block_at_height(3, seconds_to_wait)
+        .await?;
+    let genesis_b3 = genesis_node.get_block_by_height(3).await?;
+    let genesis_chose_peer1 = genesis_b3.block_hash == peer1_b3.block_hash;
+
+    // Extend the fork genesis did NOT choose to h4 (the expiry epoch). The extended
+    // branch is heavier (height 4 vs 3) → genesis reorgs onto it, carrying the
+    // canonical tip across the expiry boundary.
+    let reorg_future = genesis_node.wait_for_reorg(seconds_to_wait);
+    if genesis_chose_peer1 {
+        peer2_node.mine_block().await?;
+    } else {
+        peer1_node.mine_block().await?;
+    }
+    let reorg_event = reorg_future.await?;
+    debug!(
+        "reorg across expiry: fork_parent h={}, old_fork={} new_fork={}",
+        reorg_event.fork_parent.height,
+        reorg_event.old_fork.len(),
+        reorg_event.new_fork.len()
+    );
+
+    // Genesis must now hold the winning branch's expiry block at h4.
+    genesis_node
+        .wait_for_block_at_height(blocks_per_cycle, seconds_to_wait)
+        .await?;
+    let expiry_block = genesis_node.get_block_by_height(blocks_per_cycle).await?;
+    assert_eq!(expiry_block.height, blocks_per_cycle);
+
+    let winner_b4 = if genesis_chose_peer1 {
+        peer2_node.get_block_by_height(blocks_per_cycle).await?
+    } else {
+        peer1_node.get_block_by_height(blocks_per_cycle).await?
+    };
+    assert_eq!(
+        expiry_block.block_hash, winner_b4.block_hash,
+        "canonical expiry block must be the WINNING branch's h{blocks_per_cycle} after the reorg"
+    );
+
+    // Branch-correct settlement: the winning branch's expiry block must perm-fee
+    // -refund the expired slot-0 Submit txs. Decode the canonical EVM body and
+    // confirm the refunds are present and only for the posted Submit txs.
+    let user_addr = user_signer.address().to_alloy_address();
+    let evm_block = genesis_node
+        .wait_for_evm_block(expiry_block.evm_block_hash, seconds_to_wait)
+        .await?;
+    let refunded: BTreeSet<H256> = evm_block
+        .body
+        .transactions
+        .into_iter()
+        .filter(|tx| tx.input().len() >= 4)
+        .filter_map(|tx| {
+            let shadow_tx = ShadowTransaction::decode(&mut tx.input().as_ref()).ok()?;
+            match shadow_tx.as_v1()? {
+                TransactionPacket::PermFeeRefund(refund) if refund.target == user_addr => {
+                    Some(H256(refund.irys_ref.into()))
+                }
+                _ => None,
+            }
+        })
+        .collect();
+    assert!(
+        !refunded.is_empty(),
+        "the winning branch's expiry block must perm-fee-refund the expired slot-0 Submit txs \
+         (branch-correct settlement must survive the reorg across the expiry epoch)"
+    );
+    assert!(
+        refunded.is_subset(&posted_ids),
+        "every refund must correspond to a posted Submit tx (got {refunded:?})"
+    );
+
+    peer2_node.stop().await;
+    peer1_node.stop().await;
+    genesis_node.stop().await;
+    Ok(())
+}

--- a/crates/chain-tests/src/validation/slow_path_submit_expiry.rs
+++ b/crates/chain-tests/src/validation/slow_path_submit_expiry.rs
@@ -1,23 +1,18 @@
-// NC-0042 §4c validator consensus rule: a block that promotes a tx whose
-// Submit-ledger storage has already expired must be rejected with
-// `ShadowTransactionInvalid` — even when the expiry happened in an *earlier*
-// block (the cross-block silent double-pay, devnet 39960/39962).
+// NC-0042 integration coverage for `resolve_submit_inclusion`'s SLOW path.
 //
-// Scenario (real flow, no DB seeding):
-//   1. Drive enough data txs through the Submit ledger to force a 2nd slot, so
-//      the genesis slot genuinely expires (per-slot expiry; the last slot is
-//      never expired — see `publish_after_submit_expiry_filtered.rs`).
-//   2. Mine honestly to the expiry epoch. The honest producer drops those txs
-//      from promotion (§4b) and perm-fee-refunds them (Pipeline B).
-//   3. AFTER expiry, an `EvilPublishStrategy` produces a block that promotes one
-//      of the already-expired+refunded txs anyway (the malicious/buggy peer).
-//   4. Both the genesis node and a peer must REJECT that block with
-//      `ShadowTransactionInvalid`. Before §4c this block was accepted by every
-//      validator (no check covered the cross-block case) → permanent double-pay.
-//
-// The earlier version of this test hand-inserted `MigratedBlockHashes` rows;
-// that collides with the real chain's migration writes and crashes
-// BlockTreeService. We drive the tx through the real Submit flow instead.
+// The slow path (by-hash parent-ancestry walk) is what resolves a tx's Submit
+// inclusion when that inclusion is NOT yet in the migrated block index. It is
+// covered by unit fixtures (`resolve_submit_inclusion_slow_path_walks_untracked_tree`,
+// `find_block_range_resolves_unmigrated_tail`, the `walk_*` C1 tests), but the
+// §4b/§4c chain-tests all run with `block_migration_depth = 1`, so a real node
+// in those tests always migrates the inclusion before expiry and only ever takes
+// the O(1) fast path. In production `block_migration_depth` is large, so the
+// slow path IS reached. This test pins that integration: it raises
+// `block_migration_depth` so the expired tx's Submit inclusion is still
+// UN-migrated at the verdict block, then asserts (a) the slow path is genuinely
+// taken (the migrated-index lookup returns `None`) and (b) the §4c validator
+// still correctly rejects a block promoting that already-expired tx — proving the
+// by-hash walk resolved the un-migrated inclusion to the correct offsets.
 
 use crate::utils::{assert_validation_error, solution_context};
 use crate::validation::{send_block_and_read_state, submit_expiry_two_node_setup};
@@ -27,6 +22,7 @@ use irys_actors::{
     block_producer::ledger_expiry::LedgerExpiryBalanceDelta,
     shadow_tx_generator::PublishLedgerWithTxs,
 };
+use irys_database::{canonical_submit_height, db::IrysDatabaseExt as _};
 use irys_domain::BlockTreeReadGuard;
 use irys_types::ingress::generate_ingress_proof;
 use irys_types::{
@@ -34,12 +30,12 @@ use irys_types::{
 };
 
 #[test_log::test(tokio::test)]
-async fn heavy_block_promoting_already_expired_submit_tx_gets_rejected() -> eyre::Result<()> {
-    /// Forces an already-expired Submit tx into the Publish ledger, with a valid
-    /// ingress proof so the block fails validation *only* on the §4c expiry rule
-    /// (not on a missing/invalid proof). No refund is scheduled in the bundle, so
-    /// the in-constructor defence-in-depth guard does not fire during production —
-    /// the block is built and must be caught at validation time.
+async fn heavy_submit_expiry_resolves_unmigrated_inclusion_via_slow_path() -> eyre::Result<()> {
+    /// Same evil producer as the §4c test: promotes an already-expired tx with a
+    /// valid ingress proof and schedules NO refund, so the block is built (the
+    /// in-constructor guard does not fire) and must be caught at validation by the
+    /// §4c rule — which here can only succeed if the SLOW path resolved the
+    /// un-migrated Submit inclusion correctly.
     struct EvilPublishStrategy {
         prod: ProductionStrategy,
         expired_tx: DataTransactionHeader,
@@ -79,8 +75,14 @@ async fn heavy_block_promoting_already_expired_submit_tx_gets_rejected() -> eyre
         }
     }
 
-    // --- 1 + 2. Shared config + two-node startup + overflow data posting ---
-    let setup = submit_expiry_two_node_setup(1).await?;
+    // --- 1 + 2. Shared setup, but with a LARGE block_migration_depth. The data
+    //         block sits at height 1 and the slot expires at blocks_per_cycle (10),
+    //         so a depth > (expiry_height - 1) keeps the inclusion un-migrated
+    //         through expiry. 12 is comfortably above that 9 threshold and below
+    //         the testing block_tree_depth (>= 50), so the inclusion still lives in
+    //         the block tree for the by-hash walk to find. ---
+    const BLOCK_MIGRATION_DEPTH: u32 = 12;
+    let setup = submit_expiry_two_node_setup(BLOCK_MIGRATION_DEPTH).await?;
     let genesis_config = setup.genesis_config;
     let genesis_node = setup.genesis_node;
     let peer_node = setup.peer_node;
@@ -88,29 +90,23 @@ async fn heavy_block_promoting_already_expired_submit_tx_gets_rejected() -> eyre
     let blocks_per_cycle = setup.blocks_per_cycle;
     let seconds_to_wait = setup.seconds_to_wait;
 
-    // --- 3. Mine honestly to the expiry epoch. Pipeline B refunds the slot-0 txs
-    //         here and the honest producer drops them from promotion (§4b). ---
+    // --- 3. Mine honestly to the expiry epoch. The honest producer drops the
+    //         slot-0 txs from promotion (§4b) and refunds them (Pipeline B); both
+    //         now resolve the un-migrated inclusion via the slow path. ---
     let expiry_height = blocks_per_cycle; // = 10
     let height_before_loop = genesis_node.get_canonical_chain_height().await;
     while genesis_node.get_canonical_chain_height().await < expiry_height {
         genesis_node.mine_block().await?;
     }
-    // If the §4b producer filter were absent, the producer would panic at the
-    // expiry epoch block and the chain would stall — the loop would never
-    // terminate. Assert that height advanced so a stall fails fast instead.
     assert!(
         genesis_node.get_canonical_chain_height().await > height_before_loop,
-        "chain must have advanced past the expiry epoch (§4b filter must not have stalled the producer)"
+        "chain must advance past the expiry epoch (slow-path §4b filter must not stall the producer)"
     );
 
-    // --- 4. Pick a target tx and confirm it is genuinely expired at the NEXT
-    //         (cross-block) height we'll produce the evil block at. ---
-    let evil_height = expiry_height + 1; // E+1: cross-block, not the epoch block
-    // The current tip is the parent of the evil block we'll produce at E+1.
+    // --- 4. Pick a target tx expired at the cross-block evil height. ---
+    let evil_height = expiry_height + 1; // E+1
     let evil_parent_block = genesis_node.get_block_by_height(expiry_height).await?;
     let tip_hash = evil_parent_block.block_hash;
-    // Bind the snapshot in its own scope so the block-tree read guard is dropped
-    // before the await below (held-guard-across-await is a clippy deny).
     let tip_snapshot = genesis_node
         .node_ctx
         .block_tree_guard
@@ -132,49 +128,30 @@ async fn heavy_block_promoting_already_expired_submit_tx_gets_rejected() -> eyre
         &genesis_node.node_ctx.db,
     )
     .await?;
-
-    // Differential check: the per-candidate predicate the producer filter and
-    // validator check use (`is_submit_storage_expired`) must agree EXACTLY with the
-    // `expired_submit_tx_ids` walk oracle for every posted tx. Both are now exact
-    // offset comparisons — the refund walk's `same_block` over-inclusion (which this
-    // single-block layout hits) was closed alongside the per-candidate filter
-    // (NC-0042 §4b / R2), so the oracle no longer over-includes whole blocks. We
-    // still drive the evil block off the per-candidate verdict, which is what §4c
-    // enforces.
-    let mut per_candidate_expired = Vec::new();
-    for tx in &txs {
-        let per_candidate = irys_actors::block_producer::ledger_expiry::is_submit_storage_expired(
-            tx.header.id,
-            evil_height,
-            &tip_snapshot,
-            &evil_parent_block,
-            &genesis_node.node_ctx.config,
-            &genesis_node.node_ctx.block_producer_inner.block_index,
-            &genesis_node.node_ctx.block_tree_guard,
-            &genesis_node.node_ctx.mempool_guard,
-            &genesis_node.node_ctx.db,
-        )
-        .await?;
-        assert_eq!(
-            per_candidate,
-            expired_set.contains(&tx.header.id),
-            "is_submit_storage_expired must agree exactly with the expired_submit_tx_ids \
-             walk oracle for tx {} (both are exact offset comparisons — NC-0042 §4b/R2)",
-            tx.header.id,
-        );
-        if per_candidate {
-            per_candidate_expired.push(tx);
-        }
-    }
-
-    let target = per_candidate_expired
-        .first()
-        .copied()
-        .expect("at least one posted tx must be expired by the per-candidate (§4c) verdict");
+    let target = txs
+        .iter()
+        .find(|tx| expired_set.contains(&tx.header.id))
+        .expect("at least one posted tx must be expired at the cross-block evil height");
     let expired_tx = target.header.clone();
 
-    // --- 5. Build a valid ingress proof for the expired tx (genesis signer is
-    //         staked) so the evil block fails ONLY on the §4c expiry rule. ---
+    // --- 5. THE SLOW-PATH PRECONDITION. `resolve_submit_inclusion` takes the slow
+    //         path exactly when the migrated-index lookup returns `None`. Assert
+    //         that for the target tx at the verdict's `max_height` (evil_height - 1)
+    //         so this test cannot silently pass via the fast path. (If this ever
+    //         fails, BLOCK_MIGRATION_DEPTH is too low for the expiry timing.) ---
+    let max_height = evil_height - 1;
+    let migrated_lookup = genesis_node
+        .node_ctx
+        .db
+        .view_eyre(|tx| canonical_submit_height(tx, &expired_tx.id, max_height))?;
+    assert_eq!(
+        migrated_lookup, None,
+        "the expired tx's Submit inclusion must be UN-migrated at max_height {max_height} so \
+         resolve_submit_inclusion takes the by-hash slow path (block_migration_depth = {BLOCK_MIGRATION_DEPTH})"
+    );
+
+    // --- 6. Evil block at E+1 promotes the expired tx; build a valid ingress proof
+    //         so the block fails ONLY on the §4c expiry rule. ---
     let genesis_signer = genesis_config.signer();
     let proof_anchor = genesis_node.get_anchor().await?;
     let chunks: Vec<Vec<u8>> = vec![target.data.clone().unwrap_or_default().into()];
@@ -185,8 +162,6 @@ async fn heavy_block_promoting_already_expired_submit_tx_gets_rejected() -> eyre
         genesis_config.consensus_config().chain_id,
         proof_anchor,
     )?;
-
-    // --- 6. Evil producer builds a block at E+1 that promotes the expired tx ---
     let evil_strategy = EvilPublishStrategy {
         expired_tx: expired_tx.clone(),
         proofs: IngressProofsList(vec![proof]),
@@ -199,7 +174,6 @@ async fn heavy_block_promoting_already_expired_submit_tx_gets_rejected() -> eyre
         .fully_produce_new_block_without_gossip(&solution_context(&genesis_node.node_ctx).await?)
         .await?
         .expect("evil block should be produced (the guard fires at validation, not production)");
-
     assert_eq!(block.header().height, evil_height, "evil block at E+1");
     assert!(
         block.header().data_ledgers[DataLedger::Publish]
@@ -208,36 +182,30 @@ async fn heavy_block_promoting_already_expired_submit_tx_gets_rejected() -> eyre
         "evil block must promote the expired tx"
     );
 
-    // The §4c rejection message includes "See NC-0042." — match on that to ensure
-    // the block is rejected for the right reason and not an unrelated shadow-tx error.
+    // --- 7. Both nodes must reject it (§4c) — only possible if the slow path
+    //         resolved the un-migrated inclusion to the correct offsets. ---
     let is_nc_0042_expiry_rejection = |e: &ValidationError| match e {
         ValidationError::ShadowTransactionInvalid(msg) => msg.contains("NC-0042"),
         _ => false,
     };
-
-    // --- 7. Both nodes must reject it with ShadowTransactionInvalid (§4c) ---
     let genesis_outcome =
         send_block_and_read_state(&genesis_node.node_ctx, block.clone(), false).await?;
     assert_validation_error(
         genesis_outcome,
         is_nc_0042_expiry_rejection,
-        "Genesis must reject a block promoting an already-expired Submit tx (NC-0042 §4c)",
+        "Genesis must reject a block promoting an already-expired Submit tx resolved via the slow path (NC-0042 §4c)",
     );
 
-    // Peer must have the parent chain up to expiry_height before we send it the E+1 block;
-    // otherwise it rejects for ParentBlockMissing rather than ShadowTransactionInvalid.
     peer_node
         .wait_until_height(expiry_height, seconds_to_wait)
         .await?;
-
     let peer_outcome = send_block_and_read_state(&peer_node.node_ctx, block.clone(), false).await?;
     assert_validation_error(
         peer_outcome,
         is_nc_0042_expiry_rejection,
-        "Peer must reject a block promoting an already-expired Submit tx (NC-0042 §4c)",
+        "Peer must reject a block promoting an already-expired Submit tx resolved via the slow path (NC-0042 §4c)",
     );
 
-    // Neither node should have committed the evil block to the EVM layer.
     genesis_node
         .assert_evm_block_absent(block.header().evm_block_hash, 2)
         .await?;

--- a/crates/chain-tests/src/validation/slow_path_submit_expiry.rs
+++ b/crates/chain-tests/src/validation/slow_path_submit_expiry.rs
@@ -113,11 +113,18 @@ async fn heavy_submit_expiry_resolves_unmigrated_inclusion_via_slow_path() -> ey
         .read()
         .get_epoch_snapshot(&tip_hash)
         .expect("epoch snapshot for the current tip");
+    let evil_cascade_active = genesis_node
+        .node_ctx
+        .config
+        .consensus
+        .hardforks
+        .is_cascade_active_at(evil_parent_block.timestamp_secs());
     let expired_set = irys_actors::block_producer::ledger_expiry::expired_submit_tx_ids(
         &tip_snapshot,
         &evil_parent_block,
         evil_height,
         &genesis_node.node_ctx.config,
+        evil_cascade_active,
         genesis_node
             .node_ctx
             .block_producer_inner
@@ -154,7 +161,13 @@ async fn heavy_submit_expiry_resolves_unmigrated_inclusion_via_slow_path() -> ey
     //         so the block fails ONLY on the §4c expiry rule. ---
     let genesis_signer = genesis_config.signer();
     let proof_anchor = genesis_node.get_anchor().await?;
-    let chunks: Vec<Vec<u8>> = vec![target.data.clone().unwrap_or_default().into()];
+    // Fail fast on a missing payload rather than silently building the ingress
+    // proof over an empty chunk — that would change what is proven and could
+    // mask a fixture regression (the posted tx's data must still be retained).
+    let target_data = target.data.clone().expect(
+        "posted tx payload must be retained to build the ingress proof (fixture invariant)",
+    );
+    let chunks: Vec<Vec<u8>> = vec![target_data.into()];
     let proof = generate_ingress_proof(
         &genesis_signer,
         expired_tx.data_root,

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -52,7 +52,7 @@ use irys_reth_node_bridge::IrysRethNodeAdapter;
 use irys_reth_node_bridge::node::{NodeProvider, RethNode, RethNodeHandle};
 pub use irys_reth_node_bridge::node::{RethNodeAddOns, RethNodeProvider};
 use irys_reward_curve::HalvingCurve;
-use irys_storage::irys_consensus_data_db::open_or_create_irys_consensus_data_db;
+use irys_storage::irys_consensus_data_db::open_or_create_irys_consensus_data_db_with_args;
 use irys_types::BlockHash;
 use irys_types::chainspec::irys_chain_spec;
 use irys_types::{
@@ -2774,9 +2774,10 @@ fn init_reth_db(
 
 #[tracing::instrument(level = "trace", skip_all)]
 fn init_irys_db(node_config: &NodeConfig) -> Result<DatabaseProvider, eyre::Error> {
-    let irys_db_env = open_or_create_irys_consensus_data_db(
+    let irys_db_env = open_or_create_irys_consensus_data_db_with_args(
         node_config.irys_consensus_data_dir(),
-        node_config.database.sync_mode,
+        // Args (incl. the test geometry cap) derived from the node's DatabaseConfig.
+        irys_database::consensus_db_args(&node_config.database)?,
     )?;
     irys_database::migration::ensure_db_version_compatible(&irys_db_env)?;
     let irys_db = DatabaseProvider(Arc::new(irys_db_env));

--- a/crates/cli/src/db_utils.rs
+++ b/crates/cli/src/db_utils.rs
@@ -225,14 +225,19 @@ pub(crate) fn cli_init_reth_provider() -> eyre::Result<(
 }
 
 pub(crate) fn cli_init_irys_db(access: DatabaseEnvKind) -> eyre::Result<Arc<DatabaseEnv>> {
-    use irys_storage::irys_consensus_data_db::open_or_create_irys_consensus_data_db;
+    use irys_storage::irys_consensus_data_db::open_or_create_irys_consensus_data_db_with_args;
 
     let config = load_node_config_from_env()?;
     let db_path = config.irys_consensus_data_dir();
 
     let db_env = match access {
         DatabaseEnvKind::RW => {
-            let db = open_or_create_irys_consensus_data_db(&db_path, config.database.sync_mode)?;
+            // Honor the full database config (sync mode AND geometry_max_size),
+            // same as the node path in chain.rs — not just the sync mode.
+            let db = open_or_create_irys_consensus_data_db_with_args(
+                &db_path,
+                irys_database::consensus_db_args(&config.database)?,
+            )?;
             irys_database::migration::ensure_db_version_compatible(&db)?;
             db
         }

--- a/crates/cli/src/db_utils.rs
+++ b/crates/cli/src/db_utils.rs
@@ -242,13 +242,15 @@ pub(crate) fn cli_init_irys_db(access: DatabaseEnvKind) -> eyre::Result<Arc<Data
             db
         }
         DatabaseEnvKind::RO => {
-            let db = DatabaseEnv::open(
-                &db_path,
-                access,
-                irys_database::reth_db::mdbx::DatabaseArguments::new(default_client_version())
-                    .with_log_level(None)
-                    .with_exclusive(Some(false)),
-            )?;
+            // Honor the consensus DB geometry (same as the RW path and the node),
+            // then layer the RO-specific flags on top — so a read-only open against
+            // a test/constrained-geometry config doesn't reserve reth's large
+            // default map. (Opening an existing DB maps its on-disk geometry; this
+            // keeps the virtual-address-space reservation aligned with the RW path.)
+            let args = irys_database::consensus_db_args(&config.database)?
+                .with_log_level(None)
+                .with_exclusive(Some(false));
+            let db = DatabaseEnv::open(&db_path, access, args)?;
             //note: any migrations will fail, as this is RO env, but if they needed to run the database was out of date and you should open it as RW and migrate it first before continuing.
             irys_database::migration::ensure_db_version_compatible(&db)?;
             db

--- a/crates/database/src/data_ledger.rs
+++ b/crates/database/src/data_ledger.rs
@@ -16,9 +16,12 @@ pub struct LedgerSlot {
     pub partitions: Vec<H256>,
     /// Flag marking weather this ledger slot is expired or not
     pub is_expired: bool,
-    /// Block height at which this slot was allocated. Set once at allocation and
-    /// never mutated, so slot expiry (`last_height <= expiry_height`) is a pure
-    /// function of canonical slot state — see `get_all_expired_slot_indexes`.
+    /// Block height the slot's expiry clock counts from. Set at allocation, then
+    /// refreshed to the last write height by the Cascade-gated `touch_filled_slots`
+    /// (so expiry counts from the last data write, not from allocation). Either way
+    /// it is a deterministic function of canonical state, so slot expiry
+    /// (`last_height <= expiry_height`) stays a pure function of canonical slot
+    /// state — see `get_all_expired_slot_indexes` and `touch_filled_slots`.
     pub last_height: u64,
 }
 

--- a/crates/database/src/data_ledger.rs
+++ b/crates/database/src/data_ledger.rs
@@ -1050,4 +1050,31 @@ mod tests {
             "get_expired_slot_indexes returns only newly-expiring slots"
         );
     }
+
+    /// NC-0042 P0-1: `get_all_expired_slot_indexes` CAN return a non-contiguous
+    /// (holey) set when an empty pre-allocated middle slot ages out by its
+    /// allocation height while a lower slot stays live. This is the exact input
+    /// the `expired_submit_range` contiguity guard fails loud on — keep them in
+    /// lockstep. Built with the `last_height = [1, 100, 1, 1]` shape the touch
+    /// produces (touch only slot 1).
+    #[test]
+    fn get_all_expired_slot_indexes_can_be_non_prefix() {
+        let config = ConsensusConfig::testing();
+        let min_blocks = config.epoch.submit_ledger_epoch_length * config.epoch.num_blocks_in_epoch;
+
+        // 4 slots allocated at height 1; touch only slot 1 (chunks [12,18) with a
+        // 10-chunk partition) → last_height [1, 100, 1, 1].
+        let mut ledgers = ledgers_with_submit_slots(4, 1);
+        ledgers.touch_filled_slots(DataLedger::Submit, 12, 18, 10, 100);
+        assert_eq!(submit_last_heights(&ledgers), vec![1, 100, 1, 1]);
+
+        // expiry_height = (min_blocks + 50) - min_blocks = 50 ∈ (1, 100): slots 0
+        // and 2 expire (last_height 1), slot 1 stays live (last_height 100), slot
+        // 3 is the never-expiring last slot → the non-prefix set {0, 2}.
+        assert_eq!(
+            ledgers.get_all_expired_term_slot_indexes(DataLedger::Submit, min_blocks + 50),
+            vec![0, 2],
+            "an empty middle slot aged by allocation height yields a non-prefix expired set"
+        );
+    }
 }

--- a/crates/database/src/data_ledger.rs
+++ b/crates/database/src/data_ledger.rs
@@ -16,7 +16,9 @@ pub struct LedgerSlot {
     pub partitions: Vec<H256>,
     /// Flag marking weather this ledger slot is expired or not
     pub is_expired: bool,
-    /// Block height of most recently added transaction data (chunks)
+    /// Block height at which this slot was allocated. Set once at allocation and
+    /// never mutated, so slot expiry (`last_height <= expiry_height`) is a pure
+    /// function of canonical slot state — see `get_all_expired_slot_indexes`.
     pub last_height: u64,
 }
 

--- a/crates/database/src/data_ledger.rs
+++ b/crates/database/src/data_ledger.rs
@@ -16,11 +16,17 @@ pub struct LedgerSlot {
     pub partitions: Vec<H256>,
     /// Flag marking weather this ledger slot is expired or not
     pub is_expired: bool,
+    /// Has canonical ledger data ever landed in this slot?
+    ///
+    /// Slots are preallocated ahead of the write frontier, so allocation alone
+    /// must NOT make them eligible for expiry. This bit flips the first time the
+    /// canonical write window overlaps the slot and then stays true forever.
+    pub has_been_written: bool,
     /// Block height the slot's expiry clock counts from. Set at allocation, then
     /// refreshed to the last write height by the Cascade-gated `touch_filled_slots`
-    /// (so expiry counts from the last data write, not from allocation). Either way
-    /// it is a deterministic function of canonical state, so slot expiry
-    /// (`last_height <= expiry_height`) stays a pure function of canonical slot
+    /// once the slot has canonical data (so expiry counts from the last data
+    /// write, not from allocation). Either way it is a deterministic function of
+    /// canonical state, so slot expiry stays a pure function of canonical slot
     /// state — see `get_all_expired_slot_indexes` and `touch_filled_slots`.
     pub last_height: u64,
 }
@@ -84,7 +90,7 @@ impl TermLedger {
     }
 
     #[tracing::instrument(level = "trace", skip_all, fields(epoch_height = %epoch_height))]
-    pub fn get_expired_slot_indexes(&self, epoch_height: u64) -> Vec<usize> {
+    pub fn get_expired_slot_indexes(&self, epoch_height: u64, cascade_active: bool) -> Vec<usize> {
         let mut expired_slot_indexes = Vec::new();
 
         let min_blocks = self
@@ -128,7 +134,8 @@ impl TermLedger {
                 tracing::warn!("Skipping slot {} (last slot)", slot_index);
                 continue;
             }
-            if slot.last_height <= expiry_height && !slot.is_expired {
+            let written_ok = !cascade_active || slot.has_been_written;
+            if written_ok && slot.last_height <= expiry_height && !slot.is_expired {
                 tracing::info!("Slot {} is expired! Adding to expired_indices", slot_index);
                 expired_slot_indexes.push(slot_index);
             }
@@ -145,11 +152,18 @@ impl TermLedger {
     /// `get_expired_slot_indexes` returns only *newly* expiring slots (it filters out
     /// `is_expired`), because the refund/fee pipeline must act on each slot exactly once.
     /// The NC-0042 publish-candidate filter and validator check need the opposite: a tx
-    /// whose Submit slot expired must be treated as non-promotable for *every* block
-    /// at-or-after the expiry, not just the single epoch block where it newly expires.
-    /// Keying on `last_height` (set once at allocation, never mutated) makes this a pure
-    /// function of canonical slot state — producer and validator always agree.
-    pub fn get_all_expired_slot_indexes(&self, epoch_height: u64) -> Vec<usize> {
+    /// whose Submit slot expired must be treated as non-promotable for *every*
+    /// block at-or-after the expiry, not just the single epoch block where it
+    /// newly expires.
+    ///
+    /// Post-Cascade, unwritten preallocated slots are excluded: they never held
+    /// canonical data and therefore must not expire. Pre-Cascade replay stays
+    /// bit-identical to the allocation-anchored behavior.
+    pub fn get_all_expired_slot_indexes(
+        &self,
+        epoch_height: u64,
+        cascade_active: bool,
+    ) -> Vec<usize> {
         let min_blocks = self
             .epoch_length
             .checked_mul(self.num_blocks_in_epoch)
@@ -167,15 +181,17 @@ impl TermLedger {
             .enumerate()
             .filter(|(slot_index, slot)| {
                 // Never expire the last slot in a ledger (matches get_expired_slot_indexes).
-                *slot_index != last_slot_index && slot.last_height <= expiry_height
+                *slot_index != last_slot_index
+                    && (!cascade_active || slot.has_been_written)
+                    && slot.last_height <= expiry_height
             })
             .map(|(slot_index, _)| slot_index)
             .collect()
     }
 
     /// Returns indices of newly expired slots
-    pub fn expire_old_slots(&mut self, epoch_height: u64) -> Vec<usize> {
-        let expired_slot_indexes = self.get_expired_slot_indexes(epoch_height);
+    pub fn expire_old_slots(&mut self, epoch_height: u64, cascade_active: bool) -> Vec<usize> {
+        let expired_slot_indexes = self.get_expired_slot_indexes(epoch_height, cascade_active);
 
         // Mark collected slots as expired
         for &idx in &expired_slot_indexes {
@@ -216,6 +232,7 @@ impl LedgerCore for PermanentLedger {
             self.slots.push(LedgerSlot {
                 partitions: Vec::new(),
                 is_expired: false,
+                has_been_written: false,
                 last_height: height,
             });
             num_partitions_added += self.num_partitions_per_slot;
@@ -264,6 +281,7 @@ impl LedgerCore for TermLedger {
             self.slots.push(LedgerSlot {
                 partitions: Vec::new(),
                 is_expired: false,
+                has_been_written: false,
                 last_height: height,
             });
             num_partitions_added += self.num_partitions_per_slot;
@@ -396,11 +414,16 @@ impl Ledgers {
 
     /// Get all partition hashes that have expired out of both perm and term ledgers.
     /// Perm slots only expire when `publish_ledger_epoch_length` is configured.
-    pub fn expire_partitions(&mut self, epoch_height: u64) -> Vec<ExpiringPartitionInfo> {
+    pub fn expire_partitions(
+        &mut self,
+        epoch_height: u64,
+        cascade_active: bool,
+    ) -> Vec<ExpiringPartitionInfo> {
         let mut expired_partitions: Vec<ExpiringPartitionInfo> = Vec::new();
 
         // Expire perm ledger slots using shared helper
-        for (slot_index, partition_hashes, ledger_id) in self.get_perm_expiring_slots(epoch_height)
+        for (slot_index, partition_hashes, ledger_id) in
+            self.get_perm_expiring_slots(epoch_height, cascade_active)
         {
             self.perm.slots[slot_index].is_expired = true;
             for partition_hash in partition_hashes {
@@ -416,7 +439,7 @@ impl Ledgers {
         for term_ledger in &mut self.term {
             let ledger_id = DataLedger::try_from(term_ledger.ledger_id)
                 .expect("term ledger_id is always constructed from a valid DataLedger variant");
-            for expired_index in term_ledger.expire_old_slots(epoch_height) {
+            for expired_index in term_ledger.expire_old_slots(epoch_height, cascade_active) {
                 for partition_hash in term_ledger.slots[expired_index].partitions.iter() {
                     expired_partitions.push(ExpiringPartitionInfo {
                         partition_hash: *partition_hash,
@@ -432,11 +455,16 @@ impl Ledgers {
 
     /// Get all partition hashes that would expire at this epoch height (read-only).
     /// Unlike `expire_partitions`, this does NOT mark slots as expired.
-    pub fn get_expiring_partitions(&self, epoch_height: u64) -> Vec<ExpiringPartitionInfo> {
+    pub fn get_expiring_partitions(
+        &self,
+        epoch_height: u64,
+        cascade_active: bool,
+    ) -> Vec<ExpiringPartitionInfo> {
         let mut expired_partitions: Vec<ExpiringPartitionInfo> = Vec::new();
 
         // Check perm ledger slots using shared helper
-        for (slot_index, partition_hashes, ledger_id) in self.get_perm_expiring_slots(epoch_height)
+        for (slot_index, partition_hashes, ledger_id) in
+            self.get_perm_expiring_slots(epoch_height, cascade_active)
         {
             for partition_hash in partition_hashes {
                 expired_partitions.push(ExpiringPartitionInfo {
@@ -451,7 +479,9 @@ impl Ledgers {
         for term_ledger in &self.term {
             let ledger_id = DataLedger::try_from(term_ledger.ledger_id)
                 .expect("term ledger_id is always constructed from a valid DataLedger variant");
-            for expiring_slot_index in term_ledger.get_expired_slot_indexes(epoch_height) {
+            for expiring_slot_index in
+                term_ledger.get_expired_slot_indexes(epoch_height, cascade_active)
+            {
                 for partition_hash in term_ledger.slots[expiring_slot_index].partitions.iter() {
                     expired_partitions.push(ExpiringPartitionInfo {
                         partition_hash: *partition_hash,
@@ -474,9 +504,10 @@ impl Ledgers {
         &self,
         ledger: DataLedger,
         epoch_height: u64,
+        cascade_active: bool,
     ) -> Vec<usize> {
         self.get_term_ledger(ledger)
-            .get_all_expired_slot_indexes(epoch_height)
+            .get_all_expired_slot_indexes(epoch_height, cascade_active)
     }
 
     // Private helper methods for term ledger lookups
@@ -499,6 +530,7 @@ impl Ledgers {
     fn get_perm_expiring_slots(
         &self,
         epoch_height: u64,
+        cascade_active: bool,
     ) -> Vec<(usize, Vec<PartitionHash>, DataLedger)> {
         let Some(epoch_length) = self.publish_ledger_epoch_length else {
             return Vec::new();
@@ -524,7 +556,8 @@ impl Ledgers {
             if num_slots > 0 && slot_index == last_slot_index {
                 continue;
             }
-            if slot.last_height <= expiry_height && !slot.is_expired {
+            let written_ok = !cascade_active || slot.has_been_written;
+            if written_ok && slot.last_height <= expiry_height && !slot.is_expired {
                 result.push((slot_index, slot.partitions.clone(), perm_ledger_id));
             }
         }
@@ -576,9 +609,10 @@ impl Ledgers {
             .retain(|p| p != partition_hash);
     }
 
-    /// Refresh `last_height` on every slot that received new canonical data
-    /// during this epoch, so a slot's expiry clock counts from the last time
-    /// data was written into it rather than from when the slot was allocated.
+    /// Mark every slot that received new canonical data during this epoch as
+    /// written. When `refresh_last_height` is true, also refresh `last_height`
+    /// so the slot's expiry clock counts from the last time data was written
+    /// into it rather than from when the slot was allocated.
     ///
     /// `prev_total_chunks` / `new_total_chunks` are the ledger's cumulative
     /// chunk counts at the previous and current epoch blocks (read from the
@@ -587,7 +621,8 @@ impl Ledgers {
     /// matching the capacity model in `calculate_additional_slots` and the slot
     /// range math in `block_producer::ledger_expiry::compute_chunk_range`.
     ///
-    /// Caller is responsible for gating this on the Cascade hardfork so that
+    /// Caller always invokes this to record which slots have canonical data.
+    /// `refresh_last_height` gates the post-Cascade last-write fix so
     /// pre-activation chains replay bit-identically (slots keep their
     /// allocation-time `last_height`).
     pub fn touch_filled_slots(
@@ -597,6 +632,7 @@ impl Ledgers {
         new_total_chunks: u64,
         chunks_per_slot: u64,
         height: u64,
+        refresh_last_height: bool,
     ) {
         // No data added this epoch (or misconfigured slot size) -> nothing to do.
         if new_total_chunks <= prev_total_chunks || chunks_per_slot == 0 {
@@ -625,8 +661,10 @@ impl Ledgers {
             .min(slots.len() - 1);
 
         for slot in &mut slots[first..=last] {
+            slot.has_been_written = true;
+
             // Don't resurrect an already-expired slot.
-            if !slot.is_expired {
+            if refresh_last_height && !slot.is_expired {
                 slot.last_height = height;
             }
         }
@@ -766,7 +804,7 @@ mod tests {
         ledgers.perm.allocate_slots(1, 1);
         ledgers.perm.slots[0].partitions.push(H256::random());
         // At height 1000, nothing should expire
-        let expired = ledgers.expire_partitions(1000);
+        let expired = ledgers.expire_partitions(1000, true);
         assert!(expired.iter().all(|e| e.ledger_id != DataLedger::Publish));
     }
 
@@ -780,13 +818,15 @@ mod tests {
         // Add two perm slots
         ledgers.perm.allocate_slots(1, 1); // slot 0 at height 1
         ledgers.perm.slots[0].partitions.push(H256::random());
+        ledgers.perm.slots[0].has_been_written = true;
         ledgers.perm.allocate_slots(1, 25); // slot 1 at height 25
         ledgers.perm.slots[1].partitions.push(H256::random());
+        ledgers.perm.slots[1].has_been_written = true;
 
         // At epoch_height = 30: expiry_height = 30 - 20 = 10
         // Slot 0 (last_height=1) <= 10: EXPIRED
         // Slot 1 (last_height=25) > 10: NOT expired (also last slot)
-        let expired = ledgers.expire_partitions(30);
+        let expired = ledgers.expire_partitions(30, true);
         let perm_expired: Vec<_> = expired
             .iter()
             .filter(|e| e.ledger_id == DataLedger::Publish)
@@ -803,9 +843,10 @@ mod tests {
         // Add only one perm slot
         ledgers.perm.allocate_slots(1, 1);
         ledgers.perm.slots[0].partitions.push(H256::random());
+        ledgers.perm.slots[0].has_been_written = true;
 
         // At epoch_height = 100: should NOT expire (it's the last slot)
-        let expired = ledgers.expire_partitions(100);
+        let expired = ledgers.expire_partitions(100, true);
         let perm_expired: Vec<_> = expired
             .iter()
             .filter(|e| e.ledger_id == DataLedger::Publish)
@@ -821,9 +862,11 @@ mod tests {
         ledgers.perm.allocate_slots(2, 1);
         ledgers.perm.slots[0].partitions.push(H256::random());
         ledgers.perm.slots[1].partitions.push(H256::random());
+        ledgers.perm.slots[0].has_been_written = true;
+        ledgers.perm.slots[1].has_been_written = true;
 
         // At epoch_height = 15 (< 20 minimum): nothing expires
-        let expired = ledgers.expire_partitions(15);
+        let expired = ledgers.expire_partitions(15, true);
         let perm_expired: Vec<_> = expired
             .iter()
             .filter(|e| e.ledger_id == DataLedger::Publish)
@@ -838,9 +881,11 @@ mod tests {
         ledgers.perm.allocate_slots(2, 1);
         ledgers.perm.slots[0].partitions.push(H256::random());
         ledgers.perm.slots[1].partitions.push(H256::random());
+        ledgers.perm.slots[0].has_been_written = true;
+        ledgers.perm.slots[1].has_been_written = true;
 
         // Read-only: should report slot 0 as expiring without marking it
-        let expiring = ledgers.get_expiring_partitions(30);
+        let expiring = ledgers.get_expiring_partitions(30, true);
         let perm_expiring: Vec<_> = expiring
             .iter()
             .filter(|e| e.ledger_id == DataLedger::Publish)
@@ -875,7 +920,7 @@ mod tests {
         ledgers.perm.allocate_slots(1, 1);
         ledgers.perm.slots[0].partitions.push(H256::random());
 
-        let expiring = ledgers.get_expiring_partitions(1000);
+        let expiring = ledgers.get_expiring_partitions(1000, true);
         assert!(expiring.iter().all(|e| e.ledger_id != DataLedger::Publish));
     }
 
@@ -895,20 +940,30 @@ mod tests {
             .collect()
     }
 
+    fn submit_written_flags(ledgers: &Ledgers) -> Vec<bool> {
+        ledgers
+            .get_slots(DataLedger::Submit)
+            .iter()
+            .map(|s| s.has_been_written)
+            .collect()
+    }
+
     #[test]
     fn test_touch_filled_slots_marks_all_written_slots() {
         // 3 slots of 10 chunks each; new chunks [0, 25) span slots 0,1,2.
         let mut ledgers = ledgers_with_submit_slots(3, 1);
-        ledgers.touch_filled_slots(DataLedger::Submit, 0, 25, 10, 100);
+        ledgers.touch_filled_slots(DataLedger::Submit, 0, 25, 10, 100, true);
         assert_eq!(submit_last_heights(&ledgers), vec![100, 100, 100]);
+        assert_eq!(submit_written_flags(&ledgers), vec![true, true, true]);
     }
 
     #[test]
     fn test_touch_filled_slots_partial_window_touches_only_overlap() {
         // New chunks [12, 18) fall entirely within slot 1 (covers [10, 20)).
         let mut ledgers = ledgers_with_submit_slots(3, 1);
-        ledgers.touch_filled_slots(DataLedger::Submit, 12, 18, 10, 100);
+        ledgers.touch_filled_slots(DataLedger::Submit, 12, 18, 10, 100, true);
         assert_eq!(submit_last_heights(&ledgers), vec![1, 100, 1]);
+        assert_eq!(submit_written_flags(&ledgers), vec![false, true, false]);
     }
 
     #[test]
@@ -916,25 +971,28 @@ mod tests {
         // prev exactly on a slot boundary: [10, 11) is the first chunk of slot 1,
         // so slot 0 must NOT be touched.
         let mut ledgers = ledgers_with_submit_slots(3, 1);
-        ledgers.touch_filled_slots(DataLedger::Submit, 10, 11, 10, 100);
+        ledgers.touch_filled_slots(DataLedger::Submit, 10, 11, 10, 100, true);
         assert_eq!(submit_last_heights(&ledgers), vec![1, 100, 1]);
+        assert_eq!(submit_written_flags(&ledgers), vec![false, true, false]);
     }
 
     #[test]
     fn test_touch_filled_slots_noop_when_no_data() {
         // new <= prev means no chunks were added this epoch.
         let mut ledgers = ledgers_with_submit_slots(2, 1);
-        ledgers.touch_filled_slots(DataLedger::Submit, 15, 15, 10, 100);
-        ledgers.touch_filled_slots(DataLedger::Submit, 20, 10, 10, 100);
+        ledgers.touch_filled_slots(DataLedger::Submit, 15, 15, 10, 100, true);
+        ledgers.touch_filled_slots(DataLedger::Submit, 20, 10, 10, 100, true);
         assert_eq!(submit_last_heights(&ledgers), vec![1, 1]);
+        assert_eq!(submit_written_flags(&ledgers), vec![false, false]);
     }
 
     #[test]
     fn test_touch_filled_slots_noop_when_zero_slot_size() {
         // chunks_per_slot == 0 must be a guarded no-op (no divide-by-zero panic).
         let mut ledgers = ledgers_with_submit_slots(2, 1);
-        ledgers.touch_filled_slots(DataLedger::Submit, 0, 100, 0, 100);
+        ledgers.touch_filled_slots(DataLedger::Submit, 0, 100, 0, 100, true);
         assert_eq!(submit_last_heights(&ledgers), vec![1, 1]);
+        assert_eq!(submit_written_flags(&ledgers), vec![false, false]);
     }
 
     #[test]
@@ -942,7 +1000,7 @@ mod tests {
         // An already-expired slot must not be resurrected, even if data lands in it.
         let mut ledgers = ledgers_with_submit_slots(3, 1);
         ledgers.slots_mut(DataLedger::Submit)[1].is_expired = true;
-        ledgers.touch_filled_slots(DataLedger::Submit, 0, 25, 10, 100);
+        ledgers.touch_filled_slots(DataLedger::Submit, 0, 25, 10, 100, true);
 
         let slots = ledgers.get_slots(DataLedger::Submit);
         assert_eq!(slots[0].last_height, 100);
@@ -951,6 +1009,10 @@ mod tests {
             "expired slot keeps its last_height"
         );
         assert!(slots[1].is_expired, "expired slot stays expired");
+        assert!(
+            slots[1].has_been_written,
+            "expired slot still records that data landed in it"
+        );
         assert_eq!(slots[2].last_height, 100);
     }
 
@@ -959,8 +1021,9 @@ mod tests {
         // Window implies slots up to index 4 but only 2 slots exist: no panic,
         // existing slots still updated.
         let mut ledgers = ledgers_with_submit_slots(2, 1);
-        ledgers.touch_filled_slots(DataLedger::Submit, 0, 50, 10, 100);
+        ledgers.touch_filled_slots(DataLedger::Submit, 0, 50, 10, 100, true);
         assert_eq!(submit_last_heights(&ledgers), vec![100, 100]);
+        assert_eq!(submit_written_flags(&ledgers), vec![true, true]);
     }
 
     #[test]
@@ -974,13 +1037,19 @@ mod tests {
         let mut ledgers = Ledgers::new(&config, false);
         ledgers[DataLedger::Publish].allocate_slots(3, 1);
         // New chunks [0, 25) span perm slots 0,1,2 (10 chunks each).
-        ledgers.touch_filled_slots(DataLedger::Publish, 0, 25, 10, 100);
+        ledgers.touch_filled_slots(DataLedger::Publish, 0, 25, 10, 100, true);
         let heights: Vec<u64> = ledgers
             .get_slots(DataLedger::Publish)
             .iter()
             .map(|s| s.last_height)
             .collect();
         assert_eq!(heights, vec![100, 100, 100]);
+        assert!(
+            ledgers
+                .get_slots(DataLedger::Publish)
+                .iter()
+                .all(|slot| slot.has_been_written)
+        );
     }
 
     /// `get_all_expired_slot_indexes` is the NC-0042 §4b/§4c non-promotability
@@ -1000,12 +1069,12 @@ mod tests {
         // never expires — exactly where the cycle-math approximation diverged.
         assert!(
             ledger
-                .get_all_expired_slot_indexes(blocks_per_cycle)
+                .get_all_expired_slot_indexes(blocks_per_cycle, true)
                 .is_empty()
         );
         assert!(
             ledger
-                .get_all_expired_slot_indexes(blocks_per_cycle * 10)
+                .get_all_expired_slot_indexes(blocks_per_cycle * 10, true)
                 .is_empty()
         );
     }
@@ -1025,59 +1094,80 @@ mod tests {
         let mut ledger = TermLedger::new(DataLedger::Submit, &config, epoch_length);
         ledger.allocate_slots(1, 0); // slot 0
         ledger.allocate_slots(1, num_blocks); // slot 1 (the kept last slot)
+        ledger.slots[0].has_been_written = true;
+        ledger.slots[1].has_been_written = true;
 
         let expiry = blocks_per_cycle; // slot 0 expires here
 
         // One epoch before: nothing expired yet.
         assert!(
             ledger
-                .get_all_expired_slot_indexes(expiry - num_blocks)
+                .get_all_expired_slot_indexes(expiry - num_blocks, true)
                 .is_empty()
         );
 
         // At expiry, slot 0 is in both sets.
-        assert_eq!(ledger.get_all_expired_slot_indexes(expiry), vec![0]);
-        assert_eq!(ledger.get_expired_slot_indexes(expiry), vec![0]);
+        assert_eq!(ledger.get_all_expired_slot_indexes(expiry, true), vec![0]);
+        assert_eq!(ledger.get_expired_slot_indexes(expiry, true), vec![0]);
 
         // After it is marked expired, the inclusive set still returns it
         // (a tx in slot 0 stays non-promotable at every later block) while the
         // newly-expiring set drops it (it must only be refunded once).
-        ledger.expire_old_slots(expiry);
+        ledger.expire_old_slots(expiry, true);
         assert_eq!(
-            ledger.get_all_expired_slot_indexes(expiry + 1),
+            ledger.get_all_expired_slot_indexes(expiry + 1, true),
             vec![0],
             "an already-expired slot must remain in the inclusive set (cross-block guard)"
         );
         assert!(
-            ledger.get_expired_slot_indexes(expiry + 1).is_empty(),
+            ledger.get_expired_slot_indexes(expiry + 1, true).is_empty(),
             "get_expired_slot_indexes returns only newly-expiring slots"
         );
     }
 
-    /// NC-0042 P0-1: `get_all_expired_slot_indexes` CAN return a non-contiguous
-    /// (holey) set when an empty pre-allocated middle slot ages out by its
-    /// allocation height while a lower slot stays live. This is the exact input
-    /// the `expired_submit_range` contiguity guard fails loud on — keep them in
-    /// lockstep. Built with the `last_height = [1, 100, 1, 1]` shape the touch
-    /// produces (touch only slot 1).
+    /// Empty preallocated slots must not expire just because their allocation
+    /// height aged out. Only slots that have actually held canonical data can
+    /// expire.
     #[test]
-    fn get_all_expired_slot_indexes_can_be_non_prefix() {
+    fn get_all_expired_slot_indexes_skips_unwritten_slots() {
         let config = ConsensusConfig::testing();
         let min_blocks = config.epoch.submit_ledger_epoch_length * config.epoch.num_blocks_in_epoch;
 
-        // 4 slots allocated at height 1; touch only slot 1 (chunks [12,18) with a
-        // 10-chunk partition) → last_height [1, 100, 1, 1].
+        // 4 slots allocated at height 1. Canonical data first fills slots 0 and 1,
+        // then a later epoch touches only slot 1. Slots 2 and 3 remain unwritten.
         let mut ledgers = ledgers_with_submit_slots(4, 1);
-        ledgers.touch_filled_slots(DataLedger::Submit, 12, 18, 10, 100);
-        assert_eq!(submit_last_heights(&ledgers), vec![1, 100, 1, 1]);
-
-        // expiry_height = (min_blocks + 50) - min_blocks = 50 ∈ (1, 100): slots 0
-        // and 2 expire (last_height 1), slot 1 stays live (last_height 100), slot
-        // 3 is the never-expiring last slot → the non-prefix set {0, 2}.
+        ledgers.touch_filled_slots(DataLedger::Submit, 0, 18, 10, 50, true);
+        ledgers.touch_filled_slots(DataLedger::Submit, 18, 19, 10, 100, true);
+        assert_eq!(submit_last_heights(&ledgers), vec![50, 100, 1, 1]);
         assert_eq!(
-            ledgers.get_all_expired_term_slot_indexes(DataLedger::Submit, min_blocks + 50),
+            submit_written_flags(&ledgers),
+            vec![true, true, false, false]
+        );
+
+        // expiry_height = (min_blocks + 75) - min_blocks = 75 ∈ (50, 100): slot 0
+        // expires, slot 1 stays live, and unwritten slots 2/3 stay unexpired.
+        assert_eq!(
+            ledgers.get_all_expired_term_slot_indexes(DataLedger::Submit, min_blocks + 75, true),
+            vec![0],
+            "preallocated slots that never held data must not expire"
+        );
+    }
+
+    /// Pre-Cascade replay identity: before the hardfork, unwritten preallocated
+    /// slots still age out by allocation height.
+    #[test]
+    fn get_all_expired_slot_indexes_pre_cascade_keeps_old_unwritten_expiry() {
+        let config = ConsensusConfig::testing();
+        let min_blocks = config.epoch.submit_ledger_epoch_length * config.epoch.num_blocks_in_epoch;
+
+        let mut ledgers = ledgers_with_submit_slots(4, 1);
+        ledgers.touch_filled_slots(DataLedger::Submit, 0, 18, 10, 50, true);
+        ledgers.touch_filled_slots(DataLedger::Submit, 18, 19, 10, 100, true);
+
+        assert_eq!(
+            ledgers.get_all_expired_term_slot_indexes(DataLedger::Submit, min_blocks + 75, false),
             vec![0, 2],
-            "an empty middle slot aged by allocation height yields a non-prefix expired set"
+            "pre-Cascade replay must keep allocation-aged unwritten slots in the expired set"
         );
     }
 }

--- a/crates/database/src/data_ledger.rs
+++ b/crates/database/src/data_ledger.rs
@@ -556,6 +556,11 @@ impl Ledgers {
             if num_slots > 0 && slot_index == last_slot_index {
                 continue;
             }
+            // INVARIANT: Publish slots have `has_been_written` populated by
+            // `touch_filled_slots`, which `EpochSnapshot::touch_active_ledger_slots`
+            // calls unconditionally over `active_ledgers()` (incl. Publish) before
+            // expiry runs — so the post-Cascade unwritten-slot exclusion below is
+            // safe for the perm ledger too.
             let written_ok = !cascade_active || slot.has_been_written;
             if written_ok && slot.last_height <= expiry_height && !slot.is_expired {
                 result.push((slot_index, slot.partitions.clone(), perm_ledger_id));

--- a/crates/database/src/data_ledger.rs
+++ b/crates/database/src/data_ledger.rs
@@ -1069,6 +1069,11 @@ mod tests {
 
         let mut ledger = TermLedger::new(DataLedger::Submit, &config, epoch_length);
         ledger.allocate_slots(1, 0); // single slot allocated at genesis
+        // Mark the slot written so the `!cascade_active || has_been_written`
+        // write-window shortcut passes (cascade_active=true below) and the slot is
+        // excluded ONLY by the last-slot rule under test — not vacuously skipped as
+        // an unwritten slot.
+        ledger.slots[0].has_been_written = true;
 
         // Even far past the cycle boundary, the only slot is the last slot and
         // never expires — exactly where the cycle-math approximation diverged.

--- a/crates/database/src/data_ledger.rs
+++ b/crates/database/src/data_ledger.rs
@@ -132,6 +132,42 @@ impl TermLedger {
         expired_slot_indexes
     }
 
+    /// Like [`get_expired_slot_indexes`](Self::get_expired_slot_indexes) but returns
+    /// **all** slots whose storage has expired as of `epoch_height`, including those
+    /// already marked `is_expired` from a previous epoch. The never-expire-the-last-slot
+    /// rule is preserved.
+    ///
+    /// `get_expired_slot_indexes` returns only *newly* expiring slots (it filters out
+    /// `is_expired`), because the refund/fee pipeline must act on each slot exactly once.
+    /// The NC-0042 publish-candidate filter and validator check need the opposite: a tx
+    /// whose Submit slot expired must be treated as non-promotable for *every* block
+    /// at-or-after the expiry, not just the single epoch block where it newly expires.
+    /// Keying on `last_height` (set once at allocation, never mutated) makes this a pure
+    /// function of canonical slot state — producer and validator always agree.
+    pub fn get_all_expired_slot_indexes(&self, epoch_height: u64) -> Vec<usize> {
+        let min_blocks = self
+            .epoch_length
+            .checked_mul(self.num_blocks_in_epoch)
+            .expect("epoch_length * num_blocks_in_epoch overflows u64");
+
+        if epoch_height < min_blocks {
+            return Vec::new();
+        }
+
+        let expiry_height = epoch_height - min_blocks;
+        let last_slot_index = self.slots.len().saturating_sub(1);
+
+        self.slots
+            .iter()
+            .enumerate()
+            .filter(|(slot_index, slot)| {
+                // Never expire the last slot in a ledger (matches get_expired_slot_indexes).
+                *slot_index != last_slot_index && slot.last_height <= expiry_height
+            })
+            .map(|(slot_index, _)| slot_index)
+            .collect()
+    }
+
     /// Returns indices of newly expired slots
     pub fn expire_old_slots(&mut self, epoch_height: u64) -> Vec<usize> {
         let expired_slot_indexes = self.get_expired_slot_indexes(epoch_height);
@@ -422,6 +458,20 @@ impl Ledgers {
         }
 
         expired_partitions
+    }
+
+    /// Slot indexes of the given term `ledger` whose storage has expired as of
+    /// `epoch_height`, inclusive of already-expired slots. Used by the NC-0042
+    /// publish-candidate filter (producer) and validator check, which must treat
+    /// a tx as non-promotable for every block at-or-after its slot's expiry.
+    /// See [`TermLedger::get_all_expired_slot_indexes`].
+    pub fn get_all_expired_term_slot_indexes(
+        &self,
+        ledger: DataLedger,
+        epoch_height: u64,
+    ) -> Vec<usize> {
+        self.get_term_ledger(ledger)
+            .get_all_expired_slot_indexes(epoch_height)
     }
 
     // Private helper methods for term ledger lookups
@@ -926,5 +976,76 @@ mod tests {
             .map(|s| s.last_height)
             .collect();
         assert_eq!(heights, vec![100, 100, 100]);
+    }
+
+    /// `get_all_expired_slot_indexes` is the NC-0042 §4b/§4c non-promotability
+    /// predicate. It must never expire the last/only slot — the case a per-tx
+    /// cycle-math approximation got wrong, since the genesis slot stays the "last
+    /// slot" and its data is still stored until a newer slot is allocated.
+    #[test]
+    fn get_all_expired_slot_indexes_never_expires_the_only_slot() {
+        let config = ConsensusConfig::testing();
+        let epoch_length = config.epoch.submit_ledger_epoch_length;
+        let blocks_per_cycle = epoch_length * config.epoch.num_blocks_in_epoch;
+
+        let mut ledger = TermLedger::new(DataLedger::Submit, &config, epoch_length);
+        ledger.allocate_slots(1, 0); // single slot allocated at genesis
+
+        // Even far past the cycle boundary, the only slot is the last slot and
+        // never expires — exactly where the cycle-math approximation diverged.
+        assert!(
+            ledger
+                .get_all_expired_slot_indexes(blocks_per_cycle)
+                .is_empty()
+        );
+        assert!(
+            ledger
+                .get_all_expired_slot_indexes(blocks_per_cycle * 10)
+                .is_empty()
+        );
+    }
+
+    /// The inclusive set keeps a slot once it has expired (the cross-block
+    /// double-pay guard), whereas `get_expired_slot_indexes` returns only the
+    /// *newly* expiring slot (the once-per-slot refund trigger).
+    #[test]
+    fn get_all_expired_slot_indexes_includes_already_expired_slots() {
+        let config = ConsensusConfig::testing();
+        let epoch_length = config.epoch.submit_ledger_epoch_length;
+        let num_blocks = config.epoch.num_blocks_in_epoch;
+        let blocks_per_cycle = epoch_length * num_blocks;
+
+        // slot 0 allocated at genesis, slot 1 allocated one epoch later → slot 0
+        // is non-last and expires at 0 + blocks_per_cycle.
+        let mut ledger = TermLedger::new(DataLedger::Submit, &config, epoch_length);
+        ledger.allocate_slots(1, 0); // slot 0
+        ledger.allocate_slots(1, num_blocks); // slot 1 (the kept last slot)
+
+        let expiry = blocks_per_cycle; // slot 0 expires here
+
+        // One epoch before: nothing expired yet.
+        assert!(
+            ledger
+                .get_all_expired_slot_indexes(expiry - num_blocks)
+                .is_empty()
+        );
+
+        // At expiry, slot 0 is in both sets.
+        assert_eq!(ledger.get_all_expired_slot_indexes(expiry), vec![0]);
+        assert_eq!(ledger.get_expired_slot_indexes(expiry), vec![0]);
+
+        // After it is marked expired, the inclusive set still returns it
+        // (a tx in slot 0 stays non-promotable at every later block) while the
+        // newly-expiring set drops it (it must only be refunded once).
+        ledger.expire_old_slots(expiry);
+        assert_eq!(
+            ledger.get_all_expired_slot_indexes(expiry + 1),
+            vec![0],
+            "an already-expired slot must remain in the inclusive set (cross-block guard)"
+        );
+        assert!(
+            ledger.get_expired_slot_indexes(expiry + 1).is_empty(),
+            "get_expired_slot_indexes returns only newly-expiring slots"
+        );
     }
 }

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -732,8 +732,26 @@ pub fn ingress_proof_by_data_root_address<TX: DbTx>(
     }
 }
 
-pub fn delete_ingress_proof<T: DbTxMut>(tx: &T, data_root: DataRoot) -> eyre::Result<bool> {
-    Ok(tx.delete::<IngressProofs>(data_root, None)?)
+/// Deletes only the ingress proof row for a specific (data_root, address) pair,
+/// leaving proofs from other signers intact.
+/// Returns `true` if a row was deleted, `false` if no matching row was found.
+pub fn delete_ingress_proof_by_signer<T: DbTx + DbTxMut>(
+    tx: &T,
+    data_root: DataRoot,
+    address: IrysAddress,
+) -> eyre::Result<bool> {
+    let matches: Vec<CompactCachedIngressProof> = ingress_proofs_by_data_root(tx, data_root)?
+        .into_iter()
+        .filter(|(_, proof)| proof.address == address)
+        .map(|(_, proof)| proof)
+        .collect();
+
+    let mut deleted = false;
+    for existing in matches {
+        tx.delete::<IngressProofs>(data_root, Some(existing))?;
+        deleted = true;
+    }
+    Ok(deleted)
 }
 
 pub fn store_ingress_proof(

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -231,24 +231,42 @@ pub fn tx_header_by_txid<T: DbTx>(
 /// orphaned tip can leave a stranded `included_height` / `promoted_height`
 /// behind, and Phase-1 scrub only fires on reorg.
 ///
-/// `MigratedBlockHashes` (MBH) IS fork-aware past `block_migration_depth`
-/// — `validate_reorg_within_migration_depth` aborts any reorg that would
-/// rewrite a migrated row, so MBH attests the canonical hash from every
-/// chain's perspective.
+/// `MigratedBlockHashes` (MBH) records the local node's canonical block hash
+/// at each migrated height.  It is *branch-invariant* — attests the same hash
+/// from every chain's perspective — ONLY for heights below the reorg floor.
+///
+/// **Reorg ceiling moved (#1405).**  Network-partition / deep-reorg recovery
+/// removed the old `validate_reorg_within_migration_depth` gate (now dead): a
+/// reorg can rewind and rewrite already-migrated MBH rows up to
+/// `block_tree_depth` deep (`recover_from_network_partition` →
+/// `truncate_to_height` → `delete_block_index_range`).  So within
+/// `(tip - block_tree_depth, tip - block_migration_depth]`, MBH is a
+/// LOCAL-canonical view that can change across a reorg and disagree between
+/// nodes evaluating competing forks.  Only heights at/below
+/// `tip - block_tree_depth` are finalized and safe to key on by existence
+/// alone.
 ///
 /// The two helpers in this section return a height from `IrysDataTxMetadata`
-/// only if MBH confirms it ≤ `max_height`.  They return primitive
-/// `Option<u64>` (no header mutation) so call sites can't accidentally
-/// treat a stranded hint as canonical.
-///
-/// **Fork-awareness caveat (reorg-readiness).**  The "MBH-verified ⇒
-/// canonical-on-every-chain" inference rests on `block_migration_depth`
-/// being the absolute reorg ceiling.  If deeper reorgs are ever permitted,
-/// MBH rows past `block_migration_depth` become a LOCAL-canonical view
-/// that can disagree with the chain a validator is evaluating.  These
-/// helpers (and every site that reads from them) must be audited together
-/// with the `Searching { Publish }` arm in `data_txs_are_valid` when that
-/// invariant changes.
+/// only if MBH has a row for it ≤ `max_height`.  They return primitive
+/// `Option<u64>` (no header mutation) so call sites can't accidentally treat a
+/// stranded hint as canonical.  Because the existence check is NOT
+/// branch-invariant in the window above, every caller must either (a) only
+/// consult these helpers for heights guaranteed below the reorg floor, or
+/// (b) treat the result as a hint and confirm membership against the evaluated
+/// branch's own ancestry.  Current callers:
+///   - `data_txs_are_valid` (`block_validation.rs`) uses the content-based
+///     ancestry walk (`get_previous_tx_inclusions`) as its primary path and
+///     only falls back to these helpers for inclusions older than
+///     `tx_anchor_expiry_depth`.
+///   - the NC-0042 expiry fast path
+///     (`ledger_expiry::resolve_submit_inclusion`) relies on the config
+///     invariant that a ledger slot's lifetime exceeds `block_tree_depth`
+///     (enforced in `Config::validate`), so any *expired* tx's inclusion is
+///     necessarily below the reorg floor.
+///   - `lookup_via_migrated_metadata` (`tx_inclusion.rs`) re-reads the block
+///     and re-checks Submit membership before trusting the height.
+/// Re-audit all of these together (and the `Searching { Publish }` arm in
+/// `data_txs_are_valid`) whenever the reorg ceiling or those windows change.
 fn canonical_metadata_height<T: DbTx>(
     tx: &T,
     txid: &IrysTransactionId,

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -235,7 +235,7 @@ pub fn tx_header_by_txid<T: DbTx>(
 /// at each migrated height.  It is *branch-invariant* — attests the same hash
 /// from every chain's perspective — ONLY for heights below the reorg floor.
 ///
-/// **Reorg ceiling moved (#1405).**  Network-partition / deep-reorg recovery
+/// **Reorg ceiling moved.**  Network-partition / deep-reorg recovery
 /// removed the old `validate_reorg_within_migration_depth` gate (now dead): a
 /// reorg can rewind and rewrite already-migrated MBH rows up to
 /// `block_tree_depth` deep (`recover_from_network_partition` →
@@ -461,7 +461,7 @@ pub fn cache_data_root<T: DbTx + DbTxMut>(
     // their block_set populated by `BlockMigrationService::persist_metadata`
     // Phase 3, and unconfirmed entries get `expiry_height` set by
     // `cache_data_root_with_expiry`.  Direct callers of `cache_data_root`
-    // that bypass both paths (test fixtures, pre-fix code) can produce
+    // that bypass both paths (e.g. test fixtures) can produce
     // this state — warn so operators see them.
     if cached_data_root.block_set.is_empty() && cached_data_root.expiry_height.is_none() {
         warn!(

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -1209,6 +1209,190 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn delete_ingress_proof_by_signer_deletes_only_that_signer() -> eyre::Result<()> {
+        use super::{
+            delete_ingress_proof_by_signer, ingress_proof_by_data_root_address,
+            ingress_proofs_by_data_root,
+        };
+        use crate::{
+            db::IrysDatabaseExt as _,
+            db_cache::CachedDataRoot,
+            tables::{CachedDataRoots, CompactCachedIngressProof, IngressProofs},
+        };
+        use irys_types::{IrysAddress, ingress::CachedIngressProof};
+        use reth_db::transaction::DbTxMut as _;
+
+        let path = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db = open_or_create_db(
+            path.path(),
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing().unwrap(),
+        )
+        .unwrap();
+
+        let data_root = H256::random();
+        let addr_a = IrysAddress::random();
+        let addr_b = IrysAddress::random();
+        let addr_c = IrysAddress::random();
+
+        // Build minimal distinct proofs for addr_a and addr_b.
+        let make_proof = |address: IrysAddress, proof_hash: H256| {
+            let mut p = irys_types::IngressProof::default();
+            p.data_root = data_root;
+            p.proof = proof_hash;
+            CompactCachedIngressProof(CachedIngressProof { address, proof: p })
+        };
+
+        let proof_a = make_proof(addr_a, H256::from([1_u8; 32]));
+        let proof_b = make_proof(addr_b, H256::from([2_u8; 32]));
+
+        // Seed: minimal CDR + two proof rows.
+        db.update_eyre(|tx| {
+            tx.put::<CachedDataRoots>(
+                data_root,
+                CachedDataRoot {
+                    data_size: 64,
+                    data_size_confirmed: false,
+                    txid_set: vec![],
+                    block_set: vec![],
+                    expiry_height: None,
+                    cached_at: irys_types::UnixTimestamp::default(),
+                },
+            )?;
+            tx.put::<IngressProofs>(data_root, proof_a.clone())?;
+            tx.put::<IngressProofs>(data_root, proof_b.clone())?;
+            Ok(())
+        })?;
+
+        // Both rows present initially.
+        assert_eq!(
+            db.view_eyre(|tx| ingress_proofs_by_data_root(tx, data_root))?
+                .len(),
+            2,
+            "expected 2 proofs after seeding"
+        );
+
+        // Delete addr_a — must return true and remove only that row.
+        let deleted = db.update_eyre(|tx| delete_ingress_proof_by_signer(tx, data_root, addr_a))?;
+        assert!(deleted, "deleting addr_a row must return true");
+
+        assert!(
+            db.view_eyre(|tx| ingress_proof_by_data_root_address(tx, data_root, addr_a))?
+                .is_none(),
+            "addr_a proof must be gone"
+        );
+        assert!(
+            db.view_eyre(|tx| ingress_proof_by_data_root_address(tx, data_root, addr_b))?
+                .is_some(),
+            "addr_b proof must survive"
+        );
+
+        // Deleting addr_a again returns false (already absent).
+        let deleted_again =
+            db.update_eyre(|tx| delete_ingress_proof_by_signer(tx, data_root, addr_a))?;
+        assert!(!deleted_again, "second delete of addr_a must return false");
+
+        // Deleting a never-stored addr_c returns false.
+        let deleted_c =
+            db.update_eyre(|tx| delete_ingress_proof_by_signer(tx, data_root, addr_c))?;
+        assert!(!deleted_c, "delete of absent addr_c must return false");
+
+        Ok(())
+    }
+
+    #[test]
+    fn delete_ingress_proof_if_unchanged_preserves_refreshed_proof() -> eyre::Result<()> {
+        use super::{delete_ingress_proof_if_unchanged, ingress_proof_by_data_root_address};
+        use crate::{
+            db::IrysDatabaseExt as _,
+            db_cache::CachedDataRoot,
+            tables::{CachedDataRoots, CompactCachedIngressProof, IngressProofs},
+        };
+        use irys_types::{IrysAddress, ingress::CachedIngressProof};
+        use reth_db::transaction::DbTxMut as _;
+
+        let path = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db = open_or_create_db(
+            path.path(),
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing().unwrap(),
+        )
+        .unwrap();
+
+        let data_root = H256::random();
+        let addr_a = IrysAddress::random();
+
+        let make_proof = |proof_hash: H256| {
+            let mut p = irys_types::IngressProof::default();
+            p.data_root = data_root;
+            p.proof = proof_hash;
+            CompactCachedIngressProof(CachedIngressProof {
+                address: addr_a,
+                proof: p,
+            })
+        };
+
+        let proof_p1 = make_proof(H256::from([0xAA_u8; 32]));
+        let proof_p2 = make_proof(H256::from([0xBB_u8; 32]));
+
+        // absent-key case: returns false without error.
+        let absent = db
+            .update_eyre(|tx| delete_ingress_proof_if_unchanged(tx, data_root, proof_p1.clone()))?;
+        assert!(!absent, "absent key must return false");
+
+        // Insert CDR and P1.
+        db.update_eyre(|tx| {
+            tx.put::<CachedDataRoots>(
+                data_root,
+                CachedDataRoot {
+                    data_size: 64,
+                    data_size_confirmed: false,
+                    txid_set: vec![],
+                    block_set: vec![],
+                    expiry_height: None,
+                    cached_at: irys_types::UnixTimestamp::default(),
+                },
+            )?;
+            tx.put::<IngressProofs>(data_root, proof_p1.clone())?;
+            Ok(())
+        })?;
+
+        // Simulate refresh: replace P1 with P2 in the store (overwrite between scan and delete).
+        db.update_eyre(|tx| {
+            tx.delete::<IngressProofs>(data_root, Some(proof_p1.clone()))?;
+            tx.put::<IngressProofs>(data_root, proof_p2.clone())?;
+            Ok(())
+        })?;
+
+        // CAS with stale P1 must return false and leave P2 intact.
+        let stale = db
+            .update_eyre(|tx| delete_ingress_proof_if_unchanged(tx, data_root, proof_p1.clone()))?;
+        assert!(
+            !stale,
+            "stale expected value must return false (TOCTOU guard)"
+        );
+
+        assert!(
+            db.view_eyre(|tx| ingress_proof_by_data_root_address(tx, data_root, addr_a))?
+                .is_some(),
+            "P2 must still be present after stale CAS"
+        );
+
+        // CAS with current P2 must return true and remove the row.
+        let deleted = db
+            .update_eyre(|tx| delete_ingress_proof_if_unchanged(tx, data_root, proof_p2.clone()))?;
+        assert!(deleted, "matching expected value must return true");
+
+        assert!(
+            db.view_eyre(|tx| ingress_proof_by_data_root_address(tx, data_root, addr_a))?
+                .is_none(),
+            "row must be gone after successful CAS delete"
+        );
+
+        Ok(())
+    }
+
     mod canonical_height_tests {
         use crate::{
             canonical_promoted_height, canonical_submit_height, db::IrysDatabaseExt as _,

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -787,7 +787,13 @@ pub fn ingress_proof_by_data_root_address<TX: DbTx>(
 /// Deletes only the ingress proof row for a specific (data_root, address) pair,
 /// leaving proofs from other signers intact.
 /// Returns `true` if a row was deleted, `false` if no matching row was found.
-pub fn delete_ingress_proof_by_signer<T: DbTx + DbTxMut>(
+///
+/// **Test-only** (`#[cfg(test)]`). This performs **no content check** (no TOCTOU
+/// guard), so it must never become a production deletion path: gating it on
+/// `cfg(test)` makes that misuse impossible at compile time. Production callers
+/// that need TOCTOU safety must use [`delete_ingress_proof_if_unchanged`].
+#[cfg(test)]
+pub(crate) fn delete_ingress_proof_by_signer<T: DbTx + DbTxMut>(
     tx: &T,
     data_root: DataRoot,
     address: IrysAddress,

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -740,18 +740,35 @@ pub fn delete_ingress_proof_by_signer<T: DbTx + DbTxMut>(
     data_root: DataRoot,
     address: IrysAddress,
 ) -> eyre::Result<bool> {
-    let matches: Vec<CompactCachedIngressProof> = ingress_proofs_by_data_root(tx, data_root)?
-        .into_iter()
-        .filter(|(_, proof)| proof.address == address)
-        .map(|(_, proof)| proof)
-        .collect();
-
-    let mut deleted = false;
-    for existing in matches {
+    // O(1) seek: no need to scan all dup values for this data_root.
+    if let Some(existing) = ingress_proof_by_data_root_address(tx, data_root, address)? {
         tx.delete::<IngressProofs>(data_root, Some(existing))?;
-        deleted = true;
+        Ok(true)
+    } else {
+        Ok(false)
     }
-    Ok(deleted)
+}
+
+/// Deletes the ingress proof for (data_root, address) ONLY if the stored row
+/// still matches `expected`. Used by the prune loop to close the TOCTOU window
+/// between the scan and the delete: if another task stored a fresh proof for the
+/// same key between the scan and this call, the stale scanned value will not
+/// match and the fresh proof is preserved.
+/// Returns `true` if the row was deleted, `false` if absent or content differs.
+pub fn delete_ingress_proof_if_unchanged<T: DbTx + DbTxMut>(
+    tx: &T,
+    data_root: DataRoot,
+    expected: CompactCachedIngressProof,
+) -> eyre::Result<bool> {
+    let address = expected.address;
+    match ingress_proof_by_data_root_address(tx, data_root, address)? {
+        // Compare inner CachedIngressProof (derives PartialEq); the wrapper does not.
+        Some(current) if current.0 == expected.0 => {
+            tx.delete::<IngressProofs>(data_root, Some(current))?;
+            Ok(true)
+        }
+        _ => Ok(false),
+    }
 }
 
 pub fn store_ingress_proof(

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -61,7 +61,11 @@ impl IrysDatabaseArgs for DatabaseArguments {
     }
 
     fn irys_testing() -> eyre::Result<DatabaseArguments> {
-        Self::irys_default(DbSyncMode::UtterlyNoSync)
+        // Cap the geometry so each unit-test DB doesn't reserve reth's 8 TiB
+        // default map — many concurrent test envs would otherwise exhaust the
+        // process's virtual address space (see `TEST_DB_GEOMETRY_MAX_SIZE`).
+        Ok(Self::irys_default(DbSyncMode::UtterlyNoSync)?
+            .with_geometry_max_size(Some(irys_types::TEST_DB_GEOMETRY_MAX_SIZE)))
     }
 
     fn irys_cache(sync_mode: DbSyncMode) -> eyre::Result<DatabaseArguments> {
@@ -75,6 +79,36 @@ impl IrysDatabaseArgs for DatabaseArguments {
             // caller-provided sync_mode, not by this preset.
             .with_sync_mode(Some(sync_mode.into())))
     }
+}
+
+/// Builds [`DatabaseArguments`] for the **main consensus** database from a
+/// [`irys_types::DatabaseConfig`]. Production uses reth's large default geometry;
+/// when the config sets `geometry_max_size` (test configs do) that caps both the
+/// max DB size and the virtual address-space reservation MDBX makes at open, so
+/// many concurrent node databases don't exhaust the process's address space.
+pub fn consensus_db_args(
+    db_config: &irys_types::DatabaseConfig,
+) -> eyre::Result<DatabaseArguments> {
+    let mut args = DatabaseArguments::irys_default(db_config.sync_mode)?;
+    if let Some(max_size) = db_config.geometry_max_size {
+        args = args.with_geometry_max_size(Some(max_size));
+    }
+    Ok(args)
+}
+
+/// Builds [`DatabaseArguments`] for a **storage submodule** database from a
+/// [`irys_types::DatabaseConfig`]. Production reserves 2 TiB; `geometry_max_size`
+/// (set by test configs) overrides that with a small cap.
+pub fn submodule_db_args(
+    db_config: &irys_types::DatabaseConfig,
+) -> eyre::Result<DatabaseArguments> {
+    let max_size = db_config
+        .geometry_max_size
+        .unwrap_or(2 * irys_types::TERABYTE);
+    Ok(
+        DatabaseArguments::irys_default(db_config.sync_mode)?
+            .with_geometry_max_size(Some(max_size)),
+    )
 }
 
 /// Opens up an existing database or creates a new one at the specified path. Creates tables if

--- a/crates/database/src/submodule/db.rs
+++ b/crates/database/src/submodule/db.rs
@@ -1,8 +1,7 @@
 use std::path::Path;
 
 use irys_types::{
-    ChunkDataPath, ChunkPathHash, DataRoot, DbSyncMode, PartitionChunkOffset, TERABYTE, TxPath,
-    TxPathHash,
+    ChunkDataPath, ChunkPathHash, DataRoot, PartitionChunkOffset, TxPath, TxPathHash,
 };
 use reth_db::{
     DatabaseEnv,
@@ -11,7 +10,7 @@ use reth_db::{
 };
 
 use crate::{
-    IrysDatabaseArgs as _, open_or_create_db,
+    open_or_create_db,
     submodule::tables::{DataRootInfo, DataRootInfosByDataRoot},
 };
 
@@ -20,16 +19,16 @@ use super::tables::{
     SubmoduleTables, TxLeafBinding, TxLeafBindingByTxPathHash, TxPathByTxPathHash,
 };
 
-/// Creates or opens a *submodule* MDBX database
+/// Creates or opens a *submodule* MDBX database with the given [`DatabaseArguments`].
+///
+/// The caller supplies fully-built args (sync mode, geometry, etc.) — typically
+/// via [`crate::submodule_db_args`] — so DB tuning lives in one place instead of
+/// being threaded through as individual parameters.
 pub fn create_or_open_submodule_db<P: AsRef<Path>>(
     path: P,
-    sync_mode: DbSyncMode,
+    args: DatabaseArguments,
 ) -> eyre::Result<DatabaseEnv> {
-    open_or_create_db(
-        path,
-        SubmoduleTables::ALL,
-        DatabaseArguments::irys_default(sync_mode)?.with_geometry_max_size(Some(2 * TERABYTE)),
-    )
+    open_or_create_db(path, SubmoduleTables::ALL, args)
 }
 
 /// gets the full data path for the chunk with the provided offset

--- a/crates/domain/src/models/block_index.rs
+++ b/crates/domain/src/models/block_index.rs
@@ -204,7 +204,7 @@ impl BlockIndex {
                     .find(|item| item.ledger == ledger)
                     .map(|item| item.total_chunks)
                     .unwrap_or(0);
-                prev_total + chunks_added
+                prev_total.saturating_add(chunks_added)
             } else {
                 chunks_added
             };

--- a/crates/domain/src/models/block_index.rs
+++ b/crates/domain/src/models/block_index.rs
@@ -204,7 +204,17 @@ impl BlockIndex {
                     .find(|item| item.ledger == ledger)
                     .map(|item| item.total_chunks)
                     .unwrap_or(0);
-                prev_total.saturating_add(chunks_added)
+                // A saturating add would silently clamp and corrupt the persisted
+                // ledger boundary; reject the block instead so callers see the overflow.
+                prev_total.checked_add(chunks_added).ok_or_else(|| {
+                    eyre::eyre!(
+                        "ledger {:?} total_chunks overflow at height {}: prev_total {} + chunks_added {}",
+                        ledger,
+                        block.height,
+                        prev_total,
+                        chunks_added
+                    )
+                })?
             } else {
                 chunks_added
             };

--- a/crates/domain/src/models/storage_module.rs
+++ b/crates/domain/src/models/storage_module.rs
@@ -318,7 +318,8 @@ impl StorageModule {
             debug!("submodule_db_path: {:?}", submodule_db_path);
             let submodule_db = create_or_open_submodule_db(
                 &submodule_db_path,
-                config.node_config.database.sync_mode,
+                // Args (incl. the test geometry cap) derived from the DatabaseConfig.
+                irys_database::submodule_db_args(&config.node_config.database)?,
             )
             .map_err(|e| {
                 eyre!(

--- a/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
+++ b/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
@@ -306,8 +306,9 @@ impl EpochSnapshot {
         self.previous_epoch_block = previous_epoch_block.clone();
 
         // The retention `last_height` refresh gates on Cascade activation; the
-        // "this slot has canonical data" marker must be updated regardless so
-        // preallocated-but-never-written slots never expire.
+        // "this slot has canonical data" marker is updated unconditionally so
+        // post-Cascade expiry can distinguish written slots from empty preallocations
+        // (pre-Cascade, allocation-aged unwritten slots still expire).
         let cascade_active = self
             .config
             .consensus

--- a/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
+++ b/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
@@ -1371,6 +1371,21 @@ impl EpochSnapshot {
             .collect()
     }
 
+    /// Slot indexes of the given term `ledger` whose storage has expired as of
+    /// `epoch_height`, **inclusive** of slots that expired at an earlier epoch.
+    /// Unlike `get_expiring_partition_info` (newly-expiring only, used by the
+    /// refund pipeline), this is the set the NC-0042 publish-candidate filter and
+    /// validator check key on: a tx is non-promotable for every block at-or-after
+    /// its Submit slot's expiry. See `Ledgers::get_all_expired_term_slot_indexes`.
+    pub fn get_all_expired_term_slot_indexes(
+        &self,
+        ledger: DataLedger,
+        epoch_height: u64,
+    ) -> Vec<usize> {
+        self.ledgers
+            .get_all_expired_term_slot_indexes(ledger, epoch_height)
+    }
+
     pub fn get_first_unexpired_slot_index(&self, ledger_id: DataLedger) -> usize {
         let slots = self.ledgers[ledger_id].get_slots();
 

--- a/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
+++ b/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
@@ -305,8 +305,9 @@ impl EpochSnapshot {
         self.epoch_block = new_epoch_block.clone();
         self.previous_epoch_block = previous_epoch_block.clone();
 
-        // Cascade activation and the retention `last_height` touch both gate on
-        // the same activation timestamp; evaluate the gate once.
+        // The retention `last_height` refresh gates on Cascade activation; the
+        // "this slot has canonical data" marker must be updated regardless so
+        // preallocated-but-never-written slots never expire.
         let cascade_active = self
             .config
             .consensus
@@ -324,25 +325,23 @@ impl EpochSnapshot {
 
         self.allocate_additional_ledger_slots(previous_epoch_block, new_epoch_block);
 
-        // Cascade retention fix: a slot's expiry clock should count from the
-        // last epoch data was written into it, not from when it was allocated.
-        // Gated on the Cascade hardfork so pre-activation replay is unchanged.
-        // Must run AFTER allocation (so this epoch's new slots exist) and BEFORE
-        // expiry (so freshly-written slots aren't expired this same epoch).
+        // Update the canonical write window AFTER allocation (so this epoch's
+        // new slots exist) and BEFORE expiry (so freshly-written slots aren't
+        // expired this same epoch). The "was ever written" marker is always
+        // updated; only the last-write-height refresh is Cascade-gated.
         //
         // LOCKSTEP: the recycle set produced here (touch then `expire_ledger_slots`
         // on this post-touch snapshot) MUST equal the set the fee model settles,
         // which `block_producer::ledger_expiry` derives by calling
         // `get_expiring_partition_info` on the PARENT snapshot with the same
-        // window exclusion. Both the touch above and that exclusion are gated on
-        // this same `cascade_active` (the new epoch block's Cascade status); if
-        // one is gated and the other isn't they diverge — a slot would recycle
-        // here yet still be settled, or vice versa. Keep the two gates aligned.
-        if cascade_active {
-            self.touch_active_ledger_slots(previous_epoch_block, new_epoch_block);
-        }
+        // window exclusion. The last-height refresh above and that exclusion are
+        // gated on this same `cascade_active` (the new epoch block's Cascade
+        // status); if one is gated and the other isn't they diverge — a slot
+        // would recycle here yet still be settled, or vice versa. Keep the two
+        // gates aligned.
+        self.touch_active_ledger_slots(previous_epoch_block, new_epoch_block, cascade_active);
 
-        self.expire_ledger_slots(new_epoch_block);
+        self.expire_ledger_slots(new_epoch_block, cascade_active);
 
         self.apply_unpledges(&new_epoch_commitments)?;
 
@@ -508,10 +507,10 @@ impl EpochSnapshot {
     /// Loops through all ledgers and looks for slots that are older
     /// than their configured epoch length. Marks them expired and stores
     /// the expired partition hashes in the epoch snapshot.
-    fn expire_ledger_slots(&mut self, new_epoch_block: &IrysBlockHeader) {
+    fn expire_ledger_slots(&mut self, new_epoch_block: &IrysBlockHeader, cascade_active: bool) {
         let epoch_height = new_epoch_block.height;
         let expired_partitions: Vec<ExpiringPartitionInfo> =
-            self.ledgers.expire_partitions(epoch_height);
+            self.ledgers.expire_partitions(epoch_height, cascade_active);
 
         // Return early if there's no more work to do
         if expired_partitions.is_empty() {
@@ -562,11 +561,12 @@ impl EpochSnapshot {
     /// the per-ledger cumulative `total_chunks` between the previous and current
     /// epoch blocks (the same values `calculate_additional_slots` reads).
     ///
-    /// Caller gates this on the Cascade hardfork.
+    /// Caller passes whether the last-write-height refresh is Cascade-active.
     fn touch_active_ledger_slots(
         &mut self,
         previous_epoch_block: &Option<IrysBlockHeader>,
         new_epoch_block: &IrysBlockHeader,
+        refresh_last_height: bool,
     ) {
         let chunks_per_slot = self.config.consensus.num_chunks_in_partition;
         for ledger in self.ledgers.active_ledgers() {
@@ -581,6 +581,7 @@ impl EpochSnapshot {
                 new_total,
                 chunks_per_slot,
                 new_epoch_block.height,
+                refresh_last_height,
             );
         }
     }
@@ -1365,7 +1366,7 @@ impl EpochSnapshot {
         };
 
         self.ledgers
-            .get_expiring_partitions(epoch_height)
+            .get_expiring_partitions(epoch_height, cascade_active)
             .into_iter()
             .filter(|info| info.ledger_id == ledger && !written_this_epoch(info.slot_index))
             .collect()
@@ -1381,9 +1382,10 @@ impl EpochSnapshot {
         &self,
         ledger: DataLedger,
         epoch_height: u64,
+        cascade_active: bool,
     ) -> Vec<usize> {
         self.ledgers
-            .get_all_expired_term_slot_indexes(ledger, epoch_height)
+            .get_all_expired_term_slot_indexes(ledger, epoch_height, cascade_active)
     }
 
     pub fn get_first_unexpired_slot_index(&self, ledger_id: DataLedger) -> usize {

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -43,7 +43,7 @@ irys-testing-utils.workspace = true
 irys-types = { workspace = true, features = ["test-utils"] }
 irys-api-client = { workspace = true, features = ["test-utils"] }
 irys-actors = { workspace = true, features = ["test-utils"] }
-irys-storage.workspace = true
+irys-storage = { workspace = true, features = ["test-utils"] }
 async-trait = "0.1"
 proptest.workspace = true
 rstest.workspace = true

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -14,6 +14,12 @@ tokio.workspace = true
 irys-database.workspace = true
 reth-db.workspace = true
 
+[features]
+# Exposes test-only helpers (e.g. `open_or_create_irys_consensus_data_db`, which
+# applies the small TEST_DB_GEOMETRY_MAX_SIZE cap) to downstream crates' test
+# builds. Production code must never enable this — it opens the consensus DB via
+# `consensus_db_args` + `open_or_create_irys_consensus_data_db_with_args` instead.
+test-utils = []
 
 [dev-dependencies]
 irys-testing-utils.workspace = true

--- a/crates/storage/src/irys_consensus_data_db.rs
+++ b/crates/storage/src/irys_consensus_data_db.rs
@@ -9,9 +9,20 @@ pub fn open_or_create_irys_consensus_data_db(
     path: impl AsRef<Path>,
     sync_mode: DbSyncMode,
 ) -> eyre::Result<DatabaseEnv> {
-    open_or_create_db(
+    // Convenience for the sync-mode-only case (used by tests): build default args.
+    open_or_create_irys_consensus_data_db_with_args(
         path,
-        IrysTables::ALL,
         DatabaseArguments::irys_default(sync_mode)?,
     )
+}
+
+/// Like [`open_or_create_irys_consensus_data_db`] but the caller supplies fully-
+/// built [`DatabaseArguments`] (sync mode, geometry, etc.) — typically via
+/// [`irys_database::consensus_db_args`] — so DB tuning lives in one place instead
+/// of being threaded through as individual parameters.
+pub fn open_or_create_irys_consensus_data_db_with_args(
+    path: impl AsRef<Path>,
+    args: DatabaseArguments,
+) -> eyre::Result<DatabaseEnv> {
+    open_or_create_db(path, IrysTables::ALL, args)
 }

--- a/crates/storage/src/irys_consensus_data_db.rs
+++ b/crates/storage/src/irys_consensus_data_db.rs
@@ -5,14 +5,21 @@ use reth_db::DatabaseEnv;
 use reth_db::mdbx::DatabaseArguments;
 use std::path::Path;
 
+/// Test-oriented convenience for the sync-mode-only case. It caps the geometry to
+/// [`irys_types::TEST_DB_GEOMETRY_MAX_SIZE`] so the many concurrent unit-test
+/// consensus DBs don't each reserve reth's large default map and exhaust the
+/// process's virtual address space. **Production** opens the consensus DB via
+/// [`irys_database::consensus_db_args`] + [`open_or_create_irys_consensus_data_db_with_args`]
+/// (the node in `chain.rs` and the CLI both do), which honors the configured
+/// `geometry_max_size`.
 pub fn open_or_create_irys_consensus_data_db(
     path: impl AsRef<Path>,
     sync_mode: DbSyncMode,
 ) -> eyre::Result<DatabaseEnv> {
-    // Convenience for the sync-mode-only case (used by tests): build default args.
     open_or_create_irys_consensus_data_db_with_args(
         path,
-        DatabaseArguments::irys_default(sync_mode)?,
+        DatabaseArguments::irys_default(sync_mode)?
+            .with_geometry_max_size(Some(irys_types::TEST_DB_GEOMETRY_MAX_SIZE)),
     )
 }
 

--- a/crates/storage/src/irys_consensus_data_db.rs
+++ b/crates/storage/src/irys_consensus_data_db.rs
@@ -1,9 +1,15 @@
+use irys_database::open_or_create_db;
 use irys_database::tables::IrysTables;
-use irys_database::{IrysDatabaseArgs as _, open_or_create_db};
-use irys_types::DbSyncMode;
 use reth_db::DatabaseEnv;
 use reth_db::mdbx::DatabaseArguments;
 use std::path::Path;
+
+// Only the test-gated convenience fn below needs these; keep them out of
+// production builds where that fn is `cfg`-compiled away (avoids unused-import).
+#[cfg(any(test, feature = "test-utils"))]
+use irys_database::IrysDatabaseArgs as _;
+#[cfg(any(test, feature = "test-utils"))]
+use irys_types::DbSyncMode;
 
 /// Test-oriented convenience for the sync-mode-only case. It caps the geometry to
 /// [`irys_types::TEST_DB_GEOMETRY_MAX_SIZE`] so the many concurrent unit-test
@@ -12,6 +18,11 @@ use std::path::Path;
 /// [`irys_database::consensus_db_args`] + [`open_or_create_irys_consensus_data_db_with_args`]
 /// (the node in `chain.rs` and the CLI both do), which honors the configured
 /// `geometry_max_size`.
+///
+/// Gated to test builds (`cfg(test)`) and the `test-utils` feature so a production
+/// call site — which would silently inherit the tiny test geometry cap — is a
+/// compile error rather than a latent consensus-DB-sizing bug.
+#[cfg(any(test, feature = "test-utils"))]
 pub fn open_or_create_irys_consensus_data_db(
     path: impl AsRef<Path>,
     sync_mode: DbSyncMode,

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -280,7 +280,19 @@ impl Config {
                 ));
             }
             for (field, epoch_length) in slot_lifetimes {
-                let slot_lifetime_blocks = epoch_length.saturating_mul(num_blocks_in_epoch);
+                // checked_mul, not saturating: an overflowing product would clamp to
+                // u64::MAX and silently satisfy the `> block_tree_depth` guard below,
+                // yet the runtime expiry math (`TermLedger::get_expired_slot_indexes`'s
+                // `checked_mul(...).expect(...)`) would then panic on the same overflow.
+                // Reject it here, matching the publish_ledger_epoch_length check above.
+                let slot_lifetime_blocks = epoch_length
+                    .checked_mul(num_blocks_in_epoch)
+                    .ok_or_else(|| {
+                        eyre::eyre!(
+                            "{field} ({epoch_length}) * num_blocks_in_epoch \
+                             ({num_blocks_in_epoch}) overflows u64"
+                        )
+                    })?;
                 ensure!(
                     slot_lifetime_blocks > self.consensus.block_tree_depth,
                     "{field} ({epoch_length}) * num_blocks_in_epoch ({num_blocks_in_epoch}) = slot \
@@ -1255,6 +1267,47 @@ mod tests {
         assert!(
             config.validate().is_ok(),
             "test-mode configs must skip the slot-lifetime guard"
+        );
+
+        // Cascade arm: a Cascade term-ledger whose lifetime <= block_tree_depth is
+        // rejected even when Submit passes. submit 5 * 11 = 55 > 50 (ok), but
+        // thirty_day 4 * 11 = 44 <= 50 — so the guard must fire on the Cascade arm.
+        let mut node_config = NodeConfig::testing().with_run_mode(RunMode::Production);
+        {
+            let c = node_config.consensus.get_mut();
+            c.epoch.num_blocks_in_epoch = 11;
+            c.hardforks.cascade = Some(crate::hardfork_config::Cascade {
+                activation_timestamp: crate::UnixTimestamp::from_secs(0),
+                one_year_epoch_length: 365, // 365 * 11 = 4015 > 50 (ok)
+                thirty_day_epoch_length: 4, // 4 * 11 = 44 <= 50 (fails)
+                annual_cost_per_gb: crate::hardfork_config::Cascade::default_annual_cost_per_gb(),
+            });
+        }
+        let err = Config::new_with_random_peer_id(node_config)
+            .validate()
+            .expect_err("a Cascade term-ledger lifetime <= block_tree_depth must fail")
+            .to_string();
+        assert!(
+            err.contains("cascade.thirty_day_epoch_length") && err.contains("NC-0042"),
+            "expected the Cascade thirty-day slot-lifetime guard, got: {err}"
+        );
+
+        // Overflow: epoch_length * num_blocks_in_epoch must be rejected (not saturated
+        // to u64::MAX), so a config that validates can't later panic in the runtime
+        // expiry math (`TermLedger::get_expired_slot_indexes`'s checked_mul.expect).
+        let mut node_config = NodeConfig::testing().with_run_mode(RunMode::Production);
+        {
+            let c = node_config.consensus.get_mut();
+            c.epoch.num_blocks_in_epoch = 2;
+            c.epoch.submit_ledger_epoch_length = u64::MAX; // u64::MAX * 2 overflows
+        }
+        let err = Config::new_with_random_peer_id(node_config)
+            .validate()
+            .expect_err("an overflowing slot lifetime must be rejected, not saturated")
+            .to_string();
+        assert!(
+            err.contains("overflows u64"),
+            "expected the slot-lifetime overflow guard, got: {err}"
         );
     }
 

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -150,11 +150,22 @@ impl Config {
         let reset_window_steps = self.consensus.vdf.reset_frequency as u64;
         let confirmation_lag_steps = (self.consensus.block_migration_depth as u64)
             .saturating_mul(self.consensus.difficulty_adjustment.block_time);
+        // Reject rather than clamp: a saturating 2x would floor the requirement and
+        // could accept an under-sized reset window when the true 2x overflows u64.
+        let required_reset_window_steps =
+            confirmation_lag_steps.checked_mul(2).ok_or_else(|| {
+                eyre::eyre!(
+                    "2x the confirmation lag overflows u64 (confirmation lag {} steps = block_migration_depth {} x block_time {}s); reduce block_migration_depth or block_time",
+                    confirmation_lag_steps,
+                    self.consensus.block_migration_depth,
+                    self.consensus.difficulty_adjustment.block_time,
+                )
+            })?;
         ensure!(
-            reset_window_steps >= confirmation_lag_steps.saturating_mul(2),
+            reset_window_steps >= required_reset_window_steps,
             "vdf.reset_frequency ({} steps) must be >= 2x the confirmation lag ({} steps = block_migration_depth {} x block_time {}s); a smaller reset window wedges honest mining at the reset boundary",
             reset_window_steps,
-            confirmation_lag_steps.saturating_mul(2),
+            required_reset_window_steps,
             self.consensus.block_migration_depth,
             self.consensus.difficulty_adjustment.block_time,
         );

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -141,19 +141,18 @@ impl Config {
             "vdf.progress_timeout_secs must be > 0 (zero would make every wait_for_step instantly bail and reject every block)"
         );
 
-        // The reset-boundary confirmation gate (issue #1447) parks the VDF loop at a boundary
+        // The reset-boundary confirmation gate parks the VDF loop at a boundary
         // until the rotation block is confirmed (block_migration_depth deep). For the gate to
         // reopen before the next boundary — i.e. for honest mining not to wedge — a reset
         // window must comfortably outspan the confirmation lag. With the VDF clocked at ~1
         // step/sec a block spans ~block_time steps, so the lag is block_migration_depth blocks
-        // ≈ block_migration_depth * block_time steps; require 2x that for headroom. See
-        // design/docs/vdf-reset-seed-confirmation-gate.md.
+        // ≈ block_migration_depth * block_time steps; require 2x that for headroom.
         let reset_window_steps = self.consensus.vdf.reset_frequency as u64;
         let confirmation_lag_steps = (self.consensus.block_migration_depth as u64)
             .saturating_mul(self.consensus.difficulty_adjustment.block_time);
         ensure!(
             reset_window_steps >= confirmation_lag_steps.saturating_mul(2),
-            "vdf.reset_frequency ({} steps) must be >= 2x the confirmation lag ({} steps = block_migration_depth {} x block_time {}s); a smaller reset window wedges honest mining at the reset boundary (issue #1447 gate)",
+            "vdf.reset_frequency ({} steps) must be >= 2x the confirmation lag ({} steps = block_migration_depth {} x block_time {}s); a smaller reset window wedges honest mining at the reset boundary",
             reset_window_steps,
             confirmation_lag_steps.saturating_mul(2),
             self.consensus.block_migration_depth,
@@ -266,7 +265,7 @@ impl Config {
         // walk resolve each expired tx's ledger inclusion through the *migrated*
         // block index (`canonical_submit_height` / `migrated_predecessor_total`),
         // which is only branch-invariant BELOW the reorg floor. Deep reorgs
-        // (#1405) can now rewind already-migrated blocks up to `block_tree_depth`
+        // can now rewind already-migrated blocks up to `block_tree_depth`
         // deep, so if a slot's lifetime is shorter than that window it could
         // expire while an expired tx's inclusion is still reorg-mutable — two
         // honest nodes could then resolve different inclusions and fork. A slot
@@ -333,7 +332,7 @@ impl Config {
             // Tx anchors must resolve INSIDE the reorg window so prevalidation's
             // inclusion/anchor walks can confirm them branch-correctly by-hash. A
             // tx anchored older than the tree would fall to the by-height index/MBH
-            // shortcut, which is only branch-invariant below the reorg floor (#1405)
+            // shortcut, which is only branch-invariant below the reorg floor
             // — see `get_previous_tx_inclusions` and the ingress-anchor walk in
             // `block_discovery`. `tx_anchor_expiry_depth` bounds how old a tx anchor
             // can be, so cap it at `block_tree_depth`. (`ingress_proof_anchor_expiry_depth`
@@ -355,9 +354,8 @@ impl Config {
         // (block_validation.rs) where the per-proof intersection loop picks
         // `assigned_miners` via HashMap iteration order over `slot_ranges` — a
         // consensus-fork vector when `block_range` straddles multiple Submit
-        // slots.  The determinism fix lives on `fix/assigned-miners-determinism`
-        // and is a consensus rule change that must be coordinated with a
-        // network upgrade.  Under all currently-deployed configs the value is
+        // slots.  The determinism fix is a consensus rule change that must be
+        // coordinated with a network upgrade.  Under all currently-deployed configs the value is
         // 0 and the non-deterministic path is vacuous; raising it without the
         // determinism fix risks divergence between nodes.
         //
@@ -371,7 +369,7 @@ impl Config {
                 .number_of_ingress_proofs_from_assignees
                 == 0,
             "consensus.hardforks.frontier.number_of_ingress_proofs_from_assignees ({}) must be 0 \
-             until fix/assigned-miners-determinism lands — the current `get_assigned_ingress_proofs` \
+             until the assigned-miners determinism fix lands — the current `get_assigned_ingress_proofs` \
              impl picks `assigned_miners` via non-deterministic HashMap iteration when \
              block_range intersects multiple Submit slots",
             self.consensus
@@ -383,7 +381,7 @@ impl Config {
             ensure!(
                 fork.number_of_ingress_proofs_from_assignees == 0,
                 "consensus.hardforks.next_name_tbd.number_of_ingress_proofs_from_assignees ({}) \
-                 must be 0 until fix/assigned-miners-determinism lands — see frontier guard above",
+                 must be 0 until the assigned-miners determinism fix lands — see frontier guard above",
                 fork.number_of_ingress_proofs_from_assignees,
             );
         }

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -243,6 +243,76 @@ impl Config {
             );
         }
 
+        // NC-0042 / deep-reorg safety: a term-ledger slot's lifetime must exceed
+        // the reorg window. Once a slot expires, the promotion filter and refund
+        // walk resolve each expired tx's ledger inclusion through the *migrated*
+        // block index (`canonical_submit_height` / `migrated_predecessor_total`),
+        // which is only branch-invariant BELOW the reorg floor. Deep reorgs
+        // (#1405) can now rewind already-migrated blocks up to `block_tree_depth`
+        // deep, so if a slot's lifetime is shorter than that window it could
+        // expire while an expired tx's inclusion is still reorg-mutable — two
+        // honest nodes could then resolve different inclusions and fork. A slot
+        // lives `epoch_length * num_blocks_in_epoch` blocks, so require that to
+        // exceed `block_tree_depth` for every ledger whose expiry is resolved
+        // this way.
+        //
+        // Enforced for real networks only: test configs deliberately use tiny
+        // epochs and never trigger deep adversarial reorgs (resolution there
+        // stays within the controlled, shallow-reorg regime).
+        if !self.node_config.run_mode.is_test() {
+            let num_blocks_in_epoch = self.consensus.epoch.num_blocks_in_epoch;
+            // (config field, epochs-until-expiry) for every ledger whose
+            // expired-tx inclusion is resolved via the migrated block index.
+            let mut slot_lifetimes = vec![(
+                "submit_ledger_epoch_length",
+                self.consensus.epoch.submit_ledger_epoch_length,
+            )];
+            // The Cascade term ledgers (OneYear/ThirtyDay) expire and refund via
+            // the same migrated-index walk; ThirtyDay is the tightest bound.
+            if let Some(cascade) = self.consensus.hardforks.cascade.as_ref() {
+                slot_lifetimes.push((
+                    "cascade.thirty_day_epoch_length",
+                    cascade.thirty_day_epoch_length,
+                ));
+                slot_lifetimes.push((
+                    "cascade.one_year_epoch_length",
+                    cascade.one_year_epoch_length,
+                ));
+            }
+            for (field, epoch_length) in slot_lifetimes {
+                let slot_lifetime_blocks = epoch_length.saturating_mul(num_blocks_in_epoch);
+                ensure!(
+                    slot_lifetime_blocks > self.consensus.block_tree_depth,
+                    "{field} ({epoch_length}) * num_blocks_in_epoch ({num_blocks_in_epoch}) = slot \
+                     lifetime {slot_lifetime_blocks} blocks must be > block_tree_depth ({}): \
+                     expired-tx promotion/refund resolution reads the migrated block index, which \
+                     deep reorgs can rewind up to block_tree_depth deep — a shorter slot lifetime \
+                     leaves an expired tx's inclusion reorg-mutable, risking a consensus fork \
+                     (NC-0042)",
+                    self.consensus.block_tree_depth,
+                );
+            }
+
+            // Tx anchors must resolve INSIDE the reorg window so prevalidation's
+            // inclusion/anchor walks can confirm them branch-correctly by-hash. A
+            // tx anchored older than the tree would fall to the by-height index/MBH
+            // shortcut, which is only branch-invariant below the reorg floor (#1405)
+            // — see `get_previous_tx_inclusions` and the ingress-anchor walk in
+            // `block_discovery`. `tx_anchor_expiry_depth` bounds how old a tx anchor
+            // can be, so cap it at `block_tree_depth`. (`ingress_proof_anchor_expiry_depth`
+            // is deliberately NOT capped: ingress anchors past the floor are resolved
+            // from the finalized index, which is safe.)
+            ensure!(
+                u64::from(self.consensus.mempool.tx_anchor_expiry_depth)
+                    <= self.consensus.block_tree_depth,
+                "tx_anchor_expiry_depth ({}) must be <= block_tree_depth ({}): a tx anchored older \
+                 than the reorg window would be resolved via the by-height index shortcut, which is \
+                 only branch-invariant below the reorg floor — risking a consensus fork",
+                self.consensus.mempool.tx_anchor_expiry_depth,
+                self.consensus.block_tree_depth,
+            );
+        }
+
         // `number_of_ingress_proofs_from_assignees` MUST stay 0 in this codebase
         // version.  When > 0, the value flows through `get_assigned_ingress_proofs`
         // (block_validation.rs) where the per-proof intersection loop picks
@@ -1149,6 +1219,84 @@ mod tests {
             .publish_ledger_epoch_length = Some(u64::MAX);
         let config = Config::new_with_random_peer_id(node_config);
         assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_submit_slot_lifetime_vs_block_tree_depth_validation() {
+        // NC-0042 / deep-reorg guard: in non-test (production) mode a term-ledger
+        // slot's lifetime (epoch_length * num_blocks_in_epoch) must exceed
+        // block_tree_depth, so an expired tx's inclusion is always below the reorg
+        // floor where the migrated-index fast path is branch-invariant. The
+        // testing default block_tree_depth is 50.
+
+        // Production, lifetime <= block_tree_depth -> rejected.
+        let mut node_config = NodeConfig::testing().with_run_mode(RunMode::Production);
+        // submit_ledger_epoch_length default 5 * num_blocks_in_epoch 5 = 25 <= 50.
+        node_config.consensus.get_mut().epoch.num_blocks_in_epoch = 5;
+        let config = Config::new_with_random_peer_id(node_config);
+        let err = config
+            .validate()
+            .expect_err("slot lifetime <= block_tree_depth must fail in production")
+            .to_string();
+        assert!(
+            err.contains("NC-0042"),
+            "expected the slot-lifetime guard, got: {err}"
+        );
+
+        // Production, lifetime > block_tree_depth (default 5 * 360 = 1800 > 50) -> ok.
+        let node_config = NodeConfig::testing().with_run_mode(RunMode::Production);
+        let config = Config::new_with_random_peer_id(node_config);
+        assert!(config.validate().is_ok());
+
+        // Test mode: the guard is skipped even when the invariant is violated.
+        let mut node_config = NodeConfig::testing(); // RunMode::Test
+        node_config.consensus.get_mut().epoch.num_blocks_in_epoch = 5; // 25 <= 50
+        let config = Config::new_with_random_peer_id(node_config);
+        assert!(
+            config.validate().is_ok(),
+            "test-mode configs must skip the slot-lifetime guard"
+        );
+    }
+
+    #[test]
+    fn test_tx_anchor_expiry_depth_vs_block_tree_depth_validation() {
+        // Production: tx_anchor_expiry_depth must not exceed block_tree_depth, so a
+        // tx anchor always resolves inside the reorg window (branch-correct by-hash).
+        // testing default is block_tree_depth = 50.
+        let mut node_config = NodeConfig::testing().with_run_mode(RunMode::Production);
+        node_config
+            .consensus
+            .get_mut()
+            .mempool
+            .tx_anchor_expiry_depth = 60; // > 50
+        let config = Config::new_with_random_peer_id(node_config);
+        let err = config
+            .validate()
+            .expect_err("tx_anchor_expiry_depth > block_tree_depth must fail in production")
+            .to_string();
+        assert!(
+            err.contains("tx_anchor_expiry_depth"),
+            "expected the tx-anchor vs tree-depth guard, got: {err}"
+        );
+
+        // Production: tx_anchor_expiry_depth == block_tree_depth (testing default 50) -> ok.
+        let node_config = NodeConfig::testing().with_run_mode(RunMode::Production);
+        let config = Config::new_with_random_peer_id(node_config);
+        assert!(config.validate().is_ok());
+
+        // Test mode: the guard is skipped even when violated (tests set tiny
+        // block_tree_depth without lowering tx_anchor_expiry_depth).
+        let mut node_config = NodeConfig::testing(); // RunMode::Test
+        node_config
+            .consensus
+            .get_mut()
+            .mempool
+            .tx_anchor_expiry_depth = 60;
+        let config = Config::new_with_random_peer_id(node_config);
+        assert!(
+            config.validate().is_ok(),
+            "test-mode configs must skip the tx-anchor vs tree-depth guard"
+        );
     }
 
     #[test]

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -260,6 +260,21 @@ impl Config {
             );
         }
 
+        // These feed the slot-lifetime / expiry multiply (`epoch_length *
+        // num_blocks_in_epoch`) on every path, including test mode where the
+        // slot-lifetime > block_tree_depth guard below is skipped. A zero in either
+        // collapses every slot's lifetime to 0 blocks (so every slot reads as expired
+        // immediately) and can panic the runtime `checked_mul(...).expect(...)` expiry
+        // math. Reject unconditionally, matching the publish_ledger_epoch_length check.
+        ensure!(
+            self.consensus.epoch.num_blocks_in_epoch > 0,
+            "num_blocks_in_epoch must be > 0"
+        );
+        ensure!(
+            self.consensus.epoch.submit_ledger_epoch_length > 0,
+            "submit_ledger_epoch_length must be > 0"
+        );
+
         // NC-0042 / deep-reorg safety: a term-ledger slot's lifetime must exceed
         // the reorg window. Once a slot expires, the promotion filter and refund
         // walk resolve each expired tx's ledger inclusion through the *migrated*

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -103,12 +103,15 @@ impl Config {
             );
         }
 
-        // Partition/recall sizing must be non-zero. Zero breaks every chunk-offset
-        // and slot computation: e.g. ledger-expiry `compute_chunk_range` /
-        // `expired_submit_range` would make the §4b/§4c filter silently no-op
+        // Chunk/partition/recall sizing must be non-zero. Zero breaks every
+        // chunk-offset and slot computation: e.g. ledger-expiry `compute_chunk_range`
+        // / `expired_submit_range` would make the §4b/§4c filter silently no-op
         // (range_end collapses to 0), while the refund walk bails — an asymmetric
-        // silent bypass. The `div_ceil` below would also panic on a zero recall
-        // range. Reject loudly here. (NC-0042)
+        // silent bypass. `chunk_size == 0` is the same hazard one level down:
+        // `submit_tx_start_offset` returns `None` (→ tx read as "not expired") while
+        // `filter_transactions_by_chunk_range` bails loud. The `div_ceil` below would
+        // also panic on a zero recall range. Reject loudly here. (NC-0042)
+        ensure!(self.consensus.chunk_size > 0, "chunk_size must be > 0");
         ensure!(
             self.consensus.num_chunks_in_partition > 0,
             "num_chunks_in_partition must be > 0"
@@ -278,6 +281,13 @@ impl Config {
             let num_blocks_in_epoch = self.consensus.epoch.num_blocks_in_epoch;
             // (config field, epochs-until-expiry) for every ledger whose
             // expired-tx inclusion is resolved via the migrated block index.
+            //
+            // `publish_ledger_epoch_length` is intentionally NOT in this list:
+            // Publish-ledger expiry never resolves an expired tx's inclusion through
+            // the migrated-index / by-hash walk this guard protects (only Submit and
+            // the Cascade term ledgers do — see `ledger_expiry`), so its lifetime
+            // need not exceed `block_tree_depth`. (It has its own overflow check
+            // above.)
             let mut slot_lifetimes = vec![(
                 "submit_ledger_epoch_length",
                 self.consensus.epoch.submit_ledger_epoch_length,

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -103,6 +103,21 @@ impl Config {
             );
         }
 
+        // Partition/recall sizing must be non-zero. Zero breaks every chunk-offset
+        // and slot computation: e.g. ledger-expiry `compute_chunk_range` /
+        // `expired_submit_range` would make the §4b/§4c filter silently no-op
+        // (range_end collapses to 0), while the refund walk bails — an asymmetric
+        // silent bypass. The `div_ceil` below would also panic on a zero recall
+        // range. Reject loudly here. (NC-0042)
+        ensure!(
+            self.consensus.num_chunks_in_partition > 0,
+            "num_chunks_in_partition must be > 0"
+        );
+        ensure!(
+            self.consensus.num_chunks_in_recall_range > 0,
+            "num_chunks_in_recall_range must be > 0"
+        );
+
         // ensure that the VDF step cache is >= chunks_per_partition.div_ceil(chunks_per_recall_range)
         let minimum_step_capacity = self
             .consensus
@@ -1255,7 +1270,7 @@ mod tests {
             "expected the slot-lifetime guard, got: {err}"
         );
 
-        // Production, lifetime > block_tree_depth (default 5 * 360 = 1800 > 50) -> ok.
+        // Production, lifetime > block_tree_depth (default 5 * 100 = 500 > 50) -> ok.
         let node_config = NodeConfig::testing().with_run_mode(RunMode::Production);
         let config = Config::new_with_random_peer_id(node_config);
         assert!(config.validate().is_ok());

--- a/crates/types/src/config/node.rs
+++ b/crates/types/src/config/node.rs
@@ -64,6 +64,16 @@ pub struct DatabaseConfig {
     /// Sync mode for the cache database.
     #[serde(default = "default_cache_db_sync_mode")]
     pub cache_sync_mode: DbSyncMode,
+
+    /// Optional override for the MDBX geometry upper bound — the max DB size
+    /// *and* the virtual address-space reservation made at open — of irys-owned
+    /// databases (consensus + storage submodules). `None` = production defaults
+    /// (consensus inherits reth's 8 TiB; submodules use 2 TiB), harmless as sparse
+    /// reservations on real disks. Test configs set a small value so many
+    /// concurrent node databases don't exhaust the process's ~128 TiB user
+    /// address space. See `TEST_DB_GEOMETRY_MAX_SIZE`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub geometry_max_size: Option<usize>,
 }
 
 fn default_db_sync_mode() -> DbSyncMode {
@@ -78,6 +88,7 @@ impl Default for DatabaseConfig {
         Self {
             sync_mode: default_db_sync_mode(),
             cache_sync_mode: default_cache_db_sync_mode(),
+            geometry_max_size: None,
         }
     }
 }
@@ -1211,6 +1222,9 @@ impl NodeConfig {
             database: DatabaseConfig {
                 sync_mode: DbSyncMode::UtterlyNoSync,
                 cache_sync_mode: DbSyncMode::UtterlyNoSync,
+                // Small MDBX geometry so many concurrent test node databases don't
+                // exhaust virtual address space (see TEST_DB_GEOMETRY_MAX_SIZE).
+                geometry_max_size: Some(crate::TEST_DB_GEOMETRY_MAX_SIZE),
             },
         }
     }

--- a/crates/types/src/ledger_expiry.rs
+++ b/crates/types/src/ledger_expiry.rs
@@ -17,7 +17,13 @@ impl SubmitLedgerMetadata {
         num_blocks_in_epoch: u64,
         submit_ledger_epoch_length: u64,
     ) -> Self {
-        let blocks_per_cycle = submit_ledger_epoch_length * num_blocks_in_epoch;
+        // checked_mul matches `TermLedger::get_*_slot_indexes` / `Config::validate`:
+        // an overflowing product must fail loud, not wrap (release builds) into a
+        // bogus tiny cycle length. `Config::validate` rejects such configs, so this
+        // only fires on a call path that bypassed validation.
+        let blocks_per_cycle = submit_ledger_epoch_length
+            .checked_mul(num_blocks_in_epoch)
+            .expect("submit_ledger_epoch_length * num_blocks_in_epoch overflows u64");
         let position_in_cycle = block_height % blocks_per_cycle;
         let epoch_in_cycle = position_in_cycle / num_blocks_in_epoch;
         let epochs_remaining = submit_ledger_epoch_length - epoch_in_cycle;

--- a/crates/types/src/ledger_expiry.rs
+++ b/crates/types/src/ledger_expiry.rs
@@ -19,11 +19,14 @@ impl SubmitLedgerMetadata {
     ) -> Self {
         // checked_mul matches `TermLedger::get_*_slot_indexes` / `Config::validate`:
         // an overflowing product must fail loud, not wrap (release builds) into a
-        // bogus tiny cycle length. `Config::validate` rejects such configs, so this
-        // only fires on a call path that bypassed validation.
+        // bogus tiny cycle length. The `> 0` filter additionally rejects a zero
+        // product (either factor zero): without it `block_height % 0` below panics
+        // opaquely. `Config::validate` rejects such configs, so this only fires on
+        // a call path that bypassed validation (e.g. a test-mode Display/API path).
         let blocks_per_cycle = submit_ledger_epoch_length
             .checked_mul(num_blocks_in_epoch)
-            .expect("submit_ledger_epoch_length * num_blocks_in_epoch overflows u64");
+            .filter(|b| *b > 0)
+            .expect("submit_ledger_epoch_length * num_blocks_in_epoch must be non-zero and not overflow u64");
         let position_in_cycle = block_height % blocks_per_cycle;
         let epoch_in_cycle = position_in_cycle / num_blocks_in_epoch;
         let epochs_remaining = submit_ledger_epoch_length - epoch_in_cycle;

--- a/crates/types/src/ledger_expiry.rs
+++ b/crates/types/src/ledger_expiry.rs
@@ -31,6 +31,16 @@ impl SubmitLedgerMetadata {
     }
 }
 
+// NOTE: There is deliberately no per-tx "absolute expiry height" helper here.
+// Submit-ledger expiry is a per-*slot* property
+// (`TermLedger::get_all_expired_slot_indexes`): a slot expires at
+// `slot.last_height + blocks_per_cycle`, except the last/newest slot is never
+// expired, and slots are allocated at arbitrary epoch boundaries — not cycle
+// boundaries. A per-tx cycle-math approximation of expiry diverges from this and
+// caused both a false-positive (rejecting valid promotions) and a false-negative
+// (missing a double-pay) in the first NC-0042 fix. Promotion/refund decisions
+// must use the expired-partition set (`ledger_expiry::expired_submit_tx_ids`).
+
 /// Calculates the number of epochs remaining before the submit ledger expires.
 /// Returns a value from 1 to submit_ledger_epoch_length (never 0).
 pub fn calculate_submit_ledger_expiry(

--- a/crates/types/src/storage.rs
+++ b/crates/types/src/storage.rs
@@ -18,6 +18,19 @@ pub const MEGABYTE: usize = 1024 * 1024;
 pub const GIGABYTE: usize = MEGABYTE * 1024;
 pub const TERABYTE: usize = GIGABYTE * 1024;
 
+/// MDBX geometry upper bound for irys-owned databases in `RunMode::Test`.
+///
+/// MDBX maps the geometry's *upper bound* as virtual address space at open time
+/// (it pre-reserves the whole range so the mapping base never moves, keeping its
+/// zero-copy value pointers valid as the DB grows). The production caps are huge
+/// (consensus inherits reth's 8 TiB default; submodules use 2 TiB) — harmless as
+/// sparse reservations on a real disk, but when many test nodes run concurrently
+/// (each mapping several such envs) the summed reservations can exhaust the
+/// process's ~128 TiB user address space → `mmap` `ENOMEM` at DB open. Tests hold
+/// only KB–MB, so a few GB is ample headroom (the cap is a hard ceiling — exceeding
+/// it is `MDBX_MAP_FULL`, not an auto-grow) while shrinking the reservation ~1000x.
+pub const TEST_DB_GEOMETRY_MAX_SIZE: usize = 4 * GIGABYTE;
+
 /// Partition relative chunk offsets
 #[derive(
     Default,

--- a/crates/types/src/storage.rs
+++ b/crates/types/src/storage.rs
@@ -339,6 +339,13 @@ impl TryFrom<LedgerChunkOffset> for usize {
     }
 }
 
+/// Builds an **inclusive-inclusive** (`ii`) `LedgerChunkOffset` interval.
+///
+/// NOTE: the ledger-expiry consumers treat the resulting interval's `.end()` as
+/// **exclusive** (loops use `< end`, trims use `>= end`). That is self-consistent
+/// across those call sites today, but a future caller using nodit's `.contains()`
+/// on this `ii` interval would double-count the boundary chunk. Reach for
+/// `ledger_chunk_offset_ie!` (exclusive end) if you need half-open semantics.
 #[macro_export]
 macro_rules! ledger_chunk_offset_ii {
     ($start:expr, $end:expr) => {


### PR DESCRIPTION
## NC-0042

A devnet producer panicked repeatedly at an epoch block: a data tx was both **promoted** into the Publish (permanent) ledger and scheduled for a **`perm_fee` refund** because its Submit (term) slot was expiring. A defence-in-depth guard turned that into an `Irrecoverable` panic. The same condition also has a **silent cross-block form** (refund at epoch `E`, promotion at `E+k`) that every validator accepted — a permanent **double-pay** (refund *and* permanent storage).

## Root causes

- **Bug A — publish-vs-expiry collision.** The tx selector (promotion) and the expiry pipeline (refund) disagreed about an expiring tx; nothing reconciled them on the producer side, and the validator only checked the *same-block* case.
- **Bug B1 — ingress-proof cache delete.** `IngressProofs` is DUPSORT (one proof per signer), but the maintenance loop deleted **all** signers' proofs when **one** expired (`delete(key, None)`), so a node could never durably hold the 3 distinct-signer proofs needed to promote — which is what stalled promotion into the expiry window.

## Fix

- **B1:** precise per-signer delete (`delete_ingress_proof_by_signer`); other signers' valid proofs survive.
- **Bug A:** both the producer filter (§4b) and a new validator rule (§4c, unconditional) key off the **same expired-Submit-tx decision** the refund pipeline uses, so "is this tx refunded?" and "may this tx be promoted?" cannot diverge. The earlier cycle-math approximation was rejected — Submit expiry is a per-*slot* property (last-slot rule + slots allocated off cycle boundaries), and per-tx cycle math diverged in **both** directions (false-positive → fork risk; false-negative → the double-pay still occurs).
- **Perf:** the production check is **per-candidate** (offset cutoff from the first unexpired slot; O(1) common case, intra-block walk only at the range's last block), with the O(history) walk kept as a **differential test oracle** that asserts the cheap path matches it for every tx.

## Commits
1. `fix: precise per-signer ingress-proof delete in maintenance loop` (Bug B1)
2. `feat: shared expired-Submit-tx set keyed on partition expiry` (infra)
3. `fix(consensus): never promote a tx whose Submit storage expired` (producer + validator + heavy tests)
4. `perf(consensus): per-candidate Submit-expiry check, walk kept as oracle`

## Tests
- B1 unit (3 distinct-signer proofs, expire one, assert the other two survive).
- Slot-expiry units incl. last/only-slot (never expires) and already-expired (stays expired); `find_block_range_bounds_by_parent_not_index_tip`.
- **T2** (`heavy_producer_drops_publish_candidate_whose_submit_storage_expired`) — honest producer drops the expired candidates with no panic; dropped set == refunded set exactly.
- **T3** (`heavy_block_promoting_already_expired_submit_tx_gets_rejected`) — evil block promoting an already-expired tx one block past expiry is rejected by both nodes with `ShadowTransactionInvalid`; includes the **oracle-equivalence** differential check (per-candidate == walk).
- Regression: `invalid_perm_fee_refund`, `ledger_expiry_with_unstake`, `cascade_term_expiry`, `same_block_promotion` all green; clippy + fmt clean.

## Notes / out of scope
- §4c ships **unconditionally** (no hardfork gate) — devnet reset accepted.
- **Bug B2** (proof re-broadcast cadence vs anchor lifetime) deferred to a separate design discussion.
- The already-double-paid devnet tx is not unwound by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made expired Submit-ledger fee/expiry computation deterministic over validated parent ancestry and tightened NC-0042 submit-inclusion handling.
  * Hardened chunk/total-chunk arithmetic against overflow during block production.
  * Improved ingress-proof pruning to delete only unchanged, targeted expired proofs while preserving refreshed/sibling proofs.
* **New Features**
  * Added stronger NC-0042 publish/promote filtering and rejection for already-expired Submit storage.
  * Implemented Cascade-aware, inclusive “expiring now” term-ledger expiry semantics.
* **Tests**
  * Added end-to-end and regression coverage for publish-drop, promote-after-expiry, reorg, and slow-path inclusion expiry.
* **Chores**
  * Added an optional test-only database geometry cap and tightened config validation bounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->