### PR TITLE
Saturate millisecond timestamp conversion

### DIFF
--- a/crates/types/src/time.rs
+++ b/crates/types/src/time.rs
@@ -199,7 +199,12 @@ impl UnixTimestampMs {
     /// Converts to seconds (lossy - truncates sub-second precision)
     #[inline]
     pub const fn to_secs(self) -> UnixTimestamp {
-        UnixTimestamp::from_secs((self.0 / 1000) as u64)
+        let secs = self.0 / 1000;
+        UnixTimestamp::from_secs(if secs > u64::MAX as u128 {
+            u64::MAX
+        } else {
+            secs as u64
+        })
     }
 
     /// Creates from a UnixTimestamp (lossless - extends with zero milliseconds)
@@ -481,6 +486,12 @@ mod unix_timestamp_ms_tests {
     }
 
     #[test]
+    fn test_to_secs_saturates_on_overflow() {
+        let ts = UnixTimestampMs::from_millis((u64::MAX as u128 + 1) * 1000);
+        assert_eq!(ts.to_secs(), UnixTimestamp::from_secs(u64::MAX));
+    }
+
+    #[test]
     fn test_serde_json_string_format() {
         // Verify JSON serializes as string (matches string_u128 format)
         let ts = UnixTimestampMs::from_millis(1609459200000);
@@ -527,9 +538,14 @@ mod unix_timestamp_ms_property_tests {
         }
 
         #[test]
-        fn to_secs_consistent_with_division(millis in any::<u128>()) {
+        fn to_secs_consistent_with_saturating_division(millis in any::<u128>()) {
             let ts = UnixTimestampMs::from_millis(millis);
-            let expected_secs = (millis / 1000) as u64;
+            let secs = millis / 1000;
+            let expected_secs = if secs > u64::MAX as u128 {
+                u64::MAX
+            } else {
+                secs as u64
+            };
             prop_assert_eq!(ts.to_secs().as_secs(), expected_secs);
         }
 


### PR DESCRIPTION
`UnixTimestampMs::to_secs` converted from `u128` milliseconds to `u64` seconds with an unchecked cast. Very large millisecond values could wrap back to a smaller second value after division.

This clamps overflowing conversions to `u64::MAX`, matching the saturating style used by the timestamp helpers, and updates the regression/property coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp conversion so large millisecond values now safely saturate instead of overflowing or truncating.
  * This helps ensure time values remain valid at the upper end of the supported range.

* **Tests**
  * Added coverage for overflow cases in timestamp conversion.
  * Updated existing property-based checks to match the new saturated behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->