### PR TITLE
fix(consensus): branch-correct data-tx publish selection + content-verified canonical lookups

### DIFF
--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -206,14 +206,22 @@ impl BlockMigrationService {
         self.storage_modules_guard = Some(guard);
     }
 
-    /// Atomically persists tx metadata (included_height, promoted_height) and
-    /// keeps the `CachedDataRoots.block_set` hint consistent with the canonical
-    /// chain.
+    /// Runs at block confirmation (every tip change, `block_tree_service`), NOT
+    /// at migration. It does two things: (1) on reorg, clears canonical tx
+    /// metadata for orphaned blocks that had already migrated; (2) maintains the
+    /// non-consensus `CachedDataRoots.block_set` hint for confirmed Submit txs.
+    ///
+    /// It does NOT *write* canonical tx metadata (`included_height` /
+    /// `promoted_height`) — that happens only at migration (`persist_block`),
+    /// atomically with `MigratedBlockHashes`. Confirmation is depth 0 and its
+    /// blocks aren't durably persisted until migration, so writing canonical
+    /// metadata here would let an orphaned tip strand a row that a later block
+    /// migrating at the same height reads as canonical.
     ///
     /// For normal blocks: `blocks_to_clear` is empty, `blocks_to_confirm` contains just the tip.
     /// For reorgs: `blocks_to_clear` contains orphaned fork blocks, `blocks_to_confirm` contains
     /// the new canonical fork blocks. Both operations happen in a single DB transaction to
-    /// prevent inconsistent metadata state.
+    /// prevent inconsistent hint state.
     ///
     /// Invariant established at every commit boundary: if a Submit-ledger tx
     /// in `blocks_to_confirm` has a [`CachedDataRoot`] entry, its `block_set`
@@ -232,13 +240,12 @@ impl BlockMigrationService {
     ///     populated `block_set` and proceeds.  It may fabricate a CDR row
     ///     for a data_root the node has no chunks for yet; the entry is
     ///     harmless until either chunks arrive or the prune pass evicts it.
-    ///   - `persist_metadata` (this function) runs at migration time and is
-    ///     the authoritative writer for canonical state changes: Phase 1
+    ///   - `persist_metadata` (this function) runs at confirmation: Phase 1
     ///     scrubs orphan block_hashes from any retained `block_set`, and
     ///     Phase 3's `update_data_root_block_set` is update-only — it never
-    ///     fabricates, because by migration time any data_root the node
-    ///     cares about already has a CDR (either chunks have arrived, or
-    ///     the mempool BlockConfirmed path put one there).
+    ///     fabricates, because by confirmation any data_root the node cares
+    ///     about already has a CDR (either chunks have arrived, or the mempool
+    ///     BlockConfirmed path put one there).
     ///
     /// A stale `BlockConfirmed` arriving after a reorg can re-add an orphan
     /// block_hash to `block_set`; that is tolerated because consumers treat
@@ -248,27 +255,25 @@ impl BlockMigrationService {
     /// Reorg invariant: if a Publish-promotion remains canonical, the
     /// underlying Submit inclusion must also be present in `blocks_to_confirm`
     /// — otherwise the Publish block itself would be in `blocks_to_clear`.
-    /// Therefore Phase 1 always deletes orphaned term-ledger metadata rows
-    /// outright (the `{None, Some}` state is semantically illegal:
-    /// `promoted_height` requires a prior `included_height`).  Any matching
-    /// Publish `clear_data_tx_promoted_height` becomes a no-op on the
-    /// already-deleted row.  Phase 2 then recreates rows for txs that are
-    /// re-canonical on the new fork, restoring `promoted_height` in the same
-    /// transaction when the Publish block is also re-included.
+    /// Phase 1's clears only ever hit rows for orphaned blocks that had already
+    /// *migrated* (a deep reorg past `block_migration_depth`); orphaned
+    /// unmigrated blocks never wrote canonical metadata, so the clears are a
+    /// no-op for them. Re-canonical blocks on the new fork get their metadata
+    /// (re)written when they migrate, not here — so this function never
+    /// recreates a `{None, Some}` state.
     pub fn persist_metadata(
         &self,
         blocks_to_clear: &[Arc<SealedBlock>],
         blocks_to_confirm: &[Arc<SealedBlock>],
     ) -> eyre::Result<()> {
         // Phase 1 scrub and Phase 3 append both iterate
-        // `block.transactions().get_ledger_txs(...)`.  The in-memory
+        // `block.transactions().get_ledger_txs(Submit)`.  The in-memory
         // block-tree path always carries full transactions, but future code
         // paths (e.g. blocks hydrated from disk without their body) could
         // regress this without any error.  Surface the divergence in every
         // build so the caller fails loudly rather than committing partial
-        // state.  Checked across all data ledgers because Phase 2's
-        // `write_data_ledger_metadata` writes from `header.data_ledgers` for
-        // every ledger, not just Submit.
+        // state.  Checked across all data ledgers because Phase 1 clears
+        // orphaned metadata from `header.data_ledgers` for every ledger.
         for block in blocks_to_clear.iter().chain(blocks_to_confirm.iter()) {
             ensure_header_body_consistent(block)?;
         }
@@ -276,12 +281,12 @@ impl BlockMigrationService {
         // Defense-in-depth structural check on the reorg invariant documented
         // above: a Publish-ledger tx_id appearing in `blocks_to_confirm` while
         // its Submit row is being orphaned by `blocks_to_clear` (and NOT
-        // re-confirmed in this same batch) would leave the DB in the illegal
-        // `{None, Some}` state — promoted_height set, included_height
-        // missing.  `batch_set_data_tx_promoted_height` already errs on this,
-        // so production behavior is to fail the transaction; this assert
-        // surfaces the caller-side construction bug earlier and more loudly
-        // in debug builds, before any DB I/O.
+        // re-confirmed in this same batch) is a malformed reorg batch — it would
+        // eventually try to migrate a `promoted_height` with no prior
+        // `included_height` (the illegal `{None, Some}` state), which
+        // `batch_set_data_tx_promoted_height` rejects at migration. This assert
+        // surfaces the caller-side construction bug earlier and more loudly in
+        // debug builds, at confirmation, before the batch can reach migration.
         #[cfg(debug_assertions)]
         {
             use std::collections::HashSet;
@@ -352,29 +357,28 @@ impl BlockMigrationService {
                     )?;
                 }
             }
-            // Phase 2: Write confirmed metadata.
-            // Phase 3: Backstop the CachedDataRoot.block_set invariant for the
+            // Phase 3: Maintain the CachedDataRoot.block_set hint for the
             //          canonical Submit-ledger txs we just confirmed (update-only,
             //          does not create cache entries for data_roots the node
             //          never tracked chunks for).
             //
-            // `included_height` ↔ term ledgers (Submit, OneYear, ThirtyDay) only.
-            // `promoted_height` ↔ Publish ledger only.
-            // Writing `included_height` for Publish txs would overwrite the
-            // Submit-block height that was set when the tx first entered the
-            // Submit ledger, violating the "first included in Submit" invariant.
-            // Phase 3 reads tx bodies (not the metadata written in Phase 2), so
-            // it has no ordering dependency on Phase 2 writes and is folded into
-            // the same outer loop.
+            // Canonical tx metadata (`IrysDataTxMetadata` / `IrysCommitmentTxMetadata`)
+            // is deliberately NOT written here. It is written only at migration
+            // (`persist_block`), atomically with `MigratedBlockHashes` and the
+            // block header — so a metadata row can never exist without its MBH
+            // entry naming the same canonical block. Writing it here (at
+            // confirmation, depth 0) previously let an orphaned tip strand a
+            // metadata row that a later block migrating at the same height would
+            // read as canonical. Unmigrated blocks are served branch-correctly
+            // from the in-memory block tree (see `tx_inclusion` / the validator's
+            // by-hash walk), so the DB metadata is only ever consulted for
+            // migrated heights, where `MigratedBlockHashes` is branch-stable.
+            // `block_set` is only a non-consensus hint (never read by
+            // `find_canonical_ledger_range` / `canonical_*_height`), and the
+            // ingress-proof pipeline needs it populated at confirmation, so it
+            // stays here.
             for block in blocks_to_confirm {
-                let header = block.header();
-                let height = header.height;
-                let block_hash = header.block_hash;
-
-                write_data_ledger_metadata(tx, &header.data_ledgers, height)?;
-                self.persist_commitment_inclusions(tx, header)?;
-
-                // Phase 3: append `block_hash` to each Submit-tx's CDR.block_set.
+                let block_hash = block.header().block_hash;
                 for submit_tx in block.transactions().get_ledger_txs(DataLedger::Submit) {
                     irys_database::update_data_root_block_set(tx, submit_tx.data_root, block_hash)?;
                 }
@@ -761,9 +765,12 @@ impl BlockMigrationService {
 
 #[cfg(test)]
 mod tests {
-    //! Focused unit tests for `BlockMigrationService::persist_metadata` —
-    //! the authoritative-writer entry point for
-    //! `CachedDataRoot.block_set` and `IrysDataTxMetadata.included_height`.
+    //! Focused unit tests for `BlockMigrationService::persist_metadata` (the
+    //! confirmation-time maintainer of the `CachedDataRoot.block_set` hint and
+    //! reorg-orphan metadata cleanup) and for the migration-time metadata writer
+    //! `write_data_ledger_metadata` (`IrysDataTxMetadata` /
+    //! `IrysCommitmentTxMetadata`). Canonical metadata is written only at
+    //! migration, never at confirmation.
     //!
     //! The function only touches `self.db`; the other service fields
     //! (block_index_guard, cache, chunk_migration_sender, supply_state) are
@@ -1294,10 +1301,12 @@ mod tests {
     }
 
     /// Genesis (height 0) is excluded from the epoch skip: it genuinely
-    /// first-includes its commitments, so it writes on confirm and clears on
-    /// orphan like any inclusion block.
+    /// first-includes its commitments, so orphaning it clears the dedup row like
+    /// any inclusion block. Metadata is written at migration (`persist_block`),
+    /// so we seed the migrated row, then orphan. (The genesis migration write is
+    /// covered by `persist_block_epoch_block_skips_commitment_included_height`.)
     #[tokio::test]
-    async fn persist_metadata_genesis_writes_and_clears_commitment_rows() -> eyre::Result<()> {
+    async fn persist_metadata_genesis_orphan_clears_commitment_rows() -> eyre::Result<()> {
         let (db, _db_tmp) = open_db()?;
         let (svc, _svc_tmp) = make_service(db.clone());
 
@@ -1305,19 +1314,13 @@ mod tests {
         let genesis = make_commitment_header(0, H256::zero(), vec![commitment]);
         let genesis_sealed = make_sealed_commitment(genesis);
 
-        svc.persist_metadata(&[], std::slice::from_ref(&genesis_sealed))?;
-        assert_eq!(
-            read_commitment_tx_metadata(&db, &commitment)
-                .expect("genesis must write commitment included_height")
-                .included_height,
-            Some(0),
-            "height 0 is not skipped — genesis genuinely first-includes",
-        );
+        // Migrated state: genesis wrote its commitment dedup row at migration.
+        seed_commitment_included_height(&db, commitment, 0);
 
         svc.persist_metadata(std::slice::from_ref(&genesis_sealed), &[])?;
         assert!(
             read_commitment_tx_metadata(&db, &commitment).is_none(),
-            "height 0 keeps normal clear behavior",
+            "genesis orphan clears the commitment dedup row (height 0 not epoch-skipped)",
         );
         Ok(())
     }
@@ -1367,31 +1370,34 @@ mod tests {
     #[tokio::test]
     async fn submit_to_publish_promotion_preserves_included_height() -> eyre::Result<()> {
         let (db, _db_tmp) = open_db()?;
-        let (svc, _svc_tmp) = make_service(db.clone());
+        let (_svc, _svc_tmp) = make_service(db.clone());
 
         let tx_id = H256::random();
         let submit_height = 1_u64;
         let publish_height = 5_u64;
 
-        // Confirm in Submit ledger at height 1
+        // Migrate the Submit-ledger block at height 1 (metadata is written at
+        // migration via `write_data_ledger_metadata`, never at confirmation).
         let submit_header =
             make_block_header_with_ledger(submit_height, H256::random(), DataLedger::Submit, tx_id);
-        let submit_sealed = make_sealed_single_ledger_tx(submit_header, DataLedger::Submit, tx_id);
-        svc.persist_metadata(&[], std::slice::from_ref(&submit_sealed))?;
+        db.update_eyre(|tx| {
+            write_data_ledger_metadata(tx, &submit_header.data_ledgers, submit_height)?;
+            Ok(())
+        })?;
 
-        // Confirm same tx in Publish ledger at height 5
+        // Migrate the Publish-ledger block promoting the same tx at height 5
         let publish_header = make_block_header_with_ledger(
             publish_height,
             H256::random(),
             DataLedger::Publish,
             tx_id,
         );
-        let publish_sealed =
-            make_sealed_single_ledger_tx(publish_header, DataLedger::Publish, tx_id);
-        svc.persist_metadata(&[], std::slice::from_ref(&publish_sealed))?;
+        db.update_eyre(|tx| {
+            write_data_ledger_metadata(tx, &publish_header.data_ledgers, publish_height)?;
+            Ok(())
+        })?;
 
-        let meta =
-            read_data_tx_metadata(&db, &tx_id).expect("metadata must exist after confirmation");
+        let meta = read_data_tx_metadata(&db, &tx_id).expect("metadata must exist after migration");
         assert_eq!(
             meta.included_height,
             Some(submit_height),
@@ -1405,33 +1411,10 @@ mod tests {
         Ok(())
     }
 
-    /// Same-block Submit→Publish promotion: the term-ledger metadata write
-    /// must happen before the Publish write so `promoted_height` can be set in
-    /// the same transaction.
-    #[tokio::test]
-    async fn same_block_submit_publish_promotion_sets_both_heights() -> eyre::Result<()> {
-        let (db, _db_tmp) = open_db()?;
-        let (svc, _svc_tmp) = make_service(db.clone());
-
-        let tx_id = H256::random();
-        let data_root = H256::random();
-        let height = 11_u64;
-
-        let header = make_block_header(height, H256::random(), 50, vec![tx_id]);
-        let sealed = make_sealed_same_block_submit_publish_promotion(header, tx_id, data_root);
-
-        svc.persist_metadata(&[], std::slice::from_ref(&sealed))?;
-
-        let meta =
-            read_data_tx_metadata(&db, &tx_id).expect("metadata must exist after confirmation");
-        assert_eq!(meta.included_height, Some(height));
-        assert_eq!(meta.promoted_height, Some(height));
-        Ok(())
-    }
-
-    /// `persist_block` uses the same metadata helpers as `persist_metadata`,
-    /// so same-block promotions must also write `included_height` before
-    /// `promoted_height` during migration.
+    /// Same-block Submit→Publish promotion at migration: the term-ledger
+    /// metadata write must happen before the Publish write so `promoted_height`
+    /// can be set in the same transaction. (Covered via `persist_block` — the
+    /// real migration path — below.)
     #[tokio::test]
     async fn persist_block_same_block_submit_publish_promotion_sets_both_heights()
     -> eyre::Result<()> {
@@ -1465,18 +1448,64 @@ mod tests {
         #[case] height: u64,
     ) -> eyre::Result<()> {
         let (db, _db_tmp) = open_db()?;
-        let (svc, _svc_tmp) = make_service(db.clone());
+        let (_svc, _svc_tmp) = make_service(db.clone());
 
         let tx_id = H256::random();
 
         let header = make_block_header_with_ledger(height, H256::random(), ledger, tx_id);
-        let sealed = make_sealed_single_ledger_tx(header, ledger, tx_id);
-        svc.persist_metadata(&[], std::slice::from_ref(&sealed))?;
+        db.update_eyre(|tx| {
+            write_data_ledger_metadata(tx, &header.data_ledgers, height)?;
+            Ok(())
+        })?;
 
-        let meta =
-            read_data_tx_metadata(&db, &tx_id).expect("metadata must exist after confirmation");
+        let meta = read_data_tx_metadata(&db, &tx_id).expect("metadata must exist after migration");
         assert_eq!(meta.included_height, Some(height));
         assert_eq!(meta.promoted_height, None);
+        Ok(())
+    }
+
+    /// Root-fix guard: `persist_metadata` (confirmation, depth 0) writes NO
+    /// canonical tx metadata — `IrysDataTxMetadata` / `IrysCommitmentTxMetadata`
+    /// are written only at migration (`persist_block`). It still maintains the
+    /// non-consensus `block_set` hint. Writing canonical metadata at confirmation
+    /// would let an orphaned tip strand a row that a later block migrating at the
+    /// same height reads as canonical.
+    #[tokio::test]
+    async fn confirm_does_not_write_canonical_metadata() -> eyre::Result<()> {
+        let (db, _db_tmp) = open_db()?;
+        let (svc, _svc_tmp) = make_service(db.clone());
+
+        // A Submit-ledger data tx with a pre-existing CDR (Phase 3 is update-only).
+        let tx_id = H256::random();
+        let data_root = H256::random();
+        seed_cdr(&db, data_root, tx_id, vec![], None);
+        let header = make_block_header(1, H256::random(), 50, vec![tx_id]);
+        let block_hash = header.block_hash;
+        let sealed = make_sealed_with_submit_txs(header, &[(tx_id, data_root)]);
+
+        // A commitment tx in a separate confirmed block.
+        let commitment = H256::random();
+        let commitment_sealed =
+            make_sealed_commitment(make_commitment_header(2, H256::random(), vec![commitment]));
+
+        svc.persist_metadata(&[], &[sealed, commitment_sealed])?;
+
+        // No canonical metadata written at confirmation.
+        assert!(
+            read_data_tx_metadata(&db, &tx_id).is_none(),
+            "confirmation must NOT write IrysDataTxMetadata (written at migration only)"
+        );
+        assert!(
+            read_commitment_tx_metadata(&db, &commitment).is_none(),
+            "confirmation must NOT write IrysCommitmentTxMetadata (written at migration only)"
+        );
+
+        // But the non-consensus block_set hint IS maintained (Phase 3).
+        let cdr = read_cdr(&db, data_root).expect("CDR present");
+        assert!(
+            cdr.block_set.contains(&block_hash),
+            "confirmation still maintains the block_set hint the ingress pipeline needs"
+        );
         Ok(())
     }
 
@@ -1492,13 +1521,15 @@ mod tests {
         let submit_height = 2_u64;
         let publish_height = 8_u64;
 
-        // Confirm in Submit at height 2
+        // Migrate the Submit block at height 2 (metadata written at migration)
         let submit_header =
             make_block_header_with_ledger(submit_height, H256::random(), DataLedger::Submit, tx_id);
-        let submit_sealed = make_sealed_single_ledger_tx(submit_header, DataLedger::Submit, tx_id);
-        svc.persist_metadata(&[], std::slice::from_ref(&submit_sealed))?;
+        db.update_eyre(|tx| {
+            write_data_ledger_metadata(tx, &submit_header.data_ledgers, submit_height)?;
+            Ok(())
+        })?;
 
-        // Promote in Publish at height 8
+        // Migrate the Publish block promoting the tx at height 8
         let publish_header = make_block_header_with_ledger(
             publish_height,
             H256::random(),
@@ -1507,7 +1538,10 @@ mod tests {
         );
         let publish_sealed =
             make_sealed_single_ledger_tx(publish_header, DataLedger::Publish, tx_id);
-        svc.persist_metadata(&[], std::slice::from_ref(&publish_sealed))?;
+        db.update_eyre(|tx| {
+            write_data_ledger_metadata(tx, &publish_sealed.header().data_ledgers, publish_height)?;
+            Ok(())
+        })?;
 
         // Verify both are set
         let meta = read_data_tx_metadata(&db, &tx_id).unwrap();
@@ -1544,7 +1578,11 @@ mod tests {
         let header =
             make_block_header_with_ledger(height, H256::random(), DataLedger::Submit, tx_id);
         let sealed = make_sealed_single_ledger_tx(header, DataLedger::Submit, tx_id);
-        svc.persist_metadata(&[], std::slice::from_ref(&sealed))?;
+        // Migrated state: the Submit block wrote its metadata at migration.
+        db.update_eyre(|tx| {
+            write_data_ledger_metadata(tx, &sealed.header().data_ledgers, height)?;
+            Ok(())
+        })?;
 
         // Verify it exists
         assert!(read_data_tx_metadata(&db, &tx_id).is_some());
@@ -1576,7 +1614,11 @@ mod tests {
 
         let header = make_block_header_with_ledger(height, H256::random(), ledger, tx_id);
         let sealed = make_sealed_single_ledger_tx(header, ledger, tx_id);
-        svc.persist_metadata(&[], std::slice::from_ref(&sealed))?;
+        // Migrated state: the term-ledger block wrote its metadata at migration.
+        db.update_eyre(|tx| {
+            write_data_ledger_metadata(tx, &sealed.header().data_ledgers, height)?;
+            Ok(())
+        })?;
 
         assert!(read_data_tx_metadata(&db, &tx_id).is_some());
 
@@ -1690,21 +1732,16 @@ mod tests {
             &[new1_sealed, new2_sealed],
         )?;
 
-        // Phase 1 cleared → Phase 2 restored: included_height == new block heights.
-        let meta_a = read_data_tx_metadata(&db, &tx_id_a)
-            .expect("tx_a metadata must exist after re-confirmation");
-        assert_eq!(
-            meta_a.included_height,
-            Some(10),
-            "tx_a included_height must be updated to new canonical height"
+        // Phase 1 cleared the orphaned rows. Confirmation no longer re-writes
+        // canonical metadata — the new-fork blocks write their own
+        // `included_height` when they migrate — so both rows are absent here.
+        assert!(
+            read_data_tx_metadata(&db, &tx_id_a).is_none(),
+            "tx_a metadata cleared on reorg; re-written only when the new fork migrates"
         );
-
-        let meta_b = read_data_tx_metadata(&db, &tx_id_b)
-            .expect("tx_b metadata must exist after re-confirmation");
-        assert_eq!(
-            meta_b.included_height,
-            Some(11),
-            "tx_b included_height must be updated to new canonical height"
+        assert!(
+            read_data_tx_metadata(&db, &tx_id_b).is_none(),
+            "tx_b metadata cleared on reorg; re-written only when the new fork migrates"
         );
 
         // Phase 1 scrubbed orphan hashes; Phase 3 appended new canonical hashes.
@@ -1790,20 +1827,18 @@ mod tests {
 
         svc.persist_metadata(&[orphan1_sealed, orphan2_sealed], &[new1_sealed])?;
 
-        // tx_a: re-confirmed on the new fork.
-        let meta_a = read_data_tx_metadata(&db, &tx_id_a)
-            .expect("tx_a metadata must exist after re-confirmation");
-        assert_eq!(
-            meta_a.included_height,
-            Some(10),
-            "tx_a included_height updated to new canonical height"
+        // tx_a: cleared by Phase 1. Confirmation no longer re-writes metadata,
+        // so it's absent until the new fork migrates — the re-confirmation is
+        // visible only in the CDR block_set below.
+        assert!(
+            read_data_tx_metadata(&db, &tx_id_a).is_none(),
+            "tx_a metadata cleared on reorg; re-written only when the new fork migrates"
         );
 
-        // tx_b: row fully deleted — term-ledger Phase 1 unconditional delete,
-        // no Phase 2 recreation because tx_b is not in `blocks_to_confirm`.
+        // tx_b: row deleted by Phase 1 (permanently orphaned, never re-confirmed).
         assert!(
             read_data_tx_metadata(&db, &tx_id_b).is_none(),
-            "permanently-orphaned tx_b metadata row must be fully deleted"
+            "permanently-orphaned tx_b metadata row must be deleted"
         );
 
         // CDR A: re-confirmation path — orphan scrubbed, new canonical hash

--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -914,7 +914,7 @@ fn block_includes_ledger_tx(
 /// `MigratedBlockHashes` is branch-invariant (see `canonical_metadata_height` in
 /// `irys_database`), so an old finalized promotion (one made long before expiry,
 /// outside the reorg window) resolves identically on every node/branch.
-fn resolve_promoted_on_branch(
+pub(crate) fn resolve_promoted_on_branch(
     candidate_txids: &[IrysTransactionId],
     parent_block_hash: H256,
     block_height: u64,
@@ -3210,15 +3210,15 @@ mod tests {
     #[test]
     fn resolve_promoted_on_branch_ignores_in_window_node_local_hint() -> eyre::Result<()> {
         use irys_database::{
-            IrysDatabaseArgs as _, canonical_promoted_height, insert_tx_header, open_or_create_db,
-            set_data_tx_included_height, set_data_tx_promoted_height, tables::IrysTables,
-            tables::MigratedBlockHashes,
+            IrysDatabaseArgs as _, canonical_promoted_height, insert_block_header,
+            insert_tx_header, open_or_create_db, set_data_tx_included_height,
+            set_data_tx_promoted_height, tables::IrysTables, tables::MigratedBlockHashes,
         };
         use irys_domain::{BlockTree, BlockTreeReadGuard};
         use irys_testing_utils::IrysBlockHeaderTestExt as _;
         use irys_types::{
             BlockTransactions, DataTransactionHeaderV1, DataTransactionHeaderV1WithMetadata,
-            DataTransactionMetadata, SealedBlock,
+            DataTransactionLedger, DataTransactionMetadata, H256List, SealedBlock,
         };
         use reth_db::{mdbx::DatabaseArguments, transaction::DbTxMut as _};
         use std::sync::RwLock;
@@ -3280,9 +3280,40 @@ mod tests {
         )?;
         let db = DatabaseProvider(Arc::new(db_env));
 
-        // Plant the stale node-local promotion hint at height 1 (inside the reorg
-        // window for the block at height 3) with MBH agreeing — exactly the
-        // node-local state the old code read and the new code must ignore.
+        // Divergent sibling at height 1: `h1_alt` is a *second* child of h0 that
+        // DOES carry `target` in its Publish ledger, and is the node-local
+        // canonical block at height 1 (`MBH[1] = h1_alt`). h2's own branch goes
+        // through the `submit_only` `headers[1]`, which never carried `target`.
+        // This is the reorg-window divergence the resolver must survive: the
+        // node-canonical view (MBH + content) says "promoted", but the block's
+        // own by-hash ancestry says "not promoted". `h1_alt` is reachable only
+        // via MBH (in the DB header table), never by the parent-pointer walk.
+        let mut h1_alt = IrysBlockHeader::new_mock_header();
+        h1_alt.height = 1;
+        h1_alt.previous_block_hash = headers[0].block_hash;
+        h1_alt.cumulative_diff = 100.into();
+        h1_alt.data_ledgers = vec![
+            DataTransactionLedger {
+                ledger_id: DataLedger::Publish as u32,
+                tx_root: H256::zero(),
+                tx_ids: H256List(vec![target]),
+                total_chunks: 0,
+                expires: None,
+                proofs: None,
+                required_proof_count: None,
+            },
+            DataTransactionLedger {
+                ledger_id: DataLedger::Submit as u32,
+                tx_root: H256::zero(),
+                tx_ids: H256List(vec![]),
+                total_chunks: 0,
+                expires: None,
+                proofs: None,
+                required_proof_count: None,
+            },
+        ];
+        h1_alt.test_sign();
+
         let target_header = DataTransactionHeader::V1(DataTransactionHeaderV1WithMetadata {
             tx: DataTransactionHeaderV1 {
                 id: target,
@@ -3297,19 +3328,25 @@ mod tests {
             // value is immaterial here.
             set_data_tx_included_height(wtx, &target, 1)?;
             set_data_tx_promoted_height(wtx, &target, 1)?;
-            wtx.put::<MigratedBlockHashes>(1, headers[1].block_hash)?;
+            // The node-local canonical block at height 1 is the divergent sibling,
+            // which carries `target` in Publish — so the by-height content check
+            // is satisfied and a naive lookup is fooled.
+            insert_block_header(wtx, &h1_alt)?;
+            wtx.put::<MigratedBlockHashes>(1, h1_alt.block_hash)?;
             Ok(())
         })?;
 
         let config = Config::new_with_random_peer_id(irys_types::NodeConfig::testing());
 
         // The trap is live: a naive by-height lookup at the parent height WOULD
-        // report `target` promoted (hint 1 ≤ 2 and MBH[1] is set).
+        // report `target` promoted — MBH[1] = h1_alt, which genuinely carries
+        // `target` in its Publish ledger, so even the content check passes for
+        // the node-canonical (but off-branch) block.
         let naive = db.view_eyre(|tx| canonical_promoted_height(tx, &target, 2))?;
         assert_eq!(
             naive,
             Some(1),
-            "precondition: the stale in-window hint would fool a parent-height lookup"
+            "precondition: the in-window node-canonical block fools a parent-height lookup"
         );
 
         // The branch-correct resolver ignores it: `target` is not in any Publish

--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -922,6 +922,11 @@ pub(crate) fn resolve_promoted_on_branch(
     block_tree_guard: &BlockTreeReadGuard,
     db: &DatabaseProvider,
 ) -> eyre::Result<BTreeSet<IrysTransactionId>> {
+    // No candidates → nothing to resolve; skip the tree/DB ancestry walk entirely.
+    if candidate_txids.is_empty() {
+        return Ok(BTreeSet::new());
+    }
+
     let walk_depth = crate::block_validation::prior_inclusion_walk_depth(config);
     let walk_min_height = block_height.saturating_sub(walk_depth);
 

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -5589,14 +5589,20 @@ pub async fn data_txs_are_valid(
                         // window (max(tx_anchor_expiry_depth, block_tree_depth)).
                         // So any inclusion reaching this fallback is BELOW the
                         // reorg floor: finalized, hence branch-invariant, so the
-                        // by-height canonical-height getters in `irys_database`
+                        // canonical-height getters in `irys_database`
                         // (metadata hint + `MigratedBlockHashes`) resolve it
                         // identically on every node/branch. (Before the walk was
                         // widened, this arm could run inside the reorg-mutable
                         // `(tip - block_tree_depth, tip - block_migration_depth]`
                         // band and fork — widening the walk to the reorg window is
                         // exactly what makes this fallback safe; see the
-                        // `get_previous_tx_inclusions` docblock.)
+                        // `get_previous_tx_inclusions` docblock.) As a further
+                        // guard, both getters content-verify the hint against the
+                        // canonical block at the returned height, so a stranded
+                        // metadata row from an orphaned tip (written at depth-0
+                        // confirmation, possibly surviving a restart-interrupted
+                        // reorg) cannot yield a false `PublishTxMissingPriorSubmit`
+                        // or `PublishTxAlreadyIncluded`.
                         //
                         // `canonical_submit_height` is sufficient evidence of
                         // prior Submit: the structural pre-pass guarantees

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -5599,9 +5599,11 @@ pub async fn data_txs_are_valid(
                         // `get_previous_tx_inclusions` docblock.) As a further
                         // guard, both getters content-verify the hint against the
                         // canonical block at the returned height, so a stranded
-                        // metadata row from an orphaned tip (written at depth-0
-                        // confirmation, possibly surviving a restart-interrupted
-                        // reorg) cannot yield a false `PublishTxMissingPriorSubmit`
+                        // metadata row not backed by that block's ledger — e.g. a
+                        // legacy row from an orphaned tip written at depth-0
+                        // confirmation before canonical metadata became
+                        // migration-only, possibly surviving a restart-interrupted
+                        // reorg — cannot yield a false `PublishTxMissingPriorSubmit`
                         // or `PublishTxAlreadyIncluded`.
                         //
                         // `canonical_submit_height` is sufficient evidence of

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -458,12 +458,13 @@ impl InnerCacheTask {
                 // Pruning horizon priority: canonical tx inclusion > expiry height > evict-anomalous.
                 //
                 // CDR lifetime is bounded by either (a) `expiry_height` set at tx
-                // ingress (`cache_data_root_with_expiry`), or (b) `included_height`
-                // set atomically with the confirming tip change in
-                // `BlockMigrationService::persist_metadata` (Phase 2 sets
-                // `included_height`, Phase 3 clears `expiry_height` — same write
-                // tx).  The local-proof exemption below extends (b) indefinitely
-                // while a local ingress proof is present.
+                // ingress (`cache_data_root_with_expiry`), or (b) the tx's
+                // `included_height`, written at migration by
+                // `BlockMigrationService::persist_block` (`write_data_ledger_metadata`).
+                // `expiry_height` is cleared earlier, at confirmation, by
+                // `persist_metadata` Phase 3 (`update_data_root_block_set`).  The
+                // local-proof exemption below extends (b) indefinitely while a
+                // local ingress proof is present.
                 //
                 // The `(None, None)` arm is reachable only when a CDR has lost
                 // both bounds: a reorg cleared `included_height` for every tx in
@@ -643,7 +644,8 @@ impl InnerCacheTask {
     /// constraint and evict the CDR before chunk migration completes,
     /// destroying chunks that are still needed.  Per-txid metadata recheck
     /// inside the write tx closes that race: if `IrysDataTxMetadata[tx_id]`
-    /// is `Some` now, the tx is confirmed and the txid_set entry must stay.
+    /// is `Some` now, the tx is migrated (finalized) and the txid_set entry
+    /// must stay.
     ///
     /// Residual race the recheck does not close: a peer gossips the tx back
     /// in during the scrub window and `cache_data_root` re-adds it to

--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -503,10 +503,15 @@ impl Inner {
         self.mempool_state.wipe_blacklists().await;
     }
 
-    /// After restoring the mempool from disk, reconstruct metadata fields (included_height,
-    /// promoted_height) from the database. The `#[serde(skip)]` on `DataTransactionMetadata`
-    /// means these fields are lost during serialization. The DB is authoritative since
-    /// `BlockMigrationService` persists them at confirmation time.
+    /// After restoring the mempool from disk, reconstruct metadata fields
+    /// (included_height, promoted_height) from the database. The
+    /// `#[serde(skip)]` on `DataTransactionMetadata` means these fields are lost
+    /// during serialization. The DB carries them only for **migrated**
+    /// (finalized) inclusions — `BlockMigrationService` writes them at migration,
+    /// not at confirmation — so this restores the finalized view. A
+    /// confirmed-but-unmigrated tx correctly comes back as pending: its block was
+    /// never durably persisted, so claiming it "confirmed" would name a block the
+    /// node no longer has.
     pub async fn reconstruct_metadata_from_db(&self) {
         // Startup-only path: no other writers exist yet, so the timeout-guarded
         // `mempool_state.write()` helper is unnecessary here. Direct write is safe.

--- a/crates/actors/src/mempool_service/lifecycle.rs
+++ b/crates/actors/src/mempool_service/lifecycle.rs
@@ -14,9 +14,10 @@ use tracing::{debug, error, info, instrument, warn};
 impl Inner {
     /// Updates in-memory mempool state for a confirmed block.
     ///
-    /// DB persistence of included_height and promoted_height happens at confirmation
-    /// time (via `BlockMigrationService::persist_metadata`). Full tx header
-    /// persistence is deferred to migration time. This handler only updates:
+    /// DB persistence of canonical `included_height` / `promoted_height` (and of
+    /// full tx headers) happens at migration time via
+    /// `BlockMigrationService::persist_block`, not at confirmation. This handler
+    /// only updates:
     /// - In-memory metadata (included_height, promoted_height)
     /// - `CachedDataRoots` DB cache (needed for chunk ingress validation)
     /// - Pending tx pruning

--- a/crates/actors/src/transaction_status.rs
+++ b/crates/actors/src/transaction_status.rs
@@ -17,9 +17,10 @@ pub async fn compute_transaction_status(
     let mempool_metadata = mempool_guard.get_tx_metadata(tx_id).await;
     let in_mempool = mempool_metadata.is_some() || mempool_guard.is_recent_valid_tx(tx_id).await;
 
-    // Prefer DB metadata over mempool: BlockMigrationService writes included_height
-    // to DB synchronously at confirmation time, so it is always authoritative.
-    // Mempool metadata is the fallback for pending txs not yet in the DB.
+    // Prefer DB metadata over mempool: the DB carries `included_height` only for
+    // migrated (finalized) blocks, which is the authoritative view. Confirmed-
+    // but-unmigrated txs have no DB row yet, so the mempool is the fallback that
+    // reports the pre-migration `included_height`.
     let metadata = db_metadata.or(mempool_metadata);
 
     match (metadata, in_mempool) {

--- a/crates/actors/src/tx_selector/mod.rs
+++ b/crates/actors/src/tx_selector/mod.rs
@@ -16,14 +16,15 @@ use irys_database::{
     ingress_proofs_by_data_root, tx_header_by_txid,
 };
 use irys_domain::{
-    BlockIndex, BlockTreeEntry, BlockTreeReadGuard, CommitmentSnapshotStatus, EpochSnapshot,
-    HardforkConfigExt as _,
+    BlockIndex, BlockTreeEntry, BlockTreeReadGuard, ChainState, CommitmentSnapshotStatus,
+    EpochSnapshot, HardforkConfigExt as _,
 };
 use irys_reth_node_bridge::IrysRethNodeAdapter;
 use irys_types::ingress::{CachedIngressProof, IngressProof};
 use irys_types::transaction::fee_distribution::{PublishFeeCharges, TermFeeCharges};
 use irys_types::{
     BlockHash, BoundedFee, CommitmentTypeV2, DataLedger, DataTransactionHeader, IngressProofsList,
+    IrysTransactionId,
 };
 use irys_types::{Config, H256, IrysTransactionCommon as _, U256, app_state::DatabaseProvider};
 use irys_types::{IrysAddress, SystemLedger, UnixTimestamp};
@@ -110,6 +111,7 @@ pub async fn select_best_txs(
 
     let (
         canonical,
+        onchain_block_hashes,
         parent_block_height,
         tip_block_height,
         parent_evm_block_id,
@@ -154,6 +156,24 @@ pub async fn select_best_txs(
             .expect("canonical chain always has at least one entry")
             .height();
 
+        // Dedup against `Onchain`-only ancestors, matching
+        // `tx_inclusion::lookup_via_block_tree`. During reorg replay a canonical
+        // entry can transiently be `Validated` before the longest-chain walk
+        // promotes it; its tx_ids may be about to roll back, so counting them in
+        // the commitment/Submit dedup sets below can drop a tx that should stay
+        // includable. The parent block itself is still used for the header lookup
+        // regardless of state, so this only narrows the dedup sets.
+        let onchain_block_hashes: HashSet<BlockHash> = canonical
+            .iter()
+            .filter(|entry| {
+                matches!(
+                    tree.get_block_and_status(&entry.block_hash()),
+                    Some((_, ChainState::Onchain))
+                )
+            })
+            .map(BlockTreeEntry::block_hash)
+            .collect();
+
         let block = tree
             .get_block(&parent_block_hash)
             .ok_or_eyre(format!("Block not found: {:?}", parent_block_hash))?;
@@ -180,6 +200,7 @@ pub async fn select_best_txs(
 
         (
             canonical,
+            onchain_block_hashes,
             block_height,
             tip_block_height,
             evm_block_id,
@@ -225,17 +246,15 @@ pub async fn select_best_txs(
         "Starting mempool transaction selection"
     );
 
-    // Collect confirmed commitment transactions from canonical chain to avoid duplicates.
-    //
-    // TODO(tx-selector-onchain-filter): `canonical` here includes `Validated`
-    // and `NotOnchain(ValidBlock)` entries per `get_canonical_chain` (see
-    // `block_tree.rs:686-749`), not just `Onchain`. Under reorg replay, a
-    // dedup-against-Validated entry can briefly drop a commitment that should
-    // have been included. Self-correcting (next block re-includes it; no
-    // consensus impact), but worth filtering to Onchain-only to match the
-    // pattern in `tx_inclusion::lookup_via_block_tree:167-179`. Same gap at
-    // the `submit_txs_from_canonical` site below — fix both together.
-    for entry in canonical.iter() {
+    // Collect confirmed commitment transactions from canonical chain to avoid
+    // duplicates. Restricted to `Onchain` ancestors (`onchain_block_hashes`): a
+    // transiently-`Validated` entry's commitments may be about to roll back under
+    // reorg replay, so deduping against them could drop a commitment that should
+    // stay includable.
+    for entry in canonical
+        .iter()
+        .filter(|entry| onchain_block_hashes.contains(&entry.block_hash()))
+    {
         let commitment_ledger = entry
             .header()
             .system_ledgers
@@ -763,6 +782,7 @@ pub async fn select_best_txs(
     let publish_txs_and_proofs = get_publish_txs_and_proofs(
         ctx,
         &canonical,
+        &onchain_block_hashes,
         current_height,
         current_timestamp,
         &parent_epoch_snapshot,
@@ -835,6 +855,7 @@ pub async fn select_best_txs(
 async fn get_publish_txs_and_proofs(
     ctx: &TxSelectionContext<'_>,
     canonical: &[BlockTreeEntry],
+    onchain_block_hashes: &HashSet<BlockHash>,
     current_height: u64,
     current_timestamp: UnixTimestamp,
     epoch_snapshot: &Arc<EpochSnapshot>,
@@ -949,20 +970,20 @@ async fn get_publish_txs_and_proofs(
                 .is_none_or(|cdr| !cdr.data_size_confirmed || tx.data_size == cdr.data_size)
         });
 
-        // reduce down the canonical chain to the txs in the submit ledger.
-        //
-        // TODO(tx-selector-onchain-filter): same `canonical` includes-non-Onchain
-        // issue as the commitment-dedup site above. Under reorg replay, a
-        // `Validated` entry can leak its Submit tx_ids here, making the
-        // fast-path say "already submitted" for a tx whose Submit inclusion is
-        // about to be rolled back. The producer then skips the DB fallback
-        // and includes the tx as a publish candidate; peer validators catch any
-        // genuine double-publish via Vector B's canonical-DB check, so the worst
-        // case is a rejected block (no consensus impact, producer pays the cost).
-        let submit_txs_from_canonical = canonical.iter().fold(HashSet::new(), |mut acc, v| {
-            acc.extend(v.header().data_ledgers[DataLedger::Submit].tx_ids.0.clone());
-            acc
-        });
+        // Reduce down the canonical chain to the txs in the Submit ledger — the
+        // fast-path prior-Submit gate for publish candidates. Restricted to
+        // `Onchain` ancestors (`onchain_block_hashes`): a transiently-`Validated`
+        // entry's Submit inclusion may be about to roll back under reorg replay,
+        // so counting it here would let the gate say "already submitted" for a tx
+        // whose Submit is not durable. A miss simply falls through to the
+        // content-verified `canonical_submit_height` DB check below.
+        let submit_txs_from_canonical = canonical
+            .iter()
+            .filter(|v| onchain_block_hashes.contains(&v.block_hash()))
+            .fold(HashSet::new(), |mut acc, v| {
+                acc.extend(v.header().data_ledgers[DataLedger::Submit].tx_ids.0.clone());
+                acc
+            });
 
         // NC-0042 §4b: the expired-Submit range is the same for every candidate,
         // so compute it once here and reuse it per-candidate via `submit_tx_expired`
@@ -981,19 +1002,38 @@ async fn get_publish_txs_and_proofs(
             cascade_active_for_block,
         )?;
 
+        // Branch-correct "already promoted?" set. `DataTransactionHeader::
+        // promoted_height` is node-local mempool state, set at block confirmation
+        // within the reorg window and cleared only on reorg, so it is
+        // branch-variant: under reorg replay it can read `None` for a tx already
+        // promoted on the parent's branch, letting the producer re-select it and
+        // mint a block validators reject with `TxFoundInMultipleBlocks`.
+        // `resolve_promoted_on_branch` answers purely from the parent's ancestry
+        // (by-hash over the reorg window, MBH-verified below the floor) — the same
+        // branch-correct signal the validator's duplicate-inclusion walk uses, so
+        // an honest producer cannot select a tx the validator will reject.
+        let candidate_txids: Vec<IrysTransactionId> = tx_headers.iter().map(|tx| tx.id).collect();
+        let promoted_on_branch = crate::block_producer::ledger_expiry::resolve_promoted_on_branch(
+            &candidate_txids,
+            parent_block_header.block_hash,
+            next_block_height,
+            ctx.config,
+            ctx.block_tree,
+            ctx.db,
+        )?;
+
         for tx_header in &tx_headers {
             debug!(
                 "Processing publish candidate tx {} {:#?}",
                 &tx_header.id, &tx_header
             );
-            let is_promoted = tx_header.promoted_height().is_some();
 
-            if is_promoted {
-                // If it's promoted skip it
+            if promoted_on_branch.contains(&tx_header.id) {
+                // Already promoted on the parent's branch — re-selecting it would
+                // produce a block validators reject as a double-promotion.
                 warn!(
                     tx.id = ?tx_header.id,
-                    tx.promoted_height = ?tx_header.promoted_height(),
-                    "Publish candidate is already promoted"
+                    "Publish candidate is already promoted on the parent branch"
                 );
                 continue;
             }

--- a/crates/api-server/src/routes/tx.rs
+++ b/crates/api-server/src/routes/tx.rs
@@ -297,18 +297,25 @@ pub async fn get_tx_promotion_status(
             err: format!("Database error: {}", e),
         })?;
 
-    let promotion_height = if let Some(metadata) = db_metadata {
-        // DB metadata exists - use it unconditionally
-        metadata.promoted_height
-    } else if let Some(mempool_meta) = state.mempool_guard.get_tx_metadata(&tx_id).await {
-        // Mempool metadata exists - use its promoted_height
-        mempool_meta.promoted_height()
-    } else {
-        // Transaction not found in either DB or mempool
-        return Err(ApiError::ErrNoId {
-            id: tx_id.to_string(),
-            err: String::from("Unable to find tx"),
-        });
+    // `promoted_height` is written to the DB only at migration, so a
+    // confirmed-but-unmigrated promotion lives only in the live mempool. Prefer
+    // the DB value when present; otherwise fall back to the mempool (a DB row
+    // may exist from the Submit migration with `promoted_height = None` while
+    // the Publish block is still unmigrated).
+    let promotion_height = match db_metadata.as_ref().and_then(|m| m.promoted_height) {
+        Some(height) => Some(height),
+        None => match state.mempool_guard.get_tx_metadata(&tx_id).await {
+            Some(mempool_meta) => mempool_meta.promoted_height(),
+            // No mempool entry: known (DB row exists) but not promoted, or
+            // entirely unknown → 404.
+            None if db_metadata.is_none() => {
+                return Err(ApiError::ErrNoId {
+                    id: tx_id.to_string(),
+                    err: String::from("Unable to find tx"),
+                });
+            }
+            None => None,
+        },
     };
 
     Ok(web::Json(PromotionStatus { promotion_height }))

--- a/crates/chain-tests/src/api/client.rs
+++ b/crates/chain-tests/src/api/client.rs
@@ -4,7 +4,7 @@ use crate::utils::{IrysNodeTest, coverage_adjusted_timeout};
 use irys_api_client::ApiClientExt as _;
 use irys_api_client::{ApiClient as _, IrysApiClient, TransactionStatus};
 use irys_chain::IrysNodeCtx;
-use irys_types::{BlockIndexQuery, DataLedger, IrysTransactionResponse, NodeConfig};
+use irys_types::{BlockIndexQuery, IrysTransactionResponse, NodeConfig};
 use std::{
     net::{IpAddr, SocketAddr},
     str::FromStr as _,
@@ -435,12 +435,16 @@ async fn api_tx_status_finalized_survives_restart() {
     ctx.stop().await;
 }
 
-/// Tests that CONFIRMED (pre-migration) transaction status survives a node restart.
-/// This is the critical edge case: included_height may only live in memory before
-/// migration. After restart, the status endpoint must still return CONFIRMED with
-/// the correct block_height.
+/// A CONFIRMED-but-unmigrated transaction reverts to PENDING after a node
+/// restart. `included_height` lives only in memory before migration, and the
+/// block that included it is never durably persisted pre-migration — so after a
+/// restart the mempool restores the tx as pending. Reporting it as CONFIRMED
+/// would name a block the node no longer has. (The prior behavior persisted this
+/// metadata to the consensus DB at confirmation to fake survival across restart;
+/// that write was removed because it let an orphaned row masquerade as canonical
+/// in consensus.)
 #[test_log::test(tokio::test)]
-async fn api_tx_status_confirmed_survives_restart() {
+async fn api_tx_status_reverts_to_pending_after_restart_before_migration() {
     let mut config = NodeConfig::testing();
     // Use a larger migration depth so we can capture CONFIRMED state without risking migration.
     // Must stay <= tx_anchor_expiry_depth (20 in testing config).
@@ -503,25 +507,20 @@ async fn api_tx_status_confirmed_survives_restart() {
         ctx.node_ctx.config.node_config.http.bind_port,
     );
 
-    // Verify status after restart — must still be CONFIRMED with the same block_height
+    // After restart the confirmed-but-unmigrated tx reverts to PENDING: its
+    // block was never durably persisted, so the mempool restores the tx as
+    // pending. `block_height_before` named a block the node no longer has.
     let status_after = api_client
         .get_transaction_status(api_address, tx_id)
         .await
         .expect("get_transaction_status should succeed after restart")
-        .expect("status should still exist after restart");
+        .expect("tx should still be known (restored to mempool) after restart");
 
     assert!(
-        matches!(
-            status_after.status,
-            TransactionStatus::Confirmed | TransactionStatus::Finalized
-        ),
-        "expected CONFIRMED or FINALIZED after restart, got {:?}",
+        matches!(status_after.status, TransactionStatus::Pending),
+        "unmigrated CONFIRMED tx must revert to PENDING after restart (its block \
+         is gone); was confirmed at {block_height_before}, got {:?}",
         status_after.status
-    );
-    assert_eq!(
-        status_after.block_height.expect("should have block_height"),
-        block_height_before,
-        "block_height should be identical after restart"
     );
 
     ctx.stop().await;
@@ -604,11 +603,20 @@ async fn api_tx_status_commitment_tx() {
     ctx.stop().await;
 }
 
-/// Tests that a promoted transaction is NOT promoted a second time after node restart.
-/// Regression test for the double-promotion bug caused by `#[serde(skip)]` on metadata
-/// which loses `promoted_height` when the mempool persists to disk.
+/// A promotion that has not yet migrated does NOT survive a node restart: the
+/// promoting (Publish) block was never durably persisted, so after restart the
+/// tx reverts to un-promoted (restored to the mempool as pending). Re-promoting
+/// it afterwards is legitimate recovery, not a double-promotion — the original
+/// promotion never became canonical.
+///
+/// (Previously `promoted_height` was persisted to the consensus DB at
+/// confirmation so this state faked survival across restart; that write was
+/// removed because it let an orphaned row masquerade as canonical in consensus.
+/// The genuine same-chain double-promotion guard — a tx already promoted on the
+/// parent's branch cannot be re-promoted — is branch-correct in the producer/
+/// validator and covered by their tests.)
 #[test_log::test(tokio::test)]
-async fn api_double_promotion_after_restart() {
+async fn api_promotion_reverts_after_restart_before_migration() {
     let config = NodeConfig::testing();
     let ctx = IrysNodeTest::new_genesis(config).start().await;
     ctx.wait_for_packing(20).await;
@@ -657,53 +665,31 @@ async fn api_double_promotion_after_restart() {
         .await
         .expect("tx should be promoted");
 
-    let height_before_restart = ctx.get_canonical_chain_height().await;
-
-    // Find which block promoted the tx by scanning Publish ledgers
-    let mut promotion_height = None;
-    for h in 1..=height_before_restart {
-        let block = ctx.get_block_by_height(h).await.unwrap();
-        if block.data_ledgers[DataLedger::Publish]
-            .tx_ids
-            .0
-            .contains(&tx_id)
-        {
-            promotion_height = Some(h);
-            break;
-        }
-    }
-    let promotion_height = promotion_height.expect("tx should appear in a Publish ledger");
-    debug!(
-        "Tx {} promoted at height {}. Restarting node...",
-        tx_id, promotion_height
+    // Confirm the tx is promoted before the restart.
+    assert!(
+        ctx.get_is_promoted(&tx_id)
+            .await
+            .expect("promotion state should be queryable"),
+        "tx should be promoted before restart"
     );
 
-    // Restart the node — promoted_height metadata is lost due to #[serde(skip)]
+    // Restart the node. The promoting block was not yet migrated, so it is not
+    // durably persisted; the mempool restores the tx as pending with its
+    // `promoted_height` gone (`#[serde(skip)]` strips it and the DB never held it
+    // pre-migration).
     let ctx = ctx.stop().await.start().await;
 
-    // Mine more blocks after restart
-    let blocks_to_mine = 10;
-    for _ in 0..blocks_to_mine {
-        ctx.mine_block().await.expect("expected mined block");
-    }
-
-    let height_after = ctx.get_canonical_chain_height().await;
-
-    // Verify the tx does NOT appear in any new block's Publish ledger (no double promotion)
-    for h in (height_before_restart + 1)..=height_after {
-        let block = ctx.get_block_by_height(h).await.unwrap();
-        assert!(
-            !block.data_ledgers[DataLedger::Publish]
-                .tx_ids
-                .0
-                .contains(&tx_id),
-            "Double promotion detected! Tx {} appeared in Publish ledger at height {} \
-             (originally promoted at height {})",
-            tx_id,
-            h,
-            promotion_height,
-        );
-    }
+    // The promotion did not survive: the tx is no longer reported as promoted.
+    // (Re-promotion by subsequent mining would be legitimate recovery, since the
+    // original promotion never became canonical — so we do not assert against
+    // it; the same-chain double-promotion guard is exercised by the producer/
+    // validator branch-correctness tests.)
+    assert!(
+        !ctx.get_is_promoted(&tx_id)
+            .await
+            .expect("promotion state should be queryable after restart"),
+        "unmigrated promotion must not survive restart (its block is gone)"
+    );
 
     ctx.stop().await;
 }

--- a/crates/chain-tests/src/block_production/block_validation.rs
+++ b/crates/chain-tests/src/block_production/block_validation.rs
@@ -102,54 +102,6 @@ fn mock_data_txs(count: usize) -> Vec<DataTransactionHeader> {
         .collect()
 }
 
-/// Insert a synthetic canonical block header at `height` carrying `submit_tx_ids`
-/// in its Submit ledger and `publish_tx_ids` in its Publish ledger, and repoint
-/// `MigratedBlockHashes[height]` at it. Returns the block hash.
-///
-/// The `canonical_submit_height` / `canonical_promoted_height` helpers now
-/// content-verify the metadata hint against the canonical block at the hint
-/// height — a bare metadata + `MigratedBlockHashes` row is no longer trusted
-/// (the stranded-row defense). Genesis carries no data txs, so tests that drive
-/// the validator's canonical-DB fallback must supply a canonical block that
-/// actually carries the tx. The by-hash inclusion walk is unaffected (it follows
-/// parent pointers, not `MigratedBlockHashes`), so repointing the row here only
-/// feeds the fallback's content check.
-fn plant_canonical_block(
-    db: &irys_types::app_state::DatabaseProvider,
-    height: u64,
-    submit_tx_ids: Vec<H256>,
-    publish_tx_ids: Vec<H256>,
-) -> Result<H256> {
-    use irys_database::db::IrysDatabaseExt as _;
-    use irys_database::{insert_block_header, tables::MigratedBlockHashes};
-    use irys_types::{DataTransactionLedger, H256List};
-    use reth_db::transaction::DbTxMut as _;
-
-    let ledger = |id: DataLedger, tx_ids: Vec<H256>| DataTransactionLedger {
-        ledger_id: id as u32,
-        tx_root: H256::zero(),
-        tx_ids: H256List(tx_ids),
-        total_chunks: 0,
-        expires: None,
-        proofs: None,
-        required_proof_count: None,
-    };
-    let mut header = IrysBlockHeader::new_mock_header();
-    header.height = height;
-    header.block_hash = H256::random();
-    header.data_ledgers = vec![
-        ledger(DataLedger::Submit, submit_tx_ids),
-        ledger(DataLedger::Publish, publish_tx_ids),
-    ];
-    let block_hash = header.block_hash;
-    db.update_eyre(|tx| {
-        insert_block_header(tx, &header)?;
-        tx.put::<MigratedBlockHashes>(height, block_hash)?;
-        Ok(())
-    })?;
-    Ok(block_hash)
-}
-
 fn mock_commitment_txs(count: usize) -> Vec<CommitmentTransaction> {
     use irys_types::{IrysTransactionCommon as _, NodeConfig};
 
@@ -853,8 +805,14 @@ async fn test_prevalidation_rejects_doubly_published_tx_via_fallback() -> Result
     // carries the tx in BOTH ledgers and repoint `MigratedBlockHashes[0]`.
     let prior_submit_height = 0_u64;
     let prior_publish_height = 0_u64;
-    let prior_block_hash =
-        plant_canonical_block(&ctx.node.node_ctx.db, 0, vec![tx.id], vec![tx.id])?;
+    let prior_block_hash = crate::utils::plant_canonical_block(
+        &ctx.node.node_ctx.db,
+        0,
+        vec![
+            (DataLedger::Submit, vec![tx.id]),
+            (DataLedger::Publish, vec![tx.id]),
+        ],
+    )?;
     ctx.node.node_ctx.db.update_eyre(|db_tx| {
         insert_tx_header(db_tx, &tx)?;
         set_data_tx_included_height(db_tx, &tx.id, prior_submit_height)?;
@@ -1035,7 +993,14 @@ async fn test_prevalidation_accepts_publish_when_promoted_height_hint_stripped()
     // MBH-None-within-window strip but produces the same stripped metadata).
     let prior_submit_height = 0_u64;
     let stranded_promote_height = 1_u64;
-    let _prior_block_hash = plant_canonical_block(&ctx.node.node_ctx.db, 0, vec![tx.id], vec![])?;
+    let _prior_block_hash = crate::utils::plant_canonical_block(
+        &ctx.node.node_ctx.db,
+        0,
+        vec![
+            (DataLedger::Submit, vec![tx.id]),
+            (DataLedger::Publish, vec![]),
+        ],
+    )?;
     ctx.node.node_ctx.db.update_eyre(|db_tx| {
         insert_tx_header(db_tx, &tx)?;
         set_data_tx_included_height(db_tx, &tx.id, prior_submit_height)?;

--- a/crates/chain-tests/src/block_production/block_validation.rs
+++ b/crates/chain-tests/src/block_production/block_validation.rs
@@ -102,6 +102,54 @@ fn mock_data_txs(count: usize) -> Vec<DataTransactionHeader> {
         .collect()
 }
 
+/// Insert a synthetic canonical block header at `height` carrying `submit_tx_ids`
+/// in its Submit ledger and `publish_tx_ids` in its Publish ledger, and repoint
+/// `MigratedBlockHashes[height]` at it. Returns the block hash.
+///
+/// The `canonical_submit_height` / `canonical_promoted_height` helpers now
+/// content-verify the metadata hint against the canonical block at the hint
+/// height — a bare metadata + `MigratedBlockHashes` row is no longer trusted
+/// (the stranded-row defense). Genesis carries no data txs, so tests that drive
+/// the validator's canonical-DB fallback must supply a canonical block that
+/// actually carries the tx. The by-hash inclusion walk is unaffected (it follows
+/// parent pointers, not `MigratedBlockHashes`), so repointing the row here only
+/// feeds the fallback's content check.
+fn plant_canonical_block(
+    db: &irys_types::app_state::DatabaseProvider,
+    height: u64,
+    submit_tx_ids: Vec<H256>,
+    publish_tx_ids: Vec<H256>,
+) -> Result<H256> {
+    use irys_database::db::IrysDatabaseExt as _;
+    use irys_database::{insert_block_header, tables::MigratedBlockHashes};
+    use irys_types::{DataTransactionLedger, H256List};
+    use reth_db::transaction::DbTxMut as _;
+
+    let ledger = |id: DataLedger, tx_ids: Vec<H256>| DataTransactionLedger {
+        ledger_id: id as u32,
+        tx_root: H256::zero(),
+        tx_ids: H256List(tx_ids),
+        total_chunks: 0,
+        expires: None,
+        proofs: None,
+        required_proof_count: None,
+    };
+    let mut header = IrysBlockHeader::new_mock_header();
+    header.height = height;
+    header.block_hash = H256::random();
+    header.data_ledgers = vec![
+        ledger(DataLedger::Submit, submit_tx_ids),
+        ledger(DataLedger::Publish, publish_tx_ids),
+    ];
+    let block_hash = header.block_hash;
+    db.update_eyre(|tx| {
+        insert_block_header(tx, &header)?;
+        tx.put::<MigratedBlockHashes>(height, block_hash)?;
+        Ok(())
+    })?;
+    Ok(block_hash)
+}
+
 fn mock_commitment_txs(count: usize) -> Vec<CommitmentTransaction> {
     use irys_types::{IrysTransactionCommon as _, NodeConfig};
 
@@ -783,14 +831,7 @@ async fn test_prevalidation_rejects_doubly_published_tx_via_fallback() -> Result
     // genesis at height 0), so the bad block we'll build below has
     // `parent_height = 0`.  Both `included_height` and `promoted_height`
     // must be ≤ 0 for the fallback to consider the tx "already canonical";
-    // we collapse both onto the genesis row and pin the assertion to the
-    // genesis block hash already populated in `MigratedBlockHashes[0]`.
-    let genesis_block_hash = ctx
-        .node
-        .get_block_by_height(0)
-        .await
-        .expect("genesis block")
-        .block_hash;
+    // we collapse both onto the height-0 canonical row.
 
     // A Publish-ledger tx that will impersonate "already canonically
     // promoted" via the pre-populated metadata below.
@@ -805,19 +846,16 @@ async fn test_prevalidation_rejects_doubly_published_tx_via_fallback() -> Result
         .expect("Failed to sign test transaction");
 
     // Pre-populate canonical metadata: tx was Submit-included AND
-    // Publish-promoted at genesis (same-block promotion).  Both heights are
-    // ≤ parent_height = 0; both share `MigratedBlockHashes[0]` which the
-    // node already populated with `genesis_block_hash`.  This is the
-    // minimum-viable canonical-storage state that exercises the fallback's
-    // `promoted_height` rejection without touching adjacent canonical
-    // rows.
+    // Publish-promoted at height 0 (same-block promotion).  Because the
+    // canonical helpers now content-verify the hint against the canonical
+    // block at the height, genesis (which carries no data txs) can't back
+    // this fixture; supply a synthetic canonical block at height 0 that
+    // carries the tx in BOTH ledgers and repoint `MigratedBlockHashes[0]`.
     let prior_submit_height = 0_u64;
     let prior_publish_height = 0_u64;
+    let prior_block_hash =
+        plant_canonical_block(&ctx.node.node_ctx.db, 0, vec![tx.id], vec![tx.id])?;
     ctx.node.node_ctx.db.update_eyre(|db_tx| {
-        // `canonical_submit_height` / `canonical_promoted_height` consult
-        // `IrysDataTxMetadata` + `MigratedBlockHashes` only, but populate
-        // the header table for parity with the production write path and
-        // to keep this fixture useful if a future helper consults it.
         insert_tx_header(db_tx, &tx)?;
         set_data_tx_included_height(db_tx, &tx.id, prior_submit_height)?;
         set_data_tx_promoted_height(db_tx, &tx.id, prior_publish_height)?;
@@ -918,8 +956,8 @@ async fn test_prevalidation_rejects_doubly_published_tx_via_fallback() -> Result
         Err(PreValidationError::PublishTxAlreadyIncluded { tx_id, block_hash }) => {
             assert_eq!(tx_id, tx.id, "rejection must name the doubly-published tx");
             assert_eq!(
-                block_hash, genesis_block_hash,
-                "rejection must surface the canonical promoted-block hash from MigratedBlockHashes (= genesis hash in this fixture)"
+                block_hash, prior_block_hash,
+                "rejection must surface the canonical promoted-block hash from MigratedBlockHashes (the planted height-0 block)"
             );
         }
         other => panic!(
@@ -988,13 +1026,16 @@ async fn test_prevalidation_accepts_publish_when_promoted_height_hint_stripped()
         .sign(&ctx.config.signer())
         .expect("Failed to sign test transaction");
 
-    // Canonical Submit at genesis (`MBH[0]` is populated by node init);
-    // stranded `promoted_height = 1` that the canonical helper will strip
-    // (parent_height = 0, so `promoted_height > max_height` triggers the
-    // strip — orthogonal to the MBH-None-within-window strip but produces
-    // the same stripped metadata).
+    // Canonical Submit at height 0 — supply a synthetic canonical block that
+    // carries the tx in its Submit ledger and repoint `MigratedBlockHashes[0]`,
+    // so `canonical_submit_height` (now content-verified) attests it and control
+    // flow reaches the promoted-height check. Stranded `promoted_height = 1` is
+    // stripped by the canonical helper (parent_height = 0, so
+    // `promoted_height > max_height` triggers the strip — orthogonal to the
+    // MBH-None-within-window strip but produces the same stripped metadata).
     let prior_submit_height = 0_u64;
     let stranded_promote_height = 1_u64;
+    let _prior_block_hash = plant_canonical_block(&ctx.node.node_ctx.db, 0, vec![tx.id], vec![])?;
     ctx.node.node_ctx.db.update_eyre(|db_tx| {
         insert_tx_header(db_tx, &tx)?;
         set_data_tx_included_height(db_tx, &tx.id, prior_submit_height)?;

--- a/crates/chain-tests/src/utils.rs
+++ b/crates/chain-tests/src/utils.rs
@@ -84,6 +84,52 @@ use tokio::sync::oneshot;
 use tokio::{sync::oneshot::error::RecvError, time::sleep};
 use tracing::{debug, error, error_span, info, instrument, warn};
 
+/// Insert a synthetic canonical block header at `height` carrying the given
+/// per-ledger `tx_ids`, and repoint `MigratedBlockHashes[height]` at it. Returns
+/// the block hash.
+///
+/// The `canonical_submit_height` / `canonical_promoted_height` /
+/// `canonical_commitment_included_height` helpers content-verify the metadata
+/// hint against the canonical block at the hint height — a bare metadata +
+/// `MigratedBlockHashes` row is no longer trusted (the stranded-row defense).
+/// Genesis carries no data txs, so tests that drive the validator's canonical-DB
+/// fallback must supply a canonical block that actually carries the tx. The
+/// by-hash inclusion walk is unaffected (it follows parent pointers, not
+/// `MigratedBlockHashes`), so repointing the row here only feeds the fallback's
+/// content check.
+pub fn plant_canonical_block(
+    db: &DatabaseProvider,
+    height: u64,
+    ledgers: Vec<(DataLedger, Vec<H256>)>,
+) -> eyre::Result<H256> {
+    use irys_database::{insert_block_header, tables::MigratedBlockHashes};
+    use irys_types::DataTransactionLedger;
+    use reth_db::transaction::DbTxMut as _;
+
+    let mut header = IrysBlockHeader::new_mock_header();
+    header.height = height;
+    header.block_hash = H256::random();
+    header.data_ledgers = ledgers
+        .into_iter()
+        .map(|(id, tx_ids)| DataTransactionLedger {
+            ledger_id: id as u32,
+            tx_root: H256::zero(),
+            tx_ids: H256List(tx_ids),
+            total_chunks: 0,
+            expires: None,
+            proofs: None,
+            required_proof_count: None,
+        })
+        .collect();
+    let block_hash = header.block_hash;
+    db.update_eyre(|tx| {
+        insert_block_header(tx, &header)?;
+        tx.put::<MigratedBlockHashes>(height, block_hash)?;
+        Ok(())
+    })?;
+    Ok(block_hash)
+}
+
 /// Coverage instrumentation multiplier for in-test timeouts.
 ///
 /// `cargo-llvm-cov` sets `LLVM_PROFILE_FILE` when running under coverage.

--- a/crates/chain-tests/src/utils.rs
+++ b/crates/chain-tests/src/utils.rs
@@ -2279,24 +2279,34 @@ impl IrysNodeTest<IrysNodeCtx> {
     }
 
     pub async fn get_is_promoted(&self, tx_id: &H256) -> eyre::Result<bool> {
-        // Check DB first (authoritative source)
-        match self
+        // The DB carries `promoted_height` only once the promoting (Publish)
+        // block has migrated. A confirmed-but-unmigrated promotion lives only in
+        // the live mempool, so consult it whenever the DB doesn't already show
+        // the tx as promoted (row absent, or present from the Submit migration
+        // with `promoted_height = None`).
+        let db_header = self
             .node_ctx
             .db
             .view_eyre(|tx| tx_header_by_txid(tx, tx_id))
+            .map_err(|e| eyre::eyre!("Failed to collect tx header: {}", e))?;
+
+        if db_header
+            .as_ref()
+            .is_some_and(|h| h.promoted_height().is_some())
         {
-            Ok(Some(tx_header)) => {
-                debug!("{:?}", tx_header);
-                Ok(tx_header.promoted_height().is_some())
-            }
-            Ok(None) => {
-                // Fall back to mempool metadata
-                if let Some(meta) = self.node_ctx.mempool_guard.get_tx_metadata(tx_id).await {
-                    return Ok(meta.promoted_height().is_some());
-                }
-                Err(eyre::eyre!("No tx header found for txid {:?}", tx_id))
-            }
-            Err(e) => Err(eyre::eyre!("Failed to collect tx header: {}", e)),
+            return Ok(true);
+        }
+
+        if let Some(meta) = self.node_ctx.mempool_guard.get_tx_metadata(tx_id).await {
+            return Ok(meta.promoted_height().is_some());
+        }
+
+        // Not promoted in the mempool. Known (DB row exists) → not promoted;
+        // entirely unknown → error.
+        if db_header.is_some() {
+            Ok(false)
+        } else {
+            Err(eyre::eyre!("No tx header found for txid {:?}", tx_id))
         }
     }
 

--- a/crates/chain-tests/src/validation/commitment_replay.rs
+++ b/crates/chain-tests/src/validation/commitment_replay.rs
@@ -244,7 +244,7 @@ async fn heavy_same_block_duplicate_commitment_rejected() -> eyre::Result<()> {
 }
 
 /// Genesis first-includes its commitments but never flows through the
-/// confirm/migration metadata writers, so no dedup row is written for it at
+/// migration metadata writer, so no dedup row is written for it at
 /// init. The startup backfill must fill that gap: after a node boots, the
 /// finalized-inclusion lookup the dedup consults
 /// (`canonical_commitment_included_height`) must resolve every genesis

--- a/crates/chain-tests/src/validation/mempool_ingress_proof_dedup.rs
+++ b/crates/chain-tests/src/validation/mempool_ingress_proof_dedup.rs
@@ -168,29 +168,18 @@ async fn mempool_dedup_ingress_proof_signers() -> eyre::Result<()> {
     // submit inclusions. Genesis carries no data txs, so a bare metadata + MBH
     // hint no longer suffices. The selector reads this via the fallback only;
     // the by-hash tree fold is unaffected (it follows parent pointers).
+    use irys_types::DataLedger;
+    crate::utils::plant_canonical_block(
+        &genesis_node.node_ctx.db,
+        0,
+        vec![(DataLedger::Submit, vec![data_tx_1.id, data_tx_2.id])],
+    )?;
+
     genesis_node.node_ctx.db.update(|tx| {
-        use irys_database::insert_block_header;
         use irys_database::tables::{
             CompactCachedIngressProof, CompactTxHeader, IngressProofs, IrysDataTxHeaders,
-            MigratedBlockHashes,
         };
         use irys_types::ingress::CachedIngressProof;
-        use irys_types::{DataLedger, DataTransactionLedger, H256List, IrysBlockHeader};
-
-        let mut prior_block = IrysBlockHeader::new_mock_header();
-        prior_block.height = 0;
-        prior_block.block_hash = H256::random();
-        prior_block.data_ledgers = vec![DataTransactionLedger {
-            ledger_id: DataLedger::Submit as u32,
-            tx_root: H256::zero(),
-            tx_ids: H256List(vec![data_tx_1.id, data_tx_2.id]),
-            total_chunks: 0,
-            expires: None,
-            proofs: None,
-            required_proof_count: None,
-        }];
-        insert_block_header(tx, &prior_block)?;
-        tx.put::<MigratedBlockHashes>(0, prior_block.block_hash)?;
 
         // Insert data_root_1 proofs directly to bypass store_external_ingress_proof_checked dedup
         tx.put::<IrysDataTxHeaders>(data_tx_1.id, CompactTxHeader(data_tx_1.clone()))?;

--- a/crates/chain-tests/src/validation/mempool_ingress_proof_dedup.rs
+++ b/crates/chain-tests/src/validation/mempool_ingress_proof_dedup.rs
@@ -161,13 +161,36 @@ async fn mempool_dedup_ingress_proof_signers() -> eyre::Result<()> {
     )?;
 
     // Store both data txs and all proofs in the DB.
-    // We also set included_height metadata so the tx selector's canonical DB
-    // fallback (`canonical_submit_height`) can find them as prior submit inclusions.
+    // We also set included_height metadata AND plant a synthetic canonical block
+    // at height 0 carrying both txs in its Submit ledger (repointing
+    // `MigratedBlockHashes[0]`), so the tx selector's canonical DB fallback
+    // (`canonical_submit_height`, now content-verified) finds them as prior
+    // submit inclusions. Genesis carries no data txs, so a bare metadata + MBH
+    // hint no longer suffices. The selector reads this via the fallback only;
+    // the by-hash tree fold is unaffected (it follows parent pointers).
     genesis_node.node_ctx.db.update(|tx| {
+        use irys_database::insert_block_header;
         use irys_database::tables::{
             CompactCachedIngressProof, CompactTxHeader, IngressProofs, IrysDataTxHeaders,
+            MigratedBlockHashes,
         };
         use irys_types::ingress::CachedIngressProof;
+        use irys_types::{DataLedger, DataTransactionLedger, H256List, IrysBlockHeader};
+
+        let mut prior_block = IrysBlockHeader::new_mock_header();
+        prior_block.height = 0;
+        prior_block.block_hash = H256::random();
+        prior_block.data_ledgers = vec![DataTransactionLedger {
+            ledger_id: DataLedger::Submit as u32,
+            tx_root: H256::zero(),
+            tx_ids: H256List(vec![data_tx_1.id, data_tx_2.id]),
+            total_chunks: 0,
+            expires: None,
+            proofs: None,
+            required_proof_count: None,
+        }];
+        insert_block_header(tx, &prior_block)?;
+        tx.put::<MigratedBlockHashes>(0, prior_block.block_hash)?;
 
         // Insert data_root_1 proofs directly to bypass store_external_ingress_proof_checked dedup
         tx.put::<IrysDataTxHeaders>(data_tx_1.id, CompactTxHeader(data_tx_1.clone()))?;

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -805,7 +805,7 @@ impl IrysNode {
         }
 
         // Genesis first-includes its commitments but, as the block-index head, never
-        // flows through the confirm/migration metadata writers, so no commitment
+        // flows through the migration metadata writer, so no commitment
         // dedup row is ever written for it. Backfill it here — the single seam that
         // runs on both fresh init (genesis just persisted above) and restart (genesis
         // already in the db) — so already-initialized nodes converge on upgrade

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -281,13 +281,18 @@ pub fn tx_header_by_txid<T: DbTx>(
 /// alone.
 ///
 /// The two helpers in this section return a height from `IrysDataTxMetadata`
-/// only if MBH has a row for it ≤ `max_height`.  They return primitive
+/// only if MBH has a row for it ≤ `max_height` AND the canonical block at that
+/// height actually carries the tx in the corresponding ledger (Submit for
+/// `included_height`, Publish for `promoted_height`).  They return primitive
 /// `Option<u64>` (no header mutation) so call sites can't accidentally treat a
-/// stranded hint as canonical.  Because the existence check is NOT
-/// branch-invariant in the window above, every caller must either (a) only
-/// consult these helpers for heights guaranteed below the reorg floor, or
-/// (b) treat the result as a hint and confirm membership against the evaluated
-/// branch's own ancestry.  Current callers:
+/// stranded hint as canonical.  The content check is what makes `Some(h)` mean
+/// "canonically included at `h`" rather than "a hint pointing at `h` exists":
+/// the metadata row is written at tip-confirmation (depth 0), so an orphaned
+/// tip's row can survive a restart-interrupted reorg and later collide with a
+/// different canonical block migrated at the same height, where the
+/// MBH-existence check alone would read it as truth.  With the content check,
+/// callers may trust `Some(h)` on any branch — mirroring
+/// `canonical_commitment_included_height`.  Current callers:
 ///   - `data_txs_are_valid` (`block_validation.rs`) uses the content-based
 ///     ancestry walk (`get_previous_tx_inclusions`) as its primary path and
 ///     only falls back to these helpers for inclusions older than
@@ -306,6 +311,7 @@ fn canonical_metadata_height<T: DbTx>(
     txid: &IrysTransactionId,
     max_height: u64,
     pick: impl FnOnce(&DataTransactionMetadata) -> Option<u64>,
+    ledger: DataLedger,
     field_name: &'static str,
 ) -> eyre::Result<Option<u64>> {
     let Some(metadata) = crate::get_data_tx_metadata(tx, txid)? else {
@@ -324,7 +330,10 @@ fn canonical_metadata_height<T: DbTx>(
         );
         return Ok(None);
     }
-    if tx.get::<MigratedBlockHashes>(height)?.is_none() {
+    // MBH-verified canonical header at the hint height. `None` = no canonical
+    // block migrated at `height` (stranded local-tip write or not yet migrated);
+    // `Err` = MBH/header cross-table inconsistency (surfaced to the caller).
+    let Some(canonical_header) = canonical_header_at_height(tx, height)? else {
         debug!(
             tx.id = %txid,
             tx.height = height,
@@ -332,23 +341,45 @@ fn canonical_metadata_height<T: DbTx>(
             "canonical lookup: MigratedBlockHashes has no row for hint — rejecting (stranded write or unmigrated)"
         );
         return Ok(None);
+    };
+    // Content check: the metadata row is written at tip-confirmation (depth 0,
+    // `block_migration_service::persist_metadata`), so an orphaned tip's row can
+    // survive a restart-interrupted reorg and later collide with a *different*
+    // canonical block that migrated at the same height. `MigratedBlockHashes`
+    // existence alone would then read that stranded hint as canonical truth.
+    // Requiring the canonical block to actually carry the tx in `ledger` makes
+    // such rows harmless — `Some(h)` proves canonical inclusion at `h`, not
+    // merely that a hint exists. (This is the data-tx analogue of the check in
+    // `canonical_commitment_included_height`.)
+    if !canonical_header
+        .get_data_ledger_tx_ids_ordered(ledger)
+        .is_some_and(|ids| ids.contains(txid))
+    {
+        debug!(
+            tx.id = %txid,
+            tx.height = height,
+            field = field_name,
+            "canonical lookup: canonical block at hint does not carry tx in ledger — rejecting (stranded write)"
+        );
+        return Ok(None);
     }
     Ok(Some(height))
 }
 
-/// Returns the MBH-verified Submit-ledger inclusion height of `txid`, if
+/// Returns the content-verified Submit-ledger inclusion height of `txid`, if
 /// any, capped at `max_height`.
 ///
 /// `Some(h)` means: `IrysDataTxMetadata` carries `included_height = h ≤
-/// max_height`, AND `MigratedBlockHashes[h]` is `Some` (canonical).  The
-/// raw header table is not consulted — Submit confirmation is purely a
-/// metadata-vs-MBH question.
+/// max_height`, `MigratedBlockHashes[h]` is `Some` (canonical), AND the
+/// canonical block at `h` actually carries `txid` in its Submit ledger.  The
+/// content check neutralizes a stranded hint left behind by an orphaned tip
+/// (see `canonical_metadata_height`).
 ///
-/// `None` means: tx unknown, metadata missing, hint > `max_height`, OR
-/// hint not confirmed by MBH (stranded local-tip write).  Callers cannot
-/// distinguish these cases from the return value alone — by design, since
-/// they all share the same outcome at every existing call site ("no
-/// canonical Submit at or below `max_height`").
+/// `None` means: tx unknown, metadata missing, hint > `max_height`, hint not
+/// confirmed by MBH (stranded/unmigrated), OR the canonical block at the hint
+/// does not include the tx.  Callers cannot distinguish these cases from the
+/// return value alone — by design, since they all share the same outcome at
+/// every existing call site ("no canonical Submit at or below `max_height`").
 pub fn canonical_submit_height<T: DbTx>(
     tx: &T,
     txid: &IrysTransactionId,
@@ -359,22 +390,26 @@ pub fn canonical_submit_height<T: DbTx>(
         txid,
         max_height,
         |m| m.included_height,
+        DataLedger::Submit,
         "included_height",
     )
 }
 
-/// Returns the MBH-verified Publish (promotion) height of `txid`, if any,
+/// Returns the content-verified Publish (promotion) height of `txid`, if any,
 /// capped at `max_height`.
 ///
 /// `Some(h)` means: `IrysDataTxMetadata` carries `promoted_height = h ≤
-/// max_height`, AND `MigratedBlockHashes[h]` is `Some` (canonical).
+/// max_height`, `MigratedBlockHashes[h]` is `Some` (canonical), AND the
+/// canonical block at `h` actually carries `txid` in its Publish ledger.
 ///
 /// `None` is the validator-safe answer for *all* of: tx unknown, no
-/// `promoted_height` hint, hint > `max_height`, OR hint not confirmed by
-/// MBH.  This is the explicit fix for the stranded-`promoted_height` bug
-/// where an orphaned local-tip write left a hint behind that
-/// `MigratedBlockHashes` never recorded — previously read as cross-table
-/// corruption, now correctly classified as "no canonical promotion."
+/// `promoted_height` hint, hint > `max_height`, hint not confirmed by MBH, OR
+/// the canonical block at the hint does not include the tx.  This covers the
+/// stranded-`promoted_height` bug: an orphaned local-tip write can leave a hint
+/// that `MigratedBlockHashes` never recorded (unmigrated), or — once a
+/// *different* block later migrates at the same height — one that MBH confirms
+/// but the canonical block does not actually carry. Both now classify as "no
+/// canonical promotion."
 pub fn canonical_promoted_height<T: DbTx>(
     tx: &T,
     txid: &IrysTransactionId,
@@ -385,6 +420,7 @@ pub fn canonical_promoted_height<T: DbTx>(
         txid,
         max_height,
         |m| m.promoted_height,
+        DataLedger::Publish,
         "promoted_height",
     )
 }
@@ -1750,9 +1786,12 @@ mod tests {
         use crate::{
             canonical_promoted_height, canonical_submit_height, db::IrysDatabaseExt as _,
             db_index::set_data_tx_included_height, db_index::set_data_tx_promoted_height,
-            insert_tx_header, tables::IrysTables, tables::MigratedBlockHashes,
+            insert_block_header, insert_tx_header, tables::IrysTables, tables::MigratedBlockHashes,
         };
-        use irys_types::{DataTransactionHeader, H256};
+        use irys_types::{
+            DataLedger, DataTransactionHeader, DataTransactionLedger, H256, H256List,
+            IrysBlockHeader,
+        };
         use reth_db::{Database as _, DatabaseError, transaction::DbTxMut as _};
         use rstest::rstest;
 
@@ -1768,6 +1807,34 @@ mod tests {
                 },
                 metadata: Default::default(),
             })
+        }
+
+        /// Insert a canonical block header at `height`/`block_hash` carrying
+        /// `tx_ids` in `ledger`, and record it in `MigratedBlockHashes`. This is
+        /// the state the content check in `canonical_metadata_height` verifies:
+        /// a real migrated block whose ledger actually carries the tx.
+        fn insert_canonical_block(
+            tx: &(impl reth_db::transaction::DbTxMut + reth_db::transaction::DbTx),
+            height: u64,
+            block_hash: H256,
+            ledger: DataLedger,
+            tx_ids: Vec<H256>,
+        ) -> Result<(), DatabaseError> {
+            let mut header = IrysBlockHeader::new_mock_header();
+            header.height = height;
+            header.block_hash = block_hash;
+            header.data_ledgers = vec![DataTransactionLedger {
+                ledger_id: ledger as u32,
+                tx_root: H256::zero(),
+                tx_ids: H256List(tx_ids),
+                total_chunks: 0,
+                expires: None,
+                proofs: None,
+                required_proof_count: None,
+            }];
+            insert_block_header(tx, &header).map_err(|e| DatabaseError::Other(e.to_string()))?;
+            tx.put::<MigratedBlockHashes>(height, block_hash)?;
+            Ok(())
         }
 
         #[rstest]
@@ -1799,7 +1866,13 @@ mod tests {
                     .map_err(|e| DatabaseError::Other(e.to_string()))?;
                 set_data_tx_included_height(tx, &tx_id, 5)?;
                 if insert_migration {
-                    tx.put::<MigratedBlockHashes>(5, block_hash_at_5)?;
+                    insert_canonical_block(
+                        tx,
+                        5,
+                        block_hash_at_5,
+                        DataLedger::Submit,
+                        vec![tx_id],
+                    )?;
                 }
                 Ok(())
             })
@@ -1855,9 +1928,15 @@ mod tests {
             db.update(|tx| -> Result<(), DatabaseError> {
                 insert_tx_header(tx, &tx_header)
                     .map_err(|e| DatabaseError::Other(e.to_string()))?;
-                // Canonical Submit inclusion: metadata hint + MBH agree.
+                // Canonical Submit inclusion: metadata hint + MBH + header agree.
                 set_data_tx_included_height(tx, &tx_id, submit_height)?;
-                tx.put::<MigratedBlockHashes>(submit_height, canonical_submit_hash)?;
+                insert_canonical_block(
+                    tx,
+                    submit_height,
+                    canonical_submit_hash,
+                    DataLedger::Submit,
+                    vec![tx_id],
+                )?;
                 // Stranded promotion: metadata hint set, MBH deliberately absent.
                 set_data_tx_promoted_height(tx, &tx_id, stranded_promote_height)?;
                 Ok(())
@@ -1913,8 +1992,20 @@ mod tests {
                     .map_err(|e| DatabaseError::Other(e.to_string()))?;
                 set_data_tx_included_height(tx, &tx_id, submit_height)?;
                 set_data_tx_promoted_height(tx, &tx_id, promote_height)?;
-                tx.put::<MigratedBlockHashes>(submit_height, submit_hash)?;
-                tx.put::<MigratedBlockHashes>(promote_height, publish_hash)?;
+                insert_canonical_block(
+                    tx,
+                    submit_height,
+                    submit_hash,
+                    DataLedger::Submit,
+                    vec![tx_id],
+                )?;
+                insert_canonical_block(
+                    tx,
+                    promote_height,
+                    publish_hash,
+                    DataLedger::Publish,
+                    vec![tx_id],
+                )?;
                 Ok(())
             })
             .unwrap()
@@ -1931,7 +2022,85 @@ mod tests {
             assert_eq!(
                 promoted,
                 Some(promote_height),
-                "MBH-confirmed promotion must survive the cross-check"
+                "MBH-confirmed promotion whose canonical block carries the tx must survive the cross-check"
+            );
+        }
+
+        /// Content-check regression: a stranded `promoted_height` hint that
+        /// points at a height where a *different* canonical block has migrated
+        /// (`MBH[h] = Some`) — but that block does NOT carry the tx in its
+        /// Publish ledger. This is the restart-interrupted-reorg collision the
+        /// content check exists to neutralize: the metadata row is written at
+        /// depth-0 confirmation, so an orphaned tip's `promoted_height = h` can
+        /// survive, and once a winning block later migrates at `h` the
+        /// MBH-existence check alone would read the stale hint as a real prior
+        /// promotion → false `PublishTxAlreadyIncluded` rejecting a legitimate
+        /// block. Requiring the canonical block to actually carry the tx makes
+        /// the stranded row return `None`.
+        #[test]
+        fn promoted_height_returns_none_when_canonical_block_lacks_tx() {
+            let path = irys_testing_utils::utils::TempDirBuilder::new().build();
+            let db = open_or_create_db(
+                path.path(),
+                IrysTables::ALL,
+                DatabaseArguments::irys_testing().unwrap(),
+            )
+            .unwrap();
+
+            let tx_id = H256::random();
+            let unrelated_tx = H256::random();
+            let tx_header = make_tx_header(tx_id);
+            let submit_hash = H256::random();
+            let publish_hash = H256::random();
+            let submit_height = 5_u64;
+            let stranded_promote_height = 7_u64;
+            let parent_height = 25_000_u64;
+
+            db.update(|tx| -> Result<(), DatabaseError> {
+                insert_tx_header(tx, &tx_header)
+                    .map_err(|e| DatabaseError::Other(e.to_string()))?;
+                // Genuine canonical Submit inclusion.
+                set_data_tx_included_height(tx, &tx_id, submit_height)?;
+                insert_canonical_block(
+                    tx,
+                    submit_height,
+                    submit_hash,
+                    DataLedger::Submit,
+                    vec![tx_id],
+                )?;
+                // Stranded promotion hint at `stranded_promote_height`, where a
+                // DIFFERENT canonical block migrated that carries an unrelated
+                // tx (NOT `tx_id`) in its Publish ledger.
+                set_data_tx_promoted_height(tx, &tx_id, stranded_promote_height)?;
+                insert_canonical_block(
+                    tx,
+                    stranded_promote_height,
+                    publish_hash,
+                    DataLedger::Publish,
+                    vec![unrelated_tx],
+                )?;
+                Ok(())
+            })
+            .unwrap()
+            .unwrap();
+
+            let submit = db
+                .view_eyre(|tx| canonical_submit_height(tx, &tx_id, parent_height))
+                .unwrap();
+            let promoted = db
+                .view_eyre(|tx| canonical_promoted_height(tx, &tx_id, parent_height))
+                .unwrap();
+
+            assert_eq!(
+                submit,
+                Some(submit_height),
+                "the genuine Submit inclusion (canonical block carries the tx) must still attest"
+            );
+            assert_eq!(
+                promoted, None,
+                "a stranded promoted_height whose canonical block does not carry the tx MUST be \
+                 rejected by the content check — otherwise a legitimate promotion is falsely \
+                 rejected as PublishTxAlreadyIncluded"
             );
         }
 

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -287,12 +287,13 @@ pub fn tx_header_by_txid<T: DbTx>(
 /// `Option<u64>` (no header mutation) so call sites can't accidentally treat a
 /// stranded hint as canonical.  The content check is what makes `Some(h)` mean
 /// "canonically included at `h`" rather than "a hint pointing at `h` exists":
-/// the metadata row is written at tip-confirmation (depth 0), so an orphaned
-/// tip's row can survive a restart-interrupted reorg and later collide with a
-/// different canonical block migrated at the same height, where the
-/// MBH-existence check alone would read it as truth.  With the content check,
-/// callers may trust `Some(h)` on any branch — mirroring
-/// `canonical_commitment_included_height`.  Current callers:
+/// canonical metadata is now written only at migration (atomically with
+/// `MigratedBlockHashes`), but a legacy/stranded row — e.g. one written at
+/// depth-0 confirmation before that fix, or an orphaned tip's row surviving a
+/// restart-interrupted reorg — can still collide with a different canonical
+/// block migrated at the same height, where the MBH-existence check alone would
+/// read it as truth.  With the content check, callers may trust `Some(h)` on any
+/// branch — mirroring `canonical_commitment_included_height`.  Current callers:
 ///   - `data_txs_are_valid` (`block_validation.rs`) uses the content-based
 ///     ancestry walk (`get_previous_tx_inclusions`) as its primary path and
 ///     only falls back to these helpers for inclusions older than
@@ -342,11 +343,13 @@ fn canonical_metadata_height<T: DbTx>(
         );
         return Ok(None);
     };
-    // Content check: the metadata row is written at tip-confirmation (depth 0,
-    // `block_migration_service::persist_metadata`), so an orphaned tip's row can
-    // survive a restart-interrupted reorg and later collide with a *different*
-    // canonical block that migrated at the same height. `MigratedBlockHashes`
-    // existence alone would then read that stranded hint as canonical truth.
+    // Content check: a stranded/legacy metadata row not backed by canonical
+    // block content (one not written atomically with `MigratedBlockHashes` at
+    // migration — e.g. a depth-0 confirmation-time row from before metadata
+    // became migration-only, or an orphaned tip's row surviving a
+    // restart-interrupted reorg) can collide with a *different* canonical block
+    // that migrated at the same height. `MigratedBlockHashes` existence alone
+    // would then read that stranded hint as canonical truth.
     // Requiring the canonical block to actually carry the tx in `ledger` makes
     // such rows harmless — `Some(h)` proves canonical inclusion at `h`, not
     // merely that a hint exists. (This is the data-tx analogue of the check in
@@ -432,15 +435,17 @@ pub fn canonical_promoted_height<T: DbTx>(
 /// max_height`, `MigratedBlockHashes[h]` is `Some` (canonical), AND the
 /// canonical block at `h` actually carries `txid` in its commitment ledger.
 ///
-/// The final content check exists because the metadata row is written at
-/// tip-confirmation (depth 0), not at migration: an orphaned local tip can
-/// leave an `included_height` hint behind that no `ReorgEvent` ever clears if
-/// the node restarts before the orphan is processed (the tree is rebuilt from
-/// the block index, which forgets confirmed-but-unmigrated tips). Once ANY
-/// winning block later migrates at `h`, the MBH check alone reads that stranded
-/// hint as canonical truth. Requiring the canonical header to actually include
-/// the tx makes such stranded rows harmless — the invariant is that
-/// `Some(h)` proves canonical inclusion at `h`, not merely that a hint exists.
+/// The final content check exists to neutralize a stranded/legacy metadata row
+/// not backed by canonical block content. Canonical metadata is now written only
+/// at migration (atomically with `MigratedBlockHashes`), but a legacy row
+/// written at depth-0 confirmation — or any `included_height` hint an orphaned
+/// local tip left behind that no `ReorgEvent` cleared because the node restarted
+/// before processing the orphan (the tree is rebuilt from the block index, which
+/// forgets confirmed-but-unmigrated tips) — can survive. Once ANY winning block
+/// later migrates at `h`, the MBH check alone reads that stranded hint as
+/// canonical truth. Requiring the canonical header to actually include the tx
+/// makes such stranded rows harmless — the invariant is that `Some(h)` proves
+/// canonical inclusion at `h`, not merely that a hint exists.
 /// Like the data-tx `canonical_submit_height`, this is only branch-invariant
 /// BELOW the reorg floor — callers must pass `max_height ≤ tip -
 /// block_tree_depth` and cover the reorg window by-hash separately.
@@ -482,9 +487,9 @@ pub fn canonical_commitment_included_height<T: DbTx>(
 /// The commitment replay-dedup's finalized lookup
 /// ([`canonical_commitment_included_height`]) keys on
 /// `IrysCommitmentTxMetadata.included_height`, which is written for ordinary
-/// blocks at confirm/migration by `BlockMigrationService`. Genesis
+/// blocks at migration by `BlockMigrationService`. Genesis
 /// first-includes its commitments but is the block-index head, so it never
-/// flows through the confirm/migration metadata writers and no row is ever
+/// flows through the migration metadata writer and no row is ever
 /// written for its commitment tx ids. Once genesis falls below the reorg floor
 /// (`tip - block_tree_depth`), that finalized lookup is the ONLY dedup path
 /// that can see a replayed genesis commitment — the by-hash ancestry walk only
@@ -1507,7 +1512,7 @@ mod tests {
     }
 
     /// Genesis first-includes its commitments but never flows through the
-    /// confirm/migration metadata writers, so no dedup row is written for it at
+    /// migration metadata writer, so no dedup row is written for it at
     /// init. The startup backfill must write `included_height = 0` for each
     /// genesis commitment so the finalized lookup resolves them once genesis
     /// passes the reorg floor — and must be idempotent across boots.
@@ -2030,9 +2035,10 @@ mod tests {
         /// points at a height where a *different* canonical block has migrated
         /// (`MBH[h] = Some`) — but that block does NOT carry the tx in its
         /// Publish ledger. This is the restart-interrupted-reorg collision the
-        /// content check exists to neutralize: the metadata row is written at
-        /// depth-0 confirmation, so an orphaned tip's `promoted_height = h` can
-        /// survive, and once a winning block later migrates at `h` the
+        /// content check exists to neutralize: a legacy metadata row written at
+        /// depth-0 confirmation (before metadata became migration-only) left by
+        /// an orphaned tip with `promoted_height = h` can survive, and once a
+        /// winning block later migrates at `h` the
         /// MBH-existence check alone would read the stale hint as a real prior
         /// promotion → false `PublishTxAlreadyIncluded` rejecting a legitimate
         /// block. Requiring the canonical block to actually carry the tx makes

--- a/crates/database/src/db_index.rs
+++ b/crates/database/src/db_index.rs
@@ -208,10 +208,10 @@ pub fn batch_clear_data_tx_promoted_height<'a>(
 /// included at some prior height, and the reorg invariant in
 /// `BlockMigrationService::persist_metadata` guarantees the matching Publish
 /// block is also in `blocks_to_clear`. Its `clear_data_tx_promoted_height`
-/// call becomes a no-op on the already-deleted row. If the tx is
-/// re-canonical on the new fork, Phase 2 recreates the row via
-/// `set_data_tx_included_height` and any matching Publish re-confirmation
-/// restores `promoted_height` in the same transaction.
+/// call becomes a no-op on the already-deleted row. If the tx is re-canonical
+/// on the new fork, its row is rewritten when that fork's block migrates
+/// (`write_data_ledger_metadata` in `persist_block`), which also restores
+/// `promoted_height` for any re-included Publish block.
 pub fn clear_data_tx_included_height(
     tx: &impl DbTxMut,
     tx_id: &H256,


### PR DESCRIPTION
Data-tx branch-safety fixes, all rooted in one anti-pattern: node-local `included_height`/`promoted_height` metadata that can't prove branch membership and goes stale under reorg.

## Fix A — producer re-selects an already-promoted tx (confirmed on testnet)
`tx_selector` gated publish-candidate exclusion on the node-local `promoted_height` hint, which is branch-variant under reorg: it can read `None` for a tx already promoted on the parent's branch, so the producer re-selects it and mints a block validators reject as a double-promotion (`TxFoundInMultipleBlocks`), wasting a block slot.

- Exclude via `resolve_promoted_on_branch` — a by-hash walk of the *parent's own ancestry* over the reorg window — the same branch-correct signal the validator's duplicate-inclusion walk uses.
- Filter the commitment- and Submit-dedup folds to `Onchain` ancestors (the two `TODO(tx-selector-onchain-filter)` sites).

## Root fix — canonical metadata is written only at migration
Investigation traced the branch-safety hazard to its source: `IrysDataTxMetadata`/`IrysCommitmentTxMetadata` were written at **block confirmation (depth 0)**, before the block is durably persisted. An orphaned confirmed-but-unmigrated tip could strand such a row; once a *different* block later migrated at the same height, the `MigratedBlockHashes`-existence check read the stale row as canonical.

- `persist_metadata` no longer writes canonical metadata at confirmation. It is written only at migration (`persist_block`), atomically with `MigratedBlockHashes` and the block header — so a metadata row cannot exist without its MBH entry naming the same canonical block. Unmigrated blocks are already served branch-correctly from the in-memory block tree, so consensus never needed the confirmation-time rows.
- The non-consensus `CachedDataRoots.block_set` hint stays at confirmation (the ingress-proof pipeline depends on it pre-migration).
- Query paths that reported pre-migration state from the DB now read the live mempool for the unmigrated window (promotion-status endpoint, `get_is_promoted`).

**Behavior change:** this drops the prior "tx status survives a node restart before migration" behavior. An unmigrated block isn't durably persisted, so after a restart the mempool restores its txs as pending — reporting them CONFIRMED named a block the node no longer had. Restart tests updated to assert the honest reverts-to-pending behavior.

## Fix B — content-verified canonical lookups (defense-in-depth)
`canonical_submit_height`/`canonical_promoted_height` now require the canonical block at the returned height to actually carry the tx (mirroring `canonical_commitment_included_height`). With the root fix this is no longer load-bearing, but it's kept to guard the residual deep-reorg-past-migration case (where `MigratedBlockHashes` itself is rewritten).

## Note
Stacked on #1463 (`feat/commitment-anchor-expiry-depth`), which carries the reusable primitives. Once #1463 merges, this branch will be rebased and the diff reduces to just these commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transaction status and promotion/inclusion checks now content-verify against the canonical chain.
  * Publish/promotion selection and deduplication are restricted to on-chain ancestors.
  * Tx promotion status API now prefers durable DB promotion data, with a fallback to live mempool metadata when needed.

* **Bug Fixes**
  * Reorg handling no longer restores confirmation-time canonical inclusion metadata; promotion/inclusion is derived only from migrated canonical blocks.
  * Corrected epoch/genesis commitment backfill skipping and restart behavior for confirmed-but-unmigrated and unmigrated promotions.

* **Tests**
  * Updated fixtures and assertions for canonical-metadata seeding, epoch/genesis, reorg/restart, and promotion resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->