### PR TITLE
feat(api): add canonical ledger offset -> tx attribution endpoints

### DIFF
--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -1127,12 +1127,9 @@ fn resolve_offset_via_index(
     offset: u64,
 ) -> eyre::Result<(BlockHeight, H256, u64, u64)> {
     let bounds = block_index.get_block_bounds(ledger, LedgerChunkOffset::from(offset))?;
-    let item = block_index
-        .get_item(bounds.height)
-        .ok_or_eyre("block bounds height absent from block index")?;
     Ok((
         bounds.height,
-        item.block_hash,
+        bounds.block_hash,
         bounds.start_chunk_offset,
         bounds.end_chunk_offset,
     ))

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -3687,7 +3687,7 @@ fn get_data_poa_bounds_with_block_tree_fallback(
                     }
                     BlockBoundsError::LedgerInactive { .. } => {
                         PreValidationError::PoALedgerInactive {
-                            ledger_id: ledger as u32,
+                            ledger_id: ledger.get_id(),
                         }
                     }
                     other => PreValidationError::BlockBoundsLookupError(other.to_string()),

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -3140,6 +3140,98 @@ mod c1_side_fork_regression_tests {
 }
 
 #[cfg(test)]
+mod poa_bounds_snapshot_tests {
+    use super::*;
+    use irys_domain::{BlockIndex, BlockTree};
+    use irys_testing_utils::new_mock_signed_header;
+    use irys_testing_utils::utils::TempDirBuilder;
+    use irys_types::{BlockHash, BlockIndexItem, DataLedger, DbSyncMode, H256, LedgerIndexItem};
+    use std::sync::{Arc, RwLock};
+
+    #[test]
+    fn indexed_bounds_return_snapshot_hash_without_migrated_hash_reread() {
+        let tmp_dir = TempDirBuilder::new()
+            .prefix("poa_bounds_snapshot_hash")
+            .build();
+        let db_env = irys_storage::irys_consensus_data_db::open_or_create_irys_consensus_data_db(
+            tmp_dir.path(),
+            DbSyncMode::UtterlyNoSync,
+        )
+        .expect("open db");
+        let db = irys_types::DatabaseProvider(Arc::new(db_env));
+        let block_index = BlockIndex::new_for_testing(db.clone());
+
+        let genesis_hash = BlockHash::random();
+        let parent_hash = BlockHash::random();
+        let genesis_submit_root = H256::random();
+
+        block_index
+            .push_item(
+                &BlockIndexItem {
+                    block_hash: genesis_hash,
+                    num_ledgers: 2,
+                    ledgers: vec![
+                        LedgerIndexItem {
+                            total_chunks: 0,
+                            tx_root: H256::random(),
+                            ledger: DataLedger::Publish,
+                        },
+                        LedgerIndexItem {
+                            total_chunks: 10,
+                            tx_root: genesis_submit_root,
+                            ledger: DataLedger::Submit,
+                        },
+                    ],
+                },
+                0,
+            )
+            .expect("push genesis index item");
+        block_index
+            .push_item(
+                &BlockIndexItem {
+                    block_hash: parent_hash,
+                    num_ledgers: 2,
+                    ledgers: vec![
+                        LedgerIndexItem {
+                            total_chunks: 0,
+                            tx_root: H256::random(),
+                            ledger: DataLedger::Publish,
+                        },
+                        LedgerIndexItem {
+                            total_chunks: 20,
+                            tx_root: H256::random(),
+                            ledger: DataLedger::Submit,
+                        },
+                    ],
+                },
+                1,
+            )
+            .expect("push parent index item");
+
+        let genesis_for_tree = new_mock_signed_header();
+        let tree = BlockTree::new(&genesis_for_tree, ConsensusConfig::testing());
+        let block_index_guard = BlockIndexReadGuard::new(block_index);
+        let block_tree_guard = BlockTreeReadGuard::new(Arc::new(RwLock::new(tree)));
+
+        let (bounds, owning_hash) = get_data_poa_bounds_with_block_tree_fallback(
+            &block_index_guard,
+            &block_tree_guard,
+            &db,
+            parent_hash,
+            1,
+            DataLedger::Submit,
+            5,
+        )
+        .expect("indexed bounds should not require a second canonical hash lookup");
+
+        assert_eq!(bounds.height, 0);
+        assert_eq!(bounds.block_hash, genesis_hash);
+        assert_eq!(bounds.tx_root, genesis_submit_root);
+        assert_eq!(owning_hash, genesis_hash);
+    }
+}
+
+#[cfg(test)]
 mod perm_fee_threshold_tests {
     use super::*;
     use irys_types::U256;
@@ -3426,19 +3518,6 @@ fn ledger_tx_ids_in(header: &IrysBlockHeader, ledger: DataLedger) -> Option<Vec<
         .map(|l| l.tx_ids.0.clone())
 }
 
-/// Canonical (migrated) block hash at `height` from `MigratedBlockHashes`. Used by the
-/// PoA data-ledger branch to name the recall chunk's owning block for owning-tx lookup
-/// when it lives below `block_tree`'s window (older history is always canonical/migrated).
-/// Cheap (one point read, no header fetch) so it can run during bounds resolution; the
-/// heavier header + tx-header fetch is deferred until after `tx_path` validation succeeds.
-fn canonical_block_hash_at(db: &DatabaseProvider, height: u64) -> Result<H256, PreValidationError> {
-    db.view_eyre(|tx| {
-        tx.get::<MigratedBlockHashes>(height)?
-            .ok_or_else(|| eyre::eyre!("no canonical (migrated) block at height {height}"))
-    })
-    .map_err(|e| PreValidationError::BlockBoundsLookupError(e.to_string()))
-}
-
 /// True iff the tx whose folded `tx_root` leaf starts at cumulative byte `cursor` (prefix
 /// sums of `data_size` in `tx_ids` order) is the recall chunk's owner for a tx_path leaf
 /// at `target`. A `data_size == 0` tx contributes a zero-width leaf that shares its start
@@ -3575,7 +3654,8 @@ fn get_data_poa_bounds_with_block_tree_fallback(
     // the hash is resolved here (cheap); the header + tx-header fetch is deferred to
     // after `tx_path` validation so an invalid proof still surfaces as
     // `MerkleProofInvalid` rather than a lookup error. The tree-walk path has the
-    // owning header in hand; the index paths resolve the canonical hash by height.
+    // owning header in hand; the index paths use the hash carried by `BlockBounds`
+    // so the returned hash and bounds come from the same index snapshot.
     //
     // Fast path: parent is migrated. Identical disambiguation to the prior
     // implementation — offsets past chain-max and ledger-not-active are
@@ -3612,7 +3692,7 @@ fn get_data_poa_bounds_with_block_tree_fallback(
                     }
                     other => PreValidationError::BlockBoundsLookupError(other.to_string()),
                 })?;
-            let owning_hash = canonical_block_hash_at(db, bounds.height)?;
+            let owning_hash = bounds.block_hash;
             return Ok((bounds, owning_hash));
         }
         // Either the index doesn't have parent_height yet (un-migrated window)
@@ -3781,7 +3861,7 @@ fn get_data_poa_bounds_with_block_tree_fallback(
                         prev_height,
                     )
                     .map_err(|e| PreValidationError::BlockBoundsLookupError(e.to_string()))?;
-                let owning_hash = canonical_block_hash_at(db, bounds.height)?;
+                let owning_hash = bounds.block_hash;
                 return Ok((bounds, owning_hash));
             }
         }

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -14,8 +14,9 @@ use irys_database::{
     tables::MigratedBlockHashes,
 };
 use irys_domain::{
-    BlockBounds, BlockIndex, BlockIndexReadGuard, BlockTreeReadGuard, CommitmentSnapshot,
-    CommitmentSnapshotStatus, EmaSnapshot, EpochSnapshot, HardforkConfigExt as _,
+    BlockBounds, BlockBoundsError, BlockIndex, BlockIndexReadGuard, BlockTreeReadGuard,
+    CommitmentSnapshot, CommitmentSnapshotStatus, EmaSnapshot, EpochSnapshot,
+    HardforkConfigExt as _,
 };
 use irys_packing::{capacity_single::compute_entropy_chunk, xor_vec_u8_arrays_in_place};
 use irys_reth::shadow_tx::{ShadowTransaction, ShadowTxError, detect_and_decode};
@@ -111,9 +112,8 @@ impl ErrorClass {
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum PreValidationError {
     /// Local lookup failure during the PoA-anchored `block_bounds` binary
-    /// search. Construction sites in `get_block_bounds` /
-    /// `get_block_bounds_at_height` pre-check peer-supplied offsets against
-    /// the chain max and reject out-of-range / inactive-ledger cases first
+    /// search. Construction sites map the typed `BlockBoundsError`
+    /// out-of-range / inactive-ledger variants to consensus rejections first
     /// (`PoAChunkOffsetOutOfBlockBounds`, `PoALedgerInactive`), and the
     /// walk-off-tree fallback returns `PoAOffCanonicalAncestor` when a
     /// side-fork ancestor falls below the migration boundary; by the time
@@ -3595,24 +3595,23 @@ fn get_data_poa_bounds_with_block_tree_fallback(
         if let Some(parent_item) = index.get_item(parent_height)
             && parent_item.block_hash == parent_block_hash
         {
-            match parent_item.ledgers.iter().find(|l| l.ledger == ledger) {
-                Some(entry) if ledger_chunk_offset >= entry.total_chunks => {
-                    return Err(PreValidationError::PoAChunkOffsetOutOfBlockBounds);
-                }
-                None => {
-                    return Err(PreValidationError::PoALedgerInactive {
-                        ledger_id: ledger as u32,
-                    });
-                }
-                Some(_) => {}
-            }
             let bounds = index
                 .get_block_bounds_at_height(
                     ledger,
                     LedgerChunkOffset::from(ledger_chunk_offset),
                     parent_height,
                 )
-                .map_err(|e| PreValidationError::BlockBoundsLookupError(e.to_string()))?;
+                .map_err(|e| match e {
+                    BlockBoundsError::OffsetBeyondFrontier { .. } => {
+                        PreValidationError::PoAChunkOffsetOutOfBlockBounds
+                    }
+                    BlockBoundsError::LedgerInactive { .. } => {
+                        PreValidationError::PoALedgerInactive {
+                            ledger_id: ledger as u32,
+                        }
+                    }
+                    other => PreValidationError::BlockBoundsLookupError(other.to_string()),
+                })?;
             let owning_hash = canonical_block_hash_at(db, bounds.height)?;
             return Ok((bounds, owning_hash));
         }
@@ -3721,6 +3720,7 @@ fn get_data_poa_bounds_with_block_tree_fallback(
             return Ok((
                 BlockBounds {
                     height: curr_height,
+                    block_hash: curr.block_hash,
                     ledger,
                     start_chunk_offset: prev_total,
                     end_chunk_offset: curr_total,

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -12,7 +12,7 @@ use irys_database::{
     delete_cached_chunks_by_data_root, get_cache_size,
     tables::{CachedChunks, CachedDataRoots, CompactCachedIngressProof, IngressProofs},
 };
-use irys_domain::{BlockIndexReadGuard, BlockTreeReadGuard, EpochSnapshot};
+use irys_domain::{BlockBoundsError, BlockIndexReadGuard, BlockTreeReadGuard, EpochSnapshot};
 use irys_types::ingress::CachedIngressProof;
 use irys_types::v2::GossipBroadcastMessageV2;
 use irys_types::{
@@ -175,17 +175,25 @@ impl InnerCacheTask {
 
         // Check to see if the first overlapping block in our first active submit ledger slot is in the block index
         let mut prune_height: Option<u64> = None;
-        if let Some(latest) = self.block_index_guard.read().get_latest_item() {
-            let submit_ledger_max_chunk_offset = latest.ledgers[ledger_id].total_chunks;
-            if submit_ledger_max_chunk_offset > chunk_offset {
-                let block_bounds = self
-                    .block_index_guard
-                    .read()
-                    .get_block_bounds(ledger_id, LedgerChunkOffset::from(chunk_offset))
-                    .expect("Should be able to get block bounds as max_chunk_offset was checked");
+        match self
+            .block_index_guard
+            .read()
+            .get_block_bounds(ledger_id, LedgerChunkOffset::from(chunk_offset))
+        {
+            Ok(block_bounds) => {
                 // Genesis block (height 0) never enters block_index as it has no submit ledger
                 // data, use saturating_sub (defensive).
                 prune_height = Some(block_bounds.height.saturating_sub(1));
+            }
+            // Nothing indexed at this offset (yet) — fall through to the
+            // canonical-chain scan below.
+            Err(
+                BlockBoundsError::IndexEmpty
+                | BlockBoundsError::LedgerInactive { .. }
+                | BlockBoundsError::OffsetBeyondFrontier { .. },
+            ) => {}
+            Err(BlockBoundsError::Internal(e)) => {
+                return Err(e.wrap_err("Failed to get block bounds for cache pruning"));
             }
         }
 

--- a/crates/actors/src/storage_module_service.rs
+++ b/crates/actors/src/storage_module_service.rs
@@ -20,8 +20,8 @@ use eyre::{OptionExt as _, eyre};
 use irys_config::StorageSubmodulesConfig;
 use irys_database::submodule::{get_path_hashes_by_offset, tables::ChunkPathHashes};
 use irys_domain::{
-    BlockIndexReadGuard, BlockTreeReadGuard, PACKING_PARAMS_FILE_NAME, PackingParams,
-    StorageModule, StorageModuleInfo,
+    BlockBoundsError, BlockIndexReadGuard, BlockTreeReadGuard, PACKING_PARAMS_FILE_NAME,
+    PackingParams, StorageModule, StorageModuleInfo,
 };
 use irys_types::{
     BlockHash, Config, DataLedger, LedgerChunkOffset, PartitionChunkOffset, PartitionChunkRange,
@@ -340,7 +340,16 @@ impl StorageModuleServiceInner {
                 };
 
                 let data_ledger = DataLedger::try_from(ledger_id).unwrap();
-                let max_chunk_offset = latest_item.ledgers[data_ledger as usize].total_chunks;
+                // Frontier for this ledger; an absent entry (e.g. a term
+                // ledger before Cascade activation) means no data yet. Still
+                // read here (not just via the bounds error) because the end
+                // offset is clamped against it below.
+                let max_chunk_offset = latest_item
+                    .ledgers
+                    .iter()
+                    .find(|l| l.ledger == data_ledger)
+                    .map(|l| l.total_chunks)
+                    .unwrap_or(0);
 
                 // Check if start offset is within bounds
                 if *ledger_chunk_offset >= max_chunk_offset {
@@ -348,10 +357,21 @@ impl StorageModuleServiceInner {
                     continue;
                 }
 
-                // Now we can safely get block bounds for the start
-                let block_bounds = block_index_guard
-                    .get_block_bounds(data_ledger, ledger_chunk_offset)
-                    .expect("Should be able to get block bounds as max_chunk_offset was checked");
+                let block_bounds =
+                    match block_index_guard.get_block_bounds(data_ledger, ledger_chunk_offset) {
+                        Ok(bounds) => bounds,
+                        // The index shrank between the frontier read and the
+                        // search (reorg truncation) — skip; the next update
+                        // re-evaluates against the new index.
+                        Err(
+                            BlockBoundsError::IndexEmpty
+                            | BlockBoundsError::LedgerInactive { .. }
+                            | BlockBoundsError::OffsetBeyondFrontier { .. },
+                        ) => continue,
+                        Err(BlockBoundsError::Internal(e)) => {
+                            return Err(e.wrap_err("Failed to get start block bounds"));
+                        }
+                    };
 
                 let start_block = block_bounds.height;
 
@@ -376,9 +396,18 @@ impl StorageModuleServiceInner {
                 }
 
                 // Now get block bounds for the end
-                let end_block_bounds = block_index_guard
-                    .get_block_bounds(data_ledger, clamped_end_offset)
-                    .expect("Should be able to get end block bounds as offset was validated");
+                let end_block_bounds =
+                    match block_index_guard.get_block_bounds(data_ledger, clamped_end_offset) {
+                        Ok(bounds) => bounds,
+                        Err(
+                            BlockBoundsError::IndexEmpty
+                            | BlockBoundsError::LedgerInactive { .. }
+                            | BlockBoundsError::OffsetBeyondFrontier { .. },
+                        ) => continue,
+                        Err(BlockBoundsError::Internal(e)) => {
+                            return Err(e.wrap_err("Failed to get end block bounds"));
+                        }
+                    };
 
                 let end_block = end_block_bounds.height;
 

--- a/crates/api-server/src/lib.rs
+++ b/crates/api-server/src/lib.rs
@@ -164,6 +164,14 @@ pub fn routes() -> impl HttpServiceFactory {
             "/ledger/{miner_address}/assignments",
             web::get().to(ledger::get_all_assignments),
         )
+        .route(
+            "/ledger/{ledger_id}/offset/{ledger_offset}/tx",
+            web::get().to(ledger::get_tx_by_ledger_offset),
+        )
+        .route(
+            "/ledger/{ledger_id}/slot/{slot_index}/offset/{slot_offset}/tx",
+            web::get().to(ledger::get_tx_by_slot_offset),
+        )
         // Epoch endpoints
         .route("/epoch/current", web::get().to(ledger::get_current_epoch))
         // Storage endpoints

--- a/crates/api-server/src/routes/get_chunk.rs
+++ b/crates/api-server/src/routes/get_chunk.rs
@@ -6,7 +6,7 @@ use actix_web::{
 };
 
 use awc::http::StatusCode;
-use irys_types::{ChunkFormat, DataLedger, H256};
+use irys_types::{ChunkFormat, H256};
 use serde::Deserialize;
 use tracing::debug;
 
@@ -20,10 +20,7 @@ pub async fn get_chunk_by_ledger_offset(
     state: web::Data<ApiState>,
     path: web::Path<LedgerChunkApiPath>,
 ) -> Result<HttpResponse, ApiError> {
-    let ledger = match DataLedger::try_from(path.ledger_id) {
-        Ok(l) => l,
-        Err(e) => return Err((format!("Invalid ledger id: {e}"), StatusCode::BAD_REQUEST).into()),
-    };
+    let ledger = crate::routes::parse_ledger_id(path.ledger_id)?;
 
     match state
         .chunk_provider
@@ -58,10 +55,7 @@ pub async fn get_chunk_by_data_root_offset(
     state: web::Data<ApiState>,
     path: web::Path<DataRootChunkApiPath>,
 ) -> Result<HttpResponse, ApiError> {
-    let ledger = match DataLedger::try_from(path.ledger_id) {
-        Ok(l) => l,
-        Err(e) => return Err((format!("Invalid ledger id: {e}"), StatusCode::BAD_REQUEST).into()),
-    };
+    let ledger = crate::routes::parse_ledger_id(path.ledger_id)?;
 
     match state
         .chunk_provider

--- a/crates/api-server/src/routes/ledger.rs
+++ b/crates/api-server/src/routes/ledger.rs
@@ -1,8 +1,13 @@
 use crate::ApiState;
 use crate::error::ApiError;
 use actix_web::web::{Data, Json, Path};
+use awc::http::StatusCode;
+use irys_actors::block_tree_service;
+use irys_database::{database, db::IrysDatabaseExt as _};
+use irys_domain::BlockBounds;
 use irys_types::{
-    DataLedger, H256, IrysAddress, partition::PartitionAssignment, serialization::string_u64,
+    DataLedger, DataTransactionHeader, DataTransactionLedger, H256, IrysAddress, IrysBlockHeader,
+    LedgerChunkOffset, partition::PartitionAssignment, serialization::string_u64,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -272,6 +277,341 @@ pub async fn get_current_epoch(
     }))
 }
 
+// === Ledger offset → transaction attribution ===
+
+/// Response for the `/ledger/{ledger_id}/offset/{ledger_offset}/tx` endpoints.
+///
+/// Attributes a canonical ledger chunk offset to the data transaction that
+/// owns it, using the block index and canonical block headers — chain
+/// attribution, not local storage availability.
+///
+/// `blockEndOffset` and `txEndOffset` are exclusive upper bounds.
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct LedgerOffsetTxResponse {
+    pub ledger_id: u32,
+    pub ledger: DataLedger,
+    #[serde(with = "string_u64")]
+    pub ledger_offset: u64,
+    pub slot_index: u64,
+    pub slot_offset: u64,
+    pub block_height: u64,
+    pub block_hash: H256,
+    /// First chunk offset the block appended to the ledger (inclusive)
+    #[serde(with = "string_u64")]
+    pub block_start_offset: u64,
+    /// One past the last chunk offset the block appended (exclusive)
+    #[serde(with = "string_u64")]
+    pub block_end_offset: u64,
+    pub tx_id: H256,
+    pub data_root: H256,
+    /// Position of the tx within the block's tx list for this ledger
+    pub tx_offset: usize,
+    #[serde(with = "string_u64")]
+    pub tx_start_offset: u64,
+    /// One past the tx's last chunk offset (exclusive)
+    #[serde(with = "string_u64")]
+    pub tx_end_offset: u64,
+    pub chunks_in_tx: u64,
+}
+
+#[derive(Deserialize)]
+pub struct LedgerOffsetPath {
+    ledger_id: u32,
+    ledger_offset: u64,
+}
+
+pub async fn get_tx_by_ledger_offset(
+    state: Data<ApiState>,
+    path: Path<LedgerOffsetPath>,
+) -> Result<Json<LedgerOffsetTxResponse>, ApiError> {
+    let ledger = parse_ledger_id(path.ledger_id)?;
+    Ok(Json(resolve_tx_by_ledger_offset(
+        &state,
+        ledger,
+        path.ledger_offset,
+    )?))
+}
+
+#[derive(Deserialize)]
+pub struct SlotOffsetPath {
+    ledger_id: u32,
+    slot_index: u64,
+    slot_offset: u64,
+}
+
+pub async fn get_tx_by_slot_offset(
+    state: Data<ApiState>,
+    path: Path<SlotOffsetPath>,
+) -> Result<Json<LedgerOffsetTxResponse>, ApiError> {
+    let ledger = parse_ledger_id(path.ledger_id)?;
+    let ledger_offset = slot_to_ledger_offset(
+        path.slot_index,
+        path.slot_offset,
+        state.config.consensus.num_chunks_in_partition,
+    )
+    .map_err(|msg| ApiError::CustomWithStatus(msg, StatusCode::BAD_REQUEST))?;
+    Ok(Json(resolve_tx_by_ledger_offset(
+        &state,
+        ledger,
+        ledger_offset,
+    )?))
+}
+
+fn parse_ledger_id(ledger_id: u32) -> Result<DataLedger, ApiError> {
+    DataLedger::try_from(ledger_id).map_err(|_| {
+        (
+            format!("Invalid ledger id: {ledger_id}"),
+            StatusCode::BAD_REQUEST,
+        )
+            .into()
+    })
+}
+
+fn internal(msg: impl Into<String>) -> ApiError {
+    ApiError::CustomWithStatus(msg.into(), StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+/// Converts a slot-relative offset into an absolute ledger offset. Every data
+/// ledger's slots span `num_chunks_in_partition` chunks — the partitions
+/// within a slot are replicas, so the replication factor does not change the
+/// slot's data range.
+fn slot_to_ledger_offset(
+    slot_index: u64,
+    slot_offset: u64,
+    num_chunks_in_partition: u64,
+) -> Result<u64, String> {
+    if slot_offset >= num_chunks_in_partition {
+        return Err(format!(
+            "Slot offset {slot_offset} must be less than the number of chunks in a partition ({num_chunks_in_partition})"
+        ));
+    }
+    slot_index
+        .checked_mul(num_chunks_in_partition)
+        .and_then(|base| base.checked_add(slot_offset))
+        .ok_or_else(|| format!("Slot index {slot_index} exceeds the ledger offset space"))
+}
+
+/// Resolves a canonical ledger chunk offset to the data transaction that owns
+/// it. Works for any [`DataLedger`], including the Cascade term ledgers
+/// (OneYear/ThirtyDay): a ledger with no block-index entries yet simply has a
+/// frontier of 0, so every offset 404s until data lands in it.
+fn resolve_tx_by_ledger_offset(
+    state: &ApiState,
+    ledger: DataLedger,
+    ledger_offset: u64,
+) -> Result<LedgerOffsetTxResponse, ApiError> {
+    let consensus = &state.config.consensus;
+    let block_index = state.block_index.read();
+
+    // Distinguish "offset not (yet) allocated" (404) from index/header
+    // inconsistencies (500) up front by checking the latest indexed total for
+    // this ledger. A ledger absent from the latest index item (e.g. a Cascade
+    // term ledger before activation) has a frontier of 0.
+    let anchor_height = block_index.latest_height();
+    let anchor_item = block_index.get_item(anchor_height).ok_or_else(|| {
+        ApiError::CustomWithStatus("Block index is empty".into(), StatusCode::NOT_FOUND)
+    })?;
+    let frontier = anchor_item
+        .ledgers
+        .iter()
+        .find(|l| l.ledger == ledger)
+        .map(|l| l.total_chunks)
+        .unwrap_or(0);
+    if ledger_offset >= frontier {
+        return Err((
+            format!(
+                "Offset {ledger_offset} is beyond the {ledger:?} ledger frontier ({frontier} chunks)"
+            ),
+            StatusCode::NOT_FOUND,
+        )
+            .into());
+    }
+
+    // Anchor the search on the same height as the frontier check so both
+    // reads observe the same index state even if the index advances (or gets
+    // truncated by a reorg) in between.
+    let bounds = block_index
+        .get_block_bounds_at_height(
+            ledger,
+            LedgerChunkOffset::from(ledger_offset),
+            anchor_height,
+        )
+        .map_err(|e| internal(format!("Block index lookup failed: {e}")))?;
+
+    let index_item = block_index.get_item(bounds.height).ok_or_else(|| {
+        internal(format!(
+            "Missing block index item at height {}",
+            bounds.height
+        ))
+    })?;
+
+    // Indexed blocks are migrated, and migration persists the block header and
+    // its tx headers atomically with the index entry, so the DB lookup below
+    // cannot race migration; the tree is only consulted as a fast path.
+    let block = block_tree_service::get_block_header(
+        &state.block_tree,
+        &state.db,
+        index_item.block_hash,
+        false,
+    )
+    .map_err(|e| internal(format!("Failed to load block header: {e}")))?
+    .ok_or_else(|| {
+        internal(format!(
+            "Block {} at height {} is in the block index but its header was not found",
+            index_item.block_hash, bounds.height
+        ))
+    })?;
+
+    let ledger_entry =
+        validate_block_against_index(&bounds, index_item.block_hash, &block).map_err(internal)?;
+
+    let attribution = attribute_tx_at_offset(
+        bounds.height,
+        (bounds.start_chunk_offset, bounds.end_chunk_offset),
+        &ledger_entry.tx_ids.0,
+        consensus.chunk_size,
+        ledger_offset,
+        |tx_id| {
+            state
+                .db
+                .view_eyre(|tx| database::tx_header_by_txid(tx, tx_id))
+        },
+    )
+    .map_err(|e| internal(e.to_string()))?;
+
+    let num_chunks_in_partition = consensus.num_chunks_in_partition;
+    Ok(LedgerOffsetTxResponse {
+        ledger_id: ledger.get_id(),
+        ledger,
+        ledger_offset,
+        slot_index: ledger_offset / num_chunks_in_partition,
+        slot_offset: ledger_offset % num_chunks_in_partition,
+        block_height: bounds.height,
+        block_hash: index_item.block_hash,
+        block_start_offset: bounds.start_chunk_offset,
+        block_end_offset: bounds.end_chunk_offset,
+        tx_id: attribution.header.id,
+        data_root: attribution.header.data_root,
+        tx_offset: attribution.tx_index,
+        tx_start_offset: attribution.tx_start_offset,
+        tx_end_offset: attribution.tx_end_offset,
+        chunks_in_tx: attribution.chunks_in_tx,
+    })
+}
+
+/// Cross-checks the block header loaded for `bounds.height` against the block
+/// index item that attributed the offset to it. Any divergence is a
+/// server-side consistency violation (mapped to 500 by the caller).
+fn validate_block_against_index<'a>(
+    bounds: &BlockBounds,
+    index_block_hash: H256,
+    block: &'a IrysBlockHeader,
+) -> Result<&'a DataTransactionLedger, String> {
+    if block.block_hash != index_block_hash {
+        return Err(format!(
+            "Block index has hash {index_block_hash} at height {} but the loaded header hashes to {}",
+            bounds.height, block.block_hash
+        ));
+    }
+    if block.height != bounds.height {
+        return Err(format!(
+            "Block {index_block_hash} is indexed at height {} but its header says height {}",
+            bounds.height, block.height
+        ));
+    }
+    let ledger_entry = block
+        .data_ledgers
+        .iter()
+        .find(|dl| dl.ledger_id == bounds.ledger)
+        .ok_or_else(|| {
+            format!(
+                "Block index attributes {:?} ledger chunks to block {index_block_hash} at height {} but the block has no such ledger entry",
+                bounds.ledger, bounds.height
+            )
+        })?;
+    if ledger_entry.tx_root != bounds.tx_root {
+        return Err(format!(
+            "tx_root mismatch for {:?} ledger at height {}: block index has {} but block header has {}",
+            bounds.ledger, bounds.height, bounds.tx_root, ledger_entry.tx_root
+        ));
+    }
+    Ok(ledger_entry)
+}
+
+/// A transaction located within a block's appended chunk range.
+#[derive(Debug)]
+struct TxAttribution {
+    tx_index: usize,
+    header: DataTransactionHeader,
+    tx_start_offset: u64,
+    tx_end_offset: u64,
+    chunks_in_tx: u64,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum AttributionError {
+    #[error("Failed to load tx header {tx_id}: {err}")]
+    TxLookup { tx_id: H256, err: String },
+    #[error("Tx {tx_id} is listed in the block at height {height} but its header is missing")]
+    MissingTxHeader { tx_id: H256, height: u64 },
+    #[error(
+        "Block at height {height} introduced chunk range [{block_start}, {block_end}) but its txs only cover [{block_start}, {cursor}), leaving offset {ledger_offset} unattributed"
+    )]
+    RangeNotCovered {
+        height: u64,
+        block_start: u64,
+        block_end: u64,
+        cursor: u64,
+        ledger_offset: u64,
+    },
+}
+
+/// Walks a block's ledger txs in order, assigning each the chunk range
+/// `[cursor, cursor + ceil(data_size / chunk_size))` starting from the block's
+/// first appended offset — mirroring how `BlockIndex::push_block` accumulates
+/// `total_chunks` — and returns the tx whose range contains `ledger_offset`.
+fn attribute_tx_at_offset(
+    height: u64,
+    (block_start, block_end): (u64, u64),
+    tx_ids: &[H256],
+    chunk_size: u64,
+    ledger_offset: u64,
+    mut load_tx_header: impl FnMut(&H256) -> eyre::Result<Option<DataTransactionHeader>>,
+) -> Result<TxAttribution, AttributionError> {
+    let mut cursor = block_start;
+    for (tx_index, tx_id) in tx_ids.iter().enumerate() {
+        let header = load_tx_header(tx_id)
+            .map_err(|e| AttributionError::TxLookup {
+                tx_id: *tx_id,
+                err: e.to_string(),
+            })?
+            .ok_or(AttributionError::MissingTxHeader {
+                tx_id: *tx_id,
+                height,
+            })?;
+        let chunks_in_tx = header.data_size.div_ceil(chunk_size);
+        let tx_end_offset = cursor.saturating_add(chunks_in_tx);
+        if (cursor..tx_end_offset).contains(&ledger_offset) {
+            return Ok(TxAttribution {
+                tx_index,
+                header,
+                tx_start_offset: cursor,
+                tx_end_offset,
+                chunks_in_tx,
+            });
+        }
+        cursor = tx_end_offset;
+    }
+    Err(AttributionError::RangeNotCovered {
+        height,
+        block_start,
+        block_end,
+        cursor,
+        ledger_offset,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -365,5 +705,252 @@ mod tests {
             count_assignments_by_ledger_type(miner, &assignments, DataLedger::Submit).unwrap(),
             1
         );
+    }
+
+    // === Ledger offset → transaction attribution ===
+
+    const CHUNK_SIZE: u64 = 32;
+
+    fn data_tx(seed: u8, data_size: u64) -> DataTransactionHeader {
+        let mut header = DataTransactionHeader::default();
+        header.id = H256::from([seed; 32]);
+        header.data_root = H256::from([seed.wrapping_add(100); 32]);
+        header.data_size = data_size;
+        header
+    }
+
+    fn tx_ids(headers: &[DataTransactionHeader]) -> Vec<H256> {
+        headers.iter().map(|h| h.id).collect()
+    }
+
+    fn lookup(
+        headers: &[DataTransactionHeader],
+    ) -> impl FnMut(&H256) -> eyre::Result<Option<DataTransactionHeader>> + '_ {
+        move |tx_id| Ok(headers.iter().find(|h| h.id == *tx_id).cloned())
+    }
+
+    #[test]
+    fn attribute_single_tx_single_chunk() {
+        let txs = vec![data_tx(1, CHUNK_SIZE)];
+        let found =
+            attribute_tx_at_offset(7, (5, 6), &tx_ids(&txs), CHUNK_SIZE, 5, lookup(&txs)).unwrap();
+        assert_eq!(found.tx_index, 0);
+        assert_eq!(found.header.id, txs[0].id);
+        assert_eq!(found.tx_start_offset, 5);
+        assert_eq!(found.tx_end_offset, 6);
+        assert_eq!(found.chunks_in_tx, 1);
+    }
+
+    #[rstest]
+    #[case::first_chunk(10)]
+    #[case::middle_chunk(11)]
+    #[case::last_chunk(12)]
+    fn attribute_single_tx_multiple_chunks(#[case] offset: u64) {
+        // 65 bytes → 3 chunks (partial last chunk rounds up)
+        let txs = vec![data_tx(1, 2 * CHUNK_SIZE + 1)];
+        let found =
+            attribute_tx_at_offset(3, (10, 13), &tx_ids(&txs), CHUNK_SIZE, offset, lookup(&txs))
+                .unwrap();
+        assert_eq!(found.tx_index, 0);
+        assert_eq!(found.tx_start_offset, 10);
+        assert_eq!(found.tx_end_offset, 13);
+        assert_eq!(found.chunks_in_tx, 3);
+    }
+
+    #[rstest]
+    #[case::first_tx_first_chunk(100, 0, 100, 102)]
+    #[case::first_tx_last_chunk(101, 0, 100, 102)]
+    #[case::boundary_second_tx_first_chunk(102, 1, 102, 105)]
+    #[case::second_tx_last_chunk(104, 1, 102, 105)]
+    #[case::third_tx(105, 2, 105, 106)]
+    fn attribute_multiple_txs_in_block(
+        #[case] offset: u64,
+        #[case] expected_index: usize,
+        #[case] expected_start: u64,
+        #[case] expected_end: u64,
+    ) {
+        // tx0: 2 chunks [100, 102), tx1: 3 chunks [102, 105), tx2: 1 chunk [105, 106)
+        let txs = vec![
+            data_tx(1, 2 * CHUNK_SIZE),
+            data_tx(2, 3 * CHUNK_SIZE),
+            data_tx(3, 1),
+        ];
+        let found = attribute_tx_at_offset(
+            9,
+            (100, 106),
+            &tx_ids(&txs),
+            CHUNK_SIZE,
+            offset,
+            lookup(&txs),
+        )
+        .unwrap();
+        assert_eq!(found.tx_index, expected_index);
+        assert_eq!(found.header.id, txs[expected_index].id);
+        assert_eq!(found.tx_start_offset, expected_start);
+        assert_eq!(found.tx_end_offset, expected_end);
+    }
+
+    #[test]
+    fn attribute_zero_size_tx_owns_no_chunks() {
+        let txs = vec![data_tx(1, 0), data_tx(2, CHUNK_SIZE)];
+        let found =
+            attribute_tx_at_offset(4, (50, 51), &tx_ids(&txs), CHUNK_SIZE, 50, lookup(&txs))
+                .unwrap();
+        assert_eq!(found.tx_index, 1);
+        assert_eq!(found.header.id, txs[1].id);
+    }
+
+    #[test]
+    fn attribute_missing_tx_header() {
+        let txs = vec![data_tx(1, CHUNK_SIZE)];
+        let missing_id = H256::from([9; 32]);
+        let result = attribute_tx_at_offset(4, (0, 1), &[missing_id], CHUNK_SIZE, 0, lookup(&txs));
+        assert!(matches!(
+            result,
+            Err(AttributionError::MissingTxHeader { tx_id, height: 4 }) if tx_id == missing_id
+        ));
+    }
+
+    #[test]
+    fn attribute_tx_lookup_error() {
+        let result = attribute_tx_at_offset(4, (0, 1), &[H256::zero()], CHUNK_SIZE, 0, |_| {
+            Err(eyre::eyre!("db exploded"))
+        });
+        assert!(matches!(result, Err(AttributionError::TxLookup { .. })));
+    }
+
+    #[test]
+    fn attribute_offset_not_covered_by_txs() {
+        // Block claims [0, 3) but its single tx only covers [0, 2)
+        let txs = vec![data_tx(1, 2 * CHUNK_SIZE)];
+        let result = attribute_tx_at_offset(4, (0, 3), &tx_ids(&txs), CHUNK_SIZE, 2, lookup(&txs));
+        assert!(matches!(
+            result,
+            Err(AttributionError::RangeNotCovered {
+                cursor: 2,
+                ledger_offset: 2,
+                ..
+            })
+        ));
+    }
+
+    fn bounds_and_block(ledger: DataLedger) -> (BlockBounds, H256, irys_types::IrysBlockHeader) {
+        let tx_root = H256::from([7; 32]);
+        let block_hash = H256::from([8; 32]);
+        let mut block = irys_types::IrysBlockHeader::new_mock_header();
+        block.height = 42;
+        block.block_hash = block_hash;
+        block.data_ledgers = vec![DataTransactionLedger {
+            ledger_id: ledger.get_id(),
+            tx_root,
+            ..Default::default()
+        }];
+        let bounds = BlockBounds {
+            height: 42,
+            ledger,
+            start_chunk_offset: 10,
+            end_chunk_offset: 20,
+            tx_root,
+        };
+        (bounds, block_hash, block)
+    }
+
+    #[test]
+    fn validate_block_against_index_ok() {
+        let (bounds, block_hash, block) = bounds_and_block(DataLedger::Submit);
+        let entry = validate_block_against_index(&bounds, block_hash, &block).unwrap();
+        assert_eq!(entry.tx_root, bounds.tx_root);
+    }
+
+    #[test]
+    fn validate_block_against_index_hash_mismatch() {
+        let (bounds, _, block) = bounds_and_block(DataLedger::Submit);
+        let err = validate_block_against_index(&bounds, H256::from([9; 32]), &block).unwrap_err();
+        assert!(err.contains("hash"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn validate_block_against_index_height_mismatch() {
+        let (bounds, block_hash, mut block) = bounds_and_block(DataLedger::Submit);
+        block.height = 43;
+        let err = validate_block_against_index(&bounds, block_hash, &block).unwrap_err();
+        assert!(err.contains("height 43"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn validate_block_against_index_missing_ledger_entry() {
+        // A pre-Cascade block has no OneYear entry; the index claiming it
+        // introduced OneYear chunks is a consistency violation.
+        let (mut bounds, block_hash, block) = bounds_and_block(DataLedger::Submit);
+        bounds.ledger = DataLedger::OneYear;
+        let err = validate_block_against_index(&bounds, block_hash, &block).unwrap_err();
+        assert!(
+            err.contains("no such ledger entry"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_block_against_index_tx_root_mismatch() {
+        let (mut bounds, block_hash, block) = bounds_and_block(DataLedger::Submit);
+        bounds.tx_root = H256::from([13; 32]);
+        let err = validate_block_against_index(&bounds, block_hash, &block).unwrap_err();
+        assert!(err.contains("tx_root mismatch"), "unexpected error: {err}");
+    }
+
+    #[rstest]
+    #[case::slot_zero_start(0, 0, 100, Ok(0))]
+    #[case::slot_zero_end(0, 99, 100, Ok(99))]
+    #[case::slot_one_start(1, 0, 100, Ok(100))]
+    #[case::mid_slot(3, 29, 100, Ok(329))]
+    #[case::offset_at_partition_size(0, 100, 100, Err(()))]
+    #[case::offset_past_partition_size(2, 101, 100, Err(()))]
+    #[case::overflow(u64::MAX, 0, 100, Err(()))]
+    fn slot_to_ledger_offset_cases(
+        #[case] slot_index: u64,
+        #[case] slot_offset: u64,
+        #[case] num_chunks: u64,
+        #[case] expected: Result<u64, ()>,
+    ) {
+        let result = slot_to_ledger_offset(slot_index, slot_offset, num_chunks);
+        match expected {
+            Ok(offset) => assert_eq!(result.unwrap(), offset),
+            Err(()) => assert!(result.is_err()),
+        }
+    }
+
+    #[test]
+    fn ledger_offset_response_serialization_contract() {
+        let response = LedgerOffsetTxResponse {
+            ledger_id: 1,
+            ledger: DataLedger::Submit,
+            ledger_offset: 129,
+            slot_index: 0,
+            slot_offset: 129,
+            block_height: 157_860,
+            block_hash: H256::from([1; 32]),
+            block_start_offset: 127,
+            block_end_offset: 130,
+            tx_id: H256::from([2; 32]),
+            data_root: H256::from([3; 32]),
+            tx_offset: 2,
+            tx_start_offset: 127,
+            tx_end_offset: 130,
+            chunks_in_tx: 3,
+        };
+        let json = serde_json::to_value(&response).unwrap();
+        // u64 chunk offsets serialize as strings; heights/counts as numbers
+        assert_eq!(json["ledgerId"], 1);
+        assert_eq!(json["ledger"], "Submit");
+        assert_eq!(json["ledgerOffset"], "129");
+        assert_eq!(json["slotIndex"], 0);
+        assert_eq!(json["slotOffset"], 129);
+        assert_eq!(json["blockHeight"], 157_860);
+        assert_eq!(json["blockStartOffset"], "127");
+        assert_eq!(json["blockEndOffset"], "130");
+        assert_eq!(json["txOffset"], 2);
+        assert_eq!(json["txStartOffset"], "127");
+        assert_eq!(json["txEndOffset"], "130");
+        assert_eq!(json["chunksInTx"], 3);
     }
 }

--- a/crates/api-server/src/routes/ledger.rs
+++ b/crates/api-server/src/routes/ledger.rs
@@ -1,10 +1,10 @@
 use crate::ApiState;
 use crate::error::ApiError;
+use crate::routes::parse_ledger_id;
 use actix_web::web::{Data, Json, Path};
 use awc::http::StatusCode;
-use irys_actors::block_tree_service;
-use irys_database::{database, db::IrysDatabaseExt as _};
-use irys_domain::BlockBounds;
+use irys_database::{block_header_by_hash, database, db::IrysDatabaseExt as _};
+use irys_domain::{BlockBounds, BlockBoundsError, BlockIndex};
 use irys_types::{
     DataLedger, DataTransactionHeader, DataTransactionLedger, H256, IrysAddress, IrysBlockHeader,
     LedgerChunkOffset, partition::PartitionAssignment, serialization::string_u64,
@@ -285,7 +285,9 @@ pub async fn get_current_epoch(
 /// owns it, using the block index and canonical block headers — chain
 /// attribution, not local storage availability.
 ///
-/// `blockEndOffset` and `txEndOffset` are exclusive upper bounds.
+/// `blockEndOffset` and `txEndOffset` are exclusive upper bounds. All u64
+/// fields serialize as JSON strings (matching the rest of the API); the u32
+/// `txIndex` stays a JSON number.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct LedgerOffsetTxResponse {
@@ -293,8 +295,11 @@ pub struct LedgerOffsetTxResponse {
     pub ledger: DataLedger,
     #[serde(with = "string_u64")]
     pub ledger_offset: u64,
+    #[serde(with = "string_u64")]
     pub slot_index: u64,
+    #[serde(with = "string_u64")]
     pub slot_offset: u64,
+    #[serde(with = "string_u64")]
     pub block_height: u64,
     pub block_hash: H256,
     /// First chunk offset the block appended to the ledger (inclusive)
@@ -306,12 +311,14 @@ pub struct LedgerOffsetTxResponse {
     pub tx_id: H256,
     pub data_root: H256,
     /// Position of the tx within the block's tx list for this ledger
-    pub tx_offset: usize,
+    /// (a list index, not a chunk offset)
+    pub tx_index: u32,
     #[serde(with = "string_u64")]
     pub tx_start_offset: u64,
     /// One past the tx's last chunk offset (exclusive)
     #[serde(with = "string_u64")]
     pub tx_end_offset: u64,
+    #[serde(with = "string_u64")]
     pub chunks_in_tx: u64,
 }
 
@@ -351,25 +358,29 @@ pub async fn get_tx_by_slot_offset(
         state.config.consensus.num_chunks_in_partition,
     )
     .map_err(|msg| ApiError::CustomWithStatus(msg, StatusCode::BAD_REQUEST))?;
-    Ok(Json(resolve_tx_by_ledger_offset(
-        &state,
-        ledger,
-        ledger_offset,
-    )?))
-}
-
-fn parse_ledger_id(ledger_id: u32) -> Result<DataLedger, ApiError> {
-    DataLedger::try_from(ledger_id).map_err(|_| {
-        (
-            format!("Invalid ledger id: {ledger_id}"),
-            StatusCode::BAD_REQUEST,
-        )
-            .into()
-    })
+    resolve_tx_by_ledger_offset(&state, ledger, ledger_offset)
+        .map(Json)
+        .map_err(|err| match err {
+            // Restate not-found errors in the client's slot coordinates — the
+            // absolute offset in the inner message never appeared in the
+            // request, so on its own it can't be correlated with it.
+            ApiError::CustomWithStatus(msg, StatusCode::NOT_FOUND) => ApiError::CustomWithStatus(
+                format!(
+                    "{msg} (requested slot {}, slot offset {})",
+                    path.slot_index, path.slot_offset
+                ),
+                StatusCode::NOT_FOUND,
+            ),
+            other => other,
+        })
 }
 
 fn internal(msg: impl Into<String>) -> ApiError {
     ApiError::CustomWithStatus(msg.into(), StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+fn not_found(msg: String) -> ApiError {
+    ApiError::CustomWithStatus(msg, StatusCode::NOT_FOUND)
 }
 
 /// Converts a slot-relative offset into an absolute ledger offset. Every data
@@ -394,130 +405,122 @@ fn slot_to_ledger_offset(
 
 /// Resolves a canonical ledger chunk offset to the data transaction that owns
 /// it. Works for any [`DataLedger`], including the Cascade term ledgers
-/// (OneYear/ThirtyDay): a ledger with no block-index entries yet simply has a
-/// frontier of 0, so every offset 404s until data lands in it.
+/// (OneYear/ThirtyDay): before activation (or before any data lands) the
+/// lookup reports the offset as unallocated, which maps to 404.
+///
+/// Every read — the bounds binary search, the block header, and the tx-header
+/// walk — happens inside one MDBX view transaction, i.e. one consistent
+/// snapshot: a concurrent deep-reorg truncation of the block index can't mix
+/// states mid-request, and the walk costs one transaction instead of one per
+/// tx. (Indexed blocks are migrated, and migration persists the block header
+/// and its tx headers atomically with the index entry, so the header/tx
+/// lookups below can't miss for in-snapshot index entries.)
 fn resolve_tx_by_ledger_offset(
     state: &ApiState,
     ledger: DataLedger,
     ledger_offset: u64,
 ) -> Result<LedgerOffsetTxResponse, ApiError> {
     let consensus = &state.config.consensus;
-    let block_index = state.block_index.read();
-
-    // Distinguish "offset not (yet) allocated" (404) from index/header
-    // inconsistencies (500) up front by checking the latest indexed total for
-    // this ledger. A ledger absent from the latest index item (e.g. a Cascade
-    // term ledger before activation) has a frontier of 0.
-    let anchor_height = block_index.latest_height();
-    let anchor_item = block_index.get_item(anchor_height).ok_or_else(|| {
-        ApiError::CustomWithStatus("Block index is empty".into(), StatusCode::NOT_FOUND)
-    })?;
-    let frontier = anchor_item
-        .ledgers
-        .iter()
-        .find(|l| l.ledger == ledger)
-        .map(|l| l.total_chunks)
-        .unwrap_or(0);
-    if ledger_offset >= frontier {
-        return Err((
-            format!(
-                "Offset {ledger_offset} is beyond the {ledger:?} ledger frontier ({frontier} chunks)"
-            ),
-            StatusCode::NOT_FOUND,
-        )
-            .into());
-    }
-
-    // Anchor the search on the same height as the frontier check so both
-    // reads observe the same index state even if the index advances (or gets
-    // truncated by a reorg) in between.
-    let bounds = block_index
-        .get_block_bounds_at_height(
-            ledger,
-            LedgerChunkOffset::from(ledger_offset),
-            anchor_height,
-        )
-        .map_err(|e| internal(format!("Block index lookup failed: {e}")))?;
-
-    let index_item = block_index.get_item(bounds.height).ok_or_else(|| {
-        internal(format!(
-            "Missing block index item at height {}",
-            bounds.height
-        ))
-    })?;
-
-    // Indexed blocks are migrated, and migration persists the block header and
-    // its tx headers atomically with the index entry, so the DB lookup below
-    // cannot race migration; the tree is only consulted as a fast path.
-    let block = block_tree_service::get_block_header(
-        &state.block_tree,
-        &state.db,
-        index_item.block_hash,
-        false,
-    )
-    .map_err(|e| internal(format!("Failed to load block header: {e}")))?
-    .ok_or_else(|| {
-        internal(format!(
-            "Block {} at height {} is in the block index but its header was not found",
-            index_item.block_hash, bounds.height
-        ))
-    })?;
-
-    let ledger_entry =
-        validate_block_against_index(&bounds, index_item.block_hash, &block).map_err(internal)?;
-
-    let attribution = attribute_tx_at_offset(
-        bounds.height,
-        (bounds.start_chunk_offset, bounds.end_chunk_offset),
-        &ledger_entry.tx_ids.0,
-        consensus.chunk_size,
-        ledger_offset,
-        |tx_id| {
-            state
-                .db
-                .view_eyre(|tx| database::tx_header_by_txid(tx, tx_id))
-        },
-    )
-    .map_err(|e| internal(e.to_string()))?;
-
+    let chunk_size = consensus.chunk_size;
     let num_chunks_in_partition = consensus.num_chunks_in_partition;
-    Ok(LedgerOffsetTxResponse {
-        ledger_id: ledger.get_id(),
-        ledger,
-        ledger_offset,
-        slot_index: ledger_offset / num_chunks_in_partition,
-        slot_offset: ledger_offset % num_chunks_in_partition,
-        block_height: bounds.height,
-        block_hash: index_item.block_hash,
-        block_start_offset: bounds.start_chunk_offset,
-        block_end_offset: bounds.end_chunk_offset,
-        tx_id: attribution.header.id,
-        data_root: attribution.header.data_root,
-        tx_offset: attribution.tx_index,
-        tx_start_offset: attribution.tx_start_offset,
-        tx_end_offset: attribution.tx_end_offset,
-        chunks_in_tx: attribution.chunks_in_tx,
-    })
+
+    state
+        .db
+        .view_eyre(|tx| {
+            let bounds = match BlockIndex::block_bounds_in_tx(
+                tx,
+                ledger,
+                LedgerChunkOffset::from(ledger_offset),
+            ) {
+                Ok(bounds) => bounds,
+                Err(e) => return Ok(Err(bounds_error_to_api(ledger, ledger_offset, e))),
+            };
+
+            let Some(block) = block_header_by_hash(tx, &bounds.block_hash, false)? else {
+                return Ok(Err(internal(format!(
+                    "Block {} at height {} is in the block index but its header was not found",
+                    bounds.block_hash, bounds.height
+                ))));
+            };
+
+            let ledger_entry = match validate_block_against_index(&bounds, &block) {
+                Ok(entry) => entry,
+                Err(msg) => return Ok(Err(internal(msg))),
+            };
+
+            let attribution = match attribute_tx_at_offset(
+                bounds.height,
+                (bounds.start_chunk_offset, bounds.end_chunk_offset),
+                &ledger_entry.tx_ids.0,
+                chunk_size,
+                ledger_offset,
+                |tx_id| database::tx_header_by_txid(tx, tx_id),
+            ) {
+                Ok(attribution) => attribution,
+                Err(e) => return Ok(Err(internal(e.to_string()))),
+            };
+
+            let tx_index = match u32::try_from(attribution.tx_index) {
+                Ok(tx_index) => tx_index,
+                Err(_) => {
+                    return Ok(Err(internal(format!(
+                        "tx index {} exceeds u32",
+                        attribution.tx_index
+                    ))));
+                }
+            };
+
+            Ok(Ok(LedgerOffsetTxResponse {
+                ledger_id: ledger.get_id(),
+                ledger,
+                ledger_offset,
+                slot_index: ledger_offset / num_chunks_in_partition,
+                slot_offset: ledger_offset % num_chunks_in_partition,
+                block_height: bounds.height,
+                block_hash: bounds.block_hash,
+                block_start_offset: bounds.start_chunk_offset,
+                block_end_offset: bounds.end_chunk_offset,
+                tx_id: attribution.header.id,
+                data_root: attribution.header.data_root,
+                tx_index,
+                tx_start_offset: attribution.tx_start_offset,
+                tx_end_offset: attribution.tx_end_offset,
+                chunks_in_tx: attribution.chunks_in_tx,
+            }))
+        })
+        .map_err(|e| internal(format!("Database read failed: {e}")))?
 }
 
-/// Cross-checks the block header loaded for `bounds.height` against the block
-/// index item that attributed the offset to it. Any divergence is a
-/// server-side consistency violation (mapped to 500 by the caller).
+/// Maps the typed bounds-lookup outcomes onto HTTP semantics: "this offset is
+/// not (yet) allocated" variants become 404s, real failures become 500s.
+fn bounds_error_to_api(ledger: DataLedger, ledger_offset: u64, err: BlockBoundsError) -> ApiError {
+    match err {
+        BlockBoundsError::IndexEmpty => not_found("Block index is empty".into()),
+        BlockBoundsError::LedgerInactive { .. } => not_found(format!(
+            "The {ledger:?} ledger has no indexed data (not active yet?)"
+        )),
+        BlockBoundsError::OffsetBeyondFrontier { frontier, .. } => not_found(format!(
+            "Offset {ledger_offset} is beyond the {ledger:?} ledger frontier ({frontier} chunks)"
+        )),
+        BlockBoundsError::Internal(e) => internal(format!("Block index lookup failed: {e}")),
+    }
+}
+
+/// Cross-checks the block header loaded for `bounds.block_hash` against the
+/// index-derived bounds. Any divergence is a server-side consistency
+/// violation (mapped to 500 by the caller). The header's hash needs no check
+/// here — it was looked up by `bounds.block_hash`. The cumulative
+/// `total_chunks` comparison is the one with real signal: it distinguishes
+/// two forks that share the same tx set at this height but diverge in earlier
+/// data content.
 fn validate_block_against_index<'a>(
     bounds: &BlockBounds,
-    index_block_hash: H256,
     block: &'a IrysBlockHeader,
 ) -> Result<&'a DataTransactionLedger, String> {
-    if block.block_hash != index_block_hash {
-        return Err(format!(
-            "Block index has hash {index_block_hash} at height {} but the loaded header hashes to {}",
-            bounds.height, block.block_hash
-        ));
-    }
     if block.height != bounds.height {
         return Err(format!(
-            "Block {index_block_hash} is indexed at height {} but its header says height {}",
-            bounds.height, block.height
+            "Block {} is indexed at height {} but its header says height {}",
+            bounds.block_hash, bounds.height, block.height
         ));
     }
     let ledger_entry = block
@@ -526,14 +529,20 @@ fn validate_block_against_index<'a>(
         .find(|dl| dl.ledger_id == bounds.ledger)
         .ok_or_else(|| {
             format!(
-                "Block index attributes {:?} ledger chunks to block {index_block_hash} at height {} but the block has no such ledger entry",
-                bounds.ledger, bounds.height
+                "Block index attributes {:?} ledger chunks to block {} at height {} but the block has no such ledger entry",
+                bounds.ledger, bounds.block_hash, bounds.height
             )
         })?;
     if ledger_entry.tx_root != bounds.tx_root {
         return Err(format!(
             "tx_root mismatch for {:?} ledger at height {}: block index has {} but block header has {}",
             bounds.ledger, bounds.height, bounds.tx_root, ledger_entry.tx_root
+        ));
+    }
+    if ledger_entry.total_chunks != bounds.end_chunk_offset {
+        return Err(format!(
+            "total_chunks mismatch for {:?} ledger at height {}: block index says the ledger ends at {} but the block header says {}",
+            bounds.ledger, bounds.height, bounds.end_chunk_offset, ledger_entry.total_chunks
         ));
     }
     Ok(ledger_entry)
@@ -565,6 +574,16 @@ enum AttributionError {
         cursor: u64,
         ledger_offset: u64,
     },
+    #[error(
+        "Tx {tx_id} in the block at height {height} extends the tx chunk ranges to {tx_end_offset}, past the block's appended range [{block_start}, {block_end})"
+    )]
+    RangeOvershoot {
+        tx_id: H256,
+        height: u64,
+        block_start: u64,
+        block_end: u64,
+        tx_end_offset: u64,
+    },
 }
 
 /// Walks a block's ledger txs in order, assigning each the chunk range
@@ -592,6 +611,18 @@ fn attribute_tx_at_offset(
             })?;
         let chunks_in_tx = header.data_size.div_ceil(chunk_size);
         let tx_end_offset = cursor.saturating_add(chunks_in_tx);
+        // Over-coverage is as much a consistency violation as the
+        // under-coverage RangeNotCovered below: the block's txs must
+        // reproduce exactly the chunk range the index recorded.
+        if tx_end_offset > block_end {
+            return Err(AttributionError::RangeOvershoot {
+                tx_id: *tx_id,
+                height,
+                block_start,
+                block_end,
+                tx_end_offset,
+            });
+        }
         if (cursor..tx_end_offset).contains(&ledger_offset) {
             return Ok(TxAttribution {
                 tx_index,
@@ -834,7 +865,23 @@ mod tests {
         ));
     }
 
-    fn bounds_and_block(ledger: DataLedger) -> (BlockBounds, H256, irys_types::IrysBlockHeader) {
+    #[test]
+    fn attribute_txs_overshoot_block_range() {
+        // Block claims [0, 2) but its single tx spans 3 chunks — a
+        // consistency violation even for offsets the tx would cover
+        let txs = vec![data_tx(1, 3 * CHUNK_SIZE)];
+        let result = attribute_tx_at_offset(4, (0, 2), &tx_ids(&txs), CHUNK_SIZE, 1, lookup(&txs));
+        assert!(matches!(
+            result,
+            Err(AttributionError::RangeOvershoot {
+                tx_end_offset: 3,
+                block_end: 2,
+                ..
+            })
+        ));
+    }
+
+    fn bounds_and_block(ledger: DataLedger) -> (BlockBounds, irys_types::IrysBlockHeader) {
         let tx_root = H256::from([7; 32]);
         let block_hash = H256::from([8; 32]);
         let mut block = irys_types::IrysBlockHeader::new_mock_header();
@@ -843,37 +890,32 @@ mod tests {
         block.data_ledgers = vec![DataTransactionLedger {
             ledger_id: ledger.get_id(),
             tx_root,
+            total_chunks: 20,
             ..Default::default()
         }];
         let bounds = BlockBounds {
             height: 42,
+            block_hash,
             ledger,
             start_chunk_offset: 10,
             end_chunk_offset: 20,
             tx_root,
         };
-        (bounds, block_hash, block)
+        (bounds, block)
     }
 
     #[test]
     fn validate_block_against_index_ok() {
-        let (bounds, block_hash, block) = bounds_and_block(DataLedger::Submit);
-        let entry = validate_block_against_index(&bounds, block_hash, &block).unwrap();
+        let (bounds, block) = bounds_and_block(DataLedger::Submit);
+        let entry = validate_block_against_index(&bounds, &block).unwrap();
         assert_eq!(entry.tx_root, bounds.tx_root);
     }
 
     #[test]
-    fn validate_block_against_index_hash_mismatch() {
-        let (bounds, _, block) = bounds_and_block(DataLedger::Submit);
-        let err = validate_block_against_index(&bounds, H256::from([9; 32]), &block).unwrap_err();
-        assert!(err.contains("hash"), "unexpected error: {err}");
-    }
-
-    #[test]
     fn validate_block_against_index_height_mismatch() {
-        let (bounds, block_hash, mut block) = bounds_and_block(DataLedger::Submit);
+        let (bounds, mut block) = bounds_and_block(DataLedger::Submit);
         block.height = 43;
-        let err = validate_block_against_index(&bounds, block_hash, &block).unwrap_err();
+        let err = validate_block_against_index(&bounds, &block).unwrap_err();
         assert!(err.contains("height 43"), "unexpected error: {err}");
     }
 
@@ -881,9 +923,9 @@ mod tests {
     fn validate_block_against_index_missing_ledger_entry() {
         // A pre-Cascade block has no OneYear entry; the index claiming it
         // introduced OneYear chunks is a consistency violation.
-        let (mut bounds, block_hash, block) = bounds_and_block(DataLedger::Submit);
+        let (mut bounds, block) = bounds_and_block(DataLedger::Submit);
         bounds.ledger = DataLedger::OneYear;
-        let err = validate_block_against_index(&bounds, block_hash, &block).unwrap_err();
+        let err = validate_block_against_index(&bounds, &block).unwrap_err();
         assert!(
             err.contains("no such ledger entry"),
             "unexpected error: {err}"
@@ -892,10 +934,24 @@ mod tests {
 
     #[test]
     fn validate_block_against_index_tx_root_mismatch() {
-        let (mut bounds, block_hash, block) = bounds_and_block(DataLedger::Submit);
+        let (mut bounds, block) = bounds_and_block(DataLedger::Submit);
         bounds.tx_root = H256::from([13; 32]);
-        let err = validate_block_against_index(&bounds, block_hash, &block).unwrap_err();
+        let err = validate_block_against_index(&bounds, &block).unwrap_err();
         assert!(err.contains("tx_root mismatch"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn validate_block_against_index_total_chunks_mismatch() {
+        // Two forks can share the same tx set (same tx_root) at this height
+        // while diverging in earlier data content — the cumulative
+        // total_chunks comparison is the check that catches it.
+        let (mut bounds, block) = bounds_and_block(DataLedger::Submit);
+        bounds.end_chunk_offset = 21;
+        let err = validate_block_against_index(&bounds, &block).unwrap_err();
+        assert!(
+            err.contains("total_chunks mismatch"),
+            "unexpected error: {err}"
+        );
     }
 
     #[rstest]
@@ -933,24 +989,25 @@ mod tests {
             block_end_offset: 130,
             tx_id: H256::from([2; 32]),
             data_root: H256::from([3; 32]),
-            tx_offset: 2,
+            tx_index: 2,
             tx_start_offset: 127,
             tx_end_offset: 130,
             chunks_in_tx: 3,
         };
         let json = serde_json::to_value(&response).unwrap();
-        // u64 chunk offsets serialize as strings; heights/counts as numbers
+        // Every u64 serializes as a string (matching the rest of the API);
+        // the u32 ledgerId/txIndex stay JSON numbers
         assert_eq!(json["ledgerId"], 1);
         assert_eq!(json["ledger"], "Submit");
         assert_eq!(json["ledgerOffset"], "129");
-        assert_eq!(json["slotIndex"], 0);
-        assert_eq!(json["slotOffset"], 129);
-        assert_eq!(json["blockHeight"], 157_860);
+        assert_eq!(json["slotIndex"], "0");
+        assert_eq!(json["slotOffset"], "129");
+        assert_eq!(json["blockHeight"], "157860");
         assert_eq!(json["blockStartOffset"], "127");
         assert_eq!(json["blockEndOffset"], "130");
-        assert_eq!(json["txOffset"], 2);
+        assert_eq!(json["txIndex"], 2);
         assert_eq!(json["txStartOffset"], "127");
         assert_eq!(json["txEndOffset"], "130");
-        assert_eq!(json["chunksInTx"], 3);
+        assert_eq!(json["chunksInTx"], "3");
     }
 }

--- a/crates/api-server/src/routes/mod.rs
+++ b/crates/api-server/src/routes/mod.rs
@@ -18,3 +18,17 @@ pub mod storage;
 pub mod supply;
 pub mod tip;
 pub mod tx;
+
+/// Shared parse for `{ledger_id}` path params (numeric [`DataLedger`] ids:
+/// 0 = Publish, 1 = Submit, 10 = OneYear, 20 = ThirtyDay).
+pub(crate) fn parse_ledger_id(
+    ledger_id: u32,
+) -> Result<irys_types::DataLedger, crate::error::ApiError> {
+    irys_types::DataLedger::try_from(ledger_id).map_err(|_| {
+        (
+            format!("Invalid ledger id: {ledger_id}"),
+            awc::http::StatusCode::BAD_REQUEST,
+        )
+            .into()
+    })
+}

--- a/crates/chain-tests/src/api/ledger_offset_endpoint.rs
+++ b/crates/chain-tests/src/api/ledger_offset_endpoint.rs
@@ -130,9 +130,22 @@ async fn heavy_ledger_offset_tx_endpoint() -> eyre::Result<()> {
     let at_boundary_right = get_attribution(&app, "/v1/ledger/1/offset/3/tx").await;
     assert_ne!(at_boundary_left.tx_id, at_boundary_right.tx_id);
     assert_eq!(at_boundary_right.tx_start_offset, 3);
+    // txIndex points into the block's Submit tx list — cross-check the
+    // response indices against the canonical block content
+    let submit_tx_ids = &inclusion_block
+        .data_ledgers
+        .iter()
+        .find(|dl| dl.ledger_id == DataLedger::Submit)
+        .expect("inclusion block should carry a Submit ledger entry")
+        .tx_ids
+        .0;
     assert_eq!(
-        [at_boundary_left.tx_offset, at_boundary_right.tx_offset],
-        [0, 1]
+        at_boundary_left.tx_id,
+        submit_tx_ids[at_boundary_left.tx_index as usize]
+    );
+    assert_eq!(
+        at_boundary_right.tx_id,
+        submit_tx_ids[at_boundary_right.tx_index as usize]
     );
 
     // The slot-relative endpoint resolves to the identical response
@@ -298,7 +311,7 @@ async fn heavy_ledger_offset_tx_endpoint_cascade_term_ledgers() -> eyre::Result<
             assert_eq!(resp.block_height, inclusion_block.height);
             assert_eq!(resp.tx_id, tx.header.id);
             assert_eq!(resp.data_root, tx.header.data_root);
-            assert_eq!(resp.tx_offset, 0);
+            assert_eq!(resp.tx_index, 0);
             assert_eq!(resp.tx_start_offset, 0);
             assert_eq!(resp.tx_end_offset, 3);
             assert_eq!(resp.chunks_in_tx, 3);

--- a/crates/chain-tests/src/api/ledger_offset_endpoint.rs
+++ b/crates/chain-tests/src/api/ledger_offset_endpoint.rs
@@ -1,0 +1,329 @@
+//! Integration tests for the canonical ledger attribution endpoints:
+//! `GET /v1/ledger/{ledger_id}/offset/{ledger_offset}/tx` and the
+//! slot-relative variant
+//! `GET /v1/ledger/{ledger_id}/slot/{slot_index}/offset/{slot_offset}/tx`.
+
+use crate::utils::IrysNodeTest;
+use actix_web::body::MessageBody;
+use actix_web::dev::{Service, ServiceResponse};
+use actix_web::http::StatusCode;
+use actix_web::test::{TestRequest, call_service, read_body_json};
+use irys_api_server::routes::ledger::LedgerOffsetTxResponse;
+use irys_api_server::routes::tx::TxOffset;
+use irys_config::submodules::StorageSubmodulesConfig;
+use irys_types::{
+    BoundedFee, DataLedger, H256, NodeConfig, UnixTimestamp, hardfork_config::Cascade,
+    irys::IrysSigner,
+};
+use std::collections::HashMap;
+use std::time::Duration;
+use tokio::time::sleep;
+
+async fn get_status<T, B>(app: &T, uri: &str) -> StatusCode
+where
+    T: Service<actix_http::Request, Response = ServiceResponse<B>, Error = actix_web::Error>,
+{
+    let req = TestRequest::get().uri(uri).to_request();
+    call_service(app, req).await.status()
+}
+
+async fn get_attribution<T, B>(app: &T, uri: &str) -> LedgerOffsetTxResponse
+where
+    T: Service<actix_http::Request, Response = ServiceResponse<B>, Error = actix_web::Error>,
+    B: MessageBody,
+{
+    let req = TestRequest::get().uri(uri).to_request();
+    let resp = call_service(app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK, "GET {uri} should succeed");
+    read_body_json(resp).await
+}
+
+/// Publish/Submit flow on a pre-Cascade chain: two data txs share one block's
+/// Submit range, then one is promoted and cross-checked against the
+/// storage-derived `/tx/{tx_id}/local/data-start-offset` endpoint.
+#[test_log::test(tokio::test)]
+async fn heavy_ledger_offset_tx_endpoint() -> eyre::Result<()> {
+    let chunk_size = 32_u64;
+    let num_chunks_in_partition = 10_u64;
+    let mut config = NodeConfig::testing().with_consensus(|c| {
+        c.chunk_size = chunk_size;
+        c.num_chunks_in_partition = num_chunks_in_partition;
+        c.num_chunks_in_recall_range = 2;
+        c.num_partitions_per_slot = 1;
+        c.entropy_packing_iterations = 1_000;
+        c.block_migration_depth = 1;
+    });
+    config.storage.num_writes_before_sync = 1;
+    let signer = IrysSigner::random_signer(&config.consensus_config());
+    config.fund_genesis_accounts(vec![&signer]);
+
+    let node = IrysNodeTest::new_genesis(config).start().await;
+    node.node_ctx
+        .packing_waiter
+        .wait_for_idle(Some(Duration::from_secs(10)))
+        .await?;
+    let app = node.start_public_api().await;
+
+    // tx_a: 3 full chunks; tx_b: 2 chunks + 1 byte, so its partial last chunk
+    // must round up to 3 chunks in the attribution walk
+    let tx_a = node
+        .post_data_tx(
+            node.get_anchor().await?,
+            vec![1_u8; (3 * chunk_size) as usize],
+            &signer,
+        )
+        .await;
+    let tx_b = node
+        .post_data_tx(
+            node.get_anchor().await?,
+            vec![2_u8; (2 * chunk_size + 1) as usize],
+            &signer,
+        )
+        .await;
+    node.wait_for_mempool(tx_a.header.id, 20).await?;
+    node.wait_for_mempool(tx_b.header.id, 20).await?;
+
+    let inclusion_block = node.mine_block().await?;
+    // block_migration_depth = 1: the next block pushes the inclusion block
+    // into the block index
+    node.mine_block().await?;
+    node.wait_for_block_in_index_height(inclusion_block.height, 20)
+        .await?;
+
+    // Both txs landed in the Submit ledger; together they own [0, 6)
+    let mut offsets_by_tx: HashMap<H256, Vec<u64>> = HashMap::new();
+    for offset in 0..6_u64 {
+        let resp = get_attribution(&app, &format!("/v1/ledger/1/offset/{offset}/tx")).await;
+        assert_eq!(resp.ledger_id, 1);
+        assert_eq!(resp.ledger, DataLedger::Submit);
+        assert_eq!(resp.ledger_offset, offset);
+        assert_eq!(resp.slot_index, 0);
+        assert_eq!(resp.slot_offset, offset);
+        assert_eq!(resp.block_height, inclusion_block.height);
+        assert_eq!(resp.block_hash, inclusion_block.block_hash);
+        assert_eq!(resp.block_start_offset, 0);
+        assert_eq!(resp.block_end_offset, 6);
+        assert_eq!(resp.chunks_in_tx, 3);
+        assert!(
+            resp.tx_start_offset <= offset && offset < resp.tx_end_offset,
+            "offset {offset} outside claimed tx range [{}, {})",
+            resp.tx_start_offset,
+            resp.tx_end_offset
+        );
+        let expected_data_root = if resp.tx_id == tx_a.header.id {
+            tx_a.header.data_root
+        } else if resp.tx_id == tx_b.header.id {
+            tx_b.header.data_root
+        } else {
+            panic!("offset {offset} attributed to unknown tx {}", resp.tx_id);
+        };
+        assert_eq!(resp.data_root, expected_data_root);
+        offsets_by_tx.entry(resp.tx_id).or_default().push(offset);
+    }
+    // Each tx owns a contiguous 3-chunk range, meeting at the boundary
+    assert_eq!(offsets_by_tx.len(), 2);
+    for offsets in offsets_by_tx.values() {
+        assert_eq!(offsets.len(), 3);
+        assert_eq!(offsets[2] - offsets[0], 2, "range must be contiguous");
+    }
+    let at_boundary_left = get_attribution(&app, "/v1/ledger/1/offset/2/tx").await;
+    let at_boundary_right = get_attribution(&app, "/v1/ledger/1/offset/3/tx").await;
+    assert_ne!(at_boundary_left.tx_id, at_boundary_right.tx_id);
+    assert_eq!(at_boundary_right.tx_start_offset, 3);
+    assert_eq!(
+        [at_boundary_left.tx_offset, at_boundary_right.tx_offset],
+        [0, 1]
+    );
+
+    // The slot-relative endpoint resolves to the identical response
+    let direct = get_attribution(&app, "/v1/ledger/1/offset/4/tx").await;
+    let via_slot = get_attribution(&app, "/v1/ledger/1/slot/0/offset/4/tx").await;
+    assert_eq!(
+        serde_json::to_value(&direct)?,
+        serde_json::to_value(&via_slot)?
+    );
+
+    // Beyond the Submit frontier
+    assert_eq!(
+        get_status(&app, "/v1/ledger/1/offset/6/tx").await,
+        StatusCode::NOT_FOUND
+    );
+    // Cascade term ledgers are not active on this chain: no data, clean 404
+    assert_eq!(
+        get_status(&app, "/v1/ledger/10/offset/0/tx").await,
+        StatusCode::NOT_FOUND
+    );
+    assert_eq!(
+        get_status(&app, "/v1/ledger/20/offset/0/tx").await,
+        StatusCode::NOT_FOUND
+    );
+    // Invalid ledger ids (2 is not a DataLedger discriminant)
+    assert_eq!(
+        get_status(&app, "/v1/ledger/2/offset/0/tx").await,
+        StatusCode::BAD_REQUEST
+    );
+    assert_eq!(
+        get_status(&app, "/v1/ledger/999/offset/0/tx").await,
+        StatusCode::BAD_REQUEST
+    );
+    // Malformed offset: actix's Path extractor maps deserialization failures
+    // to 404 by default, like every other typed-path endpoint in this API
+    assert_eq!(
+        get_status(&app, "/v1/ledger/1/offset/notanumber/tx").await,
+        StatusCode::NOT_FOUND
+    );
+    // Slot offset must be < num_chunks_in_partition
+    assert_eq!(
+        get_status(
+            &app,
+            &format!("/v1/ledger/1/slot/0/offset/{num_chunks_in_partition}/tx")
+        )
+        .await,
+        StatusCode::BAD_REQUEST
+    );
+    // Slot index that overflows the ledger offset space
+    assert_eq!(
+        get_status(&app, &format!("/v1/ledger/1/slot/{}/offset/0/tx", u64::MAX)).await,
+        StatusCode::BAD_REQUEST
+    );
+
+    // Promote tx_a into the Publish ledger, then cross-check attribution
+    // against the storage-derived start offset (the spec's reverse check)
+    node.upload_chunks(&tx_a).await?;
+    node.wait_for_ingress_proofs(vec![tx_a.header.id], 60)
+        .await?;
+
+    let mut publish_offset = None;
+    for _ in 0..30 {
+        let req = TestRequest::get()
+            .uri(&format!(
+                "/v1/tx/{}/local/data-start-offset",
+                tx_a.header.id
+            ))
+            .to_request();
+        let resp = call_service(&app, req).await;
+        if resp.status() == StatusCode::OK {
+            let tx_offset: TxOffset = read_body_json(resp).await;
+            publish_offset = Some(tx_offset.data_start_offset);
+            break;
+        }
+        node.mine_block().await?;
+        sleep(Duration::from_millis(500)).await;
+    }
+    let publish_offset =
+        publish_offset.expect("tx_a should be promoted and its chunks migrated to Publish");
+
+    let resp = get_attribution(&app, &format!("/v1/ledger/0/offset/{publish_offset}/tx")).await;
+    assert_eq!(resp.ledger, DataLedger::Publish);
+    assert_eq!(resp.ledger_id, 0);
+    assert_eq!(resp.tx_id, tx_a.header.id);
+    assert_eq!(resp.data_root, tx_a.header.data_root);
+    assert_eq!(resp.tx_start_offset, publish_offset);
+    assert_eq!(resp.chunks_in_tx, 3);
+
+    node.stop().await;
+    Ok(())
+}
+
+/// Post-Cascade chain: data txs target the OneYear/ThirtyDay term ledgers
+/// directly and the attribution endpoints resolve their offsets.
+#[test_log::test(tokio::test)]
+async fn heavy_ledger_offset_tx_endpoint_cascade_term_ledgers() -> eyre::Result<()> {
+    let num_blocks_in_epoch = 2_u64;
+    let chunk_size = 32_u64;
+    let num_chunks_in_partition = 10_u64;
+
+    let mut config = NodeConfig::testing().with_consensus(|c| {
+        c.block_migration_depth = 1;
+        c.epoch.num_blocks_in_epoch = num_blocks_in_epoch;
+        c.chunk_size = chunk_size;
+        c.num_chunks_in_partition = num_chunks_in_partition;
+        c.hardforks.cascade = Some(Cascade {
+            activation_timestamp: UnixTimestamp::from_secs(0),
+            one_year_epoch_length: 8,
+            thirty_day_epoch_length: 2,
+            annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
+        });
+    });
+    let signer = config.new_random_signer();
+    config.fund_genesis_accounts(vec![&signer]);
+
+    // 5 storage submodules so all 4 data ledgers have assigned partitions
+    let test_node = IrysNodeTest::new_genesis(config);
+    StorageSubmodulesConfig::load_for_test(test_node.cfg.base_directory.clone(), 5)?;
+    let node = test_node.start_and_wait_for_packing("test", 30).await;
+    let app = node.start_public_api().await;
+
+    // Cascade activates at the first epoch boundary
+    while node.get_canonical_chain_height().await <= num_blocks_in_epoch {
+        node.mine_block().await?;
+    }
+
+    // Term-ledger txs target their ledger directly (no Submit staging)
+    let mut term_txs = Vec::new();
+    for (ledger, data) in [
+        (DataLedger::OneYear, vec![7_u8; (3 * chunk_size) as usize]),
+        (
+            DataLedger::ThirtyDay,
+            // partial last chunk rounds up to 3 chunks
+            vec![8_u8; (2 * chunk_size + 1) as usize],
+        ),
+    ] {
+        let price = node.get_data_price(ledger, data.len() as u64).await?;
+        let tx = signer.sign_transaction(signer.create_transaction_with_fees(
+            data,
+            node.get_anchor().await?,
+            ledger,
+            BoundedFee::new(price.term_fee),
+            None,
+        )?)?;
+        node.ingest_data_tx(tx.header.clone()).await?;
+        node.wait_for_mempool(tx.header.id, 30).await?;
+        term_txs.push((ledger, tx));
+    }
+
+    let inclusion_block = node.mine_block().await?;
+    node.mine_block().await?;
+    node.wait_for_block_in_index_height(inclusion_block.height, 20)
+        .await?;
+
+    for (ledger, tx) in &term_txs {
+        let ledger_id = ledger.get_id();
+        for offset in 0..3_u64 {
+            let resp =
+                get_attribution(&app, &format!("/v1/ledger/{ledger_id}/offset/{offset}/tx")).await;
+            assert_eq!(resp.ledger, *ledger);
+            assert_eq!(resp.ledger_id, ledger_id);
+            assert_eq!(resp.ledger_offset, offset);
+            assert_eq!(resp.block_height, inclusion_block.height);
+            assert_eq!(resp.tx_id, tx.header.id);
+            assert_eq!(resp.data_root, tx.header.data_root);
+            assert_eq!(resp.tx_offset, 0);
+            assert_eq!(resp.tx_start_offset, 0);
+            assert_eq!(resp.tx_end_offset, 3);
+            assert_eq!(resp.chunks_in_tx, 3);
+        }
+        // Beyond each term ledger's frontier
+        assert_eq!(
+            get_status(&app, &format!("/v1/ledger/{ledger_id}/offset/3/tx")).await,
+            StatusCode::NOT_FOUND
+        );
+    }
+
+    // Slot-relative endpoint works for term ledgers too
+    let direct = get_attribution(&app, "/v1/ledger/20/offset/1/tx").await;
+    let via_slot = get_attribution(&app, "/v1/ledger/20/slot/0/offset/1/tx").await;
+    assert_eq!(
+        serde_json::to_value(&direct)?,
+        serde_json::to_value(&via_slot)?
+    );
+
+    // Term txs never pass through the Submit staging ledger
+    assert_eq!(
+        get_status(&app, "/v1/ledger/1/offset/0/tx").await,
+        StatusCode::NOT_FOUND
+    );
+
+    node.stop().await;
+    Ok(())
+}

--- a/crates/chain-tests/src/api/mod.rs
+++ b/crates/chain-tests/src/api/mod.rs
@@ -3,6 +3,7 @@ mod api;
 mod client;
 mod external_api;
 mod hardfork_tests;
+mod ledger_offset_endpoint;
 mod pricing_endpoint;
 mod supply_endpoint;
 mod tx;

--- a/crates/domain/src/models/block_index.rs
+++ b/crates/domain/src/models/block_index.rs
@@ -238,33 +238,68 @@ impl BlockIndex {
     /// For a given chunk offset in a ledger, what block was responsible for adding
     /// that chunk to the data ledger?
     ///
-    /// Thin wrapper over [`Self::get_block_bounds_at_height`] anchored on the
-    /// latest indexed height. The anchored variant assumes a non-empty index;
-    /// the empty-index precheck lives here, the public entry point.
+    /// Thin wrapper over [`Self::block_bounds_in_tx`] in a fresh view
+    /// transaction. Callers composing multiple reads that must observe one
+    /// consistent index snapshot should open their own view transaction and
+    /// call the `_in_tx` variant instead.
     pub fn get_block_bounds(
         &self,
         ledger: DataLedger,
         chunk_offset: LedgerChunkOffset,
-    ) -> eyre::Result<BlockBounds> {
-        let latest_height = self
-            .db
-            .view_eyre(block_index_latest_height)?
-            .ok_or_else(|| eyre::eyre!("Block index is empty"))?;
-        self.get_block_bounds_at_height(ledger, chunk_offset, latest_height)
+    ) -> Result<BlockBounds, BlockBoundsError> {
+        self.db
+            .view_eyre(|tx| Ok(Self::block_bounds_in_tx(tx, ledger, chunk_offset)))
+            .map_err(BlockBoundsError::Internal)?
     }
 
-    // Note: `get_block_bounds_at_height` and `get_block_index_item` both
+    /// Like [`Self::get_block_bounds`], but anchored on `anchor_height`
+    /// instead of the latest indexed height. See
+    /// [`Self::block_bounds_at_height_in_tx`] for the anchoring semantics.
+    pub fn get_block_bounds_at_height(
+        &self,
+        ledger: DataLedger,
+        chunk_offset: LedgerChunkOffset,
+        anchor_height: u64,
+    ) -> Result<BlockBounds, BlockBoundsError> {
+        self.db
+            .view_eyre(|tx| {
+                Ok(Self::block_bounds_at_height_in_tx(
+                    tx,
+                    ledger,
+                    chunk_offset,
+                    anchor_height,
+                ))
+            })
+            .map_err(BlockBoundsError::Internal)?
+    }
+
+    /// [`Self::block_bounds_at_height_in_tx`] anchored on the latest height
+    /// indexed in the same transaction's snapshot.
+    pub fn block_bounds_in_tx<T: DbTx>(
+        tx: &T,
+        ledger: DataLedger,
+        chunk_offset: LedgerChunkOffset,
+    ) -> Result<BlockBounds, BlockBoundsError> {
+        let anchor_height = block_index_latest_height(tx)?.ok_or(BlockBoundsError::IndexEmpty)?;
+        Self::block_bounds_at_height_in_tx(tx, ledger, chunk_offset, anchor_height)
+    }
+
+    // Note: `block_bounds_at_height_in_tx` and `get_block_index_item` both
     // binary-search the index but intentionally diverge on how they treat a
     // probed block whose ledger entry is missing; any future refactor that
     // unifies them must take a missing-ledger-policy parameter rather than
     // collapse the two behaviours.
 
-    /// Like [`Self::get_block_bounds`], but anchored on `anchor_height`
-    /// instead of the latest indexed height. This produces fork-deterministic
-    /// results across peers regardless of how far their local indices have
-    /// advanced past the anchor — the caller (e.g. PoA pre-validation) passes
-    /// the block's parent height so two honest peers on the same fork compute
-    /// identical bounds.
+    /// Resolves the block introducing `chunk_offset`, anchored on
+    /// `anchor_height`. Anchoring produces fork-deterministic results across
+    /// peers regardless of how far their local indices have advanced past the
+    /// anchor — the caller (e.g. PoA pre-validation) passes the block's parent
+    /// height so two honest peers on the same fork compute identical bounds.
+    ///
+    /// Runs entirely inside the caller's view transaction, so every probe of
+    /// the binary search — and any further reads the caller makes with the
+    /// same `tx` — observes one consistent index snapshot even while a
+    /// concurrent deep-reorg truncation rewrites the index.
     ///
     /// Missing-ledger policy: a probed block whose ledger entry is absent is
     /// treated as pre-introduction (`total_chunks = 0`) so the search moves
@@ -272,99 +307,97 @@ impl BlockIndex {
     /// late-introduced ledger. This differs intentionally from
     /// [`Self::get_block_index_item`], which reports a missing ledger as
     /// `Err`; see the section comment above for why the two policies must
-    /// remain distinct.
-    pub fn get_block_bounds_at_height(
-        &self,
+    /// remain distinct. The *anchor* block lacking the ledger entirely is
+    /// reported as [`BlockBoundsError::LedgerInactive`].
+    pub fn block_bounds_at_height_in_tx<T: DbTx>(
+        tx: &T,
         ledger: DataLedger,
         chunk_offset: LedgerChunkOffset,
         anchor_height: u64,
-    ) -> eyre::Result<BlockBounds> {
-        self.db.view_eyre(|tx| {
-            let anchor_item = block_index_item_by_height(tx, &anchor_height)?;
-            let anchor_max = anchor_item
-                .ledgers
-                .iter()
-                .find(|l| l.ledger == ledger)
-                .map(|l| l.total_chunks)
-                .ok_or_else(|| {
-                    eyre::eyre!(
-                        "Ledger {:?} not found in block at height {}",
-                        ledger,
-                        anchor_height
-                    )
-                })?;
+    ) -> Result<BlockBounds, BlockBoundsError> {
+        let anchor_item = block_index_item_by_height(tx, &anchor_height)?;
+        let anchor_max = anchor_item
+            .ledgers
+            .iter()
+            .find(|l| l.ledger == ledger)
+            .map(|l| l.total_chunks)
+            .ok_or(BlockBoundsError::LedgerInactive {
+                ledger,
+                anchor_height,
+            })?;
 
-            let chunk_offset_val: u64 = chunk_offset.into();
-            eyre::ensure!(
-                chunk_offset_val < anchor_max,
-                "chunk_offset {} beyond anchor block's max_chunk_offset {}, anchor height {}",
-                chunk_offset_val,
-                anchor_max,
-                anchor_height
-            );
+        let chunk_offset_val: u64 = chunk_offset.into();
+        if chunk_offset_val >= anchor_max {
+            return Err(BlockBoundsError::OffsetBeyondFrontier {
+                ledger,
+                chunk_offset: chunk_offset_val,
+                frontier: anchor_max,
+                anchor_height,
+            });
+        }
 
-            // Binary search bounded by anchor_height (inclusive) so this never
-            // consults blocks beyond the parent — fork-deterministic regardless
-            // of how far the local tip has advanced. A probed block lacking
-            // this ledger entirely (ledger introduced at a later height) is
-            // equivalent to total_chunks = 0; the search just moves right.
-            let (block_height, found_item) = {
-                let mut lo: u64 = 0;
-                let mut hi: u64 = anchor_height;
+        // Binary search bounded by anchor_height (inclusive) so this never
+        // consults blocks beyond the parent — fork-deterministic regardless
+        // of how far the local tip has advanced. A probed block lacking
+        // this ledger entirely (ledger introduced at a later height) is
+        // equivalent to total_chunks = 0; the search just moves right.
+        let (block_height, found_item) = {
+            let mut lo: u64 = 0;
+            let mut hi: u64 = anchor_height;
 
-                while lo < hi {
-                    let mid = lo + (hi - lo) / 2;
-                    let item = block_index_item_by_height(tx, &mid)?;
-                    let total = item
-                        .ledgers
-                        .iter()
-                        .find(|l| l.ledger == ledger)
-                        .map(|l| l.total_chunks)
-                        .unwrap_or(0);
-                    if chunk_offset_val < total {
-                        hi = mid;
-                    } else {
-                        lo = mid + 1;
-                    }
-                }
-
-                let item = block_index_item_by_height(tx, &lo)?;
-                (lo, item)
-            };
-
-            // prev_total is 0 for genesis (no predecessor) and for blocks that
-            // first introduce this ledger (predecessor has no entry).
-            let prev_total = if block_height == 0 {
-                0
-            } else {
-                let previous_item = block_index_item_by_height(tx, &(block_height - 1))?;
-                previous_item
+            while lo < hi {
+                let mid = lo + (hi - lo) / 2;
+                let item = block_index_item_by_height(tx, &mid)?;
+                let total = item
                     .ledgers
                     .iter()
                     .find(|l| l.ledger == ledger)
                     .map(|l| l.total_chunks)
-                    .unwrap_or(0)
-            };
+                    .unwrap_or(0);
+                if chunk_offset_val < total {
+                    hi = mid;
+                } else {
+                    lo = mid + 1;
+                }
+            }
 
-            let found_ledger = found_item
+            let item = block_index_item_by_height(tx, &lo)?;
+            (lo, item)
+        };
+
+        // prev_total is 0 for genesis (no predecessor) and for blocks that
+        // first introduce this ledger (predecessor has no entry).
+        let prev_total = if block_height == 0 {
+            0
+        } else {
+            let previous_item = block_index_item_by_height(tx, &(block_height - 1))?;
+            previous_item
                 .ledgers
                 .iter()
                 .find(|l| l.ledger == ledger)
-                .ok_or_else(|| {
-                    eyre::eyre!(
-                        "Ledger {:?} not found in block at height {}",
-                        ledger,
-                        block_height
-                    )
-                })?;
+                .map(|l| l.total_chunks)
+                .unwrap_or(0)
+        };
 
-            Ok(BlockBounds {
-                height: block_height,
-                ledger,
-                start_chunk_offset: prev_total,
-                end_chunk_offset: found_ledger.total_chunks,
-                tx_root: found_ledger.tx_root,
-            })
+        let found_ledger = found_item
+            .ledgers
+            .iter()
+            .find(|l| l.ledger == ledger)
+            .ok_or_else(|| {
+                BlockBoundsError::Internal(eyre::eyre!(
+                    "Ledger {:?} not found in block at height {}",
+                    ledger,
+                    block_height
+                ))
+            })?;
+
+        Ok(BlockBounds {
+            height: block_height,
+            block_hash: found_item.block_hash,
+            ledger,
+            start_chunk_offset: prev_total,
+            end_chunk_offset: found_ledger.total_chunks,
+            tx_root: found_ledger.tx_root,
         })
     }
 
@@ -452,6 +485,11 @@ impl BlockIndex {
 pub struct BlockBounds {
     /// Block height where these bounds apply
     pub height: u64,
+    /// Hash of the block introducing these bounds, taken from the same index
+    /// item (and so the same snapshot) the search resolved — callers must not
+    /// re-read the index for it, or a concurrent truncation could pair these
+    /// bounds with a different fork's hash.
+    pub block_hash: H256,
     /// Target ledger (Publish or Submit)
     pub ledger: DataLedger,
     /// First chunk offset included in this block (inclusive)
@@ -462,6 +500,41 @@ pub struct BlockBounds {
     pub end_chunk_offset: u64,
     /// Merkle root (`tx_root`) of all transactions this block applied to the ledger
     pub tx_root: H256,
+}
+
+/// Typed outcome of a block-bounds lookup, so callers can tell "this offset
+/// is not (yet) allocated in this ledger" apart from a real lookup failure
+/// without re-deriving the ledger frontier themselves: API routes map the
+/// first three variants to 404, PoA pre-validation to its typed consensus
+/// errors, and background services skip the work item.
+#[derive(Debug, thiserror::Error)]
+pub enum BlockBoundsError {
+    #[error("block index is empty")]
+    IndexEmpty,
+    /// The anchor block carries no entry for this ledger — e.g. a Cascade
+    /// term ledger before activation.
+    #[error("ledger {ledger:?} has no entry in the anchor block at height {anchor_height}")]
+    LedgerInactive {
+        ledger: DataLedger,
+        anchor_height: u64,
+    },
+    #[error(
+        "chunk offset {chunk_offset} is beyond the {ledger:?} ledger frontier ({frontier} chunks) at anchor height {anchor_height}"
+    )]
+    OffsetBeyondFrontier {
+        ledger: DataLedger,
+        chunk_offset: u64,
+        frontier: u64,
+        anchor_height: u64,
+    },
+    #[error("block bounds lookup failed: {0}")]
+    Internal(eyre::Report),
+}
+
+impl From<eyre::Report> for BlockBoundsError {
+    fn from(err: eyre::Report) -> Self {
+        Self::Internal(err)
+    }
 }
 
 // === Migration-only code (temporary, will be removed once all nodes have migrated) ===
@@ -681,12 +754,20 @@ mod tests {
         assert_eq!(block_index.get_item(1).unwrap(), block_items[1]);
         assert_eq!(block_index.get_item(2).unwrap(), block_items[2]);
 
-        // check an invalid byte offset causes get_block_bounds to return an error
+        // an offset past the frontier is reported as the typed
+        // OffsetBeyondFrontier, carrying the frontier value
         let invalid_block_bounds =
             block_index.get_block_bounds(DataLedger::Publish, LedgerChunkOffset::from(300));
         assert!(
-            invalid_block_bounds.is_err(),
-            "expected invalid block bound to generate an error"
+            matches!(
+                invalid_block_bounds,
+                Err(BlockBoundsError::OffsetBeyondFrontier {
+                    frontier: 300,
+                    chunk_offset: 300,
+                    ..
+                })
+            ),
+            "expected OffsetBeyondFrontier, got {invalid_block_bounds:?}"
         );
 
         // check valid block bound
@@ -697,6 +778,7 @@ mod tests {
             block_bounds,
             BlockBounds {
                 height: 1,
+                block_hash: block_items[1].block_hash,
                 ledger: DataLedger::Publish,
                 start_chunk_offset: 100,
                 end_chunk_offset: 200,
@@ -711,6 +793,7 @@ mod tests {
             block_bounds,
             BlockBounds {
                 height: 1,
+                block_hash: block_items[1].block_hash,
                 ledger: DataLedger::Submit,
                 start_chunk_offset: 1000,
                 end_chunk_offset: 2000,


### PR DESCRIPTION
## Summary

Adds two canonical ledger attribution endpoints that resolve a ledger chunk offset to the data transaction that owns it, using the block index and canonical block headers (chain attribution, not local storage availability):

- `GET /v1/ledger/{ledger_id}/offset/{ledger_offset}/tx`
- `GET /v1/ledger/{ledger_id}/slot/{slot_index}/offset/{slot_offset}/tx` (slot-relative convenience; `ledger_offset = slot_index * num_chunks_in_partition + slot_offset`)

Works for all data ledgers, including the Cascade term ledgers (OneYear = 10, ThirtyDay = 20):

- A ledger with no block-index entries yet (e.g. a term ledger before Cascade activation) has a frontier of 0, so every offset returns a clean 404 instead of an internal error.
- Ledger entries in block headers are looked up with `.find()` rather than the panicking `Index<DataLedger>` impl, since pre-Cascade blocks lack the term-ledger entries.
- Block-index bounds lookups now return typed `BlockBoundsError` variants (`IndexEmpty`, `LedgerInactive`, `OffsetBeyondFrontier`, `Internal`) instead of opaque lookup errors, so callers can distinguish unallocated ledger offsets from real local index failures.

Design notes:

- The handler resolves bounds, loads the indexed block header, and walks tx headers inside one MDBX view transaction via the block-index `_in_tx` API, so concurrent index advancement or deep-reorg truncation cannot mix snapshots mid-request.
- Typed `BlockBoundsError` routing is shared by callers: the API maps empty/inactive/beyond-frontier outcomes to 404, PoA prevalidation maps inactive/out-of-range bounds to typed consensus errors, and internal lookup failures stay internal.
- Block index vs header consistency is cross-checked (height, tx_root, total_chunks); any divergence, missing tx header, or uncovered chunk range returns a descriptive 500.
- `BlockBounds` carries the resolved block hash from the same index snapshot as the bounds, avoiding a second canonical-hash read that could mismatch during reorgs.
- The tx walk mirrors `BlockIndex::push_block` chunk accounting (`data_size.div_ceil(chunk_size)` per tx).
- u64 chunk offsets serialize as strings, matching existing API style; `blockEndOffset`/`txEndOffset` are exclusive bounds.

## Test plan

- Unit tests in `routes/ledger.rs`: single/multi-chunk txs, multiple txs per block, first/last/boundary offsets, partial last chunk, zero-size tx, missing tx header, tx-lookup failure, uncovered range, block hash/height/tx_root/total_chunks mismatches, missing ledger entry (pre-Cascade block), slot math incl. overflow, typed `BlockBoundsError` to HTTP mapping, and a JSON serialization contract test.
- Block-index and validation regression coverage for typed bounds errors, inactive-ledger PoA classification, and indexed bounds carrying the owning block hash from the same snapshot.
- Integration tests in `crates/chain-tests/src/api/ledger_offset_endpoint.rs`:
  - `heavy_ledger_offset_tx_endpoint`: two data txs sharing one block's Submit range (boundary + contiguity checks), slot/direct equivalence, 404 beyond frontier, 400 invalid ledger ids, 400 slot-offset/overflow, term ledgers 404 pre-Cascade; then promotes a tx and cross-checks Publish attribution against `/tx/{tx_id}/local/data-start-offset`.
  - `heavy_ledger_offset_tx_endpoint_cascade_term_ledgers`: Cascade activated at genesis, posts OneYear and ThirtyDay txs and resolves every offset of each, plus frontier 404s and slot equivalence on term ledgers.
- `cargo fmt`, `cargo clippy --workspace --tests --all-targets`, and `typos` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two new transaction attribution API endpoints for retrieving the owning transaction by ledger offset, including slot-relative offset support.
  * Endpoint responses include structured attribution details (ledger/offset and related block/tx metadata).

* **Bug Fixes**
  * Improved request validation and error handling for invalid ledger IDs and out-of-range/inactive offset lookups.
  * Strengthened consistency checks so returned ownership attribution matches indexed ledger block bounds.

* **Tests**
  * Added integration tests covering success, boundary splits, parity between direct/slot-relative queries, and expected 400/404 responses.
  * Added snapshot coverage for indexed bounds owning-block hash behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
