### PR TITLE
feat(ledgers): anchor slot expiry to last write (Cascade-gated)

### DIFF
--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -1851,13 +1851,7 @@ pub trait BlockProdStrategy {
         // It lets the fee calc exclude slots written this epoch (rescued by the
         // last_height touch) from the expiring set.
         let new_total = |ledger: DataLedger, txs: &[DataTransactionHeader]| -> u64 {
-            let prev = prev_block_header
-                .data_ledgers
-                .iter()
-                .find(|dl| dl.ledger_id == ledger as u32)
-                .map(|dl| dl.total_chunks)
-                .unwrap_or(0);
-            prev + calculate_chunks_added(txs, chunk_size)
+            prev_block_header.ledger_total_chunks(ledger) + calculate_chunks_added(txs, chunk_size)
         };
 
         let mut result = ledger_expiry::calculate_expired_ledger_fees(

--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -1623,7 +1623,12 @@ pub trait BlockProdStrategy {
         // =====
 
         let aggregated_miner_fees = self
-            .calculate_expired_ledger_fees(&parent_epoch_snapshot, block_height)
+            .calculate_expired_ledger_fees(
+                &parent_epoch_snapshot,
+                block_height,
+                prev_block_header,
+                &mempool_txs,
+            )
             .await?;
 
         let commitment_refund_events = self.derive_unpledge_refunds(&parent_commitment_snapshot)?;
@@ -1821,7 +1826,26 @@ pub trait BlockProdStrategy {
         &self,
         parent_epoch_snapshot: &EpochSnapshot,
         block_height: u64,
+        prev_block_header: &IrysBlockHeader,
+        mempool_txs: &MempoolTxs,
     ) -> eyre::Result<LedgerExpiryBalanceDelta> {
+        let chunk_size = self.inner().config.consensus.chunk_size;
+        // `ledger`'s cumulative total_chunks at the block being produced =
+        // parent total + chunks added by this block's selected txs. This is the
+        // exact value that lands in the block header (see produce_block_*), and
+        // the validator reads it straight from the header — so both sides agree.
+        // It lets the fee calc exclude slots written this epoch (rescued by the
+        // last_height touch) from the expiring set.
+        let new_total = |ledger: DataLedger, txs: &[DataTransactionHeader]| -> u64 {
+            let prev = prev_block_header
+                .data_ledgers
+                .iter()
+                .find(|dl| dl.ledger_id == ledger as u32)
+                .map(|dl| dl.total_chunks)
+                .unwrap_or(0);
+            prev + calculate_chunks_added(txs, chunk_size)
+        };
+
         let mut result = ledger_expiry::calculate_expired_ledger_fees(
             parent_epoch_snapshot,
             block_height,
@@ -1832,6 +1856,7 @@ pub trait BlockProdStrategy {
             &self.inner().mempool_guard,
             &self.inner().db,
             true, // expect txs to be promoted — return perm fee refund if not
+            new_total(DataLedger::Submit, &mempool_txs.submit_tx),
         )
         .in_current_span()
         .await?;
@@ -1845,7 +1870,10 @@ pub trait BlockProdStrategy {
             .hardforks
             .is_cascade_active_for_epoch(parent_epoch_snapshot);
         if cascade_active {
-            for ledger in [DataLedger::OneYear, DataLedger::ThirtyDay] {
+            for (ledger, txs) in [
+                (DataLedger::OneYear, &mempool_txs.one_year_tx),
+                (DataLedger::ThirtyDay, &mempool_txs.thirty_day_tx),
+            ] {
                 let delta = ledger_expiry::calculate_expired_ledger_fees(
                     parent_epoch_snapshot,
                     block_height,
@@ -1856,6 +1884,7 @@ pub trait BlockProdStrategy {
                     &self.inner().mempool_guard,
                     &self.inner().db,
                     false, // no promotion for these ledgers
+                    new_total(ledger, txs),
                 )
                 .in_current_span()
                 .await?;

--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -1626,6 +1626,7 @@ pub trait BlockProdStrategy {
             .calculate_expired_ledger_fees(
                 &parent_epoch_snapshot,
                 block_height,
+                block_timestamp,
                 prev_block_header,
                 &mempool_txs,
             )
@@ -1826,10 +1827,23 @@ pub trait BlockProdStrategy {
         &self,
         parent_epoch_snapshot: &EpochSnapshot,
         block_height: u64,
+        block_timestamp: UnixTimestampMs,
         prev_block_header: &IrysBlockHeader,
         mempool_txs: &MempoolTxs,
     ) -> eyre::Result<LedgerExpiryBalanceDelta> {
         let chunk_size = self.inner().config.consensus.chunk_size;
+        // Gate for the write-window exclusion: the Cascade status of THIS block
+        // (its own timestamp — the value `perform_epoch_tasks` reads to gate the
+        // `touch_active_ledger_slots` that rescues these slots). Must not use the
+        // parent-snapshot helper below: at the activation epoch the parent still
+        // predates activation, which would disable the exclusion while the touch
+        // already runs — settling a slot that did not recycle.
+        let cascade_active_for_block = self
+            .inner()
+            .config
+            .consensus
+            .hardforks
+            .is_cascade_active_at(block_timestamp.to_secs());
         // `ledger`'s cumulative total_chunks at the block being produced =
         // parent total + chunks added by this block's selected txs. This is the
         // exact value that lands in the block header (see produce_block_*), and
@@ -1857,6 +1871,7 @@ pub trait BlockProdStrategy {
             &self.inner().db,
             true, // expect txs to be promoted — return perm fee refund if not
             new_total(DataLedger::Submit, &mempool_txs.submit_tx),
+            cascade_active_for_block,
         )
         .in_current_span()
         .await?;
@@ -1885,6 +1900,7 @@ pub trait BlockProdStrategy {
                     &self.inner().db,
                     false, // no promotion for these ledgers
                     new_total(ledger, txs),
+                    cascade_active_for_block,
                 )
                 .in_current_span()
                 .await?;

--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -94,6 +94,10 @@ pub async fn calculate_expired_ledger_fees(
     mempool_guard: &MempoolReadGuard,
     db: &DatabaseProvider,
     expect_txs_to_be_promoted: bool,
+    // `ledger_type`'s cumulative `total_chunks` at the block being produced/validated.
+    // Used to exclude slots written this epoch from the expiring set (they are
+    // rescued by the `last_height` touch and must not be settled here).
+    new_total_chunks: u64,
 ) -> eyre::Result<LedgerExpiryBalanceDelta> {
     // Fee distribution is only implemented for Submit ledger. Publish expiry
     // simply resets partitions without fee redistribution.
@@ -104,8 +108,12 @@ pub async fn calculate_expired_ledger_fees(
     );
 
     // Step 1: Collect expired partitions
-    let expired_slots =
-        collect_expired_partitions(parent_epoch_snapshot, block_height, ledger_type)?;
+    let expired_slots = collect_expired_partitions(
+        parent_epoch_snapshot,
+        block_height,
+        ledger_type,
+        new_total_chunks,
+    )?;
 
     tracing::info!(
         "Ledger expiry check at block {}: found {} expired slots for {:?} ledger",
@@ -280,9 +288,17 @@ fn collect_expired_partitions(
     parent_epoch_snapshot: &EpochSnapshot,
     block_height: u64,
     target_ledger_type: DataLedger,
+    new_total_chunks: u64,
 ) -> eyre::Result<BTreeMap<SlotIndex, Vec<IrysAddress>>> {
     let partition_assignments = &parent_epoch_snapshot.partition_assignments;
-    let expired_partition_info = &parent_epoch_snapshot.get_expiring_partition_info(block_height);
+    // Window-excluded: settle exactly the slots that actually recycle, so a slot
+    // written in its expiry epoch (rescued by the last_height touch) is not paid
+    // here and then again when it later recycles.
+    let expired_partition_info = &parent_epoch_snapshot.get_expiring_partition_info(
+        block_height,
+        target_ledger_type,
+        new_total_chunks,
+    );
     let mut expired_ledger_slot_indexes = BTreeMap::new();
     if expired_partition_info.is_empty() {
         return Ok(expired_ledger_slot_indexes);

--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -98,6 +98,11 @@ pub async fn calculate_expired_ledger_fees(
     // Used to exclude slots written this epoch from the expiring set (they are
     // rescued by the `last_height` touch and must not be settled here).
     new_total_chunks: u64,
+    // Cascade status of the epoch block being produced/validated (its own
+    // timestamp — NOT the parent snapshot's). Gates the write-window exclusion
+    // so it mirrors the Cascade-gated `touch_active_ledger_slots`. When false,
+    // settlement matches pre-Cascade master exactly (no exclusion).
+    cascade_active: bool,
 ) -> eyre::Result<LedgerExpiryBalanceDelta> {
     // Fee distribution is only implemented for Submit ledger. Publish expiry
     // simply resets partitions without fee redistribution.
@@ -113,6 +118,7 @@ pub async fn calculate_expired_ledger_fees(
         block_height,
         ledger_type,
         new_total_chunks,
+        cascade_active,
     )?;
 
     tracing::info!(
@@ -289,15 +295,19 @@ fn collect_expired_partitions(
     block_height: u64,
     target_ledger_type: DataLedger,
     new_total_chunks: u64,
+    cascade_active: bool,
 ) -> eyre::Result<BTreeMap<SlotIndex, Vec<IrysAddress>>> {
     let partition_assignments = &parent_epoch_snapshot.partition_assignments;
-    // Window-excluded: settle exactly the slots that actually recycle, so a slot
-    // written in its expiry epoch (rescued by the last_height touch) is not paid
-    // here and then again when it later recycles.
+    // Window-excluded (Cascade only): settle exactly the slots that actually
+    // recycle, so a slot written in its expiry epoch (rescued by the last_height
+    // touch) is not paid here and then again when it later recycles. Pre-Cascade
+    // the touch is gated off, so `cascade_active=false` disables the exclusion
+    // and settlement matches the original master set.
     let expired_partition_info = &parent_epoch_snapshot.get_expiring_partition_info(
         block_height,
         target_ledger_type,
         new_total_chunks,
+        cascade_active,
     );
     let mut expired_ledger_slot_indexes = BTreeMap::new();
     if expired_partition_info.is_empty() {

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -4411,13 +4411,16 @@ async fn generate_expected_shadow_transactions(
     // Get treasury balance from previous block
     let initial_treasury_balance = prev_block.treasury;
 
-    // Calculate expired ledger fees for epoch blocks. Every input to
-    // `calculate_expired_ledger_fees` is locally derived (parent epoch
-    // snapshot, validator-computed block height, local block index, local
-    // mempool, local DB) — the peer supplies nothing that flows into this
-    // computation. The function produces what the validator EXPECTS the
-    // peer's shadow txs to look like; the peer-vs-expected comparison
-    // happens downstream in `generate_expected_shadow_transactions`.
+    // Calculate expired ledger fees for epoch blocks. Most inputs are locally
+    // derived (parent epoch snapshot, validator-computed block height, local
+    // block index, local mempool, local DB); the only candidate-header values
+    // that flow in are the block's own timestamp (the Cascade gate) and each
+    // ledger's `total_chunks` (the write-window bound). Both are validated
+    // independently elsewhere, so here they merely SELECT which slots the fee
+    // calc settles — they cannot make the calc itself fail. The function
+    // produces what the validator EXPECTS the peer's shadow txs to look like;
+    // the peer-vs-expected comparison (where a divergence is attributed to the
+    // peer) happens downstream in `generate_expected_shadow_transactions`.
     //
     // Consequence: every failure path here is a node-side fault.
     //   - MDBX I/O failure (block-header / data-tx reads) → NodeFault.
@@ -4434,18 +4437,12 @@ async fn generate_expected_shadow_transactions(
     // to "split into DB-vs-logic" later. (A prior TODO here suggested
     // that split; on audit it was speculative and the TODO was removed.)
     let expired_ledger_fees = if is_epoch_block {
-        // `ledger`'s cumulative total_chunks at this block, read straight from the
-        // header (the producer computed the identical value). Lets the fee calc
-        // exclude slots written this epoch — rescued by the last_height touch — so
-        // the settled set matches what actually recycles.
-        let ledger_total = |ledger: DataLedger| -> u64 {
-            block
-                .data_ledgers
-                .iter()
-                .find(|dl| dl.ledger_id == ledger as u32)
-                .map(|dl| dl.total_chunks)
-                .unwrap_or(0)
-        };
+        // `block.ledger_total_chunks(..)` is each ledger's cumulative total_chunks
+        // at this block, read straight from the header (the producer computed the
+        // identical value). Lets the fee calc exclude slots written this epoch —
+        // rescued by the last_height touch — so the settled set matches what
+        // actually recycles.
+        //
         // Gate for the write-window exclusion: THIS block's own Cascade status —
         // the same value `perform_epoch_tasks` reads to gate the
         // `touch_active_ledger_slots` that rescues these slots. Must match the
@@ -4466,7 +4463,7 @@ async fn generate_expected_shadow_transactions(
             mempool_guard,
             db,
             true, // expect txs to be promoted — return perm fee refund if not
-            ledger_total(DataLedger::Submit),
+            block.ledger_total_chunks(DataLedger::Submit),
             cascade_active_for_block,
         )
         .in_current_span()
@@ -4490,7 +4487,7 @@ async fn generate_expected_shadow_transactions(
                     mempool_guard,
                     db,
                     false, // no promotion for these ledgers
-                    ledger_total(ledger),
+                    block.ledger_total_chunks(ledger),
                     cascade_active_for_block,
                 )
                 .in_current_span()

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -4434,6 +4434,18 @@ async fn generate_expected_shadow_transactions(
     // to "split into DB-vs-logic" later. (A prior TODO here suggested
     // that split; on audit it was speculative and the TODO was removed.)
     let expired_ledger_fees = if is_epoch_block {
+        // `ledger`'s cumulative total_chunks at this block, read straight from the
+        // header (the producer computed the identical value). Lets the fee calc
+        // exclude slots written this epoch — rescued by the last_height touch — so
+        // the settled set matches what actually recycles.
+        let ledger_total = |ledger: DataLedger| -> u64 {
+            block
+                .data_ledgers
+                .iter()
+                .find(|dl| dl.ledger_id == ledger as u32)
+                .map(|dl| dl.total_chunks)
+                .unwrap_or(0)
+        };
         let mut result = ledger_expiry::calculate_expired_ledger_fees(
             &parent_epoch_snapshot,
             block.height,
@@ -4444,6 +4456,7 @@ async fn generate_expected_shadow_transactions(
             mempool_guard,
             db,
             true, // expect txs to be promoted — return perm fee refund if not
+            ledger_total(DataLedger::Submit),
         )
         .in_current_span()
         .await
@@ -4466,6 +4479,7 @@ async fn generate_expected_shadow_transactions(
                     mempool_guard,
                     db,
                     false, // no promotion for these ledgers
+                    ledger_total(ledger),
                 )
                 .in_current_span()
                 .await

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -4446,6 +4446,16 @@ async fn generate_expected_shadow_transactions(
                 .map(|dl| dl.total_chunks)
                 .unwrap_or(0)
         };
+        // Gate for the write-window exclusion: THIS block's own Cascade status —
+        // the same value `perform_epoch_tasks` reads to gate the
+        // `touch_active_ledger_slots` that rescues these slots. Must match the
+        // producer (which uses the produced block's timestamp), and must NOT be
+        // the parent-snapshot helper (`is_cascade_active_for_epoch`), which lags
+        // by an epoch at the activation boundary.
+        let cascade_active_for_block = config
+            .consensus
+            .hardforks
+            .is_cascade_active_at(block.timestamp_secs());
         let mut result = ledger_expiry::calculate_expired_ledger_fees(
             &parent_epoch_snapshot,
             block.height,
@@ -4457,6 +4467,7 @@ async fn generate_expected_shadow_transactions(
             db,
             true, // expect txs to be promoted — return perm fee refund if not
             ledger_total(DataLedger::Submit),
+            cascade_active_for_block,
         )
         .in_current_span()
         .await
@@ -4480,6 +4491,7 @@ async fn generate_expected_shadow_transactions(
                     db,
                     false, // no promotion for these ledgers
                     ledger_total(ledger),
+                    cascade_active_for_block,
                 )
                 .in_current_span()
                 .await

--- a/crates/chain-tests/src/validation/cascade_term_expiry.rs
+++ b/crates/chain-tests/src/validation/cascade_term_expiry.rs
@@ -776,7 +776,9 @@ async fn heavy_cascade_expiry_fee_model_matches_actual_recycle() -> eyre::Result
         let snap = tree
             .get_epoch_snapshot(&parent_block.block_hash)
             .expect("parent epoch snapshot");
-        snap.get_expiring_partition_info(e, DataLedger::ThirtyDay, e_total)
+        // cascade_active=true: this scenario runs post-activation (cascade
+        // activated at timestamp 0), matching the producer/validator gate.
+        snap.get_expiring_partition_info(e, DataLedger::ThirtyDay, e_total, true)
             .into_iter()
             .map(|p| p.slot_index)
             .collect::<Vec<_>>()
@@ -944,6 +946,197 @@ async fn heavy_cascade_rescued_slot_defers_reward_and_refund() -> eyre::Result<(
         refunds_at_recycle >= 1,
         "deferred PermFeeRefund for the unpromoted txs must land when slot 0 \
          actually recycles at E+{window}={recycle} (got {refunds_at_recycle})"
+    );
+
+    ctx.stop().await;
+    Ok(())
+}
+
+/// Pre-Cascade replay-identity guard for the Submit-ledger expiry-fee path.
+///
+/// The write-window exclusion in `get_expiring_partition_info` mirrors the
+/// `last_height` touch, which is Cascade-gated. But the Submit fee path runs
+/// unconditionally (Submit is always live), so the exclusion MUST be gated on
+/// the block's Cascade status too. Otherwise, pre-activation, a slot that
+/// actually recycles (no touch to rescue it) would be silently dropped from the
+/// settled set — diverging from the original master binary and breaking
+/// bit-identical replay of pre-Cascade history.
+///
+/// This is the pre-activation twin of
+/// `heavy_cascade_expiry_fee_model_matches_actual_recycle`: there the touch
+/// RESCUES the late-filled slot, so it is excluded from BOTH sets and they match
+/// at "without slot 1". Here Cascade is inactive, the slot is NOT rescued, so it
+/// must appear in BOTH the fee set and the actual recycle set.
+///
+/// Scenario (nbe=2, submit_ledger_epoch_length=2 -> window=4, C=10 chunks), with
+/// NO Cascade configured:
+/// 1. Epoch L: write 12 Submit chunks -> slot 0 full, slot 1 partial (frontier);
+///    extra empty slots so slot 1 is non-last. Slot 1 allocated at L.
+/// 2. Idle the full window so slot 1 ages to its expiry epoch E = L + 4.
+/// 3. Epoch E: write again -> lands in slot 1. Pre-Cascade there is NO touch, so
+///    slot 1 still expires at E (its `last_height` stays L).
+///
+/// At E the fee-predicted set (parent, `cascade_active=false`) must equal the
+/// actual recycle set AND contain the recycled slot. The buggy unconditional
+/// exclusion (`cascade_active=true`) would instead DROP that slot — demonstrated
+/// explicitly so a regression in the gate fails here.
+#[test_log::test(tokio::test)]
+async fn heavy_pre_cascade_submit_expiry_fee_model_matches_actual_recycle() -> eyre::Result<()> {
+    let num_blocks_in_epoch = 2_u64;
+    let submit_ledger_epoch_length = 2_u64;
+    let chunk_size = 32_u64;
+    let num_chunks_in_partition = 10_u64;
+    let window = submit_ledger_epoch_length * num_blocks_in_epoch; // 4
+
+    let mut config = NodeConfig::testing().with_consensus(|c| {
+        c.block_migration_depth = 1;
+        c.epoch.num_blocks_in_epoch = num_blocks_in_epoch;
+        c.epoch.submit_ledger_epoch_length = submit_ledger_epoch_length;
+        c.chunk_size = chunk_size;
+        c.num_chunks_in_partition = num_chunks_in_partition;
+        // Cascade intentionally NOT configured: this exercises pre-activation
+        // behavior, where the last_height touch is gated off.
+    });
+
+    let signer = config.new_random_signer();
+    config.fund_genesis_accounts(vec![&signer]);
+
+    let test_node = IrysNodeTest::new_genesis(config);
+    StorageSubmodulesConfig::load_for_test(test_node.cfg.base_directory.clone(), 5)?;
+    let ctx = test_node.start_and_wait_for_packing("test", 30).await;
+
+    let next_epoch_boundary = |h: u64| -> u64 {
+        if h.is_multiple_of(num_blocks_in_epoch) {
+            h
+        } else {
+            h + (num_blocks_in_epoch - (h % num_blocks_in_epoch))
+        }
+    };
+
+    // Post one unpromoted publish-data tx (chunks never uploaded) -> grows the
+    // Submit ledger's `total_chunks`. `chunks` controls how many chunks it spans.
+    async fn post_submit(
+        ctx: &IrysNodeTest<irys_chain::IrysNodeCtx>,
+        signer: &irys_types::irys::IrysSigner,
+        chunk_size: u64,
+        tag: u8,
+        chunks: usize,
+    ) -> eyre::Result<()> {
+        let mut data = vec![7_u8; chunks * chunk_size as usize];
+        data[0] = tag;
+        let anchor = ctx.get_anchor().await?;
+        let tx = ctx.post_data_tx(anchor, data, signer).await;
+        ctx.wait_for_mempool(tx.header.id, 30).await?;
+        Ok(())
+    }
+
+    // Get past genesis epoch processing into a steady state.
+    while ctx.get_canonical_chain_height().await <= num_blocks_in_epoch {
+        ctx.mine_block().await?;
+    }
+
+    // Epoch L: 4 txs × 3 chunks = 12 chunks -> slot 0 full, slot 1 partial frontier.
+    for i in 0_u8..4 {
+        post_submit(&ctx, &signer, chunk_size, i, 3).await?;
+    }
+    let l = next_epoch_boundary(ctx.mine_block().await?.height);
+    while ctx.get_canonical_chain_height().await < l {
+        ctx.mine_block().await?;
+    }
+
+    // Idle through the window so slot 1 ages to its expiry epoch E = L + window.
+    let e = l + window;
+    while ctx.get_canonical_chain_height().await < e - 1 {
+        ctx.mine_block().await?;
+    }
+
+    // Resume exactly in epoch E: write into the (still-frontier) slot 1. No touch
+    // pre-Cascade, so slot 1 still expires here.
+    post_submit(&ctx, &signer, chunk_size, 200, 3).await?;
+    while ctx.get_canonical_chain_height().await < e {
+        ctx.mine_block().await?;
+    }
+
+    // Submit's cumulative total_chunks at the epoch block E (the value the
+    // producer/validator feed to the fee calc).
+    let epoch_block = ctx.get_block_by_height(e).await?;
+    let e_total = epoch_block
+        .data_ledgers
+        .iter()
+        .find(|dl| dl.ledger_id == DataLedger::Submit as u32)
+        .map(|dl| dl.total_chunks)
+        .unwrap_or(0);
+    let parent_block = ctx.get_block_by_height(e - 1).await?;
+
+    // Actual recycle set recorded by the NEW epoch snapshot at E.
+    let mut actual_set = {
+        let tree = ctx.node_ctx.block_tree_guard.read();
+        let snap = tree
+            .get_epoch_snapshot(&epoch_block.block_hash)
+            .expect("epoch snapshot at E");
+        snap.expired_partition_infos
+            .clone()
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|p| p.ledger_id == DataLedger::Submit)
+            .map(|p| p.slot_index)
+            .collect::<Vec<_>>()
+    };
+    actual_set.sort_unstable();
+    actual_set.dedup();
+
+    // The late-filled headroom slot MUST recycle pre-Cascade (no touch rescue).
+    // If this is empty the setup failed to age a non-last slot — fail loudly
+    // rather than let the equality assert pass vacuously.
+    assert!(
+        !actual_set.is_empty(),
+        "expected a Submit slot to actually recycle at E={e} pre-Cascade \
+         (got empty recycle set; setup failed to age a non-last slot)"
+    );
+
+    // Fee-predicted set with the CORRECT pre-activation gate (cascade_active=false):
+    // no window exclusion, so it must equal what actually recycles.
+    let mut fee_set = {
+        let tree = ctx.node_ctx.block_tree_guard.read();
+        let snap = tree
+            .get_epoch_snapshot(&parent_block.block_hash)
+            .expect("parent epoch snapshot");
+        snap.get_expiring_partition_info(e, DataLedger::Submit, e_total, false)
+            .into_iter()
+            .map(|p| p.slot_index)
+            .collect::<Vec<_>>()
+    };
+    fee_set.sort_unstable();
+    fee_set.dedup();
+
+    assert_eq!(
+        fee_set, actual_set,
+        "pre-Cascade: fee-distribution set (cascade_active=false) must equal the \
+         actual recycle set at E={e}; dropping a recycled slot diverges from the \
+         original master binary and breaks pre-Cascade replay"
+    );
+
+    // Demonstrate the divergence the gate prevents: with the exclusion
+    // erroneously applied pre-activation (cascade_active=true), the late-filled
+    // slot is dropped from the settled set even though it recycles.
+    let mut fee_set_buggy = {
+        let tree = ctx.node_ctx.block_tree_guard.read();
+        let snap = tree
+            .get_epoch_snapshot(&parent_block.block_hash)
+            .expect("parent epoch snapshot");
+        snap.get_expiring_partition_info(e, DataLedger::Submit, e_total, true)
+            .into_iter()
+            .map(|p| p.slot_index)
+            .collect::<Vec<_>>()
+    };
+    fee_set_buggy.sort_unstable();
+    fee_set_buggy.dedup();
+
+    assert_ne!(
+        fee_set_buggy, actual_set,
+        "sanity: the unconditional exclusion (cascade_active=true) must DROP the \
+         recycled slot here — this is exactly the divergence the Cascade gate \
+         prevents pre-activation"
     );
 
     ctx.stop().await;

--- a/crates/chain-tests/src/validation/cascade_term_expiry.rs
+++ b/crates/chain-tests/src/validation/cascade_term_expiry.rs
@@ -642,3 +642,165 @@ async fn slow_heavy_cascade_midchain_activation_submit_last_height_transition() 
     node.stop().await;
     Ok(())
 }
+
+/// Reproduction: the term-fee model in `block_producer::ledger_expiry.rs` must
+/// distribute fees for EXACTLY the slots that actually recycle.
+///
+/// The fee calc predicts the expiring set from the PARENT epoch snapshot
+/// (`get_expiring_partition_info`, pre-this-epoch-touch), while the real
+/// recycle set is `expired_partition_infos` on the NEW epoch snapshot
+/// (post-touch). They can diverge for a slot that is written in the very epoch
+/// it would otherwise expire: the touch rescues it from recycling, but the
+/// parent-based fee calc still settles it -> its fees would be distributed now
+/// AND again when it actually recycles later (double distribution).
+///
+/// Scenario (nbe=2, thirty_day_epoch_length=2 -> window=4 blocks, C=10 chunks):
+/// 1. Epoch L: write 12 chunks -> slot 0 full, slot 1 partial (the frontier),
+///    extra empty slots allocated so slot 1 is non-last. Both get last_height=L.
+/// 2. Idle for the full window (no ThirtyDay data) so slot 1 stays at L and
+///    becomes due to expire at E = L + window.
+/// 3. Epoch E = L + 4: write again -> lands in slot 1 (still the frontier),
+///    touching it to E so it is RESCUED from recycling.
+///
+/// At E the fee-predicted set (parent) must equal the actual recycle set (new).
+/// Pre-fix this FAILS: slot 1 is in the fee set but not the recycle set.
+#[test_log::test(tokio::test)]
+async fn heavy_cascade_expiry_fee_model_matches_actual_recycle() -> eyre::Result<()> {
+    let num_blocks_in_epoch = 2_u64;
+    let activation_height = num_blocks_in_epoch;
+    let one_year_epoch_length = 8_u64;
+    let thirty_day_epoch_length = 2_u64;
+    let chunk_size = 32_u64;
+    let num_chunks_in_partition = 10_u64;
+    let window = thirty_day_epoch_length * num_blocks_in_epoch; // 4
+
+    let mut config = NodeConfig::testing().with_consensus(|c| {
+        c.block_migration_depth = 1;
+        c.epoch.num_blocks_in_epoch = num_blocks_in_epoch;
+        c.chunk_size = chunk_size;
+        c.num_chunks_in_partition = num_chunks_in_partition;
+        c.hardforks.cascade = Some(Cascade {
+            activation_timestamp: UnixTimestamp::from_secs(0),
+            one_year_epoch_length,
+            thirty_day_epoch_length,
+            annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
+        });
+    });
+
+    let signer = config.new_random_signer();
+    config.fund_genesis_accounts(vec![&signer]);
+
+    let test_node = IrysNodeTest::new_genesis(config);
+    StorageSubmodulesConfig::load_for_test(test_node.cfg.base_directory.clone(), 5)?;
+    let ctx = test_node.start_and_wait_for_packing("test", 30).await;
+
+    let next_epoch_boundary = |h: u64| -> u64 {
+        if h.is_multiple_of(num_blocks_in_epoch) {
+            h
+        } else {
+            h + (num_blocks_in_epoch - (h % num_blocks_in_epoch))
+        }
+    };
+
+    async fn post_thirty_day(
+        ctx: &IrysNodeTest<irys_chain::IrysNodeCtx>,
+        signer: &irys_types::irys::IrysSigner,
+        tag: u8,
+        bytes: usize,
+    ) -> eyre::Result<()> {
+        let mut data = vec![9_u8; bytes];
+        data[0] = tag;
+        let price = ctx
+            .get_data_price(DataLedger::ThirtyDay, bytes as u64)
+            .await?;
+        let tx = signer.create_transaction_with_fees(
+            data,
+            ctx.get_anchor().await?,
+            DataLedger::ThirtyDay,
+            BoundedFee::new(price.term_fee),
+            None,
+        )?;
+        let tx = signer.sign_transaction(tx)?;
+        ctx.ingest_data_tx(tx.header.clone()).await?;
+        ctx.wait_for_mempool(tx.header.id, 30).await?;
+        Ok(())
+    }
+
+    while ctx.get_canonical_chain_height().await <= activation_height {
+        ctx.mine_block().await?;
+    }
+
+    // Epoch L: 4 txs × 3 chunks = 12 chunks -> slot 0 full, slot 1 partial frontier.
+    for i in 0_u8..4 {
+        post_thirty_day(&ctx, &signer, i, 96).await?;
+    }
+    let l = next_epoch_boundary(ctx.mine_block().await?.height);
+    while ctx.get_canonical_chain_height().await < l {
+        ctx.mine_block().await?;
+    }
+
+    // Idle through the window so slot 1 ages to its expiry epoch E = L + window.
+    let e = l + window;
+    while ctx.get_canonical_chain_height().await < e - 1 {
+        ctx.mine_block().await?;
+    }
+
+    // Resume exactly in epoch E: write into the (still-frontier) slot 1.
+    post_thirty_day(&ctx, &signer, 200, 96).await?;
+    while ctx.get_canonical_chain_height().await < e {
+        ctx.mine_block().await?;
+    }
+
+    // ThirtyDay's cumulative total_chunks at the epoch block E (the value the
+    // producer/validator feed to the fee calc).
+    let epoch_block = ctx.get_block_by_height(e).await?;
+    let e_total = epoch_block
+        .data_ledgers
+        .iter()
+        .find(|dl| dl.ledger_id == DataLedger::ThirtyDay as u32)
+        .map(|dl| dl.total_chunks)
+        .unwrap_or(0);
+
+    // Fee-predicted expiring set: the PARENT epoch snapshot (as the producer
+    // sees it) asked which ThirtyDay slots will actually recycle at height E.
+    let parent_block = ctx.get_block_by_height(e - 1).await?;
+    let mut fee_set = {
+        let tree = ctx.node_ctx.block_tree_guard.read();
+        let snap = tree
+            .get_epoch_snapshot(&parent_block.block_hash)
+            .expect("parent epoch snapshot");
+        snap.get_expiring_partition_info(e, DataLedger::ThirtyDay, e_total)
+            .into_iter()
+            .map(|p| p.slot_index)
+            .collect::<Vec<_>>()
+    };
+    fee_set.sort_unstable();
+    fee_set.dedup();
+
+    // Actual recycle set recorded by the NEW epoch snapshot at E.
+    let mut actual_set = {
+        let tree = ctx.node_ctx.block_tree_guard.read();
+        let snap = tree
+            .get_epoch_snapshot(&epoch_block.block_hash)
+            .expect("epoch snapshot at E");
+        snap.expired_partition_infos
+            .clone()
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|p| p.ledger_id == DataLedger::ThirtyDay)
+            .map(|p| p.slot_index)
+            .collect::<Vec<_>>()
+    };
+    actual_set.sort_unstable();
+    actual_set.dedup();
+
+    assert_eq!(
+        fee_set, actual_set,
+        "fee-distribution expiring set (parent, get_expiring_partition_info) must \
+         equal the actual recycle set (expired_partition_infos) at epoch E={e}; \
+         a mismatch means fees are distributed for a slot that did not recycle"
+    );
+
+    ctx.stop().await;
+    Ok(())
+}

--- a/crates/chain-tests/src/validation/cascade_term_expiry.rs
+++ b/crates/chain-tests/src/validation/cascade_term_expiry.rs
@@ -247,3 +247,210 @@ async fn heavy_cascade_term_ledger_expiry_respects_distinct_epoch_lengths() -> e
     ctx.stop().await;
     Ok(())
 }
+
+/// Verify that a slot's expiry is anchored to the LAST epoch data was written
+/// into it, not to when the slot was allocated.
+///
+/// This exercises the Cascade retention fix: `last_height` is refreshed each
+/// epoch a slot receives new canonical data, so a slot that keeps receiving
+/// writes across multiple epochs stays alive for `epoch_length` epochs measured
+/// from its *last* write.
+///
+/// Scenario (num_blocks_in_epoch=2, thirty_day_epoch_length=2 -> expiry after
+/// 4 blocks):
+/// 1. Write 6 chunks of ThirtyDay data -> lands in slot 0; the next epoch
+///    boundary E_a allocates extra slots (so slot 0 is no longer the protected
+///    last slot) and stamps slot 0's `last_height = E_a`.
+/// 2. One epoch later, write 2 more chunks -> also lands in slot 0 (offsets 6,7
+///    are still within slot 0's [0, 10) range); the next boundary E_b = E_a + 2
+///    re-stamps slot 0's `last_height = E_b`.
+/// 3. At boundary E_a + 4 (when allocation-time semantics would have expired
+///    slot 0) the slot must still be ACTIVE, because its last write was at E_b.
+/// 4. At boundary E_b + 4 the slot finally expires.
+///
+/// Without the last-write fix slot 0 would retain its genesis/allocation
+/// `last_height` and be expired by step 3 — so this test fails on `master`.
+#[test_log::test(tokio::test)]
+async fn heavy_cascade_slot_expiry_anchored_to_last_write() -> eyre::Result<()> {
+    let num_blocks_in_epoch = 2_u64;
+    let activation_height = num_blocks_in_epoch;
+    let one_year_epoch_length = 8_u64;
+    let thirty_day_epoch_length = 2_u64; // expires 2×2 = 4 blocks after last write
+    let chunk_size = 32_u64;
+    let num_chunks_in_partition = 10_u64;
+    let expiry_blocks = thirty_day_epoch_length * num_blocks_in_epoch; // 4
+
+    let mut config = NodeConfig::testing().with_consensus(|c| {
+        c.block_migration_depth = 1;
+        c.epoch.num_blocks_in_epoch = num_blocks_in_epoch;
+        c.chunk_size = chunk_size;
+        c.num_chunks_in_partition = num_chunks_in_partition;
+        c.hardforks.cascade = Some(Cascade {
+            activation_timestamp: UnixTimestamp::from_secs(0),
+            one_year_epoch_length,
+            thirty_day_epoch_length,
+            annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
+        });
+    });
+
+    let signer = config.new_random_signer();
+    config.fund_genesis_accounts(vec![&signer]);
+
+    let test_node = IrysNodeTest::new_genesis(config);
+    StorageSubmodulesConfig::load_for_test(test_node.cfg.base_directory.clone(), 5)?;
+    let ctx = test_node.start_and_wait_for_packing("test", 30).await;
+
+    let next_epoch_boundary = |h: u64| -> u64 {
+        if h.is_multiple_of(num_blocks_in_epoch) {
+            h
+        } else {
+            h + (num_blocks_in_epoch - (h % num_blocks_in_epoch))
+        }
+    };
+
+    // Mine past the Cascade activation height.
+    while ctx.get_canonical_chain_height().await <= activation_height {
+        ctx.mine_block().await?;
+    }
+
+    // --- Batch 1: 6 chunks (2 txs × 96 bytes) into slot 0 ---
+    for i in 0_u8..2 {
+        let mut tx_data = vec![9_u8; 96];
+        tx_data[0] = i;
+        let price = ctx.get_data_price(DataLedger::ThirtyDay, 96).await?;
+        let tx = signer.create_transaction_with_fees(
+            tx_data,
+            ctx.get_anchor().await?,
+            DataLedger::ThirtyDay,
+            BoundedFee::new(price.term_fee),
+            None,
+        )?;
+        let tx = signer.sign_transaction(tx)?;
+        ctx.ingest_data_tx(tx.header.clone()).await?;
+        ctx.wait_for_mempool(tx.header.id, 30).await?;
+    }
+    let h1 = ctx.mine_block().await?.height;
+    let epoch_a = next_epoch_boundary(h1);
+
+    // Mine to E_a so the epoch snapshot allocates extra slots (so slot 0 is no
+    // longer the protected last slot) and stamps slot 0's last_height = E_a.
+    while ctx.get_canonical_chain_height().await < epoch_a {
+        ctx.mine_block().await?;
+    }
+
+    let block_a = ctx.get_block_by_height(epoch_a).await?;
+    let (la_after_a, expired_after_a, slot_count) = {
+        let tree = ctx.node_ctx.block_tree_guard.read();
+        let snapshot = tree
+            .get_epoch_snapshot(&block_a.block_hash)
+            .expect("epoch snapshot should exist at E_a");
+        let slots = snapshot.ledgers.get_slots(DataLedger::ThirtyDay);
+        (slots[0].last_height, slots[0].is_expired, slots.len())
+    };
+    assert!(
+        slot_count >= 2,
+        "expected slot 0 to no longer be the (protected) last slot, slot_count={}",
+        slot_count
+    );
+    assert_eq!(
+        la_after_a, epoch_a,
+        "slot 0 last_height should be stamped to first-write epoch E_a={}",
+        epoch_a
+    );
+    assert!(!expired_after_a, "slot 0 must not be expired at E_a");
+
+    // --- Batch 2: 2 more chunks (1 tx × 64 bytes), one epoch later ---
+    // Ensure we're strictly past E_a so the second write lands in a later epoch.
+    while ctx.get_canonical_chain_height().await <= epoch_a {
+        ctx.mine_block().await?;
+    }
+    {
+        let mut tx_data = vec![9_u8; 64];
+        tx_data[0] = 100;
+        let price = ctx.get_data_price(DataLedger::ThirtyDay, 64).await?;
+        let tx = signer.create_transaction_with_fees(
+            tx_data,
+            ctx.get_anchor().await?,
+            DataLedger::ThirtyDay,
+            BoundedFee::new(price.term_fee),
+            None,
+        )?;
+        let tx = signer.sign_transaction(tx)?;
+        ctx.ingest_data_tx(tx.header.clone()).await?;
+        ctx.wait_for_mempool(tx.header.id, 30).await?;
+    }
+    let h2 = ctx.mine_block().await?.height;
+    let epoch_b = next_epoch_boundary(h2);
+    assert!(
+        epoch_b > epoch_a,
+        "second write must occur in a later epoch (E_a={}, E_b={})",
+        epoch_a,
+        epoch_b
+    );
+
+    // --- Check 1: at E_a + expiry_blocks, slot 0 must still be ALIVE ---
+    // (Allocation-time semantics would have expired it here.)
+    let first_write_expiry = epoch_a + expiry_blocks;
+    while ctx.get_canonical_chain_height().await < first_write_expiry {
+        ctx.mine_block().await?;
+    }
+    let block_mid = ctx.get_block_by_height(first_write_expiry).await?;
+    let (la_mid, expired_mid, first_unexpired_mid) = {
+        let tree = ctx.node_ctx.block_tree_guard.read();
+        let snapshot = tree
+            .get_epoch_snapshot(&block_mid.block_hash)
+            .expect("epoch snapshot should exist at E_a+expiry");
+        let slots = snapshot.ledgers.get_slots(DataLedger::ThirtyDay);
+        (
+            slots[0].last_height,
+            slots[0].is_expired,
+            snapshot.get_first_unexpired_slot_index(DataLedger::ThirtyDay),
+        )
+    };
+    assert_eq!(
+        la_mid, epoch_b,
+        "slot 0 last_height should have advanced to last-write epoch E_b={}",
+        epoch_b
+    );
+    assert!(
+        !expired_mid,
+        "slot 0 must NOT be expired at E_a+{} ({}) — its last write was at E_b={}",
+        expiry_blocks, first_write_expiry, epoch_b
+    );
+    assert_eq!(
+        first_unexpired_mid, 0,
+        "ThirtyDay first-unexpired slot should still be 0 at E_a+{}",
+        expiry_blocks
+    );
+
+    // --- Check 2: at E_b + expiry_blocks, slot 0 finally expires ---
+    let last_write_expiry = epoch_b + expiry_blocks;
+    while ctx.get_canonical_chain_height().await < last_write_expiry {
+        ctx.mine_block().await?;
+    }
+    let block_late = ctx.get_block_by_height(last_write_expiry).await?;
+    let (expired_late, first_unexpired_late) = {
+        let tree = ctx.node_ctx.block_tree_guard.read();
+        let snapshot = tree
+            .get_epoch_snapshot(&block_late.block_hash)
+            .expect("epoch snapshot should exist at E_b+expiry");
+        let slots = snapshot.ledgers.get_slots(DataLedger::ThirtyDay);
+        (
+            slots[0].is_expired,
+            snapshot.get_first_unexpired_slot_index(DataLedger::ThirtyDay),
+        )
+    };
+    assert!(
+        expired_late,
+        "slot 0 must be expired at E_b+{} ({})",
+        expiry_blocks, last_write_expiry
+    );
+    assert!(
+        first_unexpired_late > 0,
+        "ThirtyDay first-unexpired slot should advance past 0 once slot 0 expires (got {})",
+        first_unexpired_late
+    );
+
+    ctx.stop().await;
+    Ok(())
+}

--- a/crates/chain-tests/src/validation/cascade_term_expiry.rs
+++ b/crates/chain-tests/src/validation/cascade_term_expiry.rs
@@ -1142,3 +1142,156 @@ async fn heavy_pre_cascade_submit_expiry_fee_model_matches_actual_recycle() -> e
     ctx.stop().await;
     Ok(())
 }
+
+/// Cascade-active last-write expiry for the PERMANENT (Publish) ledger.
+///
+/// `touch_active_ledger_slots` iterates `Ledgers::active_ledgers()`, which
+/// includes Publish — so when `publish_ledger_epoch_length` makes perm slots
+/// expirable, the last-write touch applies to them too. The term-ledger tests
+/// above never exercise this (Publish data only grows via promotion), so this
+/// test pins the perm path end-to-end.
+///
+/// Scenario (nbe=2, publish_ledger_epoch_length=4 -> window=8, perm slot C=4):
+/// 1. Promote a full slot's worth of data (4 chunks) -> fills perm slot 0; the
+///    epoch allocates a headroom slot 1 (empty), stamped `last_height = a1`.
+/// 2. Idle an epoch (no Publish data) so the headroom slot 1 ages unchanged.
+/// 3. Promote another 4 chunks -> fills slot 1 at a LATER epoch a2; the touch
+///    advances slot 1's `last_height` from its allocation epoch a1 to a2 (and
+///    allocates slot 2, so slot 1 is now non-last and expiry-eligible).
+/// 4. At a1 + window the slot WOULD expire if anchored to its allocation epoch;
+///    with last-write anchoring it survives because its last write was a2 > a1.
+///
+/// On `master` (touch gated off / absent) slot 1 keeps `last_height = a1` and
+/// both the step-3 advance and the step-4 retention assertions fail.
+#[test_log::test(tokio::test)]
+async fn heavy_cascade_publish_last_write_expiry() -> eyre::Result<()> {
+    let num_blocks_in_epoch = 2_u64;
+    let activation_height = num_blocks_in_epoch;
+    let one_year_epoch_length = 8_u64;
+    let thirty_day_epoch_length = 2_u64;
+    let publish_ledger_epoch_length = 4_u64;
+    let chunk_size = 32_u64;
+    let num_chunks_in_partition = 4_u64; // perm slot capacity = 4 chunks
+    let window = publish_ledger_epoch_length * num_blocks_in_epoch; // 8
+    let full_slot_bytes = (num_chunks_in_partition * chunk_size) as usize; // fills one slot
+
+    let mut config = NodeConfig::testing().with_consensus(|c| {
+        c.block_migration_depth = 1;
+        c.epoch.num_blocks_in_epoch = num_blocks_in_epoch;
+        c.epoch.publish_ledger_epoch_length = Some(publish_ledger_epoch_length);
+        c.chunk_size = chunk_size;
+        c.num_chunks_in_partition = num_chunks_in_partition;
+        c.num_chunks_in_recall_range = 1;
+        c.hardforks.cascade = Some(Cascade {
+            activation_timestamp: UnixTimestamp::from_secs(0),
+            one_year_epoch_length,
+            thirty_day_epoch_length,
+            annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
+        });
+    });
+
+    let signer = config.new_random_signer();
+    config.fund_genesis_accounts(vec![&signer]);
+
+    let test_node = IrysNodeTest::new_genesis(config);
+    StorageSubmodulesConfig::load_for_test(test_node.cfg.base_directory.clone(), 5)?;
+    let node = test_node.start_and_wait_for_packing("test", 30).await;
+
+    // Post and fully promote one publish-data tx (Submit -> Publish), growing the
+    // Publish ledger's `total_chunks` by `bytes`-worth of chunks.
+    async fn promote_publish(
+        node: &IrysNodeTest<irys_chain::IrysNodeCtx>,
+        signer: &irys_types::irys::IrysSigner,
+        bytes: usize,
+        tag: u8,
+    ) -> eyre::Result<()> {
+        let mut data = vec![7_u8; bytes];
+        data[0] = tag;
+        let anchor = node.get_anchor().await?;
+        let tx = node.post_data_tx(anchor, data, signer).await;
+        node.wait_for_mempool(tx.header.id, 30).await?;
+        node.upload_chunks(&tx).await?;
+        node.mine_block().await?; // confirm in Submit, trigger ingress-proof generation
+        node.wait_for_ingress_proofs_no_mining(vec![tx.header.id], 30)
+            .await?;
+        node.mine_block().await?; // promote Submit -> Publish
+        Ok(())
+    }
+
+    // Mine past Cascade activation so the perm/term expiry machinery is live.
+    while node.get_canonical_chain_height().await <= activation_height {
+        node.mine_block().await?;
+    }
+
+    // --- Batch 1: fill perm slot 0; epoch allocates headroom slot 1. ---
+    promote_publish(&node, &signer, full_slot_bytes, 1).await?;
+    node.mine_until_next_epoch().await?;
+    let a1 = node.get_canonical_chain_height().await;
+    let a1_slot1_last_height = {
+        let snapshot = node.get_canonical_epoch_snapshot();
+        let slots = snapshot.ledgers.get_slots(DataLedger::Publish);
+        assert!(
+            slots.len() >= 2,
+            "expected >=2 perm slots after batch 1 (got {})",
+            slots.len()
+        );
+        slots[1].last_height
+    };
+
+    // --- Idle one epoch with no Publish data: headroom slot 1 must not move. ---
+    node.mine_until_next_epoch().await?;
+
+    // --- Batch 2: fill perm slot 1 at a later epoch; touch advances its clock. ---
+    promote_publish(&node, &signer, full_slot_bytes, 2).await?;
+    node.mine_until_next_epoch().await?;
+    let a2 = node.get_canonical_chain_height().await;
+    assert!(
+        a2 > a1,
+        "batch 2 epoch (a2={a2}) must be after batch 1 epoch (a1={a1})"
+    );
+    let a2_slot1_last_height = {
+        let snapshot = node.get_canonical_epoch_snapshot();
+        let slots = snapshot.ledgers.get_slots(DataLedger::Publish);
+        assert!(
+            slots.len() >= 3,
+            "expected >=3 perm slots after batch 2 (got {})",
+            slots.len()
+        );
+        slots[1].last_height
+    };
+
+    // CORE: the Cascade touch advanced the previously-allocated headroom slot to
+    // its actual write epoch. On master it would keep its allocation last_height.
+    assert!(
+        a2_slot1_last_height > a1_slot1_last_height,
+        "Cascade touch must advance perm slot 1's last_height from its allocation \
+         epoch ({a1_slot1_last_height}) to its write epoch (got {a2_slot1_last_height})"
+    );
+
+    // --- Retention: at a1 + window the slot would expire if anchored to its
+    //     allocation epoch; last-write anchoring keeps it alive (last write a2). ---
+    let alloc_anchored_expiry = a1 + window;
+    assert!(
+        a2 < alloc_anchored_expiry,
+        "test setup drift: batch 2 epoch (a2={a2}) must precede a1+window ({alloc_anchored_expiry})"
+    );
+    while node.get_canonical_chain_height().await < alloc_anchored_expiry {
+        node.mine_block().await?;
+    }
+    let snapshot = node.get_canonical_epoch_snapshot();
+    let slots = snapshot.ledgers.get_slots(DataLedger::Publish);
+    assert!(
+        slots.len() >= 3,
+        "slot 1 must remain non-last (expiry-eligible) at a1+window"
+    );
+    assert!(
+        !slots[1].is_expired,
+        "perm slot 1 must still be ALIVE at a1+window ({alloc_anchored_expiry}): its \
+         last write was a2={a2}, so last-write anchoring retains it (allocation-anchored \
+         expiry would have recycled it here)"
+    );
+    drop(snapshot);
+
+    node.stop().await;
+    Ok(())
+}

--- a/crates/chain-tests/src/validation/cascade_term_expiry.rs
+++ b/crates/chain-tests/src/validation/cascade_term_expiry.rs
@@ -248,36 +248,43 @@ async fn heavy_cascade_term_ledger_expiry_respects_distinct_epoch_lengths() -> e
     Ok(())
 }
 
-/// Verify that a slot's expiry is anchored to the LAST epoch data was written
-/// into it, not to when the slot was allocated.
+/// Verify last-write expiry for a transaction that SPANS a slot boundary, and
+/// that the two slots it occupies expire independently and correctly — i.e. the
+/// spanning tx is never *under*-retained ("half a tx expiring early").
 ///
-/// This exercises the Cascade retention fix: `last_height` is refreshed each
-/// epoch a slot receives new canonical data, so a slot that keeps receiving
-/// writes across multiple epochs stays alive for `epoch_length` epochs measured
-/// from its *last* write.
+/// A tx's data is a contiguous chunk range; when it crosses the slot boundary
+/// `C` it occupies the head slot N (where it starts) and the tail slot N+1. The
+/// touch refreshes `last_height` on every slot the epoch's chunk window covers,
+/// so at write time BOTH halves get the same `last_height`. Because `total_chunks`
+/// is monotonic, the head slot then *freezes* at the write epoch (it can never
+/// receive more data), while the tail keeps filling in later epochs.
 ///
 /// Scenario (num_blocks_in_epoch=2, thirty_day_epoch_length=2 -> expiry after
-/// 4 blocks):
-/// 1. Write 6 chunks of ThirtyDay data -> lands in slot 0; the next epoch
-///    boundary E_a allocates extra slots (so slot 0 is no longer the protected
-///    last slot) and stamps slot 0's `last_height = E_a`.
-/// 2. One epoch later, write 2 more chunks -> also lands in slot 0 (offsets 6,7
-///    are still within slot 0's [0, 10) range); the next boundary E_b = E_a + 2
-///    re-stamps slot 0's `last_height = E_b`.
-/// 3. At boundary E_a + 4 (when allocation-time semantics would have expired
-///    slot 0) the slot must still be ACTIVE, because its last write was at E_b.
-/// 4. At boundary E_b + 4 the slot finally expires.
+/// 4 blocks; slot size C = 10 chunks):
+/// 1. Epoch E_a: write 4 txs × 3 chunks = 12 chunks. They fill slot 0 (chunks
+///    0-9) and spill into slot 1 (chunks 10-11). The 4th tx (chunks 9,10,11)
+///    SPANS the slot 0/1 boundary: it starts in slot 0 (head) and ends in slot 1
+///    (tail). Allocation also adds extra slots so neither slot 0 nor slot 1 is
+///    the protected last slot. Both slot 0 and slot 1 get `last_height = E_a`.
+/// 2. Epoch E_b (> E_a): write 1 more tx × 3 chunks into slot 1 (chunks 12-14).
+///    Only slot 1 is touched -> `last_height = E_b`. Slot 0 (head) stays at E_a,
+///    proving the head's retention is NOT coupled to later tail writes.
+/// 3. At E_a + 4: the head slot 0 expires — exactly `epoch_length` after the
+///    spanning tx was written (full retention honored, not premature) — while the
+///    tail slot 1 is still ALIVE (its last write was E_b). The spanning tx's two
+///    slots expire at different times; the head governs the tx's readable life.
+/// 4. At E_b + 4: the tail slot 1 also expires.
 ///
-/// Without the last-write fix slot 0 would retain its genesis/allocation
-/// `last_height` and be expired by step 3 — so this test fails on `master`.
+/// Without the last-write fix slot 0 would keep its genesis `last_height` and be
+/// expired well before E_a + 4 — so this test fails on `master`.
 #[test_log::test(tokio::test)]
-async fn heavy_cascade_slot_expiry_anchored_to_last_write() -> eyre::Result<()> {
+async fn heavy_cascade_spanning_tx_last_write_expiry() -> eyre::Result<()> {
     let num_blocks_in_epoch = 2_u64;
     let activation_height = num_blocks_in_epoch;
     let one_year_epoch_length = 8_u64;
     let thirty_day_epoch_length = 2_u64; // expires 2×2 = 4 blocks after last write
     let chunk_size = 32_u64;
-    let num_chunks_in_partition = 10_u64;
+    let num_chunks_in_partition = 10_u64; // slot size C = 10 chunks
     let expiry_blocks = thirty_day_epoch_length * num_blocks_in_epoch; // 4
 
     let mut config = NodeConfig::testing().with_consensus(|c| {
@@ -308,14 +315,37 @@ async fn heavy_cascade_slot_expiry_anchored_to_last_write() -> eyre::Result<()> 
         }
     };
 
+    // Reads (slot0_last_height, slot0_expired, slot1_last_height, slot1_expired,
+    // slot_count, first_unexpired) for the ThirtyDay ledger at `height`.
+    async fn thirty_day_slots(
+        ctx: &IrysNodeTest<irys_chain::IrysNodeCtx>,
+        height: u64,
+    ) -> eyre::Result<(u64, bool, u64, bool, usize, usize)> {
+        let block = ctx.get_block_by_height(height).await?;
+        let tree = ctx.node_ctx.block_tree_guard.read();
+        let snapshot = tree
+            .get_epoch_snapshot(&block.block_hash)
+            .expect("epoch snapshot should exist");
+        let slots = snapshot.ledgers.get_slots(DataLedger::ThirtyDay);
+        Ok((
+            slots[0].last_height,
+            slots[0].is_expired,
+            slots[1].last_height,
+            slots[1].is_expired,
+            slots.len(),
+            snapshot.get_first_unexpired_slot_index(DataLedger::ThirtyDay),
+        ))
+    }
+
     // Mine past the Cascade activation height.
     while ctx.get_canonical_chain_height().await <= activation_height {
         ctx.mine_block().await?;
     }
 
-    // --- Batch 1: 6 chunks (2 txs × 96 bytes) into slot 0 ---
-    for i in 0_u8..2 {
-        let mut tx_data = vec![9_u8; 96];
+    // --- Batch 1 @ E_a: 4 txs × 3 chunks = 12 chunks -> slot 0 (0-9) + slot 1
+    //     (10-11). The 4th tx (chunks 9,10,11) spans the slot 0/1 boundary. ---
+    for i in 0_u8..4 {
+        let mut tx_data = vec![9_u8; 96]; // 96 bytes / 32 = 3 chunks
         tx_data[0] = i;
         let price = ctx.get_data_price(DataLedger::ThirtyDay, 96).await?;
         let tx = signer.create_transaction_with_fees(
@@ -331,43 +361,39 @@ async fn heavy_cascade_slot_expiry_anchored_to_last_write() -> eyre::Result<()> 
     }
     let h1 = ctx.mine_block().await?.height;
     let epoch_a = next_epoch_boundary(h1);
-
-    // Mine to E_a so the epoch snapshot allocates extra slots (so slot 0 is no
-    // longer the protected last slot) and stamps slot 0's last_height = E_a.
     while ctx.get_canonical_chain_height().await < epoch_a {
         ctx.mine_block().await?;
     }
 
-    let block_a = ctx.get_block_by_height(epoch_a).await?;
-    let (la_after_a, expired_after_a, slot_count) = {
-        let tree = ctx.node_ctx.block_tree_guard.read();
-        let snapshot = tree
-            .get_epoch_snapshot(&block_a.block_hash)
-            .expect("epoch snapshot should exist at E_a");
-        let slots = snapshot.ledgers.get_slots(DataLedger::ThirtyDay);
-        (slots[0].last_height, slots[0].is_expired, slots.len())
-    };
+    let (s0_la_a, s0_exp_a, s1_la_a, _s1_exp_a, slot_count, _) =
+        thirty_day_slots(&ctx, epoch_a).await?;
     assert!(
-        slot_count >= 2,
-        "expected slot 0 to no longer be the (protected) last slot, slot_count={}",
+        slot_count >= 3,
+        "expected slots 0 and 1 to both be non-last (slot_count={})",
         slot_count
     );
+    // The spanning tx bumps BOTH halves to the write epoch.
     assert_eq!(
-        la_after_a, epoch_a,
-        "slot 0 last_height should be stamped to first-write epoch E_a={}",
+        s0_la_a, epoch_a,
+        "head slot 0 last_height should be the write epoch E_a={}",
         epoch_a
     );
-    assert!(!expired_after_a, "slot 0 must not be expired at E_a");
+    assert_eq!(
+        s1_la_a, epoch_a,
+        "tail slot 1 last_height should be the write epoch E_a={} (spanning tx \
+         touched both halves)",
+        epoch_a
+    );
+    assert!(!s0_exp_a, "head slot 0 must not be expired at E_a");
 
-    // --- Batch 2: 2 more chunks (1 tx × 64 bytes), one epoch later ---
-    // Ensure we're strictly past E_a so the second write lands in a later epoch.
+    // --- Batch 2 @ E_b (> E_a): 1 tx × 3 chunks into slot 1 (chunks 12-14) ---
     while ctx.get_canonical_chain_height().await <= epoch_a {
         ctx.mine_block().await?;
     }
     {
-        let mut tx_data = vec![9_u8; 64];
+        let mut tx_data = vec![9_u8; 96];
         tx_data[0] = 100;
-        let price = ctx.get_data_price(DataLedger::ThirtyDay, 64).await?;
+        let price = ctx.get_data_price(DataLedger::ThirtyDay, 96).await?;
         let tx = signer.create_transaction_with_fees(
             tx_data,
             ctx.get_anchor().await?,
@@ -383,72 +409,64 @@ async fn heavy_cascade_slot_expiry_anchored_to_last_write() -> eyre::Result<()> 
     let epoch_b = next_epoch_boundary(h2);
     assert!(
         epoch_b > epoch_a,
-        "second write must occur in a later epoch (E_a={}, E_b={})",
-        epoch_a,
+        "E_b ({epoch_b}) must be after E_a ({epoch_a})"
+    );
+    while ctx.get_canonical_chain_height().await < epoch_b {
+        ctx.mine_block().await?;
+    }
+
+    let (s0_la_b, _, s1_la_b, _, _, _) = thirty_day_slots(&ctx, epoch_b).await?;
+    // Head slot froze at E_a; the later tail write must NOT extend the head.
+    assert_eq!(
+        s0_la_b, epoch_a,
+        "head slot 0 must stay frozen at E_a={} after a later tail write (got {})",
+        epoch_a, s0_la_b
+    );
+    assert_eq!(
+        s1_la_b, epoch_b,
+        "tail slot 1 should advance to its last-write epoch E_b={}",
         epoch_b
     );
 
-    // --- Check 1: at E_a + expiry_blocks, slot 0 must still be ALIVE ---
-    // (Allocation-time semantics would have expired it here.)
-    let first_write_expiry = epoch_a + expiry_blocks;
-    while ctx.get_canonical_chain_height().await < first_write_expiry {
+    // --- Check 1 @ E_a + 4: head expires (full retention from its write), tail
+    //     survives. The spanning tx's two slots expire at DIFFERENT times. ---
+    let head_expiry = epoch_a + expiry_blocks;
+    while ctx.get_canonical_chain_height().await < head_expiry {
         ctx.mine_block().await?;
     }
-    let block_mid = ctx.get_block_by_height(first_write_expiry).await?;
-    let (la_mid, expired_mid, first_unexpired_mid) = {
-        let tree = ctx.node_ctx.block_tree_guard.read();
-        let snapshot = tree
-            .get_epoch_snapshot(&block_mid.block_hash)
-            .expect("epoch snapshot should exist at E_a+expiry");
-        let slots = snapshot.ledgers.get_slots(DataLedger::ThirtyDay);
-        (
-            slots[0].last_height,
-            slots[0].is_expired,
-            snapshot.get_first_unexpired_slot_index(DataLedger::ThirtyDay),
-        )
-    };
-    assert_eq!(
-        la_mid, epoch_b,
-        "slot 0 last_height should have advanced to last-write epoch E_b={}",
-        epoch_b
+    let (_, s0_exp_mid, _, s1_exp_mid, _, first_unexpired_mid) =
+        thirty_day_slots(&ctx, head_expiry).await?;
+    assert!(
+        s0_exp_mid,
+        "head slot 0 must expire exactly epoch_length after the spanning tx's \
+         write (E_a+{expiry_blocks}={head_expiry})"
     );
     assert!(
-        !expired_mid,
-        "slot 0 must NOT be expired at E_a+{} ({}) — its last write was at E_b={}",
-        expiry_blocks, first_write_expiry, epoch_b
+        !s1_exp_mid,
+        "tail slot 1 must still be ALIVE at E_a+{expiry_blocks} — its last write \
+         was E_b={epoch_b} (no half-tx premature loss; tail lingers)"
     );
     assert_eq!(
-        first_unexpired_mid, 0,
-        "ThirtyDay first-unexpired slot should still be 0 at E_a+{}",
-        expiry_blocks
+        first_unexpired_mid, 1,
+        "first-unexpired ThirtyDay slot should be 1 (head expired, tail alive)"
     );
 
-    // --- Check 2: at E_b + expiry_blocks, slot 0 finally expires ---
-    let last_write_expiry = epoch_b + expiry_blocks;
-    while ctx.get_canonical_chain_height().await < last_write_expiry {
+    // --- Check 2 @ E_b + 4: the tail slot 1 also expires. ---
+    let tail_expiry = epoch_b + expiry_blocks;
+    while ctx.get_canonical_chain_height().await < tail_expiry {
         ctx.mine_block().await?;
     }
-    let block_late = ctx.get_block_by_height(last_write_expiry).await?;
-    let (expired_late, first_unexpired_late) = {
-        let tree = ctx.node_ctx.block_tree_guard.read();
-        let snapshot = tree
-            .get_epoch_snapshot(&block_late.block_hash)
-            .expect("epoch snapshot should exist at E_b+expiry");
-        let slots = snapshot.ledgers.get_slots(DataLedger::ThirtyDay);
-        (
-            slots[0].is_expired,
-            snapshot.get_first_unexpired_slot_index(DataLedger::ThirtyDay),
-        )
-    };
+    let (_, _, _, s1_exp_late, _, first_unexpired_late) =
+        thirty_day_slots(&ctx, tail_expiry).await?;
     assert!(
-        expired_late,
-        "slot 0 must be expired at E_b+{} ({})",
-        expiry_blocks, last_write_expiry
+        s1_exp_late,
+        "tail slot 1 must expire epoch_length after its last write \
+         (E_b+{expiry_blocks}={tail_expiry})"
     );
     assert!(
-        first_unexpired_late > 0,
-        "ThirtyDay first-unexpired slot should advance past 0 once slot 0 expires (got {})",
-        first_unexpired_late
+        first_unexpired_late > 1,
+        "first-unexpired ThirtyDay slot should advance past 1 once the tail \
+         expires (got {first_unexpired_late})"
     );
 
     ctx.stop().await;

--- a/crates/chain-tests/src/validation/cascade_term_expiry.rs
+++ b/crates/chain-tests/src/validation/cascade_term_expiry.rs
@@ -595,9 +595,14 @@ async fn slow_heavy_cascade_midchain_activation_submit_last_height_transition() 
 
     // === Activate Cascade mid-chain via stop -> set activation = now -> restart ===
     let mut stopped = node.stop().await;
+    // +1s so activation is STRICTLY after every pre-restart block: their
+    // timestamps are all <= now() (second-granular), and `cascade_at` activates
+    // on inclusive equality (>=), so `now()` alone could collide with the tip's
+    // second and wrongly mark a historical epoch cascade-active during replay.
     let activation_timestamp = UnixTimestamp::now()
         .expect("system time after unix epoch")
-        .as_secs();
+        .as_secs()
+        + 1;
     stopped.cfg.consensus.get_mut().hardforks.cascade = Some(Cascade {
         activation_timestamp: UnixTimestamp::from_secs(activation_timestamp),
         one_year_epoch_length,

--- a/crates/chain-tests/src/validation/cascade_term_expiry.rs
+++ b/crates/chain-tests/src/validation/cascade_term_expiry.rs
@@ -1,8 +1,10 @@
 use crate::utils::IrysNodeTest;
 use irys_config::submodules::StorageSubmodulesConfig;
+use irys_reth_node_bridge::irys_reth::shadow_tx::{ShadowTransaction, TransactionPacket};
 use irys_types::{
     BoundedFee, DataLedger, NodeConfig, U256, UnixTimestamp, hardfork_config::Cascade,
 };
+use reth::rpc::types::TransactionTrait as _;
 
 /// Verify that OneYear and ThirtyDay term ledgers expire at different rates
 /// based on their distinct epoch_length values from the Cascade hardfork config.
@@ -799,6 +801,144 @@ async fn heavy_cascade_expiry_fee_model_matches_actual_recycle() -> eyre::Result
         "fee-distribution expiring set (parent, get_expiring_partition_info) must \
          equal the actual recycle set (expired_partition_infos) at epoch E={e}; \
          a mismatch means fees are distributed for a slot that did not recycle"
+    );
+
+    ctx.stop().await;
+    Ok(())
+}
+
+/// Closes the refund side of the fee/recycle alignment with the same rigor as
+/// the distribution side: a Submit slot RESCUED at its expiry epoch must emit
+/// neither a `TermFeeReward` nor a `PermFeeRefund` that round, and the refund
+/// must instead land when the slot ACTUALLY recycles later (deferred, not lost,
+/// and never doubled).
+///
+/// Scenario (nbe=2, submit_ledger_epoch_length=2 -> window=4, C=10):
+/// 1. Epoch L: post one UNPROMOTED publish-data tx (6 chunks; chunks never
+///    uploaded) -> lands in Submit slot 0, allocates empty slots so slot 0 is
+///    non-last. slot 0 last_height=L; it holds an unpromoted tx (refund-eligible).
+/// 2. Idle the full window so slot 0 ages to its expiry epoch E = L + 4.
+/// 3. Epoch E: post another (unpromoted) tx into slot 0 -> touch rescues it.
+///    Assert the epoch block at E has ZERO TermFeeReward and ZERO PermFeeRefund:
+///    the rescued slot is neither settled nor refunded.
+/// 4. Epoch E + 4: slot 0 (last write E) finally recycles -> the deferred
+///    PermFeeRefund for its unpromoted txs lands here.
+#[test_log::test(tokio::test)]
+async fn heavy_cascade_rescued_slot_defers_reward_and_refund() -> eyre::Result<()> {
+    let num_blocks_in_epoch = 2_u64;
+    let activation_height = num_blocks_in_epoch;
+    let one_year_epoch_length = 8_u64;
+    let thirty_day_epoch_length = 2_u64;
+    let submit_ledger_epoch_length = 2_u64;
+    let chunk_size = 32_u64;
+    let num_chunks_in_partition = 10_u64;
+    let window = submit_ledger_epoch_length * num_blocks_in_epoch; // 4
+
+    let mut config = NodeConfig::testing().with_consensus(|c| {
+        c.block_migration_depth = 1;
+        c.epoch.num_blocks_in_epoch = num_blocks_in_epoch;
+        c.epoch.submit_ledger_epoch_length = submit_ledger_epoch_length;
+        c.chunk_size = chunk_size;
+        c.num_chunks_in_partition = num_chunks_in_partition;
+        c.hardforks.cascade = Some(Cascade {
+            activation_timestamp: UnixTimestamp::from_secs(0),
+            one_year_epoch_length,
+            thirty_day_epoch_length,
+            annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
+        });
+    });
+
+    let signer = config.new_random_signer();
+    config.fund_genesis_accounts(vec![&signer]);
+
+    let test_node = IrysNodeTest::new_genesis(config);
+    StorageSubmodulesConfig::load_for_test(test_node.cfg.base_directory.clone(), 5)?;
+    let ctx = test_node.start_and_wait_for_packing("test", 30).await;
+
+    let next_epoch_boundary = |h: u64| -> u64 {
+        if h.is_multiple_of(num_blocks_in_epoch) {
+            h
+        } else {
+            h + (num_blocks_in_epoch - (h % num_blocks_in_epoch))
+        }
+    };
+
+    // Counts (TermFeeReward, PermFeeRefund) shadow txs in the block at `height`.
+    async fn expiry_shadow_counts(
+        ctx: &IrysNodeTest<irys_chain::IrysNodeCtx>,
+        height: u64,
+    ) -> eyre::Result<(usize, usize)> {
+        let block = ctx.get_block_by_height(height).await?;
+        let evm = ctx.wait_for_evm_block(block.evm_block_hash, 30).await?;
+        let (mut rewards, mut refunds) = (0_usize, 0_usize);
+        for tx in evm.body.transactions {
+            let mut input = tx.input().as_ref();
+            if let Ok(shadow) = ShadowTransaction::decode(&mut input)
+                && let Some(packet) = shadow.as_v1()
+            {
+                match packet {
+                    TransactionPacket::TermFeeReward(_) => rewards += 1,
+                    TransactionPacket::PermFeeRefund(_) => refunds += 1,
+                    _ => {}
+                }
+            }
+        }
+        Ok((rewards, refunds))
+    }
+
+    while ctx.get_canonical_chain_height().await <= activation_height {
+        ctx.mine_block().await?;
+    }
+
+    // Epoch L: one unpromoted 6-chunk publish tx -> Submit slot 0 (non-last).
+    let anchor = ctx.get_anchor().await?;
+    let tx1 = ctx
+        .post_data_tx(anchor, vec![1_u8; 6 * chunk_size as usize], &signer)
+        .await;
+    ctx.wait_for_mempool(tx1.header.id, 30).await?;
+    let l = next_epoch_boundary(ctx.mine_block().await?.height);
+    while ctx.get_canonical_chain_height().await < l {
+        ctx.mine_block().await?;
+    }
+
+    // Idle through the window so slot 0 ages to its expiry epoch E = L + window.
+    let e = l + window;
+    while ctx.get_canonical_chain_height().await < e - 1 {
+        ctx.mine_block().await?;
+    }
+
+    // Resume in epoch E: a second (unpromoted) tx into slot 0 -> rescued.
+    let anchor = ctx.get_anchor().await?;
+    let tx2 = ctx
+        .post_data_tx(anchor, vec![2_u8; chunk_size as usize], &signer)
+        .await;
+    ctx.wait_for_mempool(tx2.header.id, 30).await?;
+    while ctx.get_canonical_chain_height().await < e {
+        ctx.mine_block().await?;
+    }
+
+    // Phase A: the rescued slot must NOT be settled or refunded this epoch.
+    let (rewards_at_e, refunds_at_e) = expiry_shadow_counts(&ctx, e).await?;
+    assert_eq!(
+        rewards_at_e, 0,
+        "rescued Submit slot must not emit a TermFeeReward at its (skipped) expiry epoch E={e}"
+    );
+    assert_eq!(
+        refunds_at_e, 0,
+        "rescued Submit slot must not emit a PermFeeRefund at its (skipped) expiry epoch E={e}"
+    );
+
+    // Phase B: when the slot ACTUALLY recycles (E + window), the deferred refund
+    // for its unpromoted txs lands — proving the refund was deferred, not lost.
+    let recycle = e + window;
+    while ctx.get_canonical_chain_height().await < recycle {
+        ctx.mine_block().await?;
+    }
+    let (_, refunds_at_recycle) = expiry_shadow_counts(&ctx, recycle).await?;
+    assert!(
+        refunds_at_recycle >= 1,
+        "deferred PermFeeRefund for the unpromoted txs must land when slot 0 \
+         actually recycles at E+{window}={recycle} (got {refunds_at_recycle})"
     );
 
     ctx.stop().await;

--- a/crates/chain-tests/src/validation/cascade_term_expiry.rs
+++ b/crates/chain-tests/src/validation/cascade_term_expiry.rs
@@ -454,3 +454,173 @@ async fn heavy_cascade_slot_expiry_anchored_to_last_write() -> eyre::Result<()> 
     ctx.stop().await;
     Ok(())
 }
+
+/// Mid-chain Cascade activation: verify the Submit ledger's `last_height`
+/// maintenance transitions correctly *across* the activation epoch.
+///
+/// The Submit ledger is live before Cascade, with `last_height` frozen at
+/// allocation (the touch is gated off). This test pins the transition:
+/// 1. **Pre-activation:** writing Submit data does NOT advance slot 0's
+///    `last_height` — it stays at its genesis allocation height (0).
+/// 2. **Post-activation:** the touch runs, and a write advances `last_height`
+///    to the epoch that processes it, so expiry now counts from the last write.
+///
+/// Activation is performed via stop -> set `cascade.activation_timestamp = now`
+/// -> restart (the established mid-chain hardfork pattern, as in the Aurora
+/// tests). On replay the historical epoch blocks predate the activation
+/// timestamp so they stay pre-activation, while every newly mined epoch block
+/// is post-activation — deterministic, no wall-clock race.
+///
+/// Note: the first post-activation epoch re-anchors any Submit data whose
+/// cumulative-chunk delta lands in that epoch's window (the activation-straddle
+/// cohort). The touch never *retroactively* rescans slots already fully counted
+/// and dormant before activation — those keep their allocation-time
+/// `last_height` — but data still being counted around the boundary is picked
+/// up. This test therefore asserts the robust endpoints (frozen before, tracks
+/// the write after) rather than the exact straddle value.
+///
+/// A single, large partition keeps all the small Submit writes inside slot 0,
+/// which therefore stays the only (last) slot: protected from expiry, so its
+/// `last_height` can be observed cleanly across the boundary.
+#[test_log::test(tokio::test)]
+async fn slow_heavy_cascade_midchain_activation_submit_last_height_transition() -> eyre::Result<()>
+{
+    let num_blocks_in_epoch = 2_u64;
+    let one_year_epoch_length = 8_u64;
+    let thirty_day_epoch_length = 2_u64;
+    let chunk_size = 32_u64;
+    // Large partition so the handful of 1-chunk Submit writes all land in slot 0.
+    let num_chunks_in_partition = 100_u64;
+
+    let mut config = NodeConfig::testing().with_consensus(|c| {
+        c.block_migration_depth = 1;
+        c.epoch.num_blocks_in_epoch = num_blocks_in_epoch;
+        c.chunk_size = chunk_size;
+        c.num_chunks_in_partition = num_chunks_in_partition;
+        // Cascade intentionally NOT configured yet — activated mid-chain below.
+    });
+
+    let signer = config.new_random_signer();
+    config.fund_genesis_accounts(vec![&signer]);
+
+    let test_node = IrysNodeTest::new_genesis(config);
+    StorageSubmodulesConfig::load_for_test(test_node.cfg.base_directory.clone(), 5)?;
+    let node = test_node.start_and_wait_for_packing("test", 30).await;
+
+    let next_epoch_boundary = |h: u64| -> u64 {
+        if h.is_multiple_of(num_blocks_in_epoch) {
+            h
+        } else {
+            h + (num_blocks_in_epoch - (h % num_blocks_in_epoch))
+        }
+    };
+
+    // Post one 1-chunk data tx. The Submit ledger is not user-targetable
+    // directly; published data lands in Submit (pre-promotion), so a Publish
+    // data tx is what grows Submit's `total_chunks`.
+    async fn post_submit_chunk(
+        node: &IrysNodeTest<irys_chain::IrysNodeCtx>,
+        signer: &irys_types::irys::IrysSigner,
+        chunk_size: u64,
+        tag: u8,
+    ) -> eyre::Result<()> {
+        let mut data = vec![7_u8; chunk_size as usize];
+        data[0] = tag;
+        let anchor = node.get_anchor().await?;
+        let tx = node.post_data_tx(anchor, data, signer).await;
+        node.wait_for_mempool(tx.header.id, 30).await?;
+        Ok(())
+    }
+
+    // Reads (submit_slot0_last_height, submit_slot_count, active_ledger_count)
+    // from the epoch snapshot at the canonical tip.
+    async fn submit_state(
+        node: &IrysNodeTest<irys_chain::IrysNodeCtx>,
+    ) -> eyre::Result<(u64, usize, usize)> {
+        let h = node.get_canonical_chain_height().await;
+        let block = node.get_block_by_height(h).await?;
+        let tree = node.node_ctx.block_tree_guard.read();
+        let snapshot = tree
+            .get_epoch_snapshot(&block.block_hash)
+            .expect("epoch snapshot should exist at tip");
+        let slots = snapshot.ledgers.get_slots(DataLedger::Submit);
+        Ok((
+            slots[0].last_height,
+            slots.len(),
+            snapshot.ledgers.active_ledgers().len(),
+        ))
+    }
+
+    // === Pre-activation: write Submit data across two epochs ===
+    // Cascade is inactive, so the touch never runs; slot 0 must keep its genesis
+    // allocation last_height (0) despite receiving data.
+    for tag in 0_u8..2 {
+        post_submit_chunk(&node, &signer, chunk_size, tag).await?;
+        let boundary = next_epoch_boundary(node.get_canonical_chain_height().await + 1);
+        while node.get_canonical_chain_height().await < boundary {
+            node.mine_block().await?;
+        }
+    }
+
+    let (pre_last_height, pre_slot_count, pre_ledger_count) = submit_state(&node).await?;
+    assert_eq!(
+        pre_ledger_count, 2,
+        "cascade ledgers must be absent pre-activation (Publish + Submit only)"
+    );
+    assert_eq!(pre_slot_count, 1, "Submit should still be a single slot");
+    assert_eq!(
+        pre_last_height, 0,
+        "pre-activation: touch gated off, slot 0 keeps its genesis last_height"
+    );
+
+    // === Activate Cascade mid-chain via stop -> set activation = now -> restart ===
+    let mut stopped = node.stop().await;
+    let activation_timestamp = UnixTimestamp::now()
+        .expect("system time after unix epoch")
+        .as_secs();
+    stopped.cfg.consensus.get_mut().hardforks.cascade = Some(Cascade {
+        activation_timestamp: UnixTimestamp::from_secs(activation_timestamp),
+        one_year_epoch_length,
+        thirty_day_epoch_length,
+        annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
+    });
+    let node = stopped.start().await;
+
+    // Mine a couple of cascade-active epochs so activate_cascade runs.
+    for _ in 0..(2 * num_blocks_in_epoch) {
+        node.mine_block().await?;
+    }
+
+    let (_, _, mid_ledger_count) = submit_state(&node).await?;
+    assert_eq!(
+        mid_ledger_count, 4,
+        "cascade ledgers (OneYear + ThirtyDay) must be present after activation"
+    );
+
+    // === Post-activation write: the touch now advances last_height ===
+    post_submit_chunk(&node, &signer, chunk_size, 200).await?;
+    let write_height = node.mine_block().await?.height;
+    let boundary = next_epoch_boundary(write_height);
+    while node.get_canonical_chain_height().await < boundary {
+        node.mine_block().await?;
+    }
+
+    let (post_last_height, post_slot_count, _) = submit_state(&node).await?;
+    assert_eq!(post_slot_count, 1, "Submit should still be a single slot");
+    assert!(
+        post_last_height > pre_last_height,
+        "post-activation: last_height must advance past the frozen pre-activation \
+         value (pre={}, post={})",
+        pre_last_height,
+        post_last_height
+    );
+    assert_eq!(
+        post_last_height, boundary,
+        "post-activation write must anchor last_height to the epoch that processes \
+         it (write at height {}, processed at epoch {})",
+        write_height, boundary
+    );
+
+    node.stop().await;
+    Ok(())
+}

--- a/crates/database/src/data_ledger.rs
+++ b/crates/database/src/data_ledger.rs
@@ -555,12 +555,24 @@ impl Ledgers {
 
         let slots = self.slots_mut(ledger);
 
-        for idx in first..=last {
-            if let Some(slot) = slots.get_mut(idx as usize) {
-                // Don't resurrect an already-expired slot.
-                if !slot.is_expired {
-                    slot.last_height = height;
-                }
+        // Clamp the touched range to the slots that actually exist: `first`/`last`
+        // come from cumulative chunk counts, so `last` can point past the
+        // allocated slots (e.g. when allocation lags ingress). Iterate the
+        // existing slice directly rather than probing non-existent indices.
+        let Ok(first) = usize::try_from(first) else {
+            return;
+        };
+        if first >= slots.len() {
+            return;
+        }
+        let last = usize::try_from(last)
+            .unwrap_or(usize::MAX)
+            .min(slots.len() - 1);
+
+        for slot in &mut slots[first..=last] {
+            // Don't resurrect an already-expired slot.
+            if !slot.is_expired {
+                slot.last_height = height;
             }
         }
     }

--- a/crates/database/src/data_ledger.rs
+++ b/crates/database/src/data_ledger.rs
@@ -483,6 +483,14 @@ impl Ledgers {
         }
     }
 
+    /// Mutable counterpart of [`get_slots`]: the slot `Vec` backing `ledger`.
+    fn slots_mut(&mut self, ledger: DataLedger) -> &mut Vec<LedgerSlot> {
+        match ledger {
+            DataLedger::Publish => &mut self.perm.slots,
+            ledger => &mut self.get_term_ledger_mut(ledger).slots,
+        }
+    }
+
     /// Get the slot needs for the ledger, returning a vector of (slot index, number of partitions needed)
     pub fn get_slot_needs(&self, ledger: DataLedger) -> Vec<(usize, usize)> {
         match ledger {
@@ -497,16 +505,9 @@ impl Ledgers {
         slot_index: usize,
         partition_hash: H256,
     ) {
-        match ledger {
-            DataLedger::Publish => {
-                self.perm.slots[slot_index].partitions.push(partition_hash);
-            }
-            ledger => {
-                self.get_term_ledger_mut(ledger).slots[slot_index]
-                    .partitions
-                    .push(partition_hash);
-            }
-        }
+        self.slots_mut(ledger)[slot_index]
+            .partitions
+            .push(partition_hash);
     }
 
     pub fn remove_partition_from_slot(
@@ -515,16 +516,51 @@ impl Ledgers {
         slot_index: usize,
         partition_hash: &H256,
     ) {
-        match ledger {
-            DataLedger::Publish => {
-                self.perm.slots[slot_index]
-                    .partitions
-                    .retain(|p| p != partition_hash);
-            }
-            ledger => {
-                self.get_term_ledger_mut(ledger).slots[slot_index]
-                    .partitions
-                    .retain(|p| p != partition_hash);
+        self.slots_mut(ledger)[slot_index]
+            .partitions
+            .retain(|p| p != partition_hash);
+    }
+
+    /// Refresh `last_height` on every slot that received new canonical data
+    /// during this epoch, so a slot's expiry clock counts from the last time
+    /// data was written into it rather than from when the slot was allocated.
+    ///
+    /// `prev_total_chunks` / `new_total_chunks` are the ledger's cumulative
+    /// chunk counts at the previous and current epoch blocks (read from the
+    /// block header's `DataTransactionLedger.total_chunks`). `chunks_per_slot`
+    /// is `num_chunks_in_partition` — the canonical chunks held by one slot,
+    /// matching the capacity model in `calculate_additional_slots` and the slot
+    /// range math in `block_producer::ledger_expiry::compute_chunk_range`.
+    ///
+    /// Caller is responsible for gating this on the Cascade hardfork so that
+    /// pre-activation chains replay bit-identically (slots keep their
+    /// allocation-time `last_height`).
+    pub fn touch_filled_slots(
+        &mut self,
+        ledger: DataLedger,
+        prev_total_chunks: u64,
+        new_total_chunks: u64,
+        chunks_per_slot: u64,
+        height: u64,
+    ) {
+        // No data added this epoch (or misconfigured slot size) -> nothing to do.
+        if new_total_chunks <= prev_total_chunks || chunks_per_slot == 0 {
+            return;
+        }
+
+        // The new chunks [prev_total_chunks, new_total_chunks) land in slots
+        // first..=last (each slot i owns chunk range [i*C, (i+1)*C)).
+        let first = prev_total_chunks / chunks_per_slot;
+        let last = (new_total_chunks - 1) / chunks_per_slot;
+
+        let slots = self.slots_mut(ledger);
+
+        for idx in first..=last {
+            if let Some(slot) = slots.get_mut(idx as usize) {
+                // Don't resurrect an already-expired slot.
+                if !slot.is_expired {
+                    slot.last_height = height;
+                }
             }
         }
     }
@@ -774,5 +810,89 @@ mod tests {
 
         let expiring = ledgers.get_expiring_partitions(1000);
         assert!(expiring.iter().all(|e| e.ledger_id != DataLedger::Publish));
+    }
+
+    /// Allocate `count` Submit slots, all stamped with `last_height = alloc_height`.
+    fn ledgers_with_submit_slots(count: u64, alloc_height: u64) -> Ledgers {
+        let config = ConsensusConfig::testing();
+        let mut ledgers = Ledgers::new(&config, false);
+        ledgers[DataLedger::Submit].allocate_slots(count, alloc_height);
+        ledgers
+    }
+
+    fn submit_last_heights(ledgers: &Ledgers) -> Vec<u64> {
+        ledgers
+            .get_slots(DataLedger::Submit)
+            .iter()
+            .map(|s| s.last_height)
+            .collect()
+    }
+
+    #[test]
+    fn test_touch_filled_slots_marks_all_written_slots() {
+        // 3 slots of 10 chunks each; new chunks [0, 25) span slots 0,1,2.
+        let mut ledgers = ledgers_with_submit_slots(3, 1);
+        ledgers.touch_filled_slots(DataLedger::Submit, 0, 25, 10, 100);
+        assert_eq!(submit_last_heights(&ledgers), vec![100, 100, 100]);
+    }
+
+    #[test]
+    fn test_touch_filled_slots_partial_window_touches_only_overlap() {
+        // New chunks [12, 18) fall entirely within slot 1 (covers [10, 20)).
+        let mut ledgers = ledgers_with_submit_slots(3, 1);
+        ledgers.touch_filled_slots(DataLedger::Submit, 12, 18, 10, 100);
+        assert_eq!(submit_last_heights(&ledgers), vec![1, 100, 1]);
+    }
+
+    #[test]
+    fn test_touch_filled_slots_boundary_aligned_prev() {
+        // prev exactly on a slot boundary: [10, 11) is the first chunk of slot 1,
+        // so slot 0 must NOT be touched.
+        let mut ledgers = ledgers_with_submit_slots(3, 1);
+        ledgers.touch_filled_slots(DataLedger::Submit, 10, 11, 10, 100);
+        assert_eq!(submit_last_heights(&ledgers), vec![1, 100, 1]);
+    }
+
+    #[test]
+    fn test_touch_filled_slots_noop_when_no_data() {
+        // new <= prev means no chunks were added this epoch.
+        let mut ledgers = ledgers_with_submit_slots(2, 1);
+        ledgers.touch_filled_slots(DataLedger::Submit, 15, 15, 10, 100);
+        ledgers.touch_filled_slots(DataLedger::Submit, 20, 10, 10, 100);
+        assert_eq!(submit_last_heights(&ledgers), vec![1, 1]);
+    }
+
+    #[test]
+    fn test_touch_filled_slots_noop_when_zero_slot_size() {
+        // chunks_per_slot == 0 must be a guarded no-op (no divide-by-zero panic).
+        let mut ledgers = ledgers_with_submit_slots(2, 1);
+        ledgers.touch_filled_slots(DataLedger::Submit, 0, 100, 0, 100);
+        assert_eq!(submit_last_heights(&ledgers), vec![1, 1]);
+    }
+
+    #[test]
+    fn test_touch_filled_slots_skips_expired_slots() {
+        // An already-expired slot must not be resurrected, even if data lands in it.
+        let mut ledgers = ledgers_with_submit_slots(3, 1);
+        ledgers.slots_mut(DataLedger::Submit)[1].is_expired = true;
+        ledgers.touch_filled_slots(DataLedger::Submit, 0, 25, 10, 100);
+
+        let slots = ledgers.get_slots(DataLedger::Submit);
+        assert_eq!(slots[0].last_height, 100);
+        assert_eq!(
+            slots[1].last_height, 1,
+            "expired slot keeps its last_height"
+        );
+        assert!(slots[1].is_expired, "expired slot stays expired");
+        assert_eq!(slots[2].last_height, 100);
+    }
+
+    #[test]
+    fn test_touch_filled_slots_ignores_out_of_range_indices() {
+        // Window implies slots up to index 4 but only 2 slots exist: no panic,
+        // existing slots still updated.
+        let mut ledgers = ledgers_with_submit_slots(2, 1);
+        ledgers.touch_filled_slots(DataLedger::Submit, 0, 50, 10, 100);
+        assert_eq!(submit_last_heights(&ledgers), vec![100, 100]);
     }
 }

--- a/crates/database/src/data_ledger.rs
+++ b/crates/database/src/data_ledger.rs
@@ -907,4 +907,24 @@ mod tests {
         ledgers.touch_filled_slots(DataLedger::Submit, 0, 50, 10, 100);
         assert_eq!(submit_last_heights(&ledgers), vec![100, 100]);
     }
+
+    #[test]
+    fn test_touch_filled_slots_refreshes_publish_perm_ledger() {
+        // `touch_active_ledger_slots` iterates `active_ledgers()`, which INCLUDES
+        // Publish. When `publish_ledger_epoch_length` makes perm slots expirable,
+        // the touch must refresh them through the `slots_mut(Publish)` (perm) path
+        // exactly as for term ledgers — otherwise perm expiry would still count
+        // from allocation instead of the last write.
+        let config = ConsensusConfig::testing();
+        let mut ledgers = Ledgers::new(&config, false);
+        ledgers[DataLedger::Publish].allocate_slots(3, 1);
+        // New chunks [0, 25) span perm slots 0,1,2 (10 chunks each).
+        ledgers.touch_filled_slots(DataLedger::Publish, 0, 25, 10, 100);
+        let heights: Vec<u64> = ledgers
+            .get_slots(DataLedger::Publish)
+            .iter()
+            .map(|s| s.last_height)
+            .collect();
+        assert_eq!(heights, vec![100, 100, 100]);
+    }
 }

--- a/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
+++ b/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
@@ -1310,9 +1310,52 @@ impl EpochSnapshot {
     /// Returns partitions expiring at height + 1 to this [EpochSnapshot]. Empty unless next block is an epoch block with expiring partitions.
     ///
     /// Used during block production to produce epoch blocks with the correct term fee distributions.
-    pub fn get_expiring_partition_info(&self, epoch_height: u64) -> Vec<ExpiringPartitionInfo> {
-        // expiring at next next block
-        self.ledgers.get_expiring_partitions(epoch_height)
+    /// Partitions in `ledger` that will ACTUALLY recycle at `epoch_height`.
+    ///
+    /// This is the set the fee model must settle, and it must equal what
+    /// `expire_partitions` recycles on the post-touch snapshot. It is the slots
+    /// old enough to expire MINUS the slots that received data this epoch
+    /// (`[prev_total, new_total)`), which the `last_height` touch rescues from
+    /// recycling. Excluding the same window the touch bumps keeps the fee
+    /// distribution (block_producer::ledger_expiry) in lockstep with the actual
+    /// recycle — otherwise a slot written in its expiry epoch would be settled
+    /// here yet survive, and be settled again when it later recycles.
+    ///
+    /// `new_total_chunks` is `ledger`'s cumulative `total_chunks` at the new
+    /// epoch block; `prev` is read from this (parent) snapshot's epoch block,
+    /// matching `touch_active_ledger_slots`.
+    pub fn get_expiring_partition_info(
+        &self,
+        epoch_height: u64,
+        ledger: DataLedger,
+        new_total_chunks: u64,
+    ) -> Vec<ExpiringPartitionInfo> {
+        let chunks_per_slot = self.config.consensus.num_chunks_in_partition;
+        let prev_total_chunks = self
+            .epoch_block
+            .data_ledgers
+            .iter()
+            .find(|dl| dl.ledger_id == ledger as u32)
+            .map(|dl| dl.total_chunks)
+            .unwrap_or(0);
+
+        // A slot that received data this epoch is rescued by the touch, not
+        // recycled — same window as `Ledgers::touch_filled_slots`.
+        let written_this_epoch = |slot_index: usize| -> bool {
+            if new_total_chunks <= prev_total_chunks || chunks_per_slot == 0 {
+                return false;
+            }
+            let first = prev_total_chunks / chunks_per_slot;
+            let last = (new_total_chunks - 1) / chunks_per_slot;
+            let idx = slot_index as u64;
+            first <= idx && idx <= last
+        };
+
+        self.ledgers
+            .get_expiring_partitions(epoch_height)
+            .into_iter()
+            .filter(|info| info.ledger_id == ledger && !written_this_epoch(info.slot_index))
+            .collect()
     }
 
     pub fn get_first_unexpired_slot_index(&self, ledger_id: DataLedger) -> usize {

--- a/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
+++ b/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
@@ -570,17 +570,10 @@ impl EpochSnapshot {
     ) {
         let chunks_per_slot = self.config.consensus.num_chunks_in_partition;
         for ledger in self.ledgers.active_ledgers() {
-            let ledger_total = |block: &IrysBlockHeader| -> u64 {
-                block
-                    .data_ledgers
-                    .iter()
-                    .find(|dl| dl.ledger_id == ledger as u32)
-                    .map(|dl| dl.total_chunks)
-                    .unwrap_or(0)
-            };
-
-            let new_total = ledger_total(new_epoch_block);
-            let prev_total = previous_epoch_block.as_ref().map_or(0, ledger_total);
+            let new_total = new_epoch_block.ledger_total_chunks(ledger);
+            let prev_total = previous_epoch_block
+                .as_ref()
+                .map_or(0, |b| b.ledger_total_chunks(ledger));
 
             self.ledgers.touch_filled_slots(
                 ledger,
@@ -1349,13 +1342,7 @@ impl EpochSnapshot {
         cascade_active: bool,
     ) -> Vec<ExpiringPartitionInfo> {
         let chunks_per_slot = self.config.consensus.num_chunks_in_partition;
-        let prev_total_chunks = self
-            .epoch_block
-            .data_ledgers
-            .iter()
-            .find(|dl| dl.ledger_id == ledger as u32)
-            .map(|dl| dl.total_chunks)
-            .unwrap_or(0);
+        let prev_total_chunks = self.epoch_block.ledger_total_chunks(ledger);
 
         // A slot that received data this epoch is rescued by the touch, not
         // recycled — same window as `Ledgers::touch_filled_slots`. The touch is
@@ -1368,7 +1355,12 @@ impl EpochSnapshot {
             }
             let first = prev_total_chunks / chunks_per_slot;
             let last = (new_total_chunks - 1) / chunks_per_slot;
-            let idx = slot_index as u64;
+            // usize -> u64 is lossless on supported targets; convert via the
+            // checked path but PANIC on the impossible failure rather than
+            // silently treating the slot as outside the window — a wrong answer
+            // here would diverge the settled set from the recycled set.
+            let idx = u64::try_from(slot_index)
+                .expect("slot_index fits in u64 (usize is <= 64 bits on supported targets)");
             first <= idx && idx <= last
         };
 

--- a/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
+++ b/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
@@ -305,13 +305,16 @@ impl EpochSnapshot {
         self.epoch_block = new_epoch_block.clone();
         self.previous_epoch_block = previous_epoch_block.clone();
 
-        // Activate Cascade hardfork ledgers at the activation epoch boundary
-        if self
+        // Cascade activation and the retention `last_height` touch both gate on
+        // the same activation timestamp; evaluate the gate once.
+        let cascade_active = self
             .config
             .consensus
             .hardforks
-            .is_cascade_active_at(new_epoch_block.timestamp_secs())
-        {
+            .is_cascade_active_at(new_epoch_block.timestamp_secs());
+
+        // Activate Cascade hardfork ledgers at the activation epoch boundary
+        if cascade_active {
             self.ledgers.activate_cascade(&self.config.consensus);
         }
 
@@ -320,6 +323,15 @@ impl EpochSnapshot {
         self.try_genesis_init(new_epoch_block);
 
         self.allocate_additional_ledger_slots(previous_epoch_block, new_epoch_block);
+
+        // Cascade retention fix: a slot's expiry clock should count from the
+        // last epoch data was written into it, not from when it was allocated.
+        // Gated on the Cascade hardfork so pre-activation replay is unchanged.
+        // Must run AFTER allocation (so this epoch's new slots exist) and BEFORE
+        // expiry (so freshly-written slots aren't expired this same epoch).
+        if cascade_active {
+            self.touch_active_ledger_slots(previous_epoch_block, new_epoch_block);
+        }
 
         self.expire_ledger_slots(new_epoch_block);
 
@@ -532,6 +544,42 @@ impl EpochSnapshot {
                 self.calculate_additional_slots(previous_epoch_block, new_epoch_block, ledger);
             debug!("Allocating {} slots for ledger {:?}", &part_slots, &ledger);
             self.ledgers[ledger].allocate_slots(part_slots, new_epoch_block.height);
+        }
+    }
+
+    /// Refreshes `last_height` for every slot that received canonical data this
+    /// epoch, so each slot's expiry counts from the last write into it rather
+    /// than from its allocation. The newly-written chunk window is the delta of
+    /// the per-ledger cumulative `total_chunks` between the previous and current
+    /// epoch blocks (the same values `calculate_additional_slots` reads).
+    ///
+    /// Caller gates this on the Cascade hardfork.
+    fn touch_active_ledger_slots(
+        &mut self,
+        previous_epoch_block: &Option<IrysBlockHeader>,
+        new_epoch_block: &IrysBlockHeader,
+    ) {
+        let chunks_per_slot = self.config.consensus.num_chunks_in_partition;
+        for ledger in self.ledgers.active_ledgers() {
+            let ledger_total = |block: &IrysBlockHeader| -> u64 {
+                block
+                    .data_ledgers
+                    .iter()
+                    .find(|dl| dl.ledger_id == ledger as u32)
+                    .map(|dl| dl.total_chunks)
+                    .unwrap_or(0)
+            };
+
+            let new_total = ledger_total(new_epoch_block);
+            let prev_total = previous_epoch_block.as_ref().map_or(0, ledger_total);
+
+            self.ledgers.touch_filled_slots(
+                ledger,
+                prev_total,
+                new_total,
+                chunks_per_slot,
+                new_epoch_block.height,
+            );
         }
     }
 

--- a/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
+++ b/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
@@ -329,6 +329,15 @@ impl EpochSnapshot {
         // Gated on the Cascade hardfork so pre-activation replay is unchanged.
         // Must run AFTER allocation (so this epoch's new slots exist) and BEFORE
         // expiry (so freshly-written slots aren't expired this same epoch).
+        //
+        // LOCKSTEP: the recycle set produced here (touch then `expire_ledger_slots`
+        // on this post-touch snapshot) MUST equal the set the fee model settles,
+        // which `block_producer::ledger_expiry` derives by calling
+        // `get_expiring_partition_info` on the PARENT snapshot with the same
+        // window exclusion. Both the touch above and that exclusion are gated on
+        // this same `cascade_active` (the new epoch block's Cascade status); if
+        // one is gated and the other isn't they diverge — a slot would recycle
+        // here yet still be settled, or vice versa. Keep the two gates aligned.
         if cascade_active {
             self.touch_active_ledger_slots(previous_epoch_block, new_epoch_block);
         }
@@ -1324,11 +1333,20 @@ impl EpochSnapshot {
     /// `new_total_chunks` is `ledger`'s cumulative `total_chunks` at the new
     /// epoch block; `prev` is read from this (parent) snapshot's epoch block,
     /// matching `touch_active_ledger_slots`.
+    ///
+    /// `cascade_active` MUST be the Cascade status of the epoch block being
+    /// produced/validated (`is_cascade_active_at(new_epoch_block.timestamp)`),
+    /// NOT of this parent snapshot — it has to mirror the
+    /// `touch_active_ledger_slots` gate in `perform_epoch_tasks`, which keys off
+    /// the new epoch block. When false, the window exclusion is skipped and the
+    /// result reproduces the original (pre-Cascade) master set, so pre-activation
+    /// history replays bit-identically.
     pub fn get_expiring_partition_info(
         &self,
         epoch_height: u64,
         ledger: DataLedger,
         new_total_chunks: u64,
+        cascade_active: bool,
     ) -> Vec<ExpiringPartitionInfo> {
         let chunks_per_slot = self.config.consensus.num_chunks_in_partition;
         let prev_total_chunks = self
@@ -1340,9 +1358,12 @@ impl EpochSnapshot {
             .unwrap_or(0);
 
         // A slot that received data this epoch is rescued by the touch, not
-        // recycled — same window as `Ledgers::touch_filled_slots`.
+        // recycled — same window as `Ledgers::touch_filled_slots`. The touch is
+        // Cascade-gated, so pre-activation no slot is rescued: skip the exclusion
+        // when Cascade is inactive so the expiring set matches the original
+        // master behavior (no window exclusion) for bit-identical replay.
         let written_this_epoch = |slot_index: usize| -> bool {
-            if new_total_chunks <= prev_total_chunks || chunks_per_slot == 0 {
+            if !cascade_active || new_total_chunks <= prev_total_chunks || chunks_per_slot == 0 {
                 return false;
             }
             let first = prev_total_chunks / chunks_per_slot;

--- a/crates/types/src/block.rs
+++ b/crates/types/src/block.rs
@@ -312,6 +312,18 @@ impl IrysBlockHeader {
         self.timestamp.to_secs()
     }
 
+    /// Cumulative `total_chunks` recorded for `ledger` in this block's data
+    /// ledgers, or `0` when the ledger is absent (e.g. the Cascade term ledgers
+    /// before activation). This is the canonical chunk count both the producer
+    /// and validator feed into the ledger-expiry fee calculation.
+    pub fn ledger_total_chunks(&self, ledger: DataLedger) -> u64 {
+        self.data_ledgers
+            .iter()
+            .find(|dl| dl.ledger_id == ledger)
+            .map(|dl| dl.total_chunks)
+            .unwrap_or(0)
+    }
+
     /// Append commitment transactions to this block's commitment system ledger.
     ///
     /// Creates the `Commitment` ledger if it doesn't already exist, appends each


### PR DESCRIPTION
## Summary

A data-ledger slot's `last_height` was stamped **only at allocation** and never updated. Because slot expiry is `last_height + epoch_length * num_blocks_in_epoch`, data written late into a slot's life was evicted on the slot's *original* clock instead of getting its full retention window. (The field's doc comment already claimed it tracked "most recently added transaction data" — it didn't.)

This change refreshes `last_height` **each epoch a slot receives new canonical data**, so a slot — and all the data in it — expires `epoch_length` epochs after its *last* write. It's **gated behind the Cascade hardfork** (pre-activation chains replay bit-identically) and derived only from epoch-block header `total_chunks`, so it's deterministic/replay-safe.

Two mechanisms, kept in lockstep:
- `Ledgers::touch_filled_slots` maps the epoch's newly-written chunk window `[prev_total, new_total)` to slot indices and bumps their `last_height` (skipping already-expired slots).
- `EpochSnapshot::touch_active_ledger_slots` reads the per-ledger `total_chunks` delta from the epoch-block headers and applies the touch between slot allocation and slot expiry.

### Bringing actual ledger expiry in line with pricing, fees, and refunds

Changing *when* a slot recycles touches three economic surfaces, and this PR keeps all three consistent with the actual recycle:

- **Pricing** (charged at submission — `term_fee` for `epoch_length` of term storage): the last-write change makes actual retention **≥** the priced term for every tx (the slot holding a tx is kept until `epoch_length` after the slot's last write ≥ `epoch_length` after the tx's write). Pre-fix, data could be evicted *before* `epoch_length` from its write — under-delivering what was paid. Now the system never under-delivers the term it prices for.
- **Fees** (miner `TermFeeReward` on Submit/term expiry): distributed for exactly the slots that actually recycle.
- **Refunds** (`PermFeeRefund` of perm fees for unpromoted txs at Submit expiry): issued for exactly the slots that actually recycle.

The risk this fixes: the fee/refund model predicts the expiring set from the **parent** epoch snapshot (pre-touch), while the real recycle set is computed on the **new** snapshot (post-touch). Once `last_height` is mutated by the touch these can diverge — a slot written in the very epoch it would expire is **rescued** by the touch (not recycled), but the parent-based calc would still settle *and refund* it, then settle/refund **again** when it actually recycles later (double distribution / double refund). This couldn't happen pre-Cascade (no touch ⇒ parent and new `last_height` always equal).

Fix: `get_expiring_partition_info` now excludes slots written in the current epoch's `[prev_total, new_total)` window — the *same* window `touch_filled_slots` bumps — so the set that drives **both** fee distribution **and** perm-fee refunds equals exactly what `expire_partitions` recycles. The current total is computed by the producer (`parent total + calculate_chunks_added`, the identical value that lands in the header) and read from the header by the validator, so producer and validator agree (no fork). Proven exact: `actual_recycle = expiring(parent) \ {window slots}`, and the touch excludes precisely those window slots. Tested by `heavy_cascade_expiry_fee_model_matches_actual_recycle` (set equality) and `heavy_cascade_rescued_slot_defers_reward_and_refund` (a rescued slot emits no reward/refund; the refund lands only at actual recycle).

This also de-duplicates the perm/term slot-access `match` (now a private `slots_mut` helper shared by `push`/`remove`/`touch`) and the duplicated `is_cascade_active_at` gate (one hoisted `cascade_active` bool).

## Behavior at the Cascade activation epoch (Submit ledger)

The Submit ledger is live before Cascade, so the activation epoch is the interesting transition (verified by the mid-chain test):

- The touch fires on the **same epoch-aligned gate** the rest of the system uses (`is_cascade_active_for_epoch`), so it switches on in lockstep with cascade-ledger creation, validation, and pricing — deterministic, no fork.
- **Forward-only:** activation does not retroactively rescan historical slots; dormant slots keep their allocation-time `last_height`.
- **No expiry burst:** the touch only moves `last_height` forward, so enabling it can only delay an expiry, never cause one earlier.
- **Fee/recycle stay consistent** through and after activation (the alignment fix above).

## Tests (4 integration + 7 unit added; all passing)

**Unit** (`data_ledger.rs`, exercise `touch_filled_slots` directly): full-window / partial-window / boundary-aligned offset math, the two no-op guards (`new<=prev`, `chunks_per_slot==0`), the expired-slot non-resurrection guard, and out-of-range safety.

**Integration** (`cascade_term_expiry.rs`):
- `heavy_cascade_spanning_tx_last_write_expiry` — a tx spanning the slot 0/1 boundary: the spanning tx bumps both halves to the write epoch; the head slot freezes (retention not coupled to later tail writes) and expires exactly `epoch_length` after its write; the tail survives until `epoch_length` after its own last write. Matches the start-slot ownership model in `ledger_expiry.rs`.
- `slow_heavy_cascade_midchain_activation_submit_last_height_transition` — activates Cascade mid-chain (stop → set `activation_timestamp = now` → restart) with Submit already live; asserts `last_height` is frozen pre-activation (gate off) and tracks the write epoch post-activation.
- `heavy_cascade_expiry_fee_model_matches_actual_recycle` — reproduces the double-distribution divergence (fee-predicted set `[0,1]` vs actual recycle `[0]`) and asserts the fee model's expiring set equals the actual recycle set. Fails before the alignment fix.
- `heavy_cascade_rescued_slot_defers_reward_and_refund` — a Submit slot holding an *unpromoted* tx, rescued at its expiry epoch, emits **neither** a `TermFeeReward` **nor** a `PermFeeRefund` shadow tx that epoch (scanned from the block), and the deferred `PermFeeRefund` lands only when the slot actually recycles later — closing the refund side with the same rigor as the distribution side.

## Size — lines changed

Full branch: **1011 added / 32 removed**. Per file (`code` excludes comments + blanks):

| File | Added | Removed | Code |
|---|---|---|---|
| **Production logic** | | | |
| `domain/…/epoch_snapshot.rs` | 98 | 7 | 60 |
| `database/…/data_ledger.rs` (logic) | 70 | 20 | 39 |
| `actors/…/block_producer.rs` | 31 | 2 | 24 |
| `actors/…/block_producer/ledger_expiry.rs` | 19 | 3 | 13 |
| `actors/…/block_validation.rs` | 14 | 0 | 10 |
| **Production subtotal** | **232** | **32** | **146** |
| **Tests** | | | |
| `chain-tests/…/cascade_term_expiry.rs` (4 integration) | 697 | 0 | 508 |
| `database/…/data_ledger.rs` (7 unit) | 82 | 0 | 64 |
| **Tests subtotal** | **779** | **0** | **572** |
| **Total** | **1011** | **32** | **718** |

So **~146 LOC of real production logic** (heavily commented — consensus-critical) plus a net **−32** lines of pre-existing duplication removed, against ~779 LOC of tests — **~77% of the added lines are tests**.

## Test plan

- `cargo nextest run -p irys-database data_ledger` — existing + 7 new unit tests pass
- `cargo nextest run -p irys-chain-tests -E 'test(cascade) | test(ledger_expiry) | test(term_ledger_expiry) | test(perm_ledger_expiry) | test(term_balance)'` — 31 tests pass (cascade + expiry + fee distribution + balance + pricing + reorg)
- `cargo fmt --all --check`, `cargo clippy --workspace --tests --all-targets`, `typos` — all clean

## Follow-ups (not in this PR)

If Cascade activation ever flips Submit/perm ledgers to last-write timing for *all* existing data, the gate-off `term_ledger_expiry`/`perm_ledger_expiry` tests encode allocation-time expectations and would need rewriting, plus a one-time retroactive `last_height` backfill from the block index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved ledger retention/expiry logic to align fee settlement and recycling outcomes with late writes and Cascade activation timing across ledgers.
  * Added more precise tracking of per-ledger chunk totals within a block for expiry/fee calculations.

* **Bug Fixes**
  * Prevented already-expired slots from being refreshed/resurrected.
  * Corrected Cascade-gated inclusion/exclusion for expiring slot sets, including rescued-slot reward/refund behavior.
  * Hardened slot touching against boundary, zero-chunk, and allocation-lag scenarios without panics.

* **Tests**
  * Expanded async validation coverage for term expiry, last-write retention, fee model vs actual recycle sets, and permanent-ledger behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->