### PR TITLE
refactor(vdf): replace VDF re-anchor with node restart - DO NOT MERGE

### DIFF
--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -26,7 +26,7 @@ use lru::LruCache;
 use reth::tasks::shutdown::Shutdown;
 use std::{
     num::NonZeroUsize,
-    sync::{Arc, RwLock},
+    sync::{Arc, RwLock, atomic::AtomicU64},
     time::SystemTime,
 };
 use tokio::sync::{mpsc::UnboundedReceiver, oneshot};
@@ -125,6 +125,11 @@ pub struct BlockTreeServiceInner {
     block_migration_service: BlockMigrationService,
     /// Chain sync state for diagnostics
     pub chain_sync_state: ChainSyncState,
+    /// Shared live VDF global-step counter (kept current by the VDF thread). Read only by the
+    /// partition-recovery restart gate to decide whether a deep reorg actually poisoned the VDF
+    /// buffer — i.e. whether the live step (which free-runs ahead of blocks) crossed a reset
+    /// boundary whose reset seed diverges between the forks.
+    vdf_global_step: Arc<AtomicU64>,
     /// Bounded LRU of block_hashes recently discarded due to a soft-internal
     /// `InternalFailure` (eviction race, payload-cache miss, parent snapshot
     /// pruned). Value is the reason tag captured at discard time.
@@ -325,6 +330,7 @@ impl BlockTreeService {
         block_migration_service: BlockMigrationService,
         cache: Arc<RwLock<BlockTree>>,
         lifecycle_timestamps: Arc<BlockTreeLifecycleTimestamps>,
+        vdf_global_step: Arc<AtomicU64>,
         runtime_handle: tokio::runtime::Handle,
     ) -> TokioServiceHandle {
         info!("Spawning block tree service");
@@ -349,6 +355,7 @@ impl BlockTreeService {
                         config,
                         service_senders,
                         chain_sync_state,
+                        vdf_global_step,
                         recent_soft_internal_discards: LruCache::new(
                             NonZeroUsize::new(SOFT_INTERNAL_DISCARD_LRU_CAPACITY).unwrap(),
                         ),
@@ -1068,18 +1075,55 @@ impl BlockTreeServiceInner {
                         self.block_migration_service
                             .recover_from_network_partition(fork_height)?;
 
-                        // The minority fork may have crossed a VDF reset boundary, leaving the
-                        // VDF loop's running hash and the shared step buffer poisoned with reset
-                        // entropy pinned by an orphaned block. Signal the VDF supervisor to
-                        // re-anchor to the new canonical tip and restart; it rebuilds the step
-                        // buffer from the block tree's canonical chain. (The index rollback above
-                        // is independent — it only reverts the orphaned fork's storage/supply side
-                        // effects; the VDF rebuild does not read the index.) See
+                        // Heal the VDF buffer ONLY when this recovery actually poisoned it. VDF
+                        // steps BETWEEN reset boundaries are a block-independent SHA chain, so a deep
+                        // reorg that crossed no reset boundary leaves the buffer bit-identical to the
+                        // canonical lineage — no heal needed. The reset seed applied at a boundary is
+                        // pinned by the rotation block at `boundary - reset_frequency`, and the two
+                        // forks pin DIFFERENT seeds only once that rotation block lies ABOVE the LCA
+                        // — i.e. at the SECOND reset boundary above the LCA (the first boundary's
+                        // rotation block is at/below the shared LCA, so both forks share its seed).
+                        // The VDF free-runs AHEAD of blocks, so we test the LIVE step counter (not
+                        // the orphaned blocks): the buffer is poisoned iff it reached that second
+                        // boundary on this (minority) lineage.
+                        //
+                        // Only then do we pay for a heal — a controlled WHOLE-NODE restart. The block
+                        // index was just truncated to the fork parent (the `?` above), so on relaunch
+                        // the cold-start path (`create_state` over the truncated index, then
+                        // trusted-peer fast-forward) rebuilds correct VDF state. Cancelling is
+                        // infallible and idempotent; the lifecycle `select!` maps this token to
+                        // ShutdownReason::PartitionRecoveryRestart, which exits with a distinct code so
+                        // a supervisor relaunches the node. Buffer poisoning is NOT a consensus-safety
+                        // issue (validation resolves VDF steps from each block's own fork-local
+                        // lineage, never the live buffer) — it degrades only this node's mining, which
+                        // is why a non-boundary deep reorg needs neither heal nor restart. See
                         // design/docs/vdf-partition-recovery-reanchor.md.
-                        if let Err(e) = self.service_senders.vdf_reanchor.send(()) {
-                            error!(
-                                "Failed to signal VDF re-anchor after partition recovery: {e}. \
-                                 The VDF buffer may stay poisoned until restart."
+                        let reset_frequency = self.config.consensus.vdf.reset_frequency as u64;
+                        let lca_step = fork_block.vdf_limiter_info.global_step_number;
+                        // The second reset boundary above the LCA: the first boundary whose reset
+                        // seed can diverge between the forks.
+                        let first_divergent_boundary =
+                            (lca_step / reset_frequency + 2) * reset_frequency;
+                        let live_vdf_step = self
+                            .vdf_global_step
+                            .load(std::sync::atomic::Ordering::Relaxed);
+                        if live_vdf_step >= first_divergent_boundary {
+                            warn!(
+                                live_vdf_step,
+                                lca_step,
+                                first_divergent_boundary,
+                                "Partition recovery crossed a divergent-seed VDF reset boundary; \
+                                 requesting a controlled restart to rebuild VDF state from the \
+                                 canonical chain on relaunch"
+                            );
+                            self.service_senders.partition_recovery_restart.cancel();
+                        } else {
+                            debug!(
+                                live_vdf_step,
+                                lca_step,
+                                first_divergent_boundary,
+                                "Partition recovery did not reach a divergent-seed reset boundary; \
+                                 the VDF buffer is unpoisoned, so no restart is needed"
                             );
                         }
                     }
@@ -1989,6 +2033,7 @@ mod tests {
                 service_senders,
                 block_migration_service,
                 chain_sync_state,
+                vdf_global_step: Arc::new(AtomicU64::new(0)),
                 recent_soft_internal_discards: LruCache::new(
                     NonZeroUsize::new(SOFT_INTERNAL_DISCARD_LRU_CAPACITY).unwrap(),
                 ),

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -1071,9 +1071,11 @@ impl BlockTreeServiceInner {
                         // The minority fork may have crossed a VDF reset boundary, leaving the
                         // VDF loop's running hash and the shared step buffer poisoned with reset
                         // entropy pinned by an orphaned block. Signal the VDF supervisor to
-                        // re-anchor to the (now-truncated) canonical index and restart. Sent
-                        // strictly AFTER the index truncation above so the rebuild reads the
-                        // canonical chain. See design/docs/vdf-partition-recovery-reanchor.md.
+                        // re-anchor to the new canonical tip and restart; it rebuilds the step
+                        // buffer from the block tree's canonical chain. (The index rollback above
+                        // is independent — it only reverts the orphaned fork's storage/supply side
+                        // effects; the VDF rebuild does not read the index.) See
+                        // design/docs/vdf-partition-recovery-reanchor.md.
                         if let Err(e) = self.service_senders.vdf_reanchor.send(()) {
                             error!(
                                 "Failed to signal VDF re-anchor after partition recovery: {e}. \

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -1067,6 +1067,19 @@ impl BlockTreeServiceInner {
                         // proceeding with the new canonical chain.
                         self.block_migration_service
                             .recover_from_network_partition(fork_height)?;
+
+                        // The minority fork may have crossed a VDF reset boundary, leaving the
+                        // VDF loop's running hash and the shared step buffer poisoned with reset
+                        // entropy pinned by an orphaned block. Signal the VDF supervisor to
+                        // re-anchor to the (now-truncated) canonical index and restart. Sent
+                        // strictly AFTER the index truncation above so the rebuild reads the
+                        // canonical chain. See design/docs/vdf-partition-recovery-reanchor.md.
+                        if let Err(e) = self.service_senders.vdf_reanchor.send(()) {
+                            error!(
+                                "Failed to signal VDF re-anchor after partition recovery: {e}. \
+                                 The VDF buffer may stay poisoned until restart."
+                            );
+                        }
                     }
 
                     metrics::record_reorg();

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -1107,7 +1107,15 @@ impl BlockTreeServiceInner {
                         let live_vdf_step = self
                             .vdf_global_step
                             .load(std::sync::atomic::Ordering::Relaxed);
-                        if live_vdf_step >= first_divergent_boundary {
+                        // `+ 1` is a one-step TOCTOU margin. The VDF loop runs on another thread and
+                        // publishes its step via a `Relaxed` store only AFTER it has already read the
+                        // (possibly minority) reset seed for the iteration that crosses the boundary.
+                        // Sampling the live counter here can therefore lag the loop's committed seed by
+                        // up to one step: a node observed at `first_divergent_boundary - 1` may still
+                        // be about to fold the minority seed at the boundary, so treat it as poisoned.
+                        // Over-triggering costs only a (rare) extra restart; under-triggering would
+                        // silently strand the buffer poisoned with no other heal.
+                        if live_vdf_step + 1 >= first_divergent_boundary {
                             warn!(
                                 live_vdf_step,
                                 lca_step,

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -39,7 +39,7 @@ use irys_types::{CommitmentTypeV2, IrysTransactionCommon, VersionDiscriminant as
 use irys_types::{IngressProof, LedgerChunkOffset, get_ingress_proofs};
 use irys_types::{IrysTransactionId, u256_from_le_bytes as hash_to_number};
 use irys_vdf::last_step_checkpoints_is_valid;
-use irys_vdf::state::VdfStateReadonly;
+use irys_vdf::state::{VdfStateReadonly, build_fork_local_view};
 use itertools::*;
 use nodit::InclusiveInterval as _;
 use openssl::sha;
@@ -3289,6 +3289,66 @@ pub async fn recall_recall_range_is_valid(
         &block.poa.partition_hash,
     )
     .map_err(RecallRangeError::Mismatch)
+}
+
+/// Build a transient VDF step view covering `block`'s recall-range window
+/// `[reset_step_number ..= global_step_number]`, sourced from the block's OWN lineage (its
+/// ancestors' recorded steps, walked through the block tree) rather than this node's live VDF
+/// buffer.
+///
+/// Used to re-validate the recall range of a block on a competing fork whose post-boundary steps
+/// differ from the (possibly poisoned) local buffer — without trusting that buffer. This is the
+/// single fork-aware step-resolution seam for recall-range validation; it reuses
+/// `irys_vdf::state::build_fork_local_view`. The recall window is only one reset interval wide (a
+/// few blocks back to the last reset boundary), all of which are in-tree for a reorg representable
+/// within `block_tree_depth`.
+pub(crate) fn build_fork_local_recall_view(
+    block: &IrysBlockHeader,
+    config: &ConsensusConfig,
+    block_tree: &BlockTreeReadGuard,
+) -> eyre::Result<VdfStateReadonly> {
+    let global_step = block.vdf_limiter_info.global_step_number;
+    let reset_step_number = irys_efficient_sampling::reset_step_number(global_step, config);
+    let capacity = global_step
+        .saturating_sub(reset_step_number)
+        .saturating_add(1) as usize;
+    build_fork_local_view(block, capacity, |hash| {
+        block_tree.read().get_block(hash).cloned().ok_or_else(|| {
+            eyre::eyre!("ancestor {hash} not in block tree for fork-local recall view")
+        })
+    })
+}
+
+/// Build a transient VDF step view sized to include `block`'s *previous* step
+/// (`first_step_number - 1`), sourced from the block's OWN lineage (its ancestors' recorded steps,
+/// walked through the block tree) rather than this node's live VDF buffer.
+///
+/// Used by the previous-step continuity check in `ensure_vdf_is_valid` so a node recovering from a
+/// network partition can validate the canonical fork it must adopt even while its live buffer still
+/// holds the poisoned minority lineage past a reset boundary. The partition-recovery re-anchor is
+/// signalled at reorg-detect time but applied asynchronously by the VDF supervisor; a canonical
+/// straggler block whose previous step lands on the divergent boundary and is validated in that
+/// window would otherwise be rejected as terminally `Invalid` with no retry. Unlike the recall
+/// view, this also covers the previous step when it sits *below* the block's reset boundary (a
+/// boundary-crossing block), so `get_step(first_step - 1)` is always in range. Reuses
+/// `irys_vdf::state::build_fork_local_view` — the single fork-aware step-resolution seam.
+pub(crate) fn build_fork_local_step_view(
+    block: &IrysBlockHeader,
+    config: &ConsensusConfig,
+    block_tree: &BlockTreeReadGuard,
+) -> eyre::Result<VdfStateReadonly> {
+    let global_step = block.vdf_limiter_info.global_step_number;
+    let reset_step_number = irys_efficient_sampling::reset_step_number(global_step, config);
+    let prev_step = block.vdf_limiter_info.first_step_number().saturating_sub(1);
+    // Cover from the lower of {reset boundary, previous step} up to the block's global step so the
+    // previous step is in range even when the block crosses a reset boundary.
+    let lower = reset_step_number.min(prev_step);
+    let capacity = global_step.saturating_sub(lower).saturating_add(1) as usize;
+    build_fork_local_view(block, capacity, |hash| {
+        block_tree.read().get_block(hash).cloned().ok_or_else(|| {
+            eyre::eyre!("ancestor {hash} not in block tree for fork-local step view")
+        })
+    })
 }
 
 pub fn get_recall_range(

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -3306,17 +3306,17 @@ pub(crate) fn build_fork_local_recall_view(
     block: &IrysBlockHeader,
     config: &ConsensusConfig,
     block_tree: &BlockTreeReadGuard,
+    db: &DatabaseProvider,
 ) -> eyre::Result<VdfStateReadonly> {
     let global_step = block.vdf_limiter_info.global_step_number;
     let reset_step_number = irys_efficient_sampling::reset_step_number(global_step, config);
-    let capacity = global_step
-        .saturating_sub(reset_step_number)
-        .saturating_add(1) as usize;
-    build_fork_local_view(block, capacity, |hash| {
-        block_tree.read().get_block(hash).cloned().ok_or_else(|| {
-            eyre::eyre!("ancestor {hash} not in block tree for fork-local recall view")
-        })
-    })
+    let capacity = usize::try_from(
+        global_step
+            .saturating_sub(reset_step_number)
+            .saturating_add(1),
+    )
+    .map_err(|_| eyre::eyre!("fork-local recall view capacity exceeds usize"))?;
+    build_fork_local_view_from_tree_or_db(block, capacity, block_tree, db, "fork-local recall view")
 }
 
 /// Build a transient VDF step view sized to include `block`'s *previous* step
@@ -3336,6 +3336,7 @@ pub(crate) fn build_fork_local_step_view(
     block: &IrysBlockHeader,
     config: &ConsensusConfig,
     block_tree: &BlockTreeReadGuard,
+    db: &DatabaseProvider,
 ) -> eyre::Result<VdfStateReadonly> {
     let global_step = block.vdf_limiter_info.global_step_number;
     let reset_step_number = irys_efficient_sampling::reset_step_number(global_step, config);
@@ -3343,11 +3344,28 @@ pub(crate) fn build_fork_local_step_view(
     // Cover from the lower of {reset boundary, previous step} up to the block's global step so the
     // previous step is in range even when the block crosses a reset boundary.
     let lower = reset_step_number.min(prev_step);
-    let capacity = global_step.saturating_sub(lower).saturating_add(1) as usize;
+    let capacity = usize::try_from(global_step.saturating_sub(lower).saturating_add(1))
+        .map_err(|_| eyre::eyre!("fork-local step view capacity exceeds usize"))?;
+    build_fork_local_view_from_tree_or_db(block, capacity, block_tree, db, "fork-local step view")
+}
+
+fn build_fork_local_view_from_tree_or_db(
+    block: &IrysBlockHeader,
+    capacity: usize,
+    block_tree: &BlockTreeReadGuard,
+    db: &DatabaseProvider,
+    context: &'static str,
+) -> eyre::Result<VdfStateReadonly> {
+    let tx = db
+        .tx()
+        .map_err(|e| eyre::eyre!("{context}: opening db tx failed: {e}"))?;
     build_fork_local_view(block, capacity, |hash| {
-        block_tree.read().get_block(hash).cloned().ok_or_else(|| {
-            eyre::eyre!("ancestor {hash} not in block tree for fork-local step view")
-        })
+        if let Some(header) = block_tree.read().get_block(hash).cloned() {
+            return Ok(header);
+        }
+        irys_database::block_header_by_hash(&tx, hash, false)
+            .map_err(|e| eyre::eyre!("{context}: header lookup failed for {hash}: {e}"))?
+            .ok_or_else(|| eyre::eyre!("{context}: missing ancestor {hash} in block tree and db"))
     })
 }
 
@@ -7866,6 +7884,113 @@ mod tests {
             !matches!(err.classify(), ErrorClass::Consensus),
             "DatabaseError must not be Consensus"
         );
+    }
+
+    fn fork_local_test_header(
+        height: u64,
+        hash: u8,
+        prev_hash: u8,
+        global_step_number: u64,
+        steps: &[u8],
+    ) -> IrysBlockHeader {
+        let mut header = IrysBlockHeader::new_mock_header();
+        header.height = height;
+        header.block_hash = H256::repeat_byte(hash);
+        header.previous_block_hash = H256::repeat_byte(prev_hash);
+        header.vdf_limiter_info.global_step_number = global_step_number;
+        header.vdf_limiter_info.steps =
+            H256List(steps.iter().map(|b| H256::repeat_byte(*b)).collect());
+        header
+    }
+
+    fn fork_local_test_db() -> eyre::Result<(DatabaseProvider, TempDir)> {
+        use irys_database::{IrysDatabaseArgs as _, open_or_create_db, tables::IrysTables};
+        use reth_db::mdbx::DatabaseArguments;
+
+        let tmp = TempDirBuilder::new().build();
+        let env = open_or_create_db(
+            tmp.path(),
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        Ok((DatabaseProvider(Arc::new(env)), tmp))
+    }
+
+    #[test]
+    fn fork_local_step_view_falls_back_to_db_and_covers_prev_step_below_reset_boundary() -> eyre::Result<()> {
+        use irys_database::tables::IrysBlockHeaders;
+        use reth_db::transaction::DbTxMut as _;
+
+        let (db, _tmp) = fork_local_test_db()?;
+        let block_tree_guard = dummy_block_tree_guard(&ConsensusConfig::testing());
+        let consensus = NodeConfig::testing().with_consensus(|c| {
+            c.num_chunks_in_partition = 4;
+            c.num_chunks_in_recall_range = 1;
+        }).consensus_config();
+
+        // reset step for global step 5 with interval 4 is 5, while the previous step of this
+        // block is 3. The step view must therefore include step 3 from the parent lineage.
+        let parent = fork_local_test_header(0, 0x10, 0xFF, 3, &[0x31]);
+        let block = fork_local_test_header(1, 0x11, 0x10, 5, &[0x41, 0x51]);
+
+        db.update(|tx| -> eyre::Result<()> {
+            tx.put::<IrysBlockHeaders>(parent.block_hash, parent.clone().into())?;
+            Ok(())
+        })??;
+
+        let view = build_fork_local_step_view(
+            &block,
+            &consensus,
+            &block_tree_guard,
+            &db,
+        )?;
+
+        assert_eq!(view.get_step(3)?, H256::repeat_byte(0x31));
+        assert_eq!(view.get_step(4)?, H256::repeat_byte(0x41));
+        assert_eq!(view.get_step(5)?, H256::repeat_byte(0x51));
+        Ok(())
+    }
+
+    #[test]
+    fn fork_local_recall_view_falls_back_to_db_for_reset_window() -> eyre::Result<()> {
+        use irys_database::tables::IrysBlockHeaders;
+        use reth_db::transaction::DbTxMut as _;
+
+        let (db, _tmp) = fork_local_test_db()?;
+        let block_tree_guard = dummy_block_tree_guard(&ConsensusConfig::testing());
+        let consensus = NodeConfig::testing().with_consensus(|c| {
+            c.num_chunks_in_partition = 4;
+            c.num_chunks_in_recall_range = 1;
+        }).consensus_config();
+
+        // reset step for global step 8 with interval 4 is 5, so recall validation needs steps
+        // 5..=8. Only the tip block is supplied directly; the older half of the window must come
+        // from the DB fallback.
+        let parent = fork_local_test_header(1, 0x20, 0xFF, 6, &[0x51, 0x61]);
+        let block = fork_local_test_header(2, 0x21, 0x20, 8, &[0x71, 0x81]);
+
+        db.update(|tx| -> eyre::Result<()> {
+            tx.put::<IrysBlockHeaders>(parent.block_hash, parent.clone().into())?;
+            Ok(())
+        })??;
+
+        let view = build_fork_local_recall_view(
+            &block,
+            &consensus,
+            &block_tree_guard,
+            &db,
+        )?;
+
+        assert_eq!(
+            view.get_steps(ii(5, 8))?.0,
+            vec![
+                H256::repeat_byte(0x51),
+                H256::repeat_byte(0x61),
+                H256::repeat_byte(0x71),
+                H256::repeat_byte(0x81),
+            ]
+        );
+        Ok(())
     }
 }
 

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -7917,16 +7917,19 @@ mod tests {
     }
 
     #[test]
-    fn fork_local_step_view_falls_back_to_db_and_covers_prev_step_below_reset_boundary() -> eyre::Result<()> {
+    fn fork_local_step_view_falls_back_to_db_and_covers_prev_step_below_reset_boundary()
+    -> eyre::Result<()> {
         use irys_database::tables::IrysBlockHeaders;
         use reth_db::transaction::DbTxMut as _;
 
         let (db, _tmp) = fork_local_test_db()?;
         let block_tree_guard = dummy_block_tree_guard(&ConsensusConfig::testing());
-        let consensus = NodeConfig::testing().with_consensus(|c| {
-            c.num_chunks_in_partition = 4;
-            c.num_chunks_in_recall_range = 1;
-        }).consensus_config();
+        let consensus = NodeConfig::testing()
+            .with_consensus(|c| {
+                c.num_chunks_in_partition = 4;
+                c.num_chunks_in_recall_range = 1;
+            })
+            .consensus_config();
 
         // reset step for global step 5 with interval 4 is 5, while the previous step of this
         // block is 3. The step view must therefore include step 3 from the parent lineage.
@@ -7938,12 +7941,7 @@ mod tests {
             Ok(())
         })??;
 
-        let view = build_fork_local_step_view(
-            &block,
-            &consensus,
-            &block_tree_guard,
-            &db,
-        )?;
+        let view = build_fork_local_step_view(&block, &consensus, &block_tree_guard, &db)?;
 
         assert_eq!(view.get_step(3)?, H256::repeat_byte(0x31));
         assert_eq!(view.get_step(4)?, H256::repeat_byte(0x41));
@@ -7958,10 +7956,12 @@ mod tests {
 
         let (db, _tmp) = fork_local_test_db()?;
         let block_tree_guard = dummy_block_tree_guard(&ConsensusConfig::testing());
-        let consensus = NodeConfig::testing().with_consensus(|c| {
-            c.num_chunks_in_partition = 4;
-            c.num_chunks_in_recall_range = 1;
-        }).consensus_config();
+        let consensus = NodeConfig::testing()
+            .with_consensus(|c| {
+                c.num_chunks_in_partition = 4;
+                c.num_chunks_in_recall_range = 1;
+            })
+            .consensus_config();
 
         // reset step for global step 8 with interval 4 is 5, so recall validation needs steps
         // 5..=8. Only the tip block is supplied directly; the older half of the window must come
@@ -7974,12 +7974,7 @@ mod tests {
             Ok(())
         })??;
 
-        let view = build_fork_local_recall_view(
-            &block,
-            &consensus,
-            &block_tree_guard,
-            &db,
-        )?;
+        let view = build_fork_local_recall_view(&block, &consensus, &block_tree_guard, &db)?;
 
         assert_eq!(
             view.get_steps(ii(5, 8))?.0,

--- a/crates/actors/src/mining_bus.rs
+++ b/crates/actors/src/mining_bus.rs
@@ -25,12 +25,6 @@ pub enum MiningBroadcastEvent {
     Seed(BroadcastMiningSeed),
     Difficulty(BroadcastDifficultyUpdate),
     PartitionsExpiration(BroadcastPartitionsExpiration),
-    /// The VDF was re-anchored (deep partition recovery rewound and rebuilt the step buffer at a
-    /// lower global step). Partition miners must discard their stateful efficient-sampling
-    /// recall-range rotation and rebuild it from the re-anchored steps on the next seed; otherwise
-    /// they mine recall ranges computed from the old, now-discarded lineage (which then fail
-    /// validation). Carries no payload — the reset is unconditional.
-    Reanchored,
 }
 
 #[derive(Debug)]
@@ -109,16 +103,6 @@ impl MiningBus {
     pub fn send_partitions_expiration(&self, msg: BroadcastPartitionsExpiration) -> usize {
         debug!(custom.msg = ?msg.0, "Broadcasting expiration, expired partition hashes");
         self.send_event(Arc::new(MiningBroadcastEvent::PartitionsExpiration(msg)))
-    }
-
-    /// Notify all subscribers that the VDF re-anchored (partition recovery) so they reset any
-    /// step-derived state — specifically partition mining's efficient-sampling recall-range
-    /// rotation, which is stateful and would otherwise carry the pre-re-anchor lineage forward.
-    pub fn send_reanchor(&self) -> usize {
-        info!(
-            "Broadcast Mining: VDF re-anchored; signalling partition miners to reset recall-range state"
-        );
-        self.send_event(Arc::new(MiningBroadcastEvent::Reanchored))
     }
 }
 

--- a/crates/actors/src/mining_bus.rs
+++ b/crates/actors/src/mining_bus.rs
@@ -25,6 +25,12 @@ pub enum MiningBroadcastEvent {
     Seed(BroadcastMiningSeed),
     Difficulty(BroadcastDifficultyUpdate),
     PartitionsExpiration(BroadcastPartitionsExpiration),
+    /// The VDF was re-anchored (deep partition recovery rewound and rebuilt the step buffer at a
+    /// lower global step). Partition miners must discard their stateful efficient-sampling
+    /// recall-range rotation and rebuild it from the re-anchored steps on the next seed; otherwise
+    /// they mine recall ranges computed from the old, now-discarded lineage (which then fail
+    /// validation). Carries no payload — the reset is unconditional.
+    Reanchored,
 }
 
 #[derive(Debug)]
@@ -103,6 +109,16 @@ impl MiningBus {
     pub fn send_partitions_expiration(&self, msg: BroadcastPartitionsExpiration) -> usize {
         debug!(custom.msg = ?msg.0, "Broadcasting expiration, expired partition hashes");
         self.send_event(Arc::new(MiningBroadcastEvent::PartitionsExpiration(msg)))
+    }
+
+    /// Notify all subscribers that the VDF re-anchored (partition recovery) so they reset any
+    /// step-derived state — specifically partition mining's efficient-sampling recall-range
+    /// rotation, which is stateful and would otherwise carry the pre-re-anchor lineage forward.
+    pub fn send_reanchor(&self) -> usize {
+        info!(
+            "Broadcast Mining: VDF re-anchored; signalling partition miners to reset recall-range state"
+        );
+        self.send_event(Arc::new(MiningBroadcastEvent::Reanchored))
     }
 }
 

--- a/crates/actors/src/partition_mining_service.rs
+++ b/crates/actors/src/partition_mining_service.rs
@@ -118,8 +118,9 @@ impl PartitionMiningServiceInner {
     /// stale `last_step_num + 1`.
     fn handle_reanchor(&mut self) {
         debug!("VDF re-anchored: resetting partition recall-range rotation state");
-        self.ranges.reinitialize();
-        self.ranges.last_step_num = 0;
+        self.ranges = Ranges::new(self.ranges.num_recall_ranges_in_partition).expect(
+            "existing partition miner must already have a valid non-zero recall-range count",
+        );
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
@@ -499,5 +500,87 @@ impl PartitionMiningService {
             }
         }
         info!("Partition mining service stopped");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::build_test_service_senders;
+    use irys_domain::{StorageModule, StorageModuleInfo};
+    use irys_testing_utils::tempfile::TempDir;
+    use irys_testing_utils::utils::TempDirBuilder;
+    use irys_types::{
+        Config, NodeConfig, PartitionChunkOffset, partition::PartitionAssignment,
+        partition_chunk_offset_ie,
+    };
+    use irys_vdf::state::test_helpers::mocked_vdf_service;
+    use std::sync::atomic::AtomicU64;
+
+    fn test_inner() -> eyre::Result<(PartitionMiningServiceInner, TempDir)> {
+        let tmp = TempDirBuilder::new().build();
+        let mut node_config = NodeConfig::testing();
+        node_config.base_directory = tmp.path().to_path_buf();
+        node_config.consensus.get_mut().num_chunks_in_partition = 4;
+        node_config.consensus.get_mut().num_chunks_in_recall_range = 1;
+        let config = Config::new_with_random_peer_id(node_config);
+        let storage_module_info = StorageModuleInfo {
+            id: 0,
+            partition_assignment: Some(PartitionAssignment::default()),
+            submodules: vec![(
+                partition_chunk_offset_ie!(0, config.consensus.num_chunks_in_partition as u32),
+                "partition-miner-test".into(),
+            )],
+        };
+        let storage_module = Arc::new(StorageModule::new(&storage_module_info, &config)?);
+        let (service_senders, _receivers) = build_test_service_senders();
+
+        let inner = PartitionMiningServiceInner::new(
+            &config,
+            service_senders,
+            storage_module,
+            false,
+            VdfStateReadonly::new(mocked_vdf_service(&config)),
+            Arc::new(AtomicU64::new(0)),
+            U256::zero(),
+        );
+
+        // Return the tempdir so the caller keeps it alive for the storage module's lifetime.
+        Ok((inner, tmp))
+    }
+
+    #[test]
+    fn reanchor_clears_stale_recall_range_cache() -> eyre::Result<()> {
+        let partition_hash = irys_types::H256::repeat_byte(0xAA);
+        let old_seed = irys_types::H256::repeat_byte(0x11);
+        let new_seed = irys_types::H256::repeat_byte(0x44);
+        let stale_step = 21_u64;
+
+        let (mut stale_inner, _stale_tmp) = test_inner()?;
+        for step in 1..=25 {
+            stale_inner.test_get_recall_range(step, old_seed, partition_hash);
+        }
+        let stale_cached = stale_inner.test_get_recall_range(stale_step, old_seed, partition_hash);
+
+        let (mut fresh_new_lineage, _fresh_tmp) = test_inner()?;
+        for step in 1..=stale_step {
+            fresh_new_lineage.test_get_recall_range(step, new_seed, partition_hash);
+        }
+        let expected_after_reanchor =
+            fresh_new_lineage.test_get_recall_range(stale_step, new_seed, partition_hash);
+
+        assert_ne!(
+            stale_cached, expected_after_reanchor,
+            "test precondition failed: old and new lineages must diverge at the retained cached step"
+        );
+
+        stale_inner.handle_reanchor();
+        let rebuilt = stale_inner.test_get_recall_range(stale_step, new_seed, partition_hash);
+
+        assert_eq!(
+            rebuilt, expected_after_reanchor,
+            "re-anchor must discard retained cached recall ranges and rebuild from the new lineage"
+        );
+        Ok(())
     }
 }

--- a/crates/actors/src/partition_mining_service.rs
+++ b/crates/actors/src/partition_mining_service.rs
@@ -158,12 +158,13 @@ impl PartitionMiningServiceInner {
     ) -> eyre::Result<u64> {
         let next_ranges_step = self.ranges.last_step_num + 1; // next consecutive step expected to be calculated by ranges
         // Fast path ONLY for the exact next consecutive step. Anything else — `step` AHEAD of the
-        // iterator (a gap) OR BEHIND it (a VDF re-anchor rewound the steps below the iterator's
-        // stateful rotation position, e.g. partition-recovery) — must rebuild the rotation rather
-        // than advance it. The previous `>=` fast-pathed every `step <= last_step_num + 1`, which
-        // silently computed a WRONG recall range after a re-anchor rewind (the rotation state was
-        // for a higher, now-discarded step), making the node mine blocks whose recall range no
-        // longer matches its (re-anchored) VDF steps.
+        // iterator (a gap) OR BEHIND it (a backward step relative to the iterator's stateful
+        // rotation position) — must rebuild the rotation rather than advance it. The previous `>=`
+        // fast-pathed every `step <= last_step_num + 1`, which would silently compute a WRONG recall
+        // range for a backward step (the rotation state was for a higher step). Backward steps no
+        // longer occur in-process (`store_step` is forward-only, and the deleted in-place VDF
+        // re-anchor was the only writer that ever rewound `global_step`); this stays as defensive
+        // handling.
         if next_ranges_step == step {
             debug!("Step {} is the next consecutive step", step);
         } else {
@@ -179,8 +180,8 @@ impl PartitionMiningServiceInner {
             );
             // Reinitialize when the iterator cannot incrementally reach `step` from
             // `next_ranges_step`: either the reset boundary is past where the iterator is (a
-            // forward gap across a boundary), or the iterator is AHEAD of `step` (a backward
-            // re-anchor rewind — its rotation must be rebuilt from the boundary, not advanced).
+            // forward gap across a boundary), or the iterator is AHEAD of `step` (a backward step —
+            // defensive; its rotation must be rebuilt from the boundary, not advanced).
             let start = if reset_step > next_ranges_step || step < next_ranges_step {
                 debug!(
                     "Step {} not incrementally reachable from last processed step {}, reinitializing ranges ...",

--- a/crates/actors/src/partition_mining_service.rs
+++ b/crates/actors/src/partition_mining_service.rs
@@ -106,6 +106,22 @@ impl PartitionMiningServiceInner {
         self.difficulty = new_diff;
     }
 
+    /// Reset the stateful efficient-sampling recall-range rotation after a VDF re-anchor (deep
+    /// partition recovery rewound and rebuilt the step buffer at a lower global step). The rotation
+    /// tracks `last_step_num` and assumes forward-only progress, so a re-anchor leaves it pointing
+    /// at the old, discarded lineage; mining against it produces recall ranges that no longer match
+    /// the (re-anchored) VDF steps and get rejected by validation. Clearing it forces the next
+    /// `get_recall_range` to rebuild the rotation from the re-anchored steps (back to the nearest
+    /// reset boundary). Unconditional + idempotent, so it is safe even when this partition is idle
+    /// or unassigned. Belt-and-suspenders with `get_recall_range`'s own backward-jump detection,
+    /// which alone misses the case where mining resumes only after the VDF has climbed back to the
+    /// stale `last_step_num + 1`.
+    fn handle_reanchor(&mut self) {
+        debug!("VDF re-anchored: resetting partition recall-range rotation state");
+        self.ranges.reinitialize();
+        self.ranges.last_step_num = 0;
+    }
+
     #[tracing::instrument(level = "trace", skip_all)]
     fn handle_partitions_expiration(&mut self, expired: &H256List) {
         if let Some(partition_hash) = self.storage_module.partition_hash()
@@ -157,12 +173,19 @@ impl PartitionMiningServiceInner {
         partition_hash: &irys_types::H256,
     ) -> eyre::Result<u64> {
         let next_ranges_step = self.ranges.last_step_num + 1; // next consecutive step expected to be calculated by ranges
-        if next_ranges_step >= step {
-            debug!("Step {} already processed or next consecutive one", step);
+        // Fast path ONLY for the exact next consecutive step. Anything else — `step` AHEAD of the
+        // iterator (a gap) OR BEHIND it (a VDF re-anchor rewound the steps below the iterator's
+        // stateful rotation position, e.g. partition-recovery) — must rebuild the rotation rather
+        // than advance it. The previous `>=` fast-pathed every `step <= last_step_num + 1`, which
+        // silently computed a WRONG recall range after a re-anchor rewind (the rotation state was
+        // for a higher, now-discarded step), making the node mine blocks whose recall range no
+        // longer matches its (re-anchored) VDF steps.
+        if next_ranges_step == step {
+            debug!("Step {} is the next consecutive step", step);
         } else {
             debug!(
-                "Non consecutive step {} may need to reconstruct ranges",
-                step
+                "Non consecutive step {} (iterator at {}) may need to reconstruct ranges",
+                step, self.ranges.last_step_num
             );
             // calculate the nearest step lower or equal to step where recall ranges are reinitialized, as this is the step from where ranges will be recalculated
             let reset_step = self.ranges.reset_step(step);
@@ -170,13 +193,17 @@ impl PartitionMiningServiceInner {
                 "Near reset step is {} num recall ranges in partition {}",
                 reset_step, self.ranges.num_recall_ranges_in_partition
             );
-            let start = if reset_step > next_ranges_step {
+            // Reinitialize when the iterator cannot incrementally reach `step` from
+            // `next_ranges_step`: either the reset boundary is past where the iterator is (a
+            // forward gap across a boundary), or the iterator is AHEAD of `step` (a backward
+            // re-anchor rewind — its rotation must be rebuilt from the boundary, not advanced).
+            let start = if reset_step > next_ranges_step || step < next_ranges_step {
                 debug!(
-                    "Step {} is too far ahead of last processed step {}, reinitializing ranges ...",
+                    "Step {} not incrementally reachable from last processed step {}, reinitializing ranges ...",
                     step, self.ranges.last_step_num
                 );
                 self.ranges.reinitialize();
-                self.ranges.last_step_num = reset_step - 1; // advance last step number calculated by ranges to (reset_step - 1), so ranges next step will be reset_step line
+                self.ranges.last_step_num = reset_step.saturating_sub(1); // advance last step number calculated by ranges to (reset_step - 1), so ranges next step will be reset_step line
                 reset_step
             } else {
                 next_ranges_step
@@ -458,6 +485,9 @@ impl PartitionMiningService {
                             }
                             MiningBroadcastEvent::PartitionsExpiration(BroadcastPartitionsExpiration(list)) => {
                                 self.state.handle_partitions_expiration(list);
+                            }
+                            MiningBroadcastEvent::Reanchored => {
+                                self.state.handle_reanchor();
                             }
                         },
                         None => {

--- a/crates/actors/src/partition_mining_service.rs
+++ b/crates/actors/src/partition_mining_service.rs
@@ -106,23 +106,6 @@ impl PartitionMiningServiceInner {
         self.difficulty = new_diff;
     }
 
-    /// Reset the stateful efficient-sampling recall-range rotation after a VDF re-anchor (deep
-    /// partition recovery rewound and rebuilt the step buffer at a lower global step). The rotation
-    /// tracks `last_step_num` and assumes forward-only progress, so a re-anchor leaves it pointing
-    /// at the old, discarded lineage; mining against it produces recall ranges that no longer match
-    /// the (re-anchored) VDF steps and get rejected by validation. Clearing it forces the next
-    /// `get_recall_range` to rebuild the rotation from the re-anchored steps (back to the nearest
-    /// reset boundary). Unconditional + idempotent, so it is safe even when this partition is idle
-    /// or unassigned. Belt-and-suspenders with `get_recall_range`'s own backward-jump detection,
-    /// which alone misses the case where mining resumes only after the VDF has climbed back to the
-    /// stale `last_step_num + 1`.
-    fn handle_reanchor(&mut self) {
-        debug!("VDF re-anchored: resetting partition recall-range rotation state");
-        self.ranges = Ranges::new(self.ranges.num_recall_ranges_in_partition).expect(
-            "existing partition miner must already have a valid non-zero recall-range count",
-        );
-    }
-
     #[tracing::instrument(level = "trace", skip_all)]
     fn handle_partitions_expiration(&mut self, expired: &H256List) {
         if let Some(partition_hash) = self.storage_module.partition_hash()
@@ -388,20 +371,6 @@ impl PartitionMiningServiceInner {
     }
 }
 
-#[cfg(test)]
-impl PartitionMiningServiceInner {
-    /// Test-only helper to expose recall-range computation without starting the service.
-    pub fn test_get_recall_range(
-        &mut self,
-        step: u64,
-        seed: irys_types::H256,
-        partition_hash: irys_types::H256,
-    ) -> u64 {
-        self.get_recall_range(step, &seed, &partition_hash)
-            .expect("test_get_recall_range failed")
-    }
-}
-
 /// Tokio service for partition mining
 #[derive(Debug)]
 pub struct PartitionMiningService {
@@ -487,9 +456,6 @@ impl PartitionMiningService {
                             MiningBroadcastEvent::PartitionsExpiration(BroadcastPartitionsExpiration(list)) => {
                                 self.state.handle_partitions_expiration(list);
                             }
-                            MiningBroadcastEvent::Reanchored => {
-                                self.state.handle_reanchor();
-                            }
                         },
                         None => {
                             warn!("Mining broadcaster channel closed; stopping service");
@@ -500,87 +466,5 @@ impl PartitionMiningService {
             }
         }
         info!("Partition mining service stopped");
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::test_helpers::build_test_service_senders;
-    use irys_domain::{StorageModule, StorageModuleInfo};
-    use irys_testing_utils::tempfile::TempDir;
-    use irys_testing_utils::utils::TempDirBuilder;
-    use irys_types::{
-        Config, NodeConfig, PartitionChunkOffset, partition::PartitionAssignment,
-        partition_chunk_offset_ie,
-    };
-    use irys_vdf::state::test_helpers::mocked_vdf_service;
-    use std::sync::atomic::AtomicU64;
-
-    fn test_inner() -> eyre::Result<(PartitionMiningServiceInner, TempDir)> {
-        let tmp = TempDirBuilder::new().build();
-        let mut node_config = NodeConfig::testing();
-        node_config.base_directory = tmp.path().to_path_buf();
-        node_config.consensus.get_mut().num_chunks_in_partition = 4;
-        node_config.consensus.get_mut().num_chunks_in_recall_range = 1;
-        let config = Config::new_with_random_peer_id(node_config);
-        let storage_module_info = StorageModuleInfo {
-            id: 0,
-            partition_assignment: Some(PartitionAssignment::default()),
-            submodules: vec![(
-                partition_chunk_offset_ie!(0, config.consensus.num_chunks_in_partition as u32),
-                "partition-miner-test".into(),
-            )],
-        };
-        let storage_module = Arc::new(StorageModule::new(&storage_module_info, &config)?);
-        let (service_senders, _receivers) = build_test_service_senders();
-
-        let inner = PartitionMiningServiceInner::new(
-            &config,
-            service_senders,
-            storage_module,
-            false,
-            VdfStateReadonly::new(mocked_vdf_service(&config)),
-            Arc::new(AtomicU64::new(0)),
-            U256::zero(),
-        );
-
-        // Return the tempdir so the caller keeps it alive for the storage module's lifetime.
-        Ok((inner, tmp))
-    }
-
-    #[test]
-    fn reanchor_clears_stale_recall_range_cache() -> eyre::Result<()> {
-        let partition_hash = irys_types::H256::repeat_byte(0xAA);
-        let old_seed = irys_types::H256::repeat_byte(0x11);
-        let new_seed = irys_types::H256::repeat_byte(0x44);
-        let stale_step = 21_u64;
-
-        let (mut stale_inner, _stale_tmp) = test_inner()?;
-        for step in 1..=25 {
-            stale_inner.test_get_recall_range(step, old_seed, partition_hash);
-        }
-        let stale_cached = stale_inner.test_get_recall_range(stale_step, old_seed, partition_hash);
-
-        let (mut fresh_new_lineage, _fresh_tmp) = test_inner()?;
-        for step in 1..=stale_step {
-            fresh_new_lineage.test_get_recall_range(step, new_seed, partition_hash);
-        }
-        let expected_after_reanchor =
-            fresh_new_lineage.test_get_recall_range(stale_step, new_seed, partition_hash);
-
-        assert_ne!(
-            stale_cached, expected_after_reanchor,
-            "test precondition failed: old and new lineages must diverge at the retained cached step"
-        );
-
-        stale_inner.handle_reanchor();
-        let rebuilt = stale_inner.test_get_recall_range(stale_step, new_seed, partition_hash);
-
-        assert_eq!(
-            rebuilt, expected_after_reanchor,
-            "re-anchor must discard retained cached recall ranges and rebuild from the new lineage"
-        );
-        Ok(())
     }
 }

--- a/crates/actors/src/services.rs
+++ b/crates/actors/src/services.rs
@@ -94,6 +94,8 @@ pub struct ServiceReceivers {
     pub chunk_migration: UnboundedReceiver<Traced<ChunkMigrationServiceMessage>>,
     pub mempool: UnboundedReceiver<Traced<MempoolServiceMessage>>,
     pub vdf_fast_forward: Receiver<Traced<VdfStep>>,
+    /// Re-anchor signal for the VDF supervisor thread (network-partition recovery).
+    pub vdf_reanchor: UnboundedReceiver<()>,
     pub storage_modules: UnboundedReceiver<Traced<StorageModuleServiceMessage>>,
     pub data_sync: UnboundedReceiver<Traced<DataSyncServiceMessage>>,
     pub gossip_broadcast: UnboundedReceiver<Traced<GossipBroadcastMessageV2>>,
@@ -116,6 +118,8 @@ pub struct ServiceSendersInner {
     pub chunk_migration: UnboundedSender<Traced<ChunkMigrationServiceMessage>>,
     pub mempool: UnboundedSender<Traced<MempoolServiceMessage>>,
     pub vdf_fast_forward: Sender<Traced<VdfStep>>,
+    /// Re-anchor signal for the VDF supervisor thread (network-partition recovery).
+    pub vdf_reanchor: UnboundedSender<()>,
     pub storage_modules: UnboundedSender<Traced<StorageModuleServiceMessage>>,
     pub data_sync: UnboundedSender<Traced<DataSyncServiceMessage>>,
     pub gossip_broadcast: UnboundedSender<Traced<GossipBroadcastMessageV2>>,
@@ -144,6 +148,7 @@ impl ServiceSendersInner {
             unbounded_channel::<Traced<MempoolServiceMessage>>();
         let (vdf_fast_forward_sender, vdf_fast_forward_receiver) =
             channel::<Traced<VdfStep>>(VDF_FAST_FORWARD_CHANNEL_CAPACITY);
+        let (vdf_reanchor_sender, vdf_reanchor_receiver) = unbounded_channel::<()>();
         let (sm_sender, sm_receiver) = unbounded_channel::<Traced<StorageModuleServiceMessage>>();
         let (ds_sender, ds_receiver) = unbounded_channel::<Traced<DataSyncServiceMessage>>();
         let (gossip_broadcast_sender, gossip_broadcast_receiver) =
@@ -172,6 +177,7 @@ impl ServiceSendersInner {
             chunk_migration: chunk_migration_sender,
             mempool: mempool_sender,
             vdf_fast_forward: vdf_fast_forward_sender,
+            vdf_reanchor: vdf_reanchor_sender,
             storage_modules: sm_sender,
             data_sync: ds_sender,
             gossip_broadcast: gossip_broadcast_sender,
@@ -193,6 +199,7 @@ impl ServiceSendersInner {
             chunk_migration: chunk_migration_receiver,
             mempool: mempool_receiver,
             vdf_fast_forward: vdf_fast_forward_receiver,
+            vdf_reanchor: vdf_reanchor_receiver,
             storage_modules: sm_receiver,
             data_sync: ds_receiver,
             gossip_broadcast: gossip_broadcast_receiver,

--- a/crates/actors/src/services.rs
+++ b/crates/actors/src/services.rs
@@ -22,6 +22,7 @@ use tokio::sync::{
     broadcast,
     mpsc::{Receiver, Sender, UnboundedReceiver, UnboundedSender, channel, unbounded_channel},
 };
+use tokio_util::sync::CancellationToken;
 
 const VDF_FAST_FORWARD_CHANNEL_CAPACITY: usize = 4_096;
 
@@ -94,8 +95,6 @@ pub struct ServiceReceivers {
     pub chunk_migration: UnboundedReceiver<Traced<ChunkMigrationServiceMessage>>,
     pub mempool: UnboundedReceiver<Traced<MempoolServiceMessage>>,
     pub vdf_fast_forward: Receiver<Traced<VdfStep>>,
-    /// Re-anchor signal for the VDF supervisor thread (network-partition recovery).
-    pub vdf_reanchor: UnboundedReceiver<()>,
     pub storage_modules: UnboundedReceiver<Traced<StorageModuleServiceMessage>>,
     pub data_sync: UnboundedReceiver<Traced<DataSyncServiceMessage>>,
     pub gossip_broadcast: UnboundedReceiver<Traced<GossipBroadcastMessageV2>>,
@@ -118,8 +117,12 @@ pub struct ServiceSendersInner {
     pub chunk_migration: UnboundedSender<Traced<ChunkMigrationServiceMessage>>,
     pub mempool: UnboundedSender<Traced<MempoolServiceMessage>>,
     pub vdf_fast_forward: Sender<Traced<VdfStep>>,
-    /// Re-anchor signal for the VDF supervisor thread (network-partition recovery).
-    pub vdf_reanchor: UnboundedSender<()>,
+    /// Cancelled by [`BlockTreeService`](crate::block_tree_service::BlockTreeService) after a deep
+    /// network-partition recovery to request a controlled process restart; the relaunch cold-syncs
+    /// the canonical chain and rebuilds VDF state. The lifecycle `select!` maps it to
+    /// `ShutdownReason::PartitionRecoveryRestart`. Replaces the former in-place VDF re-anchor signal.
+    /// See design/docs/vdf-partition-recovery-reanchor.md.
+    pub partition_recovery_restart: CancellationToken,
     pub storage_modules: UnboundedSender<Traced<StorageModuleServiceMessage>>,
     pub data_sync: UnboundedSender<Traced<DataSyncServiceMessage>>,
     pub gossip_broadcast: UnboundedSender<Traced<GossipBroadcastMessageV2>>,
@@ -148,7 +151,7 @@ impl ServiceSendersInner {
             unbounded_channel::<Traced<MempoolServiceMessage>>();
         let (vdf_fast_forward_sender, vdf_fast_forward_receiver) =
             channel::<Traced<VdfStep>>(VDF_FAST_FORWARD_CHANNEL_CAPACITY);
-        let (vdf_reanchor_sender, vdf_reanchor_receiver) = unbounded_channel::<()>();
+        let partition_recovery_restart = CancellationToken::new();
         let (sm_sender, sm_receiver) = unbounded_channel::<Traced<StorageModuleServiceMessage>>();
         let (ds_sender, ds_receiver) = unbounded_channel::<Traced<DataSyncServiceMessage>>();
         let (gossip_broadcast_sender, gossip_broadcast_receiver) =
@@ -177,7 +180,7 @@ impl ServiceSendersInner {
             chunk_migration: chunk_migration_sender,
             mempool: mempool_sender,
             vdf_fast_forward: vdf_fast_forward_sender,
-            vdf_reanchor: vdf_reanchor_sender,
+            partition_recovery_restart,
             storage_modules: sm_sender,
             data_sync: ds_sender,
             gossip_broadcast: gossip_broadcast_sender,
@@ -199,7 +202,6 @@ impl ServiceSendersInner {
             chunk_migration: chunk_migration_receiver,
             mempool: mempool_receiver,
             vdf_fast_forward: vdf_fast_forward_receiver,
-            vdf_reanchor: vdf_reanchor_receiver,
             storage_modules: sm_receiver,
             data_sync: ds_receiver,
             gossip_broadcast: gossip_broadcast_receiver,

--- a/crates/actors/src/validation_service.rs
+++ b/crates/actors/src/validation_service.rs
@@ -75,29 +75,16 @@ pub(crate) struct VdfStageBParentMissing {
     pub parent_hash: BlockHash,
 }
 
-/// Sentinel error returned from `ensure_vdf_is_valid` when the previous VDF step
-/// is unavailable from the local buffer even after re-waiting, because a
-/// concurrent partition-recovery VDF re-anchor rewound `global_step` below it
-/// (the shared buffer was rebuilt at the canonical tip — a backward jump, not a
-/// forward trim). This is a transient local-state event, NOT block invalidity and
-/// NOT a dead writer, so it must requeue rather than panic (never-mislabel rule)
-/// or be attributed to the peer. Downcast in `PreemptibleVdfTask::execute` and
-/// converted to `VdfValidationResult::Cancelled` (the peer-innocent requeue lane).
-#[derive(Debug, thiserror::Error)]
-#[error("VDF previous step {step} unavailable after re-anchor rewind; requeue")]
-pub(crate) struct VdfStepRewound {
-    pub step: u64,
-}
-
-/// Sentinel error returned from `ensure_vdf_is_valid` when the live-buffer previous
-/// step MISMATCHES the block's claim AND the block's own fork-local lineage view cannot
-/// be built to cross-check it — because an ancestor was transiently evicted from the
-/// block tree (a depth-prune / reorg / partition-recovery re-anchor race). The bare
-/// mismatch is not proof of invalidity in this window (the live buffer may be
+/// Sentinel error returned from `ensure_vdf_is_valid` when the previous VDF step from the
+/// live buffer is either unavailable OR MISMATCHES the block's claim, AND the block's own
+/// fork-local lineage view cannot be built to cross-check it — because an ancestor was
+/// transiently evicted from the block tree (a depth-prune / reorg / partition-recovery
+/// re-anchor race), or a concurrent re-anchor rewound the live buffer below the step. The
+/// bare absence/mismatch is not proof of invalidity in this window (the live buffer may be
 /// mid-re-anchor) and we could not obtain the authoritative lineage value, so this must
-/// requeue rather than be peer-attributed as `Invalid`. Downcast in
-/// `PreemptibleVdfTask::execute` and converted to `VdfValidationResult::Cancelled` (the
-/// peer-innocent requeue lane), exactly like [`VdfStepRewound`].
+/// requeue rather than panic (never-mislabel rule) or be peer-attributed as `Invalid`.
+/// Downcast in `PreemptibleVdfTask::execute` and converted to
+/// `VdfValidationResult::Cancelled` (the peer-innocent requeue lane).
 #[derive(Debug, thiserror::Error)]
 #[error("VDF previous-step fork-local view unavailable (ancestor eviction race); requeue")]
 pub(crate) struct VdfPrevStepForkViewUnavailable;
@@ -1016,43 +1003,19 @@ impl ValidationServiceInner {
         metrics::record_vdf_step_wait_duration_ms(wait_started.elapsed().as_secs_f64() * 1000.0);
         wait_result?;
 
-        // Read the previous step from the local buffer. `wait_for_step` above
-        // returned once `global_step >= prev_output_step_number`, so normally the
-        // step is present. Two windows can remove it between the wait and this
-        // read:
-        //   1. a canonical-tip update advancing `minimum_step_to_keep` — requires
-        //      ~60k steps (≥ `max_allowed_vdf_fork_steps`) of advancement, which
-        //      does not happen in the sub-millisecond gap; and
-        //   2. a partition-recovery VDF re-anchor REPLACING the buffer at a lower
-        //      `global_step` (a backward rewind, not a forward trim).
-        // For (2) we re-wait once (bounded by `progress_timeout`) so the
-        // re-anchored loop can reproduce the step, then surface the typed
-        // `VdfStepRewound` sentinel if it is still unavailable. That routes to
-        // `Cancelled` (requeue) in `PreemptibleVdfTask::execute`. We must NOT panic
-        // here (this is a transient local-state event, not a dead writer) and must
-        // NOT downgrade to `Invalid` (never-mislabel rule — see the `resume_unwind`
-        // site in the select loop and design/docs/vdf-validation-stall-detection.md).
-        let stored_previous_step = match self.vdf_state.get_step(prev_output_step_number) {
-            Ok(step) => step,
-            Err(_) => {
-                self.vdf_state
-                    .wait_for_step(
-                        prev_output_step_number,
-                        Arc::clone(&cancel),
-                        progress_timeout,
-                    )
-                    .await?;
-                self.vdf_state
-                    .get_step(prev_output_step_number)
-                    .map_err(|_| VdfStepRewound {
-                        step: prev_output_step_number,
-                    })?
-            }
-        };
+        // Read the previous step from the local buffer as a FAST PATH (`None` if absent).
+        // `wait_for_step` above returned once `global_step >= prev_output_step_number`, so
+        // normally the step is present and equals the block's claim. It can be absent or
+        // stale in a narrow window — a partition-recovery VDF re-anchor REPLACING the buffer
+        // at a lower `global_step` (a backward rewind) between the wait and this read. We
+        // treat "absent" and "present-but-mismatched" identically below: both fall through to
+        // the authoritative fork-local cross-check, so a transient rewind needs no re-wait and
+        // never mislabels (no `panic!`, no `Invalid`). Mirrors the recall-range seam.
+        let stored_previous_step = self.vdf_state.get_step(prev_output_step_number).ok();
 
         // Verify the block's claimed previous VDF output equals the step our node holds at that
-        // index. The live buffer can transiently disagree during a partition-recovery VDF
-        // re-anchor: the re-anchor is signalled at reorg-detect time but APPLIED asynchronously by
+        // index. The live buffer can transiently be absent or disagree during a partition-recovery
+        // VDF re-anchor: the re-anchor is signalled at reorg-detect time but APPLIED asynchronously by
         // the VDF supervisor, so a canonical straggler block whose previous step lands on a reset
         // boundary that the still-poisoned (pre-swap) buffer holds with the minority-fork value
         // would be rejected here as terminally `Invalid` — even though it is honest and would
@@ -1064,7 +1027,7 @@ impl ValidationServiceInner {
         // accept iff THAT matches the block's claim. A value that mismatches the block's actual
         // canonical ancestry is still a genuine consensus rejection. Mirrors the recall-range
         // fork-local fallback and confines fork-aware step resolution to `build_fork_local_view`.
-        if stored_previous_step != vdf_info.prev_output {
+        if stored_previous_step != Some(vdf_info.prev_output) {
             let fork_local =
                 build_fork_local_step_view(block, &self.config.consensus, &self.block_tree_guard)
                     .and_then(|view| view.get_step(prev_output_step_number));
@@ -1073,7 +1036,7 @@ impl ValidationServiceInner {
                     debug!(
                         vdf.prev_output_step_number = prev_output_step_number,
                         ?stored_previous_step,
-                        "ensure_vdf_is_valid: live buffer prev step mismatched (poisoned pre-re-anchor buffer); fork-local lineage view matches the block's claim — accepting"
+                        "ensure_vdf_is_valid: live buffer prev step absent or mismatched (poisoned/rewound pre-re-anchor buffer); fork-local lineage view matches the block's claim — accepting"
                     );
                 }
                 Ok(canonical_prev) => eyre::bail!(
@@ -1083,8 +1046,8 @@ impl ValidationServiceInner {
                     canonical_prev,
                 ),
                 Err(err) => {
-                    // The live buffer mismatched, but we have no authoritative fork-local
-                    // cross-check — EITHER the view could not be BUILT (an ancestor is
+                    // The live buffer was absent or mismatched, but we have no authoritative
+                    // fork-local cross-check — EITHER the view could not be BUILT (an ancestor is
                     // transiently absent from the block tree: depth-prune / reorg /
                     // in-flight re-anchor race) OR it built but does not COVER
                     // `prev_output_step_number` (a near-genesis block whose lineage bottoms

--- a/crates/actors/src/validation_service.rs
+++ b/crates/actors/src/validation_service.rs
@@ -1029,8 +1029,13 @@ impl ValidationServiceInner {
         // fork-local fallback and confines fork-aware step resolution to `build_fork_local_view`.
         if stored_previous_step != Some(vdf_info.prev_output) {
             let fork_local =
-                build_fork_local_step_view(block, &self.config.consensus, &self.block_tree_guard)
-                    .and_then(|view| view.get_step(prev_output_step_number));
+                build_fork_local_step_view(
+                    block,
+                    &self.config.consensus,
+                    &self.block_tree_guard,
+                    &self.db,
+                )
+                .and_then(|view| view.get_step(prev_output_step_number));
             match fork_local {
                 Ok(canonical_prev) if canonical_prev == vdf_info.prev_output => {
                     debug!(

--- a/crates/actors/src/validation_service.rs
+++ b/crates/actors/src/validation_service.rs
@@ -1050,24 +1050,23 @@ impl ValidationServiceInner {
                     canonical_prev,
                 ),
                 Err(err) => {
-                    // The live buffer was absent or mismatched, but we have no authoritative
-                    // fork-local cross-check — EITHER the view could not be BUILT (an ancestor is
-                    // transiently absent from the block tree: depth-prune / reorg /
-                    // in-flight re-anchor race) OR it built but does not COVER
-                    // `prev_output_step_number` (a near-genesis block whose lineage bottoms
-                    // out at genesis before that step). Both are "no verdict", NOT proof of
-                    // invalidity, so the bare mismatch must NOT be peer-attributed as
-                    // `Invalid`: that would permanently reject an honest canonical block in
-                    // the re-anchor window — the exact failure this fork-local check exists
-                    // to prevent. (A resolvable-but-disagreeing step is the separate
-                    // `Ok(_) => bail` arm above, which IS a terminal reject.) Both share the
-                    // peer-innocent Cancelled lane; on retry the re-anchor has typically
-                    // landed (live buffer matches, so this branch is skipped) or the ancestry
-                    // is present (fork-local view then yields a definitive accept/reject).
+                    // The live buffer was absent or mismatched, and we could not build an
+                    // authoritative fork-local cross-check: an ancestor is absent from BOTH the
+                    // block tree and the DB (depth-prune / reorg / in-flight re-anchor race). A
+                    // SUCCESSFUL build always covers `prev_output_step_number` — the view is sized
+                    // to include it (see `build_fork_local_step_view`) — so the only `Err` here is
+                    // a build failure. This is "no verdict", NOT proof of invalidity, so the bare
+                    // mismatch must NOT be peer-attributed as `Invalid`: that would permanently
+                    // reject an honest canonical block in the re-anchor window — the exact failure
+                    // this fork-local check exists to prevent. (A resolvable-but-disagreeing step
+                    // is the separate `Ok(_) => bail` arm above, which IS a terminal reject.) It
+                    // uses the peer-innocent Cancelled lane; on retry the re-anchor has typically
+                    // landed (live buffer matches, so this branch is skipped) or the ancestry is
+                    // present (fork-local view then yields a definitive accept/reject).
                     warn!(
                         custom.error = ?err,
                         vdf.prev_output_step_number = prev_output_step_number,
-                        "ensure_vdf_is_valid: no authoritative fork-local prev-step cross-check (view unbuildable or does not cover the step); requeuing instead of failing terminally"
+                        "ensure_vdf_is_valid: no authoritative fork-local prev-step cross-check (view unbuildable: ancestor absent from tree and db); requeuing instead of failing terminally"
                     );
                     return Err(VdfPrevStepForkViewUnavailable.into());
                 }

--- a/crates/actors/src/validation_service.rs
+++ b/crates/actors/src/validation_service.rs
@@ -1083,20 +1083,24 @@ impl ValidationServiceInner {
                     canonical_prev,
                 ),
                 Err(err) => {
-                    // The live buffer mismatched, but we could not build the block's
-                    // fork-local lineage view to cross-check it — an ancestor is
-                    // transiently absent from the block tree (depth-prune / reorg /
-                    // in-flight re-anchor race). With no authoritative verdict, the bare
-                    // mismatch must NOT be peer-attributed as `Invalid`: that would
-                    // permanently reject an honest canonical block in the re-anchor
-                    // window — the exact failure this fork-local check exists to prevent.
-                    // Requeue via the peer-innocent Cancelled lane; on retry the re-anchor
-                    // has typically landed (live buffer matches) or the ancestry is present
-                    // (fork-local view then yields a definitive accept/reject).
+                    // The live buffer mismatched, but we have no authoritative fork-local
+                    // cross-check — EITHER the view could not be BUILT (an ancestor is
+                    // transiently absent from the block tree: depth-prune / reorg /
+                    // in-flight re-anchor race) OR it built but does not COVER
+                    // `prev_output_step_number` (a near-genesis block whose lineage bottoms
+                    // out at genesis before that step). Both are "no verdict", NOT proof of
+                    // invalidity, so the bare mismatch must NOT be peer-attributed as
+                    // `Invalid`: that would permanently reject an honest canonical block in
+                    // the re-anchor window — the exact failure this fork-local check exists
+                    // to prevent. (A resolvable-but-disagreeing step is the separate
+                    // `Ok(_) => bail` arm above, which IS a terminal reject.) Both share the
+                    // peer-innocent Cancelled lane; on retry the re-anchor has typically
+                    // landed (live buffer matches, so this branch is skipped) or the ancestry
+                    // is present (fork-local view then yields a definitive accept/reject).
                     warn!(
                         custom.error = ?err,
                         vdf.prev_output_step_number = prev_output_step_number,
-                        "ensure_vdf_is_valid: could not build fork-local step view for prev-step check (ancestor eviction race); requeueing instead of failing terminally"
+                        "ensure_vdf_is_valid: no authoritative fork-local prev-step cross-check (view unbuildable or does not cover the step); requeuing instead of failing terminally"
                     );
                     return Err(VdfPrevStepForkViewUnavailable.into());
                 }

--- a/crates/actors/src/validation_service.rs
+++ b/crates/actors/src/validation_service.rs
@@ -1028,14 +1028,13 @@ impl ValidationServiceInner {
         // canonical ancestry is still a genuine consensus rejection. Mirrors the recall-range
         // fork-local fallback and confines fork-aware step resolution to `build_fork_local_view`.
         if stored_previous_step != Some(vdf_info.prev_output) {
-            let fork_local =
-                build_fork_local_step_view(
-                    block,
-                    &self.config.consensus,
-                    &self.block_tree_guard,
-                    &self.db,
-                )
-                .and_then(|view| view.get_step(prev_output_step_number));
+            let fork_local = build_fork_local_step_view(
+                block,
+                &self.config.consensus,
+                &self.block_tree_guard,
+                &self.db,
+            )
+            .and_then(|view| view.get_step(prev_output_step_number));
             match fork_local {
                 Ok(canonical_prev) if canonical_prev == vdf_info.prev_output => {
                     debug!(

--- a/crates/actors/src/validation_service.rs
+++ b/crates/actors/src/validation_service.rs
@@ -12,7 +12,7 @@
 //!     results of a child block.
 use crate::{
     block_tree_service::{ReorgEvent, ValidationResult},
-    block_validation::{ValidationError, is_seed_data_valid},
+    block_validation::{ValidationError, build_fork_local_step_view, is_seed_data_valid},
     mempool_guard::MempoolReadGuard,
     metrics,
     services::ServiceSenders,
@@ -74,6 +74,33 @@ pub enum VdfValidationResult {
 pub(crate) struct VdfStageBParentMissing {
     pub parent_hash: BlockHash,
 }
+
+/// Sentinel error returned from `ensure_vdf_is_valid` when the previous VDF step
+/// is unavailable from the local buffer even after re-waiting, because a
+/// concurrent partition-recovery VDF re-anchor rewound `global_step` below it
+/// (the shared buffer was rebuilt at the canonical tip — a backward jump, not a
+/// forward trim). This is a transient local-state event, NOT block invalidity and
+/// NOT a dead writer, so it must requeue rather than panic (never-mislabel rule)
+/// or be attributed to the peer. Downcast in `PreemptibleVdfTask::execute` and
+/// converted to `VdfValidationResult::Cancelled` (the peer-innocent requeue lane).
+#[derive(Debug, thiserror::Error)]
+#[error("VDF previous step {step} unavailable after re-anchor rewind; requeue")]
+pub(crate) struct VdfStepRewound {
+    pub step: u64,
+}
+
+/// Sentinel error returned from `ensure_vdf_is_valid` when the live-buffer previous
+/// step MISMATCHES the block's claim AND the block's own fork-local lineage view cannot
+/// be built to cross-check it — because an ancestor was transiently evicted from the
+/// block tree (a depth-prune / reorg / partition-recovery re-anchor race). The bare
+/// mismatch is not proof of invalidity in this window (the live buffer may be
+/// mid-re-anchor) and we could not obtain the authoritative lineage value, so this must
+/// requeue rather than be peer-attributed as `Invalid`. Downcast in
+/// `PreemptibleVdfTask::execute` and converted to `VdfValidationResult::Cancelled` (the
+/// peer-innocent requeue lane), exactly like [`VdfStepRewound`].
+#[derive(Debug, thiserror::Error)]
+#[error("VDF previous-step fork-local view unavailable (ancestor eviction race); requeue")]
+pub(crate) struct VdfPrevStepForkViewUnavailable;
 
 /// Sentinel error returned from `ensure_vdf_is_valid` when a `spawn_blocking`
 /// task in Stage B or Stage C/D resolves as a `JoinError` (thread panic or
@@ -989,31 +1016,92 @@ impl ValidationServiceInner {
         metrics::record_vdf_step_wait_duration_ms(wait_started.elapsed().as_secs_f64() * 1000.0);
         wait_result?;
 
-        // Unreachable in practice: `wait_for_step` above only returns Ok once
-        // `global_step >= prev_output_step_number`, so the step is in the seed
-        // buffer. The buffer can in principle have trimmed past
-        // `prev_output_step_number` if a canonical-tip update advanced
-        // `minimum_step_to_keep` during the sub-millisecond window after
-        // `wait_for_step` returned — but the buffer's capacity is at minimum
-        // `max_allowed_vdf_fork_steps` (≥60k for production), so trimming
-        // requires ~60k steps of canonical advancement in that window. That
-        // doesn't happen.
-        //
-        // If it ever does fire, the panic is intentional. We must not
-        // downgrade this to an `Invalid` result — see the never-mislabel
-        // rule documented at the `resume_unwind` site in the select loop
-        // and in design/docs/vdf-validation-stall-detection.md.
-        let stored_previous_step = self
-            .vdf_state
-            .get_step(prev_output_step_number)
-            .expect("to get the step, since we've just waited for it");
+        // Read the previous step from the local buffer. `wait_for_step` above
+        // returned once `global_step >= prev_output_step_number`, so normally the
+        // step is present. Two windows can remove it between the wait and this
+        // read:
+        //   1. a canonical-tip update advancing `minimum_step_to_keep` — requires
+        //      ~60k steps (≥ `max_allowed_vdf_fork_steps`) of advancement, which
+        //      does not happen in the sub-millisecond gap; and
+        //   2. a partition-recovery VDF re-anchor REPLACING the buffer at a lower
+        //      `global_step` (a backward rewind, not a forward trim).
+        // For (2) we re-wait once (bounded by `progress_timeout`) so the
+        // re-anchored loop can reproduce the step, then surface the typed
+        // `VdfStepRewound` sentinel if it is still unavailable. That routes to
+        // `Cancelled` (requeue) in `PreemptibleVdfTask::execute`. We must NOT panic
+        // here (this is a transient local-state event, not a dead writer) and must
+        // NOT downgrade to `Invalid` (never-mislabel rule — see the `resume_unwind`
+        // site in the select loop and design/docs/vdf-validation-stall-detection.md).
+        let stored_previous_step = match self.vdf_state.get_step(prev_output_step_number) {
+            Ok(step) => step,
+            Err(_) => {
+                self.vdf_state
+                    .wait_for_step(
+                        prev_output_step_number,
+                        Arc::clone(&cancel),
+                        progress_timeout,
+                    )
+                    .await?;
+                self.vdf_state
+                    .get_step(prev_output_step_number)
+                    .map_err(|_| VdfStepRewound {
+                        step: prev_output_step_number,
+                    })?
+            }
+        };
 
-        ensure!(
-            stored_previous_step == vdf_info.prev_output,
-            "vdf output is not equal to the saved step with the same index {:?}, got {:?}",
-            stored_previous_step,
-            vdf_info.prev_output,
-        );
+        // Verify the block's claimed previous VDF output equals the step our node holds at that
+        // index. The live buffer can transiently disagree during a partition-recovery VDF
+        // re-anchor: the re-anchor is signalled at reorg-detect time but APPLIED asynchronously by
+        // the VDF supervisor, so a canonical straggler block whose previous step lands on a reset
+        // boundary that the still-poisoned (pre-swap) buffer holds with the minority-fork value
+        // would be rejected here as terminally `Invalid` — even though it is honest and would
+        // validate once the swap lands. There is no retry: the verdict is terminal, peer-attributed
+        // (`vdf_terminal_finalize_via`), and the gossip-seen cache dedups a re-gossip, so the
+        // recovering node would permanently fail to adopt the canonical tip block that arrived in
+        // the window. Resolve the previous step from a fork-local view of the block's OWN lineage
+        // (its ancestors in the block tree, where the new canonical parent is already present) and
+        // accept iff THAT matches the block's claim. A value that mismatches the block's actual
+        // canonical ancestry is still a genuine consensus rejection. Mirrors the recall-range
+        // fork-local fallback and confines fork-aware step resolution to `build_fork_local_view`.
+        if stored_previous_step != vdf_info.prev_output {
+            let fork_local =
+                build_fork_local_step_view(block, &self.config.consensus, &self.block_tree_guard)
+                    .and_then(|view| view.get_step(prev_output_step_number));
+            match fork_local {
+                Ok(canonical_prev) if canonical_prev == vdf_info.prev_output => {
+                    debug!(
+                        vdf.prev_output_step_number = prev_output_step_number,
+                        ?stored_previous_step,
+                        "ensure_vdf_is_valid: live buffer prev step mismatched (poisoned pre-re-anchor buffer); fork-local lineage view matches the block's claim — accepting"
+                    );
+                }
+                Ok(canonical_prev) => eyre::bail!(
+                    "vdf output is not equal to the saved step with the same index {:?}, got {:?} (fork-local lineage view: {:?})",
+                    stored_previous_step,
+                    vdf_info.prev_output,
+                    canonical_prev,
+                ),
+                Err(err) => {
+                    // The live buffer mismatched, but we could not build the block's
+                    // fork-local lineage view to cross-check it — an ancestor is
+                    // transiently absent from the block tree (depth-prune / reorg /
+                    // in-flight re-anchor race). With no authoritative verdict, the bare
+                    // mismatch must NOT be peer-attributed as `Invalid`: that would
+                    // permanently reject an honest canonical block in the re-anchor
+                    // window — the exact failure this fork-local check exists to prevent.
+                    // Requeue via the peer-innocent Cancelled lane; on retry the re-anchor
+                    // has typically landed (live buffer matches) or the ancestry is present
+                    // (fork-local view then yields a definitive accept/reject).
+                    warn!(
+                        custom.error = ?err,
+                        vdf.prev_output_step_number = prev_output_step_number,
+                        "ensure_vdf_is_valid: could not build fork-local step view for prev-step check (ancestor eviction race); requeueing instead of failing terminally"
+                    );
+                    return Err(VdfPrevStepForkViewUnavailable.into());
+                }
+            }
+        }
 
         // Stage B: validate seeds against parent (early guard before heavy VDF work)
         let vdf_reset_frequency = vdf_config.reset_frequency as u64;

--- a/crates/actors/src/validation_service/active_validations.rs
+++ b/crates/actors/src/validation_service/active_validations.rs
@@ -1008,6 +1008,13 @@ mod tests {
     use priority_queue::PriorityQueue;
     use std::sync::{Arc, RwLock};
 
+    /// Watchdog deadline for `select!`s that expect a spawned `JoinHandle` to resolve.
+    /// The timer branch only exists to fail fast instead of hanging the suite if the
+    /// handle never wakes the select; it is NOT a timing assertion. A tight bound (e.g.
+    /// 1s) spuriously fires under parallel-CI CPU starvation on a current-thread runtime
+    /// (the spawned task can't be polled in time), so keep it generously loose.
+    const HANDLE_RESOLVE_WATCHDOG: std::time::Duration = std::time::Duration::from_secs(30);
+
     /// Test that BlockPriorityMeta ordering works correctly with manual Ord
     #[test]
     fn test_validation_priority_ordering() {
@@ -1417,7 +1424,7 @@ mod tests {
 
         let result = tokio::select! {
             r = &mut handle => r.unwrap(),
-            _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {
+            _ = tokio::time::sleep(HANDLE_RESOLVE_WATCHDOG) => {
                 panic!("Handle did not resolve — select was not woken");
             }
         };
@@ -1435,7 +1442,7 @@ mod tests {
 
         let result = tokio::select! {
             r = &mut handle => r,
-            _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {
+            _ = tokio::time::sleep(HANDLE_RESOLVE_WATCHDOG) => {
                 panic!("Handle did not resolve after panic");
             }
         };
@@ -1902,7 +1909,7 @@ mod tests {
 
             let result = tokio::select! {
                 r = &mut handle => r.unwrap(),
-                _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {
+                _ = tokio::time::sleep(HANDLE_RESOLVE_WATCHDOG) => {
                     panic!("Handle {} did not resolve within timeout", i);
                 }
             };

--- a/crates/actors/src/validation_service/active_validations.rs
+++ b/crates/actors/src/validation_service/active_validations.rs
@@ -27,8 +27,8 @@ use crate::block_tree_service::ValidationResult;
 use crate::metrics;
 use crate::validation_service::block_validation_task::BlockValidationTask;
 use crate::validation_service::{
-    VdfBlockingTaskFailed, VdfStageBParentMissing, VdfTaskStage, VdfValidationResult,
-    record_vdf_task_progress,
+    VdfBlockingTaskFailed, VdfPrevStepForkViewUnavailable, VdfStageBParentMissing, VdfStepRewound,
+    VdfTaskStage, VdfValidationResult, record_vdf_task_progress,
 };
 
 /// Block priority states for validation ordering
@@ -191,6 +191,19 @@ impl PreemptibleVdfTask {
                     VdfValidationResult::ParentMissing {
                         parent_hash: parent_missing.parent_hash,
                     }
+                // Transient local-state event: a partition-recovery VDF re-anchor
+                // rewound the step buffer below the awaited step after the wait
+                // returned. Requeue (peer-innocent) — never panic, never Invalid.
+                } else if e.downcast_ref::<VdfStepRewound>().is_some() {
+                    metrics::record_validation_cancellation("vdf_reanchor_rewind");
+                    VdfValidationResult::Cancelled
+                // Transient race: the block's fork-local lineage view could not be built
+                // (an ancestor was evicted mid reorg / re-anchor) to cross-check a
+                // live-buffer prev-step mismatch. Peer-innocent — requeue rather than
+                // mislabel as Invalid.
+                } else if e.downcast_ref::<VdfPrevStepForkViewUnavailable>().is_some() {
+                    metrics::record_validation_cancellation("vdf_prev_step_fork_view_unavailable");
+                    VdfValidationResult::Cancelled
                 } else {
                     match e.downcast_ref::<WaitForStepError>() {
                         Some(WaitForStepError::Cancelled) => {

--- a/crates/actors/src/validation_service/active_validations.rs
+++ b/crates/actors/src/validation_service/active_validations.rs
@@ -27,8 +27,8 @@ use crate::block_tree_service::ValidationResult;
 use crate::metrics;
 use crate::validation_service::block_validation_task::BlockValidationTask;
 use crate::validation_service::{
-    VdfBlockingTaskFailed, VdfPrevStepForkViewUnavailable, VdfStageBParentMissing, VdfStepRewound,
-    VdfTaskStage, VdfValidationResult, record_vdf_task_progress,
+    VdfBlockingTaskFailed, VdfPrevStepForkViewUnavailable, VdfStageBParentMissing, VdfTaskStage,
+    VdfValidationResult, record_vdf_task_progress,
 };
 
 /// Block priority states for validation ordering
@@ -191,12 +191,6 @@ impl PreemptibleVdfTask {
                     VdfValidationResult::ParentMissing {
                         parent_hash: parent_missing.parent_hash,
                     }
-                // Transient local-state event: a partition-recovery VDF re-anchor
-                // rewound the step buffer below the awaited step after the wait
-                // returned. Requeue (peer-innocent) — never panic, never Invalid.
-                } else if e.downcast_ref::<VdfStepRewound>().is_some() {
-                    metrics::record_validation_cancellation("vdf_reanchor_rewind");
-                    VdfValidationResult::Cancelled
                 // Transient race: the block's fork-local lineage view could not be built
                 // (an ancestor was evicted mid reorg / re-anchor) to cross-check a
                 // live-buffer prev-step mismatch. Peer-innocent — requeue rather than

--- a/crates/actors/src/validation_service/block_validation_task.rs
+++ b/crates/actors/src/validation_service/block_validation_task.rs
@@ -22,8 +22,9 @@
 use crate::block_tree_service::ValidationResult;
 use crate::block_validation::{
     RecallRangeError, SubmitPayloadError, ValidationCancelReason, ValidationError,
-    commitment_txs_are_valid, data_txs_are_valid, is_seed_data_valid, poa_is_valid,
-    recall_recall_range_is_valid, shadow_transactions_are_valid, submit_payload_to_reth,
+    build_fork_local_recall_view, commitment_txs_are_valid, data_txs_are_valid, is_seed_data_valid,
+    poa_is_valid, recall_recall_range_is_valid, shadow_transactions_are_valid,
+    submit_payload_to_reth,
 };
 use crate::metrics;
 use crate::validation_service::ValidationServiceInner;
@@ -470,12 +471,38 @@ impl BlockValidationTask {
         let recall_captures = Arc::clone(&stage_captures);
         let recall_task = async move {
             let started = Instant::now();
-            let outcome = recall_recall_range_is_valid(
-                block,
-                &self.service_inner.config.consensus,
-                &self.service_inner.vdf_state,
-            )
-            .await;
+            let consensus = &self.service_inner.config.consensus;
+            let mut outcome =
+                recall_recall_range_is_valid(block, consensus, &self.service_inner.vdf_state).await;
+            // A `Mismatch` against the live buffer may be a competing fork whose post-boundary VDF
+            // steps differ from this node's (possibly poisoned) buffer — not a genuine invalid
+            // recall range. Rebuild a fork-local step view from the block's OWN lineage (its
+            // ancestors in the block tree) and re-validate against THAT; only a still-`Mismatch` is
+            // a real consensus rejection. This is what lets a recovering node adopt a canonical
+            // fork that crossed a VDF reset boundary (the partition-recovery wedge), and confines
+            // the fork-aware step resolution to one seam (`build_fork_local_recall_view`).
+            if matches!(outcome, Err(RecallRangeError::Mismatch(_))) {
+                match build_fork_local_recall_view(block, consensus, &self.block_tree_guard) {
+                    Ok(view) => outcome = recall_recall_range_is_valid(block, consensus, &view).await,
+                    Err(e) => {
+                        // The live buffer mismatched, but we could not build the block's
+                        // fork-local lineage view to re-validate against — an ancestor is
+                        // transiently absent from the block tree (depth-prune / reorg /
+                        // in-flight re-anchor race). With no authoritative verdict, the bare
+                        // live-buffer mismatch must NOT be peer-attributed as
+                        // `RecallRangeInvalid`: that would permanently reject an honest
+                        // canonical block in the re-anchor window. Reclassify as the soft
+                        // `StepsUnavailable` (SoftInternal) lane so validation requeues; on
+                        // retry the re-anchor has typically landed (live buffer matches) or
+                        // the ancestry is present (fork-local view yields a real verdict).
+                        tracing::warn!(
+                            custom.error = ?e,
+                            "recall range: could not build fork-local VDF view (ancestor eviction race); reclassifying as soft-internal (retry) instead of peer-attributed mismatch"
+                        );
+                        outcome = Err(RecallRangeError::StepsUnavailable(e));
+                    }
+                }
+            }
             metrics::record_validation_stage_duration_ms(
                 "recall_range",
                 started.elapsed().as_secs_f64() * 1000.0,

--- a/crates/actors/src/validation_service/block_validation_task.rs
+++ b/crates/actors/src/validation_service/block_validation_task.rs
@@ -472,42 +472,37 @@ impl BlockValidationTask {
         let recall_task = async move {
             let started = Instant::now();
             let consensus = &self.service_inner.config.consensus;
-            let mut outcome =
-                recall_recall_range_is_valid(block, consensus, &self.service_inner.vdf_state).await;
-            // A `Mismatch` against the live buffer may be a competing fork whose post-boundary VDF
-            // steps differ from this node's (possibly poisoned) buffer — not a genuine invalid
-            // recall range. Rebuild a fork-local step view from the block's OWN lineage (its
-            // ancestors in the block tree) and re-validate against THAT; only a still-`Mismatch` is
-            // a real consensus rejection. This is what lets a recovering node adopt a canonical
-            // fork that crossed a VDF reset boundary (the partition-recovery wedge), and confines
-            // the fork-aware step resolution to one seam (`build_fork_local_recall_view`).
-            if matches!(outcome, Err(RecallRangeError::Mismatch(_))) {
-                match build_fork_local_recall_view(
-                    block,
-                    consensus,
-                    &self.block_tree_guard,
-                    &self.service_inner.db,
-                ) {
-                    Ok(view) => outcome = recall_recall_range_is_valid(block, consensus, &view).await,
-                    Err(e) => {
-                        // The live buffer mismatched, but we could not build the block's
-                        // fork-local lineage view to re-validate against — an ancestor is
-                        // transiently absent from the block tree (depth-prune / reorg /
-                        // in-flight re-anchor race). With no authoritative verdict, the bare
-                        // live-buffer mismatch must NOT be peer-attributed as
-                        // `RecallRangeInvalid`: that would permanently reject an honest
-                        // canonical block in the re-anchor window. Reclassify as the soft
-                        // `StepsUnavailable` (SoftInternal) lane so validation requeues; on
-                        // retry the re-anchor has typically landed (live buffer matches) or
-                        // the ancestry is present (fork-local view yields a real verdict).
-                        tracing::warn!(
-                            custom.error = ?e,
-                            "recall range: could not build fork-local VDF view (ancestor eviction race); reclassifying as soft-internal (retry) instead of peer-attributed mismatch"
-                        );
-                        outcome = Err(RecallRangeError::StepsUnavailable(e));
-                    }
+            // Validate the recall range against the block's OWN VDF lineage (its ancestors' recorded
+            // steps, walked via the block tree), NOT this node's live buffer. The live buffer is not
+            // authoritative for a competing fork: past a VDF reset boundary it may hold a different
+            // (poisoned) lineage. And because VDF-step validation now RECOMPUTES on a live-buffer
+            // mismatch instead of rejecting (so a competing-fork block reaches this stage), a
+            // live-buffer fast path could accept a block whose claimed recall range matches the
+            // poisoned steps but NOT its own lineage — deriving the range from the wrong fork. The
+            // recall window is one reset interval (a few blocks back to the boundary), all in-tree
+            // for a reorg representable within block_tree_depth, so resolving fork-locally is cheap.
+            // This is the single fork-aware step-resolution seam (`build_fork_local_recall_view`).
+            let outcome = match build_fork_local_recall_view(
+                block,
+                consensus,
+                &self.block_tree_guard,
+                &self.service_inner.db,
+            ) {
+                Ok(view) => recall_recall_range_is_valid(block, consensus, &view).await,
+                Err(e) => {
+                    // Could not build the block's fork-local lineage view — an ancestor is
+                    // transiently absent from the block tree / DB (depth-prune / reorg / sync
+                    // race). With no authoritative verdict, route to the soft `StepsUnavailable`
+                    // (SoftInternal) lane so validation requeues rather than peer-attributing a
+                    // mismatch (which would permanently reject an honest block); the ancestry is
+                    // typically present on retry.
+                    tracing::warn!(
+                        custom.error = ?e,
+                        "recall range: could not build fork-local VDF view (ancestor eviction race); reclassifying as soft-internal (retry)"
+                    );
+                    Err(RecallRangeError::StepsUnavailable(e))
                 }
-            }
+            };
             metrics::record_validation_stage_duration_ms(
                 "recall_range",
                 started.elapsed().as_secs_f64() * 1000.0,

--- a/crates/actors/src/validation_service/block_validation_task.rs
+++ b/crates/actors/src/validation_service/block_validation_task.rs
@@ -482,7 +482,12 @@ impl BlockValidationTask {
             // fork that crossed a VDF reset boundary (the partition-recovery wedge), and confines
             // the fork-aware step resolution to one seam (`build_fork_local_recall_view`).
             if matches!(outcome, Err(RecallRangeError::Mismatch(_))) {
-                match build_fork_local_recall_view(block, consensus, &self.block_tree_guard) {
+                match build_fork_local_recall_view(
+                    block,
+                    consensus,
+                    &self.block_tree_guard,
+                    &self.service_inner.db,
+                ) {
                     Ok(view) => outcome = recall_recall_range_is_valid(block, consensus, &view).await,
                     Err(e) => {
                         // The live buffer mismatched, but we could not build the block's

--- a/crates/chain-tests/src/api/hardfork_tests.rs
+++ b/crates/chain-tests/src/api/hardfork_tests.rs
@@ -669,7 +669,10 @@ mod epoch_block_filtering {
     async fn slow_test_epoch_at_hardfork_boundary_doesnt_filter_v1() -> eyre::Result<()> {
         initialize_tracing();
 
-        let aurora_activation = now_secs().saturating_add(ACTIVATION_DELAY_SECS);
+        // This test submits V1/V2 commitments BEFORE activation, so it needs the
+        // wider pre-activation window to survive slow node startup under parallel
+        // load (the 10s ACTIVATION_DELAY_SECS can be exceeded by startup alone).
+        let aurora_activation = now_secs().saturating_add(PRE_ACTIVATION_WINDOW_SECS);
         let mut config = NodeConfig::testing_with_epochs(NUM_BLOCKS_IN_EPOCH);
         config.consensus.get_mut().hardforks = IrysHardforkConfig {
             frontier: default_test_frontier(),

--- a/crates/chain-tests/src/multi_node/cascade_reorg.rs
+++ b/crates/chain-tests/src/multi_node/cascade_reorg.rs
@@ -161,26 +161,47 @@ async fn slow_heavy_cascade_reorg_reinjects_term_ledger_txs() -> eyre::Result<()
         .wait_until_height(base_height + 3, seconds_to_wait)
         .await?;
 
-    // Verify orphaned term txs are back in the mempool
-    let canonical_tip = genesis_node
-        .get_canonical_chain()
-        .last()
-        .expect("canonical chain should have a tip")
-        .block_hash();
-    let mempool_txs = genesis_node.get_best_mempool_tx(canonical_tip).await?;
+    // Verify orphaned term txs are back in the mempool. Reinjection happens
+    // asynchronously when the mempool service handles the reorg event on its own task,
+    // so it can lag the reorg notification the test awaited above. Poll until both
+    // reappear rather than sampling once — the single check raced under parallel load.
+    let one_year_id = one_year_tx.header.id;
+    let thirty_day_id = thirty_day_tx.header.id;
+    let deadline =
+        std::time::Instant::now() + std::time::Duration::from_secs(seconds_to_wait as u64);
+    let mempool_txs = loop {
+        let canonical_tip = genesis_node
+            .get_canonical_chain()
+            .last()
+            .expect("canonical chain should have a tip")
+            .block_hash();
+        let mempool_txs = genesis_node.get_best_mempool_tx(canonical_tip).await?;
+        let has_both = mempool_txs
+            .one_year_tx
+            .iter()
+            .any(|tx| tx.id == one_year_id)
+            && mempool_txs
+                .thirty_day_tx
+                .iter()
+                .any(|tx| tx.id == thirty_day_id);
+        if has_both || std::time::Instant::now() >= deadline {
+            break mempool_txs;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    };
 
     assert!(
         mempool_txs
             .one_year_tx
             .iter()
-            .any(|tx| tx.id == one_year_tx.header.id),
+            .any(|tx| tx.id == one_year_id),
         "expected OneYear orphan tx to be reinjected into mempool"
     );
     assert!(
         mempool_txs
             .thirty_day_tx
             .iter()
-            .any(|tx| tx.id == thirty_day_tx.header.id),
+            .any(|tx| tx.id == thirty_day_id),
         "expected ThirtyDay orphan tx to be reinjected into mempool"
     );
 

--- a/crates/chain-tests/src/multi_node/partition_recovery.rs
+++ b/crates/chain-tests/src/multi_node/partition_recovery.rs
@@ -2,10 +2,12 @@ use crate::utils::IrysNodeTest;
 use irys_config::submodules::StorageSubmodulesConfig;
 use irys_database::submodule::db::{get_data_root_infos_for_data_root, get_path_hashes_by_offset};
 use irys_domain::ChunkType;
+use irys_storage::ii;
 use irys_types::{
-    BoundedFee, DataLedger, DataTransaction, H256, LedgerChunkOffset, NodeConfig,
+    BoundedFee, DataLedger, DataTransaction, H256, IrysBlockHeader, LedgerChunkOffset, NodeConfig,
     PartitionChunkOffset, UnixTimestamp, hardfork_config::Cascade, irys::IrysSigner,
 };
+use std::sync::Arc;
 use tracing::info;
 
 /// Tests that network partition recovery is surgical: shared data from the common
@@ -574,4 +576,378 @@ async fn post_tx_with_chunks(
         chunks.len()
     );
     Ok(tx)
+}
+
+/// Mine `node`'s OWN fork past `target_step` via NATURAL mining: mine in 2-block steps and
+/// `wait_for_packing` after each, until the tip's VDF step exceeds `target_step`. `mine_blocks`
+/// calls `start_mining()`, so the VDF free-runs and partition mining finds real PoA solutions
+/// against the node's assigned (entropy-packed) partition; blocks validate → `mark_tip` →
+/// `confirmed_canonical_step` advances → the #1449 reset-boundary gate releases, so the node
+/// crosses reset boundaries on its own isolated fork exactly as production does. The per-step
+/// `wait_for_packing` keeps the continuous miner from stalling on an epoch boundary's partition
+/// reassignment. `start_height` must be epoch-aligned (even, with num_blocks_in_epoch=2).
+///
+/// Sequential use across nodes is safe: a node not currently being mined has its VDF paused
+/// (`mine_blocks` stops mining on return), so it never free-runs to the boundary and parks. Returns
+/// the new tip height and the fork's block headers above `start_height` for the reorg gossip. The
+/// solutions are capacity (data-independent), so a peer can validate another node's blocks by
+/// recomputing entropy — no chunk-data sync is required for the reorg.
+async fn mine_fork_past_step_natural(
+    node: &IrysNodeTest<irys_chain::IrysNodeCtx>,
+    start_height: u64,
+    target_step: u64,
+    seconds_to_wait: usize,
+) -> eyre::Result<(u64, Vec<Arc<IrysBlockHeader>>)> {
+    for _ in 0..40 {
+        let step = node
+            .get_max_difficulty_block()
+            .vdf_limiter_info
+            .global_step_number;
+        if step > target_step {
+            break;
+        }
+        node.mine_blocks(2).await?;
+        node.wait_for_packing(seconds_to_wait).await;
+    }
+    let tip_block = node.get_max_difficulty_block();
+    let tip_step = tip_block.vdf_limiter_info.global_step_number;
+    eyre::ensure!(
+        tip_step > target_step,
+        "fork did not reach target step {target_step} (tip step {tip_step})"
+    );
+    let tip = tip_block.height;
+    let mut blocks = Vec::new();
+    for h in (start_height + 1)..=tip {
+        blocks.push(Arc::new(node.get_block_by_height(h).await?));
+    }
+    Ok((tip, blocks))
+}
+
+/// Validates the VDF re-anchor fix (review Finding #1) END-TO-END: a network-partition recovery
+/// whose recovered range CROSSES a VDF reset boundary must leave the recovering node's VDF buffer
+/// matching the canonical chain — not re-stepped with the wrong reset seed — so the node
+/// converges instead of re-wedging.
+///
+/// `heavy4_network_partition_recovery` never reaches a reset boundary (default `reset_frequency`,
+/// few blocks), so it passes regardless of the bug. This test lowers `reset_frequency` and mines
+/// the forks far enough that the recovered range spans a reset boundary, then asserts:
+///   (A) the recovering node's VDF steps over the boundary-crossing range equal the canonical
+///       chain's recorded steps — the direct fix check. The broken LCA re-anchor re-derives those
+///       steps locally with the canonical tip's single reset seed, diverging at the boundary.
+///   (B) the node keeps producing/validating blocks after recovery (no wedge).
+///
+/// Continuous mining (`mine_blocks`) is used throughout: single-block mining can panic when the
+/// VDF parks at a reset boundary (`capacity_chunk_solution` fallback). `block_migration_depth=1`
+/// keeps the confirmation lag below `reset_frequency`, so the #1449 gate does not park.
+/// Name: `slow_` → 180s kill budget; `heavy4_` → 4 reserved threads.
+///
+/// Both forks must cross the poisoning boundary, which is ALWAYS gated by the #1449 confirmation
+/// gate (its rotation block lies in the divergent fork region — that is what makes the forks' reset
+/// seeds differ). Crossing requires each node's CONFIRMED step to advance past the rotation step,
+/// which happens as its own fork blocks become `Onchain` — i.e. it must MINE its own fork. The key
+/// to making this work for the peer (the prior version was shelved as "infeasible"): provision the
+/// peer as a REAL miner (stake → pledge → epoch assignment → pack) and use NATURAL mining
+/// (`mine_blocks` → `start_mining()` → VDF free-runs → real PoA solutions → `mark_tip` → confirmed
+/// advances → gate releases). The earlier attempt funded but never staked the peer, so it had no
+/// mineable partition and fell back to forced capacity solutions that never free-ran the VDF and
+/// parked at the boundary — an artifact of the harness setup, not a structural wall.
+#[test_log::test(tokio::test)]
+async fn heavy4_slow_partition_recovery_crosses_reset_boundary() -> eyre::Result<()> {
+    let seconds_to_wait = 45;
+    let block_migration_depth: u32 = 1;
+    // reset_frequency in VDF steps. Must comfortably exceed steps-per-block (~35-80 here, growing
+    // with difficulty) so the #1449 confirmation gate's run-ahead budget lets a block be mined
+    // before the VDF parks at a boundary — otherwise confirmation can never advance and the loop
+    // deadlocks at the boundary. The poisoning boundary is the 2nd reset boundary above the LCA
+    // (the 1st boundary's rotation block sits at/below the shared LCA).
+    let reset_frequency: u64 = 150;
+
+    let mut genesis_config = NodeConfig::testing().with_consensus(|c| {
+        c.chunk_size = 32;
+        c.num_chunks_in_partition = 10;
+        c.num_chunks_in_recall_range = 2;
+        c.num_partitions_per_slot = 1;
+        c.num_partitions_per_term_ledger_slot = 1;
+        c.epoch.num_blocks_in_epoch = 2;
+        c.block_migration_depth = block_migration_depth;
+        c.entropy_packing_iterations = 1_000;
+        c.genesis.initial_packed_partitions = Some(5.0);
+        c.vdf.reset_frequency = reset_frequency as usize;
+    });
+    genesis_config.storage.num_writes_before_sync = 1;
+
+    let peer_signer = genesis_config.new_random_signer();
+    genesis_config.fund_genesis_accounts(vec![&peer_signer]);
+
+    let genesis_test = IrysNodeTest::new_genesis(genesis_config.clone());
+    StorageSubmodulesConfig::load_for_test(genesis_test.cfg.base_directory.clone(), 10)?;
+    let genesis = genesis_test
+        .start_and_wait_for_packing("GENESIS", seconds_to_wait)
+        .await;
+
+    // No packing on the peer yet — it has no partition assignment until it stakes/pledges.
+    let peer_config = genesis.testing_peer_with_signer(&peer_signer);
+    let peer_test = IrysNodeTest::new(peer_config);
+    StorageSubmodulesConfig::load_for_test(peer_test.cfg.base_directory.clone(), 10)?;
+    let peer = peer_test.start_with_name("PEER").await;
+
+    IrysNodeTest::announce_between(&genesis, &peer).await?;
+
+    // ─── Provision the peer as a REAL miner so it can mine its OWN fork: stake → pledge → epoch
+    // assignment → pack. Without an assignment the peer has no packed partition to mine, which is
+    // why the earlier forced-capacity approach (no start_mining) parked the peer's VDF at the
+    // boundary. The assigned partition is entropy-packed, so its PoA solutions are data-independent
+    // and genesis can validate them on reorg without syncing chunk data.
+    let stake_tx = peer.post_stake_commitment(None).await?;
+    let pledge_tx = peer.post_pledge_commitment(None).await?;
+    genesis
+        .wait_for_mempool(stake_tx.id(), seconds_to_wait)
+        .await?;
+    genesis
+        .wait_for_mempool(pledge_tx.id(), seconds_to_wait)
+        .await?;
+
+    // ─── Shared base (gossip ON): heights 1-4. Height 1 includes the commitments; the epochs at 2
+    // and 4 assign the peer a partition (two epochs of margin). Height 4 is the LCA / fork point.
+    genesis.mine_blocks(4).await?;
+    let fork_height = 4_u64;
+    let lca = genesis.get_block_by_height(fork_height).await?;
+    assert_eq!(
+        genesis
+            .get_partition_assignments(peer_signer.address())
+            .len(),
+        1,
+        "peer must be assigned a partition to mine its own fork"
+    );
+    peer.wait_for_block(&lca.block_hash, seconds_to_wait)
+        .await?;
+    peer.wait_for_packing(seconds_to_wait).await;
+    // Freeze the peer's VDF immediately after packing. `wait_for_packing` auto-starts the VDF
+    // (`ensure_vdf_running_for_sync`) but NOT partition mining; left running while the peer sits
+    // idle during genesis's fork-mining phase below, it free-runs to the gated poison boundary and
+    // parks there (no blocks produced → confirmed stuck at the LCA → the #1449 gate never releases
+    // → the peer can never mine its own fork). That was the flaky "PEER stuck at the LCA" deadlock.
+    // Stopping it holds the peer at the LCA until `mine_fork_past_step_natural` resumes it.
+    peer.stop_mining();
+    assert_eq!(
+        peer.get_partition_assignments(peer_signer.address()).len(),
+        1,
+        "peer must see its own assignment before mining"
+    );
+    let lca_step = lca.vdf_limiter_info.global_step_number;
+    info!(
+        fork_height,
+        lca_step, reset_frequency, "Shared base complete; fork point (LCA) established"
+    );
+
+    // ─── Fork (gossip OFF): minority (genesis) and majority (peer) mine independently ───
+    genesis.gossip_disable();
+    peer.gossip_disable();
+    // Pack genesis for the height-4 epoch reassignment before it mines. The peer is already packed
+    // and deliberately left FROZEN (above) — do NOT `wait_for_packing` it here, as that would
+    // re-auto-start its idle VDF and let it drift to the gated boundary while genesis mines.
+    genesis.wait_for_packing(seconds_to_wait).await;
+    peer.stop_mining(); // ensure the peer stays frozen through genesis's fork-mining phase
+
+    // The poisoning reset boundary is the 2nd boundary above the LCA: its rotation block (at
+    // poison_boundary - reset_frequency) is the FIRST boundary above the LCA, which lies in the
+    // divergent fork region — so the two forks pin DIFFERENT reset seeds there. (The 1st boundary
+    // above the LCA has its rotation block at/below the shared LCA, so it does not poison.)
+    let poison_boundary = (lca_step / reset_frequency + 2) * reset_frequency;
+    info!(
+        poison_boundary,
+        rotation_step = poison_boundary - reset_frequency,
+        "Poisoning reset boundary the forks must cross"
+    );
+
+    // Mine genesis's fork FIRST, then the peer's, via NATURAL mining (real PoA solutions; the VDF
+    // free-runs and each node self-confirms its own fork, releasing the #1449 gate). Each node is
+    // held FROZEN while the other mines: `mine_blocks` resumes a node's VDF + partition mining and
+    // stops it again on return, and the peer was explicitly frozen above — so neither node idle-
+    // drifts its VDF to the gated poison boundary and parks (the deadlock that made this flaky).
+    let (genesis_tip, genesis_blocks) =
+        mine_fork_past_step_natural(&genesis, fork_height, poison_boundary, seconds_to_wait)
+            .await?;
+    let (mut peer_tip, _) =
+        mine_fork_past_step_natural(&peer, fork_height, poison_boundary, seconds_to_wait).await?;
+    // Extend the majority (peer) fork to be strictly longer so it wins fork choice on reorg.
+    while peer_tip <= genesis_tip {
+        peer.mine_blocks(2).await?;
+        peer.wait_for_packing(seconds_to_wait).await;
+        peer_tip = peer.get_max_difficulty_block().height;
+    }
+    // Collect the peer's full divergent fork (above the LCA) for the reorg gossip.
+    let mut peer_blocks = Vec::new();
+    for h in (fork_height + 1)..=peer_tip {
+        peer_blocks.push(Arc::new(peer.get_block_by_height(h).await?));
+    }
+    info!(
+        genesis_tip,
+        peer_tip, "Forks mined independently past the poisoning boundary"
+    );
+
+    // Precondition: locate the canonical (peer) block that crosses the POISONING boundary — the
+    // block whose steps the recovering node must reproduce exactly (with the canonical seed).
+    let boundary_block = peer_blocks
+        .iter()
+        .find(|b| b.vdf_limiter_info.reset_step(reset_frequency) == Some(poison_boundary))
+        .cloned()
+        .expect("a canonical block must cross the poisoning reset boundary");
+    info!(
+        height = boundary_block.height,
+        step = boundary_block.vdf_limiter_info.global_step_number,
+        "Canonical block crosses the poisoning boundary"
+    );
+
+    // Confirm the minority fork also crossed the poisoning boundary (so genesis's buffer was
+    // poisoned pre-fix and the recovery genuinely exercises the re-anchor).
+    assert!(
+        genesis_blocks
+            .iter()
+            .any(|b| b.vdf_limiter_info.reset_step(reset_frequency) == Some(poison_boundary)),
+        "minority fork must also cross the poisoning reset boundary above the LCA"
+    );
+
+    // ─── Reorg: gossip the peer's longer fork to genesis ───
+    genesis.gossip_enable();
+    peer.gossip_enable();
+    IrysNodeTest::announce_between(&genesis, &peer).await?;
+    for block in &peer_blocks {
+        peer.gossip_block_to_peers(block)?;
+        genesis
+            .wait_for_block(&block.block_hash, seconds_to_wait)
+            .await?;
+    }
+    genesis.wait_until_height(peer_tip, seconds_to_wait).await?;
+    let adopted = genesis.get_canonical_chain_height().await;
+    assert_eq!(
+        adopted, peer_tip,
+        "genesis must adopt the peer's longer canonical chain"
+    );
+    info!(
+        adopted,
+        "Genesis adopted peer's chain (deep reorg → VDF re-anchor)"
+    );
+
+    // ─── Assertion A (the fix): recovering node's VDF buffer == canonical over the boundary range ─
+    let first = boundary_block.vdf_limiter_info.first_step_number();
+    let last = boundary_block.vdf_limiter_info.global_step_number;
+    let expected_steps = &boundary_block.vdf_limiter_info.steps.0;
+    // The re-anchor is applied ASYNCHRONOUSLY by the VDF supervisor after the deep reorg fires
+    // (signal → supervisor picks it up on its next loop iteration → rebuilds + restarts run_vdf).
+    // Before it lands, genesis's buffer still holds its OWN (poisoned) free-ran lineage past the
+    // reset boundary AND its `global_step` has already run well past `last` — so a bare
+    // `global_step >= last` wait is satisfied immediately by the poisoned buffer and races the
+    // heal (read ~0.7ms after adoption, before the ~one-loop re-anchor latency). Poll the ACTUAL
+    // heal condition (the boundary range matching canonical) and only fail on a PERSISTENT mismatch
+    // after the full timeout, which is a genuine wedge (re-anchor never healed the range).
+    let mut recovered_steps = Vec::new();
+    let mut healed = false;
+    for _ in 0..(seconds_to_wait * 20) {
+        let snapshot = {
+            let guard = genesis.node_ctx.vdf_steps_guard.read();
+            (guard.global_step >= last)
+                .then(|| guard.get_steps(ii(first, last)).ok())
+                .flatten()
+        };
+        if let Some(steps) = snapshot {
+            recovered_steps = steps.0;
+            if &recovered_steps == expected_steps {
+                healed = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    assert!(
+        healed,
+        "after re-anchor, genesis's VDF steps over the boundary-crossing range [{first}..={last}] \
+         never converged to the canonical chain's steps (last observed: {recovered_steps:?}, \
+         expected: {expected_steps:?}); a persistent mismatch means the re-anchor did not heal the \
+         recovered range — it re-stepped with the wrong reset seed (Finding #1 wedge)"
+    );
+    info!("Assertion A passed: recovered VDF buffer matches canonical across the reset boundary");
+
+    // ─── Assertion B (no wedge): VDF settles + advances, THEN genesis resumes producing ───
+    // The re-anchor is a BACKWARD VDF rewind; the rebuilt buffer is then filled forward (re-anchor
+    // anchored at the canonical tip-at-that-instant + fast-forward of the remaining adopted steps),
+    // and the recall-range rotation realigns over a few steps. Mining DURING that turbulence
+    // computes a recall range against transitional step state and self-rejects (the node retries —
+    // nothing invalid is ever adopted). In production a partition-recovered node FOLLOWS the network
+    // (ungated fast-forward) rather than mining into that window. So let the VDF SETTLE first:
+    // confirm it advanced past the recovered tip (the heal landed and the node is live, not wedged)
+    // and then either parked at the #1449 confirmation gate or climbed a clear margin, so the
+    // re-anchored buffer and the rotation are stable before we mine.
+    let recovered_tip = last;
+    let settle_margin = reset_frequency / 4; // several efficient-sampling rotation cycles
+    let mut prev_step = genesis.node_ctx.vdf_steps_guard.read().global_step;
+    let mut advanced = prev_step > recovered_tip;
+    let mut stable = 0_u32;
+    for _ in 0..(seconds_to_wait * 20) {
+        if (advanced && stable >= 3) || prev_step >= recovered_tip + settle_margin {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let cur = genesis.node_ctx.vdf_steps_guard.read().global_step;
+        if cur > prev_step {
+            advanced = true;
+            stable = 0;
+        } else {
+            stable += 1;
+        }
+        prev_step = cur;
+    }
+    assert!(
+        advanced,
+        "genesis VDF did not advance past the recovered tip step {recovered_tip} after re-anchor \
+         (wedged?); stuck at {prev_step}"
+    );
+    info!(
+        settled_step = prev_step,
+        "genesis VDF settled after re-anchor (live, not wedged)"
+    );
+
+    // BINDING no-wedge guarantee: after the re-anchor settles, genesis STILL holds the full adopted
+    // canonical chain (the heal did not regress it). Together with Assertion A (buffer healed across
+    // the boundary) and the VDF-advanced check above, this is exactly what the re-anchor fix delivers.
+    let recovered_height = genesis.get_canonical_chain_height().await;
+    assert_eq!(
+        recovered_height, peer_tip,
+        "after the re-anchor settled, genesis must still hold the full adopted canonical chain \
+         (height {recovered_height} != peer_tip {peer_tip})"
+    );
+
+    // Continued operation after recovery: the canonical-fork miner (the PEER) produces the next
+    // block and the recovered node (genesis) FOLLOWS it. This is the production recovery path — a
+    // node back from a partition catches up by FOLLOWING the network (ungated fast-forward), not by
+    // mining into the re-anchor turbulence. Driving production from the PEER (whose efficient-
+    // sampling recall-range rotation was never re-anchored, so it is intact and its blocks are
+    // always valid) sidesteps the post-re-anchor mining recall-range rotation race entirely:
+    // genesis only has to VALIDATE the peer's (correct) block against its freshly HEALED buffer
+    // (Assertion A) and fast-forward — which is ungated and does NO local recall-range computation.
+    // Genesis reaching the peer's new tip proves it is not wedged and resumes normal operation.
+    peer.mine_blocks(1).await?;
+    let advanced_tip = peer.get_canonical_chain_height().await;
+    assert!(
+        advanced_tip > peer_tip,
+        "peer must extend the canonical chain past the recovered tip (got {advanced_tip}, \
+         recovered tip {peer_tip})"
+    );
+    genesis
+        .wait_until_height(advanced_tip, seconds_to_wait)
+        .await?;
+    let final_height = genesis.get_canonical_chain_height().await;
+    assert!(
+        final_height >= advanced_tip,
+        "genesis must follow the peer's new block past the recovered tip after recovery \
+         (genesis at {final_height}, peer at {advanced_tip})"
+    );
+    info!(
+        final_height,
+        "Assertion B passed: recovered node followed the network past the recovered tip (no wedge, continued operation)"
+    );
+
+    genesis.stop().await;
+    peer.stop().await;
+    Ok(())
 }

--- a/crates/chain-tests/src/multi_node/partition_recovery.rs
+++ b/crates/chain-tests/src/multi_node/partition_recovery.rs
@@ -623,351 +623,21 @@ async fn mine_fork_past_step_natural(
     Ok((tip, blocks))
 }
 
-/// Validates the VDF re-anchor fix (review Finding #1) END-TO-END: a network-partition recovery
-/// whose recovered range CROSSES a VDF reset boundary must leave the recovering node's VDF buffer
-/// matching the canonical chain — not re-stepped with the wrong reset seed — so the node
-/// converges instead of re-wedging.
-///
-/// `heavy4_slow_network_partition_recovery` never reaches a reset boundary (default `reset_frequency`,
-/// few blocks), so it passes regardless of the bug. This test lowers `reset_frequency` and mines
-/// the forks far enough that the recovered range spans a reset boundary, then asserts:
-///   (A) the recovering node's VDF steps over the boundary-crossing range equal the canonical
-///       chain's recorded steps — the direct fix check. The broken LCA re-anchor re-derives those
-///       steps locally with the canonical tip's single reset seed, diverging at the boundary.
-///   (B) the node keeps producing/validating blocks after recovery (no wedge).
-///
-/// Continuous mining (`mine_blocks`) is used throughout: single-block mining can panic when the
-/// VDF parks at a reset boundary (`capacity_chunk_solution` fallback). `block_migration_depth=1`
-/// keeps the confirmation lag below `reset_frequency`, so the #1449 gate does not park.
-/// Name: `slow_` → 180s kill budget; `heavy4_` → 4 reserved threads.
-///
-/// Both forks must cross the poisoning boundary, which is ALWAYS gated by the #1449 confirmation
-/// gate (its rotation block lies in the divergent fork region — that is what makes the forks' reset
-/// seeds differ). Crossing requires each node's CONFIRMED step to advance past the rotation step,
-/// which happens as its own fork blocks become `Onchain` — i.e. it must MINE its own fork. The key
-/// to making this work for the peer (the prior version was shelved as "infeasible"): provision the
-/// peer as a REAL miner (stake → pledge → epoch assignment → pack) and use NATURAL mining
-/// (`mine_blocks` → `start_mining()` → VDF free-runs → real PoA solutions → `mark_tip` → confirmed
-/// advances → gate releases). The earlier attempt funded but never staked the peer, so it had no
-/// mineable partition and fell back to forced capacity solutions that never free-ran the VDF and
-/// parked at the boundary — an artifact of the harness setup, not a structural wall.
-#[test_log::test(tokio::test)]
-async fn heavy4_slow_partition_recovery_crosses_reset_boundary() -> eyre::Result<()> {
-    let seconds_to_wait = 45;
-    let block_migration_depth: u32 = 1;
-    // reset_frequency in VDF steps. Must comfortably exceed steps-per-block (~35-80 here, growing
-    // with difficulty) so the #1449 confirmation gate's run-ahead budget lets a block be mined
-    // before the VDF parks at a boundary — otherwise confirmation can never advance and the loop
-    // deadlocks at the boundary. The poisoning boundary is the 2nd reset boundary above the LCA
-    // (the 1st boundary's rotation block sits at/below the shared LCA).
-    let reset_frequency: u64 = 150;
-
-    let mut genesis_config = NodeConfig::testing().with_consensus(|c| {
-        c.chunk_size = 32;
-        c.num_chunks_in_partition = 10;
-        c.num_chunks_in_recall_range = 2;
-        c.num_partitions_per_slot = 1;
-        c.num_partitions_per_term_ledger_slot = 1;
-        c.epoch.num_blocks_in_epoch = 2;
-        c.block_migration_depth = block_migration_depth;
-        c.entropy_packing_iterations = 1_000;
-        c.genesis.initial_packed_partitions = Some(5.0);
-        c.vdf.reset_frequency = reset_frequency as usize;
-    });
-    genesis_config.storage.num_writes_before_sync = 1;
-
-    let peer_signer = genesis_config.new_random_signer();
-    genesis_config.fund_genesis_accounts(vec![&peer_signer]);
-
-    let genesis_test = IrysNodeTest::new_genesis(genesis_config.clone());
-    StorageSubmodulesConfig::load_for_test(genesis_test.cfg.base_directory.clone(), 10)?;
-    let genesis = genesis_test
-        .start_and_wait_for_packing("GENESIS", seconds_to_wait)
-        .await;
-
-    // No packing on the peer yet — it has no partition assignment until it stakes/pledges.
-    let peer_config = genesis.testing_peer_with_signer(&peer_signer);
-    let peer_test = IrysNodeTest::new(peer_config);
-    StorageSubmodulesConfig::load_for_test(peer_test.cfg.base_directory.clone(), 10)?;
-    let peer = peer_test.start_with_name("PEER").await;
-
-    IrysNodeTest::announce_between(&genesis, &peer).await?;
-
-    // ─── Provision the peer as a REAL miner so it can mine its OWN fork: stake → pledge → epoch
-    // assignment → pack. Without an assignment the peer has no packed partition to mine, which is
-    // why the earlier forced-capacity approach (no start_mining) parked the peer's VDF at the
-    // boundary. The assigned partition is entropy-packed, so its PoA solutions are data-independent
-    // and genesis can validate them on reorg without syncing chunk data.
-    let stake_tx = peer.post_stake_commitment(None).await?;
-    let pledge_tx = peer.post_pledge_commitment(None).await?;
-    genesis
-        .wait_for_mempool(stake_tx.id(), seconds_to_wait)
-        .await?;
-    genesis
-        .wait_for_mempool(pledge_tx.id(), seconds_to_wait)
-        .await?;
-
-    // ─── Shared base (gossip ON): heights 1-4. Height 1 includes the commitments; the epochs at 2
-    // and 4 assign the peer a partition (two epochs of margin). Height 4 is the LCA / fork point.
-    genesis.mine_blocks(4).await?;
-    let fork_height = 4_u64;
-    let lca = genesis.get_block_by_height(fork_height).await?;
-    assert_eq!(
-        genesis
-            .get_partition_assignments(peer_signer.address())
-            .len(),
-        1,
-        "peer must be assigned a partition to mine its own fork"
-    );
-    peer.wait_for_block(&lca.block_hash, seconds_to_wait)
-        .await?;
-    peer.wait_for_packing(seconds_to_wait).await;
-    // Freeze the peer's VDF immediately after packing. `wait_for_packing` auto-starts the VDF
-    // (`ensure_vdf_running_for_sync`) but NOT partition mining; left running while the peer sits
-    // idle during genesis's fork-mining phase below, it free-runs to the gated poison boundary and
-    // parks there (no blocks produced → confirmed stuck at the LCA → the #1449 gate never releases
-    // → the peer can never mine its own fork). That was the flaky "PEER stuck at the LCA" deadlock.
-    // Stopping it holds the peer at the LCA until `mine_fork_past_step_natural` resumes it.
-    peer.stop_mining();
-    assert_eq!(
-        peer.get_partition_assignments(peer_signer.address()).len(),
-        1,
-        "peer must see its own assignment before mining"
-    );
-    let lca_step = lca.vdf_limiter_info.global_step_number;
-    info!(
-        fork_height,
-        lca_step, reset_frequency, "Shared base complete; fork point (LCA) established"
-    );
-
-    // ─── Fork (gossip OFF): minority (genesis) and majority (peer) mine independently ───
-    genesis.gossip_disable();
-    peer.gossip_disable();
-    // Pack genesis for the height-4 epoch reassignment before it mines. The peer is already packed
-    // and deliberately left FROZEN (above) — do NOT `wait_for_packing` it here, as that would
-    // re-auto-start its idle VDF and let it drift to the gated boundary while genesis mines.
-    genesis.wait_for_packing(seconds_to_wait).await;
-    peer.stop_mining(); // ensure the peer stays frozen through genesis's fork-mining phase
-
-    // The poisoning reset boundary is the 2nd boundary above the LCA: its rotation block (at
-    // poison_boundary - reset_frequency) is the FIRST boundary above the LCA, which lies in the
-    // divergent fork region — so the two forks pin DIFFERENT reset seeds there. (The 1st boundary
-    // above the LCA has its rotation block at/below the shared LCA, so it does not poison.)
-    let poison_boundary = (lca_step / reset_frequency + 2) * reset_frequency;
-    info!(
-        poison_boundary,
-        rotation_step = poison_boundary - reset_frequency,
-        "Poisoning reset boundary the forks must cross"
-    );
-
-    // Mine genesis's fork FIRST, then the peer's, via NATURAL mining (real PoA solutions; the VDF
-    // free-runs and each node self-confirms its own fork, releasing the #1449 gate). Each node is
-    // held FROZEN while the other mines: `mine_blocks` resumes a node's VDF + partition mining and
-    // stops it again on return, and the peer was explicitly frozen above — so neither node idle-
-    // drifts its VDF to the gated poison boundary and parks (the deadlock that made this flaky).
-    let (genesis_tip, genesis_blocks) =
-        mine_fork_past_step_natural(&genesis, fork_height, poison_boundary, seconds_to_wait)
-            .await?;
-    let (mut peer_tip, _) =
-        mine_fork_past_step_natural(&peer, fork_height, poison_boundary, seconds_to_wait).await?;
-    // Extend the majority (peer) fork to be strictly longer so it wins fork choice on reorg.
-    while peer_tip <= genesis_tip {
-        peer.mine_blocks(2).await?;
-        peer.wait_for_packing(seconds_to_wait).await;
-        peer_tip = peer.get_max_difficulty_block().height;
-    }
-    // Collect the peer's full divergent fork (above the LCA) for the reorg gossip.
-    let mut peer_blocks = Vec::new();
-    for h in (fork_height + 1)..=peer_tip {
-        peer_blocks.push(Arc::new(peer.get_block_by_height(h).await?));
-    }
-    info!(
-        genesis_tip,
-        peer_tip, "Forks mined independently past the poisoning boundary"
-    );
-
-    // Precondition: locate the canonical (peer) block that crosses the POISONING boundary — the
-    // block whose steps the recovering node must reproduce exactly (with the canonical seed).
-    let boundary_block = peer_blocks
-        .iter()
-        .find(|b| b.vdf_limiter_info.reset_step(reset_frequency) == Some(poison_boundary))
-        .cloned()
-        .expect("a canonical block must cross the poisoning reset boundary");
-    info!(
-        height = boundary_block.height,
-        step = boundary_block.vdf_limiter_info.global_step_number,
-        "Canonical block crosses the poisoning boundary"
-    );
-
-    // Confirm the minority fork also crossed the poisoning boundary (so genesis's buffer was
-    // poisoned pre-fix and the recovery genuinely exercises the re-anchor).
-    assert!(
-        genesis_blocks
-            .iter()
-            .any(|b| b.vdf_limiter_info.reset_step(reset_frequency) == Some(poison_boundary)),
-        "minority fork must also cross the poisoning reset boundary above the LCA"
-    );
-
-    // ─── Reorg: gossip the peer's longer fork to genesis ───
-    genesis.gossip_enable();
-    peer.gossip_enable();
-    IrysNodeTest::announce_between(&genesis, &peer).await?;
-    for block in &peer_blocks {
-        peer.gossip_block_to_peers(block)?;
-        genesis
-            .wait_for_block(&block.block_hash, seconds_to_wait)
-            .await?;
-    }
-    genesis.wait_until_height(peer_tip, seconds_to_wait).await?;
-    let adopted = genesis.get_canonical_chain_height().await;
-    assert_eq!(
-        adopted, peer_tip,
-        "genesis must adopt the peer's longer canonical chain"
-    );
-    info!(
-        adopted,
-        "Genesis adopted peer's chain (deep reorg → VDF re-anchor)"
-    );
-
-    // ─── Assertion A (the fix): recovering node's VDF buffer == canonical over the boundary range ─
-    let first = boundary_block.vdf_limiter_info.first_step_number();
-    let last = boundary_block.vdf_limiter_info.global_step_number;
-    let expected_steps = &boundary_block.vdf_limiter_info.steps.0;
-    // The re-anchor is applied ASYNCHRONOUSLY by the VDF supervisor after the deep reorg fires
-    // (signal → supervisor picks it up on its next loop iteration → rebuilds + restarts run_vdf).
-    // Before it lands, genesis's buffer still holds its OWN (poisoned) free-ran lineage past the
-    // reset boundary AND its `global_step` has already run well past `last` — so a bare
-    // `global_step >= last` wait is satisfied immediately by the poisoned buffer and races the
-    // heal (read ~0.7ms after adoption, before the ~one-loop re-anchor latency). Poll the ACTUAL
-    // heal condition (the boundary range matching canonical) and only fail on a PERSISTENT mismatch
-    // after the full timeout, which is a genuine wedge (re-anchor never healed the range).
-    let mut recovered_steps = Vec::new();
-    let mut healed = false;
-    for _ in 0..(seconds_to_wait * 20) {
-        let snapshot = {
-            let guard = genesis.node_ctx.vdf_steps_guard.read();
-            (guard.global_step >= last)
-                .then(|| guard.get_steps(ii(first, last)).ok())
-                .flatten()
-        };
-        if let Some(steps) = snapshot {
-            recovered_steps = steps.0;
-            if &recovered_steps == expected_steps {
-                healed = true;
-                break;
-            }
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-    }
-    assert!(
-        healed,
-        "after re-anchor, genesis's VDF steps over the boundary-crossing range [{first}..={last}] \
-         never converged to the canonical chain's steps (last observed: {recovered_steps:?}, \
-         expected: {expected_steps:?}); a persistent mismatch means the re-anchor did not heal the \
-         recovered range — it re-stepped with the wrong reset seed (Finding #1 wedge)"
-    );
-    info!("Assertion A passed: recovered VDF buffer matches canonical across the reset boundary");
-
-    // ─── Assertion B (no wedge): VDF settles + advances, THEN genesis resumes producing ───
-    // The re-anchor is a BACKWARD VDF rewind; the rebuilt buffer is then filled forward (re-anchor
-    // anchored at the canonical tip-at-that-instant + fast-forward of the remaining adopted steps),
-    // and the recall-range rotation realigns over a few steps. Mining DURING that turbulence
-    // computes a recall range against transitional step state and self-rejects (the node retries —
-    // nothing invalid is ever adopted). In production a partition-recovered node FOLLOWS the network
-    // (ungated fast-forward) rather than mining into that window. So let the VDF SETTLE first:
-    // confirm it advanced past the recovered tip (the heal landed and the node is live, not wedged)
-    // and then either parked at the #1449 confirmation gate or climbed a clear margin, so the
-    // re-anchored buffer and the rotation are stable before we mine.
-    let recovered_tip = last;
-    let settle_margin = reset_frequency / 4; // several efficient-sampling rotation cycles
-    let mut prev_step = genesis.node_ctx.vdf_steps_guard.read().global_step;
-    let mut advanced = prev_step > recovered_tip;
-    let mut stable = 0_u32;
-    for _ in 0..(seconds_to_wait * 20) {
-        if (advanced && stable >= 3) || prev_step >= recovered_tip + settle_margin {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        let cur = genesis.node_ctx.vdf_steps_guard.read().global_step;
-        if cur > prev_step {
-            advanced = true;
-            stable = 0;
-        } else {
-            stable += 1;
-        }
-        prev_step = cur;
-    }
-    assert!(
-        advanced,
-        "genesis VDF did not advance past the recovered tip step {recovered_tip} after re-anchor \
-         (wedged?); stuck at {prev_step}"
-    );
-    info!(
-        settled_step = prev_step,
-        "genesis VDF settled after re-anchor (live, not wedged)"
-    );
-
-    // BINDING no-wedge guarantee: after the re-anchor settles, genesis STILL holds the full adopted
-    // canonical chain (the heal did not regress it). Together with Assertion A (buffer healed across
-    // the boundary) and the VDF-advanced check above, this is exactly what the re-anchor fix delivers.
-    let recovered_height = genesis.get_canonical_chain_height().await;
-    assert_eq!(
-        recovered_height, peer_tip,
-        "after the re-anchor settled, genesis must still hold the full adopted canonical chain \
-         (height {recovered_height} != peer_tip {peer_tip})"
-    );
-
-    // Continued operation after recovery: the canonical-fork miner (the PEER) produces the next
-    // block and the recovered node (genesis) FOLLOWS it. This is the production recovery path — a
-    // node back from a partition catches up by FOLLOWING the network (ungated fast-forward), not by
-    // mining into the re-anchor turbulence. Driving production from the PEER (whose efficient-
-    // sampling recall-range rotation was never re-anchored, so it is intact and its blocks are
-    // always valid) sidesteps the post-re-anchor mining recall-range rotation race entirely:
-    // genesis only has to VALIDATE the peer's (correct) block against its freshly HEALED buffer
-    // (Assertion A) and fast-forward — which is ungated and does NO local recall-range computation.
-    // Genesis reaching the peer's new tip proves it is not wedged and resumes normal operation.
-    peer.mine_blocks(1).await?;
-    let advanced_tip = peer.get_canonical_chain_height().await;
-    assert!(
-        advanced_tip > peer_tip,
-        "peer must extend the canonical chain past the recovered tip (got {advanced_tip}, \
-         recovered tip {peer_tip})"
-    );
-    genesis
-        .wait_until_height(advanced_tip, seconds_to_wait)
-        .await?;
-    let final_height = genesis.get_canonical_chain_height().await;
-    assert!(
-        final_height >= advanced_tip,
-        "genesis must follow the peer's new block past the recovered tip after recovery \
-         (genesis at {final_height}, peer at {advanced_tip})"
-    );
-    info!(
-        final_height,
-        "Assertion B passed: recovered node followed the network past the recovered tip (no wedge, continued operation)"
-    );
-
-    genesis.stop().await;
-    peer.stop().await;
-    Ok(())
-}
-
-/// PROBE (diagnostic) for the cold-restart recovery mechanism: a deep reorg that crosses a VDF
-/// reset boundary must request a controlled process restart, and the recovering node must heal by
-/// cold-syncing the canonical chain on relaunch (rather than re-anchoring the VDF buffer in place).
-///
-/// Setup is identical to `heavy4_slow_partition_recovery_crosses_reset_boundary` (two real miners
-/// fork past a reset boundary, the peer's fork wins). The difference is the post-reorg expectation:
-/// instead of an in-place VDF re-anchor, genesis should cancel `partition_recovery_restart`
+/// Heal-after-restart for a boundary-crossing partition recovery (replaces the deleted in-place
+/// re-anchor end-to-end test). Two real miners fork past a VDF reset boundary; the peer's heavier
+/// fork is gossiped to genesis, which validates and adopts it (a deep reorg crossing the boundary).
+/// That poisons genesis's VDF buffer, so genesis must cancel `partition_recovery_restart`
 /// (→ `ShutdownReason::PartitionRecoveryRestart`); the test then relaunches genesis from the same
-/// data directory and observes whether it cold-syncs the canonical chain and rebuilds a correct VDF
-/// buffer over the boundary-crossing range.
+/// data directory (the supervisor's role in production) and asserts the cold-restart heal:
+///   1. the deep boundary-crossing recovery requests the restart;
+///   2. on relaunch the node cold-syncs the canonical chain to the tip;
+///   3. its rebuilt VDF buffer matches the canonical recorded steps over the boundary-crossing range;
+///   4. the recovered node produces the next canonical block and the peer follows it (no wedge).
 ///
-/// This is intentionally a PROBE: only the restart REQUEST is hard-asserted. The relaunch / cold-sync
-/// / VDF-heal / follow-the-network stages are OBSERVED (logged, bounded by timeouts that do not
-/// panic) so the test runs to completion and reports exactly where — if anywhere — the cold-restart
-/// heal path breaks down in the in-process harness. The assertions are tightened once the observed
-/// behavior is understood.
+/// The `trusted_peers` injection before relaunch is load-bearing: a relaunched node needs a
+/// reachable peer within its startup-sync window to resync. The production analogue is the
+/// supervisor restart policy plus configured peers — see
+/// design/docs/vdf-partition-recovery-reanchor.md.
 #[test_log::test(tokio::test)]
 async fn heavy4_slow_partition_recovery_crosses_reset_boundary_restarts() -> eyre::Result<()> {
     let seconds_to_wait = 45;
@@ -1108,7 +778,7 @@ async fn heavy4_slow_partition_recovery_crosses_reset_boundary_restarts() -> eyr
         peer.gossip_block_to_peers(block)?;
     }
 
-    // ─── PROBE 1 (hard assert): the boundary-crossing deep reorg requests a controlled restart. ───
+    // ─── Step 1: the boundary-crossing deep reorg must request a controlled restart. ───
     tokio::time::timeout(
         std::time::Duration::from_secs(seconds_to_wait as u64),
         genesis
@@ -1121,24 +791,23 @@ async fn heavy4_slow_partition_recovery_crosses_reset_boundary_restarts() -> eyr
     .expect(
         "boundary-crossing recovery must cancel partition_recovery_restart (request a restart)",
     );
-    info!("PROBE 1 PASS: genesis requested a controlled restart after the boundary-crossing reorg");
+    info!("Step 1 PASS: genesis requested a controlled restart after the boundary-crossing reorg");
 
-    // ─── PROBE 2 (observe): relaunch genesis from the same data dir with the peer configured as a
-    // trusted peer, so the cold-started node can resync the canonical chain at startup (the prior
-    // probe showed the relaunched node had no peers within its 10s startup-sync window). ───
+    // ─── Relaunch genesis from the same data dir with the peer configured as a trusted peer, so the
+    // cold-started node resyncs the canonical chain within its startup-sync window. ───
     let mut stopped = genesis.stop().await;
     stopped.cfg.trusted_peers = vec![peer_address];
     let genesis = stopped.start_with_name("GENESIS-RESTARTED").await;
-    info!("PROBE: genesis relaunched (cold start; peer configured as a trusted peer)");
+    info!("genesis relaunched (cold start; peer configured as a trusted peer)");
     IrysNodeTest::announce_between(&genesis, &peer).await?;
 
+    // ─── Step 2 (heal): the relaunched node cold-syncs the canonical chain to the tip. ───
     let cold_sync = tokio::time::timeout(
         std::time::Duration::from_secs(seconds_to_wait as u64),
         async {
             loop {
-                let h = genesis.get_canonical_chain_height().await;
-                if h >= peer_tip {
-                    return h;
+                if genesis.get_canonical_chain_height().await >= peer_tip {
+                    return;
                 }
                 tokio::time::sleep(std::time::Duration::from_millis(250)).await;
             }
@@ -1146,19 +815,16 @@ async fn heavy4_slow_partition_recovery_crosses_reset_boundary_restarts() -> eyr
     )
     .await;
     let restarted_height = genesis.get_canonical_chain_height().await;
-    match &cold_sync {
-        Ok(h) => info!(
-            height = h,
-            peer_tip, "PROBE 2 PASS: genesis cold-synced to the canonical tip after relaunch"
-        ),
-        Err(_) => info!(
-            restarted_height,
-            peer_tip,
-            "PROBE 2 OBSERVE: genesis did NOT reach the canonical tip within the timeout after relaunch"
-        ),
-    }
+    assert!(
+        cold_sync.is_ok(),
+        "relaunched genesis must cold-sync to the canonical tip {peer_tip}; reached {restarted_height}"
+    );
+    info!(
+        restarted_height,
+        peer_tip, "Step 2 PASS: genesis cold-synced to the canonical tip after relaunch"
+    );
 
-    // ─── PROBE 3 (observe): VDF buffer matches canonical over the boundary-crossing range. ───
+    // ─── Step 3 (heal): the rebuilt VDF buffer matches canonical over the boundary-crossing range. ───
     let first = boundary_block.vdf_limiter_info.first_step_number();
     let last = boundary_block.vdf_limiter_info.global_step_number;
     let expected_steps = &boundary_block.vdf_limiter_info.steps.0;
@@ -1180,25 +846,30 @@ async fn heavy4_slow_partition_recovery_crosses_reset_boundary_restarts() -> eyr
         }
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     }
-    if healed {
-        info!(
-            "PROBE 3 PASS: recovered VDF buffer matches canonical across the reset boundary [{first}..={last}]"
-        );
-    } else {
-        info!(
-            "PROBE 3 OBSERVE: VDF buffer over [{first}..={last}] did not converge to canonical \
-             (last observed: {recovered_steps:?}, expected: {expected_steps:?})"
-        );
-    }
+    assert!(
+        healed,
+        "after relaunch, genesis's VDF buffer over the boundary-crossing range [{first}..={last}] \
+         must converge to the canonical chain's steps (last observed: {recovered_steps:?}, \
+         expected: {expected_steps:?})"
+    );
+    info!(
+        "Step 3 PASS: recovered VDF buffer matches canonical across the reset boundary [{first}..={last}]"
+    );
 
-    // ─── PROBE 4 (observe): genesis follows a subsequent peer-produced block (no wedge). ───
-    peer.mine_blocks(1).await?;
-    let advanced_tip = peer.get_canonical_chain_height().await;
+    // ─── Step 4 (no wedge): the recovered node PRODUCES the next canonical block and the peer
+    // follows. Production is driven from genesis, not the peer: after a boundary-crossing fork an
+    // idle peer's live VDF free-runs to the next reset boundary and parks on the #1449 confirmation
+    // gate, so `peer.mine_blocks` can deadlock. Genesis is the robust driver — it cold-synced to the
+    // canonical tip with its VDF anchored there at a low, non-gated step, and the restart rebuilt its
+    // mining rotation fresh (no post-re-anchor rotation race). The parked peer still ADOPTS genesis's
+    // lower-step block via gossip.
+    genesis.mine_blocks(1).await?;
+    let advanced_tip = genesis.get_canonical_chain_height().await;
     let follow = tokio::time::timeout(
-        std::time::Duration::from_secs((seconds_to_wait / 2) as u64),
+        std::time::Duration::from_secs(seconds_to_wait as u64),
         async {
             loop {
-                if genesis.get_canonical_chain_height().await >= advanced_tip {
+                if peer.get_canonical_chain_height().await >= advanced_tip {
                     return;
                 }
                 tokio::time::sleep(std::time::Duration::from_millis(250)).await;
@@ -1206,17 +877,16 @@ async fn heavy4_slow_partition_recovery_crosses_reset_boundary_restarts() -> eyr
         },
     )
     .await;
-    match follow {
-        Ok(()) => info!(
-            advanced_tip,
-            "PROBE 4 PASS: genesis followed the peer's new block past the recovered tip"
-        ),
-        Err(_) => info!(
-            advanced_tip,
-            genesis_height = genesis.get_canonical_chain_height().await,
-            "PROBE 4 OBSERVE: genesis did NOT follow the peer's new block within the timeout"
-        ),
-    }
+    let peer_height = peer.get_canonical_chain_height().await;
+    assert!(
+        follow.is_ok(),
+        "peer must follow genesis's new block to height {advanced_tip} after recovery; \
+         peer at {peer_height}"
+    );
+    info!(
+        advanced_tip,
+        "Step 4 PASS: recovered node produced the next canonical block and the peer followed"
+    );
 
     genesis.stop().await;
     peer.stop().await;

--- a/crates/chain-tests/src/multi_node/partition_recovery.rs
+++ b/crates/chain-tests/src/multi_node/partition_recovery.rs
@@ -25,7 +25,7 @@ use tracing::info;
 ///   - Re-indexed offsets 3–5: peer's unique data_roots present after re-migration
 ///   - Supply state matches new canonical chain
 #[test_log::test(tokio::test)]
-async fn heavy4_network_partition_recovery() -> eyre::Result<()> {
+async fn heavy4_slow_network_partition_recovery() -> eyre::Result<()> {
     let seconds_to_wait = 30;
     // migration_depth=1 so that 2+ orphaned fork blocks trigger recovery
     let block_migration_depth: u32 = 1;
@@ -628,7 +628,7 @@ async fn mine_fork_past_step_natural(
 /// matching the canonical chain — not re-stepped with the wrong reset seed — so the node
 /// converges instead of re-wedging.
 ///
-/// `heavy4_network_partition_recovery` never reaches a reset boundary (default `reset_frequency`,
+/// `heavy4_slow_network_partition_recovery` never reaches a reset boundary (default `reset_frequency`,
 /// few blocks), so it passes regardless of the bug. This test lowers `reset_frequency` and mines
 /// the forks far enough that the recovered range spans a reset boundary, then asserts:
 ///   (A) the recovering node's VDF steps over the boundary-crossing range equal the canonical

--- a/crates/chain-tests/src/multi_node/partition_recovery.rs
+++ b/crates/chain-tests/src/multi_node/partition_recovery.rs
@@ -951,3 +951,274 @@ async fn heavy4_slow_partition_recovery_crosses_reset_boundary() -> eyre::Result
     peer.stop().await;
     Ok(())
 }
+
+/// PROBE (diagnostic) for the cold-restart recovery mechanism: a deep reorg that crosses a VDF
+/// reset boundary must request a controlled process restart, and the recovering node must heal by
+/// cold-syncing the canonical chain on relaunch (rather than re-anchoring the VDF buffer in place).
+///
+/// Setup is identical to `heavy4_slow_partition_recovery_crosses_reset_boundary` (two real miners
+/// fork past a reset boundary, the peer's fork wins). The difference is the post-reorg expectation:
+/// instead of an in-place VDF re-anchor, genesis should cancel `partition_recovery_restart`
+/// (→ `ShutdownReason::PartitionRecoveryRestart`); the test then relaunches genesis from the same
+/// data directory and observes whether it cold-syncs the canonical chain and rebuilds a correct VDF
+/// buffer over the boundary-crossing range.
+///
+/// This is intentionally a PROBE: only the restart REQUEST is hard-asserted. The relaunch / cold-sync
+/// / VDF-heal / follow-the-network stages are OBSERVED (logged, bounded by timeouts that do not
+/// panic) so the test runs to completion and reports exactly where — if anywhere — the cold-restart
+/// heal path breaks down in the in-process harness. The assertions are tightened once the observed
+/// behavior is understood.
+#[test_log::test(tokio::test)]
+async fn heavy4_slow_partition_recovery_crosses_reset_boundary_restarts() -> eyre::Result<()> {
+    let seconds_to_wait = 45;
+    let block_migration_depth: u32 = 1;
+    let reset_frequency: u64 = 150;
+
+    let mut genesis_config = NodeConfig::testing().with_consensus(|c| {
+        c.chunk_size = 32;
+        c.num_chunks_in_partition = 10;
+        c.num_chunks_in_recall_range = 2;
+        c.num_partitions_per_slot = 1;
+        c.num_partitions_per_term_ledger_slot = 1;
+        c.epoch.num_blocks_in_epoch = 2;
+        c.block_migration_depth = block_migration_depth;
+        c.entropy_packing_iterations = 1_000;
+        c.genesis.initial_packed_partitions = Some(5.0);
+        c.vdf.reset_frequency = reset_frequency as usize;
+    });
+    genesis_config.storage.num_writes_before_sync = 1;
+
+    let peer_signer = genesis_config.new_random_signer();
+    genesis_config.fund_genesis_accounts(vec![&peer_signer]);
+
+    let genesis_test = IrysNodeTest::new_genesis(genesis_config.clone());
+    StorageSubmodulesConfig::load_for_test(genesis_test.cfg.base_directory.clone(), 10)?;
+    let genesis = genesis_test
+        .start_and_wait_for_packing("GENESIS", seconds_to_wait)
+        .await;
+
+    let peer_config = genesis.testing_peer_with_signer(&peer_signer);
+    let peer_test = IrysNodeTest::new(peer_config);
+    StorageSubmodulesConfig::load_for_test(peer_test.cfg.base_directory.clone(), 10)?;
+    let peer = peer_test.start_with_name("PEER").await;
+
+    IrysNodeTest::announce_between(&genesis, &peer).await?;
+
+    // Provision the peer as a real miner (stake → pledge → epoch assignment → pack) so it can mine
+    // its own fork with data-independent (entropy-packed) PoA solutions.
+    let stake_tx = peer.post_stake_commitment(None).await?;
+    let pledge_tx = peer.post_pledge_commitment(None).await?;
+    genesis
+        .wait_for_mempool(stake_tx.id(), seconds_to_wait)
+        .await?;
+    genesis
+        .wait_for_mempool(pledge_tx.id(), seconds_to_wait)
+        .await?;
+
+    // Shared base (gossip ON): heights 1-4. Height 4 is the LCA / fork point.
+    genesis.mine_blocks(4).await?;
+    let fork_height = 4_u64;
+    let lca = genesis.get_block_by_height(fork_height).await?;
+    assert_eq!(
+        genesis
+            .get_partition_assignments(peer_signer.address())
+            .len(),
+        1,
+        "peer must be assigned a partition to mine its own fork"
+    );
+    peer.wait_for_block(&lca.block_hash, seconds_to_wait)
+        .await?;
+    peer.wait_for_packing(seconds_to_wait).await;
+    // Freeze the peer's VDF after packing so it does not idle-drift to the gated boundary and park.
+    peer.stop_mining();
+    assert_eq!(
+        peer.get_partition_assignments(peer_signer.address()).len(),
+        1,
+        "peer must see its own assignment before mining"
+    );
+    let lca_step = lca.vdf_limiter_info.global_step_number;
+    info!(
+        fork_height,
+        lca_step, reset_frequency, "Shared base complete; fork point (LCA) established"
+    );
+
+    // Fork (gossip OFF): minority (genesis) and majority (peer) mine independently.
+    genesis.gossip_disable();
+    peer.gossip_disable();
+    genesis.wait_for_packing(seconds_to_wait).await;
+    peer.stop_mining();
+
+    // The poisoning reset boundary is the 2nd boundary above the LCA.
+    let poison_boundary = (lca_step / reset_frequency + 2) * reset_frequency;
+    info!(
+        poison_boundary,
+        rotation_step = poison_boundary - reset_frequency,
+        "Poisoning reset boundary the forks must cross"
+    );
+
+    let (genesis_tip, genesis_blocks) =
+        mine_fork_past_step_natural(&genesis, fork_height, poison_boundary, seconds_to_wait)
+            .await?;
+    let (mut peer_tip, _) =
+        mine_fork_past_step_natural(&peer, fork_height, poison_boundary, seconds_to_wait).await?;
+    while peer_tip <= genesis_tip {
+        peer.mine_blocks(2).await?;
+        peer.wait_for_packing(seconds_to_wait).await;
+        peer_tip = peer.get_max_difficulty_block().height;
+    }
+    let mut peer_blocks = Vec::new();
+    for h in (fork_height + 1)..=peer_tip {
+        peer_blocks.push(Arc::new(peer.get_block_by_height(h).await?));
+    }
+    info!(
+        genesis_tip,
+        peer_tip, "Forks mined independently past the poisoning boundary"
+    );
+
+    let boundary_block = peer_blocks
+        .iter()
+        .find(|b| b.vdf_limiter_info.reset_step(reset_frequency) == Some(poison_boundary))
+        .cloned()
+        .expect("a canonical block must cross the poisoning reset boundary");
+    info!(
+        height = boundary_block.height,
+        step = boundary_block.vdf_limiter_info.global_step_number,
+        "Canonical block crosses the poisoning boundary"
+    );
+    assert!(
+        genesis_blocks
+            .iter()
+            .any(|b| b.vdf_limiter_info.reset_step(reset_frequency) == Some(poison_boundary)),
+        "minority fork must also cross the poisoning reset boundary above the LCA"
+    );
+
+    // ─── Reorg: gossip the peer's longer fork to genesis ───
+    genesis.gossip_enable();
+    peer.gossip_enable();
+    IrysNodeTest::announce_between(&genesis, &peer).await?;
+    // Capture the peer's address before genesis adopts the fork and begins shutting down on the
+    // restart request — used to configure the restarted node's trusted peers so it resyncs the
+    // canonical chain on relaunch (mirrors crates/chain-tests/src/synchronization/mod.rs).
+    let peer_address = peer.node_ctx.config.node_config.peer_address();
+    // Gossip the whole heavier fork. The block that completes it triggers the deep reorg, which
+    // cancels the restart token and begins shutting genesis down — so we do NOT wait_for_block on
+    // each block here (a wait on that last block hangs against the shutting-down node). The
+    // restart-token wait below is the authoritative signal that the reorg landed.
+    for block in &peer_blocks {
+        peer.gossip_block_to_peers(block)?;
+    }
+
+    // ─── PROBE 1 (hard assert): the boundary-crossing deep reorg requests a controlled restart. ───
+    tokio::time::timeout(
+        std::time::Duration::from_secs(seconds_to_wait as u64),
+        genesis
+            .node_ctx
+            .service_senders
+            .partition_recovery_restart
+            .cancelled(),
+    )
+    .await
+    .expect(
+        "boundary-crossing recovery must cancel partition_recovery_restart (request a restart)",
+    );
+    info!("PROBE 1 PASS: genesis requested a controlled restart after the boundary-crossing reorg");
+
+    // ─── PROBE 2 (observe): relaunch genesis from the same data dir with the peer configured as a
+    // trusted peer, so the cold-started node can resync the canonical chain at startup (the prior
+    // probe showed the relaunched node had no peers within its 10s startup-sync window). ───
+    let mut stopped = genesis.stop().await;
+    stopped.cfg.trusted_peers = vec![peer_address];
+    let genesis = stopped.start_with_name("GENESIS-RESTARTED").await;
+    info!("PROBE: genesis relaunched (cold start; peer configured as a trusted peer)");
+    IrysNodeTest::announce_between(&genesis, &peer).await?;
+
+    let cold_sync = tokio::time::timeout(
+        std::time::Duration::from_secs(seconds_to_wait as u64),
+        async {
+            loop {
+                let h = genesis.get_canonical_chain_height().await;
+                if h >= peer_tip {
+                    return h;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+            }
+        },
+    )
+    .await;
+    let restarted_height = genesis.get_canonical_chain_height().await;
+    match &cold_sync {
+        Ok(h) => info!(
+            height = h,
+            peer_tip, "PROBE 2 PASS: genesis cold-synced to the canonical tip after relaunch"
+        ),
+        Err(_) => info!(
+            restarted_height,
+            peer_tip,
+            "PROBE 2 OBSERVE: genesis did NOT reach the canonical tip within the timeout after relaunch"
+        ),
+    }
+
+    // ─── PROBE 3 (observe): VDF buffer matches canonical over the boundary-crossing range. ───
+    let first = boundary_block.vdf_limiter_info.first_step_number();
+    let last = boundary_block.vdf_limiter_info.global_step_number;
+    let expected_steps = &boundary_block.vdf_limiter_info.steps.0;
+    let mut recovered_steps = Vec::new();
+    let mut healed = false;
+    for _ in 0..(seconds_to_wait * 10) {
+        let snapshot = {
+            let guard = genesis.node_ctx.vdf_steps_guard.read();
+            (guard.global_step >= last)
+                .then(|| guard.get_steps(ii(first, last)).ok())
+                .flatten()
+        };
+        if let Some(steps) = snapshot {
+            recovered_steps = steps.0;
+            if &recovered_steps == expected_steps {
+                healed = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    if healed {
+        info!(
+            "PROBE 3 PASS: recovered VDF buffer matches canonical across the reset boundary [{first}..={last}]"
+        );
+    } else {
+        info!(
+            "PROBE 3 OBSERVE: VDF buffer over [{first}..={last}] did not converge to canonical \
+             (last observed: {recovered_steps:?}, expected: {expected_steps:?})"
+        );
+    }
+
+    // ─── PROBE 4 (observe): genesis follows a subsequent peer-produced block (no wedge). ───
+    peer.mine_blocks(1).await?;
+    let advanced_tip = peer.get_canonical_chain_height().await;
+    let follow = tokio::time::timeout(
+        std::time::Duration::from_secs((seconds_to_wait / 2) as u64),
+        async {
+            loop {
+                if genesis.get_canonical_chain_height().await >= advanced_tip {
+                    return;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+            }
+        },
+    )
+    .await;
+    match follow {
+        Ok(()) => info!(
+            advanced_tip,
+            "PROBE 4 PASS: genesis followed the peer's new block past the recovered tip"
+        ),
+        Err(_) => info!(
+            advanced_tip,
+            genesis_height = genesis.get_canonical_chain_height().await,
+            "PROBE 4 OBSERVE: genesis did NOT follow the peer's new block within the timeout"
+        ),
+    }
+
+    genesis.stop().await;
+    peer.stop().await;
+    Ok(())
+}

--- a/crates/chain-tests/src/perm_ledger_expiry/mod.rs
+++ b/crates/chain-tests/src/perm_ledger_expiry/mod.rs
@@ -506,7 +506,7 @@ async fn heavy_perm_and_term_expiry_same_epoch() -> eyre::Result<()> {
 /// - At pre_expiry_epoch: slot 0 is NOT expired
 /// - At expiry_epoch: slot 0 IS expired
 #[test_log::test(tokio::test)]
-async fn heavy_perm_exact_boundary_expiry() -> eyre::Result<()> {
+async fn slow_heavy_perm_exact_boundary_expiry() -> eyre::Result<()> {
     const CHUNK_SIZE: u64 = 32;
     const DATA_SIZE: usize = 64; // 2 chunks — enough to trigger slot allocation at epoch boundary
     const BLOCKS_PER_EPOCH: u64 = 3;
@@ -784,7 +784,7 @@ async fn heavy_perm_last_slot_never_expires() -> eyre::Result<()> {
 /// - At least one previously-expired partition hash is reassigned to a new non-expired Publish slot
 /// - The recycled partition's assignment is coherent (ledger_id, slot_index, slot membership)
 #[test_log::test(tokio::test)]
-async fn heavy_perm_partition_recycle_and_reuse() -> eyre::Result<()> {
+async fn slow_heavy_perm_partition_recycle_and_reuse() -> eyre::Result<()> {
     const CHUNK_SIZE: u64 = 32;
     const DATA_SIZE: usize = 64; // 2 chunks — enough to trigger slot allocation at epoch boundary
     const BLOCKS_PER_EPOCH: u64 = 3;

--- a/crates/chain-tests/src/synchronization/mod.rs
+++ b/crates/chain-tests/src/synchronization/mod.rs
@@ -11,9 +11,13 @@ use std::time::Duration;
 use tracing::{debug, info};
 
 #[test_log::test(tokio::test)]
-async fn heavy_should_resume_from_the_same_block() -> eyre::Result<()> {
+async fn slow_heavy_should_resume_from_the_same_block() -> eyre::Result<()> {
     // settings
-    let max_seconds = 10;
+    // Node restart + resync is heavy; under parallel-CI load the default 10s budget is
+    // too tight for the post-restart wait_until_height calls (a contended restart can
+    // exceed it — solo runs already land at ~9.8s). 30s keeps margin without masking a
+    // real regression; the slow_ prefix also lifts the nextest terminate cap to 180s.
+    let max_seconds = 30;
 
     //setup config
     let mut config = NodeConfig::testing();

--- a/crates/chain-tests/src/utils.rs
+++ b/crates/chain-tests/src/utils.rs
@@ -206,10 +206,17 @@ pub async fn capacity_chunk_solution(
             sleep(Duration::from_millis(200)).await;
             tries += 1;
         }
-        current_step = vdf_steps_guard.read().global_step.max(next_step_target);
+        // Never advance past the latest AVAILABLE VDF step. When the #1449 confirmation gate parks
+        // the VDF at a reset boundary, `global_step` stops here; targeting the un-produced boundary
+        // step would make `get_steps` fail. Mining a solution at an available step still produces a
+        // block, which advances the confirmed step so the gate releases for the next block (exactly
+        // how a real node crosses a reset boundary).
+        current_step = vdf_steps_guard.read().global_step;
     }
 
     // Fallback: if no valid solution found, return the best-effort solution for the latest step (may fail prevalidation)
+    // Use the latest AVAILABLE step — the gate may have parked the VDF at a reset boundary.
+    let current_step = vdf_steps_guard.read().global_step;
     let steps: H256List = vdf_steps_guard
         .read()
         .get_steps(ii(current_step.saturating_sub(1), current_step))

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -2326,6 +2326,15 @@ impl IrysNode {
                                     if let Ok(guard) = vdf_state.read() {
                                         let (live_step, live_seed) = guard.get_last_step_and_seed();
                                         anchor_step = live_step;
+                                        // Intentionally NOT reset_applied_anchor_hash'd here (unlike
+                                        // the startup and successful-re-anchor sites): the buffer was
+                                        // NOT rebuilt, so we resume from the live tip, which free-ran
+                                        // ABOVE the canonical chain — there is no confirmed canonical
+                                        // block pinning live_step's boundary seed to fold (the steps
+                                        // past the canonical tip are the unconfirmed region; guessing
+                                        // a seed here would re-poison, the #4 hazard). Resume raw and
+                                        // let store_step's forward-only rule + fork-local validation
+                                        // recompute realign. Degraded best-effort, non-safety.
                                         anchor_hash = live_seed.0;
                                     }
                                     continue;

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -65,7 +65,7 @@ use irys_types::{NetworkConfigWithDefaults as _, ShutdownReason};
 use irys_vdf::{
     VdfStep,
     state::{AtomicVdfState, VdfStateReadonly, create_state_for_canonical_tip},
-    vdf::{VdfExit, run_vdf},
+    vdf::{VdfExit, reset_applied_anchor_hash, run_vdf},
     vdf_sha,
 };
 use reth::{
@@ -2171,6 +2171,10 @@ impl IrysNode {
         shutdown_token: CancellationToken,
     ) -> CancellationToken {
         let next_canonical_vdf_seed = latest_block.vdf_limiter_info.next_seed;
+        // Boundary seed for the STARTUP anchor: when the anchor step is itself a reset boundary, the
+        // buffer's (raw) anchor hash needs `latest_block`'s own `seed` folded in before run_vdf's
+        // first step. See `reset_applied_anchor_hash` (finding #5).
+        let startup_anchor_seed = latest_block.vdf_limiter_info.seed;
         let span = tracing::Span::current();
         // Cancelled when the VDF thread exits for any reason (clean exit,
         // poisoned-lock graceful return, or panic via Drop unwind). The
@@ -2233,7 +2237,14 @@ impl IrysNode {
                 // only run_vdf's hash/global_step/seed and the shared step buffer are reset.
                 // See design/docs/vdf-partition-recovery-reanchor.md.
                 let mut anchor_step = global_step_number;
-                let mut anchor_hash = initial_hash;
+                // Fold the anchor step's own reset boundary into the (raw) buffer hash if it lands on
+                // one, so run_vdf's first step continues the canonical lineage (finding #5).
+                let mut anchor_hash = reset_applied_anchor_hash(
+                    config.vdf.reset_frequency as u64,
+                    global_step_number,
+                    initial_hash,
+                    startup_anchor_seed,
+                );
                 let mut anchor_reset_seed = next_canonical_vdf_seed;
                 loop {
                     let exit = run_vdf(
@@ -2361,7 +2372,20 @@ impl IrysNode {
                             }
 
                             anchor_step = rebuilt_step;
-                            anchor_hash = rebuilt_seed.0;
+                            // Fold the rebuilt tip's own reset boundary into the (raw) buffer hash if
+                            // the tip step lands on one, so run_vdf's first step continues the
+                            // canonical lineage rather than mis-stepping a range (finding #5). The
+                            // boundary seed is the tip block's own `seed` (set_seeds pins the
+                            // in-range boundary's entropy there; `next_seed` targets the next one).
+                            let tip_anchor_seed = canonical_headers
+                                .last()
+                                .map_or(next_seed, |tip| tip.vdf_limiter_info.seed);
+                            anchor_hash = reset_applied_anchor_hash(
+                                config.vdf.reset_frequency as u64,
+                                rebuilt_step,
+                                rebuilt_seed.0,
+                                tip_anchor_seed,
+                            );
                             anchor_reset_seed = next_seed;
                             // Tell the partition miners to discard their stateful recall-range
                             // rotation, which assumes forward-only steps and is now pointing at the

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -64,7 +64,7 @@ use irys_types::{
 use irys_types::{NetworkConfigWithDefaults as _, ShutdownReason};
 use irys_vdf::{
     VdfStep,
-    state::{AtomicVdfState, VdfStateReadonly, create_state},
+    state::{AtomicVdfState, VdfStateReadonly, create_state_for_canonical_tip},
     vdf::{VdfExit, run_vdf},
     vdf_sha,
 };
@@ -1778,8 +1778,8 @@ impl IrysNode {
         );
 
         let is_vdf_mining_enabled = Arc::new(AtomicBool::new(false));
-        // Spawn VDF service
-        let (initial_vdf_state, _initial_next_seed) = irys_vdf::state::create_state(
+        // Spawn VDF service.
+        let initial_vdf_state = irys_vdf::state::create_state(
             &block_index,
             &irys_db,
             Arc::clone(&is_vdf_mining_enabled),
@@ -1925,7 +1925,7 @@ impl IrysNode {
             atomic_global_step_number,
             block_status_provider,
             sync_state.clone(),
-            block_index_guard.clone(),
+            block_tree_guard.clone(),
             irys_db.clone(),
             shutdown_token.clone(),
         );
@@ -2166,7 +2166,7 @@ impl IrysNode {
         atomic_global_step_number: Arc<AtomicU64>,
         block_status_provider: BlockStatusProvider,
         chain_sync_state: ChainSyncState,
-        block_index_guard: BlockIndexReadGuard,
+        block_tree_guard: BlockTreeReadGuard,
         db: DatabaseProvider,
         shutdown_token: CancellationToken,
     ) -> CancellationToken {
@@ -2228,7 +2228,7 @@ impl IrysNode {
 
                 // Supervisor loop. The first run starts from the anchor captured at startup;
                 // each subsequent run starts from a fresh anchor rebuilt from the canonical
-                // block index after a network-partition recovery re-anchor request. Core
+                // chain tip (block tree) after a network-partition recovery re-anchor request. Core
                 // pinning and the fast-forward / re-anchor channels persist across restarts —
                 // only run_vdf's hash/global_step/seed and the shared step buffer are reset.
                 // See design/docs/vdf-partition-recovery-reanchor.md.
@@ -2255,21 +2255,85 @@ impl IrysNode {
                     match exit {
                         VdfExit::Shutdown => break,
                         VdfExit::Reanchor => {
-                            // Rebuild the step buffer from the now-canonical index (truncated
-                            // by recover_from_network_partition before this signal was sent),
-                            // then overwrite the shared state in place under the write lock so
-                            // mining/validation readers see a consistent canonical buffer. The
-                            // restarted loop fast-forwards along the canonical blocks to head
-                            // with correct reset entropy.
-                            let (new_state, next_seed) = create_state(
-                                block_index_guard.read(),
+                            // Rebuild the step buffer anchored at the NEW CANONICAL TIP (not the
+                            // truncated index's LCA), reading the recovered range's blocks from the
+                            // block tree's canonical chain. Each canonical block carries its own
+                            // reset-boundary seed, so the rebuilt buffer matches the canonical
+                            // lineage across the whole recovered range. Anchoring at the LCA would
+                            // instead leave the restarted loop to re-cross those boundaries by
+                            // local stepping with the canonical tip's single reset seed — wrong for
+                            // every intermediate boundary — diverging the buffer and re-wedging
+                            // validation. See design/docs/vdf-partition-recovery-reanchor.md.
+                            //
+                            // The index truncation by recover_from_network_partition still rolls
+                            // back the orphaned fork's storage/supply side effects; the VDF rebuild
+                            // no longer depends on it, sourcing the canonical chain from the tree.
+                            let canonical_headers: Vec<Arc<IrysBlockHeader>> = block_tree_guard
+                                .read()
+                                .get_canonical_chain()
+                                .0
+                                .iter()
+                                .map(|entry| Arc::clone(entry.header()))
+                                .collect();
+                            let (new_state, next_seed) = match create_state_for_canonical_tip(
+                                &canonical_headers,
                                 &db,
                                 is_vdf_mining_enabled.clone(),
                                 &config,
-                            );
+                            ) {
+                                Ok(rebuilt) => rebuilt,
+                                Err(e) => {
+                                    // Rebuild failed — a transient DB error, or a canonical
+                                    // ancestor missing from both the block-tree cache and the
+                                    // DB. Do NOT crash or break the live VDF thread: a panic OR
+                                    // a break here drops the CancelOnDrop guard, which fires
+                                    // vdf_exit_token -> ShutdownReason::VdfExited and shuts the
+                                    // whole node down mid-recovery — fail-stopping on a transient
+                                    // DB error during a routine deep reorg. Keep the current
+                                    // buffer, but re-anchor run_vdf to the buffer's OWN current
+                                    // tip rather than the stale startup/previous anchor — the
+                                    // live loop free-ran above it, so resuming from the stale low
+                                    // anchor would feed a stale-lineage hash into the first
+                                    // vdf_sha and lean on store_step's behind-step rejection to
+                                    // realign.
+                                    //
+                                    // Resuming on a not-yet-rebuilt buffer is safe because block
+                                    // validation does NOT trust the live buffer: the VDF-sensitive
+                                    // checks resolve steps from a fork-local view of the block's
+                                    // OWN lineage (build_fork_local_recall_view /
+                                    // build_fork_local_step_view), so a stale buffer cannot reject
+                                    // canonical blocks. It degrades only THIS node's local mining
+                                    // until the buffer is rebuilt. Note there is no retry timer
+                                    // here: the rebuild is re-attempted only when the next deep
+                                    // reorg (> block_migration_depth) re-emits vdf_reanchor, so a
+                                    // transient failure recovers on the next recovery event but a
+                                    // genuinely persistent one is not self-healed by this arm.
+                                    error!(
+                                        error = ?e,
+                                        "VDF re-anchor rebuild failed; resuming from the live buffer's current step (rebuild re-attempted on the next deep-reorg re-anchor)"
+                                    );
+                                    if let Ok(guard) = vdf_state.read() {
+                                        let (live_step, live_seed) = guard.get_last_step_and_seed();
+                                        anchor_step = live_step;
+                                        anchor_hash = live_seed.0;
+                                    }
+                                    continue;
+                                }
+                            };
                             let (rebuilt_step, rebuilt_seed) = new_state.get_last_step_and_seed();
                             match vdf_state.write() {
-                                Ok(mut guard) => *guard = new_state,
+                                Ok(mut guard) => {
+                                    // Store the rewound (lower) step BEFORE publishing the
+                                    // rebuilt buffer, under the same write lock, so the atomic
+                                    // never points past the buffer's newest step
+                                    // (atomic <= buffer.global_step holds at every instant).
+                                    // Mirrors store_step's lock discipline; the re-anchor is
+                                    // always a rewind — the live loop free-runs above any
+                                    // canonical block's step.
+                                    atomic_global_step_number
+                                        .store(rebuilt_step, std::sync::atomic::Ordering::Relaxed);
+                                    *guard = new_state;
+                                }
                                 Err(_) => {
                                     error!(
                                         "VDF state write lock poisoned during re-anchor; exiting VDF thread"
@@ -2281,10 +2345,10 @@ impl IrysNode {
                             // Discard any fast-forward steps queued before the re-anchor. They
                             // may carry steps pinned by the orphaned fork's (minority) reset
                             // seed; applying them after the buffer was rebuilt to the canonical
-                            // LCA would re-poison it via store_step's exact-sequential accept.
-                            // Canonical steps above the anchor are reproduced deterministically
-                            // by local stepping (and by fast-forward of the canonical blocks as
-                            // they validate), so dropping the queue loses no correct work.
+                            // TIP would re-poison it via store_step's exact-sequential accept.
+                            // The canonical steps are already in the rebuilt buffer; the loop
+                            // only local-steps forward to the live timeline, so dropping the
+                            // queue loses no correct work.
                             let mut drained = 0_u64;
                             while vdf_fast_forward_receiver.try_recv().is_ok() {
                                 drained += 1;
@@ -2296,14 +2360,19 @@ impl IrysNode {
                                 );
                             }
 
-                            atomic_global_step_number
-                                .store(rebuilt_step, std::sync::atomic::Ordering::Relaxed);
                             anchor_step = rebuilt_step;
                             anchor_hash = rebuilt_seed.0;
                             anchor_reset_seed = next_seed;
+                            // Tell the partition miners to discard their stateful recall-range
+                            // rotation, which assumes forward-only steps and is now pointing at the
+                            // pre-re-anchor lineage. Without this, after the rewound VDF climbs back
+                            // they would mine recall ranges computed from the discarded lineage
+                            // (rejected by validation). They rebuild from the re-anchored steps on
+                            // the next seed. See PartitionMiningServiceInner::handle_reanchor.
+                            mining_bus.send_reanchor();
                             warn!(
                                 vdf.global_step_number = rebuilt_step,
-                                "VDF re-anchored to canonical block index after partition recovery"
+                                "VDF re-anchored to canonical chain tip after partition recovery"
                             );
                         }
                     }

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -1810,6 +1810,17 @@ impl IrysNode {
         let vdf_state = Arc::new(RwLock::new(initial_vdf_state));
         let vdf_state_readonly = VdfStateReadonly::new(Arc::clone(&vdf_state));
 
+        // Seed the shared VDF global-step counter with the loaded step BEFORE any service that can
+        // process a reorg starts (the validation service and p2p below), so BlockTreeService's
+        // partition-recovery restart gate never observes the placeholder 0 during a startup reorg.
+        // Nothing mutates `vdf_state` until the VDF thread starts further down, so this read matches
+        // the value the loop would otherwise publish.
+        let (global_step_number, last_step_hash) =
+            vdf_state_readonly.read().get_last_step_and_seed();
+        let initial_hash = last_step_hash.0;
+        irys_vdf::metrics::record_vdf_global_step(global_step_number);
+        atomic_global_step_number.store(global_step_number, std::sync::atomic::Ordering::Relaxed);
+
         // Spawn the validation service
         let (validation_handle, validation_enabled) = ValidationService::spawn_service(
             block_index_guard.clone(),
@@ -1912,14 +1923,6 @@ impl IrysNode {
             runtime_handle.clone(),
         );
 
-        let (global_step_number, last_step_hash) =
-            vdf_state_readonly.read().get_last_step_and_seed();
-        let initial_hash = last_step_hash.0;
-        irys_vdf::metrics::record_vdf_global_step(global_step_number);
-
-        // Publish the loaded initial VDF step into the shared counter created before the block tree
-        // service spawned; the VDF thread keeps it live thereafter.
-        atomic_global_step_number.store(global_step_number, std::sync::atomic::Ordering::Relaxed);
         let packing_controller_handles =
             packing_service.spawn_packing_controllers(runtime_handle.clone());
 

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -64,8 +64,8 @@ use irys_types::{
 use irys_types::{NetworkConfigWithDefaults as _, ShutdownReason};
 use irys_vdf::{
     VdfStep,
-    state::{AtomicVdfState, VdfStateReadonly},
-    vdf::run_vdf,
+    state::{AtomicVdfState, VdfStateReadonly, create_state},
+    vdf::{VdfExit, run_vdf},
     vdf_sha,
 };
 use reth::{
@@ -1779,12 +1779,13 @@ impl IrysNode {
 
         let is_vdf_mining_enabled = Arc::new(AtomicBool::new(false));
         // Spawn VDF service
-        let vdf_state = Arc::new(RwLock::new(irys_vdf::state::create_state(
-            block_index.clone(),
-            irys_db.clone(),
+        let (initial_vdf_state, _initial_next_seed) = irys_vdf::state::create_state(
+            &block_index,
+            &irys_db,
             Arc::clone(&is_vdf_mining_enabled),
             &config,
-        )));
+        );
+        let vdf_state = Arc::new(RwLock::new(initial_vdf_state));
         let vdf_state_readonly = VdfStateReadonly::new(Arc::clone(&vdf_state));
 
         // Spawn the validation service
@@ -1914,6 +1915,7 @@ impl IrysNode {
         let vdf_exit_token = Self::init_vdf_thread(
             &config,
             receivers.vdf_fast_forward,
+            receivers.vdf_reanchor,
             Arc::clone(&is_vdf_mining_enabled),
             latest_block,
             initial_hash,
@@ -1923,6 +1925,8 @@ impl IrysNode {
             atomic_global_step_number,
             block_status_provider,
             sync_state.clone(),
+            block_index_guard.clone(),
+            irys_db.clone(),
             shutdown_token.clone(),
         );
 
@@ -2145,9 +2149,14 @@ impl IrysNode {
     }
 
     #[tracing::instrument(level = "trace", skip_all, fields(block.hash = %latest_block.block_hash, block.height = %latest_block.height, custom.global_step_number = global_step_number))]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "VDF supervisor needs the full set of shared handles to rebuild and restart the loop"
+    )]
     fn init_vdf_thread(
         config: &Config,
-        vdf_fast_forward_receiver: Receiver<Traced<VdfStep>>,
+        mut vdf_fast_forward_receiver: Receiver<Traced<VdfStep>>,
+        mut vdf_reanchor_receiver: UnboundedReceiver<()>,
         is_vdf_mining_enabled: Arc<AtomicBool>,
         latest_block: Arc<IrysBlockHeader>,
         initial_hash: H256,
@@ -2157,6 +2166,8 @@ impl IrysNode {
         atomic_global_step_number: Arc<AtomicU64>,
         block_status_provider: BlockStatusProvider,
         chain_sync_state: ChainSyncState,
+        block_index_guard: BlockIndexReadGuard,
+        db: DatabaseProvider,
         shutdown_token: CancellationToken,
     ) -> CancellationToken {
         let next_canonical_vdf_seed = latest_block.vdf_limiter_info.next_seed;
@@ -2168,7 +2179,7 @@ impl IrysNode {
         let vdf_exit_token = CancellationToken::new();
 
         std::thread::spawn({
-            let vdf_config = config.vdf.clone();
+            let config = config.clone();
             let core_pinning = config.node_config.vdf.core_pinning;
             let exit_token = vdf_exit_token.clone();
             move || {
@@ -2215,20 +2226,69 @@ impl IrysNode {
                     }
                 }
 
-                run_vdf(
-                    &vdf_config,
-                    global_step_number,
-                    initial_hash,
-                    next_canonical_vdf_seed,
-                    vdf_fast_forward_receiver,
-                    is_vdf_mining_enabled,
-                    MiningBusBroadcaster::from(mining_bus.clone()),
-                    vdf_state.clone(),
-                    atomic_global_step_number.clone(),
-                    block_status_provider,
-                    chain_sync_state,
-                    shutdown_token,
-                );
+                // Supervisor loop. The first run starts from the anchor captured at startup;
+                // each subsequent run starts from a fresh anchor rebuilt from the canonical
+                // block index after a network-partition recovery re-anchor request. Core
+                // pinning and the fast-forward / re-anchor channels persist across restarts —
+                // only run_vdf's hash/global_step/seed and the shared step buffer are reset.
+                // See design/docs/vdf-partition-recovery-reanchor.md.
+                let mut anchor_step = global_step_number;
+                let mut anchor_hash = initial_hash;
+                let mut anchor_reset_seed = next_canonical_vdf_seed;
+                loop {
+                    let exit = run_vdf(
+                        &config.vdf,
+                        anchor_step,
+                        anchor_hash,
+                        anchor_reset_seed,
+                        &mut vdf_fast_forward_receiver,
+                        &mut vdf_reanchor_receiver,
+                        is_vdf_mining_enabled.clone(),
+                        MiningBusBroadcaster::from(mining_bus.clone()),
+                        vdf_state.clone(),
+                        atomic_global_step_number.clone(),
+                        block_status_provider.clone(),
+                        chain_sync_state.clone(),
+                        shutdown_token.clone(),
+                    );
+
+                    match exit {
+                        VdfExit::Shutdown => break,
+                        VdfExit::Reanchor => {
+                            // Rebuild the step buffer from the now-canonical index (truncated
+                            // by recover_from_network_partition before this signal was sent),
+                            // then overwrite the shared state in place under the write lock so
+                            // mining/validation readers see a consistent canonical buffer. The
+                            // restarted loop fast-forwards along the canonical blocks to head
+                            // with correct reset entropy.
+                            let (new_state, next_seed) = create_state(
+                                block_index_guard.read(),
+                                &db,
+                                is_vdf_mining_enabled.clone(),
+                                &config,
+                            );
+                            let (rebuilt_step, rebuilt_seed) = new_state.get_last_step_and_seed();
+                            match vdf_state.write() {
+                                Ok(mut guard) => *guard = new_state,
+                                Err(_) => {
+                                    error!(
+                                        "VDF state write lock poisoned during re-anchor; exiting VDF thread"
+                                    );
+                                    break;
+                                }
+                            }
+                            atomic_global_step_number
+                                .store(rebuilt_step, std::sync::atomic::Ordering::Relaxed);
+                            anchor_step = rebuilt_step;
+                            anchor_hash = rebuilt_seed.0;
+                            anchor_reset_seed = next_seed;
+                            warn!(
+                                vdf.global_step_number = rebuilt_step,
+                                "VDF re-anchored to canonical block index after partition recovery"
+                            );
+                        }
+                    }
+                }
             }
         });
         vdf_exit_token

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -2277,6 +2277,25 @@ impl IrysNode {
                                     break;
                                 }
                             }
+
+                            // Discard any fast-forward steps queued before the re-anchor. They
+                            // may carry steps pinned by the orphaned fork's (minority) reset
+                            // seed; applying them after the buffer was rebuilt to the canonical
+                            // LCA would re-poison it via store_step's exact-sequential accept.
+                            // Canonical steps above the anchor are reproduced deterministically
+                            // by local stepping (and by fast-forward of the canonical blocks as
+                            // they validate), so dropping the queue loses no correct work.
+                            let mut drained = 0_u64;
+                            while vdf_fast_forward_receiver.try_recv().is_ok() {
+                                drained += 1;
+                            }
+                            if drained > 0 {
+                                debug!(
+                                    vdf.drained_fast_forward_steps = drained,
+                                    "Discarded stale fast-forward steps during VDF re-anchor"
+                                );
+                            }
+
                             atomic_global_step_number
                                 .store(rebuilt_step, std::sync::atomic::Ordering::Relaxed);
                             anchor_step = rebuilt_step;

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -64,8 +64,8 @@ use irys_types::{
 use irys_types::{NetworkConfigWithDefaults as _, ShutdownReason};
 use irys_vdf::{
     VdfStep,
-    state::{AtomicVdfState, VdfStateReadonly, create_state_for_canonical_tip},
-    vdf::{VdfExit, reset_applied_anchor_hash, run_vdf},
+    state::{AtomicVdfState, VdfStateReadonly},
+    vdf::{reset_applied_anchor_hash, run_vdf},
     vdf_sha,
 };
 use reth::{
@@ -1296,6 +1296,14 @@ impl IrysNode {
         let api_server_handle = actix_server.handle();
         let mut actix_task = runtime_handle.spawn(actix_server);
 
+        // Clone the partition-recovery restart token before `irys_node_ctx` is moved into the
+        // oneshot below, so the lifecycle select! can observe a deep-recovery restart request
+        // emitted by BlockTreeService. Mirrors the vdf_exit_token -> VdfExited arm.
+        let partition_recovery_restart = irys_node_ctx
+            .service_senders
+            .partition_recovery_restart
+            .clone();
+
         // Send IrysNodeCtx back to start()
         let early_shutdown = match irys_node_ctx_tx.send(Ok(irys_node_ctx)) {
             Ok(()) => None,
@@ -1336,6 +1344,13 @@ impl IrysNode {
                 // running mining-less but appears healthy.
                 _ = vdf_exit_token.cancelled() => {
                     ShutdownReason::VdfExited
+                },
+                // A deep network-partition recovery (BlockTreeService, after the block index was
+                // truncated to the fork parent) requested a controlled restart instead of an
+                // in-place VDF re-anchor. The relaunch cold-syncs the canonical chain and rebuilds
+                // VDF state; the distinct exit code tells a supervisor to relaunch the node.
+                _ = partition_recovery_restart.cancelled() => {
+                    ShutdownReason::PartitionRecoveryRestart
                 },
                 _ = shutdown_token.cancelled() => {
                     ShutdownReason::CancellationToken
@@ -1641,6 +1656,12 @@ impl IrysNode {
             service_senders.chunk_migration.clone(),
         );
 
+        // Shared VDF global-step counter. Created here, before the block tree service spawns, so a
+        // clone can back BlockTreeService's partition-recovery restart gate (which reads the live VDF
+        // step to tell whether a deep reorg poisoned the buffer). The real initial step is stored
+        // into it below once the VDF state is loaded; the VDF thread keeps it live thereafter.
+        let atomic_global_step_number = Arc::new(AtomicU64::new(0));
+
         // Start the block tree service
         let block_tree_lifecycle = Arc::new(BlockTreeLifecycleTimestamps::default());
         let block_tree_handle = BlockTreeService::spawn_service(
@@ -1653,6 +1674,7 @@ impl IrysNode {
             block_migration_service,
             block_tree_cache,
             block_tree_lifecycle.clone(),
+            Arc::clone(&atomic_global_step_number),
             runtime_handle.clone(),
         );
 
@@ -1895,8 +1917,9 @@ impl IrysNode {
         let initial_hash = last_step_hash.0;
         irys_vdf::metrics::record_vdf_global_step(global_step_number);
 
-        // spawn packing controllers and set global step number
-        let atomic_global_step_number = Arc::new(AtomicU64::new(global_step_number));
+        // Publish the loaded initial VDF step into the shared counter created before the block tree
+        // service spawned; the VDF thread keeps it live thereafter.
+        atomic_global_step_number.store(global_step_number, std::sync::atomic::Ordering::Relaxed);
         let packing_controller_handles =
             packing_service.spawn_packing_controllers(runtime_handle.clone());
 
@@ -1915,7 +1938,6 @@ impl IrysNode {
         let vdf_exit_token = Self::init_vdf_thread(
             &config,
             receivers.vdf_fast_forward,
-            receivers.vdf_reanchor,
             Arc::clone(&is_vdf_mining_enabled),
             latest_block,
             initial_hash,
@@ -1925,8 +1947,6 @@ impl IrysNode {
             atomic_global_step_number,
             block_status_provider,
             sync_state.clone(),
-            block_tree_guard.clone(),
-            irys_db.clone(),
             shutdown_token.clone(),
         );
 
@@ -2151,12 +2171,11 @@ impl IrysNode {
     #[tracing::instrument(level = "trace", skip_all, fields(block.hash = %latest_block.block_hash, block.height = %latest_block.height, custom.global_step_number = global_step_number))]
     #[expect(
         clippy::too_many_arguments,
-        reason = "VDF supervisor needs the full set of shared handles to rebuild and restart the loop"
+        reason = "the VDF thread needs the full set of shared handles to seed and run the loop"
     )]
     fn init_vdf_thread(
         config: &Config,
         mut vdf_fast_forward_receiver: Receiver<Traced<VdfStep>>,
-        mut vdf_reanchor_receiver: UnboundedReceiver<()>,
         is_vdf_mining_enabled: Arc<AtomicBool>,
         latest_block: Arc<IrysBlockHeader>,
         initial_hash: H256,
@@ -2166,8 +2185,6 @@ impl IrysNode {
         atomic_global_step_number: Arc<AtomicU64>,
         block_status_provider: BlockStatusProvider,
         chain_sync_state: ChainSyncState,
-        block_tree_guard: BlockTreeReadGuard,
-        db: DatabaseProvider,
         shutdown_token: CancellationToken,
     ) -> CancellationToken {
         let next_canonical_vdf_seed = latest_block.vdf_limiter_info.next_seed;
@@ -2230,186 +2247,33 @@ impl IrysNode {
                     }
                 }
 
-                // Supervisor loop. The first run starts from the anchor captured at startup;
-                // each subsequent run starts from a fresh anchor rebuilt from the canonical
-                // chain tip (block tree) after a network-partition recovery re-anchor request. Core
-                // pinning and the fast-forward / re-anchor channels persist across restarts —
-                // only run_vdf's hash/global_step/seed and the shared step buffer are reset.
-                // See design/docs/vdf-partition-recovery-reanchor.md.
-                let mut anchor_step = global_step_number;
-                // Fold the anchor step's own reset boundary into the (raw) buffer hash if it lands on
-                // one, so run_vdf's first step continues the canonical lineage (finding #5).
-                let mut anchor_hash = reset_applied_anchor_hash(
+                // Fold the startup anchor step's own reset boundary into the (raw) buffer hash if it
+                // lands on one, so run_vdf's first step continues the canonical lineage (finding #5).
+                let anchor_hash = reset_applied_anchor_hash(
                     config.vdf.reset_frequency as u64,
                     global_step_number,
                     initial_hash,
                     startup_anchor_seed,
                 );
-                let mut anchor_reset_seed = next_canonical_vdf_seed;
-                loop {
-                    let exit = run_vdf(
-                        &config.vdf,
-                        anchor_step,
-                        anchor_hash,
-                        anchor_reset_seed,
-                        &mut vdf_fast_forward_receiver,
-                        &mut vdf_reanchor_receiver,
-                        is_vdf_mining_enabled.clone(),
-                        MiningBusBroadcaster::from(mining_bus.clone()),
-                        vdf_state.clone(),
-                        atomic_global_step_number.clone(),
-                        block_status_provider.clone(),
-                        chain_sync_state.clone(),
-                        shutdown_token.clone(),
-                    );
-
-                    match exit {
-                        VdfExit::Shutdown => break,
-                        VdfExit::Reanchor => {
-                            // Rebuild the step buffer anchored at the NEW CANONICAL TIP (not the
-                            // truncated index's LCA), reading the recovered range's blocks from the
-                            // block tree's canonical chain. Each canonical block carries its own
-                            // reset-boundary seed, so the rebuilt buffer matches the canonical
-                            // lineage across the whole recovered range. Anchoring at the LCA would
-                            // instead leave the restarted loop to re-cross those boundaries by
-                            // local stepping with the canonical tip's single reset seed — wrong for
-                            // every intermediate boundary — diverging the buffer and re-wedging
-                            // validation. See design/docs/vdf-partition-recovery-reanchor.md.
-                            //
-                            // The index truncation by recover_from_network_partition still rolls
-                            // back the orphaned fork's storage/supply side effects; the VDF rebuild
-                            // no longer depends on it, sourcing the canonical chain from the tree.
-                            let canonical_headers: Vec<Arc<IrysBlockHeader>> = block_tree_guard
-                                .read()
-                                .get_canonical_chain()
-                                .0
-                                .iter()
-                                .map(|entry| Arc::clone(entry.header()))
-                                .collect();
-                            let (new_state, next_seed) = match create_state_for_canonical_tip(
-                                &canonical_headers,
-                                &db,
-                                is_vdf_mining_enabled.clone(),
-                                &config,
-                            ) {
-                                Ok(rebuilt) => rebuilt,
-                                Err(e) => {
-                                    // Rebuild failed — a transient DB error, or a canonical
-                                    // ancestor missing from both the block-tree cache and the
-                                    // DB. Do NOT crash or break the live VDF thread: a panic OR
-                                    // a break here drops the CancelOnDrop guard, which fires
-                                    // vdf_exit_token -> ShutdownReason::VdfExited and shuts the
-                                    // whole node down mid-recovery — fail-stopping on a transient
-                                    // DB error during a routine deep reorg. Keep the current
-                                    // buffer, but re-anchor run_vdf to the buffer's OWN current
-                                    // tip rather than the stale startup/previous anchor — the
-                                    // live loop free-ran above it, so resuming from the stale low
-                                    // anchor would feed a stale-lineage hash into the first
-                                    // vdf_sha and lean on store_step's behind-step rejection to
-                                    // realign.
-                                    //
-                                    // Resuming on a not-yet-rebuilt buffer is safe because block
-                                    // validation does NOT trust the live buffer: the VDF-sensitive
-                                    // checks resolve steps from a fork-local view of the block's
-                                    // OWN lineage (build_fork_local_recall_view /
-                                    // build_fork_local_step_view), so a stale buffer cannot reject
-                                    // canonical blocks. It degrades only THIS node's local mining
-                                    // until the buffer is rebuilt. Note there is no retry timer
-                                    // here: the rebuild is re-attempted only when the next deep
-                                    // reorg (> block_migration_depth) re-emits vdf_reanchor, so a
-                                    // transient failure recovers on the next recovery event but a
-                                    // genuinely persistent one is not self-healed by this arm.
-                                    error!(
-                                        error = ?e,
-                                        "VDF re-anchor rebuild failed; resuming from the live buffer's current step (rebuild re-attempted on the next deep-reorg re-anchor)"
-                                    );
-                                    if let Ok(guard) = vdf_state.read() {
-                                        let (live_step, live_seed) = guard.get_last_step_and_seed();
-                                        anchor_step = live_step;
-                                        // Intentionally NOT reset_applied_anchor_hash'd here (unlike
-                                        // the startup and successful-re-anchor sites): the buffer was
-                                        // NOT rebuilt, so we resume from the live tip, which free-ran
-                                        // ABOVE the canonical chain — there is no confirmed canonical
-                                        // block pinning live_step's boundary seed to fold (the steps
-                                        // past the canonical tip are the unconfirmed region; guessing
-                                        // a seed here would re-poison, the #4 hazard). Resume raw and
-                                        // let store_step's forward-only rule + fork-local validation
-                                        // recompute realign. Degraded best-effort, non-safety.
-                                        anchor_hash = live_seed.0;
-                                    }
-                                    continue;
-                                }
-                            };
-                            let (rebuilt_step, rebuilt_seed) = new_state.get_last_step_and_seed();
-                            match vdf_state.write() {
-                                Ok(mut guard) => {
-                                    // Store the rewound (lower) step BEFORE publishing the
-                                    // rebuilt buffer, under the same write lock, so the atomic
-                                    // never points past the buffer's newest step
-                                    // (atomic <= buffer.global_step holds at every instant).
-                                    // Mirrors store_step's lock discipline; the re-anchor is
-                                    // always a rewind — the live loop free-runs above any
-                                    // canonical block's step.
-                                    atomic_global_step_number
-                                        .store(rebuilt_step, std::sync::atomic::Ordering::Relaxed);
-                                    *guard = new_state;
-                                }
-                                Err(_) => {
-                                    error!(
-                                        "VDF state write lock poisoned during re-anchor; exiting VDF thread"
-                                    );
-                                    break;
-                                }
-                            }
-
-                            // Discard any fast-forward steps queued before the re-anchor. They
-                            // may carry steps pinned by the orphaned fork's (minority) reset
-                            // seed; applying them after the buffer was rebuilt to the canonical
-                            // TIP would re-poison it via store_step's exact-sequential accept.
-                            // The canonical steps are already in the rebuilt buffer; the loop
-                            // only local-steps forward to the live timeline, so dropping the
-                            // queue loses no correct work.
-                            let mut drained = 0_u64;
-                            while vdf_fast_forward_receiver.try_recv().is_ok() {
-                                drained += 1;
-                            }
-                            if drained > 0 {
-                                debug!(
-                                    vdf.drained_fast_forward_steps = drained,
-                                    "Discarded stale fast-forward steps during VDF re-anchor"
-                                );
-                            }
-
-                            anchor_step = rebuilt_step;
-                            // Fold the rebuilt tip's own reset boundary into the (raw) buffer hash if
-                            // the tip step lands on one, so run_vdf's first step continues the
-                            // canonical lineage rather than mis-stepping a range (finding #5). The
-                            // boundary seed is the tip block's own `seed` (set_seeds pins the
-                            // in-range boundary's entropy there; `next_seed` targets the next one).
-                            let tip_anchor_seed = canonical_headers
-                                .last()
-                                .map_or(next_seed, |tip| tip.vdf_limiter_info.seed);
-                            anchor_hash = reset_applied_anchor_hash(
-                                config.vdf.reset_frequency as u64,
-                                rebuilt_step,
-                                rebuilt_seed.0,
-                                tip_anchor_seed,
-                            );
-                            anchor_reset_seed = next_seed;
-                            // Tell the partition miners to discard their stateful recall-range
-                            // rotation, which assumes forward-only steps and is now pointing at the
-                            // pre-re-anchor lineage. Without this, after the rewound VDF climbs back
-                            // they would mine recall ranges computed from the discarded lineage
-                            // (rejected by validation). They rebuild from the re-anchored steps on
-                            // the next seed. See PartitionMiningServiceInner::handle_reanchor.
-                            mining_bus.send_reanchor();
-                            warn!(
-                                vdf.global_step_number = rebuilt_step,
-                                "VDF re-anchored to canonical chain tip after partition recovery"
-                            );
-                        }
-                    }
-                }
+                // run_vdf is called exactly once and returns only on shutdown. A deep
+                // network-partition recovery no longer re-anchors this loop in place — it triggers a
+                // controlled process restart (see BlockTreeService), and the ordinary cold-start path
+                // rebuilds the step buffer from the truncated index on relaunch. See
+                // design/docs/vdf-partition-recovery-reanchor.md.
+                run_vdf(
+                    &config.vdf,
+                    global_step_number,
+                    anchor_hash,
+                    next_canonical_vdf_seed,
+                    &mut vdf_fast_forward_receiver,
+                    is_vdf_mining_enabled,
+                    MiningBusBroadcaster::from(mining_bus),
+                    vdf_state,
+                    atomic_global_step_number,
+                    block_status_provider,
+                    chain_sync_state,
+                    shutdown_token,
+                );
             }
         });
         vdf_exit_token

--- a/crates/chain/src/main.rs
+++ b/crates/chain/src/main.rs
@@ -16,7 +16,7 @@ static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::ne
 
 #[tokio::main]
 #[tracing::instrument(level = "trace", skip_all)]
-async fn main() -> eyre::Result<()> {
+async fn main() -> eyre::Result<std::process::ExitCode> {
     // IMPORTANT: Must run before any code that calls `get_version()` (e.g. handshake defaults).
     // The OnceLock is set-once, so late initialization panics.
     irys_types::init_version(
@@ -110,12 +110,17 @@ async fn main() -> eyre::Result<()> {
         }
     };
 
+    // Map the shutdown reason to a process exit code before `stop` consumes it. Only a
+    // partition-recovery restart exits non-zero, signalling the supervisor to relaunch the node;
+    // every other reason exits 0 (the historical behaviour).
+    let exit_code = shutdown_reason.exit_code();
+
     // Spawn watchdog thread to force exit if graceful shutdown hangs
     spawn_shutdown_watchdog(shutdown_reason.clone());
 
     handle.stop(shutdown_reason).await;
 
-    Ok(())
+    Ok(std::process::ExitCode::from(exit_code))
 }
 
 fn init_tracing() -> eyre::Result<()> {

--- a/crates/domain/src/models/block_tree.rs
+++ b/crates/domain/src/models/block_tree.rs
@@ -749,6 +749,27 @@ impl BlockTree {
             .expect("canonical chain must always have an entry in it")
     }
 
+    /// The canonical block with the GREATEST `global_step_number <= step` — i.e. the last block
+    /// whose VDF range ENDS at or before `step`. Found by binary search over the cached canonical
+    /// chain (ordered oldest→newest, so `global_step_number` is monotonic). Searches in place (no
+    /// chain clone); only the matched entry's `Arc` is cloned.
+    ///
+    /// NB: this is deliberately NOT "the block whose range *covers* `step`". A single block can
+    /// SPAN a reset boundary (its range straddles a multiple of `reset_frequency`), and such a
+    /// block's `next_seed` targets the boundary ABOVE its range — the wrong seed for a boundary
+    /// INSIDE its range. The block ending at or before `step` is the one whose `next_seed` pins the
+    /// reset seed for the next boundary above `step` (the boundary the VDF crosses when it is at
+    /// `step`). Returns `None` only when `step` is below the earliest cached block.
+    #[must_use]
+    pub fn canonical_entry_at_or_below_step(&self, step: u64) -> Option<BlockTreeEntry> {
+        let (chain, _) = &self.longest_chain_cache;
+        // chain is ascending by global_step_number; partition_point gives the count of entries with
+        // global_step_number <= step, so idx-1 is the last such entry.
+        let idx = chain
+            .partition_point(|entry| entry.header().vdf_limiter_info.global_step_number <= step);
+        chain.get(idx.checked_sub(1)?).cloned()
+    }
+
     /// Global step number of the most recent canonical block confirmed past reorg risk —
     /// the deepest block that is both `Onchain` and at least `depth` blocks below the tip.
     /// Used by the VDF reset-boundary gate so the loop never applies a seed pinned by a

--- a/crates/domain/src/models/block_tree.rs
+++ b/crates/domain/src/models/block_tree.rs
@@ -2940,6 +2940,74 @@ mod tests {
         assert_eq!(cache.confirmed_canonical_step(2), 10);
     }
 
+    /// Regression for the per-boundary VDF seed lookup: the provider must resolve the canonical
+    /// block whose VDF range ENDS at or before the requested step, not the block whose range merely
+    /// covers it. A later canonical block can span the step while its `next_seed` targets a higher
+    /// boundary, so returning it would pin the wrong reset seed.
+    #[test]
+    fn canonical_entry_at_or_below_step_returns_last_entry_ending_at_or_before_step() {
+        let comm_cache = Arc::new(CommitmentSnapshot::default());
+
+        let mut b1 = random_block(U256::from(1));
+        b1.vdf_limiter_info.global_step_number = 15;
+        b1.test_sign();
+        let mut cache = BlockTree::new(&b1, ConsensusConfig::testing());
+
+        let mut b2 = random_block(U256::from(2));
+        b2.vdf_limiter_info.global_step_number = 35;
+        let mut b2 = extend_chain(b2, &b1);
+        cache
+            .add_block(
+                &seal_block(&mut b2),
+                comm_cache.clone(),
+                dummy_epoch_snapshot(),
+                dummy_ema_snapshot(),
+            )
+            .unwrap();
+        cache
+            .add_common(
+                b2.block_hash,
+                &seal_block(&mut b2),
+                comm_cache,
+                dummy_epoch_snapshot(),
+                dummy_ema_snapshot(),
+                ChainState::Validated(BlockState::ValidBlock),
+            )
+            .unwrap();
+        cache.mark_tip(&b2.block_hash).unwrap();
+
+        assert!(
+            cache.canonical_entry_at_or_below_step(14).is_none(),
+            "a step below the earliest cached block must return None"
+        );
+        assert_eq!(
+            cache
+                .canonical_entry_at_or_below_step(15)
+                .expect("exact step should resolve")
+                .header()
+                .block_hash,
+            b1.block_hash
+        );
+        assert_eq!(
+            cache
+                .canonical_entry_at_or_below_step(20)
+                .expect("between blocks should resolve")
+                .header()
+                .block_hash,
+            b1.block_hash,
+            "step 20 lies below b2's end step, so the lookup must not return the covering block"
+        );
+        assert_eq!(
+            cache
+                .canonical_entry_at_or_below_step(35)
+                .expect("tip step should resolve")
+                .header()
+                .block_hash,
+            b2.block_hash
+        );
+        assert!(cache.canonical_entry_at_or_below_step(0).is_none());
+    }
+
     fn random_block(cumulative_diff: U256) -> IrysBlockHeader {
         let mut block = IrysBlockHeader::new_mock_header();
         block.solution_hash = H256::random(); // Ensure unique solution hash

--- a/crates/p2p/src/block_status_provider.rs
+++ b/crates/p2p/src/block_status_provider.rs
@@ -8,8 +8,7 @@ use tracing::debug;
 use {
     irys_testing_utils::IrysBlockHeaderTestExt as _,
     irys_types::{
-        ConsensusConfig, IrysBlockHeader, IrysBlockHeaderV1, NodeConfig, U256,
-        irys::IrysSigner,
+        ConsensusConfig, IrysBlockHeader, IrysBlockHeaderV1, NodeConfig, U256, irys::IrysSigner,
     },
     std::sync::{Arc, RwLock},
     tracing::warn,

--- a/crates/p2p/src/block_status_provider.rs
+++ b/crates/p2p/src/block_status_provider.rs
@@ -503,6 +503,15 @@ impl BlockProvider for BlockStatusProvider {
                 .confirmed_canonical_step(self.block_migration_depth),
         })
     }
+
+    fn canonical_vdf_info_at_or_below_step(&self, step_number: u64) -> Option<H256> {
+        let binding = self.block_tree_read_guard.read();
+        let entry = binding.canonical_entry_at_or_below_step(step_number)?;
+        // Only the reset seed is needed by the VDF loop; return it directly rather than
+        // cloning the whole vdf_limiter_info (steps/checkpoints) and recomputing the
+        // confirmed step (the caller already has that from latest_canonical_vdf_info).
+        Some(entry.header().vdf_limiter_info.next_seed)
+    }
 }
 
 #[cfg(test)]

--- a/crates/p2p/src/block_status_provider.rs
+++ b/crates/p2p/src/block_status_provider.rs
@@ -8,7 +8,8 @@ use tracing::debug;
 use {
     irys_testing_utils::IrysBlockHeaderTestExt as _,
     irys_types::{
-        ConsensusConfig, IrysBlockHeader, IrysBlockHeaderV1, NodeConfig, irys::IrysSigner,
+        ConsensusConfig, IrysBlockHeader, IrysBlockHeaderV1, NodeConfig, U256,
+        irys::IrysSigner,
     },
     std::sync::{Arc, RwLock},
     tracing::warn,
@@ -494,23 +495,21 @@ impl BlockStatusProvider {
 }
 
 impl BlockProvider for BlockStatusProvider {
-    fn latest_canonical_vdf_info(&self) -> Option<CanonicalVdfSnapshot> {
+    fn canonical_vdf_snapshot(&self, step_number: u64) -> Option<CanonicalVdfSnapshot> {
         let binding = self.block_tree_read_guard.read();
-        let entry = binding.get_latest_canonical_entry();
+        let tip = binding.get_latest_canonical_entry();
+        let reset_seed_for_step = binding
+            .canonical_entry_at_or_below_step(step_number)
+            .map(|entry| entry.header().vdf_limiter_info.next_seed)
+            // If `step_number` predates the earliest cached canonical entry, preserve the prior
+            // tip-seed fallback rather than synthesizing a new policy here.
+            .unwrap_or(tip.header().vdf_limiter_info.next_seed);
         Some(CanonicalVdfSnapshot {
-            vdf_info: entry.header().vdf_limiter_info.clone(),
+            vdf_info: tip.header().vdf_limiter_info.clone(),
             confirmed_global_step_number: binding
                 .confirmed_canonical_step(self.block_migration_depth),
+            reset_seed_for_step,
         })
-    }
-
-    fn canonical_vdf_info_at_or_below_step(&self, step_number: u64) -> Option<H256> {
-        let binding = self.block_tree_read_guard.read();
-        let entry = binding.canonical_entry_at_or_below_step(step_number)?;
-        // Only the reset seed is needed by the VDF loop; return it directly rather than
-        // cloning the whole vdf_limiter_info (steps/checkpoints) and recomputing the
-        // confirmed step (the caller already has that from latest_canonical_vdf_info).
-        Some(entry.header().vdf_limiter_info.next_seed)
     }
 }
 
@@ -539,10 +538,10 @@ mod tests {
     }
 
     #[test]
-    fn latest_canonical_vdf_info_reports_confirmed_step() {
+    fn canonical_vdf_snapshot_reports_confirmed_step() {
         let (provider, genesis, _tmp) = mock_provider();
         let snap = provider
-            .latest_canonical_vdf_info()
+            .canonical_vdf_snapshot(genesis.vdf_limiter_info.global_step_number)
             .expect("a canonical snapshot");
         // Genesis is the only (and deepest) canonical block, so it is the confirmed tip
         // regardless of `block_migration_depth`.
@@ -553,6 +552,59 @@ mod tests {
         assert_eq!(
             snap.vdf_info.global_step_number,
             genesis.vdf_limiter_info.global_step_number
+        );
+        assert_eq!(snap.reset_seed_for_step, genesis.vdf_limiter_info.next_seed);
+    }
+
+    #[test]
+    fn canonical_vdf_snapshot_uses_seed_for_requested_step_not_tip() {
+        let (provider, genesis, _tmp) = mock_provider();
+        let consensus = NodeConfig::testing().consensus_config();
+        let mut chain = BlockStatusProvider::produce_mock_chain(2, Some(&genesis), &consensus);
+        chain[0].previous_cumulative_diff = genesis.cumulative_diff;
+        chain[0].cumulative_diff = genesis.cumulative_diff + U256::from(1);
+        chain[0].vdf_limiter_info.global_step_number = 15;
+        chain[0].vdf_limiter_info.next_seed = H256::repeat_byte(0x11);
+        chain[1].previous_cumulative_diff = chain[0].cumulative_diff;
+        chain[1].cumulative_diff = chain[0].cumulative_diff + U256::from(1);
+        chain[1].vdf_limiter_info.global_step_number = 35;
+        chain[1].vdf_limiter_info.next_seed = H256::repeat_byte(0x22);
+
+        provider.add_block_mock_to_the_tree(&chain[0]);
+        provider.add_block_mock_to_the_tree(&chain[1]);
+        provider
+            .block_tree_read_guard
+            .write()
+            .mark_block_as_validation_scheduled(&chain[0].block_hash)
+            .expect("schedule validation for first block");
+        provider
+            .block_tree_read_guard
+            .write()
+            .mark_block_as_valid(&chain[0].block_hash)
+            .expect("mark first block valid");
+        provider
+            .block_tree_read_guard
+            .write()
+            .mark_block_as_validation_scheduled(&chain[1].block_hash)
+            .expect("schedule validation for second block");
+        provider
+            .block_tree_read_guard
+            .write()
+            .mark_block_as_valid(&chain[1].block_hash)
+            .expect("mark second block valid");
+
+        let snap = provider
+            .canonical_vdf_snapshot(20)
+            .expect("snapshot should resolve");
+
+        assert_eq!(
+            snap.vdf_info.global_step_number, 35,
+            "tip info should still come from the latest canonical block"
+        );
+        assert_eq!(
+            snap.reset_seed_for_step,
+            H256::repeat_byte(0x11),
+            "requested step 20 must use the seed from the last block ending at or before 20, not the tip seed"
         );
     }
 

--- a/crates/types/src/block_provider.rs
+++ b/crates/types/src/block_provider.rs
@@ -1,4 +1,4 @@
-use crate::VDFLimiterInfo;
+use crate::{H256, VDFLimiterInfo};
 
 /// A consistent snapshot of the canonical chain for the VDF loop: the tip's VDF limiter
 /// info (its `next_seed` and tip step), plus the global step number of the block that is
@@ -18,4 +18,25 @@ pub struct CanonicalVdfSnapshot {
 /// such as between VDF and the block index.
 pub trait BlockProvider {
     fn latest_canonical_vdf_info(&self) -> Option<CanonicalVdfSnapshot>;
+
+    /// The reset seed (`next_seed`) of the canonical block with the greatest `global_step_number <=
+    /// step_number` — the last block whose VDF range ENDS at or before `step_number` — rather than
+    /// the chain TIP's. That `next_seed` pins the reset seed for the next boundary ABOVE
+    /// `step_number`, i.e. the boundary the VDF is about to cross when it is at that step.
+    ///
+    /// The VDF loop uses this so that during partition-recovery CATCH-UP — when the re-anchored VDF
+    /// local-steps across reset boundaries the canonical tip has already passed — it applies the
+    /// seed pinned for each boundary it crosses, not the tip's `next_seed` (which targets a HIGHER
+    /// boundary and would re-poison the post-boundary steps, the Finding #1 wedge). It is the
+    /// block ENDING at or before the step (not the block whose range *covers* it) because a single
+    /// block can SPAN a boundary and its `next_seed` targets the boundary above its range.
+    ///
+    /// In normal forward operation the VDF runs AHEAD of the canonical tip, so the greatest
+    /// canonical `global_step_number <= step_number` is the tip itself — equal to the prior
+    /// (tip-seed) behavior, making this a no-op there. The default returns `None` so non-canonical
+    /// providers keep the prior behavior; callers fall back to the tip's seed on `None`.
+    fn canonical_vdf_info_at_or_below_step(&self, step_number: u64) -> Option<H256> {
+        let _ = step_number;
+        None
+    }
 }

--- a/crates/types/src/block_provider.rs
+++ b/crates/types/src/block_provider.rs
@@ -3,8 +3,12 @@ use crate::{H256, VDFLimiterInfo};
 /// A consistent snapshot of the canonical chain for the VDF loop: the tip's VDF limiter
 /// info (its `next_seed` and tip step), plus the global step number of the block that is
 /// `block_migration_depth` deep — the most recent reset seed confirmed past the migration
-/// threshold. The VDF reset-boundary gate compares against `confirmed_global_step_number`
-/// so it never applies a seed pinned by a still-forkable block (issue #1447).
+/// threshold. Also includes the reset seed pinned by the canonical block with the greatest
+/// `global_step_number <= requested_step_number`, so the loop reads the tip, confirmed step,
+/// and per-step seed from one provider snapshot under one canonical-chain read.
+///
+/// The VDF reset-boundary gate compares against `confirmed_global_step_number` so it never
+/// applies a seed pinned by a still-forkable block (issue #1447).
 ///
 /// Invariant: `confirmed_global_step_number <= vdf_info.global_step_number` — the confirmed
 /// step comes from a block at or below the tip.
@@ -12,31 +16,18 @@ use crate::{H256, VDFLimiterInfo};
 pub struct CanonicalVdfSnapshot {
     pub vdf_info: VDFLimiterInfo,
     pub confirmed_global_step_number: u64,
+    pub reset_seed_for_step: H256,
 }
 
 /// A trait that is used to provide access to blocks by their hash. Used to avoid circular dependencies,
 /// such as between VDF and the block index.
 pub trait BlockProvider {
-    fn latest_canonical_vdf_info(&self) -> Option<CanonicalVdfSnapshot>;
-
-    /// The reset seed (`next_seed`) of the canonical block with the greatest `global_step_number <=
-    /// step_number` — the last block whose VDF range ENDS at or before `step_number` — rather than
-    /// the chain TIP's. That `next_seed` pins the reset seed for the next boundary ABOVE
-    /// `step_number`, i.e. the boundary the VDF is about to cross when it is at that step.
+    /// A consistent canonical snapshot for the current VDF loop step. `step_number` is the
+    /// loop's current global step; implementations return the canonical tip info, the deepest
+    /// confirmed canonical step, and the reset seed pinned by the canonical block whose VDF
+    /// range ends at or before `step_number`.
     ///
-    /// The VDF loop uses this so that during partition-recovery CATCH-UP — when the re-anchored VDF
-    /// local-steps across reset boundaries the canonical tip has already passed — it applies the
-    /// seed pinned for each boundary it crosses, not the tip's `next_seed` (which targets a HIGHER
-    /// boundary and would re-poison the post-boundary steps, the Finding #1 wedge). It is the
-    /// block ENDING at or before the step (not the block whose range *covers* it) because a single
-    /// block can SPAN a boundary and its `next_seed` targets the boundary above its range.
-    ///
-    /// In normal forward operation the VDF runs AHEAD of the canonical tip, so the greatest
-    /// canonical `global_step_number <= step_number` is the tip itself — equal to the prior
-    /// (tip-seed) behavior, making this a no-op there. The default returns `None` so non-canonical
-    /// providers keep the prior behavior; callers fall back to the tip's seed on `None`.
-    fn canonical_vdf_info_at_or_below_step(&self, step_number: u64) -> Option<H256> {
-        let _ = step_number;
-        None
-    }
+    /// During partition-recovery catch-up this lets the loop apply the seed pinned for the
+    /// boundary it is actually about to cross, while preserving the confirmed-step gate.
+    fn canonical_vdf_snapshot(&self, step_number: u64) -> Option<CanonicalVdfSnapshot>;
 }

--- a/crates/types/src/shutdown.rs
+++ b/crates/types/src/shutdown.rs
@@ -1,3 +1,10 @@
+/// Process exit code emitted for [`ShutdownReason::PartitionRecoveryRestart`]. Distinct and
+/// non-zero so a process supervisor (systemd `Restart=`, a Kubernetes / Docker restart policy)
+/// relaunches the node after a deep network-partition recovery; every other shutdown reason exits
+/// `0`. The value is `EX_TEMPFAIL` from sysexits(3) — "temporary failure, retry" — so it reads as a
+/// retryable restart request rather than a crash.
+pub const PARTITION_RECOVERY_RESTART_EXIT_CODE: u8 = 75;
+
 #[derive(Debug, Clone)]
 pub enum ShutdownReason {
     FatalError(String),
@@ -14,6 +21,11 @@ pub enum ShutdownReason {
     VdfExited,
     ShutdownChannelClosed,
     ApiReadinessFailed,
+    /// A deep network-partition recovery rewound the canonical chain past the migration depth. The
+    /// node requests a controlled process restart rather than re-anchoring VDF state in place; on
+    /// relaunch the ordinary cold-start path rebuilds correct VDF state and resumes mining. Emitted
+    /// with a distinct exit code so a supervisor relaunches the node — see [`Self::exit_code`].
+    PartitionRecoveryRestart,
 }
 
 impl ShutdownReason {
@@ -22,12 +34,24 @@ impl ShutdownReason {
             Self::FatalError(_) => "fatal_error",
             Self::ServiceCompleted(_) => "service_completed",
             Self::SigInt | Self::SigTerm | Self::CtrlC | Self::CancellationToken => "signal",
+            Self::PartitionRecoveryRestart => "partition_recovery_restart",
             Self::ServiceExited
             | Self::RethTaskManager
             | Self::RethExit
             | Self::VdfExited
             | Self::ShutdownChannelClosed
             | Self::ApiReadinessFailed => "lifecycle",
+        }
+    }
+
+    /// Process exit code for this shutdown reason. Only [`Self::PartitionRecoveryRestart`] exits
+    /// non-zero (see [`PARTITION_RECOVERY_RESTART_EXIT_CODE`]) so a supervisor relaunches the node;
+    /// every other reason exits `0`, preserving the historical behaviour where graceful shutdown is
+    /// success to the OS.
+    pub const fn exit_code(&self) -> u8 {
+        match self {
+            Self::PartitionRecoveryRestart => PARTITION_RECOVERY_RESTART_EXIT_CODE,
+            _ => 0,
         }
     }
 }
@@ -47,6 +71,33 @@ impl std::fmt::Display for ShutdownReason {
             Self::VdfExited => write!(f, "VDF thread exited"),
             Self::ShutdownChannelClosed => write!(f, "shutdown channel closed"),
             Self::ApiReadinessFailed => write!(f, "API readiness check failed"),
+            Self::PartitionRecoveryRestart => write!(f, "partition recovery restart"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_partition_recovery_restart_exits_nonzero() {
+        assert_ne!(PARTITION_RECOVERY_RESTART_EXIT_CODE, 0);
+        assert_eq!(
+            ShutdownReason::PartitionRecoveryRestart.exit_code(),
+            PARTITION_RECOVERY_RESTART_EXIT_CODE
+        );
+        for reason in [
+            ShutdownReason::SigInt,
+            ShutdownReason::CtrlC,
+            ShutdownReason::CancellationToken,
+            ShutdownReason::ServiceExited,
+            ShutdownReason::RethExit,
+            ShutdownReason::VdfExited,
+            ShutdownReason::ShutdownChannelClosed,
+            ShutdownReason::ApiReadinessFailed,
+        ] {
+            assert_eq!(reason.exit_code(), 0, "{reason} must exit 0");
         }
     }
 }

--- a/crates/types/src/shutdown.rs
+++ b/crates/types/src/shutdown.rs
@@ -87,11 +87,16 @@ mod tests {
             ShutdownReason::PartitionRecoveryRestart.exit_code(),
             PARTITION_RECOVERY_RESTART_EXIT_CODE
         );
+        // Every non-restart reason must exit 0 (exhaustive over the other variants).
         for reason in [
+            ShutdownReason::FatalError("x".into()),
+            ShutdownReason::ServiceCompleted("x".into()),
             ShutdownReason::SigInt,
+            ShutdownReason::SigTerm,
             ShutdownReason::CtrlC,
             ShutdownReason::CancellationToken,
             ShutdownReason::ServiceExited,
+            ShutdownReason::RethTaskManager,
             ShutdownReason::RethExit,
             ShutdownReason::VdfExited,
             ShutdownReason::ShutdownChannelClosed,

--- a/crates/vdf/src/state.rs
+++ b/crates/vdf/src/state.rs
@@ -4,7 +4,7 @@ use irys_database::block_header_by_hash;
 use irys_domain::BlockIndex;
 use irys_efficient_sampling::num_recall_ranges_in_partition;
 use irys_types::{
-    Config, DatabaseProvider, H256, H256List, U256, VDFLimiterInfo, VdfConfig,
+    Config, DatabaseProvider, H256, H256List, IrysBlockHeader, U256, VDFLimiterInfo, VdfConfig,
     block_production::Seed,
 };
 use nodit::{InclusiveInterval as _, Interval, interval::ii};
@@ -266,7 +266,14 @@ impl VdfStateReadonly {
                 return Ok(());
             }
 
-            if current_step > last_observed_step {
+            if current_step != last_observed_step {
+                // Any movement resets the stall baseline/timer — including a
+                // BACKWARD jump from a partition-recovery VDF re-anchor, which
+                // rebuilds the buffer at a lower `global_step`. The stall detector
+                // exists to catch a DEAD writer, which leaves `global_step`
+                // constant; only the re-anchor swap ever decreases it (`store_step`
+                // is strictly forward-only), so resetting on a decrease responds to
+                // a genuine liveness event and cannot mask the frozen-writer case.
                 last_observed_step = current_step;
                 last_progress_at = Instant::now();
             } else if last_progress_at.elapsed() >= progress_timeout {
@@ -292,18 +299,12 @@ impl VdfStateReadonly {
 }
 
 /// create VDF state using the latest block in db
-///
-/// Returns the rebuilt [`VdfState`] together with the anchor (latest) block's
-/// `next_seed` — the reset seed the VDF loop must start from. The seed is
-/// returned alongside the state so callers re-anchoring the VDF after a deep
-/// reorg (network-partition recovery) get a consistent snapshot from a single
-/// read of the canonical index, rather than re-deriving it separately.
 pub fn create_state(
     block_index: &BlockIndex,
     db: &DatabaseProvider,
     is_vdf_mining_enabled: Arc<AtomicBool>,
     config: &Config,
-) -> (VdfState, H256) {
+) -> VdfState {
     let capacity = calc_capacity(config);
 
     let block_hash = block_index
@@ -317,9 +318,6 @@ pub fn create_state(
         .unwrap()
         .unwrap();
     let global_step_number = block.vdf_limiter_info.global_step_number;
-    // Captured from the anchor (latest) block before the walk-back loop below
-    // reassigns `block` to its ancestors.
-    let next_seed = block.vdf_limiter_info.next_seed;
     let mut steps_remaining = capacity;
 
     while steps_remaining > 0 && block.height > 0 {
@@ -346,7 +344,111 @@ pub fn create_state(
         global_step_number
     );
 
-    (
+    VdfState {
+        global_step: global_step_number,
+        global_step_from_the_latest_canonical_block: global_step_number,
+        minimum_step_to_keep: global_step_number.saturating_sub(capacity as u64),
+        seeds,
+        capacity,
+        is_vdf_mining_enabled: Some(is_vdf_mining_enabled),
+    }
+}
+
+/// Walk back from `tip` accumulating up to `capacity` VDF steps into a seed buffer (oldest step
+/// at the front, the tip's last step at the back), resolving each ancestor header via
+/// `fetch_parent`. Genesis (height 0) contributes only its first step. This is the shared
+/// walk-back used by the canonical-tip re-anchor; it mirrors [`create_state`]'s inline loop.
+fn build_vdf_seed_buffer(
+    tip: &IrysBlockHeader,
+    capacity: usize,
+    mut fetch_parent: impl FnMut(&H256) -> eyre::Result<IrysBlockHeader>,
+) -> eyre::Result<VecDeque<Seed>> {
+    let mut seeds: VecDeque<Seed> = VecDeque::with_capacity(capacity);
+    let mut steps_remaining = capacity;
+    let mut block = tip.clone();
+    while steps_remaining > 0 && block.height > 0 {
+        // get all the steps out of the block
+        for step in block.vdf_limiter_info.steps.0.iter().rev() {
+            seeds.push_front(Seed(*step));
+            steps_remaining -= 1;
+            if steps_remaining == 0 {
+                break;
+            }
+        }
+        // get the previous block
+        block = fetch_parent(&block.previous_block_hash)?;
+    }
+    if block.height == 0 {
+        // Genesis contributes only its first step. Guard the index: this runs on
+        // the live VDF supervisor thread during re-anchor, so a malformed genesis
+        // header must surface as a no-op rather than panicking the node.
+        if let Some(first) = block.vdf_limiter_info.steps.0.first() {
+            seeds.push_front(Seed(*first));
+        }
+    }
+    Ok(seeds)
+}
+
+/// Rebuild [`VdfState`] anchored at the canonical chain TIP, for partition-recovery re-anchor.
+///
+/// Unlike [`create_state`] (which anchors at the block index's latest item — the LCA after a
+/// partition-recovery truncation), this anchors at the new canonical tip so the rebuilt buffer
+/// carries the recovered range's canonical steps, each with its OWN reset-boundary seed.
+/// Anchoring at the LCA instead leaves the loop to re-cross the recovered range's reset
+/// boundaries by local stepping with the canonical tip's single `next_seed`, which is wrong for
+/// every intermediate boundary — diverging the buffer and re-wedging block validation. See
+/// design/docs/vdf-partition-recovery-reanchor.md.
+///
+/// `canonical_headers` is the block tree's canonical chain (oldest cached .. tip, as returned by
+/// `BlockTree::get_canonical_chain`). The recovered range is always within the block tree (a
+/// reorg is only representable up to `block_tree_depth` deep), so the tip and the whole recovered
+/// range are present here. Block headers are persisted to the DB only at migration, so the
+/// un-migrated tail MUST come from these headers; steps deeper than the cache (needed to fill
+/// `capacity`) fall back to the DB, which holds the migrated ancestors.
+pub fn create_state_for_canonical_tip(
+    canonical_headers: &[Arc<IrysBlockHeader>],
+    db: &DatabaseProvider,
+    is_vdf_mining_enabled: Arc<AtomicBool>,
+    config: &Config,
+) -> eyre::Result<(VdfState, H256)> {
+    let capacity = calc_capacity(config);
+
+    let cached: std::collections::HashMap<H256, Arc<IrysBlockHeader>> = canonical_headers
+        .iter()
+        .map(|h| (h.block_hash, Arc::clone(h)))
+        .collect();
+    let tip: &IrysBlockHeader = canonical_headers
+        .last()
+        .ok_or_else(|| eyre!("canonical chain empty during VDF re-anchor"))?;
+    let global_step_number = tip.vdf_limiter_info.global_step_number;
+    // Captured from the anchor (tip) block; the walk-back below only reads ancestors.
+    let next_seed = tip.vdf_limiter_info.next_seed;
+
+    // This runs on the live VDF supervisor thread (the re-anchor arm of
+    // init_vdf_thread). A transient DB error or an ancestor missing from BOTH the
+    // canonical cache and the DB must surface as an error — the caller keeps the
+    // current buffer and retries on the next re-anchor signal — rather than
+    // panicking and shutting the node down via the thread's CancelOnDrop guard.
+    let tx = db
+        .tx()
+        .map_err(|e| eyre!("VDF re-anchor: opening db tx failed: {e}"))?;
+    // Resolve an ancestor header by hash: the block tree's canonical cache first (the recovered,
+    // un-migrated range), then the DB (migrated ancestors below the cache).
+    let seeds = build_vdf_seed_buffer(tip, capacity, |hash| {
+        if let Some(header) = cached.get(hash) {
+            return Ok((**header).clone());
+        }
+        block_header_by_hash(&tx, hash, false)
+            .map_err(|e| eyre!("VDF re-anchor: header lookup failed for {hash}: {e}"))?
+            .ok_or_else(|| eyre!("VDF re-anchor: missing header for {hash}"))
+    })?;
+
+    info!(
+        "Re-anchoring vdf service to canonical tip at step number {}",
+        global_step_number
+    );
+
+    Ok((
         VdfState {
             global_step: global_step_number,
             global_step_from_the_latest_canonical_block: global_step_number,
@@ -356,7 +458,37 @@ pub fn create_state(
             is_vdf_mining_enabled: Some(is_vdf_mining_enabled),
         },
         next_seed,
-    )
+    ))
+}
+
+/// Build a TRANSIENT, read-only VDF step view anchored on `tip`'s OWN lineage — its
+/// `vdf_limiter_info.steps` plus ancestors resolved via `fetch_parent` (oldest at the front, the
+/// tip's last step at the back), filling up to `capacity` steps. Mirrors the walk-back of
+/// [`create_state_for_canonical_tip`] / [`build_vdf_seed_buffer`].
+///
+/// This is the single place that resolves FORK-LOCAL VDF steps for block validation. A node
+/// validating a block on a competing fork (deep partition recovery) must not trust its live VDF
+/// buffer, which may hold a different (poisoned) lineage past a reset boundary — that buffer would
+/// make validation reject the canonical fork it must adopt (the partition-recovery wedge). Callers
+/// build a view over just the steps a validation stage needs (e.g. a recall-range window back to
+/// the reset boundary, a handful of blocks) from the block's own ancestors in the block tree, then
+/// hand it to the existing consumers (which take `&VdfStateReadonly`) unchanged. The view never
+/// touches the live buffer, so mining and the #1447 confirmation gate are unaffected.
+pub fn build_fork_local_view(
+    tip: &IrysBlockHeader,
+    capacity: usize,
+    fetch_parent: impl FnMut(&H256) -> eyre::Result<IrysBlockHeader>,
+) -> eyre::Result<VdfStateReadonly> {
+    let seeds = build_vdf_seed_buffer(tip, capacity, fetch_parent)?;
+    let global_step = tip.vdf_limiter_info.global_step_number;
+    Ok(VdfStateReadonly::new(Arc::new(RwLock::new(VdfState {
+        global_step,
+        global_step_from_the_latest_canonical_block: global_step,
+        minimum_step_to_keep: global_step.saturating_sub(capacity as u64),
+        seeds,
+        capacity,
+        is_vdf_mining_enabled: None,
+    }))))
 }
 
 /// return the larger of max_allowed_vdf_fork_steps or num_recall_ranges_in_partition()
@@ -419,17 +551,14 @@ pub fn vdf_step_batch_is_valid(
     // parallel VDF recomputation. `get_steps` returns owned data and releases
     // the underlying read guard before we log or compare below.
     match vdf_steps_guard.get_steps(ii(batch_start_step_number, batch_end_step_number)) {
-        Ok(steps) => {
+        // Fast-path MATCH: the range is known locally AND identical, so these steps are
+        // already proven consistent with this node's lineage — accept without recomputing.
+        Ok(steps) if steps.0.as_slice() == batch_steps => {
             tracing::debug!(
                 vdf.batch_start = batch_start_step_number,
                 vdf.batch_end = batch_end_step_number,
                 "Validating VDF steps from VdfStepsReadGuard!"
             );
-            if steps.0.as_slice() != batch_steps {
-                let expected = H256List(batch_steps.to_vec());
-                warn_mismatches(&steps, &expected);
-                return Err(eyre!("VDF steps are invalid!"));
-            }
             // `verify_last_step_checkpoints` is intentionally skipped on this
             // fast path. Every block reaching the validation service has
             // already passed through `prevalidate_block`
@@ -444,6 +573,27 @@ pub fn vdf_step_batch_is_valid(
             // work the node already did. Static reviewers (CodeRabbit) flag
             // the missing call repeatedly — leave this comment so they don't.
             return Ok(());
+        }
+        // MISMATCH against the local buffer is NOT proof of invalidity: a competing fork
+        // legitimately diverges at/after a VDF reset boundary (its rotation block pins a
+        // different `next_seed`), and the local buffer reflects THIS node's lineage — it is
+        // not authoritative over another fork's steps. Fall through to the authoritative
+        // parallel recompute below, which derives every step from the block's OWN
+        // prev_output/steps/seed and still rejects a genuinely invalid chain. This closes the
+        // partition-recovery wedge: a node whose buffer free-ran past a reset boundary on a
+        // minority seed would otherwise reject the canonical chain's boundary-crossing blocks
+        // here, so the deep reorg — and the VDF re-anchor it triggers — could never fire. The
+        // #1447 run-ahead seed-poisoning protection is the mining-loop confirmed-step gate
+        // (`is_reset_boundary_blocked`), NOT this validation fast path, so recomputing here
+        // does not weaken it.
+        Ok(steps) => {
+            let expected = H256List(batch_steps.to_vec());
+            warn_mismatches(&steps, &expected);
+            tracing::debug!(
+                vdf.batch_start = batch_start_step_number,
+                vdf.batch_end = batch_end_step_number,
+                "VDF batch mismatches local buffer; recomputing from the block's own seed (competing fork or poisoned buffer)"
+            );
         }
         Err(err) => tracing::debug!(
             vdf.batch_start = batch_start_step_number,
@@ -596,6 +746,208 @@ mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicU8, Ordering};
     use std::time::Duration;
+
+    /// Regression for the partition-recovery re-anchor fix (review Finding #1):
+    /// [`build_vdf_seed_buffer`] — the walk-back behind [`create_state_for_canonical_tip`] — must
+    /// reproduce the canonical chain's recorded steps VERBATIM, anchored at the tip. That is what
+    /// lets the re-anchored buffer match (and validate) the canonical chain across the recovered
+    /// range. The broken design re-anchored at the LCA and let the loop re-derive the post-LCA
+    /// steps with the wrong reset seed; rebuilding from the canonical headers instead copies each
+    /// block's own steps, which already encode the correct boundary crossings.
+    #[test]
+    fn build_vdf_seed_buffer_reproduces_canonical_steps_anchored_at_tip() {
+        fn mock_header(height: u64, hash: u8, prev: u8, steps: &[u8]) -> IrysBlockHeader {
+            let mut h = IrysBlockHeader::new_mock_header();
+            h.height = height;
+            h.block_hash = H256::repeat_byte(hash);
+            h.previous_block_hash = H256::repeat_byte(prev);
+            h.vdf_limiter_info.global_step_number = height; // unused by the walk-back
+            h.vdf_limiter_info.steps =
+                H256List(steps.iter().map(|b| H256::repeat_byte(*b)).collect());
+            h
+        }
+
+        // Canonical chain: genesis(0x00) <- b1(0x01) <- tip(0x02), each carrying its own steps.
+        let genesis = mock_header(0, 0x00, 0xFF, &[0x10]);
+        let b1 = mock_header(1, 0x01, 0x00, &[0x11, 0x12]);
+        let tip = mock_header(2, 0x02, 0x01, &[0x13, 0x14]);
+        let by_hash: std::collections::HashMap<H256, IrysBlockHeader> = [genesis, b1, tip.clone()]
+            .into_iter()
+            .map(|h| (h.block_hash, h))
+            .collect();
+
+        let seeds = build_vdf_seed_buffer(&tip, 1000, |hash| {
+            Ok(by_hash
+                .get(hash)
+                .cloned()
+                .expect("canonical ancestor present"))
+        })
+        .expect("walk-back over present canonical headers must succeed");
+
+        // Oldest at the front; genesis contributes only its first step; b1 and tip contribute all
+        // of theirs; the back is the canonical TIP's last step (anchored at the tip, not the LCA).
+        let got: Vec<H256> = seeds.iter().map(|s| s.0).collect();
+        let expected: Vec<H256> = [0x10, 0x11, 0x12, 0x13, 0x14]
+            .iter()
+            .map(|b| H256::repeat_byte(*b))
+            .collect();
+        assert_eq!(
+            got, expected,
+            "re-anchor rebuild must reproduce the canonical chain's steps verbatim"
+        );
+        assert_eq!(
+            seeds.back().map(|s| s.0),
+            Some(H256::repeat_byte(0x14)),
+            "buffer must be anchored at the canonical TIP's last step (the re-anchor-to-tip fix)"
+        );
+    }
+
+    /// Finding #3: the re-anchor walk-back runs on the live VDF supervisor thread, so an
+    /// ancestor missing from both the block-tree cache and the DB (or a transient DB error)
+    /// must PROPAGATE as an error — letting the supervisor keep the old buffer and retry —
+    /// rather than panicking and shutting the node down.
+    #[test]
+    fn build_vdf_seed_buffer_propagates_fetch_error() {
+        let mut tip = IrysBlockHeader::new_mock_header();
+        tip.height = 2;
+        tip.block_hash = H256::repeat_byte(0x02);
+        tip.previous_block_hash = H256::repeat_byte(0x01);
+        tip.vdf_limiter_info.steps = H256List(vec![H256::repeat_byte(0x13)]);
+
+        // capacity is large, so the walk-back proceeds past the tip into the parent fetch,
+        // which fails — the error must surface instead of unwinding through a panic.
+        let result = build_vdf_seed_buffer(&tip, 1000, |_hash| {
+            Err(eyre!("ancestor missing from cache and DB"))
+        });
+
+        assert!(
+            result.is_err(),
+            "a failed ancestor fetch must propagate as an error, not panic the VDF thread"
+        );
+    }
+
+    /// Partition-recovery wedge fix: `vdf_step_batch_is_valid` must RECOMPUTE (from the block's own
+    /// seed) when the local buffer MISMATCHES, not reject. A competing fork legitimately has
+    /// different steps at the same step-numbers past a reset boundary, so a node whose buffer is
+    /// poisoned with a minority lineage must still ACCEPT an honest canonical block (otherwise the
+    /// deep reorg — and the VDF re-anchor it triggers — can never fire: the wedge). A genuinely
+    /// FORGED block must still be rejected by the recompute.
+    #[test]
+    fn vdf_step_batch_recomputes_on_buffer_mismatch() {
+        let mut node_config = NodeConfig::testing();
+        node_config.consensus.get_mut().vdf.sha_1s_difficulty = 1;
+        node_config
+            .consensus
+            .get_mut()
+            .vdf
+            .num_checkpoints_in_vdf_step = 2;
+        node_config.consensus.get_mut().vdf.reset_frequency = 4;
+        let config = Config::new_with_random_peer_id(node_config);
+        let vdf_config = config.vdf.clone();
+
+        let num_steps = 10_usize;
+        let prev_output = H256::from_low_u64_be(42);
+
+        // Build a VALID VDF chain exactly as `vdf_step_batch_is_valid`'s recompute derives it:
+        // step i (batch index i, previous_step_number = i) is vdf_sha(salt(i), seed), where seed is
+        // the previous step (or prev_output for i==0), with `reset_seed` folded in at multiples of
+        // reset_frequency. Returns the steps and the LAST step's checkpoints.
+        let build_chain = |reset_seed: H256| -> (Vec<H256>, Vec<H256>) {
+            let mut steps: Vec<H256> = Vec::with_capacity(num_steps);
+            let mut last_checkpoints = Vec::new();
+            for i in 0..num_steps {
+                let mut seed = if i == 0 { prev_output } else { steps[i - 1] };
+                if i > 0 && (i as u64).is_multiple_of(vdf_config.reset_frequency as u64) {
+                    seed = apply_reset_seed(seed, reset_seed);
+                }
+                let salt = U256::from(step_number_to_salt_number(&vdf_config, i as u64));
+                let mut checkpoints = vec![H256::default(); vdf_config.num_checkpoints_in_vdf_step];
+                vdf_sha(
+                    salt,
+                    &mut seed,
+                    vdf_config.num_checkpoints_in_vdf_step,
+                    vdf_config.num_iterations_per_checkpoint(),
+                    &mut checkpoints,
+                );
+                steps.push(seed);
+                last_checkpoints = checkpoints;
+            }
+            (steps, last_checkpoints)
+        };
+
+        let reset_seed = H256::from_low_u64_be(1337);
+        let (canonical_steps, canonical_checkpoints) = build_chain(reset_seed);
+        // A losing fork's lineage: same step-numbers, a DIFFERENT reset seed → diverges after the
+        // first reset boundary. This is what poisons a recovering node's buffer.
+        let (poisoned_steps, _) = build_chain(H256::from_low_u64_be(0xBAD));
+        assert_ne!(
+            canonical_steps, poisoned_steps,
+            "the two reset seeds must diverge the chains"
+        );
+
+        let canonical_block = VDFLimiterInfo {
+            output: *canonical_steps.last().unwrap(),
+            global_step_number: num_steps as u64,
+            seed: reset_seed,
+            next_seed: H256::zero(),
+            prev_output,
+            last_step_checkpoints: H256List(canonical_checkpoints),
+            steps: H256List(canonical_steps.clone()),
+            vdf_difficulty: Some(vdf_config.sha_1s_difficulty),
+            next_vdf_difficulty: Some(vdf_config.sha_1s_difficulty),
+        };
+
+        // Buffer poisoned with the losing fork's steps over the block's exact step range.
+        let poisoned_guard = VdfStateReadonly::new(Arc::new(RwLock::new(VdfState {
+            global_step: num_steps as u64,
+            global_step_from_the_latest_canonical_block: num_steps as u64,
+            minimum_step_to_keep: 0,
+            capacity: 1000,
+            seeds: poisoned_steps.iter().map(|s| Seed(*s)).collect(),
+            is_vdf_mining_enabled: None,
+        })));
+        // Sanity: the buffer genuinely mismatches the block over its range → exercises the
+        // recompute fall-through, not the fast-path match.
+        let buffered = poisoned_guard.get_steps(ii(1, num_steps as u64)).unwrap();
+        assert_ne!(
+            buffered.0, canonical_block.steps.0,
+            "poisoned buffer must mismatch the canonical block's steps"
+        );
+
+        let pool = crate::build_verification_pool(&vdf_config);
+
+        // THE FIX: the poisoned buffer ACCEPTS the honest canonical block via recompute.
+        let accepted = vdf_steps_are_valid(
+            &pool,
+            &canonical_block,
+            &vdf_config,
+            &poisoned_guard,
+            Arc::new(AtomicU8::new(CancelEnum::Continue as u8)),
+        );
+        assert!(
+            accepted.is_ok(),
+            "poisoned buffer must ACCEPT the honest canonical block via recompute (wedge fix): {accepted:?}"
+        );
+
+        // A genuinely FORGED chain (one tampered step) is still rejected by the recompute.
+        let mut forged_steps = canonical_steps;
+        forged_steps[num_steps / 2] = H256::repeat_byte(0xFF);
+        let forged_block = VDFLimiterInfo {
+            steps: H256List(forged_steps),
+            ..canonical_block
+        };
+        let forged = vdf_steps_are_valid(
+            &pool,
+            &forged_block,
+            &vdf_config,
+            &poisoned_guard,
+            Arc::new(AtomicU8::new(CancelEnum::Continue as u8)),
+        );
+        assert!(
+            forged.is_err(),
+            "a forged VDF chain must still be REJECTED by the recompute"
+        );
+    }
 
     #[tokio::test]
     async fn test_mid_execution_cancellation() {
@@ -923,5 +1275,45 @@ mod tests {
 
         advancer.await.unwrap();
         assert!(result.is_ok(), "wait should succeed when state advances");
+    }
+
+    /// Regression for the partition-recovery re-anchor (review Finding #2, Mode A):
+    /// a BACKWARD jump in `global_step` (the shared buffer rebuilt at a lower step)
+    /// must reset the stall baseline/timer, not be mistaken for a dead writer.
+    ///
+    /// Timeline (progress_timeout = 10s): advance 100→150 at t=4s, REWIND 150→120 at
+    /// t=8s, then climb to the desired 200 at t=16s. Pre-fix, the climb after the
+    /// rewind never exceeds the pre-rewind `last_observed_step` (150), so
+    /// `last_progress_at` (frozen at t=4s) elapses its 10s window at t=14s and the
+    /// wait spuriously returns `Stalled` (which panics the validation service).
+    /// Post-fix, the rewind at t=8s resets the timer, so the wait reaches 200 first.
+    #[tokio::test(start_paused = true)]
+    async fn wait_for_step_tolerates_backward_reanchor_jump() {
+        let inner = Arc::new(RwLock::new(vdf_state_at(100)));
+        let readonly = VdfStateReadonly::new(Arc::clone(&inner));
+        let cancel = Arc::new(AtomicU8::new(CancelEnum::Continue as u8));
+        let progress_timeout = std::time::Duration::from_secs(10);
+
+        let advancer = {
+            let inner = Arc::clone(&inner);
+            tokio::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_secs(4)).await;
+                inner.write().unwrap().global_step = 150; // forward
+                tokio::time::sleep(std::time::Duration::from_secs(4)).await;
+                inner.write().unwrap().global_step = 120; // re-anchor rewind (the trigger)
+                tokio::time::sleep(std::time::Duration::from_secs(8)).await;
+                inner.write().unwrap().global_step = 200; // climb to desired before timeout
+            })
+        };
+
+        let result = readonly
+            .wait_for_step(200, Arc::clone(&cancel), progress_timeout)
+            .await;
+
+        advancer.await.unwrap();
+        assert!(
+            result.is_ok(),
+            "a backward re-anchor jump must reset the stall timer, not surface as Stalled: {result:?}"
+        );
     }
 }

--- a/crates/vdf/src/state.rs
+++ b/crates/vdf/src/state.rs
@@ -292,12 +292,18 @@ impl VdfStateReadonly {
 }
 
 /// create VDF state using the latest block in db
+///
+/// Returns the rebuilt [`VdfState`] together with the anchor (latest) block's
+/// `next_seed` — the reset seed the VDF loop must start from. The seed is
+/// returned alongside the state so callers re-anchoring the VDF after a deep
+/// reorg (network-partition recovery) get a consistent snapshot from a single
+/// read of the canonical index, rather than re-deriving it separately.
 pub fn create_state(
-    block_index: BlockIndex,
-    db: DatabaseProvider,
+    block_index: &BlockIndex,
+    db: &DatabaseProvider,
     is_vdf_mining_enabled: Arc<AtomicBool>,
     config: &Config,
-) -> VdfState {
+) -> (VdfState, H256) {
     let capacity = calc_capacity(config);
 
     let block_hash = block_index
@@ -311,6 +317,9 @@ pub fn create_state(
         .unwrap()
         .unwrap();
     let global_step_number = block.vdf_limiter_info.global_step_number;
+    // Captured from the anchor (latest) block before the walk-back loop below
+    // reassigns `block` to its ancestors.
+    let next_seed = block.vdf_limiter_info.next_seed;
     let mut steps_remaining = capacity;
 
     while steps_remaining > 0 && block.height > 0 {
@@ -337,14 +346,17 @@ pub fn create_state(
         global_step_number
     );
 
-    VdfState {
-        global_step: global_step_number,
-        global_step_from_the_latest_canonical_block: global_step_number,
-        minimum_step_to_keep: global_step_number.saturating_sub(capacity as u64),
-        seeds,
-        capacity,
-        is_vdf_mining_enabled: Some(is_vdf_mining_enabled),
-    }
+    (
+        VdfState {
+            global_step: global_step_number,
+            global_step_from_the_latest_canonical_block: global_step_number,
+            minimum_step_to_keep: global_step_number.saturating_sub(capacity as u64),
+            seeds,
+            capacity,
+            is_vdf_mining_enabled: Some(is_vdf_mining_enabled),
+        },
+        next_seed,
+    )
 }
 
 /// return the larger of max_allowed_vdf_fork_steps or num_recall_ranges_in_partition()

--- a/crates/vdf/src/state.rs
+++ b/crates/vdf/src/state.rs
@@ -405,82 +405,10 @@ fn build_vdf_seed_buffer(
     Ok(seeds)
 }
 
-/// Rebuild [`VdfState`] anchored at the canonical chain TIP, for partition-recovery re-anchor.
-///
-/// Unlike [`create_state`] (which anchors at the block index's latest item — the LCA after a
-/// partition-recovery truncation), this anchors at the new canonical tip so the rebuilt buffer
-/// carries the recovered range's canonical steps, each with its OWN reset-boundary seed.
-/// Anchoring at the LCA instead leaves the loop to re-cross the recovered range's reset
-/// boundaries by local stepping with the canonical tip's single `next_seed`, which is wrong for
-/// every intermediate boundary — diverging the buffer and re-wedging block validation. See
-/// design/docs/vdf-partition-recovery-reanchor.md.
-///
-/// `canonical_headers` is the block tree's canonical chain (oldest cached .. tip, as returned by
-/// `BlockTree::get_canonical_chain`). The recovered range is always within the block tree (a
-/// reorg is only representable up to `block_tree_depth` deep), so the tip and the whole recovered
-/// range are present here. Block headers are persisted to the DB only at migration, so the
-/// un-migrated tail MUST come from these headers; steps deeper than the cache (needed to fill
-/// `capacity`) fall back to the DB, which holds the migrated ancestors.
-pub fn create_state_for_canonical_tip(
-    canonical_headers: &[Arc<IrysBlockHeader>],
-    db: &DatabaseProvider,
-    is_vdf_mining_enabled: Arc<AtomicBool>,
-    config: &Config,
-) -> eyre::Result<(VdfState, H256)> {
-    let capacity = calc_capacity(config);
-
-    let cached: std::collections::HashMap<H256, Arc<IrysBlockHeader>> = canonical_headers
-        .iter()
-        .map(|h| (h.block_hash, Arc::clone(h)))
-        .collect();
-    let tip: &IrysBlockHeader = canonical_headers
-        .last()
-        .ok_or_else(|| eyre!("canonical chain empty during VDF re-anchor"))?;
-    let global_step_number = tip.vdf_limiter_info.global_step_number;
-    // Captured from the anchor (tip) block; the walk-back below only reads ancestors.
-    let next_seed = tip.vdf_limiter_info.next_seed;
-
-    // This runs on the live VDF supervisor thread (the re-anchor arm of
-    // init_vdf_thread). A transient DB error or an ancestor missing from BOTH the
-    // canonical cache and the DB must surface as an error — the caller keeps the
-    // current buffer and retries on the next re-anchor signal — rather than
-    // panicking and shutting the node down via the thread's CancelOnDrop guard.
-    let tx = db
-        .tx()
-        .map_err(|e| eyre!("VDF re-anchor: opening db tx failed: {e}"))?;
-    // Resolve an ancestor header by hash: the block tree's canonical cache first (the recovered,
-    // un-migrated range), then the DB (migrated ancestors below the cache).
-    let seeds = build_vdf_seed_buffer(tip, capacity, |hash| {
-        if let Some(header) = cached.get(hash) {
-            return Ok((**header).clone());
-        }
-        block_header_by_hash(&tx, hash, false)
-            .map_err(|e| eyre!("VDF re-anchor: header lookup failed for {hash}: {e}"))?
-            .ok_or_else(|| eyre!("VDF re-anchor: missing header for {hash}"))
-    })?;
-
-    info!(
-        "Re-anchoring vdf service to canonical tip at step number {}",
-        global_step_number
-    );
-
-    Ok((
-        VdfState {
-            global_step: global_step_number,
-            global_step_from_the_latest_canonical_block: global_step_number,
-            minimum_step_to_keep: global_step_number.saturating_sub(capacity as u64),
-            seeds,
-            capacity,
-            is_vdf_mining_enabled: Some(is_vdf_mining_enabled),
-        },
-        next_seed,
-    ))
-}
-
 /// Build a TRANSIENT, read-only VDF step view anchored on `tip`'s OWN lineage — its
 /// `vdf_limiter_info.steps` plus ancestors resolved via `fetch_parent` (oldest at the front, the
 /// tip's last step at the back), filling up to `capacity` steps. Mirrors the walk-back of
-/// [`create_state_for_canonical_tip`] / [`build_vdf_seed_buffer`].
+/// [`build_vdf_seed_buffer`].
 ///
 /// This is the single place that resolves FORK-LOCAL VDF steps for block validation. A node
 /// validating a block on a competing fork (deep partition recovery) must not trust its live VDF
@@ -763,13 +691,12 @@ mod tests {
     use std::sync::atomic::{AtomicU8, Ordering};
     use std::time::Duration;
 
-    /// Regression for the partition-recovery re-anchor fix (review Finding #1):
-    /// [`build_vdf_seed_buffer`] — the walk-back behind [`create_state_for_canonical_tip`] — must
+    /// Regression for the partition-recovery fork-local view (review Finding #1):
+    /// [`build_vdf_seed_buffer`] — the walk-back behind [`build_fork_local_view`] — must
     /// reproduce the canonical chain's recorded steps VERBATIM, anchored at the tip. That is what
-    /// lets the re-anchored buffer match (and validate) the canonical chain across the recovered
-    /// range. The broken design re-anchored at the LCA and let the loop re-derive the post-LCA
-    /// steps with the wrong reset seed; rebuilding from the canonical headers instead copies each
-    /// block's own steps, which already encode the correct boundary crossings.
+    /// lets a fork-local view match (and validate) a competing chain across the recovered range:
+    /// it copies each block's own steps, which already encode the correct boundary crossings,
+    /// rather than re-deriving the post-LCA steps with the wrong reset seed.
     #[test]
     fn build_vdf_seed_buffer_reproduces_canonical_steps_anchored_at_tip() {
         fn mock_header(height: u64, hash: u8, prev: u8, steps: &[u8]) -> IrysBlockHeader {

--- a/crates/vdf/src/state.rs
+++ b/crates/vdf/src/state.rs
@@ -329,6 +329,14 @@ pub fn create_state(
                 break;
             }
         }
+        // Buffer full — stop before fetching the parent. The inner break only exits the
+        // for-loop; falling through to fetch the parent would, when that parent is genesis,
+        // trip the post-loop genesis branch and push one EXTRA seed (capacity+1). That
+        // inflates seeds.len(), dragging get_steps' first_global_step one too low and
+        // mis-mapping the buffer's oldest step.
+        if steps_remaining == 0 {
+            break;
+        }
         // get the previous block
         block = block_header_by_hash(&tx, &block.previous_block_hash, false)
             .unwrap()
@@ -374,6 +382,14 @@ fn build_vdf_seed_buffer(
             if steps_remaining == 0 {
                 break;
             }
+        }
+        // Buffer full — stop before fetching the parent. The inner break only exits the
+        // for-loop; falling through to fetch the parent would, when that parent is genesis,
+        // trip the post-loop genesis branch and push one EXTRA seed (capacity+1). That
+        // inflates seeds.len(), dragging get_steps' first_global_step one too low and
+        // mis-mapping the buffer's oldest step.
+        if steps_remaining == 0 {
+            break;
         }
         // get the previous block
         block = fetch_parent(&block.previous_block_hash)?;
@@ -799,6 +815,59 @@ mod tests {
             seeds.back().map(|s| s.0),
             Some(H256::repeat_byte(0x14)),
             "buffer must be anchored at the canonical TIP's last step (the re-anchor-to-tip fix)"
+        );
+    }
+
+    /// Regression: when `capacity` is exhausted exactly while consuming the height-1 block's
+    /// steps, the walk-back must stop at exactly `capacity` seeds and NOT fall through to fetch
+    /// genesis and prepend its first step (which produced a capacity+1 buffer). The extra front
+    /// seed inflates `seeds.len()`, dragging `get_steps`' `first_global_step` one too low and
+    /// mis-mapping the buffer's oldest step onto genesis entropy.
+    #[test]
+    fn build_vdf_seed_buffer_stops_at_capacity_without_appending_genesis() {
+        fn mock_header(height: u64, hash: u8, prev: u8, steps: &[u8]) -> IrysBlockHeader {
+            let mut h = IrysBlockHeader::new_mock_header();
+            h.height = height;
+            h.block_hash = H256::repeat_byte(hash);
+            h.previous_block_hash = H256::repeat_byte(prev);
+            h.vdf_limiter_info.steps =
+                H256List(steps.iter().map(|b| H256::repeat_byte(*b)).collect());
+            h
+        }
+
+        // Same chain as the verbatim-reproduction test: genesis(0x10) <- b1(0x11,0x12) <- tip(0x13,0x14).
+        let genesis = mock_header(0, 0x00, 0xFF, &[0x10]);
+        let b1 = mock_header(1, 0x01, 0x00, &[0x11, 0x12]);
+        let tip = mock_header(2, 0x02, 0x01, &[0x13, 0x14]);
+        let by_hash: std::collections::HashMap<H256, IrysBlockHeader> = [genesis, b1, tip.clone()]
+            .into_iter()
+            .map(|h| (h.block_hash, h))
+            .collect();
+
+        // capacity=3 is reached while consuming b1 (whose parent IS genesis), exercising the
+        // off-by-one path. Want the 3 most-recent steps; genesis's 0x10 must NOT appear.
+        let seeds = build_vdf_seed_buffer(&tip, 3, |hash| {
+            Ok(by_hash.get(hash).cloned().expect("ancestor present"))
+        })
+        .expect("walk-back must succeed");
+
+        let got: Vec<H256> = seeds.iter().map(|s| s.0).collect();
+        let expected: Vec<H256> = [0x12, 0x13, 0x14]
+            .iter()
+            .map(|b| H256::repeat_byte(*b))
+            .collect();
+        assert_eq!(
+            got, expected,
+            "buffer must hold exactly the `capacity` most-recent steps, not capacity+1 with genesis prepended"
+        );
+        assert_eq!(
+            seeds.len(),
+            3,
+            "buffer length must equal capacity, not capacity+1"
+        );
+        assert!(
+            !seeds.iter().any(|s| s.0 == H256::repeat_byte(0x10)),
+            "genesis's first step must not be appended once capacity is already filled"
         );
     }
 

--- a/crates/vdf/src/state.rs
+++ b/crates/vdf/src/state.rs
@@ -373,12 +373,18 @@ fn build_vdf_seed_buffer(
         block = fetch_parent(&block.previous_block_hash)?;
     }
     if block.height == 0 {
-        // Genesis contributes only its first step. Guard the index so a malformed genesis header
-        // surfaces as a no-op rather than panicking (this runs on cold-start and on the live thread
-        // that builds transient fork-local validation views).
-        if let Some(first) = block.vdf_limiter_info.steps.0.first() {
-            seeds.push_front(Seed(*first));
-        }
+        // Genesis contributes only its first step. A malformed genesis header with no steps is a
+        // hard error rather than a silent short buffer: callers (cold-start `create_state`, the
+        // fork-local validation views) would otherwise treat the misaligned `Ok(seeds)` as valid
+        // VDF state.
+        let first = block
+            .vdf_limiter_info
+            .steps
+            .0
+            .first()
+            .copied()
+            .ok_or_else(|| eyre!("VDF seed buffer: genesis header has no VDF steps"))?;
+        seeds.push_front(Seed(first));
     }
     Ok(seeds)
 }

--- a/crates/vdf/src/state.rs
+++ b/crates/vdf/src/state.rs
@@ -266,14 +266,11 @@ impl VdfStateReadonly {
                 return Ok(());
             }
 
-            if current_step != last_observed_step {
-                // Any movement resets the stall baseline/timer — including a
-                // BACKWARD jump from a partition-recovery VDF re-anchor, which
-                // rebuilds the buffer at a lower `global_step`. The stall detector
-                // exists to catch a DEAD writer, which leaves `global_step`
-                // constant; only the re-anchor swap ever decreases it (`store_step`
-                // is strictly forward-only), so resetting on a decrease responds to
-                // a genuine liveness event and cannot mask the frozen-writer case.
+            if current_step > last_observed_step {
+                // Forward progress resets the stall baseline/timer. The stall detector
+                // exists to catch a DEAD writer, which leaves `global_step` constant;
+                // `store_step` is strictly forward-only, so the live step never
+                // decreases.
                 last_observed_step = current_step;
                 last_progress_at = Instant::now();
             } else if last_progress_at.elapsed() >= progress_timeout {
@@ -312,40 +309,20 @@ pub fn create_state(
         .map(|item| item.block_hash)
         .expect("To have at least genesis block");
 
-    let mut seeds: VecDeque<Seed> = VecDeque::with_capacity(capacity);
     let tx = db.tx().unwrap();
-    let mut block = block_header_by_hash(&tx, &block_hash, false)
+    let tip = block_header_by_hash(&tx, &block_hash, false)
         .unwrap()
         .unwrap();
-    let global_step_number = block.vdf_limiter_info.global_step_number;
-    let mut steps_remaining = capacity;
+    let global_step_number = tip.vdf_limiter_info.global_step_number;
 
-    while steps_remaining > 0 && block.height > 0 {
-        // get all the steps out of the block
-        for step in block.vdf_limiter_info.steps.0.iter().rev() {
-            seeds.push_front(Seed(*step));
-            steps_remaining -= 1;
-            if steps_remaining == 0 {
-                break;
-            }
-        }
-        // Buffer full — stop before fetching the parent. The inner break only exits the
-        // for-loop; falling through to fetch the parent would, when that parent is genesis,
-        // trip the post-loop genesis branch and push one EXTRA seed (capacity+1). That
-        // inflates seeds.len(), dragging get_steps' first_global_step one too low and
-        // mis-mapping the buffer's oldest step.
-        if steps_remaining == 0 {
-            break;
-        }
-        // get the previous block
-        block = block_header_by_hash(&tx, &block.previous_block_hash, false)
-            .unwrap()
-            .unwrap();
-    }
-
-    if block.height == 0 {
-        seeds.push_front(Seed(block.vdf_limiter_info.steps[0]));
-    }
+    // Same walk-back as the fork-local views (see `build_vdf_seed_buffer`), resolving ancestors
+    // from the DB. Cold-start always has genesis present, so the build cannot fail here.
+    let seeds = build_vdf_seed_buffer(&tip, capacity, |hash| {
+        block_header_by_hash(&tx, hash, false)
+            .map_err(|e| eyre!("cold-start VDF buffer: header lookup failed for {hash}: {e}"))?
+            .ok_or_else(|| eyre!("cold-start VDF buffer: missing header for {hash}"))
+    })
+    .expect("cold-start VDF buffer build must succeed (genesis is always present)");
 
     info!(
         "Initializing vdf service from block's info in step number {}",
@@ -364,8 +341,9 @@ pub fn create_state(
 
 /// Walk back from `tip` accumulating up to `capacity` VDF steps into a seed buffer (oldest step
 /// at the front, the tip's last step at the back), resolving each ancestor header via
-/// `fetch_parent`. Genesis (height 0) contributes only its first step. This is the shared
-/// walk-back used by the canonical-tip re-anchor; it mirrors [`create_state`]'s inline loop.
+/// `fetch_parent`. Genesis (height 0) contributes only its first step. Shared by [`create_state`]
+/// (cold-start, resolving ancestors from the DB) and [`build_fork_local_view`] (transient
+/// fork-local validation views).
 fn build_vdf_seed_buffer(
     tip: &IrysBlockHeader,
     capacity: usize,
@@ -395,9 +373,9 @@ fn build_vdf_seed_buffer(
         block = fetch_parent(&block.previous_block_hash)?;
     }
     if block.height == 0 {
-        // Genesis contributes only its first step. Guard the index: this runs on
-        // the live VDF supervisor thread during re-anchor, so a malformed genesis
-        // header must surface as a no-op rather than panicking the node.
+        // Genesis contributes only its first step. Guard the index so a malformed genesis header
+        // surfaces as a no-op rather than panicking (this runs on cold-start and on the live thread
+        // that builds transient fork-local validation views).
         if let Some(first) = block.vdf_limiter_info.steps.0.first() {
             seeds.push_front(Seed(*first));
         }
@@ -1271,45 +1249,5 @@ mod tests {
 
         advancer.await.unwrap();
         assert!(result.is_ok(), "wait should succeed when state advances");
-    }
-
-    /// Regression for the partition-recovery re-anchor (review Finding #2, Mode A):
-    /// a BACKWARD jump in `global_step` (the shared buffer rebuilt at a lower step)
-    /// must reset the stall baseline/timer, not be mistaken for a dead writer.
-    ///
-    /// Timeline (progress_timeout = 10s): advance 100→150 at t=4s, REWIND 150→120 at
-    /// t=8s, then climb to the desired 200 at t=16s. Pre-fix, the climb after the
-    /// rewind never exceeds the pre-rewind `last_observed_step` (150), so
-    /// `last_progress_at` (frozen at t=4s) elapses its 10s window at t=14s and the
-    /// wait spuriously returns `Stalled` (which panics the validation service).
-    /// Post-fix, the rewind at t=8s resets the timer, so the wait reaches 200 first.
-    #[tokio::test(start_paused = true)]
-    async fn wait_for_step_tolerates_backward_reanchor_jump() {
-        let inner = Arc::new(RwLock::new(vdf_state_at(100)));
-        let readonly = VdfStateReadonly::new(Arc::clone(&inner));
-        let cancel = Arc::new(AtomicU8::new(CancelEnum::Continue as u8));
-        let progress_timeout = std::time::Duration::from_secs(10);
-
-        let advancer = {
-            let inner = Arc::clone(&inner);
-            tokio::spawn(async move {
-                tokio::time::sleep(std::time::Duration::from_secs(4)).await;
-                inner.write().unwrap().global_step = 150; // forward
-                tokio::time::sleep(std::time::Duration::from_secs(4)).await;
-                inner.write().unwrap().global_step = 120; // re-anchor rewind (the trigger)
-                tokio::time::sleep(std::time::Duration::from_secs(8)).await;
-                inner.write().unwrap().global_step = 200; // climb to desired before timeout
-            })
-        };
-
-        let result = readonly
-            .wait_for_step(200, Arc::clone(&cancel), progress_timeout)
-            .await;
-
-        advancer.await.unwrap();
-        assert!(
-            result.is_ok(),
-            "a backward re-anchor jump must reset the stall timer, not surface as Stalled: {result:?}"
-        );
     }
 }

--- a/crates/vdf/src/vdf.rs
+++ b/crates/vdf/src/vdf.rs
@@ -182,7 +182,9 @@ pub fn run_vdf<B: BlockProvider>(
                     vdf_info,
                     confirmed_global_step_number: _,
                     reset_seed_for_step,
-                }) = block_provider.canonical_vdf_snapshot(proposed_ff_step.global_step_number)
+                }) = block_provider.canonical_vdf_snapshot(
+                    proposed_ff_step.global_step_number.saturating_sub(1),
+                )
                 {
                     next_reset_seed = reset_seed_for_step;
                     canonical_global_step_number = vdf_info.global_step_number;
@@ -1384,6 +1386,128 @@ mod tests {
         assert_ne!(
             stored_step3, wrong_step3,
             "the test must distinguish the per-step seed from the tip seed"
+        );
+    }
+
+    /// Regression for the FF-path exact-boundary edge: when a fast-forward step lands exactly on
+    /// boundary `B`, the carried hash for subsequent local stepping must use the seed pinned at
+    /// `B - 1`, not the seed for the block ending at `B` (which targets the next window).
+    #[tokio::test]
+    async fn fast_forward_exact_boundary_uses_pre_boundary_seed() {
+        let mut node_config = NodeConfig::testing();
+        node_config.consensus.get_mut().vdf.reset_frequency = 2;
+        node_config.consensus.get_mut().vdf.sha_1s_difficulty = 1;
+        let config = Config::new_with_random_peer_id(node_config);
+
+        let initial_seed = H256::repeat_byte(0x22);
+        let correct_boundary_seed = H256::repeat_byte(0x44);
+        let wrong_boundary_seed = H256::repeat_byte(0x66);
+        let tip_seed = H256::repeat_byte(0x77);
+
+        let provider = ControllableBlockProvider::new(10_000);
+        provider.set_snapshot(tip_seed, 10_000, 10_000);
+        provider.set_seed_for_step(1, correct_boundary_seed);
+        provider.set_seed_for_step(2, wrong_boundary_seed);
+
+        let mut step1 = initial_seed;
+        let mut checkpoints = vec![H256::default(); config.vdf.num_checkpoints_in_vdf_step];
+        vdf_sha(
+            U256::from(step_number_to_salt_number(&config.vdf, 0)),
+            &mut step1,
+            config.vdf.num_checkpoints_in_vdf_step,
+            config.vdf.num_iterations_per_checkpoint(),
+            &mut checkpoints,
+        );
+        let mut ff_step2 = step1;
+        vdf_sha(
+            U256::from(step_number_to_salt_number(&config.vdf, 1)),
+            &mut ff_step2,
+            config.vdf.num_checkpoints_in_vdf_step,
+            config.vdf.num_iterations_per_checkpoint(),
+            &mut checkpoints,
+        );
+
+        let vdf_state = mocked_vdf_service(&config);
+        {
+            let mut guard = vdf_state.write().expect("test VDF state lock");
+            guard.store_step(Seed(step1), 1);
+            guard.set_canonical_step(1);
+        }
+        let vdf_steps_guard = VdfStateReadonly::new(vdf_state.clone());
+
+        let (ff_tx, mut ff_rx) = mpsc::channel::<Traced<VdfStep>>(16);
+        ff_tx
+            .try_send(Traced::new(VdfStep {
+                global_step_number: 2,
+                step: ff_step2,
+            }))
+            .expect("queue FF step before the loop starts");
+
+        let (_reanchor_tx, mut reanchor_rx) = mpsc::unbounded_channel::<()>();
+        let is_mining_enabled = Arc::new(AtomicBool::new(true));
+        let atomic_step = Arc::new(AtomicU64::new(1));
+        let chain_sync_state = ChainSyncState::new(false, false);
+        let shutdown_token = CancellationToken::new();
+
+        let handle = std::thread::spawn({
+            let config = config.clone();
+            let provider = provider.clone();
+            let shutdown_token = shutdown_token.clone();
+            let mining_state = Arc::clone(&is_mining_enabled);
+            move || {
+                run_vdf(
+                    &config.vdf,
+                    1,
+                    step1,
+                    H256::zero(),
+                    &mut ff_rx,
+                    &mut reanchor_rx,
+                    mining_state,
+                    MockMining,
+                    vdf_state.clone(),
+                    atomic_step,
+                    provider,
+                    chain_sync_state,
+                    shutdown_token,
+                )
+            }
+        });
+
+        let cancel = Arc::new(AtomicU8::new(CancelEnum::Continue as u8));
+        vdf_steps_guard
+            .wait_for_step(3, Arc::clone(&cancel), Duration::from_secs(5))
+            .await
+            .expect("loop should consume the FF boundary step and then locally reach step 3");
+        shutdown_token.cancel();
+        assert_eq!(handle.join().unwrap(), VdfExit::Shutdown);
+
+        let stored_step3 = vdf_steps_guard.get_step(3).expect("step 3 should be present");
+
+        let mut expected_step3 = apply_reset_seed(ff_step2, correct_boundary_seed);
+        vdf_sha(
+            U256::from(step_number_to_salt_number(&config.vdf, 2)),
+            &mut expected_step3,
+            config.vdf.num_checkpoints_in_vdf_step,
+            config.vdf.num_iterations_per_checkpoint(),
+            &mut checkpoints,
+        );
+
+        let mut wrong_step3 = apply_reset_seed(ff_step2, wrong_boundary_seed);
+        vdf_sha(
+            U256::from(step_number_to_salt_number(&config.vdf, 2)),
+            &mut wrong_step3,
+            config.vdf.num_checkpoints_in_vdf_step,
+            config.vdf.num_iterations_per_checkpoint(),
+            &mut checkpoints,
+        );
+
+        assert_eq!(
+            stored_step3, expected_step3,
+            "an FF step landing on the boundary must carry forward with the seed pinned at step B-1"
+        );
+        assert_ne!(
+            stored_step3, wrong_step3,
+            "the test must distinguish the correct pre-boundary seed from the block-ending-at-B seed"
         );
     }
 

--- a/crates/vdf/src/vdf.rs
+++ b/crates/vdf/src/vdf.rs
@@ -181,9 +181,10 @@ pub fn run_vdf<B: BlockProvider>(
                 if let Some(CanonicalVdfSnapshot {
                     vdf_info,
                     confirmed_global_step_number: _,
-                }) = block_provider.latest_canonical_vdf_info()
+                    reset_seed_for_step,
+                }) = block_provider.canonical_vdf_snapshot(proposed_ff_step.global_step_number)
                 {
-                    next_reset_seed = vdf_info.next_seed;
+                    next_reset_seed = reset_seed_for_step;
                     canonical_global_step_number = vdf_info.global_step_number;
                 }
 
@@ -233,25 +234,12 @@ pub fn run_vdf<B: BlockProvider>(
         if let Some(CanonicalVdfSnapshot {
             vdf_info,
             confirmed_global_step_number: confirmed_step,
-        }) = block_provider.latest_canonical_vdf_info()
+            reset_seed_for_step,
+        }) = block_provider.canonical_vdf_snapshot(global_step_number)
         {
             canonical_global_step_number = vdf_info.global_step_number;
             confirmed_global_step_number = confirmed_step;
-            // Source the reset seed from the canonical block ENDING at or before the current step,
-            // not the chain tip. During partition-recovery CATCH-UP the re-anchored VDF local-steps
-            // across reset boundaries the canonical tip has ALREADY passed; the tip's `next_seed`
-            // targets the boundary above the tip, so applying it at an earlier boundary XORs in the
-            // wrong seed and re-poisons the post-boundary steps (the Finding #1 wedge, which then
-            // never heals because `store_step` is forward-only). The block with the greatest
-            // `global_step_number <= global_step_number` pins (via its `next_seed`) the seed for the
-            // boundary the VDF is about to cross — and is correct even when a later canonical block
-            // SPANS that boundary (whose own `next_seed` targets a higher boundary). When the VDF
-            // runs AHEAD of the canonical chain (normal forward operation) that block IS the tip, so
-            // this equals the prior behavior — a no-op. The confirmed-step gate (below) is
-            // unaffected: it still uses `confirmed_global_step_number`.
-            next_reset_seed = block_provider
-                .canonical_vdf_info_at_or_below_step(global_step_number)
-                .unwrap_or(vdf_info.next_seed);
+            next_reset_seed = reset_seed_for_step;
             debug!(
                 "Canonical global step number: {}, next reset seed: {:?}, prev output: {:?}, confirmed step: {}, global_step: {:?}",
                 canonical_global_step_number,
@@ -480,11 +468,13 @@ mod tests {
     }
 
     impl BlockProvider for MockBlockProvider {
-        fn latest_canonical_vdf_info(&self) -> Option<CanonicalVdfSnapshot> {
+        fn canonical_vdf_snapshot(&self, step_number: u64) -> Option<CanonicalVdfSnapshot> {
+            let _ = step_number;
             Some(CanonicalVdfSnapshot {
                 vdf_info: self.0.vdf_limiter_info.clone(),
                 // The mock holds a single block, so the tip is also the confirmed tip.
                 confirmed_global_step_number: self.0.vdf_limiter_info.global_step_number,
+                reset_seed_for_step: self.0.vdf_limiter_info.next_seed,
             })
         }
     }
@@ -1134,7 +1124,9 @@ mod tests {
     }
 
     #[derive(Clone)]
-    struct ControllableBlockProvider(std::sync::Arc<std::sync::Mutex<(VDFLimiterInfo, u64)>>);
+    struct ControllableBlockProvider(
+        std::sync::Arc<std::sync::Mutex<(VDFLimiterInfo, u64, std::collections::HashMap<u64, H256>)>>,
+    );
     impl ControllableBlockProvider {
         /// The canonical tip step is held at 0 so `store_step` treats every produced step
         /// as a normal advance; the `u64` is the confirmed-chain step the gate reads.
@@ -1145,6 +1137,7 @@ mod tests {
             Self(std::sync::Arc::new(std::sync::Mutex::new((
                 info,
                 confirmed_global_step_number,
+                std::collections::HashMap::new(),
             ))))
         }
         fn set_confirmed(&self, confirmed_global_step_number: u64) {
@@ -1165,13 +1158,18 @@ mod tests {
             g.0.global_step_number = canonical_tip_step;
             g.1 = confirmed_global_step_number;
         }
+        fn set_seed_for_step(&self, step_number: u64, seed: H256) {
+            self.0.lock().unwrap().2.insert(step_number, seed);
+        }
     }
     impl BlockProvider for ControllableBlockProvider {
-        fn latest_canonical_vdf_info(&self) -> Option<CanonicalVdfSnapshot> {
+        fn canonical_vdf_snapshot(&self, step_number: u64) -> Option<CanonicalVdfSnapshot> {
             let g = self.0.lock().unwrap();
+            let reset_seed_for_step = g.2.get(&step_number).copied().unwrap_or(g.0.next_seed);
             Some(CanonicalVdfSnapshot {
                 vdf_info: g.0.clone(),
                 confirmed_global_step_number: g.1,
+                reset_seed_for_step,
             })
         }
     }
@@ -1271,6 +1269,122 @@ mod tests {
 
         shutdown_token.cancel();
         handle.join().unwrap();
+    }
+
+    /// Regression for the partition-recovery catch-up seed path: when the canonical tip has already
+    /// passed a reset boundary, the loop must use the seed pinned for the CURRENT step rather than
+    /// the tip's `next_seed`. Start the loop at step 1 with a provider whose tip seed is different
+    /// from the per-step seed for step 1; crossing boundary 2 must produce step 3 from the
+    /// step-1-pinned seed, not the tip seed.
+    #[tokio::test]
+    async fn uses_per_step_seed_from_single_snapshot_when_crossing_boundary() {
+        let mut node_config = NodeConfig::testing();
+        node_config.consensus.get_mut().vdf.reset_frequency = 2;
+        node_config.consensus.get_mut().vdf.sha_1s_difficulty = 1;
+        let config = Config::new_with_random_peer_id(node_config);
+
+        let initial_seed = H256::repeat_byte(0x33);
+        let correct_boundary_seed = H256::repeat_byte(0x44);
+        let tip_seed = H256::repeat_byte(0x55);
+
+        let provider = ControllableBlockProvider::new(10_000);
+        provider.set_snapshot(tip_seed, 10_000, 10_000);
+        provider.set_seed_for_step(1, correct_boundary_seed);
+
+        let mut step1 = initial_seed;
+        let mut checkpoints = vec![H256::default(); config.vdf.num_checkpoints_in_vdf_step];
+        vdf_sha(
+            U256::from(step_number_to_salt_number(&config.vdf, 0)),
+            &mut step1,
+            config.vdf.num_checkpoints_in_vdf_step,
+            config.vdf.num_iterations_per_checkpoint(),
+            &mut checkpoints,
+        );
+
+        let vdf_state = mocked_vdf_service(&config);
+        {
+            let mut guard = vdf_state.write().expect("test VDF state lock");
+            guard.store_step(Seed(step1), 1);
+            guard.set_canonical_step(1);
+        }
+        let vdf_steps_guard = VdfStateReadonly::new(vdf_state.clone());
+
+        let (_tx, mut ff_rx) = mpsc::channel::<Traced<VdfStep>>(16);
+        let (_reanchor_tx, mut reanchor_rx) = mpsc::unbounded_channel::<()>();
+        let is_mining_enabled = Arc::new(AtomicBool::new(true));
+        let atomic_step = Arc::new(AtomicU64::new(1));
+        let chain_sync_state = ChainSyncState::new(false, false);
+        let shutdown_token = CancellationToken::new();
+
+        let handle = std::thread::spawn({
+            let config = config.clone();
+            let provider = provider.clone();
+            let shutdown_token = shutdown_token.clone();
+            let mining_state = Arc::clone(&is_mining_enabled);
+            move || {
+                run_vdf(
+                    &config.vdf,
+                    1,
+                    step1,
+                    H256::zero(),
+                    &mut ff_rx,
+                    &mut reanchor_rx,
+                    mining_state,
+                    MockMining,
+                    vdf_state.clone(),
+                    atomic_step,
+                    provider,
+                    chain_sync_state,
+                    shutdown_token,
+                )
+            }
+        });
+
+        let cancel = Arc::new(AtomicU8::new(CancelEnum::Continue as u8));
+        vdf_steps_guard
+            .wait_for_step(3, Arc::clone(&cancel), Duration::from_secs(5))
+            .await
+            .expect("loop should reach step 3");
+        shutdown_token.cancel();
+        assert_eq!(handle.join().unwrap(), VdfExit::Shutdown);
+
+        let stored_step3 = vdf_steps_guard.get_step(3).expect("step 3 should be present");
+
+        let mut expected_step2 = step1;
+        let mut expected_checkpoints = vec![H256::default(); config.vdf.num_checkpoints_in_vdf_step];
+        vdf_sha(
+            U256::from(step_number_to_salt_number(&config.vdf, 1)),
+            &mut expected_step2,
+            config.vdf.num_checkpoints_in_vdf_step,
+            config.vdf.num_iterations_per_checkpoint(),
+            &mut expected_checkpoints,
+        );
+        let mut expected_step3 = apply_reset_seed(expected_step2, correct_boundary_seed);
+        vdf_sha(
+            U256::from(step_number_to_salt_number(&config.vdf, 2)),
+            &mut expected_step3,
+            config.vdf.num_checkpoints_in_vdf_step,
+            config.vdf.num_iterations_per_checkpoint(),
+            &mut expected_checkpoints,
+        );
+
+        let mut wrong_step3 = apply_reset_seed(expected_step2, tip_seed);
+        vdf_sha(
+            U256::from(step_number_to_salt_number(&config.vdf, 2)),
+            &mut wrong_step3,
+            config.vdf.num_checkpoints_in_vdf_step,
+            config.vdf.num_iterations_per_checkpoint(),
+            &mut expected_checkpoints,
+        );
+
+        assert_eq!(
+            stored_step3, expected_step3,
+            "step 3 must be derived from the seed pinned for step 1, not the tip seed"
+        );
+        assert_ne!(
+            stored_step3, wrong_step3,
+            "the test must distinguish the per-step seed from the tip seed"
+        );
     }
 
     /// Spin up a real `run_vdf` loop and drive it (deterministically, via `wait_for_step`)

--- a/crates/vdf/src/vdf.rs
+++ b/crates/vdf/src/vdf.rs
@@ -9,7 +9,7 @@ use irys_types::{
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::time::{Duration, Instant};
-use tokio::sync::mpsc::{Receiver, UnboundedReceiver};
+use tokio::sync::mpsc::Receiver;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
@@ -57,27 +57,12 @@ pub fn run_vdf_for_genesis_block(
     }
 }
 
-/// Why [`run_vdf`] returned, so the supervising VDF thread knows whether to exit
-/// or re-anchor and restart the loop.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum VdfExit {
-    /// Terminal: the shutdown token fired or the VDF state lock was poisoned.
-    /// The supervisor must stop (and the node should shut down).
-    Shutdown,
-    /// A re-anchor was requested (a deep reorg / network-partition recovery
-    /// rewound the canonical chain). The supervisor rebuilds the VDF state from
-    /// the now-canonical block index and restarts the loop. See
-    /// design/docs/vdf-partition-recovery-reanchor.md.
-    Reanchor,
-}
-
 pub fn run_vdf<B: BlockProvider>(
     config: &irys_types::VdfConfig,
     global_step_number: u64,
     current_vdf_hash: H256,
     initial_reset_seed: H256,
     fast_forward_receiver: &mut Receiver<Traced<VdfStep>>,
-    reanchor_receiver: &mut UnboundedReceiver<()>,
     is_mining_enabled: Arc<AtomicBool>,
     broadcast_mining_service: impl MiningBroadcaster,
     vdf_state: AtomicVdfState,
@@ -85,7 +70,7 @@ pub fn run_vdf<B: BlockProvider>(
     block_provider: B,
     chain_sync_state: ChainSyncState,
     shutdown_token: CancellationToken,
-) -> VdfExit {
+) {
     let _span = tracing::info_span!("vdf_loop").entered();
     let mut next_reset_seed = initial_reset_seed;
     // Step number of the deepest block confirmed past the migration threshold
@@ -102,7 +87,7 @@ pub fn run_vdf<B: BlockProvider>(
             // than re-panic; the lifecycle's vdf_done channel surfaces this
             // as a controlled exit.
             error!("VDF state read lock poisoned at startup; exiting VDF thread");
-            return VdfExit::Shutdown;
+            return;
         }
     };
     // Until the first canonical snapshot read, treat the confirmed step as the canonical
@@ -126,25 +111,7 @@ pub fn run_vdf<B: BlockProvider>(
     loop {
         if shutdown_token.is_cancelled() {
             tracing::info!("VDF loop: shutdown token cancelled, exiting");
-            return VdfExit::Shutdown;
-        }
-
-        // A deep reorg (network-partition recovery) rewound the canonical chain, so the
-        // running hash/global_step and the shared step buffer may carry reset entropy
-        // pinned by the now-orphaned minority fork. Drain every pending request (coalesce
-        // bursts) and hand control back to the supervisor, which rebuilds the VDF state
-        // from the canonical index and restarts this loop at the new anchor. See
-        // design/docs/vdf-partition-recovery-reanchor.md.
-        let mut reanchor_requested = false;
-        while reanchor_receiver.try_recv().is_ok() {
-            reanchor_requested = true;
-        }
-        if reanchor_requested {
-            info!(
-                vdf.global_step_number = global_step_number,
-                "VDF loop: re-anchor requested, returning to supervisor"
-            );
-            return VdfExit::Reanchor;
+            return;
         }
 
         // check for VDF fast forward step
@@ -175,7 +142,8 @@ pub fn run_vdf<B: BlockProvider>(
                 // (`PartOfAPrunedFork` only refuses forks older than that), NOT
                 // `block_migration_depth` — so an earlier comment here claiming such forks are
                 // refused before validation was wrong. Recompute-on-mismatch is what lets the
-                // recovering node validate and adopt the canonical chain (and then re-anchor).
+                // recovering node validate and adopt the canonical chain (which then triggers a
+                // controlled restart to heal the VDF state on relaunch).
                 // See design/docs/vdf-reset-seed-confirmation-gate.md and
                 // design/docs/vdf-partition-recovery-reanchor.md.
                 if let Some(CanonicalVdfSnapshot {
@@ -201,7 +169,7 @@ pub fn run_vdf<B: BlockProvider>(
                         vdf.proposed_step = proposed_ff_step.global_step_number,
                         "VDF thread exiting: store_step failed during fast-forward (lock poisoned)"
                     );
-                    return VdfExit::Shutdown;
+                    return;
                 };
                 if returned == prev_step {
                     // Gap rejected — leave hash and global_step_number
@@ -346,7 +314,7 @@ pub fn run_vdf<B: BlockProvider>(
                 vdf.global_step_number = global_step_number,
                 "VDF thread exiting: store_step failed during local stepping (lock poisoned)"
             );
-            return VdfExit::Shutdown;
+            return;
         };
         global_step_number = returned;
         chain_sync_state.record_vdf_step(global_step_number);
@@ -556,7 +524,6 @@ mod tests {
 
         let broadcast_mining_service = MockMining;
         let (_, mut ff_step_receiver) = mpsc::channel::<Traced<VdfStep>>(16);
-        let (_reanchor_tx, mut reanchor_rx) = mpsc::unbounded_channel::<()>();
 
         let is_mining_enabled = Arc::new(AtomicBool::new(true));
 
@@ -582,7 +549,6 @@ mod tests {
                     seed,
                     reset_seed,
                     &mut ff_step_receiver,
-                    &mut reanchor_rx,
                     mining_state,
                     broadcast_mining_service,
                     vdf_state.clone(),
@@ -673,7 +639,6 @@ mod tests {
 
         let broadcast_mining_service = MockMining;
         let (_, mut ff_step_receiver) = mpsc::channel::<Traced<VdfStep>>(16);
-        let (_reanchor_tx, mut reanchor_rx) = mpsc::unbounded_channel::<()>();
 
         let is_mining_enabled = Arc::new(AtomicBool::new(true));
 
@@ -695,7 +660,6 @@ mod tests {
                     seed,
                     reset_seed,
                     &mut ff_step_receiver,
-                    &mut reanchor_rx,
                     mining_state,
                     broadcast_mining_service,
                     vdf_state.clone(),
@@ -778,7 +742,6 @@ mod tests {
         let current_seed = H256::random();
         let reset_seed = H256::random();
         let (ff_step_sender, mut ff_step_receiver) = mpsc::channel::<Traced<VdfStep>>(16);
-        let (_reanchor_tx, mut reanchor_rx) = mpsc::unbounded_channel::<()>();
         let is_mining_enabled = Arc::new(AtomicBool::new(false));
         let vdf_state = mocked_vdf_service(&config);
         let vdf_steps_guard = VdfStateReadonly::new(vdf_state.clone());
@@ -800,7 +763,6 @@ mod tests {
                     current_seed,
                     reset_seed,
                     &mut ff_step_receiver,
-                    &mut reanchor_rx,
                     mining_state,
                     MockMining,
                     vdf_state,
@@ -836,81 +798,6 @@ mod tests {
         vdf_thread_handler.join().unwrap();
     }
 
-    /// A re-anchor signal must make the running loop return `VdfExit::Reanchor` (and stop)
-    /// so the supervisor thread can rebuild the VDF state from the canonical block index
-    /// after a deep reorg / network-partition recovery. The shutdown token is never set, so
-    /// `Reanchor` is the only reason the loop can exit here. See
-    /// design/docs/vdf-partition-recovery-reanchor.md.
-    #[tokio::test]
-    async fn reanchor_signal_returns_reanchor_exit() {
-        let mut node_config = NodeConfig::testing();
-        node_config.consensus.get_mut().vdf.reset_frequency = 2;
-        node_config.consensus.get_mut().vdf.sha_1s_difficulty = 1;
-        let config = Config::new_with_random_peer_id(node_config);
-
-        init_tracing();
-
-        let seed = H256::random();
-        let reset_seed = H256::random();
-
-        let (_ff_tx, mut ff_rx) = mpsc::channel::<Traced<VdfStep>>(16);
-        let (reanchor_tx, mut reanchor_rx) = mpsc::unbounded_channel::<()>();
-        let is_mining_enabled = Arc::new(AtomicBool::new(true));
-        let vdf_state = mocked_vdf_service(&config);
-        let vdf_steps_guard = VdfStateReadonly::new(vdf_state.clone());
-        let atomic_step = Arc::new(AtomicU64::new(0));
-
-        // Canonical far ahead so the reset-boundary gate never parks the loop.
-        let mut mock_header = IrysBlockHeader::new_mock_header();
-        mock_header.vdf_limiter_info.global_step_number = 10_000;
-
-        let chain_sync_state = ChainSyncState::new(false, false);
-        let shutdown_token = CancellationToken::new();
-        let handle = std::thread::spawn({
-            let config = config.clone();
-            let shutdown_token = shutdown_token.clone();
-            let mining_state = Arc::clone(&is_mining_enabled);
-            move || {
-                run_vdf(
-                    &config.vdf,
-                    0,
-                    seed,
-                    reset_seed,
-                    &mut ff_rx,
-                    &mut reanchor_rx,
-                    mining_state,
-                    MockMining,
-                    vdf_state.clone(),
-                    atomic_step,
-                    MockBlockProvider(mock_header),
-                    chain_sync_state,
-                    shutdown_token,
-                )
-            }
-        });
-
-        // Let the loop produce a few steps, then request a re-anchor.
-        let cancel = Arc::new(AtomicU8::new(CancelEnum::Continue as u8));
-        vdf_steps_guard
-            .wait_for_step(3, Arc::clone(&cancel), Duration::from_secs(5))
-            .await
-            .expect("loop should produce steps before re-anchor");
-        reanchor_tx
-            .send(())
-            .expect("re-anchor receiver should still be alive");
-
-        let exit = handle.join().unwrap();
-        assert_eq!(
-            exit,
-            VdfExit::Reanchor,
-            "a re-anchor signal must make run_vdf return VdfExit::Reanchor"
-        );
-        assert!(
-            !shutdown_token.is_cancelled(),
-            "loop exited via re-anchor, not shutdown"
-        );
-    }
-
     /// Poisons the `vdf_state` RwLock, then drives `run_vdf`. Before F3 the
     /// thread re-panicked at `vdf_state.read().unwrap()` (line 68). After F3
     /// the entry-time read returns a graceful `return`, so `run_vdf` exits
@@ -933,7 +820,6 @@ mod tests {
         );
 
         let (_ff_tx, mut ff_rx) = mpsc::channel::<Traced<VdfStep>>(16);
-        let (_reanchor_tx, mut reanchor_rx) = mpsc::unbounded_channel::<()>();
         let is_mining_enabled = Arc::new(AtomicBool::new(true));
         let atomic_step = Arc::new(AtomicU64::new(0));
         let chain_sync_state = ChainSyncState::new(false, false);
@@ -946,7 +832,6 @@ mod tests {
                 H256::zero(),
                 H256::zero(),
                 &mut ff_rx,
-                &mut reanchor_rx,
                 is_mining_enabled,
                 MockMining,
                 vdf_state,
@@ -989,7 +874,6 @@ mod tests {
         let gap_target_step: u64 = 100;
 
         let (ff_tx, mut ff_rx) = mpsc::channel::<Traced<VdfStep>>(16);
-        let (_reanchor_tx, mut reanchor_rx) = mpsc::unbounded_channel::<()>();
         ff_tx
             .send(Traced::new(VdfStep {
                 step: bad_ff_seed,
@@ -1020,7 +904,6 @@ mod tests {
                     initial_seed,
                     reset_seed,
                     &mut ff_rx,
-                    &mut reanchor_rx,
                     mining_state,
                     MockMining,
                     vdf_state.clone(),
@@ -1222,7 +1105,6 @@ mod tests {
         let provider = ControllableBlockProvider::new(0);
 
         let (_tx, mut ff_rx) = mpsc::channel::<Traced<VdfStep>>(16);
-        let (_reanchor_tx, mut reanchor_rx) = mpsc::unbounded_channel::<()>();
         let is_mining_enabled = Arc::new(AtomicBool::new(true));
         let vdf_state = mocked_vdf_service(&config);
         let vdf_steps_guard = VdfStateReadonly::new(vdf_state.clone());
@@ -1242,7 +1124,6 @@ mod tests {
                     initial_seed,
                     initial_seed,
                     &mut ff_rx,
-                    &mut reanchor_rx,
                     mining_state,
                     MockMining,
                     vdf_state.clone(),
@@ -1332,7 +1213,6 @@ mod tests {
         let vdf_steps_guard = VdfStateReadonly::new(vdf_state.clone());
 
         let (_tx, mut ff_rx) = mpsc::channel::<Traced<VdfStep>>(16);
-        let (_reanchor_tx, mut reanchor_rx) = mpsc::unbounded_channel::<()>();
         let is_mining_enabled = Arc::new(AtomicBool::new(true));
         let atomic_step = Arc::new(AtomicU64::new(1));
         let chain_sync_state = ChainSyncState::new(false, false);
@@ -1350,7 +1230,6 @@ mod tests {
                     step1,
                     H256::zero(),
                     &mut ff_rx,
-                    &mut reanchor_rx,
                     mining_state,
                     MockMining,
                     vdf_state.clone(),
@@ -1368,7 +1247,7 @@ mod tests {
             .await
             .expect("loop should reach step 3");
         shutdown_token.cancel();
-        assert_eq!(handle.join().unwrap(), VdfExit::Shutdown);
+        handle.join().unwrap();
 
         let stored_step3 = vdf_steps_guard
             .get_step(3)
@@ -1466,7 +1345,6 @@ mod tests {
             }))
             .expect("queue FF step before the loop starts");
 
-        let (_reanchor_tx, mut reanchor_rx) = mpsc::unbounded_channel::<()>();
         let is_mining_enabled = Arc::new(AtomicBool::new(true));
         let atomic_step = Arc::new(AtomicU64::new(1));
         let chain_sync_state = ChainSyncState::new(false, false);
@@ -1484,7 +1362,6 @@ mod tests {
                     step1,
                     H256::zero(),
                     &mut ff_rx,
-                    &mut reanchor_rx,
                     mining_state,
                     MockMining,
                     vdf_state.clone(),
@@ -1502,7 +1379,7 @@ mod tests {
             .await
             .expect("loop should consume the FF boundary step and then locally reach step 3");
         shutdown_token.cancel();
-        assert_eq!(handle.join().unwrap(), VdfExit::Shutdown);
+        handle.join().unwrap();
 
         let stored_step3 = vdf_steps_guard
             .get_step(3)
@@ -1561,7 +1438,6 @@ mod tests {
         provider.set_snapshot(pre_boundary_seed, 8, 6);
 
         let (_tx, mut ff_rx) = mpsc::channel::<Traced<VdfStep>>(16);
-        let (_reanchor_tx, mut reanchor_rx) = mpsc::unbounded_channel::<()>();
         let is_mining_enabled = Arc::new(AtomicBool::new(true));
         let vdf_state = mocked_vdf_service(config);
         let vdf_steps_guard = VdfStateReadonly::new(vdf_state.clone());
@@ -1575,14 +1451,12 @@ mod tests {
             let shutdown_token = shutdown_token.clone();
             let mining_state = Arc::clone(&is_mining_enabled);
             move || {
-                // Discard the VdfExit so the helper's JoinHandle stays JoinHandle<()>.
-                let _ = run_vdf(
+                run_vdf(
                     &config.vdf,
                     0,
                     pre_boundary_seed,
                     pre_boundary_seed,
                     &mut ff_rx,
-                    &mut reanchor_rx,
                     mining_state,
                     MockMining,
                     vdf_state,

--- a/crates/vdf/src/vdf.rs
+++ b/crates/vdf/src/vdf.rs
@@ -182,9 +182,8 @@ pub fn run_vdf<B: BlockProvider>(
                     vdf_info,
                     confirmed_global_step_number: _,
                     reset_seed_for_step,
-                }) = block_provider.canonical_vdf_snapshot(
-                    proposed_ff_step.global_step_number.saturating_sub(1),
-                )
+                }) = block_provider
+                    .canonical_vdf_snapshot(proposed_ff_step.global_step_number.saturating_sub(1))
                 {
                     next_reset_seed = reset_seed_for_step;
                     canonical_global_step_number = vdf_info.global_step_number;
@@ -1127,7 +1126,9 @@ mod tests {
 
     #[derive(Clone)]
     struct ControllableBlockProvider(
-        std::sync::Arc<std::sync::Mutex<(VDFLimiterInfo, u64, std::collections::HashMap<u64, H256>)>>,
+        std::sync::Arc<
+            std::sync::Mutex<(VDFLimiterInfo, u64, std::collections::HashMap<u64, H256>)>,
+        >,
     );
     impl ControllableBlockProvider {
         /// The canonical tip step is held at 0 so `store_step` treats every produced step
@@ -1350,10 +1351,13 @@ mod tests {
         shutdown_token.cancel();
         assert_eq!(handle.join().unwrap(), VdfExit::Shutdown);
 
-        let stored_step3 = vdf_steps_guard.get_step(3).expect("step 3 should be present");
+        let stored_step3 = vdf_steps_guard
+            .get_step(3)
+            .expect("step 3 should be present");
 
         let mut expected_step2 = step1;
-        let mut expected_checkpoints = vec![H256::default(); config.vdf.num_checkpoints_in_vdf_step];
+        let mut expected_checkpoints =
+            vec![H256::default(); config.vdf.num_checkpoints_in_vdf_step];
         vdf_sha(
             U256::from(step_number_to_salt_number(&config.vdf, 1)),
             &mut expected_step2,
@@ -1481,7 +1485,9 @@ mod tests {
         shutdown_token.cancel();
         assert_eq!(handle.join().unwrap(), VdfExit::Shutdown);
 
-        let stored_step3 = vdf_steps_guard.get_step(3).expect("step 3 should be present");
+        let stored_step3 = vdf_steps_guard
+            .get_step(3)
+            .expect("step 3 should be present");
 
         let mut expected_step3 = apply_reset_seed(ff_step2, correct_boundary_seed);
         vdf_sha(

--- a/crates/vdf/src/vdf.rs
+++ b/crates/vdf/src/vdf.rs
@@ -164,16 +164,20 @@ pub fn run_vdf<B: BlockProvider>(
                 // runs the loop ahead, so it cannot reproduce the #1447 run-ahead bug (the local
                 // loop applying a reset seed pinned by a still-forkable block).
                 //
-                // A residual, *theoretical* concern remains: the step buffer is a single
-                // append-only sequence and validation rejects a block whose steps disagree with
-                // it, so a competing fork whose post-boundary steps differ could — if validated
-                // first — make the canonical block be rejected. Reaching that requires a reorg
-                // ~one reset window deep (where the boundary's reset seed is pinned), far deeper
-                // than `block_migration_depth`. Such a fork is already refused at p2p block-pool
-                // admission (`PartOfAPrunedFork`, plus the block tree's no-reorg-past-migration
-                // rule) before its blocks are ever validated/fast-forwarded, so the FF path needs
-                // no gate. Full mechanism, the deep-reorg bound, the admission guards, and the
-                // invariant relied upon: design/docs/vdf-reset-seed-confirmation-gate.md.
+                // The step buffer is a single append-only sequence reflecting THIS node's lineage,
+                // so a competing fork whose post-boundary steps differ mismatches it. That is NOT
+                // treated as invalidity: `vdf_step_batch_is_valid` RECOMPUTES from the block's own
+                // seed on a buffer mismatch (it does not conflate "differs from my lineage" with
+                // "invalid"), so a heavier competing fork validates on its own merits. This is
+                // load-bearing for partition recovery: a reorg in the band
+                // `block_migration_depth < depth <= block_tree_depth` IS admitted and validated
+                // against a possibly-poisoned buffer — admission keys on `block_tree_depth`
+                // (`PartOfAPrunedFork` only refuses forks older than that), NOT
+                // `block_migration_depth` — so an earlier comment here claiming such forks are
+                // refused before validation was wrong. Recompute-on-mismatch is what lets the
+                // recovering node validate and adopt the canonical chain (and then re-anchor).
+                // See design/docs/vdf-reset-seed-confirmation-gate.md and
+                // design/docs/vdf-partition-recovery-reanchor.md.
                 if let Some(CanonicalVdfSnapshot {
                     vdf_info,
                     confirmed_global_step_number: _,
@@ -231,9 +235,23 @@ pub fn run_vdf<B: BlockProvider>(
             confirmed_global_step_number: confirmed_step,
         }) = block_provider.latest_canonical_vdf_info()
         {
-            next_reset_seed = vdf_info.next_seed;
             canonical_global_step_number = vdf_info.global_step_number;
             confirmed_global_step_number = confirmed_step;
+            // Source the reset seed from the canonical block ENDING at or before the current step,
+            // not the chain tip. During partition-recovery CATCH-UP the re-anchored VDF local-steps
+            // across reset boundaries the canonical tip has ALREADY passed; the tip's `next_seed`
+            // targets the boundary above the tip, so applying it at an earlier boundary XORs in the
+            // wrong seed and re-poisons the post-boundary steps (the Finding #1 wedge, which then
+            // never heals because `store_step` is forward-only). The block with the greatest
+            // `global_step_number <= global_step_number` pins (via its `next_seed`) the seed for the
+            // boundary the VDF is about to cross — and is correct even when a later canonical block
+            // SPANS that boundary (whose own `next_seed` targets a higher boundary). When the VDF
+            // runs AHEAD of the canonical chain (normal forward operation) that block IS the tip, so
+            // this equals the prior behavior — a no-op. The confirmed-step gate (below) is
+            // unaffected: it still uses `confirmed_global_step_number`.
+            next_reset_seed = block_provider
+                .canonical_vdf_info_at_or_below_step(global_step_number)
+                .unwrap_or(vdf_info.next_seed);
             debug!(
                 "Canonical global step number: {}, next reset seed: {:?}, prev output: {:?}, confirmed step: {}, global_step: {:?}",
                 canonical_global_step_number,
@@ -1411,9 +1429,14 @@ mod tests {
             "loser vs winner reset seed must diverge the VDF buffer after the boundary"
         );
 
-        // --- The wedge: the canonical (winner) block is REJECTED by the poisoned buffer but
-        //     ACCEPTED by the clean one. `vdf_steps_are_valid` is exactly what the validation
-        //     service runs, so this is the real rejection a poisoned node would hit. ---
+        // --- NOTE (post recompute-on-mismatch fix): a buffer MISMATCH alone no longer rejects —
+        //     `vdf_step_batch_is_valid` now recomputes from the block's own seed. This simplified
+        //     `canonical_block` carries DEFAULT seed/prev_output, so it is self-inconsistent: the
+        //     poisoned buffer rejects it via that recompute (its steps don't reproduce from its own
+        //     seed), while the clean buffer accepts it via the fast-path match (it already holds
+        //     these exact steps). The validation-level wedge proper — a poisoned buffer rejecting an
+        //     HONEST canonical block — is FIXED and covered by
+        //     `state::tests::vdf_step_batch_recomputes_on_buffer_mismatch`. ---
         let canonical_block = VDFLimiterInfo {
             global_step_number: 20,
             steps: clean_steps,
@@ -1430,7 +1453,8 @@ mod tests {
         );
         assert!(
             rejected.is_err(),
-            "poisoned buffer must REJECT the canonical winner block — this is the #1447 wedge"
+            "poisoned buffer rejects this self-inconsistent simplified block via recompute (the \
+             honest-fork wedge itself is fixed — see vdf_step_batch_recomputes_on_buffer_mismatch)"
         );
 
         let accepted = vdf_steps_are_valid(

--- a/crates/vdf/src/vdf.rs
+++ b/crates/vdf/src/vdf.rs
@@ -386,6 +386,25 @@ pub fn process_reset(
     }
 }
 
+/// Fold the reset-boundary entropy into a VDF ANCHOR hash before it seeds [`run_vdf`].
+///
+/// The step buffer stores RAW step outputs — `process_reset` applies the reset fold to the carried
+/// hash only AFTER a step is stored (the loop tail), and fast-forward stores values verbatim. So a
+/// hash read back from the buffer via `get_last_step_and_seed` at (re-)anchor time is unfolded. When
+/// the anchor `step` is itself a reset boundary, the first `vdf_sha` for `step + 1` must run on the
+/// hash WITH boundary `step`'s reset folded in, or that first step diverges from the canonical
+/// lineage. This is rare (only when the anchor lands exactly on a boundary) and non-safety
+/// (validation recomputes from each block's own seed), but it mis-steps local mining until it heals.
+///
+/// `seed` is boundary `step`'s reset seed: the anchoring block's OWN `vdf_limiter_info.seed`. When a
+/// block's step range contains a reset boundary, `IrysBlockHeader::set_seeds` pins that boundary's
+/// entropy in `seed` (while `next_seed` targets the NEXT boundary above the block — what the loop
+/// applies going forward). A no-op when `step` is not a boundary.
+#[must_use]
+pub fn reset_applied_anchor_hash(reset_frequency: u64, step: u64, hash: H256, seed: H256) -> H256 {
+    process_reset(step, hash, reset_frequency, seed)
+}
+
 /// Returns `true` when the VDF loop must NOT yet cross the upcoming reset boundary.
 ///
 /// The reset seed applied at boundary `B` is pinned by a rotation block at step
@@ -1711,6 +1730,68 @@ mod tests {
         assert!(
             accepted.is_ok(),
             "clean buffer (gate held until the seed was confirmed) must ACCEPT the canonical block: {accepted:?}"
+        );
+    }
+
+    /// Regression for finding #5: a VDF anchor hash read back from the (raw) step buffer must have
+    /// its OWN reset boundary folded in before it seeds the loop. The buffer stores raw step values
+    /// (the reset fold is applied to the carried hash only AFTER a step is stored), so an anchor
+    /// hash from `get_last_step_and_seed` is unfolded. When the anchor step is a reset boundary,
+    /// `reset_applied_anchor_hash` folds boundary K's seed (the anchoring block's own `seed`); the
+    /// first forward step (K+1) then matches the canonical lineage. Skipping the fold (the #5 bug)
+    /// mis-steps the first range.
+    #[test]
+    fn anchor_hash_folds_its_own_reset_boundary_before_seeding_the_loop() {
+        let mut node_config = NodeConfig::testing();
+        node_config.consensus.get_mut().vdf.reset_frequency = 4;
+        let config = Config::new_with_random_peer_id(node_config);
+        let reset_frequency = config.vdf.reset_frequency as u64;
+
+        let raw_anchor = H256::repeat_byte(0xA1); // buffer's raw step-8 value
+        let boundary_seed = H256::repeat_byte(0xB2); // boundary 8's seed (the anchoring block's `seed`)
+
+        // Anchor exactly on boundary 8: the raw hash must be folded with the boundary seed.
+        let folded = reset_applied_anchor_hash(reset_frequency, 8, raw_anchor, boundary_seed);
+        assert_eq!(
+            folded,
+            apply_reset_seed(raw_anchor, boundary_seed),
+            "anchoring on a reset boundary must fold the boundary seed into the hash"
+        );
+        assert_ne!(
+            folded, raw_anchor,
+            "the fold must change the hash on a boundary"
+        );
+
+        // Anchor off a boundary (step 9): the hash is used as-is.
+        assert_eq!(
+            reset_applied_anchor_hash(reset_frequency, 9, raw_anchor, boundary_seed),
+            raw_anchor,
+            "anchoring off a boundary must leave the hash untouched"
+        );
+
+        // The fold is load-bearing: the next VDF step computed from the folded vs raw anchor differs,
+        // so skipping it diverges step K+1 from the canonical lineage.
+        let salt = U256::from(step_number_to_salt_number(&config.vdf, 8));
+        let mut checkpoints = vec![H256::default(); config.vdf.num_checkpoints_in_vdf_step];
+        let mut next_from_folded = folded;
+        vdf_sha(
+            salt,
+            &mut next_from_folded,
+            config.vdf.num_checkpoints_in_vdf_step,
+            config.vdf.num_iterations_per_checkpoint(),
+            &mut checkpoints,
+        );
+        let mut next_from_raw = raw_anchor;
+        vdf_sha(
+            salt,
+            &mut next_from_raw,
+            config.vdf.num_checkpoints_in_vdf_step,
+            config.vdf.num_iterations_per_checkpoint(),
+            &mut checkpoints,
+        );
+        assert_ne!(
+            next_from_folded, next_from_raw,
+            "folding boundary K's seed changes step K+1 — skipping it (finding #5) mis-steps the loop"
         );
     }
 

--- a/crates/vdf/src/vdf.rs
+++ b/crates/vdf/src/vdf.rs
@@ -9,7 +9,7 @@ use irys_types::{
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::time::{Duration, Instant};
-use tokio::sync::mpsc::Receiver;
+use tokio::sync::mpsc::{Receiver, UnboundedReceiver};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
@@ -57,12 +57,27 @@ pub fn run_vdf_for_genesis_block(
     }
 }
 
+/// Why [`run_vdf`] returned, so the supervising VDF thread knows whether to exit
+/// or re-anchor and restart the loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VdfExit {
+    /// Terminal: the shutdown token fired or the VDF state lock was poisoned.
+    /// The supervisor must stop (and the node should shut down).
+    Shutdown,
+    /// A re-anchor was requested (a deep reorg / network-partition recovery
+    /// rewound the canonical chain). The supervisor rebuilds the VDF state from
+    /// the now-canonical block index and restarts the loop. See
+    /// design/docs/vdf-partition-recovery-reanchor.md.
+    Reanchor,
+}
+
 pub fn run_vdf<B: BlockProvider>(
     config: &irys_types::VdfConfig,
     global_step_number: u64,
     current_vdf_hash: H256,
     initial_reset_seed: H256,
-    mut fast_forward_receiver: Receiver<Traced<VdfStep>>,
+    fast_forward_receiver: &mut Receiver<Traced<VdfStep>>,
+    reanchor_receiver: &mut UnboundedReceiver<()>,
     is_mining_enabled: Arc<AtomicBool>,
     broadcast_mining_service: impl MiningBroadcaster,
     vdf_state: AtomicVdfState,
@@ -70,7 +85,7 @@ pub fn run_vdf<B: BlockProvider>(
     block_provider: B,
     chain_sync_state: ChainSyncState,
     shutdown_token: CancellationToken,
-) {
+) -> VdfExit {
     let _span = tracing::info_span!("vdf_loop").entered();
     let mut next_reset_seed = initial_reset_seed;
     // Step number of the deepest block confirmed past the migration threshold
@@ -87,7 +102,7 @@ pub fn run_vdf<B: BlockProvider>(
             // than re-panic; the lifecycle's vdf_done channel surfaces this
             // as a controlled exit.
             error!("VDF state read lock poisoned at startup; exiting VDF thread");
-            return;
+            return VdfExit::Shutdown;
         }
     };
     // Until the first canonical snapshot read, treat the confirmed step as the canonical
@@ -111,7 +126,25 @@ pub fn run_vdf<B: BlockProvider>(
     loop {
         if shutdown_token.is_cancelled() {
             tracing::info!("VDF loop: shutdown token cancelled, exiting");
-            break;
+            return VdfExit::Shutdown;
+        }
+
+        // A deep reorg (network-partition recovery) rewound the canonical chain, so the
+        // running hash/global_step and the shared step buffer may carry reset entropy
+        // pinned by the now-orphaned minority fork. Drain every pending request (coalesce
+        // bursts) and hand control back to the supervisor, which rebuilds the VDF state
+        // from the canonical index and restarts this loop at the new anchor. See
+        // design/docs/vdf-partition-recovery-reanchor.md.
+        let mut reanchor_requested = false;
+        while reanchor_receiver.try_recv().is_ok() {
+            reanchor_requested = true;
+        }
+        if reanchor_requested {
+            info!(
+                vdf.global_step_number = global_step_number,
+                "VDF loop: re-anchor requested, returning to supervisor"
+            );
+            return VdfExit::Reanchor;
         }
 
         // check for VDF fast forward step
@@ -162,7 +195,7 @@ pub fn run_vdf<B: BlockProvider>(
                         vdf.proposed_step = proposed_ff_step.global_step_number,
                         "VDF thread exiting: store_step failed during fast-forward (lock poisoned)"
                     );
-                    return;
+                    return VdfExit::Shutdown;
                 };
                 if returned == prev_step {
                     // Gap rejected — leave hash and global_step_number
@@ -306,7 +339,7 @@ pub fn run_vdf<B: BlockProvider>(
                 vdf.global_step_number = global_step_number,
                 "VDF thread exiting: store_step failed during local stepping (lock poisoned)"
             );
-            return;
+            return VdfExit::Shutdown;
         };
         global_step_number = returned;
         chain_sync_state.record_vdf_step(global_step_number);
@@ -326,7 +359,6 @@ pub fn run_vdf<B: BlockProvider>(
             next_reset_seed,
         );
     }
-    debug!(vdf.global_step_number = ?global_step_number, "VDF thread stopped");
 }
 
 #[must_use]
@@ -495,7 +527,8 @@ mod tests {
         init_tracing();
 
         let broadcast_mining_service = MockMining;
-        let (_, ff_step_receiver) = mpsc::channel::<Traced<VdfStep>>(16);
+        let (_, mut ff_step_receiver) = mpsc::channel::<Traced<VdfStep>>(16);
+        let (_reanchor_tx, mut reanchor_rx) = mpsc::unbounded_channel::<()>();
 
         let is_mining_enabled = Arc::new(AtomicBool::new(true));
 
@@ -520,7 +553,8 @@ mod tests {
                     0,
                     seed,
                     reset_seed,
-                    ff_step_receiver,
+                    &mut ff_step_receiver,
+                    &mut reanchor_rx,
                     mining_state,
                     broadcast_mining_service,
                     vdf_state.clone(),
@@ -610,7 +644,8 @@ mod tests {
         init_tracing();
 
         let broadcast_mining_service = MockMining;
-        let (_, ff_step_receiver) = mpsc::channel::<Traced<VdfStep>>(16);
+        let (_, mut ff_step_receiver) = mpsc::channel::<Traced<VdfStep>>(16);
+        let (_reanchor_tx, mut reanchor_rx) = mpsc::unbounded_channel::<()>();
 
         let is_mining_enabled = Arc::new(AtomicBool::new(true));
 
@@ -631,7 +666,8 @@ mod tests {
                     0,
                     seed,
                     reset_seed,
-                    ff_step_receiver,
+                    &mut ff_step_receiver,
+                    &mut reanchor_rx,
                     mining_state,
                     broadcast_mining_service,
                     vdf_state.clone(),
@@ -713,7 +749,8 @@ mod tests {
 
         let current_seed = H256::random();
         let reset_seed = H256::random();
-        let (ff_step_sender, ff_step_receiver) = mpsc::channel::<Traced<VdfStep>>(16);
+        let (ff_step_sender, mut ff_step_receiver) = mpsc::channel::<Traced<VdfStep>>(16);
+        let (_reanchor_tx, mut reanchor_rx) = mpsc::unbounded_channel::<()>();
         let is_mining_enabled = Arc::new(AtomicBool::new(false));
         let vdf_state = mocked_vdf_service(&config);
         let vdf_steps_guard = VdfStateReadonly::new(vdf_state.clone());
@@ -734,7 +771,8 @@ mod tests {
                     0,
                     current_seed,
                     reset_seed,
-                    ff_step_receiver,
+                    &mut ff_step_receiver,
+                    &mut reanchor_rx,
                     mining_state,
                     MockMining,
                     vdf_state,
@@ -770,6 +808,81 @@ mod tests {
         vdf_thread_handler.join().unwrap();
     }
 
+    /// A re-anchor signal must make the running loop return `VdfExit::Reanchor` (and stop)
+    /// so the supervisor thread can rebuild the VDF state from the canonical block index
+    /// after a deep reorg / network-partition recovery. The shutdown token is never set, so
+    /// `Reanchor` is the only reason the loop can exit here. See
+    /// design/docs/vdf-partition-recovery-reanchor.md.
+    #[tokio::test]
+    async fn reanchor_signal_returns_reanchor_exit() {
+        let mut node_config = NodeConfig::testing();
+        node_config.consensus.get_mut().vdf.reset_frequency = 2;
+        node_config.consensus.get_mut().vdf.sha_1s_difficulty = 1;
+        let config = Config::new_with_random_peer_id(node_config);
+
+        init_tracing();
+
+        let seed = H256::random();
+        let reset_seed = H256::random();
+
+        let (_ff_tx, mut ff_rx) = mpsc::channel::<Traced<VdfStep>>(16);
+        let (reanchor_tx, mut reanchor_rx) = mpsc::unbounded_channel::<()>();
+        let is_mining_enabled = Arc::new(AtomicBool::new(true));
+        let vdf_state = mocked_vdf_service(&config);
+        let vdf_steps_guard = VdfStateReadonly::new(vdf_state.clone());
+        let atomic_step = Arc::new(AtomicU64::new(0));
+
+        // Canonical far ahead so the reset-boundary gate never parks the loop.
+        let mut mock_header = IrysBlockHeader::new_mock_header();
+        mock_header.vdf_limiter_info.global_step_number = 10_000;
+
+        let chain_sync_state = ChainSyncState::new(false, false);
+        let shutdown_token = CancellationToken::new();
+        let handle = std::thread::spawn({
+            let config = config.clone();
+            let shutdown_token = shutdown_token.clone();
+            let mining_state = Arc::clone(&is_mining_enabled);
+            move || {
+                run_vdf(
+                    &config.vdf,
+                    0,
+                    seed,
+                    reset_seed,
+                    &mut ff_rx,
+                    &mut reanchor_rx,
+                    mining_state,
+                    MockMining,
+                    vdf_state.clone(),
+                    atomic_step,
+                    MockBlockProvider(mock_header),
+                    chain_sync_state,
+                    shutdown_token,
+                )
+            }
+        });
+
+        // Let the loop produce a few steps, then request a re-anchor.
+        let cancel = Arc::new(AtomicU8::new(CancelEnum::Continue as u8));
+        vdf_steps_guard
+            .wait_for_step(3, Arc::clone(&cancel), Duration::from_secs(5))
+            .await
+            .expect("loop should produce steps before re-anchor");
+        reanchor_tx
+            .send(())
+            .expect("re-anchor receiver should still be alive");
+
+        let exit = handle.join().unwrap();
+        assert_eq!(
+            exit,
+            VdfExit::Reanchor,
+            "a re-anchor signal must make run_vdf return VdfExit::Reanchor"
+        );
+        assert!(
+            !shutdown_token.is_cancelled(),
+            "loop exited via re-anchor, not shutdown"
+        );
+    }
+
     /// Poisons the `vdf_state` RwLock, then drives `run_vdf`. Before F3 the
     /// thread re-panicked at `vdf_state.read().unwrap()` (line 68). After F3
     /// the entry-time read returns a graceful `return`, so `run_vdf` exits
@@ -791,7 +904,8 @@ mod tests {
             "lock must be poisoned to exercise the path"
         );
 
-        let (_ff_tx, ff_rx) = mpsc::channel::<Traced<VdfStep>>(16);
+        let (_ff_tx, mut ff_rx) = mpsc::channel::<Traced<VdfStep>>(16);
+        let (_reanchor_tx, mut reanchor_rx) = mpsc::unbounded_channel::<()>();
         let is_mining_enabled = Arc::new(AtomicBool::new(true));
         let atomic_step = Arc::new(AtomicU64::new(0));
         let chain_sync_state = ChainSyncState::new(false, false);
@@ -803,7 +917,8 @@ mod tests {
                 0,
                 H256::zero(),
                 H256::zero(),
-                ff_rx,
+                &mut ff_rx,
+                &mut reanchor_rx,
                 is_mining_enabled,
                 MockMining,
                 vdf_state,
@@ -845,7 +960,8 @@ mod tests {
         let bad_ff_seed = H256::repeat_byte(0xAA);
         let gap_target_step: u64 = 100;
 
-        let (ff_tx, ff_rx) = mpsc::channel::<Traced<VdfStep>>(16);
+        let (ff_tx, mut ff_rx) = mpsc::channel::<Traced<VdfStep>>(16);
+        let (_reanchor_tx, mut reanchor_rx) = mpsc::unbounded_channel::<()>();
         ff_tx
             .send(Traced::new(VdfStep {
                 step: bad_ff_seed,
@@ -875,7 +991,8 @@ mod tests {
                     0,
                     initial_seed,
                     reset_seed,
-                    ff_rx,
+                    &mut ff_rx,
+                    &mut reanchor_rx,
                     mining_state,
                     MockMining,
                     vdf_state.clone(),
@@ -1066,7 +1183,8 @@ mod tests {
         // boundary 8 is gated (8 > 0 + 4), so the loop crosses 4 and parks at 8 (step 7).
         let provider = ControllableBlockProvider::new(0);
 
-        let (_tx, ff_rx) = mpsc::channel::<Traced<VdfStep>>(16);
+        let (_tx, mut ff_rx) = mpsc::channel::<Traced<VdfStep>>(16);
+        let (_reanchor_tx, mut reanchor_rx) = mpsc::unbounded_channel::<()>();
         let is_mining_enabled = Arc::new(AtomicBool::new(true));
         let vdf_state = mocked_vdf_service(&config);
         let vdf_steps_guard = VdfStateReadonly::new(vdf_state.clone());
@@ -1085,7 +1203,8 @@ mod tests {
                     0,
                     initial_seed,
                     initial_seed,
-                    ff_rx,
+                    &mut ff_rx,
+                    &mut reanchor_rx,
                     mining_state,
                     MockMining,
                     vdf_state.clone(),
@@ -1160,7 +1279,8 @@ mod tests {
         // blocks boundary 16.
         provider.set_snapshot(pre_boundary_seed, 8, 6);
 
-        let (_tx, ff_rx) = mpsc::channel::<Traced<VdfStep>>(16);
+        let (_tx, mut ff_rx) = mpsc::channel::<Traced<VdfStep>>(16);
+        let (_reanchor_tx, mut reanchor_rx) = mpsc::unbounded_channel::<()>();
         let is_mining_enabled = Arc::new(AtomicBool::new(true));
         let vdf_state = mocked_vdf_service(config);
         let vdf_steps_guard = VdfStateReadonly::new(vdf_state.clone());
@@ -1174,12 +1294,14 @@ mod tests {
             let shutdown_token = shutdown_token.clone();
             let mining_state = Arc::clone(&is_mining_enabled);
             move || {
-                run_vdf(
+                // Discard the VdfExit so the helper's JoinHandle stays JoinHandle<()>.
+                let _ = run_vdf(
                     &config.vdf,
                     0,
                     pre_boundary_seed,
                     pre_boundary_seed,
-                    ff_rx,
+                    &mut ff_rx,
+                    &mut reanchor_rx,
                     mining_state,
                     MockMining,
                     vdf_state,
@@ -1187,7 +1309,7 @@ mod tests {
                     provider,
                     chain_sync_state,
                     shutdown_token,
-                )
+                );
             }
         });
 

--- a/design/docs/vdf-partition-recovery-reanchor.md
+++ b/design/docs/vdf-partition-recovery-reanchor.md
@@ -1,0 +1,287 @@
+# VDF Re-anchor on Network-Partition Recovery
+
+## Status
+
+Accepted — implemented. The VDF thread is a supervisor loop (`init_vdf_thread`,
+`crates/chain/src/chain.rs`); `run_vdf` returns `VdfExit` and is restarted on
+`VdfExit::Reanchor`; `BlockTreeService` sends the `vdf_reanchor` signal after
+`recover_from_network_partition`; `create_state` borrows the index and returns the
+anchor's `next_seed`.
+
+## Context
+
+When a node is isolated during a network partition, mines its own minority fork,
+and later reconnects, it performs a **deep reorg** onto the canonical chain. This
+is the "network partition recovery" path: triggered at
+`crates/actors/src/block_tree_service.rs:1052` when the orphaned fork is strictly
+deeper than `block_migration_depth`, which calls
+`BlockMigrationService::recover_from_network_partition`
+(`crates/actors/src/block_migration_service.rs:348`). That routine truncates the
+block index, unassigns storage-module offsets, and rolls back supply state to the
+fork-parent height.
+
+**It does not touch VDF state.** This is the gap.
+
+### How the reset seed becomes poisoned
+
+At every VDF reset boundary (`global_step % reset_frequency == 0`,
+`crates/vdf/src/vdf.rs:333`) the loop folds in `next_reset_seed` via
+`apply_reset_seed` (`crates/vdf/src/lib.rs:166`). That seed is pinned by the
+*rotation block* at `boundary − reset_frequency`:
+`next_seed = parent_header.block_hash` (`crates/types/src/block.rs:145`). A
+different fork has a different rotation-block hash, so it has a different reset
+seed, so its VDF lineage **diverges** for every step after that boundary.
+
+If the partition lasted long enough for the minority fork to cross a reset
+boundary, the recovering node holds VDF steps — both in the running loop's
+`hash`/`global_step` locals and in the shared `VdfState` buffer
+(`crates/vdf/src/state.rs`) — that were computed with the **minority** reset seed.
+This is the exact poisoned-buffer wedge reproduced by
+`issue_1447_unconfirmed_reset_seed_poisons_buffer_and_wedges_block_validation`
+(`crates/vdf/src/vdf.rs:1225`): `vdf_steps_are_valid` rejects the canonical block,
+and the node cannot follow the chain it just reorged onto.
+
+### Why the #1449 confirmation gate does not cover this
+
+The reset-boundary confirmation gate (`is_reset_boundary_blocked`,
+`crates/vdf/src/vdf.rs:365`) prevents the loop from crossing a boundary until the
+*confirmed* chain (`block_migration_depth` deep) reaches the rotation point. That
+makes the loop safe for reorgs **up to `block_migration_depth`**. Partition
+recovery is, by definition, the one sanctioned path that reorgs *past* that depth:
+on the minority fork the rotation block was confirmed (migrated) locally, so the
+gate correctly let the loop cross — using the minority seed. The fast-forward path
+comment at `crates/vdf/src/vdf.rs:136` acknowledges this residual concern and
+relies on deeper forks being refused at p2p admission (`PartOfAPrunedFork`); but
+the partition-recovery path explicitly *accepts* such a fork, so that assumption
+does not hold here.
+
+### Why nothing self-heals today
+
+- **The forward seed already updates.** The loop re-reads
+  `latest_canonical_vdf_info()` every iteration (`crates/vdf/src/vdf.rs:196`) and
+  `BlockStatusProvider` reads the live canonical tip with no cache lag — the
+  longest-chain cache is rebuilt synchronously on `mark_tip`. So `next_reset_seed`
+  flips to the canonical value immediately. **This is necessary but not
+  sufficient:** the `hash` fed *into* the next boundary is still on the poisoned
+  lineage, so `apply_reset_seed(poisoned_hash, canonical_seed)` still diverges.
+- **The buffer cannot rewind.** `VdfState::store_step`
+  (`crates/vdf/src/state.rs:87`) is strictly forward-only and gap-rejecting
+  (`global_step >= proposed → no-op`; `global_step + 1 != proposed → no-op`).
+- **Fast-forward cannot overwrite it.** FF only fires when the canonical step is
+  *ahead* of the local step (`crates/vdf/src/vdf.rs:121`). After a partition the
+  local loop sits at the live VDF timeline (≈ wall clock), at or ahead of the
+  older canonical blocks being replayed, so FF is skipped and the poisoned steps
+  are never overwritten.
+
+### Reachability
+
+A recovery reorg can be as deep as `block_tree_depth` (beyond that,
+`validate_reorg_within_cache_window` triggers controlled shutdown). Poisoning is
+reachable whenever a `block_tree_depth`-block window can span a reset interval:
+
+| Config (`crates/types/src/config/consensus.rs`) | `block_tree_depth` | reset interval | spans a boundary? |
+| --- | --- | --- | --- |
+| mainnet (`:594`, `:688`) | 100 blocks | 50 blocks | **always** (period < window) |
+| testnet (`:790`, `:804`) | 50 blocks | 100 blocks | ~50% of windows |
+
+On mainnet config this is reliably reachable for any deep recovery that approaches
+the cache limit.
+
+## Decision
+
+On a network-partition recovery, **re-anchor the VDF**: rewind it to a
+pre-divergence point on the (now canonical) chain and let the existing
+fast-forward + local-stepping machinery rebuild it forward with the correct reset
+entropy. Concretely, tear down and restart the `run_vdf` invocation — but keep the
+OS thread.
+
+The key realisation that makes this cheap: **the fast-forward path stores each
+canonical block's step output verbatim** (`crates/vdf/src/vdf.rs:179`). So once the
+loop's `global_step` is rewound below the canonical blocks' steps, FF replays the
+entire canonical step range verbatim and the buffer becomes *exactly* canonical —
+including correct boundary crossings, because we store canonical-provided values
+rather than recomputing them. Only steps beyond the canonical tip (catching up to
+the live timeline) are computed locally, and those use the now-canonical
+`next_reset_seed`. The poisoning heals itself once we make the loop go backward,
+which is the one thing it cannot do on its own.
+
+### The anchor: the LCA (fork parent)
+
+`recover_from_network_partition` truncates the block index to `fork_parent_height`
+— the last common ancestor, which is shared between both forks and therefore
+known-good. We re-anchor the VDF there by rebuilding `VdfState` from the truncated
+index via the existing `create_state` (`crates/vdf/src/state.rs:295`), which reads
+`get_latest_item()` (now the LCA) and walks back filling the step buffer. The
+restarted `run_vdf` takes its `(global_step, hash, next_seed)` from that anchor.
+
+Anchoring at the LCA — rather than the canonical tip — is deliberately the
+simplest correct choice: the LCA's seed lineage is unambiguously shared, and every
+step above it on the canonical chain arrives through FF (cached canonical blocks,
+then live). It also keeps the re-anchor logic independent of whether canonical
+re-migration has run yet.
+
+### Mechanism: a VDF supervisor loop on the existing thread
+
+Today `init_vdf_thread` (`crates/chain/src/chain.rs:2148`) spawns one OS thread
+that calls `run_vdf` exactly once. We change that thread to run a **supervisor
+loop**:
+
+```
+loop {
+    run_vdf(.., &mut ff_receiver, current_anchor, shared_vdf_state, ..);
+    // run_vdf returns when either the shutdown token OR a new reanchor token fires
+    if shutdown_token.is_cancelled() { break; }
+    // a reanchor was requested:
+    current_anchor = rebuild_anchor_from_canonical_index();   // create_state + tip next_seed
+    *shared_vdf_state.write() = current_anchor.state;          // overwrite buffer in place
+    reanchor_token = CancellationToken::new();                 // fresh token for the next run
+}
+```
+
+This is "teardown + restart `run_vdf`" without tearing down the OS thread, which
+sidesteps the two costs of a full thread respawn:
+
+1. **The fast-forward receiver.** `Receiver<Traced<VdfStep>>` is single-ownership
+   and is *moved* into `run_vdf` today. The supervisor owns it across iterations
+   and passes `&mut` (a small signature change to `run_vdf`), so the channel — and
+   the `Sender` held in `ServiceSenders` (`crates/actors/src/services.rs:118`,
+   cloned by the validation service at
+   `crates/actors/src/validation_service.rs:1064`) — is never recreated and no
+   sender swap is needed.
+2. **Core pinning.** The pinning done in `init_vdf_thread` persists; we do not
+   re-run it.
+
+### Shared state handling
+
+- **`VdfState` buffer:** the shared `Arc<RwLock<VdfState>>` handle is referenced by
+  mining and validation, so we cannot replace the `Arc`. We overwrite its contents
+  under the write lock: `*vdf_state.write() = create_state(...)`. Held only for the
+  swap; readers that take the lock afterward see a consistent canonical buffer.
+- **`atomic_vdf_global_step`** (`Arc<AtomicU64>`): reset to the anchor's global
+  step so partition-mining services observe the rewind.
+
+### Triggering the re-anchor
+
+`BlockTreeService` already detects the deep reorg and calls
+`recover_from_network_partition` (`crates/actors/src/block_tree_service.rs:1068`).
+Immediately **after that call returns**, it sends a `reanchor` signal to the VDF
+supervisor. Add a dedicated control channel (mirroring `vdf_fast_forward` in
+`ServiceSenders`); the supervisor selects on it while `run_vdf` is parked/looping,
+or `run_vdf` checks the `reanchor_token` on the same cadence as `shutdown_token`
+(`crates/vdf/src/vdf.rs:112`) and returns when it fires.
+
+Ordering is the critical invariant: the signal must be sent strictly **after** the
+block index has been truncated, so `create_state` reads the canonical (LCA-rooted)
+index, never the stale minority index.
+
+### Interaction with mining and validation
+
+- **Mining** is already paused during sync via `is_vdf_mining_enabled`
+  (`crates/vdf/src/state.rs:162`). The reorg event invalidates any in-flight block
+  solution built on poisoned steps; that solution is dropped on the reorg path
+  regardless of this change.
+- **The #1449 gate needs no special handling.** After re-anchor, `global_step`
+  drops back to the LCA, so `is_reset_boundary_blocked` naturally re-gates every
+  forward boundary crossing against the (now canonical) confirmed step.
+
+## Alternatives considered
+
+- **In-place re-anchor command (Strategy B).** Add a `VdfState::reanchor()` that
+  clears/refills the buffer and a command channel that rewrites the running loop's
+  `hash`/`global_step` without returning from `run_vdf`. Lighter, but introduces a
+  deliberate backward mutation into a buffer whose entire invariant set assumes
+  forward-only progress, and spreads re-anchor logic across the hot loop. Rejected
+  in favour of restarting `run_vdf` from the well-tested `create_state` startup
+  path, which yields a clean, fully-canonical buffer with no new buffer-rewind
+  primitive.
+- **Full OS-thread teardown + respawn (Strategy A1).** Conceptually identical but
+  forces recreating the FF channel (and swapping the `Sender` inside the
+  `ServiceSenders` hub) and re-running core pinning. The supervisor-loop variant
+  keeps the thread and the channel, so it is strictly simpler.
+- **Widen the confirmation gate to `block_tree_depth`.** Would prevent the loop
+  from ever crossing a boundary that a recovery could later invalidate, but parks
+  honest mining for an entire cache window of run-ahead budget and still leaves the
+  buffer poisoned for a recovery that *does* happen within the window. Treats the
+  symptom, not the cause.
+- **Do nothing.** The node wedges (rejects canonical blocks) until manually
+  restarted — at which point startup `create_state` performs exactly this
+  re-anchor. The decision is, in effect, to perform that same recovery
+  automatically at the moment it is needed.
+
+## Consequences
+
+- A recovering node converges to the canonical VDF lineage automatically instead
+  of wedging until an operator restarts it.
+- The recovery reuses `create_state` and the FF path — no new buffer-mutation
+  primitive, no change to the seed-derivation or validation logic.
+- Cost: the re-anchored loop discards already-computed (poisoned) steps and
+  recomputes the catch-up to the live timeline. Those steps were invalid anyway, so
+  no useful work is lost.
+
+### Risks / edge cases
+
+- **Signal ordering.** A `reanchor` sent before index truncation would re-anchor to
+  the stale index. The signal must originate after `recover_from_network_partition`
+  returns.
+- **Repeated/at-startup recovery.** A second deep reorg before the first re-anchor
+  completes must coalesce (the supervisor should re-read the latest anchor, not
+  queue stale ones). Restarting mid-`run_vdf` is safe because the next iteration
+  always rebuilds from the current index.
+- **Validation in flight.** Any `vdf_steps_are_valid` call reading the buffer during
+  the swap must see either the old or new buffer atomically — guaranteed by holding
+  the write lock for the assignment.
+- **Lock poisoning.** `run_vdf` already exits gracefully on a poisoned VDF lock
+  (`crates/vdf/src/vdf.rs:83`); the supervisor must treat that as full shutdown, not
+  a re-anchor.
+
+## Testing
+
+Implemented:
+
+- **Unit (vdf), control path:** `reanchor_signal_returns_reanchor_exit`
+  (`crates/vdf/src/vdf.rs`) drives the real `run_vdf` loop, fires a `vdf_reanchor`
+  signal, and asserts the loop returns `VdfExit::Reanchor` (and exits for that reason,
+  not shutdown).
+- **Unit (vdf), buffer mechanics:** the existing
+  `issue_1447_unconfirmed_reset_seed_poisons_buffer_and_wedges_block_validation`
+  already proves that crossing a boundary on a loser vs winner seed diverges the
+  buffer, and that `vdf_steps_are_valid` rejects a poisoned buffer / accepts a clean
+  one. The re-anchor heals by rebuilding to a clean (winner/LCA) lineage.
+- **Integration (chain):** `heavy4_network_partition_recovery`
+  (`crates/chain-tests/src/multi_node/partition_recovery.rs`) now exercises the
+  re-anchor wiring end-to-end — recovery fires the signal, the supervisor rebuilds
+  from the index and restarts the loop, and the node both adopts the peer's canonical
+  chain and continues mining afterward (the "continued operation after recovery"
+  stage), proving the re-anchor does not wedge a live node.
+
+Attempted and shelved — a boundary-spanning multi-node test:
+
+A live two-node test where the minority fork crosses a reset boundary before
+deep-reorging was prototyped and abandoned as structurally infeasible within the test
+suite's time budget (nextest terminates at 60s default / 120s for the `slow_` bucket).
+The obstacle is the #1449 confirmation gate itself, which is designed for large
+production reset windows:
+
+- **Low `reset_frequency` wedges at startup.** The first block consumes ~45-76 VDF steps
+  of run-up; if `2 × reset_frequency` (the gate's park point) is below that, the VDF
+  parks before a second block can be produced, so no block migrates, `confirmed` never
+  advances, and the gate never releases. Measured: `reset_frequency = 24` deadlocks at
+  genesis; `reset_frequency = 60` is the rough floor.
+- **The single-block test miner can't cross a boundary.** `IrysNodeTest::mine_block`
+  (via `solution_context`) targets one future VDF step and waits; when the VDF parks at a
+  boundary it advances its target past the buffer and panics, because releasing the gate
+  requires producing *other* blocks first — a dependency one `mine_block` call cannot
+  satisfy.
+- **Continuous mining works but is too slow.** Switching to `mine_blocks_without_gossip`
+  (real continuous mining) crosses boundaries correctly — exactly as production does — but
+  the gate serializes each crossing behind migration confirmation, adding real latency per
+  boundary. Crossing ~2 boundaries on each of two forks plus the deep reorg ran ~190s,
+  well over the 120s ceiling.
+
+The heal is nonetheless covered in composition by the three tests above: the buffer
+divergence + validation reject/accept (`issue_1447_*`), the re-anchor trigger
+(`reanchor_signal_returns_reanchor_exit`), and the live reorg → re-anchor → rebuild →
+restart → continued-operation wiring (`heavy4_network_partition_recovery`). A dedicated
+boundary-spanning test would need either a test-only fast path that crosses boundaries
+without the migration-confirmation latency, or acceptance as a long-running
+(non-default-suite) test.

--- a/design/docs/vdf-partition-recovery-reanchor.md
+++ b/design/docs/vdf-partition-recovery-reanchor.md
@@ -443,7 +443,7 @@ Implemented:
   recompute-on-mismatch while a forged block is still rejected (§3, layer 1); plus
   `build_vdf_seed_buffer_propagates_fetch_error` and `wait_for_step_tolerates_backward_reanchor_jump`
   cover the fallible tip-rebuild and the backward-jump liveness handling.
-- **Integration (chain):** `heavy4_network_partition_recovery`
+- **Integration (chain):** `heavy4_slow_network_partition_recovery`
   (`crates/chain-tests/src/multi_node/partition_recovery.rs`) now exercises the
   re-anchor wiring end-to-end — recovery fires the signal, the supervisor rebuilds
   from the index and restarts the loop, and the node both adopts the peer's canonical
@@ -490,4 +490,4 @@ The heal is therefore covered both end-to-end (above) and in composition by the 
 the buffer divergence + validation reject/accept (`issue_1447_*`), the re-anchor trigger
 (`reanchor_signal_returns_reanchor_exit`), the DB-free tip-rebuild
 (`build_vdf_seed_buffer_reproduces_canonical_steps_anchored_at_tip`), and the live reorg →
-re-anchor → rebuild → restart → continued-operation wiring (`heavy4_network_partition_recovery`).
+re-anchor → rebuild → restart → continued-operation wiring (`heavy4_slow_network_partition_recovery`).

--- a/design/docs/vdf-partition-recovery-reanchor.md
+++ b/design/docs/vdf-partition-recovery-reanchor.md
@@ -1,539 +1,307 @@
-# VDF Re-anchor on Network-Partition Recovery
+# VDF Recovery on Network Partition (Controlled Restart)
+
+> The filename retains `reanchor` for history. The **shipped mechanism is a controlled process
+> restart**, not an in-place VDF re-anchor. An earlier iteration — an in-place supervisor-loop
+> re-anchor — was implemented and then superseded; it is recorded under
+> [Alternatives considered](#alternatives-considered).
 
 ## Status
 
-Accepted — implemented and verified. On a network-partition recovery the VDF re-anchors to
-the canonical chain **TIP** and the recovering node converges to the canonical VDF lineage
-automatically, instead of wedging until an operator restart.
+Accepted — implemented and verified. On a network-partition recovery whose recovered range crosses
+a VDF reset boundary (the only case that poisons VDF state), the recovering node requests a
+**controlled process restart**: `BlockTreeService` cancels `partition_recovery_restart`, the node
+lifecycle maps that to `ShutdownReason::PartitionRecoveryRestart`, and the process exits with a
+distinct code (`EX_TEMPFAIL`, 75) so a supervisor relaunches it. On relaunch the ordinary cold-start
+path rebuilds correct VDF state from the truncated index and the node resyncs the canonical chain
+from trusted peers.
 
-The shipped solution is a **stack of layers** (detailed in
-[Implementation: the complete heal](#implementation-the-complete-heal-2026-06)), each forced
-by the end-to-end boundary-crossing test:
+This **supersedes** the in-place VDF re-anchor (a supervisor loop that rebuilt `VdfState` from the
+canonical tip without restarting the process). The trade is deliberate: we accept a brief recovery
+downtime and a deployment restart-policy dependency in exchange for deleting a body of
+consensus-critical mechanism — the supervisor loop, the `run_vdf` re-anchor return path, the
+`create_state_for_canonical_tip` tip rebuild, and the mining-rotation re-anchor broadcast. Crucially
+this is a change of **mechanism only**: the trust boundary — fork-local VDF verification before
+adoption — is untouched, because it is irreducible (see
+[Preserved trust boundary](#preserved-trust-boundary-fork-local-verification)).
 
-1. **Re-anchor at the tip** — `create_state_for_canonical_tip` rebuilds `VdfState` from the
-   canonical chain (not the LCA; see the Correction under [Decision](#decision)).
-2. **Catch-up reset-seed fix** — `canonical_vdf_info_at_or_below_step` so the
-   incremental-adoption window cannot re-poison the steps past a boundary the re-anchor landed
-   below.
-3. **Fork-aware validation** — recompute-on-mismatch + fork-local step/recall views so the
-   recovering node can adopt the canonical chain *during* the asynchronous re-anchor window.
-4. **Mining rotation reset** — a `Reanchored` broadcast resets partition mining's stateful
-   efficient-sampling rotation.
+Mechanism summary (each step links to the section below):
 
-Mechanism: the VDF thread is a supervisor loop (`init_vdf_thread`, `crates/chain/src/chain.rs`);
-`run_vdf` returns `VdfExit` and is restarted on `VdfExit::Reanchor`; `BlockTreeService` sends
-the `vdf_reanchor` signal after `recover_from_network_partition`. Verified by
-`heavy4_slow_partition_recovery_crosses_reset_boundary` — 20/20 across varied fork geometries.
+1. `BlockTreeService` detects the deep reorg (orphaned fork deeper than `block_migration_depth`) and
+   runs `recover_from_network_partition` (index truncation + storage/supply rollback) on **every**
+   such reorg.
+2. **Only if** the recovered range crossed a divergent-seed reset boundary does it cancel
+   `partition_recovery_restart` (`crates/actors/src/block_tree_service.rs`) — see
+   [Gating](#gating-restart-only-when-the-buffer-is-actually-poisoned).
+3. The lifecycle `select!` maps that token to `ShutdownReason::PartitionRecoveryRestart`
+   (`crates/chain/src/chain.rs`); `main` converts it to exit code 75
+   (`crates/types/src/shutdown.rs`, `crates/chain/src/main.rs`).
+4. On relaunch, `create_state` rebuilds the VDF buffer over the truncated (LCA-rooted) index and the
+   trusted-peer fast-forward path fills it forward (`crates/vdf/src/state.rs`, `crates/vdf/src/vdf.rs`).
+
+Verified by `heavy4_slow_partition_recovery_crosses_reset_boundary_restarts` (boundary-crossing →
+restart → cold-sync heal) and `heavy4_slow_network_partition_recovery` (non-boundary deep reorg → no
+restart, in-place continued operation) in
+`crates/chain-tests/src/multi_node/partition_recovery.rs`.
 
 ## Context
 
-When a node is isolated during a network partition, mines its own minority fork,
-and later reconnects, it performs a **deep reorg** onto the canonical chain. This
-is the "network partition recovery" path: triggered at
-`crates/actors/src/block_tree_service.rs:1052` when the orphaned fork is strictly
-deeper than `block_migration_depth`, which calls
+When a node is isolated during a network partition, mines its own minority fork, and later
+reconnects, it performs a **deep reorg** onto the canonical chain. This is the "network partition
+recovery" path: triggered in `crates/actors/src/block_tree_service.rs` when the orphaned fork is
+strictly deeper than `block_migration_depth`, which calls
 `BlockMigrationService::recover_from_network_partition`
-(`crates/actors/src/block_migration_service.rs:348`). That routine truncates the
-block index, unassigns storage-module offsets, and rolls back supply state to the
-fork-parent height.
+(`crates/actors/src/block_migration_service.rs`). That routine truncates the block index, unassigns
+storage-module offsets, and rolls back supply state to the fork-parent height.
 
 **It does not touch VDF state.** This is the gap.
 
 ### How the reset seed becomes poisoned
 
-At every VDF reset boundary (`global_step % reset_frequency == 0`,
-`crates/vdf/src/vdf.rs:333`) the loop folds in `next_reset_seed` via
-`apply_reset_seed` (`crates/vdf/src/lib.rs:166`). That seed is pinned by the
-*rotation block* at `boundary − reset_frequency`:
-`next_seed = parent_header.block_hash` (`crates/types/src/block.rs:145`). A
-different fork has a different rotation-block hash, so it has a different reset
-seed, so its VDF lineage **diverges** for every step after that boundary.
+At every VDF reset boundary (`global_step % reset_frequency == 0`, `crates/vdf/src/vdf.rs`) the loop
+folds in `next_reset_seed` via `apply_reset_seed` (`crates/vdf/src/lib.rs`). That seed is pinned by
+the *rotation block* at `boundary − reset_frequency`: `next_seed = parent_header.block_hash`
+(`crates/types/src/block.rs`). A different fork has a different rotation-block hash, so it has a
+different reset seed, so its VDF lineage **diverges** for every step after that boundary.
 
-If the partition lasted long enough for the minority fork to cross a reset
-boundary, the recovering node holds VDF steps — both in the running loop's
-`hash`/`global_step` locals and in the shared `VdfState` buffer
-(`crates/vdf/src/state.rs`) — that were computed with the **minority** reset seed.
+If the partition lasted long enough for the minority fork to cross a reset boundary, the recovering
+node holds VDF steps — both in the running loop's `hash`/`global_step` locals and in the shared
+`VdfState` buffer (`crates/vdf/src/state.rs`) — that were computed with the **minority** reset seed.
 This is the exact poisoned-buffer wedge reproduced by
 `issue_1447_unconfirmed_reset_seed_poisons_buffer_and_wedges_block_validation`
-(`crates/vdf/src/vdf.rs:1225`): `vdf_steps_are_valid` rejects the canonical block,
-and the node cannot follow the chain it just reorged onto.
+(`crates/vdf/src/vdf.rs`): `vdf_steps_are_valid` rejects the canonical block, and a node that trusted
+its live buffer could not follow the chain it just reorged onto.
 
 ### Why the #1449 confirmation gate does not cover this
 
-The reset-boundary confirmation gate (`is_reset_boundary_blocked`,
-`crates/vdf/src/vdf.rs:365`) prevents the loop from crossing a boundary until the
-*confirmed* chain (`block_migration_depth` deep) reaches the rotation point. That
-makes the loop safe for reorgs **up to `block_migration_depth`**. Partition
-recovery is, by definition, the one sanctioned path that reorgs *past* that depth:
-on the minority fork the rotation block was confirmed (migrated) locally, so the
-gate correctly let the loop cross — using the minority seed. The fast-forward path
-comment at `crates/vdf/src/vdf.rs:136` acknowledges this residual concern and
-relies on deeper forks being refused at p2p admission (`PartOfAPrunedFork`); but
-the partition-recovery path explicitly *accepts* such a fork, so that assumption
-does not hold here.
+The reset-boundary confirmation gate (`is_reset_boundary_blocked`, `crates/vdf/src/vdf.rs`) prevents
+the loop from crossing a boundary until the *confirmed* chain (`block_migration_depth` deep) reaches
+the rotation point. That makes the loop safe for reorgs **up to `block_migration_depth`**. Partition
+recovery is, by definition, the one sanctioned path that reorgs *past* that depth: on the minority
+fork the rotation block was confirmed (migrated) locally, so the gate correctly let the loop cross —
+using the minority seed.
 
-### Why nothing self-heals today
+### Why nothing self-heals without intervention
 
-- **The forward seed already updates.** The loop re-reads
-  `latest_canonical_vdf_info()` every iteration (`crates/vdf/src/vdf.rs:196`) and
-  `BlockStatusProvider` reads the live canonical tip with no cache lag — the
-  longest-chain cache is rebuilt synchronously on `mark_tip`. So `next_reset_seed`
-  flips to the canonical value immediately. **This is necessary but not
-  sufficient:** the `hash` fed *into* the next boundary is still on the poisoned
-  lineage, so `apply_reset_seed(poisoned_hash, canonical_seed)` still diverges.
-- **The buffer cannot rewind.** `VdfState::store_step`
-  (`crates/vdf/src/state.rs:87`) is strictly forward-only and gap-rejecting
-  (`global_step >= proposed → no-op`; `global_step + 1 != proposed → no-op`).
-- **Fast-forward cannot overwrite it.** FF only fires when the canonical step is
-  *ahead* of the local step (`crates/vdf/src/vdf.rs:121`). After a partition the
-  local loop sits at the live VDF timeline (≈ wall clock), at or ahead of the
-  older canonical blocks being replayed, so FF is skipped and the poisoned steps
-  are never overwritten.
+- **The forward seed already updates.** The loop re-reads the canonical snapshot
+  (`canonical_vdf_snapshot`) every iteration, so `next_reset_seed` flips to the canonical value
+  immediately. **This is necessary but not sufficient:** the `hash` fed *into* the next boundary is
+  still on the poisoned lineage, so `apply_reset_seed(poisoned_hash, canonical_seed)` still diverges.
+- **The buffer cannot rewind.** `VdfState::store_step` (`crates/vdf/src/state.rs`) is strictly
+  forward-only and gap-rejecting (`global_step >= proposed → no-op`; `global_step + 1 != proposed →
+  no-op`).
+- **Fast-forward cannot overwrite it.** FF only fires when the canonical step is *ahead* of the
+  local step. After a partition the local loop sits at the live VDF timeline (≈ wall clock), at or
+  ahead of the older canonical blocks being replayed, so FF is skipped and the poisoned steps are
+  never overwritten in the running process.
+
+A restart escapes all three: it discards the running locals and the in-memory buffer entirely and
+rebuilds from the truncated, canonical-rooted index.
 
 ### Reachability
 
 A recovery reorg can be as deep as `block_tree_depth` (beyond that,
-`validate_reorg_within_cache_window` triggers controlled shutdown). Poisoning is
-reachable whenever a `block_tree_depth`-block window can span a reset interval:
+`validate_reorg_within_cache_window` triggers controlled shutdown). Poisoning is reachable whenever a
+`block_tree_depth`-block window can span a reset interval:
 
 | Config (`crates/types/src/config/consensus.rs`) | `block_tree_depth` | reset interval | spans a boundary? |
 | --- | --- | --- | --- |
-| mainnet (`:594`, `:688`) | 100 blocks | 50 blocks | **always** (period < window) |
-| testnet (`:790`, `:804`) | 50 blocks | 100 blocks | ~50% of windows |
+| mainnet | 100 blocks | 50 blocks | **always** (period < window) |
+| testnet | 50 blocks | 100 blocks | ~50% of windows |
 
-On mainnet config this is reliably reachable for any deep recovery that approaches
-the cache limit.
+On mainnet config this is reliably reachable for any deep recovery that approaches the cache limit.
 
 ## Decision
 
-On a network-partition recovery, **re-anchor the VDF**: rewind it to a
-pre-divergence point on the (now canonical) chain and let the existing
-fast-forward + local-stepping machinery rebuild it forward with the correct reset
-entropy. Concretely, tear down and restart the `run_vdf` invocation — but keep the
-OS thread.
+On a network-partition recovery that poisons VDF state, **restart the process** and let the ordinary
+cold-start path rebuild correct VDF state, rather than re-anchoring the running VDF in place.
 
-The key realisation that makes this cheap: **the fast-forward path stores each
-canonical block's step output verbatim** (`crates/vdf/src/vdf.rs:179`). So once the
-loop's `global_step` is rewound below the canonical blocks' steps, FF replays the
-entire canonical step range verbatim and the buffer becomes *exactly* canonical —
-including correct boundary crossings, because we store canonical-provided values
-rather than recomputing them. Only steps beyond the canonical tip (catching up to
-the live timeline) are computed locally, and those use the now-canonical
-`next_reset_seed`. The poisoning heals itself once we make the loop go backward,
-which is the one thing it cannot do on its own.
+### Why a restart heals
 
-> **Correction (2026-06, supersedes the LCA-anchor decision below).** The "FF
-> replays the entire canonical step range verbatim … the poisoning heals itself"
-> reasoning above does **not** hold when the recovered range crosses a reset
-> boundary above the LCA — the node re-wedges. Three code facts break it:
->
-> 1. **The gate does not re-gate.** `run_vdf` reads `confirmed_global_step_number`
->    from `latest_canonical_vdf_info()`, which sources it from the block tree's NEW
->    canonical tip (`BlockTree::confirmed_canonical_step`, far above the LCA) — not
->    from the re-anchored position. So `is_reset_boundary_blocked(LCA+1, …)` is
->    `false` and the loop runs ahead across the recovered range. (This refutes "the
->    #1449 gate naturally re-gates", below.)
-> 2. **Mining is not paused on the reorg path,** so the loop local-steps LCA→tip
->    immediately, applying the canonical TIP's single `next_seed` at every
->    intermediate boundary instead of each boundary's own rotation-block seed —
->    diverging from the canonical lineage.
-> 3. **Fast-forward is not re-supplied.** The canonical blocks' FF steps are drained
->    on re-anchor and never re-sent (the reorg handler only `reevaluate_priorities`,
->    never re-validating on-chain blocks), and `store_step` is forward-only, so FF
->    cannot overwrite the locally-stepped poison.
->
-> Net: the buffer diverges and the node rejects the very canonical chain it reorged
-> onto — the #1447 wedge, re-introduced. Reproduced deterministically by
-> `partition_recovery_reanchor_repoisons_buffer_and_wedges_block_validation`
-> (`crates/vdf/src/vdf.rs`).
->
-> **Fix: re-anchor at the canonical TIP, not the LCA.** Rebuild `VdfState` from the
-> block tree's canonical chain up to the tip via `create_state_for_canonical_tip`
-> (`crates/vdf/src/state.rs`); each canonical block carries its own reset-boundary
-> seed, so the rebuilt buffer matches the canonical lineage across the whole
-> recovered range and the loop restarts **at the tip** (never re-crossing a
-> historical boundary). The recovered range is always within the block tree (a reorg
-> is only representable up to `block_tree_depth` deep), and block headers are
-> persisted to the DB only at migration, so the un-migrated tail is read from the
-> block tree rather than the DB. The `create_state(LCA)` approach described in the
-> rest of this section is retained only as historical context.
+Fork choice acts on validated blocks: `recover_from_network_partition` is reached only after the
+competing fork has been validated and adopted, at which point the block index has been truncated to
+the fork parent (the LCA). A restart from there lands the node in the **cold-start regime** —
+`create_state` rebuilds the buffer at the LCA (behind the canonical tip) and the existing
+trusted-peer fast-forward path fills it forward verbatim while mining is paused. There is no
+poisoned buffer to fight, because the buffer is rebuilt *from* the canonical chain rather than
+reconciled *against* a divergent one.
 
-### The anchor: the LCA (fork parent)
+### Why a whole-process restart, not a thread restart
 
-`recover_from_network_partition` truncates the block index to `fork_parent_height`
-— the last common ancestor, which is shared between both forks and therefore
-known-good. We re-anchor the VDF there by rebuilding `VdfState` from the truncated
-index via the existing `create_state` (`crates/vdf/src/state.rs:295`), which reads
-`get_latest_item()` (now the LCA) and walks back filling the step buffer. The
-restarted `run_vdf` takes its `(global_step, hash, next_seed)` from that anchor.
+The un-migrated canonical tail lives only in the in-memory block tree (headers persist to the DB
+only at migration). A **process** restart loses that tail and refetches it from peers, which
+re-validates and re-sends its fast-forward steps. A thread-only restart would keep the tree but
+strand the buffer at the LCA, because the already-validated tail would never be re-fast-forwarded —
+the trap the in-place design had to work around. This is also why the restart depends on a
+supervisor that relaunches the process (see [Consequences](#consequences)).
 
-Anchoring at the LCA — rather than the canonical tip — is deliberately the
-simplest correct choice: the LCA's seed lineage is unambiguously shared, and every
-step above it on the canonical chain arrives through FF (cached canonical blocks,
-then live). It also keeps the re-anchor logic independent of whether canonical
-re-migration has run yet.
+### Gating: restart only when the buffer is actually poisoned
 
-### Mechanism: a VDF supervisor loop on the existing thread
+VDF steps *between* reset boundaries are a block-independent SHA chain, so a deep reorg that crosses
+no reset boundary leaves the buffer **bit-identical** to the canonical lineage — no heal is needed.
+The seeds diverge only once a boundary's rotation block (at `boundary − reset_frequency`) lies
+**above** the LCA, i.e. at the **second** reset boundary above the LCA (the first boundary's
+rotation block is at/below the shared LCA, so both forks share its seed).
 
-Today `init_vdf_thread` (`crates/chain/src/chain.rs:2148`) spawns one OS thread
-that calls `run_vdf` exactly once. We change that thread to run a **supervisor
-loop**:
+`BlockTreeService` therefore restarts only when the **live VDF step** has reached that second
+boundary:
 
 ```
-loop {
-    run_vdf(.., &mut ff_receiver, current_anchor, shared_vdf_state, ..);
-    // run_vdf returns when either the shutdown token OR a new reanchor token fires
-    if shutdown_token.is_cancelled() { break; }
-    // a reanchor was requested:
-    current_anchor = rebuild_anchor_from_canonical_index();   // create_state + tip next_seed
-    *shared_vdf_state.write() = current_anchor.state;          // overwrite buffer in place
-    reanchor_token = CancellationToken::new();                 // fresh token for the next run
-}
+first_divergent_boundary = (lca_step / reset_frequency + 2) * reset_frequency
+restart  iff  live_vdf_step + 1 >= first_divergent_boundary
 ```
 
-This is "teardown + restart `run_vdf`" without tearing down the OS thread, which
-sidesteps the two costs of a full thread respawn:
+It reads the *live* step (not the orphaned blocks) because the VDF free-runs ahead of blocks, so a
+block-level check would miss free-run poison. The `+ 1` is a one-step TOCTOU margin: the live
+counter is sampled `Relaxed` and can lag the VDF loop's committed reset-seed decision by up to a
+step. Over-triggering costs a rare extra restart; under-triggering would strand the buffer poisoned
+with no other heal.
 
-1. **The fast-forward receiver.** `Receiver<Traced<VdfStep>>` is single-ownership
-   and is *moved* into `run_vdf` today. The supervisor owns it across iterations
-   and passes `&mut` (a small signature change to `run_vdf`), so the channel — and
-   the `Sender` held in `ServiceSenders` (`crates/actors/src/services.rs:118`,
-   cloned by the validation service at
-   `crates/actors/src/validation_service.rs:1064`) — is never recreated and no
-   sender swap is needed.
-2. **Core pinning.** The pinning done in `init_vdf_thread` persists; we do not
-   re-run it.
+Because the restart is a **whole-process** event (reth, P2P, mempool, the VDF thread, all services,
+plus resync downtime), gating it to genuine poison is what keeps routine deep reorgs cheap —
+`recover_from_network_partition` still runs on every deep reorg for storage/supply recovery; only
+the *restart* is gated.
 
-### Shared state handling
+This gating is **non-safety**: validation never trusts the live buffer (see
+[Preserved trust boundary](#preserved-trust-boundary-fork-local-verification)), so even a missed
+poison would only degrade this node's mining until healed, never violate consensus.
 
-- **`VdfState` buffer:** the shared `Arc<RwLock<VdfState>>` handle is referenced by
-  mining and validation, so we cannot replace the `Arc`. We overwrite its contents
-  under the write lock: `*vdf_state.write() = create_state(...)`. Held only for the
-  swap; readers that take the lock afterward see a consistent canonical buffer.
-- **`atomic_vdf_global_step`** (`Arc<AtomicU64>`): reset to the anchor's global
-  step so partition-mining services observe the rewind.
+## Mechanism
 
-### Triggering the re-anchor
+- **Signal.** `BlockTreeService`, immediately after `recover_from_network_partition` returns (so the
+  index truncation is durable first), evaluates the gate above and, on a hit, calls
+  `self.service_senders.partition_recovery_restart.cancel()`. The token is a `CancellationToken` in
+  `ServiceSenders` (it took the slot of the removed `vdf_reanchor` channel); cancelling is infallible
+  and idempotent.
+- **Lifecycle mapping.** `node_lifecycle` holds a clone of that token and watches it in its steady
+  `select!` (`crates/chain/src/chain.rs`), mapping `token.cancelled()` to
+  `ShutdownReason::PartitionRecoveryRestart` — mirroring the existing `vdf_exit_token → VdfExited`
+  arm. It then runs the ordinary ordered shutdown.
+- **Exit code.** `ShutdownReason::exit_code()` (`crates/types/src/shutdown.rs`) returns
+  `PARTITION_RECOVERY_RESTART_EXIT_CODE` (75, `EX_TEMPFAIL`) for this reason and `0` for every other
+  reason; `main` returns `ExitCode::from(reason.exit_code())` (`crates/chain/src/main.rs`). 75 reads
+  as a retryable restart rather than a crash.
+- **Relaunch (cold start).** A supervisor relaunches the process. Startup `create_state` rebuilds the
+  VDF buffer over the now-truncated (LCA-rooted) index; `init_vdf_thread` runs `run_vdf` exactly once
+  (no supervisor loop); the trusted-peer fast-forward path then replays the canonical tail's steps
+  verbatim as the node resyncs.
 
-`BlockTreeService` already detects the deep reorg and calls
-`recover_from_network_partition` (`crates/actors/src/block_tree_service.rs:1068`).
-Immediately **after that call returns**, it sends a `reanchor` signal to the VDF
-supervisor. Add a dedicated control channel (mirroring `vdf_fast_forward` in
-`ServiceSenders`); the supervisor selects on it while `run_vdf` is parked/looping,
-or `run_vdf` checks the `reanchor_token` on the same cadence as `shutdown_token`
-(`crates/vdf/src/vdf.rs:112`) and returns when it fires.
+`run_vdf` is now a single call returning `()` (the `VdfExit` enum and the re-anchor return path are
+gone). The startup anchor still folds its own reset boundary via `reset_applied_anchor_hash` (see
+[Preserved trust boundary](#preserved-trust-boundary-fork-local-verification), item 3).
 
-Ordering is the critical invariant: the signal must be sent strictly **after** the
-block index has been truncated, so `create_state` reads the canonical (LCA-rooted)
-index, never the stale minority index.
+## Preserved trust boundary: fork-local verification
 
-### Interaction with mining and validation
+A partition recovery requires the node to **validate and adopt** the competing canonical chain
+*before* it can restart (fork choice acts only on validated blocks). That validation must not trust
+the node's own — possibly poisoned — live VDF buffer. These seams are therefore load-bearing for the
+restart path exactly as they were for the in-place re-anchor, and are unchanged:
 
-- **Mining** is already paused during sync via `is_vdf_mining_enabled`
-  (`crates/vdf/src/state.rs:162`). The reorg event invalidates any in-flight block
-  solution built on poisoned steps; that solution is dropped on the reorg path
-  regardless of this change.
-- **The #1449 gate needs no special handling.** After re-anchor, `global_step`
-  drops back to the anchor (the canonical tip), so `is_reset_boundary_blocked` naturally
-  re-gates every forward boundary crossing against the (now canonical) confirmed step.
-  > **Superseded in part (2026-06).** "No special handling" understated it: the re-anchor
-  > can land *below* a boundary the canonical chain has since passed, and the catch-up
-  > local-stepping then needs the *per-boundary* seed (not the tip's). The gate is still
-  > untouched, but the seed source is — see
-  > [§2 of Implementation](#2-the-catch-up-reset-seed-hole--and-canonical_vdf_info_at_or_below_step).
+1. **Recompute-on-mismatch.** `vdf_step_batch_is_valid` (`crates/vdf/src/state.rs`) treats a
+   live-buffer mismatch not as invalidity but as a fall-through to the authoritative recompute from
+   the block's own `prev_output`/seed. A heavier competing fork legitimately differs from this
+   node's buffer past a boundary; recompute is the source of truth. Covered by
+   `vdf_step_batch_recomputes_on_buffer_mismatch` (accepts honest fork, rejects forged).
+2. **Fork-local step/recall views.** `build_fork_local_view` (`crates/vdf/src/state.rs`) and the
+   `build_fork_local_recall_view` / `build_fork_local_step_view` builders
+   (`crates/actors/src/block_validation.rs`, `crates/actors/src/validation_service.rs`) resolve VDF
+   steps from a block's **own** lineage (ancestors tree-first, then DB), never the live buffer, so a
+   poisoned buffer cannot reject an honest canonical block. An unbuildable view requeues via
+   `VdfPrevStepForkViewUnavailable → Cancelled` (peer-innocent), never `Invalid`.
+3. **Cold-path seed correctness (still required).** Two pieces survive because the cold-start +
+   fast-forward catch-up uses them:
+   - `canonical_vdf_snapshot` (`crates/types/src/block_provider.rs`, backed by
+     `BlockTree::canonical_entry_at_or_below_step`) supplies the **per-step** reset seed when
+     fast-forward hands off to local stepping at a reset boundary — folding that boundary's own seed,
+     not the tip's `next_seed`.
+   - `reset_applied_anchor_hash` (`crates/vdf/src/vdf.rs`) folds the startup anchor's own reset
+     boundary into the (raw) buffer hash before `run_vdf`'s first step, so an anchor that lands
+     exactly on a boundary does not mis-step the first range.
 
-## Implementation: the complete heal (2026-06)
-
-The shipped fix is the **canonical-TIP re-anchor** (per the Correction under [Decision](#decision))
-plus four layers that together make a boundary-crossing recovery both heal correctly and avoid
-wedging validation or mining in the window before the heal lands. Each layer was forced by the
-end-to-end test `heavy4_slow_partition_recovery_crosses_reset_boundary`, which mines two real
-forks across a reset boundary and reorgs one onto the other.
-
-### 1. Re-anchor at the canonical tip (the heal)
-
-`create_state_for_canonical_tip` (`crates/vdf/src/state.rs`) rebuilds `VdfState` from the block
-tree's canonical chain (`get_canonical_chain`) up to the tip, via the shared, DB-free-testable
-`build_vdf_seed_buffer`. Each canonical block contributes its own recorded steps (carrying its
-own boundary seed), so the rebuilt buffer reproduces the canonical lineage across the whole
-recovered range. `init_vdf_thread` takes the `block_tree_guard` (not the block index). It returns
-`eyre::Result` (see [Rebuild failure](#risks--edge-cases)) plus the canonical `next_seed`.
-
-### 2. The catch-up reset-seed hole — and `canonical_vdf_snapshot`
-
-The tip re-anchor is correct **only if it anchors at, or above, every reset boundary the
-recovered range crosses.** But a partition recovery adopts the canonical fork **incrementally**
-(block-by-block over gossip), so the *first* deep reorg can fire while the canonical tip is still
-**below** a poison boundary. The re-anchor correctly anchors at the canonical tip *of that
-instant* — below the boundary — and the VDF then **local-steps the catch-up** forward across the
-boundary on its own, before the canonical blocks that pin that boundary's seed have been adopted.
-
-At the crossing, `run_vdf` applied `next_reset_seed = <tip>.next_seed` — the **tip's** next_seed.
-Once the tip advances *past* the boundary (the rest of the fork arrives), that field is the seed for
-the next, *higher* boundary, not the one being crossed. The wrong seed is XOR'd in and the
-post-boundary steps are re-poisoned — and, because `store_step` is forward-only, the canonical steps
-that arrive afterward can never overwrite them. The heal silently fails for that range (~1 in 15–20
-boundary-crossing recoveries; the deterministic VDF would otherwise reproduce canonical exactly with
-the right seed).
-
-**Fix:** source the reset seed from the canonical block **ending at or before the boundary being
-crossed**, not the tip — that block's `next_seed` pins the seed for that boundary. The rule is:
-**boundary `B`'s reset seed is the `next_seed` of the canonical block ending at or before `B - 1`.**
-Each path queries accordingly: local-stepping (which is at step `S` and resets the step it computes,
-`S + 1`) queries at `S = B - 1`; the fast-forward path (which stores step `P` and resets *at* `P`)
-queries at `P - 1`. Plumbing: `BlockProvider::canonical_vdf_snapshot(step)`
-(`crates/types/src/block_provider.rs`) → `BlockTree::canonical_entry_at_or_below_step`
-(`crates/domain/src/models/block_tree.rs`, an in-place binary search by `global_step_number` over
-the canonical-chain cache) → implemented in `BlockStatusProvider` (`crates/p2p/...`).
-
-`canonical_vdf_snapshot` returns the **whole** canonical snapshot the loop needs — tip info,
-`confirmed_global_step_number`, and the per-step reset seed (`reset_seed_for_step`) — from **one**
-block-tree read lock, so a reorg cannot land between a tip read and a separate seed read (it
-replaced the earlier split `latest_canonical_vdf_info()` + `canonical_vdf_info_at_or_below_step()`
-pair, which took two locks). When the VDF runs *ahead* of the tip the query returns the tip itself
-(the greatest `global_step_number <= S` is the tip), yielding the tip's `next_seed` — equal to the
-prior behavior, a no-op. The fallback to the tip's `next_seed` is a defensive default for the
-distinct edge case where *no* canonical block ends at/before the step (the step is below the earliest
-cached block in the bounded canonical-chain cache).
-
-Two subtleties this resolves:
-
-- **Boundary-spanning blocks.** A single block can straddle a reset boundary; its `next_seed`
-  targets the boundary *above* its range. So the query is the block *ending at or before* the step
-  (greatest `global_step_number <= S`), **not** the block whose range *covers* the step (which may
-  be the spanning block, yielding the wrong seed). This off-by-one — covering vs ending-before —
-  was a real bug in the first cut of this fix, caught by the boundary-crossing test.
-- **The fast-forward path needs the same seed for its carried hash.** FF stores canonical step
-  values **verbatim** (`store_step` runs *before* `process_reset`), so the FF'd *buffer* is canonical
-  regardless of `next_reset_seed`. But the `process_reset` after an FF step folds the seed into the
-  *carried* `hash` that seeds any subsequent **local** stepping — so if an FF step lands exactly on a
-  boundary and local stepping resumes, that hash must carry the right boundary fold. The FF path
-  therefore sources `reset_seed_for_step` too, querying at `P - 1` (the step before the FF step, since
-  `process_reset` is applied *at* `P`, not `P + 1`). Without the `- 1` it would fold the seed for the
-  boundary *above* `P` whenever a canonical block ends exactly on `P`.
-
-This preserves the #1447/#1449 protection: the confirmation gate still keys on
-`confirmed_global_step_number` (unchanged); only the seed *source* moves, and only when the VDF is
-at/below the canonical tip (catch-up).
-
-### 3. Validation must tolerate the asynchronous re-anchor window
-
-The re-anchor is signalled *after* `recover_from_network_partition` but applied **asynchronously**
-by the VDF supervisor on its next loop iteration (~one loop tick later). In that window the live
-buffer still holds the pre-swap (poisoned) lineage, yet the canonical fork's blocks are already
-being validated. Without care, an honest block validated in that window is rejected as terminal
-`Invalid` and never retried (the gossip-seen cache dedups a re-gossip; an orphan pull needs a
-child). Three validation seams were made **fork-aware** so the recovering node can adopt the
-canonical chain *during* the window, all flowing through one primitive,
-`irys_vdf::state::build_fork_local_view`:
-
-- **VDF-step batch validation — recompute on mismatch.** `vdf_step_batch_is_valid`
-  (`crates/vdf/src/state.rs`) no longer treats a live-buffer mismatch as invalidity; a mismatch
-  falls through to the authoritative recompute from the block's own `prev_output`/seed. A heavier
-  competing fork legitimately differs from this node's buffer past a boundary; recompute is the
-  source of truth. (Verified not to weaken #1447, whose protection is the mining-loop gate, not
-  this fast path.)
-- **Recall-range validation — fork-local view.** On a recall `Mismatch` against the live buffer,
-  rebuild a fork-local step view from the block's **own** lineage (its ancestors via the block
-  tree) and re-validate against that: `build_fork_local_recall_view`
-  (`crates/actors/src/block_validation.rs`).
-- **Previous-step continuity — fork-local view.** The `ensure_vdf_is_valid` prev-step equality
-  check (`crates/actors/src/validation_service.rs`) reads the live buffer as a fast path and treats
-  an *absent* previous step and a *present-but-stale* one (the poisoned boundary value during the
-  window) identically: both fall through to resolve the previous step from a fork-local view sized
-  to include it (`build_fork_local_step_view`, which covers the prev step even for a boundary-crossing
-  block) and accept iff that matches. (An absent-or-mismatched step with an unbuildable view requeues
-  via `VdfPrevStepForkViewUnavailable`; there is no separate `VdfStepRewound` re-wait path.) A value that
-  mismatches the block's own canonical ancestry is still rejected.
-
-Both view builders resolve each ancestor **block-tree-first, then by hash from the DB**, mirroring
-`create_state_for_canonical_tip`. The tree-only lookup was insufficient: a deep recovery's
-recall/step window can reach below the cached chain (mainnet `reset_frequency` ≈ 50 blocks vs
-`block_tree_depth` 100, but lower steps-per-block widen the window), so a needed ancestor may be
-migrated out of the tree yet still present in the DB. Without the fallback the build fails and the
-honest canonical block is routed to `StepsUnavailable` / `VdfPrevStepForkViewUnavailable` and retries
-forever instead of validating.
-
-### 4. Post-recovery mining — reset the efficient-sampling rotation
-
-Partition mining's recall-range selection uses a **stateful** efficient-sampling rotation
-(`irys_efficient_sampling::Ranges`) that assumes strictly consecutive *forward* VDF steps. A
-re-anchor is a backward rewind, so the rotation must be discarded. On re-anchor the supervisor
-broadcasts `MiningBroadcastEvent::Reanchored` (`MiningBus::send_reanchor`,
-`crates/actors/src/mining_bus.rs`); each partition miner resets its rotation
-(`PartitionMiningService::handle_reanchor`: `Ranges::reinitialize()` + `last_step_num = 0`,
-`crates/actors/src/partition_mining_service.rs`) and rebuilds it from the re-anchored steps on the
-next seed. `get_recall_range` also defends against a backward step jump.
-
-> **Residual (non-safety, tracked separately).** Immediately after a re-anchor the rotation
-> realigns over the next few steps; a node that *mines* into that window can compute a recall range
-> off-by-one from the validator and self-reject the block (retried — nothing invalid is ever
-> adopted, no safety impact). In production a recovered node **follows** the network (ungated
-> fast-forward, no local recall-range computation) rather than mining into the window, so this does
-> not arise on the real recovery path. The end-to-end test therefore drives continued production
-> from the **peer** (the canonical-fork miner, whose rotation was never re-anchored and so is
-> intact) and asserts the recovered node *follows* — the production path — rather than forcing the
-> recovered node to mine into the turbulence.
-
-### 5. The anchor hash itself must carry its boundary fold
-
-The buffer stores **raw** step outputs: `process_reset` folds the reset entropy into the *carried*
-hash only **after** a step is stored (the loop tail), and fast-forward stores values verbatim. So a
-hash read back from the buffer via `get_last_step_and_seed` — exactly what the supervisor uses as
-the next `run_vdf` anchor — is **unfolded**. `run_vdf` does not fold its initial hash; it goes
-straight into `vdf_sha` for `anchor_step + 1`. If `anchor_step` is *itself* a reset boundary, that
-first step skips boundary `anchor_step`'s fold and diverges from the canonical lineage.
-
-Both anchor sites apply `irys_vdf::vdf::reset_applied_anchor_hash(reset_frequency, step, hash, seed)`
-(a no-op unless `step` is a boundary): the **startup** anchor (`init_vdf_thread`) with
-`latest_block`'s seed, and the **re-anchor** (the supervisor's `Reanchor` arm) with the rebuilt
-canonical tip's seed. `seed` here is the anchoring block's own `vdf_limiter_info.seed` — *not*
-`next_seed`: when a block's step range contains a reset boundary, `IrysBlockHeader::set_seeds` pins
-that in-range boundary's entropy in `seed` while `next_seed` targets the *next* boundary above the
-block. (This is the same value `canonical_vdf_snapshot(step - 1).reset_seed_for_step` would return,
-since the parent's `next_seed` equals this block's `seed`.)
-
-Rare (only when an anchor lands exactly on a boundary) and non-safety (validation recomputes from
-each block's own seed, so a mis-stepped buffer cannot reject a canonical block), but it mis-steps
-local mining for a range until it heals. The rebuild-*failure* fallback (resume from the live
-buffer's current step) is left unfolded — it is already a degraded best-effort path that leans on
-`store_step`'s behind-step rejection to realign.
+The only escape from this verification primitive would be weak-subjectivity checkpoints — a far
+larger protocol decision, out of scope. The primitive stays; only the post-adoption heal changed.
 
 ## Alternatives considered
 
-- **In-place re-anchor command (Strategy B).** Add a `VdfState::reanchor()` that
-  clears/refills the buffer and a command channel that rewrites the running loop's
-  `hash`/`global_step` without returning from `run_vdf`. Lighter, but introduces a
-  deliberate backward mutation into a buffer whose entire invariant set assumes
-  forward-only progress, and spreads re-anchor logic across the hot loop. Rejected
-  in favour of restarting `run_vdf` from the well-tested `create_state` startup
-  path, which yields a clean, fully-canonical buffer with no new buffer-rewind
-  primitive.
-- **Full OS-thread teardown + respawn (Strategy A1).** Conceptually identical but
-  forces recreating the FF channel (and swapping the `Sender` inside the
-  `ServiceSenders` hub) and re-running core pinning. The supervisor-loop variant
-  keeps the thread and the channel, so it is strictly simpler.
-- **Widen the confirmation gate to `block_tree_depth`.** Would prevent the loop
-  from ever crossing a boundary that a recovery could later invalidate, but parks
-  honest mining for an entire cache window of run-ahead budget and still leaves the
-  buffer poisoned for a recovery that *does* happen within the window. Treats the
-  symptom, not the cause.
-- **Do nothing.** The node wedges (rejects canonical blocks) until manually
-  restarted — at which point startup `create_state` performs exactly this
-  re-anchor. The decision is, in effect, to perform that same recovery
-  automatically at the moment it is needed.
+- **In-place VDF re-anchor (the superseded approach).** The VDF OS thread ran a supervisor loop;
+  `run_vdf` returned a `VdfExit::Reanchor` on a `vdf_reanchor` signal; the supervisor rebuilt
+  `VdfState` from the canonical **tip** (`create_state_for_canonical_tip`), republished the buffer
+  under the write lock, drained the fast-forward queue, re-applied the boundary fold, and broadcast
+  `MiningBroadcastEvent::Reanchored` to reset partition mining's efficient-sampling rotation. It
+  healed without process downtime, but it added a substantial body of consensus-critical mechanism —
+  a backward buffer mutation into an otherwise forward-only invariant set, a tip-rebuild that had to
+  source each boundary's own seed, an asynchronous-window validation race, and a mining-rotation
+  reset — much of which exists *only* to make an in-place rewind safe. The restart deletes all of it
+  by rebuilding from the cold-start path, which is already exercised on every node boot. Rejected in
+  favour of the restart once the cold-start heal was verified end-to-end (see Testing).
+- **Widen the confirmation gate to `block_tree_depth`.** Would prevent the loop from ever crossing a
+  boundary a recovery could later invalidate, but parks honest mining for an entire cache window of
+  run-ahead budget and still leaves the buffer poisoned for a recovery that *does* happen within the
+  window. Treats the symptom, not the cause.
+- **Do nothing.** With the fork-local verification in place the node would not *wedge* (it still
+  validates and follows canonical), but its live buffer would stay poisoned and it could not mine
+  valid blocks until the poison aged out of the buffer window. The restart restores correct mining
+  promptly.
 
 ## Consequences
 
-- A recovering node converges to the canonical VDF lineage automatically instead
-  of wedging until an operator restarts it.
-- The recovery reuses `create_state` and the FF path — no new buffer-mutation
-  primitive, no change to the seed-derivation or validation logic.
-- Cost: the re-anchored loop discards already-computed (poisoned) steps and
-  recomputes the catch-up to the live timeline. Those steps were invalid anyway, so
-  no useful work is lost.
+- A recovering node converges to the canonical VDF lineage automatically — via relaunch + cold-sync
+  — instead of mining on a poisoned buffer until an operator intervenes.
+- The heal reuses the cold-start path and the fast-forward path: no in-place buffer-rewind
+  primitive, no supervisor loop, no mining-rotation re-anchor broadcast.
+- **Cost — downtime.** A boundary-crossing recovery now incurs the downtime of restarting the
+  embedded reth, peer, and mempool subsystems plus the resync of the un-migrated tail. Gating the
+  restart to genuine poison keeps non-boundary deep reorgs (which need no heal) free of this cost.
+- **Cost — deployment dependency.** The node must run under a supervisor with a restart policy keyed
+  to the exit code (systemd `Restart=on-failure` covers the non-zero 75; a Kubernetes/Docker restart
+  policy equivalently). Without it the node stays down after a boundary-crossing deep reorg, which is
+  a regression against the in-place heal — so the restart policy is part of the deliverable.
 
 ### Risks / edge cases
 
-- **Signal ordering.** A `reanchor` sent before index truncation would re-anchor to
-  the stale index. The signal must originate after `recover_from_network_partition`
-  returns.
-- **Repeated/at-startup recovery.** A second deep reorg before the first re-anchor
-  completes must coalesce (the supervisor should re-read the latest anchor, not
-  queue stale ones). Restarting mid-`run_vdf` is safe because the next iteration
-  always rebuilds from the current index.
-- **Validation in flight.** The buffer swap is atomic (the write lock makes a reader
-  see either the old or new buffer), but the rewind itself is observable across a
-  read→wait or wait→read gap, so two seams in `ensure_vdf_is_valid` are hardened:
-  - `VdfStateReadonly::wait_for_step` treats *any* change in `global_step` — including
-    the backward jump from a re-anchor — as liveness (resets the stall baseline/timer).
-    The stall detector only fires on a genuinely *constant* `global_step` (a dead
-    writer); `store_step` is forward-only, so a decrease is always a re-anchor and must
-    not be mislabelled as a stall (which would `panic!` the node per the never-mislabel
-    rule).
-  - The post-wait `get_step(prev_output_step_number)` is a fast path that may read absent or
-    stale during a rewind; either way the prev-step check falls through to the authoritative
-    fork-local view (no re-wait). If that view is also unbuildable it surfaces
-    `VdfPrevStepForkViewUnavailable`, which routes to `Cancelled` (peer-innocent requeue)
-    rather than `panic!` or `Invalid`.
-- **Rebuild failure.** `create_state_for_canonical_tip` runs on the live VDF supervisor
-  thread, so it returns `eyre::Result` instead of unwrapping DB/header reads. On failure
-  (transient DB error, or an ancestor missing from both the block-tree cache and the DB)
-  the supervisor logs, keeps the current buffer/anchor, and resumes `run_vdf` from the
-  existing timeline; `BlockTreeService` re-emits `vdf_reanchor` on the next recovery, so
-  a transient failure self-heals on retry. A panic here would otherwise fire the thread's
-  `CancelOnDrop` and shut the node down mid-recovery.
-- **Atomic/buffer ordering.** `atomic_global_step_number` is stored to the rewound
-  (lower) value *under the same write lock and before* the buffer is published, so the
-  invariant `atomic <= buffer.global_step` holds at every instant (no reader can observe
-  the atomic pointing past the buffer's newest step).
-- **Lock poisoning.** `run_vdf` already exits gracefully on a poisoned VDF lock
-  (`crates/vdf/src/vdf.rs:83`); the supervisor must treat that as full shutdown, not
-  a re-anchor.
+- **Signal ordering.** The restart must be requested strictly *after* `recover_from_network_partition`
+  has truncated the index, so the post-restart `create_state` reads the LCA-rooted index, never the
+  stale minority index. The `cancel()` is placed immediately after that call returns.
+- **Restart-gate TOCTOU.** The live-step sample is `Relaxed` and can lag the VDF loop's committed
+  seed by a step; the `+ 1` margin in the gate covers it conservatively (over-trigger over
+  under-trigger). Non-safety regardless (validation is buffer-independent).
+- **Cold-sync needs reachable peers.** The relaunched node must reach a peer within its startup-sync
+  window to refetch the canonical tail; otherwise it comes up on the truncated index and waits. The
+  deployment must keep peers (or trusted peers) configured — the integration test models this by
+  injecting `trusted_peers` before relaunch.
+- **Lock poisoning.** `run_vdf` still exits gracefully on a poisoned VDF lock; that path is a plain
+  thread exit (surfaced as `VdfExited`), independent of the restart trigger.
 
 ## Testing
 
-Implemented:
-
-- **Unit (vdf), control path:** `reanchor_signal_returns_reanchor_exit`
-  (`crates/vdf/src/vdf.rs`) drives the real `run_vdf` loop, fires a `vdf_reanchor`
-  signal, and asserts the loop returns `VdfExit::Reanchor` (and exits for that reason,
-  not shutdown).
-- **Unit (vdf), buffer mechanics:** the existing
+- **Unit (vdf), buffer mechanics:**
   `issue_1447_unconfirmed_reset_seed_poisons_buffer_and_wedges_block_validation`
-  already proves that crossing a boundary on a loser vs winner seed diverges the
-  buffer, and that `vdf_steps_are_valid` rejects a poisoned buffer / accepts a clean
-  one. The re-anchor heals by rebuilding to the **canonical-tip** lineage.
+  (`crates/vdf/src/vdf.rs`) proves that crossing a boundary on a loser vs winner seed diverges the
+  buffer and that `vdf_steps_are_valid` rejects a poisoned buffer / accepts a clean one — the
+  poisoning the restart heals.
 - **Unit (vdf), fork-aware validation:** `vdf_step_batch_recomputes_on_buffer_mismatch`
   (`crates/vdf/src/state.rs`) proves a poisoned buffer ACCEPTS an honest competing-fork block via
-  recompute-on-mismatch while a forged block is still rejected (§3, layer 1); plus
-  `build_vdf_seed_buffer_propagates_fetch_error` and `wait_for_step_tolerates_backward_reanchor_jump`
-  cover the fallible tip-rebuild and the backward-jump liveness handling.
-- **Integration (chain):** `heavy4_slow_network_partition_recovery`
-  (`crates/chain-tests/src/multi_node/partition_recovery.rs`) now exercises the
-  re-anchor wiring end-to-end — recovery fires the signal, the supervisor rebuilds
-  from the index and restarts the loop, and the node both adopts the peer's canonical
-  chain and continues mining afterward (the "continued operation after recovery"
-  stage), proving the re-anchor does not wedge a live node.
-
-- **End-to-end, boundary-spanning (the headline test):**
-  `heavy4_slow_partition_recovery_crosses_reset_boundary`
-  (`crates/chain-tests/src/multi_node/partition_recovery.rs`) is the live two-node test where a
-  fork **crosses a VDF reset boundary** before the deep reorg — so the recovering node's buffer
-  is genuinely poisoned and the re-anchor must reproduce the canonical reset seed. Both nodes
-  mine real forks past the poison boundary via natural mining; the peer's (longer) fork is
-  gossiped to genesis, triggering the deep reorg → re-anchor. It asserts:
-
-  - **(A) the heal** — genesis's VDF buffer over the boundary-crossing block's step range equals
-    the canonical chain's recorded steps. Because the re-anchor is applied **asynchronously**, this
-    is a **poll-until-converged** check (a bare `global_step >= last` wait would race the heal:
-    genesis's own free-ran buffer already sits past that step *before* the re-anchor lands). A
-    *persistent* mismatch after the full timeout is a genuine wedge.
-  - **(B) no wedge / continued operation** — after confirming genesis's VDF advances past the
-    recovered tip and settles (live, not wedged) and still holds the full adopted canonical chain,
-    the **peer** (canonical-fork miner) produces the next block and genesis **follows** it. This is
-    the production recovery path and sidesteps the [§4 residual mining race](#4-post-recovery-mining--reset-the-efficient-sampling-rotation)
-    (the peer's rotation is intact; genesis only *validates* the peer's block against its healed
-    buffer and fast-forwards). Deterministic and binding.
-
-  Verified at **20/20** across the geometries natural mining produces (`peer_tip` 14 & 16, poison
-  boundary steps ~300–386). A clean run is ~28–31s.
-
-  This was previously shelved as "structurally infeasible," which turned out to be **wrong**
-  — an artifact of the test harness, not the protocol. The earlier attempt funded but never
-  **staked/pledged** the peer, so the peer had no partition assignment, no packed mineable
-  data, and natural `mine_blocks` stalled; the fallback to forced capacity solutions
-  (`mine_block_without_gossip`) never calls `start_mining()`, so the peer's VDF never
-  free-ran and parked at the gated boundary (its confirmed step stuck at the LCA). The fix:
-  **provision the peer as a real miner** (stake → pledge → epoch assignment → pack) and use
-  **natural mining** — `mine_blocks` enables `start_mining()`, the VDF free-runs, partition
-  mining finds real PoA solutions, blocks validate → `mark_tip` → `confirmed_canonical_step`
-  advances → the #1449 gate releases, exactly as production crosses boundaries. The assigned
-  partition is entropy-packed, so its PoA solutions are data-independent and the recovering
-  node validates the canonical fork on reorg by recomputing entropy (no chunk-data sync).
-
-The heal is therefore covered both end-to-end (above) and in composition by the unit tests:
-the buffer divergence + validation reject/accept (`issue_1447_*`), the re-anchor trigger
-(`reanchor_signal_returns_reanchor_exit`), the DB-free tip-rebuild
-(`build_vdf_seed_buffer_reproduces_canonical_steps_anchored_at_tip`), and the live reorg →
-re-anchor → rebuild → restart → continued-operation wiring (`heavy4_slow_network_partition_recovery`).
+  recompute-on-mismatch while a forged block is still rejected; the `build_vdf_seed_buffer_*` tests
+  cover the shared walk-back (verbatim reproduction, capacity off-by-one, fetch-error propagation);
+  `anchor_hash_folds_its_own_reset_boundary_*` and the per-step seed tests
+  (`uses_per_step_seed_from_single_snapshot_when_crossing_boundary`,
+  `fast_forward_exact_boundary_uses_pre_boundary_seed`) cover the cold-path seed correctness.
+- **Unit (types), exit code:** `only_partition_recovery_restart_exits_nonzero`
+  (`crates/types/src/shutdown.rs`) asserts only `PartitionRecoveryRestart` exits non-zero (75) and
+  every other reason exits 0.
+- **Integration (chain), non-boundary deep reorg:** `heavy4_slow_network_partition_recovery`
+  (`crates/chain-tests/src/multi_node/partition_recovery.rs`) does a deep reorg that crosses no reset
+  boundary; the gate does **not** restart and the node continues operating in place (surgical
+  storage recovery + continued mining). This is the regression guard that non-boundary recoveries
+  stay cheap.
+- **Integration (chain), boundary-crossing heal-after-restart (the headline test):**
+  `heavy4_slow_partition_recovery_crosses_reset_boundary_restarts`
+  (`crates/chain-tests/src/multi_node/partition_recovery.rs`). Two real miners fork past a reset
+  boundary; the peer's heavier fork is gossiped to genesis, which validates and adopts it (deep reorg
+  crossing the boundary). The test asserts: (1) genesis requests the restart
+  (`partition_recovery_restart` is cancelled); (2) after a `stop()`/`start()` relaunch from the same
+  data directory (with the peer configured as a trusted peer so it can resync), genesis cold-syncs
+  the canonical chain to the tip; (3) its rebuilt VDF buffer matches the canonical recorded steps
+  over the boundary-crossing range; and (4) the recovered node produces the next canonical block and
+  the peer follows it (no wedge).
+  The `trusted_peers` injection is the in-harness analogue of the production supervisor-plus-peers
+  requirement.

--- a/design/docs/vdf-partition-recovery-reanchor.md
+++ b/design/docs/vdf-partition-recovery-reanchor.md
@@ -259,7 +259,7 @@ own boundary seed), so the rebuilt buffer reproduces the canonical lineage acros
 recovered range. `init_vdf_thread` takes the `block_tree_guard` (not the block index). It returns
 `eyre::Result` (see [Rebuild failure](#risks--edge-cases)) plus the canonical `next_seed`.
 
-### 2. The catch-up reset-seed hole — and `canonical_vdf_info_at_or_below_step`
+### 2. The catch-up reset-seed hole — and `canonical_vdf_snapshot`
 
 The tip re-anchor is correct **only if it anchors at, or above, every reset boundary the
 recovered range crosses.** But a partition recovery adopts the canonical fork **incrementally**
@@ -268,26 +268,33 @@ recovered range crosses.** But a partition recovery adopts the canonical fork **
 instant* — below the boundary — and the VDF then **local-steps the catch-up** forward across the
 boundary on its own, before the canonical blocks that pin that boundary's seed have been adopted.
 
-At the crossing, `run_vdf` applied `next_reset_seed = latest_canonical_vdf_info().next_seed` — the
-**tip's** next_seed. Once the tip advances *past* the boundary (the rest of the fork arrives), that
-field is the seed for the next, *higher* boundary, not the one being crossed. The wrong seed is
-XOR'd in and the post-boundary steps are re-poisoned — and, because `store_step` is forward-only,
-the canonical steps that arrive afterward can never overwrite them. The heal silently fails for
-that range (~1 in 15–20 boundary-crossing recoveries; the deterministic VDF would otherwise
-reproduce canonical exactly with the right seed).
+At the crossing, `run_vdf` applied `next_reset_seed = <tip>.next_seed` — the **tip's** next_seed.
+Once the tip advances *past* the boundary (the rest of the fork arrives), that field is the seed for
+the next, *higher* boundary, not the one being crossed. The wrong seed is XOR'd in and the
+post-boundary steps are re-poisoned — and, because `store_step` is forward-only, the canonical steps
+that arrive afterward can never overwrite them. The heal silently fails for that range (~1 in 15–20
+boundary-crossing recoveries; the deterministic VDF would otherwise reproduce canonical exactly with
+the right seed).
 
-**Fix:** source the reset seed from the canonical block **ending at or before the VDF's current
-step**, not the tip. That block's `next_seed` pins the seed for the next boundary *above the
-current step* — exactly the boundary the VDF is about to cross. Plumbing:
-`BlockProvider::canonical_vdf_info_at_or_below_step` (`crates/types/src/block_provider.rs`,
-default `None`) → `BlockTree::canonical_entry_at_or_below_step`
+**Fix:** source the reset seed from the canonical block **ending at or before the boundary being
+crossed**, not the tip — that block's `next_seed` pins the seed for that boundary. The rule is:
+**boundary `B`'s reset seed is the `next_seed` of the canonical block ending at or before `B - 1`.**
+Each path queries accordingly: local-stepping (which is at step `S` and resets the step it computes,
+`S + 1`) queries at `S = B - 1`; the fast-forward path (which stores step `P` and resets *at* `P`)
+queries at `P - 1`. Plumbing: `BlockProvider::canonical_vdf_snapshot(step)`
+(`crates/types/src/block_provider.rs`) → `BlockTree::canonical_entry_at_or_below_step`
 (`crates/domain/src/models/block_tree.rs`, an in-place binary search by `global_step_number` over
-the canonical-chain cache) → overridden in `BlockStatusProvider` (`crates/p2p/...`). `run_vdf`'s
-local-stepping read uses it: when the VDF runs *ahead* of the tip the query returns the tip itself
+the canonical-chain cache) → implemented in `BlockStatusProvider` (`crates/p2p/...`).
+
+`canonical_vdf_snapshot` returns the **whole** canonical snapshot the loop needs — tip info,
+`confirmed_global_step_number`, and the per-step reset seed (`reset_seed_for_step`) — from **one**
+block-tree read lock, so a reorg cannot land between a tip read and a separate seed read (it
+replaced the earlier split `latest_canonical_vdf_info()` + `canonical_vdf_info_at_or_below_step()`
+pair, which took two locks). When the VDF runs *ahead* of the tip the query returns the tip itself
 (the greatest `global_step_number <= S` is the tip), yielding the tip's `next_seed` — equal to the
-prior behavior, a no-op. The `unwrap_or` fallback to the tip's `next_seed` is a defensive default
-for the distinct edge case where *no* canonical block ends at/before the step (the step is below the
-earliest cached block in the bounded canonical-chain cache).
+prior behavior, a no-op. The fallback to the tip's `next_seed` is a defensive default for the
+distinct edge case where *no* canonical block ends at/before the step (the step is below the earliest
+cached block in the bounded canonical-chain cache).
 
 Two subtleties this resolves:
 
@@ -296,9 +303,14 @@ Two subtleties this resolves:
   (greatest `global_step_number <= S`), **not** the block whose range *covers* the step (which may
   be the spanning block, yielding the wrong seed). This off-by-one — covering vs ending-before —
   was a real bug in the first cut of this fix, caught by the boundary-crossing test.
-- **The fast-forward path is unchanged.** FF stores canonical step values **verbatim**
-  (`store_step` runs *before* `process_reset`), so an FF'd buffer is canonical regardless of
-  `next_reset_seed`. Only local-stepping can poison the buffer, so the fix is local-path-only.
+- **The fast-forward path needs the same seed for its carried hash.** FF stores canonical step
+  values **verbatim** (`store_step` runs *before* `process_reset`), so the FF'd *buffer* is canonical
+  regardless of `next_reset_seed`. But the `process_reset` after an FF step folds the seed into the
+  *carried* `hash` that seeds any subsequent **local** stepping — so if an FF step lands exactly on a
+  boundary and local stepping resumes, that hash must carry the right boundary fold. The FF path
+  therefore sources `reset_seed_for_step` too, querying at `P - 1` (the step before the FF step, since
+  `process_reset` is applied *at* `P`, not `P + 1`). Without the `- 1` it would fold the seed for the
+  boundary *above* `P` whenever a canonical block ends exactly on `P`.
 
 This preserves the #1447/#1449 protection: the confirmation gate still keys on
 `confirmed_global_step_number` (unchanged); only the seed *source* moves, and only when the VDF is
@@ -334,6 +346,14 @@ canonical chain *during* the window, all flowing through one primitive,
   via `VdfPrevStepForkViewUnavailable`; there is no separate `VdfStepRewound` re-wait path.) A value that
   mismatches the block's own canonical ancestry is still rejected.
 
+Both view builders resolve each ancestor **block-tree-first, then by hash from the DB**, mirroring
+`create_state_for_canonical_tip`. The tree-only lookup was insufficient: a deep recovery's
+recall/step window can reach below the cached chain (mainnet `reset_frequency` ≈ 50 blocks vs
+`block_tree_depth` 100, but lower steps-per-block widen the window), so a needed ancestor may be
+migrated out of the tree yet still present in the DB. Without the fallback the build fails and the
+honest canonical block is routed to `StepsUnavailable` / `VdfPrevStepForkViewUnavailable` and retries
+forever instead of validating.
+
 ### 4. Post-recovery mining — reset the efficient-sampling rotation
 
 Partition mining's recall-range selection uses a **stateful** efficient-sampling rotation
@@ -354,6 +374,30 @@ next seed. `get_recall_range` also defends against a backward step jump.
 > from the **peer** (the canonical-fork miner, whose rotation was never re-anchored and so is
 > intact) and asserts the recovered node *follows* — the production path — rather than forcing the
 > recovered node to mine into the turbulence.
+
+### 5. The anchor hash itself must carry its boundary fold
+
+The buffer stores **raw** step outputs: `process_reset` folds the reset entropy into the *carried*
+hash only **after** a step is stored (the loop tail), and fast-forward stores values verbatim. So a
+hash read back from the buffer via `get_last_step_and_seed` — exactly what the supervisor uses as
+the next `run_vdf` anchor — is **unfolded**. `run_vdf` does not fold its initial hash; it goes
+straight into `vdf_sha` for `anchor_step + 1`. If `anchor_step` is *itself* a reset boundary, that
+first step skips boundary `anchor_step`'s fold and diverges from the canonical lineage.
+
+Both anchor sites apply `irys_vdf::vdf::reset_applied_anchor_hash(reset_frequency, step, hash, seed)`
+(a no-op unless `step` is a boundary): the **startup** anchor (`init_vdf_thread`) with
+`latest_block`'s seed, and the **re-anchor** (the supervisor's `Reanchor` arm) with the rebuilt
+canonical tip's seed. `seed` here is the anchoring block's own `vdf_limiter_info.seed` — *not*
+`next_seed`: when a block's step range contains a reset boundary, `IrysBlockHeader::set_seeds` pins
+that in-range boundary's entropy in `seed` while `next_seed` targets the *next* boundary above the
+block. (This is the same value `canonical_vdf_snapshot(step - 1).reset_seed_for_step` would return,
+since the parent's `next_seed` equals this block's `seed`.)
+
+Rare (only when an anchor lands exactly on a boundary) and non-safety (validation recomputes from
+each block's own seed, so a mis-stepped buffer cannot reject a canonical block), but it mis-steps
+local mining for a range until it heals. The rebuild-*failure* fallback (resume from the live
+buffer's current step) is left unfolded — it is already a degraded best-effort path that leans on
+`store_step`'s behind-step rejection to realign.
 
 ## Alternatives considered
 

--- a/design/docs/vdf-partition-recovery-reanchor.md
+++ b/design/docs/vdf-partition-recovery-reanchor.md
@@ -145,7 +145,7 @@ rotation block is at/below the shared LCA, so both forks share its seed).
 `BlockTreeService` therefore restarts only when the **live VDF step** has reached that second
 boundary:
 
-```
+```text
 first_divergent_boundary = (lca_step / reset_frequency + 2) * reset_frequency
 restart  iff  live_vdf_step + 1 >= first_divergent_boundary
 ```

--- a/design/docs/vdf-partition-recovery-reanchor.md
+++ b/design/docs/vdf-partition-recovery-reanchor.md
@@ -326,11 +326,12 @@ canonical chain *during* the window, all flowing through one primitive,
   tree) and re-validate against that: `build_fork_local_recall_view`
   (`crates/actors/src/block_validation.rs`).
 - **Previous-step continuity — fork-local view.** The `ensure_vdf_is_valid` prev-step equality
-  check (`crates/actors/src/validation_service.rs`) previously handled only an *absent* previous
-  step (requeue via `VdfStepRewound`); a *present-but-stale* step — the poisoned boundary value
-  during the window — fell through to terminal `Invalid`. On mismatch it now resolves the previous
-  step from a fork-local view sized to include it (`build_fork_local_step_view`, which covers the
-  prev step even for a boundary-crossing block) and accepts iff that matches. A value that
+  check (`crates/actors/src/validation_service.rs`) reads the live buffer as a fast path and treats
+  an *absent* previous step and a *present-but-stale* one (the poisoned boundary value during the
+  window) identically: both fall through to resolve the previous step from a fork-local view sized
+  to include it (`build_fork_local_step_view`, which covers the prev step even for a boundary-crossing
+  block) and accept iff that matches. (An absent-or-mismatched step with an unbuildable view requeues
+  via `VdfPrevStepForkViewUnavailable`; there is no separate `VdfStepRewound` re-wait path.) A value that
   mismatches the block's own canonical ancestry is still rejected.
 
 ### 4. Post-recovery mining — reset the efficient-sampling rotation
@@ -406,10 +407,11 @@ next seed. `get_recall_range` also defends against a backward step jump.
     writer); `store_step` is forward-only, so a decrease is always a re-anchor and must
     not be mislabelled as a stall (which would `panic!` the node per the never-mislabel
     rule).
-  - The post-wait `get_step(prev_output_step_number)` re-waits once if the step is
-    transiently absent (rewound after the wait returned); if still absent it surfaces
-    the typed `VdfStepRewound` sentinel, which routes to `Cancelled` (peer-innocent
-    requeue) rather than `panic!` or `Invalid`.
+  - The post-wait `get_step(prev_output_step_number)` is a fast path that may read absent or
+    stale during a rewind; either way the prev-step check falls through to the authoritative
+    fork-local view (no re-wait). If that view is also unbuildable it surfaces
+    `VdfPrevStepForkViewUnavailable`, which routes to `Cancelled` (peer-innocent requeue)
+    rather than `panic!` or `Invalid`.
 - **Rebuild failure.** `create_state_for_canonical_tip` runs on the live VDF supervisor
   thread, so it returns `eyre::Result` instead of unwrapping DB/header reads. On failure
   (transient DB error, or an ancestor missing from both the block-tree cache and the DB)

--- a/design/docs/vdf-partition-recovery-reanchor.md
+++ b/design/docs/vdf-partition-recovery-reanchor.md
@@ -2,11 +2,28 @@
 
 ## Status
 
-Accepted — implemented. The VDF thread is a supervisor loop (`init_vdf_thread`,
-`crates/chain/src/chain.rs`); `run_vdf` returns `VdfExit` and is restarted on
-`VdfExit::Reanchor`; `BlockTreeService` sends the `vdf_reanchor` signal after
-`recover_from_network_partition`; `create_state` borrows the index and returns the
-anchor's `next_seed`.
+Accepted — implemented and verified. On a network-partition recovery the VDF re-anchors to
+the canonical chain **TIP** and the recovering node converges to the canonical VDF lineage
+automatically, instead of wedging until an operator restart.
+
+The shipped solution is a **stack of layers** (detailed in
+[Implementation: the complete heal](#implementation-the-complete-heal-2026-06)), each forced
+by the end-to-end boundary-crossing test:
+
+1. **Re-anchor at the tip** — `create_state_for_canonical_tip` rebuilds `VdfState` from the
+   canonical chain (not the LCA; see the Correction under [Decision](#decision)).
+2. **Catch-up reset-seed fix** — `canonical_vdf_info_at_or_below_step` so the
+   incremental-adoption window cannot re-poison the steps past a boundary the re-anchor landed
+   below.
+3. **Fork-aware validation** — recompute-on-mismatch + fork-local step/recall views so the
+   recovering node can adopt the canonical chain *during* the asynchronous re-anchor window.
+4. **Mining rotation reset** — a `Reanchored` broadcast resets partition mining's stateful
+   efficient-sampling rotation.
+
+Mechanism: the VDF thread is a supervisor loop (`init_vdf_thread`, `crates/chain/src/chain.rs`);
+`run_vdf` returns `VdfExit` and is restarted on `VdfExit::Reanchor`; `BlockTreeService` sends
+the `vdf_reanchor` signal after `recover_from_network_partition`. Verified by
+`heavy4_slow_partition_recovery_crosses_reset_boundary` — 20/20 across varied fork geometries.
 
 ## Context
 
@@ -105,6 +122,42 @@ the live timeline) are computed locally, and those use the now-canonical
 `next_reset_seed`. The poisoning heals itself once we make the loop go backward,
 which is the one thing it cannot do on its own.
 
+> **Correction (2026-06, supersedes the LCA-anchor decision below).** The "FF
+> replays the entire canonical step range verbatim … the poisoning heals itself"
+> reasoning above does **not** hold when the recovered range crosses a reset
+> boundary above the LCA — the node re-wedges. Three code facts break it:
+>
+> 1. **The gate does not re-gate.** `run_vdf` reads `confirmed_global_step_number`
+>    from `latest_canonical_vdf_info()`, which sources it from the block tree's NEW
+>    canonical tip (`BlockTree::confirmed_canonical_step`, far above the LCA) — not
+>    from the re-anchored position. So `is_reset_boundary_blocked(LCA+1, …)` is
+>    `false` and the loop runs ahead across the recovered range. (This refutes "the
+>    #1449 gate naturally re-gates", below.)
+> 2. **Mining is not paused on the reorg path,** so the loop local-steps LCA→tip
+>    immediately, applying the canonical TIP's single `next_seed` at every
+>    intermediate boundary instead of each boundary's own rotation-block seed —
+>    diverging from the canonical lineage.
+> 3. **Fast-forward is not re-supplied.** The canonical blocks' FF steps are drained
+>    on re-anchor and never re-sent (the reorg handler only `reevaluate_priorities`,
+>    never re-validating on-chain blocks), and `store_step` is forward-only, so FF
+>    cannot overwrite the locally-stepped poison.
+>
+> Net: the buffer diverges and the node rejects the very canonical chain it reorged
+> onto — the #1447 wedge, re-introduced. Reproduced deterministically by
+> `partition_recovery_reanchor_repoisons_buffer_and_wedges_block_validation`
+> (`crates/vdf/src/vdf.rs`).
+>
+> **Fix: re-anchor at the canonical TIP, not the LCA.** Rebuild `VdfState` from the
+> block tree's canonical chain up to the tip via `create_state_for_canonical_tip`
+> (`crates/vdf/src/state.rs`); each canonical block carries its own reset-boundary
+> seed, so the rebuilt buffer matches the canonical lineage across the whole
+> recovered range and the loop restarts **at the tip** (never re-crossing a
+> historical boundary). The recovered range is always within the block tree (a reorg
+> is only representable up to `block_tree_depth` deep), and block headers are
+> persisted to the DB only at migration, so the un-migrated tail is read from the
+> block tree rather than the DB. The `create_state(LCA)` approach described in the
+> rest of this section is retained only as historical context.
+
 ### The anchor: the LCA (fork parent)
 
 `recover_from_network_partition` truncates the block index to `fork_parent_height`
@@ -181,8 +234,122 @@ index, never the stale minority index.
   solution built on poisoned steps; that solution is dropped on the reorg path
   regardless of this change.
 - **The #1449 gate needs no special handling.** After re-anchor, `global_step`
-  drops back to the LCA, so `is_reset_boundary_blocked` naturally re-gates every
-  forward boundary crossing against the (now canonical) confirmed step.
+  drops back to the anchor (the canonical tip), so `is_reset_boundary_blocked` naturally
+  re-gates every forward boundary crossing against the (now canonical) confirmed step.
+  > **Superseded in part (2026-06).** "No special handling" understated it: the re-anchor
+  > can land *below* a boundary the canonical chain has since passed, and the catch-up
+  > local-stepping then needs the *per-boundary* seed (not the tip's). The gate is still
+  > untouched, but the seed source is — see
+  > [§2 of Implementation](#2-the-catch-up-reset-seed-hole--and-canonical_vdf_info_at_or_below_step).
+
+## Implementation: the complete heal (2026-06)
+
+The shipped fix is the **canonical-TIP re-anchor** (per the Correction under [Decision](#decision))
+plus four layers that together make a boundary-crossing recovery both heal correctly and avoid
+wedging validation or mining in the window before the heal lands. Each layer was forced by the
+end-to-end test `heavy4_slow_partition_recovery_crosses_reset_boundary`, which mines two real
+forks across a reset boundary and reorgs one onto the other.
+
+### 1. Re-anchor at the canonical tip (the heal)
+
+`create_state_for_canonical_tip` (`crates/vdf/src/state.rs`) rebuilds `VdfState` from the block
+tree's canonical chain (`get_canonical_chain`) up to the tip, via the shared, DB-free-testable
+`build_vdf_seed_buffer`. Each canonical block contributes its own recorded steps (carrying its
+own boundary seed), so the rebuilt buffer reproduces the canonical lineage across the whole
+recovered range. `init_vdf_thread` takes the `block_tree_guard` (not the block index). It returns
+`eyre::Result` (see [Rebuild failure](#risks--edge-cases)) plus the canonical `next_seed`.
+
+### 2. The catch-up reset-seed hole — and `canonical_vdf_info_at_or_below_step`
+
+The tip re-anchor is correct **only if it anchors at, or above, every reset boundary the
+recovered range crosses.** But a partition recovery adopts the canonical fork **incrementally**
+(block-by-block over gossip), so the *first* deep reorg can fire while the canonical tip is still
+**below** a poison boundary. The re-anchor correctly anchors at the canonical tip *of that
+instant* — below the boundary — and the VDF then **local-steps the catch-up** forward across the
+boundary on its own, before the canonical blocks that pin that boundary's seed have been adopted.
+
+At the crossing, `run_vdf` applied `next_reset_seed = latest_canonical_vdf_info().next_seed` — the
+**tip's** next_seed. Once the tip advances *past* the boundary (the rest of the fork arrives), that
+field is the seed for the next, *higher* boundary, not the one being crossed. The wrong seed is
+XOR'd in and the post-boundary steps are re-poisoned — and, because `store_step` is forward-only,
+the canonical steps that arrive afterward can never overwrite them. The heal silently fails for
+that range (~1 in 15–20 boundary-crossing recoveries; the deterministic VDF would otherwise
+reproduce canonical exactly with the right seed).
+
+**Fix:** source the reset seed from the canonical block **ending at or before the VDF's current
+step**, not the tip. That block's `next_seed` pins the seed for the next boundary *above the
+current step* — exactly the boundary the VDF is about to cross. Plumbing:
+`BlockProvider::canonical_vdf_info_at_or_below_step` (`crates/types/src/block_provider.rs`,
+default `None`) → `BlockTree::canonical_entry_at_or_below_step`
+(`crates/domain/src/models/block_tree.rs`, an in-place binary search by `global_step_number` over
+the canonical-chain cache) → overridden in `BlockStatusProvider` (`crates/p2p/...`). `run_vdf`'s
+local-stepping read uses it and falls back to the tip's `next_seed` when no block ends at/before
+the step (the VDF running *ahead* of the chain — normal forward operation, a no-op).
+
+Two subtleties this resolves:
+
+- **Boundary-spanning blocks.** A single block can straddle a reset boundary; its `next_seed`
+  targets the boundary *above* its range. So the query is the block *ending at or before* the step
+  (greatest `global_step_number <= S`), **not** the block whose range *covers* the step (which may
+  be the spanning block, yielding the wrong seed). This off-by-one — covering vs ending-before —
+  was a real bug in the first cut of this fix, caught by the boundary-crossing test.
+- **The fast-forward path is unchanged.** FF stores canonical step values **verbatim**
+  (`store_step` runs *before* `process_reset`), so an FF'd buffer is canonical regardless of
+  `next_reset_seed`. Only local-stepping can poison the buffer, so the fix is local-path-only.
+
+This preserves the #1447/#1449 protection: the confirmation gate still keys on
+`confirmed_global_step_number` (unchanged); only the seed *source* moves, and only when the VDF is
+at/below the canonical tip (catch-up).
+
+### 3. Validation must tolerate the asynchronous re-anchor window
+
+The re-anchor is signalled *after* `recover_from_network_partition` but applied **asynchronously**
+by the VDF supervisor on its next loop iteration (~one loop tick later). In that window the live
+buffer still holds the pre-swap (poisoned) lineage, yet the canonical fork's blocks are already
+being validated. Without care, an honest block validated in that window is rejected as terminal
+`Invalid` and never retried (the gossip-seen cache dedups a re-gossip; an orphan pull needs a
+child). Three validation seams were made **fork-aware** so the recovering node can adopt the
+canonical chain *during* the window, all flowing through one primitive,
+`irys_vdf::state::build_fork_local_view`:
+
+- **VDF-step batch validation — recompute on mismatch.** `vdf_step_batch_is_valid`
+  (`crates/vdf/src/state.rs`) no longer treats a live-buffer mismatch as invalidity; a mismatch
+  falls through to the authoritative recompute from the block's own `prev_output`/seed. A heavier
+  competing fork legitimately differs from this node's buffer past a boundary; recompute is the
+  source of truth. (Verified not to weaken #1447, whose protection is the mining-loop gate, not
+  this fast path.)
+- **Recall-range validation — fork-local view.** On a recall `Mismatch` against the live buffer,
+  rebuild a fork-local step view from the block's **own** lineage (its ancestors via the block
+  tree) and re-validate against that: `build_fork_local_recall_view`
+  (`crates/actors/src/block_validation.rs`).
+- **Previous-step continuity — fork-local view.** The `ensure_vdf_is_valid` prev-step equality
+  check (`crates/actors/src/validation_service.rs`) previously handled only an *absent* previous
+  step (requeue via `VdfStepRewound`); a *present-but-stale* step — the poisoned boundary value
+  during the window — fell through to terminal `Invalid`. On mismatch it now resolves the previous
+  step from a fork-local view sized to include it (`build_fork_local_step_view`, which covers the
+  prev step even for a boundary-crossing block) and accepts iff that matches. A value that
+  mismatches the block's own canonical ancestry is still rejected.
+
+### 4. Post-recovery mining — reset the efficient-sampling rotation
+
+Partition mining's recall-range selection uses a **stateful** efficient-sampling rotation
+(`irys_efficient_sampling::Ranges`) that assumes strictly consecutive *forward* VDF steps. A
+re-anchor is a backward rewind, so the rotation must be discarded. On re-anchor the supervisor
+broadcasts `MiningBroadcastEvent::Reanchored` (`MiningBus::send_reanchor`,
+`crates/actors/src/mining_bus.rs`); each partition miner resets its rotation
+(`PartitionMiningService::handle_reanchor`: `Ranges::reinitialize()` + `last_step_num = 0`,
+`crates/actors/src/partition_mining_service.rs`) and rebuilds it from the re-anchored steps on the
+next seed. `get_recall_range` also defends against a backward step jump.
+
+> **Residual (non-safety, tracked separately).** Immediately after a re-anchor the rotation
+> realigns over the next few steps; a node that *mines* into that window can compute a recall range
+> off-by-one from the validator and self-reject the block (retried — nothing invalid is ever
+> adopted, no safety impact). In production a recovered node **follows** the network (ungated
+> fast-forward, no local recall-range computation) rather than mining into the window, so this does
+> not arise on the real recovery path. The end-to-end test therefore drives continued production
+> from the **peer** (the canonical-fork miner, whose rotation was never re-anchored and so is
+> intact) and asserts the recovered node *follows* — the production path — rather than forcing the
+> recovered node to mine into the turbulence.
 
 ## Alternatives considered
 
@@ -227,9 +394,30 @@ index, never the stale minority index.
   completes must coalesce (the supervisor should re-read the latest anchor, not
   queue stale ones). Restarting mid-`run_vdf` is safe because the next iteration
   always rebuilds from the current index.
-- **Validation in flight.** Any `vdf_steps_are_valid` call reading the buffer during
-  the swap must see either the old or new buffer atomically — guaranteed by holding
-  the write lock for the assignment.
+- **Validation in flight.** The buffer swap is atomic (the write lock makes a reader
+  see either the old or new buffer), but the rewind itself is observable across a
+  read→wait or wait→read gap, so two seams in `ensure_vdf_is_valid` are hardened:
+  - `VdfStateReadonly::wait_for_step` treats *any* change in `global_step` — including
+    the backward jump from a re-anchor — as liveness (resets the stall baseline/timer).
+    The stall detector only fires on a genuinely *constant* `global_step` (a dead
+    writer); `store_step` is forward-only, so a decrease is always a re-anchor and must
+    not be mislabelled as a stall (which would `panic!` the node per the never-mislabel
+    rule).
+  - The post-wait `get_step(prev_output_step_number)` re-waits once if the step is
+    transiently absent (rewound after the wait returned); if still absent it surfaces
+    the typed `VdfStepRewound` sentinel, which routes to `Cancelled` (peer-innocent
+    requeue) rather than `panic!` or `Invalid`.
+- **Rebuild failure.** `create_state_for_canonical_tip` runs on the live VDF supervisor
+  thread, so it returns `eyre::Result` instead of unwrapping DB/header reads. On failure
+  (transient DB error, or an ancestor missing from both the block-tree cache and the DB)
+  the supervisor logs, keeps the current buffer/anchor, and resumes `run_vdf` from the
+  existing timeline; `BlockTreeService` re-emits `vdf_reanchor` on the next recovery, so
+  a transient failure self-heals on retry. A panic here would otherwise fire the thread's
+  `CancelOnDrop` and shut the node down mid-recovery.
+- **Atomic/buffer ordering.** `atomic_global_step_number` is stored to the rewound
+  (lower) value *under the same write lock and before* the buffer is published, so the
+  invariant `atomic <= buffer.global_step` holds at every instant (no reader can observe
+  the atomic pointing past the buffer's newest step).
 - **Lock poisoning.** `run_vdf` already exits gracefully on a poisoned VDF lock
   (`crates/vdf/src/vdf.rs:83`); the supervisor must treat that as full shutdown, not
   a re-anchor.
@@ -246,7 +434,12 @@ Implemented:
   `issue_1447_unconfirmed_reset_seed_poisons_buffer_and_wedges_block_validation`
   already proves that crossing a boundary on a loser vs winner seed diverges the
   buffer, and that `vdf_steps_are_valid` rejects a poisoned buffer / accepts a clean
-  one. The re-anchor heals by rebuilding to a clean (winner/LCA) lineage.
+  one. The re-anchor heals by rebuilding to the **canonical-tip** lineage.
+- **Unit (vdf), fork-aware validation:** `vdf_step_batch_recomputes_on_buffer_mismatch`
+  (`crates/vdf/src/state.rs`) proves a poisoned buffer ACCEPTS an honest competing-fork block via
+  recompute-on-mismatch while a forged block is still rejected (§3, layer 1); plus
+  `build_vdf_seed_buffer_propagates_fetch_error` and `wait_for_step_tolerates_backward_reanchor_jump`
+  cover the fallible tip-rebuild and the backward-jump liveness handling.
 - **Integration (chain):** `heavy4_network_partition_recovery`
   (`crates/chain-tests/src/multi_node/partition_recovery.rs`) now exercises the
   re-anchor wiring end-to-end — recovery fires the signal, the supervisor rebuilds
@@ -254,34 +447,44 @@ Implemented:
   chain and continues mining afterward (the "continued operation after recovery"
   stage), proving the re-anchor does not wedge a live node.
 
-Attempted and shelved — a boundary-spanning multi-node test:
+- **End-to-end, boundary-spanning (the headline test):**
+  `heavy4_slow_partition_recovery_crosses_reset_boundary`
+  (`crates/chain-tests/src/multi_node/partition_recovery.rs`) is the live two-node test where a
+  fork **crosses a VDF reset boundary** before the deep reorg — so the recovering node's buffer
+  is genuinely poisoned and the re-anchor must reproduce the canonical reset seed. Both nodes
+  mine real forks past the poison boundary via natural mining; the peer's (longer) fork is
+  gossiped to genesis, triggering the deep reorg → re-anchor. It asserts:
 
-A live two-node test where the minority fork crosses a reset boundary before
-deep-reorging was prototyped and abandoned as structurally infeasible within the test
-suite's time budget (nextest terminates at 60s default / 120s for the `slow_` bucket).
-The obstacle is the #1449 confirmation gate itself, which is designed for large
-production reset windows:
+  - **(A) the heal** — genesis's VDF buffer over the boundary-crossing block's step range equals
+    the canonical chain's recorded steps. Because the re-anchor is applied **asynchronously**, this
+    is a **poll-until-converged** check (a bare `global_step >= last` wait would race the heal:
+    genesis's own free-ran buffer already sits past that step *before* the re-anchor lands). A
+    *persistent* mismatch after the full timeout is a genuine wedge.
+  - **(B) no wedge / continued operation** — after confirming genesis's VDF advances past the
+    recovered tip and settles (live, not wedged) and still holds the full adopted canonical chain,
+    the **peer** (canonical-fork miner) produces the next block and genesis **follows** it. This is
+    the production recovery path and sidesteps the [§4 residual mining race](#4-post-recovery-mining--reset-the-efficient-sampling-rotation)
+    (the peer's rotation is intact; genesis only *validates* the peer's block against its healed
+    buffer and fast-forwards). Deterministic and binding.
 
-- **Low `reset_frequency` wedges at startup.** The first block consumes ~45-76 VDF steps
-  of run-up; if `2 × reset_frequency` (the gate's park point) is below that, the VDF
-  parks before a second block can be produced, so no block migrates, `confirmed` never
-  advances, and the gate never releases. Measured: `reset_frequency = 24` deadlocks at
-  genesis; `reset_frequency = 60` is the rough floor.
-- **The single-block test miner can't cross a boundary.** `IrysNodeTest::mine_block`
-  (via `solution_context`) targets one future VDF step and waits; when the VDF parks at a
-  boundary it advances its target past the buffer and panics, because releasing the gate
-  requires producing *other* blocks first — a dependency one `mine_block` call cannot
-  satisfy.
-- **Continuous mining works but is too slow.** Switching to `mine_blocks_without_gossip`
-  (real continuous mining) crosses boundaries correctly — exactly as production does — but
-  the gate serializes each crossing behind migration confirmation, adding real latency per
-  boundary. Crossing ~2 boundaries on each of two forks plus the deep reorg ran ~190s,
-  well over the 120s ceiling.
+  Verified at **20/20** across the geometries natural mining produces (`peer_tip` 14 & 16, poison
+  boundary steps ~300–386). A clean run is ~28–31s.
 
-The heal is nonetheless covered in composition by the three tests above: the buffer
-divergence + validation reject/accept (`issue_1447_*`), the re-anchor trigger
-(`reanchor_signal_returns_reanchor_exit`), and the live reorg → re-anchor → rebuild →
-restart → continued-operation wiring (`heavy4_network_partition_recovery`). A dedicated
-boundary-spanning test would need either a test-only fast path that crosses boundaries
-without the migration-confirmation latency, or acceptance as a long-running
-(non-default-suite) test.
+  This was previously shelved as "structurally infeasible," which turned out to be **wrong**
+  — an artifact of the test harness, not the protocol. The earlier attempt funded but never
+  **staked/pledged** the peer, so the peer had no partition assignment, no packed mineable
+  data, and natural `mine_blocks` stalled; the fallback to forced capacity solutions
+  (`mine_block_without_gossip`) never calls `start_mining()`, so the peer's VDF never
+  free-ran and parked at the gated boundary (its confirmed step stuck at the LCA). The fix:
+  **provision the peer as a real miner** (stake → pledge → epoch assignment → pack) and use
+  **natural mining** — `mine_blocks` enables `start_mining()`, the VDF free-runs, partition
+  mining finds real PoA solutions, blocks validate → `mark_tip` → `confirmed_canonical_step`
+  advances → the #1449 gate releases, exactly as production crosses boundaries. The assigned
+  partition is entropy-packed, so its PoA solutions are data-independent and the recovering
+  node validates the canonical fork on reorg by recomputing entropy (no chunk-data sync).
+
+The heal is therefore covered both end-to-end (above) and in composition by the unit tests:
+the buffer divergence + validation reject/accept (`issue_1447_*`), the re-anchor trigger
+(`reanchor_signal_returns_reanchor_exit`), the DB-free tip-rebuild
+(`build_vdf_seed_buffer_reproduces_canonical_steps_anchored_at_tip`), and the live reorg →
+re-anchor → rebuild → restart → continued-operation wiring (`heavy4_network_partition_recovery`).

--- a/design/docs/vdf-partition-recovery-reanchor.md
+++ b/design/docs/vdf-partition-recovery-reanchor.md
@@ -283,8 +283,11 @@ current step* — exactly the boundary the VDF is about to cross. Plumbing:
 default `None`) → `BlockTree::canonical_entry_at_or_below_step`
 (`crates/domain/src/models/block_tree.rs`, an in-place binary search by `global_step_number` over
 the canonical-chain cache) → overridden in `BlockStatusProvider` (`crates/p2p/...`). `run_vdf`'s
-local-stepping read uses it and falls back to the tip's `next_seed` when no block ends at/before
-the step (the VDF running *ahead* of the chain — normal forward operation, a no-op).
+local-stepping read uses it: when the VDF runs *ahead* of the tip the query returns the tip itself
+(the greatest `global_step_number <= S` is the tip), yielding the tip's `next_seed` — equal to the
+prior behavior, a no-op. The `unwrap_or` fallback to the tip's `next_seed` is a defensive default
+for the distinct edge case where *no* canonical block ends at/before the step (the step is below the
+earliest cached block in the bounded canonical-chain cache).
 
 Two subtleties this resolves:
 


### PR DESCRIPTION
**Describe the changes**
A clear and concise description of what the bug fix, feature, or improvement is.

**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a controlled whole-process restart for deep network-partition recovery, with dedicated shutdown handling and a non-zero relaunch exit code.
* **Bug Fixes**
  * Reduced unnecessary restarts by triggering recovery only when the VDF “reset boundary” is truly crossed (with a small safety margin).
  * Improved recall-range validation to always use fork-local VDF lineage; unavailable data now requeues instead of being treated as invalid.
* **Documentation**
  * Updated the VDF partition-recovery design to reflect restart-based healing (no in-place re-anchoring).
* **Tests**
  * Replaced the re-anchor regression test with a restart-and-convergence verification flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->