### PR TITLE
fix(consensus): fork-safe canonical metadata lookups + reorg-floor prevalidation cap

### DIFF
--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -969,6 +969,10 @@ pub(crate) fn resolve_promoted_on_branch(
     // reorg floor, where MBH (and thus `canonical_promoted_height`) is
     // branch-invariant. Cap strictly below the window so a reorg-mutable height
     // can never be trusted here — the walk already covered that band by hash.
+    // (The validator's sibling fallback in `data_txs_are_valid` caps the same
+    // way — strictly below its own walk window, not just at the reorg floor.
+    // Keep the two cap forms in sync when the walk depth or reorg ceiling
+    // changes.)
     if !remaining.is_empty() {
         let max_height = walk_min_height.saturating_sub(1);
         db.view_eyre(|tx| {

--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -61,7 +61,7 @@ use crate::block_ancestry::{block_header_from_tree_then_db, walk_ancestors_tree_
 use crate::block_discovery::get_data_tx_in_parallel;
 use crate::mempool_guard::MempoolReadGuard;
 use crate::shadow_tx_generator::RollingHash;
-use eyre::{OptionExt as _, eyre};
+use eyre::{OptionExt as _, ensure, eyre};
 use irys_database::{
     canonical_promoted_height, canonical_submit_height, db::IrysDatabaseExt as _,
     reth_db::transaction::DbTx as _, tables::MigratedBlockHashes,
@@ -1340,8 +1340,20 @@ fn find_block_range(
             // so it is exactly the next block's first offset. The old `+ 1` here
             // skipped that boundary chunk, so a block whose first chunk landed on a
             // slot boundary was never resolved — silently dropping its expired txs
-            // from the refund/fee walk (NC-0042). `block_total > chunk_offset`
-            // always (the offset lies within this block), so progress is guaranteed.
+            // from the refund/fee walk (NC-0042). A well-formed index always has
+            // `block_total > chunk_offset` (the offset lies within this block);
+            // fail loud on a corrupted index instead of spinning forever on a
+            // non-advancing probe.
+            ensure!(
+                block_total > chunk_offset,
+                "non-advancing block-index probe in {:?} ledger: block at height {} \
+                 resolved for chunk offset {} has cumulative total {} (must exceed \
+                 the probed offset) — corrupted ledger index",
+                ledger_type,
+                height,
+                chunk_offset,
+                block_total,
+            );
             chunk_offset = block_total.min(*chunk_range.end());
         }
     }

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -5599,12 +5599,17 @@ pub async fn data_txs_are_valid(
                         // node's own chain, not the candidate's branch — trusting
                         // it there lets nodes that saw a sibling-branch inclusion
                         // decide validity differently from nodes that did not,
-                        // which forks the network. So we cap the fallback at the
-                        // reorg floor (`block.height - block_tree_depth`): the walk
-                        // owns the reorg window by hash, and only finalized rows —
-                        // where MBH is branch-invariant — reach the fallback. This
-                        // cap is what makes "any row consulted here is finalized"
-                        // true; it does not follow from the walk width alone.
+                        // which forks the network. So we cap the fallback strictly
+                        // BELOW the by-hash walk window (`block.height -
+                        // prior_inclusion_walk_depth(config) - 1`): the fallback
+                        // never consults a height the walk already owns, and since
+                        // this arm is reached only in `Searching` state — the walk
+                        // found no inclusion on the candidate's branch anywhere in
+                        // the window — every row the fallback can still see sits
+                        // outside the window and is therefore finalized and
+                        // branch-invariant. This is what makes "any row consulted
+                        // here is finalized" true; it does not follow from the
+                        // walk width alone.
                         //
                         // `canonical_submit_height` is sufficient evidence of
                         // prior Submit: the structural pre-pass guarantees
@@ -5624,12 +5629,18 @@ pub async fn data_txs_are_valid(
                         // window is already surfaced as `Found` by the walk, so
                         // only a finalized, content-verified prior promotion
                         // reaches here.
-                        let reorg_floor = block
+                        //
+                        // Sibling: `ledger_expiry::resolve_promoted_on_branch` caps
+                        // its finalized fallback the same way — strictly below its
+                        // own by-hash walk window. Keep the two cap forms in sync
+                        // if the walk depth or reorg ceiling changes.
+                        let fallback_cap = block
                             .height
-                            .saturating_sub(config.consensus.block_tree_depth);
+                            .saturating_sub(prior_inclusion_walk_depth(config))
+                            .saturating_sub(1);
 
                         let submit_lookup =
-                            canonical_submit_height(&ro_tx, &tx.id, reorg_floor).map_err(|e| {
+                            canonical_submit_height(&ro_tx, &tx.id, fallback_cap).map_err(|e| {
                                 error!(
                                     "canonical_submit_height DB error for tx {}: {}",
                                     &tx.id, &e
@@ -5647,7 +5658,7 @@ pub async fn data_txs_are_valid(
                         }
 
                         let promoted_lookup =
-                            canonical_promoted_height(&ro_tx, &tx.id, reorg_floor).map_err(
+                            canonical_promoted_height(&ro_tx, &tx.id, fallback_cap).map_err(
                                 |e| {
                                     error!(
                                         "canonical_promoted_height DB error for tx {}: {}",
@@ -5691,8 +5702,8 @@ pub async fn data_txs_are_valid(
 
                         warn!(
                             tx.id = %tx.id,
-                            reorg_floor,
-                            "submit inclusion outside inclusion-history walk window; resolved via canonical DB index below the reorg floor"
+                            fallback_cap,
+                            "submit inclusion outside inclusion-history walk window; resolved via canonical DB index below the inclusion-history walk window"
                         );
                     }
                     DataLedger::Submit => {
@@ -6318,9 +6329,9 @@ pub(crate) fn prior_inclusion_walk_depth(config: &Config) -> u64 {
 ///    deep reorgs moved from `block_migration_depth` to `block_tree_depth`.
 ///    Walking the full reorg window resolves every in-window inclusion on the
 ///    candidate's own branch by-hash; the fallback then caps its by-height
-///    lookups at the reorg floor so a node-local row inside the reorg-mutable
-///    band can never decide validity. Together the two cover [0, block.height)
-///    with no gap: finalized heights by-height, the reorg window by-hash.
+///    lookups strictly below the walk window (`block.height - walk_depth -
+///    1`), so the two paths cover `[0, block.height)` with no gap and no
+///    shared height: finalized heights by-height, the walk window by-hash.
 ///
 /// (Config invariant `tx_anchor_expiry_depth ≤ block_tree_depth` makes #2 the
 /// binding term in production; `max(...)` keeps the walk correct for test configs

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -5584,46 +5584,52 @@ pub async fn data_txs_are_valid(
             TxInclusionState::Searching { ledger_current } => {
                 match ledger_current {
                     DataLedger::Publish => {
-                        // Prior Submit/promotion was deeper than the by-hash
-                        // inclusion walk above — which now covers the full reorg
-                        // window (max(tx_anchor_expiry_depth, block_tree_depth)).
-                        // So any inclusion reaching this fallback is BELOW the
-                        // reorg floor: finalized, hence branch-invariant, so the
-                        // canonical-height getters in `irys_database`
-                        // (metadata hint + `MigratedBlockHashes`) resolve it
-                        // identically on every node/branch. (Before the walk was
-                        // widened, this arm could run inside the reorg-mutable
-                        // `(tip - block_tree_depth, tip - block_migration_depth]`
-                        // band and fork — widening the walk to the reorg window is
-                        // exactly what makes this fallback safe; see the
-                        // `get_previous_tx_inclusions` docblock.) As a further
-                        // guard, both getters content-verify the hint against the
-                        // canonical block at the returned height, so a stranded
-                        // metadata row not backed by that block's ledger — e.g. a
-                        // legacy row from an orphaned tip written at depth-0
-                        // confirmation before canonical metadata became
-                        // migration-only, possibly surviving a restart-interrupted
-                        // reorg — cannot yield a false `PublishTxMissingPriorSubmit`
-                        // or `PublishTxAlreadyIncluded`.
+                        // The by-hash inclusion walk above covers the full reorg
+                        // window (max(tx_anchor_expiry_depth, block_tree_depth))
+                        // on THIS candidate's own branch. Any prior Submit or
+                        // promotion on the candidate's branch is therefore already
+                        // resolved by the walk; a tx reaching this fallback has no
+                        // such inclusion within the reorg window of its branch.
+                        //
+                        // The canonical-height getters answer from node-LOCAL
+                        // state (metadata hint + `MigratedBlockHashes`), which is
+                        // only branch-invariant BELOW the reorg floor. In the
+                        // reorg-mutable band `(tip - block_tree_depth, tip -
+                        // block_migration_depth]` a node-local row describes this
+                        // node's own chain, not the candidate's branch — trusting
+                        // it there lets nodes that saw a sibling-branch inclusion
+                        // decide validity differently from nodes that did not,
+                        // which forks the network. So we cap the fallback at the
+                        // reorg floor (`block.height - block_tree_depth`): the walk
+                        // owns the reorg window by hash, and only finalized rows —
+                        // where MBH is branch-invariant — reach the fallback. This
+                        // cap is what makes "any row consulted here is finalized"
+                        // true; it does not follow from the walk width alone.
                         //
                         // `canonical_submit_height` is sufficient evidence of
                         // prior Submit: the structural pre-pass guarantees
                         // `tx.ledger_id == Publish`, and term ledgers reject
-                        // `ledger_id == Publish`, so the only term ledger that
-                        // could have produced an `included_height` is Submit. An
-                        // MDBX I/O failure is a local fault surfaced as
+                        // `ledger_id == Publish`, so the only ledger that could
+                        // have produced an `included_height` is Submit. The
+                        // lookup's content check further requires the finalized
+                        // block to actually carry the tx in Submit, so a stranded
+                        // row reads as "no prior Submit" (Ok(None)) rather than a
+                        // false accept. An MDBX I/O failure or a missing header for a
+                        // canonical MBH row is a local fault surfaced as
                         // `BlockBoundsLookupError` (classified `NodeFault`, so the
                         // caller aborts rather than peer-attributing the DB error).
                         //
                         // The `canonical_promoted_height` rejection below is
                         // defense-in-depth: a prior promotion within the reorg
                         // window is already surfaced as `Found` by the walk, so
-                        // only a finalized prior promotion reaches here — where MBH
-                        // is branch-invariant.
-                        let parent_height = block.height.saturating_sub(1);
+                        // only a finalized, content-verified prior promotion
+                        // reaches here.
+                        let reorg_floor = block
+                            .height
+                            .saturating_sub(config.consensus.block_tree_depth);
 
                         let submit_lookup =
-                            canonical_submit_height(&ro_tx, &tx.id, parent_height).map_err(|e| {
+                            canonical_submit_height(&ro_tx, &tx.id, reorg_floor).map_err(|e| {
                                 error!(
                                     "canonical_submit_height DB error for tx {}: {}",
                                     &tx.id, &e
@@ -5641,7 +5647,7 @@ pub async fn data_txs_are_valid(
                         }
 
                         let promoted_lookup =
-                            canonical_promoted_height(&ro_tx, &tx.id, parent_height).map_err(
+                            canonical_promoted_height(&ro_tx, &tx.id, reorg_floor).map_err(
                                 |e| {
                                     error!(
                                         "canonical_promoted_height DB error for tx {}: {}",
@@ -5654,12 +5660,13 @@ pub async fn data_txs_are_valid(
                                 },
                             )?;
                         if let Some(promoted_height) = promoted_lookup {
-                            // `canonical_promoted_height` already attested
-                            // `MBH[promoted_height] = Some` inside this
-                            // snapshot; a missing row on re-read would mean
-                            // MDBX returned a different value for the same
-                            // key within one read tx — cross-table
-                            // corruption, surfaced as NodeFault.
+                            // `canonical_promoted_height` already loaded the header
+                            // MBH names at `promoted_height` and content-verified
+                            // the Publish inclusion inside this snapshot; re-read
+                            // MBH only to name the offending block in the reject.
+                            // A missing row on re-read would mean MDBX returned a
+                            // different value for the same key within one read tx —
+                            // cross-table corruption, surfaced as NodeFault.
                             let promoted_block_hash = ro_tx
                                 .get::<MigratedBlockHashes>(promoted_height)
                                 .map_err(|e| {
@@ -5684,8 +5691,8 @@ pub async fn data_txs_are_valid(
 
                         warn!(
                             tx.id = %tx.id,
-                            parent_height,
-                            "submit inclusion outside inclusion-history walk window; resolved via canonical DB index"
+                            reorg_floor,
+                            "submit inclusion outside inclusion-history walk window; resolved via canonical DB index below the reorg floor"
                         );
                     }
                     DataLedger::Submit => {
@@ -6309,8 +6316,11 @@ pub(crate) fn prior_inclusion_walk_depth(config: &Config) -> u64 {
 ///    index/MBH shortcut (the `Searching { ledger_current: Publish }` arm in
 ///    `data_txs_are_valid`) is only branch-invariant BELOW the reorg floor, which
 ///    deep reorgs moved from `block_migration_depth` to `block_tree_depth`.
-///    Walking the full reorg window guarantees that fallback is reached only for
-///    *finalized* inclusions, where node-canonical == every branch.
+///    Walking the full reorg window resolves every in-window inclusion on the
+///    candidate's own branch by-hash; the fallback then caps its by-height
+///    lookups at the reorg floor so a node-local row inside the reorg-mutable
+///    band can never decide validity. Together the two cover [0, block.height)
+///    with no gap: finalized heights by-height, the reorg window by-hash.
 ///
 /// (Config invariant `tx_anchor_expiry_depth ≤ block_tree_depth` makes #2 the
 /// binding term in production; `max(...)` keeps the walk correct for test configs

--- a/crates/actors/src/tx_selector/mod.rs
+++ b/crates/actors/src/tx_selector/mod.rs
@@ -16,8 +16,8 @@ use irys_database::{
     ingress_proofs_by_data_root, tx_header_by_txid,
 };
 use irys_domain::{
-    BlockIndex, BlockTreeEntry, BlockTreeReadGuard, ChainState, CommitmentSnapshotStatus,
-    EpochSnapshot, HardforkConfigExt as _,
+    BlockIndex, BlockTreeEntry, BlockTreeReadGuard, CommitmentSnapshotStatus, EpochSnapshot,
+    HardforkConfigExt as _,
 };
 use irys_reth_node_bridge::IrysRethNodeAdapter;
 use irys_types::ingress::{CachedIngressProof, IngressProof};
@@ -111,7 +111,6 @@ pub async fn select_best_txs(
 
     let (
         canonical,
-        onchain_block_hashes,
         parent_block_height,
         tip_block_height,
         parent_evm_block_id,
@@ -156,23 +155,20 @@ pub async fn select_best_txs(
             .expect("canonical chain always has at least one entry")
             .height();
 
-        // Dedup against `Onchain`-only ancestors, matching
-        // `tx_inclusion::lookup_via_block_tree`. During reorg replay a canonical
-        // entry can transiently be `Validated` before the longest-chain walk
-        // promotes it; its tx_ids may be about to roll back, so counting them in
-        // the commitment/Submit dedup sets below can drop a tx that should stay
-        // includable. The parent block itself is still used for the header lookup
-        // regardless of state, so this only narrows the dedup sets.
-        let onchain_block_hashes: HashSet<BlockHash> = canonical
-            .iter()
-            .filter(|entry| {
-                matches!(
-                    tree.get_block_and_status(&entry.block_hash()),
-                    Some((_, ChainState::Onchain))
-                )
-            })
-            .map(BlockTreeEntry::block_hash)
-            .collect();
+        // The commitment/Submit dedup sets below iterate `canonical`
+        // (`full_canonical[..=parent_pos]`) directly, i.e. every ancestor of the
+        // parent we build on. We must NOT narrow this to `Onchain`-only entries:
+        // the validator dedups against the parent ancestry BY HASH regardless of
+        // `ChainState` (`commitment_dedup::ancestor_commitment_tx_ids` and
+        // `data_txs_are_valid`'s inclusion walk both follow `previous_block_hash`,
+        // not chain state). During reorg replay an in-window ancestor can
+        // transiently be `Validated` before the longest-chain walk promotes it; if
+        // the producer skipped it here while the validator still saw it by hash,
+        // the producer would re-select a tx the validator rejects
+        // (`DuplicateCommitmentTransaction` / double-publish). Deduping against the
+        // full parent ancestry keeps the producer symmetric with the validator.
+        // (An ancestor that later rolls back takes the parent with it, so the
+        // whole production attempt is on a doomed branch and self-corrects.)
 
         let block = tree
             .get_block(&parent_block_hash)
@@ -200,7 +196,6 @@ pub async fn select_best_txs(
 
         (
             canonical,
-            onchain_block_hashes,
             block_height,
             tip_block_height,
             evm_block_id,
@@ -246,15 +241,12 @@ pub async fn select_best_txs(
         "Starting mempool transaction selection"
     );
 
-    // Collect confirmed commitment transactions from canonical chain to avoid
-    // duplicates. Restricted to `Onchain` ancestors (`onchain_block_hashes`): a
-    // transiently-`Validated` entry's commitments may be about to roll back under
-    // reorg replay, so deduping against them could drop a commitment that should
-    // stay includable.
-    for entry in canonical
-        .iter()
-        .filter(|entry| onchain_block_hashes.contains(&entry.block_hash()))
-    {
+    // Collect confirmed commitment transactions from the parent ancestry to
+    // avoid duplicates. Iterates every entry in `canonical` (all ancestors of the
+    // parent) regardless of `ChainState` — matching the validator's by-hash
+    // replay-dedup walk (`commitment_dedup::ancestor_commitment_tx_ids`). See the
+    // rationale where `canonical` is built.
+    for entry in canonical.iter() {
         let commitment_ledger = entry
             .header()
             .system_ledgers
@@ -782,7 +774,6 @@ pub async fn select_best_txs(
     let publish_txs_and_proofs = get_publish_txs_and_proofs(
         ctx,
         &canonical,
-        &onchain_block_hashes,
         current_height,
         current_timestamp,
         &parent_epoch_snapshot,
@@ -855,7 +846,6 @@ pub async fn select_best_txs(
 async fn get_publish_txs_and_proofs(
     ctx: &TxSelectionContext<'_>,
     canonical: &[BlockTreeEntry],
-    onchain_block_hashes: &HashSet<BlockHash>,
     current_height: u64,
     current_timestamp: UnixTimestamp,
     epoch_snapshot: &Arc<EpochSnapshot>,
@@ -970,20 +960,18 @@ async fn get_publish_txs_and_proofs(
                 .is_none_or(|cdr| !cdr.data_size_confirmed || tx.data_size == cdr.data_size)
         });
 
-        // Reduce down the canonical chain to the txs in the Submit ledger — the
-        // fast-path prior-Submit gate for publish candidates. Restricted to
-        // `Onchain` ancestors (`onchain_block_hashes`): a transiently-`Validated`
-        // entry's Submit inclusion may be about to roll back under reorg replay,
-        // so counting it here would let the gate say "already submitted" for a tx
-        // whose Submit is not durable. A miss simply falls through to the
-        // content-verified `canonical_submit_height` DB check below.
-        let submit_txs_from_canonical = canonical
-            .iter()
-            .filter(|v| onchain_block_hashes.contains(&v.block_hash()))
-            .fold(HashSet::new(), |mut acc, v| {
-                acc.extend(v.header().data_ledgers[DataLedger::Submit].tx_ids.0.clone());
-                acc
-            });
+        // Reduce down the parent ancestry to the txs in the Submit ledger — the
+        // fast-path prior-Submit gate for publish candidates. Iterates every
+        // entry in `canonical` (all ancestors of the parent) regardless of
+        // `ChainState`, matching the validator's by-hash inclusion walk; skipping
+        // a transiently-`Validated` ancestor here would drop a genuine prior
+        // Submit and make the producer promote a tx the validator rejects. A miss
+        // still falls through to the content-verified `canonical_submit_height` DB
+        // check below.
+        let submit_txs_from_canonical = canonical.iter().fold(HashSet::new(), |mut acc, v| {
+            acc.extend(v.header().data_ledgers[DataLedger::Submit].tx_ids.0.clone());
+            acc
+        });
 
         // NC-0042 §4b: the expired-Submit range is the same for every candidate,
         // so compute it once here and reuse it per-candidate via `submit_tx_expired`

--- a/crates/chain-tests/src/block_production/block_validation.rs
+++ b/crates/chain-tests/src/block_production/block_validation.rs
@@ -1254,7 +1254,7 @@ async fn test_prevalidation_ignores_content_verified_row_inside_walk_window() ->
     // A Publish-ledger tx that will impersonate "already canonically
     // included/promoted" via the fabricated in-window prior seeded below.
     let mut tx = DataTransactionHeader::new(&ctx.config.consensus_config());
-    tx.data_root = H256::from_low_u64_be(0x1_1DE_1DE_5EED);
+    tx.data_root = H256::from_low_u64_be(0x011D_E1DE_5EED);
     tx.data_size = 0;
     tx.term_fee = BoundedFee::from_u64(1_000_000_000_000_000_000);
     tx.perm_fee = Some(BoundedFee::from_u64(1_000_000_000_000_000_000));

--- a/crates/chain-tests/src/block_production/block_validation.rs
+++ b/crates/chain-tests/src/block_production/block_validation.rs
@@ -759,34 +759,46 @@ async fn test_prevalidation_rejects_too_many_commitment_txs() -> Result<()> {
 /// `PublishTxAlreadyIncluded` — never fires because the prior Publish is
 /// past the scan window.  Without a `promoted_height` check in the fallback,
 /// the canonical-DB lookup would accept the tx (warns + continues) and the
-/// peer would succeed in re-publishing.  The fix is to inspect the
-/// metadata's `promoted_height` and reject when set to a migrated height
-/// ≤ parent_height.
+/// peer would succeed in re-publishing.  The fix is to reject when the
+/// canonical lookup content-verifies a prior promotion below the walk
+/// window.
 ///
-/// **Test driver:** force the in-window walk to be empty by overriding
-/// `tx_anchor_expiry_depth = 0`, then construct a Publish-ledger block whose
-/// tx already has both `included_height` and `promoted_height` set in
-/// `IrysDataTxMetadata` (with matching `MigratedBlockHashes` rows).  Expect
-/// `Err(PublishTxAlreadyIncluded { tx_id, block_hash })` matching the
-/// pre-populated promoted block hash.
+/// **Test driver:** mine to height 3, then validate a sibling candidate at
+/// height 3 (parent = the real block 2) under an override of
+/// `tx_anchor_expiry_depth = 0` and `block_tree_depth = 1`.  The by-hash
+/// walk (depth `max(0, 1) = 1`) then covers exactly the real, tx-free block
+/// 2 on the candidate's own branch, so the tx stays `Searching` and the
+/// canonical-DB fallback owns the heights below the window.  The canonical
+/// prior is a fabricated finalized block at height 1 — stored as a real
+/// header carrying the tx in both Submit and Publish, and pointed at by
+/// `MigratedBlockHashes[1]` — so both canonical lookups content-verify
+/// against it.  Expect `Err(PublishTxAlreadyIncluded { tx_id, block_hash })`
+/// naming the fabricated promoted block.
 #[tokio::test]
 async fn test_prevalidation_rejects_doubly_published_tx_via_fallback() -> Result<()> {
     use irys_database::db::IrysDatabaseExt as _;
+    use irys_database::tables::MigratedBlockHashes;
     use irys_database::{
-        insert_tx_header, set_data_tx_included_height, set_data_tx_promoted_height,
+        insert_block_header, insert_tx_header, set_data_tx_included_height,
+        set_data_tx_promoted_height,
     };
-    use irys_types::H256List;
+    use irys_types::{BlockBody, H256List};
+    use reth_db::transaction::DbTxMut as _;
 
     let ctx = PrevalidationTestContext::new().await?;
 
-    // `PrevalidationTestContext` lands `ctx.block` at height 1 (parent =
-    // genesis at height 0), so the bad block we'll build below has
-    // `parent_height = 0`.  Both `included_height` and `promoted_height`
-    // must be ≤ 0 for the fallback to consider the tx "already canonical";
-    // we collapse both onto the height-0 canonical row.
+    // Extend the chain so a content-verified canonical prior can sit BELOW
+    // the by-hash walk window.  `ctx.block` was produced without broadcast
+    // and never lands on-chain, so the tip is still genesis; mine three real
+    // blocks to put the tip at height 3.  With the walk-depth override below
+    // (`max(tx_anchor_expiry_depth = 0, block_tree_depth = 1) = 1`) the walk
+    // for a height-3 candidate covers exactly the real, tx-free block 2,
+    // leaving height 1 to the canonical-DB fallback.
+    ctx.node.mine_blocks(3).await?;
+    let real_tip = ctx.node.get_block_by_height(3).await?;
 
     // A Publish-ledger tx that will impersonate "already canonically
-    // promoted" via the pre-populated metadata below.
+    // promoted" via the fabricated finalized prior seeded below.
     let mut tx = DataTransactionHeader::new(&ctx.config.consensus_config());
     tx.data_root = H256::from_low_u64_be(0x517A_1EBA_DD15);
     tx.data_size = 0;
@@ -797,36 +809,38 @@ async fn test_prevalidation_rejects_doubly_published_tx_via_fallback() -> Result
         .sign(&ctx.config.signer())
         .expect("Failed to sign test transaction");
 
-    // Pre-populate canonical metadata: tx was Submit-included AND
-    // Publish-promoted at height 0 (same-block promotion).  Because the
-    // canonical helpers now content-verify the hint against the canonical
-    // block at the height, genesis (which carries no data txs) can't back
-    // this fixture; supply a synthetic canonical block at height 0 that
-    // carries the tx in BOTH ledgers and repoint `MigratedBlockHashes[0]`.
-    let prior_submit_height = 0_u64;
-    let prior_publish_height = 0_u64;
-    let prior_block_hash = crate::utils::plant_canonical_block(
-        &ctx.node.node_ctx.db,
-        0,
-        vec![
-            (DataLedger::Submit, vec![tx.id]),
-            (DataLedger::Publish, vec![tx.id]),
-        ],
-    )?;
+    // Fabricated finalized prior at height 1, NOT on the candidate's
+    // ancestry: a real header carrying the tx in BOTH Submit and Publish
+    // (same-block promotion), pointed at by `MigratedBlockHashes[1]`.
+    // `canonical_submit_height` / `canonical_promoted_height` load the block
+    // MBH names at the hinted height and content-verify ledger membership,
+    // so the header must genuinely carry the tx — a bare metadata hint would
+    // read as a stranded row and resolve to None.  (At tip height 3 with
+    // testing `block_migration_depth = 6` no post-genesis block has
+    // migrated, so the MBH[1] write collides with nothing.)  Below the walk
+    // window this MBH-keyed, content-verified row IS the canonical answer —
+    // exactly the regime the fallback is designed for.
+    let prior_height = 1_u64;
+    let mut prior_block = IrysBlockHeader::new_mock_header();
+    prior_block.height = prior_height;
+    prior_block.block_hash = H256::random();
+    prior_block.data_ledgers[DataLedger::Submit].tx_ids = H256List(vec![tx.id]);
+    prior_block.data_ledgers[DataLedger::Publish].tx_ids = H256List(vec![tx.id]);
+    let promoted_block_hash = prior_block.block_hash;
+
     ctx.node.node_ctx.db.update_eyre(|db_tx| {
         insert_tx_header(db_tx, &tx)?;
-        set_data_tx_included_height(db_tx, &tx.id, prior_submit_height)?;
-        set_data_tx_promoted_height(db_tx, &tx.id, prior_publish_height)?;
+        set_data_tx_included_height(db_tx, &tx.id, prior_height)?;
+        set_data_tx_promoted_height(db_tx, &tx.id, prior_height)?;
+        insert_block_header(db_tx, &prior_block)?;
+        db_tx.put::<MigratedBlockHashes>(prior_height, promoted_block_hash)?;
         Ok(())
     })?;
 
-    // Build a block whose Publish ledger re-includes `tx`.  Mirror the
-    // pattern from `test_prevalidation_rejects_submit_targeted_tx`: keep
-    // ctx.block as the structural baseline and swap the data ledgers.
-    let mut body = ctx.block.to_block_body();
-    body.data_transactions = vec![tx.clone()];
-
-    let mut header = (**ctx.block.header()).clone();
+    // Build a sibling candidate at height 3 (parent = the real block 2)
+    // whose Publish ledger re-includes `tx`: clone the real height-3 header
+    // as the structural baseline and swap the data ledgers.
+    let mut header = real_tip.clone();
     let publish_ledger = header
         .data_ledgers
         .iter_mut()
@@ -841,7 +855,11 @@ async fn test_prevalidation_rejects_doubly_published_tx_via_fallback() -> Result
     submit_ledger.tx_ids = H256List(Vec::new());
 
     ctx.config.signer().sign_block_header(&mut header)?;
-    body.block_hash = header.block_hash;
+    let body = BlockBody {
+        block_hash: header.block_hash,
+        data_transactions: vec![tx.clone()],
+        commitment_transactions: Vec::new(),
+    };
     let bad_block = Arc::new(SealedBlock::new(header, body)?);
 
     {
@@ -875,11 +893,15 @@ async fn test_prevalidation_rejects_doubly_published_tx_via_fallback() -> Result
         }
     });
 
-    // `tx_anchor_expiry_depth = 0` collapses the in-window walk to zero
-    // blocks, forcing every Publish-ledger tx to take the canonical-DB
-    // fallback path that this regression exists to cover.
+    // Walk-depth override: `max(tx_anchor_expiry_depth = 0, block_tree_depth
+    // = 1) = 1`, so the by-hash walk for the height-3 candidate covers
+    // exactly the real, tx-free block 2 on its own branch — the tx stays
+    // `Searching` and the canonical-DB fallback (which owns the heights
+    // below the walk window, where the fabricated prior at height 1 lives)
+    // is the path this regression exists to cover.
     let mut consensus = ctx.config.consensus_config();
     consensus.mempool.tx_anchor_expiry_depth = 0;
+    consensus.block_tree_depth = 1;
     let mut node_config = ctx.config.clone();
     node_config.consensus = ConsensusOptions::Custom(consensus);
     let config_override = Config::new_with_random_peer_id(node_config);
@@ -914,8 +936,8 @@ async fn test_prevalidation_rejects_doubly_published_tx_via_fallback() -> Result
         Err(PreValidationError::PublishTxAlreadyIncluded { tx_id, block_hash }) => {
             assert_eq!(tx_id, tx.id, "rejection must name the doubly-published tx");
             assert_eq!(
-                block_hash, prior_block_hash,
-                "rejection must surface the canonical promoted-block hash from MigratedBlockHashes (the planted height-0 block)"
+                block_hash, promoted_block_hash,
+                "rejection must surface the canonical promoted-block hash from MigratedBlockHashes (= the fabricated height-1 prior in this fixture)"
             );
         }
         other => panic!(
@@ -940,17 +962,20 @@ async fn test_prevalidation_rejects_doubly_published_tx_via_fallback() -> Result
 /// falls through to warn-and-accept the current Publish as a legitimate
 /// first promotion.
 ///
-/// **Harness scope.** `PrevalidationTestContext` lands `parent_height = 0`,
-/// and `MigratedBlockHashes[0]` is populated by node init — so the exact
-/// "stranded within validator's window" geometry from the production fault
-/// (MBH disagreement at a height ≤ parent_height) cannot be reproduced
-/// here without reaching for a deeper chain.  That branch is covered
-/// directly at the helper boundary by
-/// `database::canonical_height_tests::promoted_height_returns_none_when_mbh_disagrees`.
-/// This test exercises the same end-to-end fall-through via the orthogonal
-/// `promoted_height > max_height` rejection: both branches surface
-/// `canonical_promoted_height = None` to the validator, so the downstream
-/// behaviour is shared.
+/// **Harness scope.** The fixture mines to height 3 and validates a sibling
+/// candidate at height 3 under a walk-depth override
+/// (`max(tx_anchor_expiry_depth = 0, block_tree_depth = 1) = 1`), so the
+/// by-hash walk covers exactly the real, tx-free block 2 and the tx stays
+/// `Searching`.  The prior Submit is a fabricated finalized block at height
+/// 1 (below the walk window, content-verified via `MigratedBlockHashes[1]`)
+/// so the fallback's Submit gate passes; the stranded `promoted_height = 3`
+/// exceeds the fallback's height cap, so the hint is stripped by the
+/// `max_height` check before MBH is even consulted.  The exact "MBH
+/// disagreement" strip branch from the production fault is covered directly
+/// at the helper boundary by
+/// `database::canonical_height_tests::promoted_height_returns_none_when_mbh_disagrees`;
+/// both branches surface `canonical_promoted_height = None` to the
+/// validator, so the downstream behaviour is shared.
 ///
 /// **What this asserts.** That the validator does NOT regress to any of:
 /// `BlockBoundsLookupError` (pre-fix panic-then-restart),
@@ -965,15 +990,26 @@ async fn test_prevalidation_rejects_doubly_published_tx_via_fallback() -> Result
 #[test_log::test(tokio::test)]
 async fn test_prevalidation_accepts_publish_when_promoted_height_hint_stripped() -> Result<()> {
     use irys_database::db::IrysDatabaseExt as _;
+    use irys_database::tables::MigratedBlockHashes;
     use irys_database::{
-        insert_tx_header, set_data_tx_included_height, set_data_tx_promoted_height,
+        insert_block_header, insert_tx_header, set_data_tx_included_height,
+        set_data_tx_promoted_height,
     };
-    use irys_types::H256List;
+    use irys_types::{BlockBody, H256List};
+    use reth_db::transaction::DbTxMut as _;
 
     let ctx = PrevalidationTestContext::new().await?;
 
+    // Same geometry as the sibling regression test: extend the chain (the
+    // context's unbroadcast block never lands on-chain, so mine three real
+    // blocks to reach height 3) so a content-verified prior Submit can sit
+    // BELOW the by-hash walk window (which, under the override below, covers
+    // exactly the real block 2 for a height-3 candidate).
+    ctx.node.mine_blocks(3).await?;
+    let real_tip = ctx.node.get_block_by_height(3).await?;
+
     // A Publish-ledger tx whose `IrysDataTxMetadata` will carry a
-    // `promoted_height` the canonical helper cannot confirm via MBH.
+    // `promoted_height` the canonical helper must strip.
     let mut tx = DataTransactionHeader::new(&ctx.config.consensus_config());
     tx.data_root = H256::from_low_u64_be(0xDEAD_BEEF_C0DE);
     tx.data_size = 0;
@@ -984,36 +1020,35 @@ async fn test_prevalidation_accepts_publish_when_promoted_height_hint_stripped()
         .sign(&ctx.config.signer())
         .expect("Failed to sign test transaction");
 
-    // Canonical Submit at height 0 — supply a synthetic canonical block that
-    // carries the tx in its Submit ledger and repoint `MigratedBlockHashes[0]`,
-    // so `canonical_submit_height` (now content-verified) attests it and control
-    // flow reaches the promoted-height check. Stranded `promoted_height = 1` is
-    // stripped by the canonical helper (parent_height = 0, so
-    // `promoted_height > max_height` triggers the strip — orthogonal to the
-    // MBH-None-within-window strip but produces the same stripped metadata).
-    let prior_submit_height = 0_u64;
-    let stranded_promote_height = 1_u64;
-    let _prior_block_hash = crate::utils::plant_canonical_block(
-        &ctx.node.node_ctx.db,
-        0,
-        vec![
-            (DataLedger::Submit, vec![tx.id]),
-            (DataLedger::Publish, vec![]),
-        ],
-    )?;
+    // Canonical prior Submit: a fabricated finalized block at height 1
+    // (below the walk window) carrying the tx in its Submit ledger ONLY,
+    // pointed at by `MigratedBlockHashes[1]`, so `canonical_submit_height`
+    // content-verifies it and the fallback's Submit gate passes.  The
+    // stranded `promoted_height = 3` exceeds the fallback's height cap, so
+    // the canonical helper strips it via the `max_height` check (before MBH
+    // is even consulted — orthogonal to the MBH-None strip but producing
+    // the same stripped metadata).
+    let prior_submit_height = 1_u64;
+    let stranded_promote_height = 3_u64;
+    let mut prior_block = IrysBlockHeader::new_mock_header();
+    prior_block.height = prior_submit_height;
+    prior_block.block_hash = H256::random();
+    prior_block.data_ledgers[DataLedger::Submit].tx_ids = H256List(vec![tx.id]);
+    let prior_block_hash = prior_block.block_hash;
+
     ctx.node.node_ctx.db.update_eyre(|db_tx| {
         insert_tx_header(db_tx, &tx)?;
         set_data_tx_included_height(db_tx, &tx.id, prior_submit_height)?;
         set_data_tx_promoted_height(db_tx, &tx.id, stranded_promote_height)?;
+        insert_block_header(db_tx, &prior_block)?;
+        db_tx.put::<MigratedBlockHashes>(prior_submit_height, prior_block_hash)?;
         Ok(())
     })?;
 
-    // Same block shape as the sibling regression test: re-include the tx
-    // on the Publish ledger of a sibling-of-ctx.block at height 1.
-    let mut body = ctx.block.to_block_body();
-    body.data_transactions = vec![tx.clone()];
-
-    let mut header = (**ctx.block.header()).clone();
+    // Same block shape as the sibling regression test: re-include the tx on
+    // the Publish ledger of a sibling candidate at height 3 (parent = the
+    // real block 2).
+    let mut header = real_tip.clone();
     let publish_ledger = header
         .data_ledgers
         .iter_mut()
@@ -1028,7 +1063,11 @@ async fn test_prevalidation_accepts_publish_when_promoted_height_hint_stripped()
     submit_ledger.tx_ids = H256List(Vec::new());
 
     ctx.config.signer().sign_block_header(&mut header)?;
-    body.block_hash = header.block_hash;
+    let body = BlockBody {
+        block_hash: header.block_hash,
+        data_transactions: vec![tx.clone()],
+        commitment_transactions: Vec::new(),
+    };
     let bad_block = Arc::new(SealedBlock::new(header, body)?);
 
     {
@@ -1062,10 +1101,14 @@ async fn test_prevalidation_accepts_publish_when_promoted_height_hint_stripped()
         }
     });
 
-    // Force the validator to take the canonical-DB fallback path that
-    // this regression exercises.
+    // Walk-depth override: `max(tx_anchor_expiry_depth = 0, block_tree_depth
+    // = 1) = 1`, so the by-hash walk for the height-3 candidate covers
+    // exactly the real, tx-free block 2 — the tx stays `Searching` and the
+    // validator takes the canonical-DB fallback path this regression
+    // exercises.
     let mut consensus = ctx.config.consensus_config();
     consensus.mempool.tx_anchor_expiry_depth = 0;
+    consensus.block_tree_depth = 1;
     let mut node_config = ctx.config.clone();
     node_config.consensus = ConsensusOptions::Custom(consensus);
     let config_override = Config::new_with_random_peer_id(node_config);
@@ -1118,15 +1161,15 @@ async fn test_prevalidation_accepts_publish_when_promoted_height_hint_stripped()
         Err(PreValidationError::PublishTxMissingPriorSubmit { tx_id }) => {
             // This is the Submit branch of the same fallback arm under
             // test — not "downstream".  Firing here means
-            // `canonical_submit_height` failed to attest the
-            // genesis-height Submit row (`MBH[0]` is populated by node
-            // init), so control flow never reached the promoted-height
-            // strip the test is actually exercising.
+            // `canonical_submit_height` failed to content-verify the
+            // fabricated height-1 Submit block seeded via `MBH[1]`, so
+            // control flow never reached the promoted-height strip the
+            // test is actually exercising.
             panic!(
                 "regression: validator rejected as PublishTxMissingPriorSubmit \
                  (tx={tx_id}) — canonical_submit_height must attest the \
-                 genesis-height Submit row (MBH[0]) so control flow reaches \
-                 the promoted-height check this test exercises"
+                 fabricated height-1 Submit row (MBH[1]) so control flow \
+                 reaches the promoted-height check this test exercises"
             );
         }
         Err(downstream) => {

--- a/crates/chain-tests/src/block_production/block_validation.rs
+++ b/crates/chain-tests/src/block_production/block_validation.rs
@@ -1191,3 +1191,214 @@ async fn test_prevalidation_accepts_publish_when_promoted_height_hint_stripped()
     ctx.stop().await;
     Ok(())
 }
+
+/// Pins the EXCLUSION side of the `Searching { Publish }` fallback cap in
+/// `data_txs_are_valid`.
+///
+/// The two sibling fixtures above pin the INCLUSION side: a content-verified
+/// canonical row strictly below the cap is trusted. Neither would fail if the
+/// cap regressed to a looser bound (`parent_height`, or the reorg floor
+/// `block.height - block_tree_depth`) — both fixtures seed their fabricated
+/// prior far enough below the window that a looser cap still admits it. This
+/// test seeds the fabricated prior INSIDE the walk window instead, so a
+/// loosened cap would wrongly admit it.
+///
+/// The by-hash walk owns its window by hash on the candidate's own branch — a
+/// content-verified node-local row at an in-window height describes THIS
+/// node's chain, not necessarily the candidate's branch. The fallback cap
+/// (`block.height - prior_inclusion_walk_depth(config) - 1`) is the only
+/// thing keeping such a row out of consideration. This test fails if the cap
+/// is ever loosened to `parent_height` or the reorg floor.
+///
+/// **Test driver:** same scaffolding as
+/// `test_prevalidation_rejects_doubly_published_tx_via_fallback` — mine to
+/// height 3, validate a sibling candidate at height 3 (parent = the real
+/// block 2) under `tx_anchor_expiry_depth = 0` / `block_tree_depth = 1`, so
+/// the by-hash walk (depth 1) covers exactly the real block 2 on the
+/// candidate's branch. The fabricated canonical prior here sits at height
+/// **2** — inside that walk window — carrying the tx in both Submit and
+/// Publish (metadata `included_height = promoted_height = 2`), and
+/// `MigratedBlockHashes[2]` is repointed at it (overwriting the real block-2
+/// row if one exists; at tip height 3 with testing `block_migration_depth =
+/// 6` nothing has migrated yet, so nothing is actually clobbered). The real
+/// block 2 on the candidate's ancestry does not carry the tx, so the walk
+/// still leaves the tx `Searching`.
+///
+/// The fallback cap is `3 - 1 - 1 = 1`, strictly below height 2, so
+/// `canonical_submit_height` rejects the height-2 hint before ever reading
+/// `MigratedBlockHashes[2]` and returns `None` → `PublishTxMissingPriorSubmit`.
+/// A cap of `parent_height` (2) or the old `reorg_floor` (`3 - 1 = 2`) would
+/// instead admit the fabricated row, content-verify it via the (now
+/// overwritten) MBH entry, and reject with `PublishTxAlreadyIncluded` naming
+/// the fabricated block — a node-history-dependent outcome that forks the
+/// network. That panic arm below is this test's falsifiability check.
+#[tokio::test]
+async fn test_prevalidation_ignores_content_verified_row_inside_walk_window() -> Result<()> {
+    use irys_database::db::IrysDatabaseExt as _;
+    use irys_database::tables::MigratedBlockHashes;
+    use irys_database::{
+        insert_block_header, insert_tx_header, set_data_tx_included_height,
+        set_data_tx_promoted_height,
+    };
+    use irys_types::{BlockBody, H256List};
+    use reth_db::transaction::DbTxMut as _;
+
+    let ctx = PrevalidationTestContext::new().await?;
+
+    // Same geometry as the sibling regression tests: mine three real blocks
+    // so the by-hash walk (depth 1 under the override below) covers exactly
+    // the real, tx-free block 2 for a height-3 candidate.
+    ctx.node.mine_blocks(3).await?;
+    let real_tip = ctx.node.get_block_by_height(3).await?;
+
+    // A Publish-ledger tx that will impersonate "already canonically
+    // included/promoted" via the fabricated in-window prior seeded below.
+    let mut tx = DataTransactionHeader::new(&ctx.config.consensus_config());
+    tx.data_root = H256::from_low_u64_be(0x1_1DE_1DE_5EED);
+    tx.data_size = 0;
+    tx.term_fee = BoundedFee::from_u64(1_000_000_000_000_000_000);
+    tx.perm_fee = Some(BoundedFee::from_u64(1_000_000_000_000_000_000));
+    tx.ledger_id = DataLedger::Publish as u32;
+    let tx = tx
+        .sign(&ctx.config.signer())
+        .expect("Failed to sign test transaction");
+
+    // Fabricated canonical prior at height 2 — INSIDE the by-hash walk
+    // window, not on the candidate's ancestry: a real header carrying the tx
+    // in BOTH Submit and Publish, pointed at by `MigratedBlockHashes[2]`
+    // (overwriting the real block-2 row, which is fine at this tip height
+    // since nothing has migrated yet). This is a node-local, content-verified
+    // row describing this node's chain — not the candidate's branch — and
+    // only the fallback cap keeps it from being trusted.
+    let seeded_height = 2_u64;
+    let mut prior_block = IrysBlockHeader::new_mock_header();
+    prior_block.height = seeded_height;
+    prior_block.block_hash = H256::random();
+    prior_block.data_ledgers[DataLedger::Submit].tx_ids = H256List(vec![tx.id]);
+    prior_block.data_ledgers[DataLedger::Publish].tx_ids = H256List(vec![tx.id]);
+    let seeded_block_hash = prior_block.block_hash;
+
+    ctx.node.node_ctx.db.update_eyre(|db_tx| {
+        insert_tx_header(db_tx, &tx)?;
+        set_data_tx_included_height(db_tx, &tx.id, seeded_height)?;
+        set_data_tx_promoted_height(db_tx, &tx.id, seeded_height)?;
+        insert_block_header(db_tx, &prior_block)?;
+        db_tx.put::<MigratedBlockHashes>(seeded_height, seeded_block_hash)?;
+        Ok(())
+    })?;
+
+    // Build a sibling candidate at height 3 (parent = the real block 2)
+    // whose Publish ledger re-includes `tx`: clone the real height-3 header
+    // as the structural baseline and swap the data ledgers.
+    let mut header = real_tip.clone();
+    let publish_ledger = header
+        .data_ledgers
+        .iter_mut()
+        .find(|l| l.ledger_id == DataLedger::Publish as u32)
+        .expect("Publish ledger should exist");
+    publish_ledger.tx_ids = H256List(vec![tx.id]);
+    let submit_ledger = header
+        .data_ledgers
+        .iter_mut()
+        .find(|l| l.ledger_id == DataLedger::Submit as u32)
+        .expect("Submit ledger should exist");
+    submit_ledger.tx_ids = H256List(Vec::new());
+
+    ctx.config.signer().sign_block_header(&mut header)?;
+    let body = BlockBody {
+        block_hash: header.block_hash,
+        data_transactions: vec![tx.clone()],
+        commitment_transactions: Vec::new(),
+    };
+    let bad_block = Arc::new(SealedBlock::new(header, body)?);
+
+    {
+        let mut tree = ctx.node.node_ctx.block_tree_guard.write();
+        let parent_hash = bad_block.header().previous_block_hash;
+        let commitment_snapshot = tree
+            .get_commitment_snapshot(&parent_hash)
+            .expect("parent commitment snapshot");
+        let epoch_snapshot = tree
+            .get_epoch_snapshot(&parent_hash)
+            .expect("parent epoch snapshot");
+        let ema_snapshot = tree
+            .get_ema_snapshot(&parent_hash)
+            .expect("parent ema snapshot");
+        tree.add_block(
+            &bad_block,
+            commitment_snapshot,
+            epoch_snapshot,
+            ema_snapshot,
+        )?;
+    }
+
+    let (service_senders, mut service_receivers) = build_test_service_senders();
+    let block_tree_guard = ctx.node.node_ctx.block_tree_guard.clone();
+    tokio::spawn(async move {
+        while let Some(msg) = service_receivers.block_tree.recv().await {
+            let BlockTreeServiceMessage::GetBlockTreeReadGuard { response } = msg.inner else {
+                continue;
+            };
+            let _ = response.send(block_tree_guard.clone());
+        }
+    });
+
+    // Walk-depth override: `max(tx_anchor_expiry_depth = 0, block_tree_depth
+    // = 1) = 1`, so the by-hash walk for the height-3 candidate covers
+    // exactly the real, tx-free block 2 on its own branch — the tx stays
+    // `Searching` and the canonical-DB fallback (capped at `3 - 1 - 1 = 1`,
+    // strictly below the seeded height 2) is the path under test.
+    let mut consensus = ctx.config.consensus_config();
+    consensus.mempool.tx_anchor_expiry_depth = 0;
+    consensus.block_tree_depth = 1;
+    let mut node_config = ctx.config.clone();
+    node_config.consensus = ConsensusOptions::Custom(consensus);
+    let config_override = Config::new_with_random_peer_id(node_config);
+
+    let (parent_epoch_snapshot, parent_ema_snapshot) = {
+        let tree = ctx.node.node_ctx.block_tree_guard.read();
+        let parent_hash = bad_block.header().previous_block_hash;
+        (
+            tree.get_epoch_snapshot(&parent_hash)
+                .expect("parent epoch snapshot"),
+            tree.get_ema_snapshot(&parent_hash)
+                .expect("parent ema snapshot"),
+        )
+    };
+
+    let result = irys_actors::block_validation::data_txs_are_valid(
+        &config_override,
+        &service_senders,
+        bad_block.header(),
+        &ctx.node.node_ctx.db,
+        &ctx.node.node_ctx.block_tree_guard,
+        bad_block.transactions(),
+        parent_epoch_snapshot,
+        parent_ema_snapshot,
+    )
+    .await;
+
+    match result {
+        Err(PreValidationError::PublishTxMissingPriorSubmit { tx_id }) => {
+            assert_eq!(tx_id, tx.id, "rejection must name the tx under test");
+        }
+        Err(PreValidationError::PublishTxAlreadyIncluded { tx_id, block_hash }) => {
+            panic!(
+                "regression: the fallback trusted a content-verified node-local \
+                 row INSIDE the by-hash walk window (tx={tx_id}, block={block_hash}) \
+                 — this is the fork vector the fallback cap exists to close: a \
+                 row at this height describes only this node's chain, not \
+                 necessarily the candidate's branch, so it must never decide \
+                 validity"
+            );
+        }
+        other => panic!(
+            "expected PublishTxMissingPriorSubmit (fallback cap excludes the \
+             in-window seeded height), got {:?}",
+            other
+        ),
+    }
+
+    ctx.stop().await;
+    Ok(())
+}

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -296,8 +296,8 @@ pub fn tx_header_by_txid<T: DbTx>(
 /// branch — mirroring `canonical_commitment_included_height`.  Current callers:
 ///   - `data_txs_are_valid` (`block_validation.rs`) uses the content-based
 ///     ancestry walk (`get_previous_tx_inclusions`) as its primary path and
-///     only falls back to these helpers for inclusions older than
-///     `tx_anchor_expiry_depth`.
+///     only falls back to these helpers for inclusions strictly below its
+///     inclusion-history walk window (which spans at least the reorg window).
 ///   - the NC-0042 expiry fast path
 ///     (`ledger_expiry::resolve_submit_inclusion`) relies on the config
 ///     invariant that a ledger slot's lifetime exceeds `block_tree_depth`
@@ -2157,11 +2157,15 @@ mod tests {
         /// Band-cap invariant that the promotion-prevalidation fallback in
         /// `data_txs_are_valid` relies on: a fully-canonical, content-valid row
         /// at a height inside the reorg-mutable band `(reorg_floor, parent]` is
-        /// returned when queried up to `parent_height` but excluded when the
-        /// query is capped at `reorg_floor`.  The Searching{Publish} fallback
-        /// now caps at `reorg_floor` precisely so a node-local band row (which
-        /// describes this node's chain, not the candidate's branch) cannot
-        /// decide validity and fork the network.
+        /// returned when queried up to `parent_height` but excluded once the
+        /// query is capped at or below `reorg_floor`.  The Searching{Publish}
+        /// fallback now caps strictly *below* its inclusion-history walk
+        /// window — in production config that walk bottoms out at the reorg
+        /// floor, so the fallback's actual cap sits one height below it — so a
+        /// node-local band row (which describes this node's chain, not the
+        /// candidate's branch) cannot decide validity and fork the network.
+        /// Any cap `<= reorg_floor`, including the validator's stricter one,
+        /// excludes the band row exercised below.
         #[test]
         fn band_height_row_excluded_below_reorg_floor() {
             let path = irys_testing_utils::utils::TempDirBuilder::new().build();

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -286,14 +286,24 @@ pub fn tx_header_by_txid<T: DbTx>(
 /// `included_height`, Publish for `promoted_height`).  They return primitive
 /// `Option<u64>` (no header mutation) so call sites can't accidentally treat a
 /// stranded hint as canonical.  The content check is what makes `Some(h)` mean
-/// "canonically included at `h`" rather than "a hint pointing at `h` exists":
-/// canonical metadata is now written only at migration (atomically with
-/// `MigratedBlockHashes`), but a legacy/stranded row — e.g. one written at
-/// depth-0 confirmation before that fix, or an orphaned tip's row surviving a
-/// restart-interrupted reorg — can still collide with a different canonical
-/// block migrated at the same height, where the MBH-existence check alone would
-/// read it as truth.  With the content check, callers may trust `Some(h)` on any
-/// branch — mirroring `canonical_commitment_included_height`.  Current callers:
+/// "canonically included at `h` on THIS node's canonical chain" rather than "a
+/// hint pointing at `h` exists": canonical metadata is now written only at
+/// migration (atomically with `MigratedBlockHashes`), but a legacy/stranded
+/// row — e.g. one written at depth-0 confirmation before that fix, or an
+/// orphaned tip's row surviving a restart-interrupted reorg — can still collide
+/// with a different canonical block migrated at the same height, where the
+/// MBH-existence check alone would read it as truth.
+///
+/// The content check neutralizes stranded rows, but it does NOT make the result
+/// branch-invariant inside the reorg window: `MigratedBlockHashes` is node-local
+/// and can differ per branch above the reorg floor, so `Some(h)` is only
+/// branch-agnostic when `h` is BELOW the reorg floor (`tip - block_tree_depth`),
+/// where MBH is stable across every node/branch — exactly the contract of
+/// `canonical_commitment_included_height`.  Callers evaluating a specific branch
+/// within the reorg window must therefore either cap `max_height` at/below the
+/// reorg floor or confirm membership against that branch's own by-hash ancestry;
+/// they must not treat an in-window `Some(h)` as authoritative for a branch other
+/// than this node's own.  Current callers:
 ///   - `data_txs_are_valid` (`block_validation.rs`) uses the content-based
 ///     ancestry walk (`get_previous_tx_inclusions`) as its primary path and
 ///     only falls back to these helpers for inclusions strictly below its

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -2154,6 +2154,66 @@ mod tests {
                  it's not visible to the validator's parent_height window"
             );
         }
+        /// Band-cap invariant that the promotion-prevalidation fallback in
+        /// `data_txs_are_valid` relies on: a fully-canonical, content-valid row
+        /// at a height inside the reorg-mutable band `(reorg_floor, parent]` is
+        /// returned when queried up to `parent_height` but excluded when the
+        /// query is capped at `reorg_floor`.  The Searching{Publish} fallback
+        /// now caps at `reorg_floor` precisely so a node-local band row (which
+        /// describes this node's chain, not the candidate's branch) cannot
+        /// decide validity and fork the network.
+        #[test]
+        fn band_height_row_excluded_below_reorg_floor() {
+            let path = irys_testing_utils::utils::TempDirBuilder::new().build();
+            let db = open_or_create_db(
+                path.path(),
+                IrysTables::ALL,
+                DatabaseArguments::irys_testing().unwrap(),
+            )
+            .unwrap();
+
+            let tx_id = H256::random();
+            let tx_header = make_tx_header(tx_id);
+            // Candidate at height 100 with block_tree_depth = 8 -> reorg_floor 92.
+            // The row sits at 95, inside the reorg-mutable band (92, 99].
+            let band_height = 95_u64;
+            let parent_height = 99_u64;
+            let reorg_floor = 92_u64;
+            let block_hash = H256::random();
+
+            db.update(|tx| -> Result<(), DatabaseError> {
+                insert_tx_header(tx, &tx_header)
+                    .map_err(|e| DatabaseError::Other(e.to_string()))?;
+                set_data_tx_included_height(tx, &tx_id, band_height)?;
+                insert_canonical_block(
+                    tx,
+                    band_height,
+                    block_hash,
+                    DataLedger::Submit,
+                    vec![tx_id],
+                )?;
+                Ok(())
+            })
+            .unwrap()
+            .unwrap();
+
+            let at_parent = db
+                .view_eyre(|tx| canonical_submit_height(tx, &tx_id, parent_height))
+                .unwrap();
+            assert_eq!(
+                at_parent,
+                Some(band_height),
+                "the old parent-height cap WOULD consult the band row (the fork vector)"
+            );
+
+            let at_floor = db
+                .view_eyre(|tx| canonical_submit_height(tx, &tx_id, reorg_floor))
+                .unwrap();
+            assert_eq!(
+                at_floor, None,
+                "capping at the reorg floor must exclude the band-height row"
+            );
+        }
     }
 
     /// Direct tests for the `update_data_root_block_set` /


### PR DESCRIPTION
## Why

The by-height canonical-metadata lookups (`IrysDataTxMetadata` hint + `MigratedBlockHashes`) are only branch-invariant **below the reorg floor**. Two paths could let honest nodes reach different validity decisions for the same block — a network fork:

1. A **stranded metadata row** (a confirmed-but-unmigrated tip write orphaned while the node was down, so no `ReorgEvent` ever scrubbed it) points at a height where a *different* block later migrated. The bare `MBH[h].is_some()` gate read that row as canonical truth.
2. The `Searching { Publish }` prevalidation fallback consulted MBH by height up to `parent_height`, i.e. **inside the reorg-mutable band**, where a node-local row describes this node's chain, not the candidate's branch.

## What

- **Content-verify canonical metadata lookups.** `canonical_submit_height` / `canonical_promoted_height` now require the canonical block `MBH` names at the height to actually carry the txid in the expected ledger (Submit / Publish). A stranded row resolves to `Ok(None)` identically on every node; a missing header for a present MBH row is genuine cross-table corruption → `Err` (classified `NodeFault`, never peer-attributed).
- **Cap the promotion-prevalidation fallback at the reorg floor.** The by-hash inclusion walk owns the reorg window on the candidate's own branch; the by-height fallback now caps at `block.height − block_tree_depth`, so only finalized (branch-invariant) rows are consulted by height. The walk and the fallback together cover `[0, block.height)` with no gap.
- **Fail loud on a non-advancing block-index probe.** `find_block_range` guards against an infinite loop on a corrupted ledger index (`block_total > chunk_offset`), surfaced as an error that aborts locally rather than spinning.
- **Follow-up hardening:** dedupe the ledger-membership predicate into `IrysBlockHeader::includes_data_ledger_tx`; return the already-loaded canonical block hash from `canonical_promoted_height` so the double-publish reject drops a redundant `MigratedBlockHashes` re-read; cross-reference the two sibling fallback caps; add a `v1→v2` migration regression test proving a genuinely promoted tx keeps its Submit `included_height` (so the content check accepts it on upgraded nodes exactly as on fresh-sync nodes).

## Testing

- Affected unit tests pass (`irys-database`, `irys-actors`), including new stranded-row / missing-header / reorg-floor-band / migration regression cases.
- `cargo check --tests`, `cargo fmt --check`, and `cargo clippy` are clean on the touched crates.
- Reviewed with an independent pass plus CodeRabbit (0 findings) and Codex; no fork-safety issues survived verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened inclusion validation to fail loudly when ledger index probing does not advance as expected.
  * Tightened canonical fallback behavior for publish/submit validation: reorg-window capping, clearer fallback cutoff semantics, and correct promoted-block hash handling.
  * Updated transaction selection deduplication to consider already-confirmed commitments across the full truncated canonical ancestry.
* **Tests**
  * Expanded consensus prevalidation and canonical-height regression tests to cover reorg-floor and walk-window edge cases, including updated expected error details and safer block construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->