### PR TITLE
fix(consensus): strictly-below dedup fallback caps + CDR scrub confirmed-window recheck

### DIFF
--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -642,18 +642,25 @@ impl InnerCacheTask {
     /// docs).  Removing an entry whose tx has since been (re-)confirmed
     /// would make the prune loop miss that confirmation's chunk-retention
     /// constraint and evict the CDR before chunk migration completes,
-    /// destroying chunks that are still needed.  Per-txid metadata recheck
-    /// inside the write tx closes that race: if `IrysDataTxMetadata[tx_id]`
-    /// is `Some` now, the tx is migrated (finalized) and the txid_set entry
-    /// must stay.
+    /// destroying chunks that are still needed.  Per-txid recheck in
+    /// [`Self::prune_txids_from_cached_data_roots`] closes that race across
+    /// both confirmation states, keeping a txid if either holds:
+    ///   - `IrysDataTxMetadata[tx_id]` is `Some`: the tx is migrated
+    ///     (canonical metadata is written only at migration).
+    ///   - the tx_id appears in the canonical block-tree window: the tx is
+    ///     confirmed but not yet migrated, so no metadata row exists yet.
+    ///     Only the canonical chain counts — "(re-)confirmed" means on the
+    ///     branch this node currently follows.
+    /// Together they restore the pre-migration retention contract.
     ///
     /// Residual race the recheck does not close: a peer gossips the tx back
     /// in during the scrub window and `cache_data_root` re-adds it to
-    /// `txid_set`, but the tx has not yet confirmed (no metadata row).  The
-    /// scrub would drop it.  Bounded by mempool TTL re-population and
-    /// `cache_data_root` idempotency on the next ingress.  Acceptable for
-    /// the current architecture; revisit if the mempool grows a strong
-    /// "currently-pending" signal that can be consulted from MDBX context.
+    /// `txid_set`, but the tx has NOT confirmed anywhere — no metadata row
+    /// and not in the canonical tree window.  The scrub would drop it.
+    /// Bounded by mempool TTL re-population and `cache_data_root` idempotency
+    /// on the next ingress.  Acceptable for the current architecture; revisit
+    /// if the mempool grows a strong "currently-pending" signal that can be
+    /// consulted from MDBX context.
     ///
     /// Uses a background thread (matching `spawn_pruning_task`) to avoid
     /// blocking the actor loop.  Sends `PruneTxidsCompleted` when done so
@@ -667,77 +674,17 @@ impl InnerCacheTask {
             // jams permanently.  `AssertUnwindSafe` is sound here — the
             // captured `clone` is `Send + Clone`, and on the panic path we
             // immediately stop using it after the catch.
-            let result: eyre::Result<()> = match std::panic::catch_unwind(
-                std::panic::AssertUnwindSafe(|| {
-                    clone.db.update_eyre(|db_tx| {
-                for (data_root, txids_to_remove) in &by_data_root {
-                    let Some(mut cached) = cached_data_root_by_data_root(db_tx, *data_root)? else {
-                        continue;
-                    };
-
-                    // Build the actually-safe-to-remove set: any tx_id whose
-                    // metadata row exists now was (re-)confirmed since the
-                    // scrub was queued and must stay in txid_set — see the
-                    // race rationale in the function docs above.
-                    let mut removal_set: HashSet<H256> = HashSet::new();
-                    let mut raced_confirmed: usize = 0;
-                    for tx_id in txids_to_remove {
-                        if get_data_tx_metadata(db_tx, tx_id)?.is_some() {
-                            raced_confirmed += 1;
-                            continue;
-                        }
-                        removal_set.insert(*tx_id);
+            let result: eyre::Result<()> =
+                match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    clone.prune_txids_from_cached_data_roots(&by_data_root)
+                })) {
+                    Ok(r) => r,
+                    Err(payload) => {
+                        let msg = panic_payload_string(payload);
+                        error!(custom.panic = %msg, "spawn_prune_txids_task body panicked");
+                        Err(eyre::eyre!("spawn_prune_txids_task panicked: {msg}"))
                     }
-                    if raced_confirmed > 0 {
-                        debug!(
-                            data_root = %data_root,
-                            raced_confirmed,
-                            "Skipped txid scrub for tx(es) (re-)confirmed during scrub window"
-                        );
-                    }
-                    if removal_set.is_empty() {
-                        continue;
-                    }
-
-                    let before_len = cached.txid_set.len();
-                    cached.txid_set.retain(|id| !removal_set.contains(id));
-
-                    if cached.txid_set.len() < before_len {
-                        debug!(
-                            data_root = %data_root,
-                            removed = before_len - cached.txid_set.len(),
-                            remaining = cached.txid_set.len(),
-                            "Pruned stale txids from CachedDataRoot.txid_set"
-                        );
-                        // Mirrors the `(None, None)` warn in
-                        // `remove_data_root_block_set_entry`: draining the
-                        // last txid while `expiry_height` is already None
-                        // leaves the CDR vacuously eviction-eligible (only
-                        // the local-proof exemption keeps it alive).
-                        // Surface this transition so observability is
-                        // symmetric across the two paths that produce it.
-                        if cached.txid_set.is_empty() && cached.expiry_height.is_none() {
-                            warn!(
-                                data_root = %data_root,
-                                "CachedDataRoot left in anomalous (no expiry, empty txid_set) state \
-                                 after stale-txid prune; entry now eviction-eligible unless held by \
-                                 a local ingress proof"
-                            );
-                        }
-                        db_tx.put::<CachedDataRoots>(*data_root, cached)?;
-                    }
-                }
-                Ok(())
-            })
-                }),
-            ) {
-                Ok(r) => r,
-                Err(payload) => {
-                    let msg = panic_payload_string(payload);
-                    error!(custom.panic = %msg, "spawn_prune_txids_task body panicked");
-                    Err(eyre::eyre!("spawn_prune_txids_task panicked: {msg}"))
-                }
-            };
+                };
 
             let completion = match &result {
                 Ok(_) => Ok(()),
@@ -753,6 +700,96 @@ impl InnerCacheTask {
                 warn!(custom.error = ?e, "Failed to notify PruneTxidsCompleted");
             }
         });
+    }
+
+    /// Scrub body for [`Self::spawn_prune_txids_task`]: inside a single write
+    /// txn, removes the queued txids from their `CachedDataRoot.txid_set`
+    /// entries, keeping any that has been (re-)confirmed since the scrub was
+    /// queued. See that method's docs for the full race rationale.
+    fn prune_txids_from_cached_data_roots(
+        &self,
+        by_data_root: &HashMap<H256, Vec<H256>>,
+    ) -> eyre::Result<()> {
+        // Snapshot the txids carried by the canonical block-tree window BEFORE
+        // opening the write txn. Confirmed-but-unmigrated inclusions live only
+        // here: canonical `IrysDataTxMetadata` rows are written at migration,
+        // so a tx re-confirmed in a still-unmigrated block during the scrub
+        // window has no metadata row yet. Reading only the canonical chain
+        // scopes "(re-)confirmed" to the branch this node currently follows.
+        // The tree read guard is released before any DB I/O — never held across
+        // the write txn (two-phase; see commitment_dedup.rs docs).
+        let tree_set: HashSet<H256> = {
+            let (canonical, _) = self.block_tree_guard.read().get_canonical_chain();
+            let mut set = HashSet::new();
+            for entry in &canonical {
+                for tx_ids in entry.header().get_data_ledger_tx_ids().into_values() {
+                    set.extend(tx_ids);
+                }
+            }
+            set
+        };
+
+        self.db.update_eyre(|db_tx| {
+            for (data_root, txids_to_remove) in by_data_root {
+                let Some(mut cached) = cached_data_root_by_data_root(db_tx, *data_root)? else {
+                    continue;
+                };
+
+                // Build the actually-safe-to-remove set: keep any tx_id that
+                // has been (re-)confirmed since the scrub was queued. A tx is
+                // (re-)confirmed if its metadata row exists (migrated) OR it
+                // appears in the canonical tree snapshot (confirmed but not yet
+                // migrated) — see the race rationale in `spawn_prune_txids_task`.
+                let mut removal_set: HashSet<H256> = HashSet::new();
+                let mut raced_confirmed: usize = 0;
+                for tx_id in txids_to_remove {
+                    if get_data_tx_metadata(db_tx, tx_id)?.is_some() || tree_set.contains(tx_id) {
+                        raced_confirmed += 1;
+                        continue;
+                    }
+                    removal_set.insert(*tx_id);
+                }
+                if raced_confirmed > 0 {
+                    debug!(
+                        data_root = %data_root,
+                        raced_confirmed,
+                        "Skipped txid scrub for tx(es) (re-)confirmed during scrub window"
+                    );
+                }
+                if removal_set.is_empty() {
+                    continue;
+                }
+
+                let before_len = cached.txid_set.len();
+                cached.txid_set.retain(|id| !removal_set.contains(id));
+
+                if cached.txid_set.len() < before_len {
+                    debug!(
+                        data_root = %data_root,
+                        removed = before_len - cached.txid_set.len(),
+                        remaining = cached.txid_set.len(),
+                        "Pruned stale txids from CachedDataRoot.txid_set"
+                    );
+                    // Mirrors the `(None, None)` warn in
+                    // `remove_data_root_block_set_entry`: draining the
+                    // last txid while `expiry_height` is already None
+                    // leaves the CDR vacuously eviction-eligible (only
+                    // the local-proof exemption keeps it alive).
+                    // Surface this transition so observability is
+                    // symmetric across the two paths that produce it.
+                    if cached.txid_set.is_empty() && cached.expiry_height.is_none() {
+                        warn!(
+                            data_root = %data_root,
+                            "CachedDataRoot left in anomalous (no expiry, empty txid_set) state \
+                             after stale-txid prune; entry now eviction-eligible unless held by \
+                             a local ingress proof"
+                        );
+                    }
+                    db_tx.put::<CachedDataRoots>(*data_root, cached)?;
+                }
+            }
+            Ok(())
+        })
     }
 
     /// Removes a single stale block hash from `CachedDataRoot.block_set`.
@@ -1370,11 +1407,13 @@ mod tests {
         tables::{CachedChunks, CachedChunksIndex, CachedDataRoots, IrysTables},
     };
     use irys_domain::{BlockIndex, BlockTree};
-    use irys_testing_utils::{initialize_tracing, new_mock_signed_header};
+    use irys_testing_utils::{
+        IrysBlockHeaderTestExt as _, initialize_tracing, new_mock_signed_header,
+    };
     use irys_types::{
         Base64, Config, DataTransactionHeader, DataTransactionHeaderV1,
-        DataTransactionHeaderV1WithMetadata, DataTransactionMetadata, IrysAddress, NodeConfig,
-        TxChunkOffset, UnpackedChunk, app_state::DatabaseProvider,
+        DataTransactionHeaderV1WithMetadata, DataTransactionMetadata, H256List, IrysAddress,
+        NodeConfig, TxChunkOffset, UnpackedChunk, app_state::DatabaseProvider,
     };
     use reth_db::cursor::DbDupCursorRO as _;
     use reth_db::mdbx::DatabaseArguments;
@@ -2914,6 +2953,233 @@ mod tests {
                 irys_database::ingress_proof_by_data_root_address(rtx, data_root, addr_c)?
                     .is_none(),
                 "addr_c expired proof must be deleted"
+            );
+            Ok(())
+        })??;
+
+        Ok(())
+    }
+
+    // Builds an `InnerCacheTask` whose canonical block-tree window carries
+    // `submit_tx_ids` in the Submit ledger of a canonical block, so those txids
+    // appear in the tree snapshot the scrub reads. The scrub reads only
+    // headers, so the child is sealed with `new_unchecked` and an empty body
+    // (as in the `tx_inclusion` test tree builder) rather than fabricating
+    // signed matching txs. With no ids, the window is just an empty genesis.
+    // Returns the task so tests can drive the scrub directly.
+    fn task_with_canonical_submit_txids(
+        db: &DatabaseProvider,
+        config: Config,
+        submit_tx_ids: Vec<H256>,
+    ) -> InnerCacheTask {
+        use irys_domain::{ChainState, CommitmentSnapshot, EpochSnapshot, dummy_ema_snapshot};
+        use irys_types::{BlockTransactions, SealedBlock};
+
+        let mut genesis_block = new_mock_signed_header();
+        genesis_block.height = 0;
+        genesis_block.cumulative_diff = 0.into();
+        genesis_block.test_sign();
+        let mut block_tree = BlockTree::new(&genesis_block, config.consensus.clone());
+
+        if !submit_tx_ids.is_empty() {
+            let mut child = new_mock_signed_header();
+            child.height = 1;
+            child.previous_block_hash = genesis_block.block_hash;
+            // Above genesis' 0, so the canonical chain cache follows the child.
+            child.cumulative_diff = 1.into();
+            // new_mock_header's data_ledgers layout is not guaranteed; target
+            // the Submit ledger by id rather than assuming the index.
+            let submit = child
+                .data_ledgers
+                .iter_mut()
+                .find(|l| l.ledger_id == DataLedger::Submit as u32)
+                .expect("mock header must carry a Submit ledger");
+            submit.tx_ids = H256List(submit_tx_ids);
+            child.test_sign();
+
+            let sealed = Arc::new(SealedBlock::new_unchecked(
+                Arc::new(child.clone()),
+                BlockTransactions::default(),
+            ));
+            block_tree
+                .add_common(
+                    child.block_hash,
+                    &sealed,
+                    Arc::new(CommitmentSnapshot::default()),
+                    Arc::new(EpochSnapshot::default()),
+                    dummy_ema_snapshot(),
+                    ChainState::Onchain,
+                )
+                .expect("add canonical child");
+        }
+
+        let block_tree_guard =
+            irys_domain::BlockTreeReadGuard::new(Arc::new(RwLock::new(block_tree)));
+        let block_index = BlockIndex::new_for_testing(db.clone());
+        let block_index_guard =
+            irys_domain::block_index_guard::BlockIndexReadGuard::new(block_index);
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        InnerCacheTask {
+            db: db.clone(),
+            block_tree_guard,
+            block_index_guard,
+            config,
+            gossip_broadcast: tokio::sync::mpsc::unbounded_channel().0,
+            ingress_proof_generation_state: IngressProofGenerationState::new(),
+            cache_sender: tx,
+        }
+    }
+
+    // T1 (regression pin): a tx re-confirmed in a canonical-but-unmigrated
+    // block (present in the tree's Submit ledger, NO metadata row) must NOT be
+    // scrubbed from txid_set. Before the tree-snapshot recheck, the scrub only
+    // consulted the migration-time metadata row and would wrongly drop it.
+    #[tokio::test]
+    async fn keeps_txid_confirmed_in_canonical_tree_without_metadata() -> eyre::Result<()> {
+        let node_config = NodeConfig::testing();
+        let config = Config::new_with_random_peer_id(node_config);
+        let _temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db_env = open_or_create_db(
+            &_temp_dir,
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        let db = DatabaseProvider(Arc::new(db_env));
+
+        let data_root = H256::random();
+        let tx_a = H256::random();
+        // CDR whose txid_set carries tx_a; no metadata row is written for it.
+        let cdr = CachedDataRoot {
+            data_size: 64,
+            data_size_confirmed: false,
+            txid_set: vec![tx_a],
+            block_set: vec![],
+            expiry_height: Some(100),
+            cached_at: irys_types::UnixTimestamp::now()?,
+        };
+        db.update(|wtx| -> eyre::Result<()> {
+            wtx.put::<CachedDataRoots>(data_root, cdr)?;
+            Ok(())
+        })??;
+
+        // tx_a lives in a canonical tree block's Submit ledger.
+        let task = task_with_canonical_submit_txids(&db, config, vec![tx_a]);
+
+        // Queue tx_a for removal; the tree snapshot must keep it.
+        let mut by_data_root: HashMap<H256, Vec<H256>> = HashMap::new();
+        by_data_root.insert(data_root, vec![tx_a]);
+        task.prune_txids_from_cached_data_roots(&by_data_root)?;
+
+        db.view(|rtx| -> eyre::Result<()> {
+            let cached = rtx
+                .get::<CachedDataRoots>(data_root)?
+                .expect("CDR must still exist");
+            eyre::ensure!(
+                cached.txid_set.contains(&tx_a),
+                "tx re-confirmed in the canonical (unmigrated) tree must be kept in txid_set"
+            );
+            Ok(())
+        })??;
+
+        Ok(())
+    }
+
+    // T2 (still removes stale): a tx in neither the canonical tree window nor
+    // the metadata table is genuinely stale and must be scrubbed.
+    #[tokio::test]
+    async fn removes_txid_absent_from_tree_and_metadata() -> eyre::Result<()> {
+        let node_config = NodeConfig::testing();
+        let config = Config::new_with_random_peer_id(node_config);
+        let _temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db_env = open_or_create_db(
+            &_temp_dir,
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        let db = DatabaseProvider(Arc::new(db_env));
+
+        let data_root = H256::random();
+        let tx_b = H256::random();
+        let cdr = CachedDataRoot {
+            data_size: 64,
+            data_size_confirmed: false,
+            txid_set: vec![tx_b],
+            block_set: vec![],
+            expiry_height: Some(100),
+            cached_at: irys_types::UnixTimestamp::now()?,
+        };
+        db.update(|wtx| -> eyre::Result<()> {
+            wtx.put::<CachedDataRoots>(data_root, cdr)?;
+            Ok(())
+        })??;
+
+        // The canonical window carries only an unrelated txid, so tx_b is absent.
+        let task = task_with_canonical_submit_txids(&db, config, vec![H256::random()]);
+
+        let mut by_data_root: HashMap<H256, Vec<H256>> = HashMap::new();
+        by_data_root.insert(data_root, vec![tx_b]);
+        task.prune_txids_from_cached_data_roots(&by_data_root)?;
+
+        db.view(|rtx| -> eyre::Result<()> {
+            let cached = rtx
+                .get::<CachedDataRoots>(data_root)?
+                .expect("CDR must still exist");
+            eyre::ensure!(
+                !cached.txid_set.contains(&tx_b),
+                "stale tx (not in tree, not migrated) must be scrubbed from txid_set"
+            );
+            Ok(())
+        })??;
+
+        Ok(())
+    }
+
+    // T3 (migrated still kept): a tx with a metadata row (migration state) and
+    // absent from the tree window must be kept — the pre-existing recheck arm.
+    #[tokio::test]
+    async fn keeps_migrated_txid_with_metadata_row() -> eyre::Result<()> {
+        let node_config = NodeConfig::testing();
+        let config = Config::new_with_random_peer_id(node_config);
+        let _temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db_env = open_or_create_db(
+            &_temp_dir,
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        let db = DatabaseProvider(Arc::new(db_env));
+
+        let data_root = H256::random();
+        let tx_c = H256::random();
+        let cdr = CachedDataRoot {
+            data_size: 64,
+            data_size_confirmed: false,
+            txid_set: vec![tx_c],
+            block_set: vec![],
+            expiry_height: Some(100),
+            cached_at: irys_types::UnixTimestamp::now()?,
+        };
+        db.update(|wtx| -> eyre::Result<()> {
+            wtx.put::<CachedDataRoots>(data_root, cdr)?;
+            // Migration-time metadata row for tx_c.
+            irys_database::set_data_tx_included_height(wtx, &tx_c, 5)
+                .map_err(|e| eyre::eyre!("set_data_tx_included_height: {:?}", e))?;
+            Ok(())
+        })??;
+
+        // The canonical window does NOT carry tx_c; only the metadata row keeps it.
+        let task = task_with_canonical_submit_txids(&db, config, vec![]);
+
+        let mut by_data_root: HashMap<H256, Vec<H256>> = HashMap::new();
+        by_data_root.insert(data_root, vec![tx_c]);
+        task.prune_txids_from_cached_data_roots(&by_data_root)?;
+
+        db.view(|rtx| -> eyre::Result<()> {
+            let cached = rtx
+                .get::<CachedDataRoots>(data_root)?
+                .expect("CDR must still exist");
+            eyre::ensure!(
+                cached.txid_set.contains(&tx_c),
+                "migrated tx (metadata row present) must be kept in txid_set"
             );
             Ok(())
         })??;

--- a/crates/actors/src/commitment_dedup.rs
+++ b/crates/actors/src/commitment_dedup.rs
@@ -349,4 +349,56 @@ mod tests {
         );
         Ok(())
     }
+
+    // Near genesis the floor saturates: `block_tree_depth >= height` clamps
+    // both the walk floor and the finalized cap to 0. The walk then owns the
+    // entire `[0, height)` range, so it — not the finalized lookup — must
+    // still flag an in-window inclusion, the double `saturating_sub` must not
+    // underflow, and a never-included commitment must not be flagged.
+    #[test]
+    fn saturated_floor_near_genesis_still_flags_replay() -> eyre::Result<()> {
+        use irys_database::tables::MigratedBlockHashes;
+        use irys_database::{batch_set_commitment_tx_included_height, insert_block_header};
+        use reth_db::transaction::DbTxMut as _;
+
+        let genesis = signed_genesis();
+        let commitment = signed_commitment();
+        let cid = commitment.id();
+        // b1 first-includes C at height 1; the candidate at height 2 replays it
+        // with block_tree_depth >> height, so floor = 0 and cap = 0. The
+        // inclusion metadata is present but sits ABOVE the saturated cap — the
+        // walk (resolving b1 via its DB fallback) is the only path that may
+        // decide.
+        let b1 = child_with_commitments(&genesis, 1, vec![cid]);
+        let b2 = child_with_commitments(&b1, 2, vec![cid]);
+
+        let cache = BlockTree::new(&genesis, ConsensusConfig::testing());
+        let block_tree = BlockTreeReadGuard::new(Arc::new(RwLock::new(cache)));
+        let (_tmp, db) = test_db();
+
+        db.update_eyre(|tx| {
+            // The saturated walk descends all the way to height 0, and once it
+            // falls back to the DB (at b1) it stays there — so genesis must be
+            // resolvable from the DB too, as in production.
+            insert_block_header(tx, &genesis)?;
+            insert_block_header(tx, &b1)?;
+            tx.put::<MigratedBlockHashes>(1, b1.block_hash)?;
+            batch_set_commitment_tx_included_height(tx, std::iter::once(&cid), 1)?;
+            Ok(())
+        })?;
+
+        let result = find_replayed_commitment(&block_tree, &db, &b2, &[commitment], 100)?;
+        assert_eq!(
+            result,
+            Some(cid),
+            "an in-window inclusion must still be flagged when the floor saturates to 0"
+        );
+
+        // Control: saturation must not manufacture a false positive for a
+        // commitment included nowhere.
+        let fresh = signed_commitment();
+        let result = find_replayed_commitment(&block_tree, &db, &b2, &[fresh], 100)?;
+        assert_eq!(result, None);
+        Ok(())
+    }
 }

--- a/crates/actors/src/commitment_dedup.rs
+++ b/crates/actors/src/commitment_dedup.rs
@@ -259,4 +259,94 @@ mod tests {
             find_replayed_commitment(&block_tree, &db, &block1, &[tx_a, tx_b], 100).unwrap();
         assert_eq!(result, None);
     }
+
+    // The by-hash walk owns the floor height (`height - block_tree_depth`)
+    // inclusively on the candidate's own branch, so a node-local
+    // `MigratedBlockHashes` inclusion EXACTLY at the floor is reorg-mutable and
+    // must never decide replay-validity. The finalized lookup is capped strictly
+    // below the floor: a boundary-height sibling on a divergent local branch
+    // carrying the same commitment is not a duplicate.
+    #[test]
+    fn floor_height_sibling_inclusion_is_not_replay() -> eyre::Result<()> {
+        use irys_database::tables::MigratedBlockHashes;
+        use irys_database::{batch_set_commitment_tx_included_height, insert_block_header};
+        use reth_db::transaction::DbTxMut as _;
+
+        let genesis = signed_genesis();
+        // b1 on the candidate's own branch at the floor height (1), carrying no
+        // commitments; only in the DB (below the retained tree window), so the
+        // walk resolves the floor via its DB fallback and finds no replay.
+        let b1 = child_with_commitments(&genesis, 1, vec![]);
+        // Candidate at height 2 carrying commitment C; floor = 2 - 1 = 1.
+        let commitment = signed_commitment();
+        let cid = commitment.id();
+        let b2 = child_with_commitments(&b1, 2, vec![cid]);
+
+        // Node-local SIBLING at the floor height whose commitment ledger carries
+        // C: the local canonical chain diverges from the candidate's branch at
+        // the boundary, and the metadata row points at this sibling.
+        let mut sibling = mock_header_with_commitments(1, vec![cid]);
+        sibling.test_sign();
+
+        let cache = BlockTree::new(&genesis, ConsensusConfig::testing());
+        let block_tree = BlockTreeReadGuard::new(Arc::new(RwLock::new(cache)));
+        let (_tmp, db) = test_db();
+
+        db.update_eyre(|tx| {
+            insert_block_header(tx, &b1)?;
+            insert_block_header(tx, &sibling)?;
+            tx.put::<MigratedBlockHashes>(1, sibling.block_hash)?;
+            batch_set_commitment_tx_included_height(tx, std::iter::once(&cid), 1)?;
+            Ok(())
+        })?;
+
+        let result = find_replayed_commitment(&block_tree, &db, &b2, &[commitment], 1)?;
+        assert_eq!(
+            result, None,
+            "a canonical inclusion exactly at the walk floor must not count as replay"
+        );
+        Ok(())
+    }
+
+    // A genuine finalized inclusion STRICTLY below the floor is still flagged:
+    // the stricter cap loses no coverage. C2 is included at height 1, the
+    // candidate at height 3 replays it, floor = 2 (walk covers height 2 only),
+    // so the finalized lookup (capped at 1) is the sole path that can see it.
+    #[test]
+    fn finalized_inclusion_below_floor_is_replay() -> eyre::Result<()> {
+        use irys_database::tables::MigratedBlockHashes;
+        use irys_database::{batch_set_commitment_tx_included_height, insert_block_header};
+        use reth_db::transaction::DbTxMut as _;
+
+        let genesis = signed_genesis();
+        let commitment = signed_commitment();
+        let cid = commitment.id();
+        // b1 finalizes C2 at height 1 (below the candidate's floor of 2).
+        let b1 = child_with_commitments(&genesis, 1, vec![cid]);
+        // b2 at the floor carries no commitments; the walk covers it and finds
+        // nothing.
+        let b2 = child_with_commitments(&b1, 2, vec![]);
+        // Candidate at height 3 replays C2; floor = 3 - 1 = 2, cap = 1.
+        let b3 = child_with_commitments(&b2, 3, vec![cid]);
+
+        let cache = BlockTree::new(&genesis, ConsensusConfig::testing());
+        let block_tree = BlockTreeReadGuard::new(Arc::new(RwLock::new(cache)));
+        let (_tmp, db) = test_db();
+
+        db.update_eyre(|tx| {
+            insert_block_header(tx, &b1)?;
+            insert_block_header(tx, &b2)?;
+            tx.put::<MigratedBlockHashes>(1, b1.block_hash)?;
+            batch_set_commitment_tx_included_height(tx, std::iter::once(&cid), 1)?;
+            Ok(())
+        })?;
+
+        let result = find_replayed_commitment(&block_tree, &db, &b3, &[commitment], 1)?;
+        assert_eq!(
+            result,
+            Some(cid),
+            "a finalized inclusion strictly below the floor must still be a replay"
+        );
+        Ok(())
+    }
 }

--- a/crates/actors/src/commitment_dedup.rs
+++ b/crates/actors/src/commitment_dedup.rs
@@ -26,9 +26,14 @@ use std::ops::ControlFlow;
 ///   - Reorg window `[floor, height)`: resolved by-hash along THIS block's own
 ///     ancestry (block tree, DB fallback), so a reorged-out sibling's inclusion
 ///     never counts. See [`ancestor_commitment_tx_ids`].
-///   - Below `floor`: the chain is finalized, so a content-verified lookup
-///     ([`canonical_commitment_included_height`], capped at `floor`) is
-///     branch-invariant there.
+///   - Strictly below `floor`: the chain is finalized, so a content-verified
+///     lookup ([`canonical_commitment_included_height`], capped at `floor - 1`)
+///     is branch-invariant there. The walk owns the floor height itself: a
+///     node-local `MigratedBlockHashes` row there is reorg-mutable, and since
+///     the walk resolves the floor on the candidate's own branch, a
+///     lookup answer at that height is never a true positive — the same
+///     strictly-below cap as the data-tx fallbacks in `data_txs_are_valid` and
+///     `resolve_promoted_on_branch` (keep the cap forms in sync).
 ///
 /// The in-memory reorg-window set is checked before the DB lookup, so a
 /// commitment-free branch or an in-window hit never pays for a finalized read.
@@ -52,9 +57,13 @@ pub fn find_replayed_commitment(
 
     let prior_ids =
         ancestor_commitment_tx_ids(block_tree, db, block_under_validation, block_tree_depth)?;
-    let floor = block_under_validation
+    // Cap the finalized lookup strictly below the walk window (see the
+    // two-range contract above). Zero coverage loss: the walk covers `[floor,
+    // height)` inclusively on the candidate's branch.
+    let finalized_cap = block_under_validation
         .height
-        .saturating_sub(block_tree_depth);
+        .saturating_sub(block_tree_depth)
+        .saturating_sub(1);
 
     // One read txn covers every finalized-inclusion lookup (a single MDBX txn
     // instead of one per commitment). The walk's own DB descent (Phase 2 below)
@@ -69,7 +78,7 @@ pub fn find_replayed_commitment(
             // reorg-window check; only pay the DB read on a miss on both.
             if !seen.insert(tx.id())
                 || prior_ids.contains(&tx.id())
-                || canonical_commitment_included_height(read_tx, &tx.id(), floor)?.is_some()
+                || canonical_commitment_included_height(read_tx, &tx.id(), finalized_cap)?.is_some()
             {
                 return Ok(Some(tx.id()));
             }

--- a/crates/actors/src/tx_selector/mod.rs
+++ b/crates/actors/src/tx_selector/mod.rs
@@ -775,6 +775,7 @@ pub async fn select_best_txs(
         ctx,
         &canonical,
         current_height,
+        tip_block_height,
         current_timestamp,
         &parent_epoch_snapshot,
     )
@@ -847,6 +848,7 @@ async fn get_publish_txs_and_proofs(
     ctx: &TxSelectionContext<'_>,
     canonical: &[BlockTreeEntry],
     current_height: u64,
+    tip_block_height: u64,
     current_timestamp: UnixTimestamp,
     epoch_snapshot: &Arc<EpochSnapshot>,
 ) -> Result<PublishLedgerWithTxs, eyre::Error> {
@@ -1036,11 +1038,19 @@ async fn get_publish_txs_and_proofs(
             // others must have a canonical (migrated) Submit inclusion. The §4b
             // expiry check below resolves the inclusion itself (branch-correct),
             // so we only need the gate's continue-on-missing side effect here.
+            //
+            // Cap the DB lookup at the tip's reorg floor: the fold already
+            // covers the parent's ancestry down to the cache floor, so any
+            // in-band (reorg-mutable) inclusion is answered from the fold and
+            // the DB is only consulted for finalized, branch-invariant heights
+            // — mirroring `commitment_finalized_floor` above and the validator's
+            // strictly-below-walk-window cap (keep the cap forms in sync).
             if !submit_txs_from_canonical.contains(&tx_header.id) {
-                match ctx
-                    .db
-                    .view_eyre(|tx| canonical_submit_height(tx, &tx_header.id, current_height))
-                {
+                let submit_finalized_floor =
+                    tip_block_height.saturating_sub(ctx.config.consensus.block_tree_depth);
+                match ctx.db.view_eyre(|tx| {
+                    canonical_submit_height(tx, &tx_header.id, submit_finalized_floor)
+                }) {
                     Ok(Some(_)) => {}
                     Ok(None) => {
                         warn!(

--- a/crates/chain-tests/src/promotion/mod.rs
+++ b/crates/chain-tests/src/promotion/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod data_promotion_basic;
 pub(crate) mod data_promotion_double;
 pub(crate) mod promotion_with_multiple_proofs;
+pub(crate) mod publish_gate_reorg_band;
 pub(crate) mod stale_txid_in_cached_data_root;

--- a/crates/chain-tests/src/promotion/publish_gate_reorg_band.rs
+++ b/crates/chain-tests/src/promotion/publish_gate_reorg_band.rs
@@ -1,0 +1,207 @@
+use crate::utils::IrysNodeTest;
+use irys_database::db::IrysDatabaseExt as _;
+use irys_database::db_cache::CachedDataRoot;
+use irys_database::tables::{CachedDataRoots, MigratedBlockHashes};
+use irys_database::{insert_block_header, insert_tx_header, set_data_tx_included_height};
+use irys_types::ingress::generate_ingress_proof;
+use irys_types::{
+    DataLedger, H256, H256List, IrysBlockHeader, NodeConfig, UnixTimestamp, irys::IrysSigner,
+};
+use reth_db::transaction::DbTxMut as _;
+use tracing::info;
+
+/// Fabricate a canonical (migrated) Submit inclusion for `txid` at `height`:
+/// a mock block carrying the tx in its Submit ledger, `MigratedBlockHashes[height]`
+/// repointed at it, and the `IrysDataTxMetadata.included_height` hint set. The
+/// block's parent is a real, already-migrated header so the migrated-metadata
+/// range lookup (`find_canonical_ledger_range`) resolves without error and the
+/// tx can proceed to promotion when the gate admits it.
+fn plant_submit_inclusion(
+    node: &IrysNodeTest<irys_chain::IrysNodeCtx>,
+    txid: H256,
+    height: u64,
+    prev_block_hash: H256,
+) -> eyre::Result<()> {
+    let mut planted = IrysBlockHeader::new_mock_header();
+    planted.height = height;
+    planted.block_hash = H256::random();
+    planted.previous_block_hash = prev_block_hash;
+    planted.data_ledgers[DataLedger::Submit].tx_ids = H256List(vec![txid]);
+    planted.data_ledgers[DataLedger::Submit].total_chunks = 0;
+    let planted_hash = planted.block_hash;
+
+    node.node_ctx.db.update_eyre(|db_tx| {
+        insert_block_header(db_tx, &planted)?;
+        db_tx.put::<MigratedBlockHashes>(height, planted_hash)?;
+        set_data_tx_included_height(db_tx, &txid, height)?;
+        Ok(())
+    })?;
+    Ok(())
+}
+
+/// Manufacture a publish candidate whose data tx the node never included in a
+/// real block: insert the tx header into the DB (so it resolves), cache its
+/// data_root with the tx pinned in `txid_set`, and store a valid, staked ingress
+/// proof for it. This is exactly the state the publish-candidate scan reads
+/// before applying the prior-Submit gate.
+async fn make_publish_candidate(
+    node: &IrysNodeTest<irys_chain::IrysNodeCtx>,
+    signer: &IrysSigner,
+    config: &NodeConfig,
+    seed: u8,
+) -> eyre::Result<H256> {
+    let chunks: Vec<[u8; 32]> = vec![
+        [seed; 32],
+        [seed.wrapping_add(1); 32],
+        [seed.wrapping_add(2); 32],
+    ];
+    let data: Vec<u8> = chunks.iter().flat_map(|c| c.iter()).copied().collect();
+
+    let price_info = node
+        .get_data_price(DataLedger::Publish, data.len() as u64)
+        .await?;
+    let data_tx = signer.create_publish_transaction(
+        data,
+        node.get_anchor().await?,
+        price_info.perm_fee.into(),
+        price_info.term_fee.into(),
+    )?;
+    let data_tx = signer.sign_transaction(data_tx)?;
+    let txid = data_tx.header.id;
+    let data_root = data_tx.header.data_root;
+
+    // The tx is never posted to the mempool; the publish-candidate lookup falls
+    // back to the DB, so the header must be resolvable there (otherwise the
+    // stale-txid debug_assert in get_publish_txs_and_proofs hard-fails).
+    node.node_ctx.db.update_eyre(|db_tx| {
+        insert_tx_header(db_tx, &data_tx.header)?;
+        let cached = CachedDataRoot {
+            data_size: data_tx.header.data_size,
+            data_size_confirmed: true,
+            txid_set: vec![txid],
+            block_set: vec![],
+            expiry_height: Some(1000),
+            cached_at: UnixTimestamp::from_secs(0),
+        };
+        db_tx.put::<CachedDataRoots>(data_root, cached)?;
+        Ok(())
+    })?;
+
+    let anchor = node.get_anchor().await?;
+    let ingress_proof = generate_ingress_proof(
+        signer,
+        data_root,
+        chunks.iter().copied().map(Ok),
+        config.consensus_config().chain_id,
+        anchor,
+    )?;
+    node.node_ctx.db.update_eyre(|db_tx| {
+        irys_database::store_ingress_proof_checked(db_tx, &ingress_proof, signer)
+    })?;
+
+    Ok(txid)
+}
+
+/// Producer-side sibling of the validator pin
+/// `test_prevalidation_ignores_content_verified_row_inside_walk_window`.
+///
+/// The producer's publish prior-Submit gate consults the content-verified
+/// canonical Submit index only for FINALIZED heights — capped at
+/// `tip - block_tree_depth`. A canonical Submit row INSIDE the reorg-mutable
+/// band (strictly above that floor) describes only this node's current chain,
+/// not necessarily the branch being built, so it must NOT satisfy the gate:
+/// the parent's own ancestry is already resolved by the canonical fold, and any
+/// in-band inclusion must come from the fold, never the DB.
+///
+/// This test plants two content-verified canonical Submit inclusions for two txs
+/// that appear in NO real block-tree block (so the fold misses both, and the DB
+/// gate is the deciding check):
+///   - `band_txid` at `floor + 1` (inside the reorg-mutable band) — must be
+///     SKIPPED: no finalized prior Submit at or below the cap.
+///   - `control_txid` at `floor - 1` (finalized) — must be PROMOTED: the gate is
+///     satisfied by a branch-invariant row, proving the cap does not over-skip.
+///
+/// Under the old `parent_height` cap the band row satisfied the gate and the tx
+/// was wrongly promoted; under the finalized-floor cap only the control survives.
+#[test_log::test(tokio::test)]
+async fn heavy_publish_gate_skips_reorg_band_submit_row() -> eyre::Result<()> {
+    let config = NodeConfig::testing()
+        .with_consensus(|consensus| {
+            consensus.chunk_size = 32;
+            consensus.num_partitions_per_slot = 1;
+            // Small depths so the finalized floor (tip - block_tree_depth) is
+            // reachable quickly while leaving a reorg-mutable band above it.
+            // Invariants (Config::validate): migration < tree_depth, and
+            // block_migration <= tx_anchor_expiry <= block_tree_depth.
+            consensus.block_migration_depth = 1;
+            consensus.block_tree_depth = 3;
+            consensus.mempool.tx_anchor_expiry_depth = 3;
+            consensus.hardforks.frontier.number_of_ingress_proofs_total = 1;
+            consensus
+                .hardforks
+                .frontier
+                .number_of_ingress_proofs_from_assignees = 0;
+        })
+        .with_genesis_peer_discovery_timeout(1000);
+
+    let signer = config.signer();
+    let node = IrysNodeTest::new_genesis(config.clone())
+        .start_and_wait_for_packing("GENESIS", 30)
+        .await;
+
+    // Mine enough blocks that the finalized floor is strictly positive and a
+    // reorg-mutable band exists above it.
+    node.mine_blocks(6).await?;
+
+    let tip = node.get_canonical_chain_height().await;
+    let floor = tip - config.consensus_config().block_tree_depth;
+    assert!(floor >= 1, "finalized floor must be positive (tip={tip})");
+    let band_height = floor + 1; // inside the reorg-mutable band, above the cap
+    let control_height = floor - 1; // finalized, at/below the cap
+
+    info!(tip, floor, band_height, control_height, "geometry");
+
+    // Two publish candidates the node never included in any real block.
+    let band_txid = make_publish_candidate(&node, &signer, &config, 0x10).await?;
+    let control_txid = make_publish_candidate(&node, &signer, &config, 0x40).await?;
+
+    // Plant content-verified canonical Submit inclusions at the two heights.
+    // Parent = the real, already-migrated header one below the planted height.
+    // Read the real parent headers from the block index: at block_tree_depth = 3
+    // these heights have already been pruned from the in-memory block tree.
+    let band_prev = node
+        .get_block_by_height_from_index(band_height - 1, false)?
+        .block_hash;
+    let control_prev = node
+        .get_block_by_height_from_index(control_height - 1, false)?
+        .block_hash;
+    plant_submit_inclusion(&node, band_txid, band_height, band_prev)?;
+    plant_submit_inclusion(&node, control_txid, control_height, control_prev)?;
+
+    // Run producer tx selection against the canonical tip (the parent we build on).
+    let canonical_tip = node.get_canonical_chain().last().unwrap().block_hash();
+    let mempool_txs = node.get_best_mempool_tx(canonical_tip).await?;
+    let promoted: Vec<H256> = mempool_txs.publish_tx.txs.iter().map(|h| h.id).collect();
+
+    // Regression pin: the in-band row must NOT satisfy the gate.
+    assert!(
+        !promoted.contains(&band_txid),
+        "regression: producer promoted a publish candidate whose only Submit \
+         inclusion sits INSIDE the reorg-mutable band (height {band_height} > \
+         finalized floor {floor}) — such a row describes only this node's chain, \
+         not necessarily the branch being built, so the prior-Submit gate must \
+         skip it. promoted={promoted:?}"
+    );
+
+    // Control: a finalized Submit row (height {control_height} <= floor {floor})
+    // must still satisfy the gate, proving the cap does not over-skip.
+    assert!(
+        promoted.contains(&control_txid),
+        "expected the publish candidate with a FINALIZED Submit inclusion \
+         (height {control_height} <= floor {floor}) to be promoted; the cap must \
+         not over-skip branch-invariant rows. promoted={promoted:?}"
+    );
+
+    node.stop().await;
+    Ok(())
+}

--- a/crates/chain-tests/src/promotion/publish_gate_reorg_band.rs
+++ b/crates/chain-tests/src/promotion/publish_gate_reorg_band.rs
@@ -155,7 +155,10 @@ async fn heavy_publish_gate_skips_reorg_band_submit_row() -> eyre::Result<()> {
 
     let tip = node.get_canonical_chain_height().await;
     let floor = tip - config.consensus_config().block_tree_depth;
-    assert!(floor >= 1, "finalized floor must be positive (tip={tip})");
+    // The geometry below derives control_height = floor - 1 and reads its
+    // parent at floor - 2, so floor >= 2 is the minimum that keeps every
+    // height subtraction non-negative.
+    assert!(floor >= 2, "finalized floor must be >= 2 (tip={tip})");
     let band_height = floor + 1; // inside the reorg-mutable band, above the cap
     let control_height = floor - 1; // finalized, at/below the cap
 


### PR DESCRIPTION
Follow-ups from a composition review of #1463 / #1468 / #1464 — three narrow fixes to keep the invariants those PRs established consistent across all their call sites.

## 1. Commitment replay dedup: cap the finalized lookup strictly below the walk window

`find_replayed_commitment` capped its finalized DB lookup **at** the walk floor (`height - block_tree_depth`), overlapping the by-hash walk's inclusive coverage of that height. A node-local `MigratedBlockHashes` row at the boundary is reorg-mutable, and since the walk already resolves the floor on the candidate's own branch, a lookup answer there is never a true positive — only a potential false `DuplicateCommitmentTransaction` (a hard reject) on a maximal-depth fork whose boundary sibling carries the same commitment. #1464 applied exactly this reasoning to the data-tx fallbacks (`data_txs_are_valid`, `resolve_promoted_on_branch`) with a "keep the cap forms in sync" note; this brings the commitment path in line. Zero coverage loss: the walk owns `[floor, height)`.

Not reachable today — block-tree retention (`prune(block_tree_depth - 1)` + fork-subtree cascade) forces every fork point to at least the floor, so the candidate branch and node-local MBH always agree there — but that safety margin is exactly one height and lives in unrelated prune arithmetic.

## 2. Producer publish prior-Submit gate: consult only finalized rows

The gate's `canonical_submit_height` fallback was capped at the parent height, admitting node-local reorg-band rows. The canonical fold already resolves the parent's ancestry through the band, so the DB is now consulted only at or below `tip - block_tree_depth` (finalized, branch-invariant), mirroring the commitment selection dedup floor. Anchoring at the tip rather than the parent keeps `(parent - depth, tip - depth]` covered when building on a non-tip parent.

## 3. CachedDataRoots scrub: recheck the canonical tree window

#1468 moved canonical metadata writes to migration time, which widened the txid-scrub race: the scrub's re-confirmation recheck keyed solely on `IrysDataTxMetadata` existence, so a tx re-confirmed in a still-unmigrated block during the scrub window (now ~`block_migration_depth` blocks wide) was wrongly scrubbed from `txid_set`, letting the prune loop evict chunks that chunk migration still needs. The recheck now also consults a snapshot of the canonical block-tree window (where confirmed-but-unmigrated inclusions live), keeping a queued txid when either signal holds — a kept entry is re-scrubbed by the next TTL/reorg pass, so over-keeping is safe. The tree guard is released before the write txn opens (two-phase, matching the commitment-dedup pattern).

Mechanically, the scrub body moves out of the spawned thread into `prune_txids_from_cached_data_roots` so the recheck is directly testable; thread wrapper, panic handling, and completion signaling are unchanged. Non-consensus; the residual gossip-readd race remains as documented.

## Tests

Every fix ships a regression pin verified to fail against the pre-fix code:
- `commitment_dedup`: `floor_height_sibling_inclusion_is_not_replay` (exclusion side) + `finalized_inclusion_below_floor_is_replay` (no coverage loss) + `saturated_floor_near_genesis_still_flags_replay` (floor/cap saturation at `block_tree_depth >= height`)
- chain-tests: `heavy_publish_gate_skips_reorg_band_submit_row` — producer-side sibling of `test_prevalidation_ignores_content_verified_row_inside_walk_window`, with a finalized-row control proving no over-skip
- `cache_service`: `keeps_txid_confirmed_in_canonical_tree_without_metadata` (regression), with `removes_txid_absent_from_tree_and_metadata` and `keeps_migrated_txid_with_metadata_row` as controls on both sides

Full `cargo clippy --workspace --tests --all-targets` clean; commitment replay / fork-recovery integration suite (`heavy_commitment_*`, `heavy_finalized_commitment_not_reselected_by_producer`) passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background cache pruning to keep canonically confirmed txids (even before migration) while preserving the existing anomaly warning behavior.
  * Fixed replay detection boundary logic so only finalized inclusion strictly below the walk floor is treated as a replay.
  * Tightened publish-tx promotion gate checks using a tip-aligned finalized floor, and refined high rejection-rate warning gating.
* **Documentation**
  * Updated stale-txid scrubber documentation to match the new retention contract and race semantics.
* **Tests**
  * Added canonical-tree regression tests for txid retention/scrubbing and an integration test covering publish-gate reorg-band promotion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
