### PR TITLE
feat: flaky nextest detection

### DIFF
--- a/.claude/skills/debugging-flaky-tests/SKILL.md
+++ b/.claude/skills/debugging-flaky-tests/SKILL.md
@@ -21,6 +21,36 @@ You will always receive a **GitHub Actions run URL** (e.g., `https://github.com/
 
 Important caveat: CI-only assertion failures and CI-only panics can still be flaky if they depend on asynchronous propagation across services.
 
+## Reproduce & diagnose locally with `cargo xtask flaky`
+
+Once you know which tests are suspect (from the CI logs, or the run's
+`report.json` artifact), don't run the full suite to rediscover them — target
+them directly. This is the fast path for the "figure out why and fix" loop:
+
+```sh
+# Diagnose known tests (skips 40-min full-suite discovery; scopes phase 1 to
+# just these, then stresses + isolates them). --json prints a parsable payload.
+cargo xtask flaky --tests 'crate::mod::test_a,crate::mod::test_b' --json
+
+# Or reproduce exactly what CI flagged, from the downloaded report:
+cargo xtask flaky --tests-from report.json --json
+```
+
+Read the report (`report.json` / `report.md` under
+`target/nextest-monitor/flaky/<ts>/`, or the stdout JSON). Each test carries:
+
+- **classification** — `GENUINE FLAKY` / `BROKEN` / `TIMEOUT-BOUND` are real bugs
+  (fail in isolation); `CONTENTION (peers|full-suite)` means it only fails
+  alongside other tests → a resource/scheduling issue (see the patterns below).
+- **failure_signatures** — the panic/assertion message + `file:line`, so you can
+  jump straight to the root cause. Multiple distinct signatures = multiple bugs.
+- **log_dir** — per-iteration logs named by outcome (`run-N.FAIL.log`,
+  `run-N.TIMEOUT.log`) with full tracing, plus a `summary.txt`.
+
+The `CONTENTION` vs genuine split tells you *which kind of fix* you need before
+you start: a genuine flake needs a logic/readiness fix; a contention flake needs
+thread allocation / `serial_` / event-driven waits (Patterns 1–3 below).
+
 ## Step 1: Pull CI Logs
 
 ```sh
@@ -154,16 +184,18 @@ Run both commands — **both must pass**:
 
 ```sh
 cargo nextest run -p irys-chain test_name          # sanity check
-# Scope phase 1 to the target test; the isolation phase re-runs it alone.
-# "No flaky tests detected" (exit 0) means the fix holds.
-cargo xtask flaky -i 10 -y 10 -- -E 'test(test_name)'
+# Verify mode: isolation only, high count. Exit 0 = fix holds.
+cargo xtask flaky --verify 'crate::mod::test_name' -y 20
 ```
 
 If `flaky` reports the test as GENUINE FLAKY / BROKEN / TIMEOUT-BOUND (or exits
-non-zero), the fix is incomplete. Go back to Step 5. A `CONTENTION`
-classification means it only fails alongside other tests — see Step 5 on
-resource contention. The full report (per-test failure rates and isolation logs)
-is written to `target/nextest-monitor/flaky/<timestamp>/`.
+non-zero), the fix is incomplete. Go back to Step 5. A `CLEAN` classification
+(exit 0) means it passed every isolated run — the fix holds. The full report
+(per-test failure rates, failure signatures, and isolation logs) is written to
+`target/nextest-monitor/flaky/<timestamp>/`.
+
+For contention-class flakes, `--verify` (isolation-only) won't reproduce them —
+use `cargo xtask flaky --tests '...'` so the stress phase runs too.
 
 ## Common Mistakes
 

--- a/.claude/skills/debugging-flaky-tests/SKILL.md
+++ b/.claude/skills/debugging-flaky-tests/SKILL.md
@@ -154,10 +154,16 @@ Run both commands — **both must pass**:
 
 ```sh
 cargo nextest run -p irys-chain test_name          # sanity check
-cargo xtask flaky -i 10 -- -E 'test(test_name)'   # must show 0 failures
+# Scope phase 1 to the target test; the isolation phase re-runs it alone.
+# "No flaky tests detected" (exit 0) means the fix holds.
+cargo xtask flaky -i 10 -y 10 -- -E 'test(test_name)'
 ```
 
-If `flaky` still shows failures, the fix is incomplete. Go back to Step 5.
+If `flaky` reports the test as GENUINE FLAKY / BROKEN / TIMEOUT-BOUND (or exits
+non-zero), the fix is incomplete. Go back to Step 5. A `CONTENTION`
+classification means it only fails alongside other tests — see Step 5 on
+resource contention. The full report (per-test failure rates and isolation logs)
+is written to `target/nextest-monitor/flaky/<timestamp>/`.
 
 ## Common Mistakes
 

--- a/.github/workflows/flaky.yml
+++ b/.github/workflows/flaky.yml
@@ -6,12 +6,22 @@ on:
   workflow_dispatch:
     inputs:
       iterations:
-        description: 'Number of iterations to run'
+        description: 'Phase 1: full-suite iterations'
         required: false
         default: '3'
         type: string
+      stress_iterations:
+        description: 'Phase 2: stress iterations over the suspect set'
+        required: false
+        default: '3'
+        type: string
+      isolation_iterations:
+        description: 'Phase 3: per-test isolated iterations'
+        required: false
+        default: '5'
+        type: string
       tolerable_failures:
-        description: 'Number of tolerable failures'
+        description: 'Genuinely-flaky tests to tolerate before failing'
         required: false
         default: '5'
         type: string
@@ -30,6 +40,8 @@ concurrency:
 # are set by the setup-repo composite action via GITHUB_ENV.
 env:
   ITERATIONS: ${{ github.event.inputs.iterations || '3' }}
+  STRESS_ITERATIONS: ${{ github.event.inputs.stress_iterations || '3' }}
+  ISOLATION_ITERATIONS: ${{ github.event.inputs.isolation_iterations || '5' }}
   TOLERABLE_FAILURES: ${{ github.event.inputs.tolerable_failures || '5' }}
   RETENTION_DAYS: 10
   CARGO_TERM_COLOR: always
@@ -68,90 +80,59 @@ jobs:
         run: |
           # Use available cores (Linux/macOS fallback)
           export RUST_TEST_THREADS="$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 8)"
-          
+
           START_TIME=$(date +%s)
           set +e
-          cargo xtask flaky --clean --save -i ${{ env.ITERATIONS }} -f ${{ env.TOLERABLE_FAILURES }}
+          cargo xtask flaky --clean \
+            -i ${{ env.ITERATIONS }} \
+            --stress-iterations ${{ env.STRESS_ITERATIONS }} \
+            -y ${{ env.ISOLATION_ITERATIONS }} \
+            -f ${{ env.TOLERABLE_FAILURES }}
           EXIT_CODE=$?
           END_TIME=$(date +%s)
-          
-          # Copy the timestamped output file to results directory
-          if ls target/flaky-test-output-*.txt 1> /dev/null 2>&1; then
-            cp target/flaky-test-output-*.txt flaky-test-results/flaky-test-output.txt
+
+          # Locate the most recent flaky report directory produced by the run.
+          REPORT_DIR="$(ls -dt .target/nextest-monitor/flaky/*/ target/nextest-monitor/flaky/*/ 2>/dev/null | head -1)"
+          if [ -n "$REPORT_DIR" ] && [ -f "${REPORT_DIR}report.md" ]; then
+            cp "${REPORT_DIR}report.md" flaky-test-results/report.md
+            cp "${REPORT_DIR}report.json" flaky-test-results/report.json 2>/dev/null || true
+            # Preserve per-test isolation logs for debugging.
+            tar -czf flaky-test-results/isolation-logs.tar.gz -C "$REPORT_DIR" phase3-isolation 2>/dev/null || true
           else
-            echo "No flaky output file found in target directory" > flaky-test-results/flaky-test-output.txt
+            echo "# Flaky Test Detection Report" > flaky-test-results/report.md
+            echo "No report produced (no flaky tests detected, or the run failed early)." >> flaky-test-results/report.md
           fi
-          
+
           echo $EXIT_CODE > flaky-test-results/exit_code.txt
           echo "Duration: $((END_TIME - START_TIME)) seconds" > flaky-test-results/duration.txt
         continue-on-error: true
 
       - name: Generate summary report
+        id: parse
         if: always()
         shell: bash
         run: |
-          # Read duration if available
           DURATION=$(cat flaky-test-results/duration.txt 2>/dev/null || echo "n/a")
-          
+          EXIT_CODE=$(cat flaky-test-results/exit_code.txt 2>/dev/null || echo "n/a")
+
+          # genuine_flakes is a top-level field in report.json.
+          GENUINE=$(python3 -c "import json;print(json.load(open('flaky-test-results/report.json')).get('genuine_flakes',0))" 2>/dev/null || echo 0)
+          SUSPECTS=$(python3 -c "import json;print(json.load(open('flaky-test-results/report.json')).get('total_suspects',0))" 2>/dev/null || echo 0)
+          echo "genuine_flakes=$GENUINE" >> "$GITHUB_OUTPUT"
+
           {
             echo "# Flaky Test Detection Report"
             echo "**Date:** $(date -u +'%Y-%m-%d %H:%M:%S UTC')"
             echo "**Commit:** ${{ github.sha }}"
             echo "**Runner:** ${{ runner.name }}"
-            echo "**Tool:** cargo xtask flaky"
-            echo "**Iterations:** ${{ env.ITERATIONS }}"
-            echo "**Tolerable Failures:** ${{ env.TOLERABLE_FAILURES }}"
-            echo "**Clean Workspace:** Yes"
-            echo "**Output Saved:** Yes (timestamped file in target/)"
+            echo "**Phases:** full-suite ×${{ env.ITERATIONS }}, stress ×${{ env.STRESS_ITERATIONS }}, isolation ×${{ env.ISOLATION_ITERATIONS }}"
+            echo "**Tolerable genuine flakes:** ${{ env.TOLERABLE_FAILURES }}"
             echo "**Duration:** $DURATION"
+            echo "**Exit code:** $EXIT_CODE"
+            echo "**Suspects:** $SUSPECTS — **Genuine flakes:** $GENUINE"
             echo
-            echo "## Results"
-            if grep -Eiq 'Found.*failing test|flaky|intermittent' flaky-test-results/flaky-test-output.txt; then
-              echo "### Flaky Tests Detected"
-              echo
-              echo '```text'
-              # Show matching lines with line numbers (top 200 for brevity)
-              grep -Ein 'Found.*failing test|flaky|intermittent' flaky-test-results/flaky-test-output.txt | head -n 200 || true
-              echo '```'
-            else
-              echo "### No Flaky Tests Detected"
-            fi
-            echo
-            echo "### Exit Code"
-            echo '```text'
-            cat flaky-test-results/exit_code.txt 2>/dev/null || echo "n/a"
-            echo '```'
+            cat flaky-test-results/report.md 2>/dev/null || echo "_No report available._"
           } > flaky-test-results/summary.md
-
-      - name: Parse flaky test details
-        id: parse
-        if: always()
-        shell: bash
-        run: |
-          # Extract test names and failure counts
-          grep -E "^test:.*stdout" flaky-test-results/flaky-test-output.txt | \
-            awk '{print $2, $3}' | \
-            sort | uniq > flaky-test-results/flaky-tests-list.txt || true
-          
-          # Count for metrics
-          FLAKY_COUNT=$(wc -l < flaky-test-results/flaky-tests-list.txt 2>/dev/null || echo 0)
-          echo "flaky_count=$FLAKY_COUNT" >> "$GITHUB_OUTPUT"
-          
-          # Add count to summary
-          echo "" >> flaky-test-results/summary.md
-          echo "### Flaky Test Count: $FLAKY_COUNT" >> flaky-test-results/summary.md
-
-      - name: Compress results
-        if: always()
-        shell: bash
-        run: |
-          # Create a tar.gz of everything except summary.md
-          cd flaky-test-results
-          tar -czf compressed-results.tar.gz \
-            --exclude=summary.md \
-            --exclude=compressed-results.tar.gz \
-            *.txt 2>/dev/null || true
-          cd ..
 
       - name: Upload flaky test results
         if: always()
@@ -160,8 +141,9 @@ jobs:
           name: flaky-test-results-${{ github.run_number }}
           path: |
             flaky-test-results/summary.md
-            flaky-test-results/compressed-results.tar.gz
-            target/flaky-test-output-*.txt
+            flaky-test-results/report.md
+            flaky-test-results/report.json
+            flaky-test-results/isolation-logs.tar.gz
           retention-days: ${{ env.RETENTION_DAYS }}
 
       - name: Post to job summary

--- a/.github/workflows/flaky.yml
+++ b/.github/workflows/flaky.yml
@@ -164,3 +164,19 @@ jobs:
         if: always()
         continue-on-error: true
         run: sccache --show-stats
+
+      # Re-raise the flaky detector's exit code so the job reflects reality: it
+      # exits non-zero only when genuine flakes exceeded -f (TOLERABLE_FAILURES),
+      # or the run errored. A red job triggers GitHub's scheduled-failure email
+      # and any Slack "GitHub" app workflow subscription. All reporting/upload
+      # steps above run first (via if: always()), so artifacts survive the fail.
+      - name: Surface flaky detection result
+        if: always()
+        shell: bash
+        run: |
+          EXIT_CODE=$(cat flaky-test-results/exit_code.txt 2>/dev/null || echo 1)
+          if [ "$EXIT_CODE" != "0" ]; then
+            echo "::error::Flaky detection exited ${EXIT_CODE}: genuine flakes exceeded tolerance (-f ${{ env.TOLERABLE_FAILURES }}) or the run errored. See the job summary and the flaky-test-results artifact."
+            exit 1
+          fi
+          echo "Flaky detection within tolerance (exit 0)."

--- a/.github/workflows/flaky.yml
+++ b/.github/workflows/flaky.yml
@@ -83,19 +83,25 @@ jobs:
 
           START_TIME=$(date +%s)
           set +e
-          cargo xtask flaky --clean \
+          # --json emits the report to stdout wrapped in sentinel lines; tee so we
+          # can both stream to the CI log and extract the machine-readable payload.
+          cargo xtask flaky --clean --json \
             -i ${{ env.ITERATIONS }} \
             --stress-iterations ${{ env.STRESS_ITERATIONS }} \
             -y ${{ env.ISOLATION_ITERATIONS }} \
-            -f ${{ env.TOLERABLE_FAILURES }}
-          EXIT_CODE=$?
+            -f ${{ env.TOLERABLE_FAILURES }} 2>&1 | tee flaky-test-results/run-output.log
+          EXIT_CODE=${PIPESTATUS[0]}
           END_TIME=$(date +%s)
 
-          # Locate the most recent flaky report directory produced by the run.
+          # Extract the sentinel-wrapped JSON payload (authoritative; no path glob).
+          sed -n '/<<<FLAKY_REPORT_JSON_BEGIN>>>/{n;p;}' flaky-test-results/run-output.log \
+            > flaky-test-results/report.json || true
+
+          # Copy the human report + isolation logs from the run's report directory.
           REPORT_DIR="$(ls -dt .target/nextest-monitor/flaky/*/ target/nextest-monitor/flaky/*/ 2>/dev/null | head -1)"
           if [ -n "$REPORT_DIR" ] && [ -f "${REPORT_DIR}report.md" ]; then
             cp "${REPORT_DIR}report.md" flaky-test-results/report.md
-            cp "${REPORT_DIR}report.json" flaky-test-results/report.json 2>/dev/null || true
+            [ -s flaky-test-results/report.json ] || cp "${REPORT_DIR}report.json" flaky-test-results/report.json 2>/dev/null || true
             # Preserve per-test isolation logs for debugging.
             tar -czf flaky-test-results/isolation-logs.tar.gz -C "$REPORT_DIR" phase3-isolation 2>/dev/null || true
           else
@@ -143,6 +149,7 @@ jobs:
             flaky-test-results/summary.md
             flaky-test-results/report.md
             flaky-test-results/report.json
+            flaky-test-results/run-output.log
             flaky-test-results/isolation-logs.tar.gz
           retention-days: ${{ env.RETENTION_DAYS }}
 

--- a/.github/workflows/flaky.yml
+++ b/.github/workflows/flaky.yml
@@ -85,11 +85,14 @@ jobs:
           set +e
           # --json emits the report to stdout wrapped in sentinel lines; tee so we
           # can both stream to the CI log and extract the machine-readable payload.
+          # Pass the workflow-level env vars via shell expansion (quoted) rather
+          # than ${{ }} interpolation, so untrusted workflow_dispatch inputs can't
+          # inject into the run script.
           cargo xtask flaky --clean --json \
-            -i ${{ env.ITERATIONS }} \
-            --stress-iterations ${{ env.STRESS_ITERATIONS }} \
-            -y ${{ env.ISOLATION_ITERATIONS }} \
-            -f ${{ env.TOLERABLE_FAILURES }} 2>&1 | tee flaky-test-results/run-output.log
+            -i "$ITERATIONS" \
+            --stress-iterations "$STRESS_ITERATIONS" \
+            -y "$ISOLATION_ITERATIONS" \
+            -f "$TOLERABLE_FAILURES" 2>&1 | tee flaky-test-results/run-output.log
           EXIT_CODE=${PIPESTATUS[0]}
           END_TIME=$(date +%s)
 
@@ -117,6 +120,11 @@ jobs:
         id: parse
         if: always()
         shell: bash
+        # Expose github/runner context as env vars so the script uses shell
+        # expansion instead of ${{ }} interpolation (injection-safe).
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          RUNNER_NAME: ${{ runner.name }}
         run: |
           DURATION=$(cat flaky-test-results/duration.txt 2>/dev/null || echo "n/a")
           EXIT_CODE=$(cat flaky-test-results/exit_code.txt 2>/dev/null || echo "n/a")
@@ -129,10 +137,10 @@ jobs:
           {
             echo "# Flaky Test Detection Report"
             echo "**Date:** $(date -u +'%Y-%m-%d %H:%M:%S UTC')"
-            echo "**Commit:** ${{ github.sha }}"
-            echo "**Runner:** ${{ runner.name }}"
-            echo "**Phases:** full-suite ×${{ env.ITERATIONS }}, stress ×${{ env.STRESS_ITERATIONS }}, isolation ×${{ env.ISOLATION_ITERATIONS }}"
-            echo "**Tolerable genuine flakes:** ${{ env.TOLERABLE_FAILURES }}"
+            echo "**Commit:** $COMMIT_SHA"
+            echo "**Runner:** $RUNNER_NAME"
+            echo "**Phases:** full-suite ×$ITERATIONS, stress ×$STRESS_ITERATIONS, isolation ×$ISOLATION_ITERATIONS"
+            echo "**Tolerable genuine flakes:** $TOLERABLE_FAILURES"
             echo "**Duration:** $DURATION"
             echo "**Exit code:** $EXIT_CODE"
             echo "**Suspects:** $SUSPECTS — **Genuine flakes:** $GENUINE"
@@ -176,7 +184,7 @@ jobs:
         run: |
           EXIT_CODE=$(cat flaky-test-results/exit_code.txt 2>/dev/null || echo 1)
           if [ "$EXIT_CODE" != "0" ]; then
-            echo "::error::Flaky detection exited ${EXIT_CODE}: genuine flakes exceeded tolerance (-f ${{ env.TOLERABLE_FAILURES }}) or the run errored. See the job summary and the flaky-test-results artifact."
+            echo "::error::Flaky detection exited ${EXIT_CODE}: genuine flakes exceeded tolerance (-f ${TOLERABLE_FAILURES}) or the run errored. See the job summary and the flaky-test-results artifact."
             exit 1
           fi
           echo "Flaky detection within tolerance (exit 0)."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ cargo xtask test               # Run tests via nextest with failure tracking
 cargo xtask test --rerun-failures  # Re-run only previously failed tests
 cargo xtask local-checks       # Run ~99% of CI checks (fmt, check, clippy, unused-deps, typos)
 cargo xtask local-checks --fix # Auto-fix issues
-cargo xtask flaky -i 5         # Run tests 5 times to detect flakiness
+cargo xtask flaky -i 5         # Nextest flaky detection: full suite ×5, then stress + isolate failures
 ```
 
 Run a single test:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14612,6 +14612,7 @@ dependencies = [
  "eyre",
  "irys-testing-utils",
  "nextest-monitor",
+ "rstest",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/types/src/canonical.rs
+++ b/crates/types/src/canonical.rs
@@ -857,7 +857,7 @@ mod tests {
 
     #[test]
     fn hashmap_keys_use_camel_case() {
-        let v = to_canonical(&ConsensusConfig::testnet()).unwrap();
+        let v = to_canonical(&ConsensusConfig::testing()).unwrap();
         // `alloc` is now nested under the `genesis_evm_state` enum (camelCased to
         // `genesisEvmState`); its map keys (addresses) must survive canonicalization.
         assert!(v["reth"]["genesisEvmState"]["alloc"].is_object());

--- a/crates/types/src/config/consensus.rs
+++ b/crates/types/src/config/consensus.rs
@@ -1181,7 +1181,7 @@ mod tests {
     fn test_testnet_borealis_activation_time() {
         let config = ConsensusConfig::testnet();
 
-        // Borealis — 2026-06-10T12:00:00+00:00 (epoch-aligned at runtime).
+        // Borealis — 2026-05-22T08:00:00+00:00 (epoch-aligned at runtime).
         assert_eq!(
             config
                 .hardforks
@@ -1189,7 +1189,7 @@ mod tests {
                 .as_ref()
                 .expect("testnet Borealis must be configured")
                 .activation_timestamp,
-            UnixTimestamp::from_secs(1781092800)
+            UnixTimestamp::from_secs(1779436800)
         );
     }
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -25,6 +25,7 @@ nextest-monitor = { path = "../crates/utils/nextest-monitor" }
 
 [dev-dependencies]
 irys-testing-utils.workspace = true
+rstest.workspace = true
 
 [lints]
 workspace = true

--- a/xtask/src/flaky.rs
+++ b/xtask/src/flaky.rs
@@ -1046,6 +1046,7 @@ fn render_markdown(report: &Report) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     fn counts(runs: usize, fails: usize, timeouts: usize) -> PhaseCounts {
         PhaseCounts {
@@ -1074,64 +1075,56 @@ mod tests {
         }
     }
 
-    #[test]
-    fn classify_broken_when_isolation_always_fails() {
-        let r = report(counts(5, 5, 0), None, Some(counts(10, 10, 0)));
-        assert_eq!(r.classify(), Classification::Broken);
-    }
-
-    #[test]
-    fn classify_genuine_when_isolation_sometimes_fails() {
-        let r = report(counts(5, 3, 0), None, Some(counts(10, 4, 0)));
-        assert_eq!(r.classify(), Classification::GenuineFlaky);
-    }
-
-    #[test]
-    fn classify_timeout_bound_when_all_isolation_failures_are_timeouts() {
-        let r = report(counts(5, 3, 3), None, Some(counts(10, 3, 3)));
-        assert_eq!(r.classify(), Classification::TimeoutBound);
-    }
-
-    #[test]
-    fn classify_peer_contention_when_isolation_clean_but_stress_fails() {
-        let r = report(
-            counts(5, 2, 0),
-            Some(counts(5, 2, 0)),
-            Some(counts(10, 0, 0)),
-        );
-        assert_eq!(r.classify(), Classification::PeerContention);
-    }
-
-    #[test]
-    fn classify_suite_contention_when_only_full_suite_fails() {
-        let r = report(
-            counts(5, 2, 0),
-            Some(counts(5, 0, 0)),
-            Some(counts(10, 0, 0)),
-        );
-        assert_eq!(r.classify(), Classification::SuiteContention);
-    }
-
-    #[test]
-    fn classify_clean_when_isolation_passes_with_no_earlier_failures() {
-        // verify mode: phase1/stress empty, isolation all-pass → CLEAN, not contention.
-        let r = report(counts(0, 0, 0), None, Some(counts(10, 0, 0)));
-        assert_eq!(r.classify(), Classification::Clean);
-        assert!(!Classification::Clean.is_genuine());
-    }
-
-    #[test]
-    fn classify_unverified_when_isolation_skipped_and_stress_clean() {
-        let r = report(counts(5, 2, 0), Some(counts(5, 0, 0)), None);
-        assert_eq!(r.classify(), Classification::Unverified);
-    }
-
-    #[test]
-    fn classify_unverified_when_isolation_skipped_even_if_stress_fails() {
-        // Without an isolation pass we can't prove the test passes alone, so a
-        // stress failure must not be labeled PeerContention — stays Unverified.
-        let r = report(counts(5, 2, 0), Some(counts(5, 2, 0)), None);
-        assert_eq!(r.classify(), Classification::Unverified);
+    #[rstest]
+    #[case::broken(counts(5, 5, 0), None, Some(counts(10, 10, 0)), Classification::Broken)]
+    #[case::genuine(
+        counts(5, 3, 0),
+        None,
+        Some(counts(10, 4, 0)),
+        Classification::GenuineFlaky
+    )]
+    // All isolation failures are timeouts → distinct, actionable category.
+    #[case::timeout_bound(
+        counts(5, 3, 3),
+        None,
+        Some(counts(10, 3, 3)),
+        Classification::TimeoutBound
+    )]
+    #[case::peer_contention(
+        counts(5, 2, 0),
+        Some(counts(5, 2, 0)),
+        Some(counts(10, 0, 0)),
+        Classification::PeerContention
+    )]
+    #[case::suite_contention(
+        counts(5, 2, 0),
+        Some(counts(5, 0, 0)),
+        Some(counts(10, 0, 0)),
+        Classification::SuiteContention
+    )]
+    // verify mode: phase1/stress empty, isolation all-pass → CLEAN, not contention.
+    #[case::clean(counts(0, 0, 0), None, Some(counts(10, 0, 0)), Classification::Clean)]
+    #[case::unverified_stress_clean(
+        counts(5, 2, 0),
+        Some(counts(5, 0, 0)),
+        None,
+        Classification::Unverified
+    )]
+    // Without an isolation pass we can't prove the test passes alone, so a stress
+    // failure must not be labeled PeerContention — stays Unverified.
+    #[case::unverified_stress_fails(
+        counts(5, 2, 0),
+        Some(counts(5, 2, 0)),
+        None,
+        Classification::Unverified
+    )]
+    fn classify_cases(
+        #[case] phase1: PhaseCounts,
+        #[case] stress: Option<PhaseCounts>,
+        #[case] isolation: Option<PhaseCounts>,
+        #[case] expected: Classification,
+    ) {
+        assert_eq!(report(phase1, stress, isolation).classify(), expected);
     }
 
     #[test]
@@ -1141,6 +1134,7 @@ mod tests {
         assert!(Classification::TimeoutBound.is_genuine());
         assert!(!Classification::PeerContention.is_genuine());
         assert!(!Classification::SuiteContention.is_genuine());
+        assert!(!Classification::Clean.is_genuine());
         assert!(!Classification::Unverified.is_genuine());
     }
 

--- a/xtask/src/flaky.rs
+++ b/xtask/src/flaky.rs
@@ -31,7 +31,9 @@ use xshell::{Shell, cmd};
 use crate::failures::{
     FailuresFile, build_failure_filter, generate_nextest_config, get_monitor_dir,
 };
-use crate::util::{RING_ENV_VARS, build_wrapper, remove_ring_env_vars, shell_quote};
+use crate::util::{
+    NEXTEST_VERSION, RING_ENV_VARS, build_wrapper, remove_ring_env_vars, shell_quote,
+};
 
 /// Options for the flaky-detection run, parsed from the CLI.
 #[derive(Debug, Clone)]
@@ -487,7 +489,11 @@ pub fn run_flaky(sh: &Shell, opts: FlakyOptions) -> eyre::Result<()> {
     let targeted = !target_tests.is_empty();
 
     // Ensure nextest is available (matches the version pinned by `xtask test`).
-    let _ = cmd!(sh, "cargo install --locked --version 0.9.124 cargo-nextest").run();
+    let _ = cmd!(
+        sh,
+        "cargo install --locked --version {NEXTEST_VERSION} cargo-nextest"
+    )
+    .run();
 
     if opts.clean {
         println!("Cleaning workspace...");

--- a/xtask/src/flaky.rs
+++ b/xtask/src/flaky.rs
@@ -288,8 +288,13 @@ fn run_isolated(
         "--test-threads",
         "1",
         "--no-fail-fast",
+        // Stream the test's own stdout/stderr (panics, tracing) into our capture
+        // instead of letting nextest buffer it — this is what makes the isolated
+        // failure logs actually useful.
+        "--no-capture",
     ]);
-    cmd.env("RUST_BACKTRACE", "1");
+    // Full backtraces in isolation to maximize debugging signal.
+    cmd.env("RUST_BACKTRACE", "full");
     if let Some(log) = isolation_log {
         cmd.env("RUST_LOG", log);
     }
@@ -493,15 +498,23 @@ pub fn run_flaky(sh: &Shell, opts: FlakyOptions) -> eyre::Result<()> {
             std::io::stdout().flush().ok();
 
             let counts = isolation.entry(test.clone()).or_default();
+            // Per-test summary of each iteration's outcome, written alongside the
+            // logs so a failing test's history is readable at a glance.
+            let mut summary = String::new();
             for i in 1..=opts.isolation_iterations {
-                let log_path = test_dir.join(format!("run-{i}.log"));
-                match run_isolated(test, &log_path, opts.isolation_log.as_deref())? {
+                // Write to a temp name, then rename to encode the outcome so the
+                // failing runs' logs are trivially findable (*.FAIL.log).
+                let tmp_log = test_dir.join(format!("run-{i}.log"));
+                let result = run_isolated(test, &tmp_log, opts.isolation_log.as_deref())?;
+                match result {
                     IsoResult::Passed => {
                         counts.record(Outcome {
                             passed: true,
                             timed_out: false,
                             duration_ms: 0,
                         });
+                        let _ = fs::rename(&tmp_log, test_dir.join(format!("run-{i}.pass.log")));
+                        summary.push_str(&format!("run {i}: PASS\n"));
                         print!(".");
                     }
                     IsoResult::Failed {
@@ -513,10 +526,17 @@ pub fn run_flaky(sh: &Shell, opts: FlakyOptions) -> eyre::Result<()> {
                             timed_out,
                             duration_ms,
                         });
+                        let tag = if timed_out { "TIMEOUT" } else { "FAIL" };
+                        let _ = fs::rename(&tmp_log, test_dir.join(format!("run-{i}.{tag}.log")));
+                        summary.push_str(&format!("run {i}: {tag} ({duration_ms}ms)\n"));
                         print!("{}", if timed_out { "T" } else { "F" });
                     }
                     IsoResult::NoMatch => {
                         // Don't count runs that never executed; note and stop.
+                        let _ = fs::remove_file(&tmp_log);
+                        summary.push_str(&format!(
+                            "run {i}: NO MATCH (filter matched no tests — name may have changed)\n"
+                        ));
                         print!("?");
                         break;
                     }
@@ -524,6 +544,10 @@ pub fn run_flaky(sh: &Shell, opts: FlakyOptions) -> eyre::Result<()> {
                 std::io::stdout().flush().ok();
             }
             let c = &isolation[test];
+            let header = format!("{test}\n{}/{} isolated runs failed\n\n", c.fails, c.runs);
+            if let Err(e) = fs::write(test_dir.join("summary.txt"), header + &summary) {
+                eprintln!("warning: failed to write isolation summary for {test}: {e}");
+            }
             println!(" → {}/{} failed", c.fails, c.runs);
         }
     } else {

--- a/xtask/src/flaky.rs
+++ b/xtask/src/flaky.rs
@@ -273,12 +273,9 @@ impl TestReport {
             return Classification::Clean;
         }
 
-        // No isolation data: fall back to stress, then to timeout heuristic.
-        if let Some(stress) = self.stress
-            && stress.fails > 0
-        {
-            return Classification::PeerContention;
-        }
+        // No isolation data: PeerContention asserts the test passes *alone*, which
+        // only an isolation pass can establish — so a stress failure here can't be
+        // called contention. Leave it Unverified (unless it's purely timeouts).
         if self.phase1.timeouts == self.phase1.fails && self.phase1.fails > 0 {
             return Classification::TimeoutBound;
         }
@@ -493,16 +490,17 @@ pub fn run_flaky(sh: &Shell, opts: FlakyOptions) -> eyre::Result<()> {
     let _ = cmd!(sh, "cargo install --locked --version 0.9.124 cargo-nextest").run();
 
     if opts.clean {
-        println!("Cleaning workspace and prebuilding...");
-        cmd!(sh, "cargo build --workspace --tests").run()?;
+        println!("Cleaning workspace...");
+        cmd!(sh, "cargo clean").run()?;
     }
 
     // Build tests once up front so compile time doesn't pollute iteration 1 and
-    // every iteration measures pure test time.
+    // every iteration measures pure test time. Fail fast: a compile error here
+    // must abort, otherwise every phase fails confusingly downstream.
     println!("Prebuilding tests (cargo nextest run --no-run)...");
-    let _ = remove_ring_env_vars(cmd!(sh, "cargo nextest run --workspace --no-run"))
+    remove_ring_env_vars(cmd!(sh, "cargo nextest run --workspace --no-run"))
         .env("RUST_BACKTRACE", "1")
-        .run();
+        .run()?;
 
     // Build the wrapper and generate the phase-1 config (default profile with
     // the monitoring run-wrapper attached — retries stay at the profile default
@@ -602,6 +600,11 @@ pub fn run_flaky(sh: &Shell, opts: FlakyOptions) -> eyre::Result<()> {
             );
             if s.is_empty() {
                 println!("No flaky tests detected. 🎉");
+                // No genuine flakes → clear stale failures so `--rerun-failures`
+                // doesn't re-run a previous run's entries.
+                if let Err(e) = FailuresFile::clear() {
+                    eprintln!("warning: failed to clear failures.json: {e}");
+                }
                 // Only phase 1 ran on this path.
                 write_reports(&run_dir, &started, &opts, opts.iterations, 0, 0, Vec::new())?;
                 return Ok(());
@@ -734,13 +737,15 @@ pub fn run_flaky(sh: &Shell, opts: FlakyOptions) -> eyre::Result<()> {
                         print!("{}", if timed_out { "T" } else { "F" });
                     }
                     IsoResult::NoMatch => {
-                        // Don't count runs that never executed; note and stop.
+                        // A suspect whose filter matches nothing in isolation is a
+                        // configuration problem (renamed/removed test), not a flake —
+                        // fail hard rather than let it fall through and be silently
+                        // classified as contention/clean on zero recorded runs.
                         let _ = fs::remove_file(&tmp_log);
-                        summary.push_str(&format!(
-                            "run {i}: NO MATCH (filter matched no tests — name may have changed)\n"
-                        ));
-                        print!("?");
-                        break;
+                        println!();
+                        eyre::bail!(
+                            "isolation filter matched no tests for '{test}' — the test name may have changed or been removed"
+                        );
                     }
                 }
                 std::io::stdout().flush().ok();
@@ -791,7 +796,9 @@ pub fn run_flaky(sh: &Shell, opts: FlakyOptions) -> eyre::Result<()> {
     let genuine_count = genuine.len();
 
     // Feed genuine flakes into failures.json so `xtask test --rerun-failures`
-    // can pick them up.
+    // can pick them up. Always rewrite it for the current run — when there are no
+    // genuine flakes, clear it so `--rerun-failures` doesn't re-run stale entries
+    // from a previous run.
     if genuine_count > 0 {
         let mut failures = FailuresFile {
             failed_tests: genuine.iter().map(|r| r.name.clone()).collect(),
@@ -800,6 +807,8 @@ pub fn run_flaky(sh: &Shell, opts: FlakyOptions) -> eyre::Result<()> {
         if let Err(e) = failures.save() {
             eprintln!("warning: failed to update failures.json: {e}");
         }
+    } else if let Err(e) = FailuresFile::clear() {
+        eprintln!("warning: failed to clear failures.json: {e}");
     }
 
     print_summary(&reports);
@@ -1108,6 +1117,14 @@ mod tests {
     #[test]
     fn classify_unverified_when_isolation_skipped_and_stress_clean() {
         let r = report(counts(5, 2, 0), Some(counts(5, 0, 0)), None);
+        assert_eq!(r.classify(), Classification::Unverified);
+    }
+
+    #[test]
+    fn classify_unverified_when_isolation_skipped_even_if_stress_fails() {
+        // Without an isolation pass we can't prove the test passes alone, so a
+        // stress failure must not be labeled PeerContention — stays Unverified.
+        let r = report(counts(5, 2, 0), Some(counts(5, 2, 0)), None);
         assert_eq!(r.classify(), Classification::Unverified);
     }
 

--- a/xtask/src/flaky.rs
+++ b/xtask/src/flaky.rs
@@ -52,6 +52,8 @@ pub struct FlakyOptions {
     pub tolerable_failures: usize,
     /// `RUST_LOG` value to set during the isolation phase (for richer logs).
     pub isolation_log: Option<String>,
+    /// Emit the machine-readable report to stdout (sentinel-wrapped) on completion.
+    pub json: bool,
     /// Passthrough args forwarded to the phase-1 nextest invocation.
     pub args: Vec<String>,
 }
@@ -694,8 +696,24 @@ fn write_reports(
     let md_path = run_dir.join("report.md");
     fs::write(&md_path, render_markdown(&report))?;
 
+    // When requested, emit the report to stdout for downstream tooling (CI).
+    // The phases stream lots of nextest output to stdout, so the payload is
+    // wrapped in unambiguous sentinel lines and printed as a single compact
+    // line. Extract with e.g.:
+    //   sed -n "/$JSON_BEGIN/{n;p;}" <log>
+    if opts.json {
+        println!("{JSON_BEGIN}");
+        println!("{}", serde_json::to_string(&report)?);
+        println!("{JSON_END}");
+    }
+
     Ok((json_path, md_path))
 }
+
+/// Sentinel lines bracketing the machine-readable JSON payload on stdout.
+/// Kept distinctive so tooling can extract the payload amid nextest output.
+pub const JSON_BEGIN: &str = "<<<FLAKY_REPORT_JSON_BEGIN>>>";
+pub const JSON_END: &str = "<<<FLAKY_REPORT_JSON_END>>>";
 
 fn render_markdown(report: &Report) -> String {
     let mut s = String::new();

--- a/xtask/src/flaky.rs
+++ b/xtask/src/flaky.rs
@@ -1,0 +1,844 @@
+//! Nextest-based flaky-test detection.
+//!
+//! Three phases, each narrowing the signal:
+//!
+//! 1. **Full suite** — run the entire test suite `iterations` times under normal
+//!    parallelism. Any test that fails at least once becomes a "suspect". This
+//!    reflects real-world contention (many tests sharing the machine).
+//! 2. **Stress** — run *only* the suspect set together, at high concurrency,
+//!    `stress_iterations` times. This reproduces peer-contention flakiness far
+//!    faster than re-running the whole suite, and sharpens the diagnosis.
+//! 3. **Isolation** — run each suspect *alone* (single-threaded, one test per
+//!    process) `isolation_iterations` times, capturing full logs. A test that
+//!    fails here is genuinely flaky/broken; one that only failed earlier is
+//!    contention-sensitive.
+//!
+//! Pass/fail for phases 1 and 2 is captured via the `nextest-wrapper` run-wrapper
+//! (structured per-test JSON), pointed at a per-invocation output path. Phase 3
+//! derives pass/fail directly from the process exit code, since exactly one test
+//! runs per invocation.
+
+use std::collections::{BTreeMap, HashMap};
+use std::fs;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+use chrono::Local;
+use nextest_monitor::types::AggregatedStats;
+use serde::Serialize;
+use xshell::{Shell, cmd};
+
+use crate::failures::{FailuresFile, generate_nextest_config, get_monitor_dir};
+use crate::util::{RING_ENV_VARS, build_wrapper, remove_ring_env_vars, shell_quote};
+
+/// Options for the flaky-detection run, parsed from the CLI.
+#[derive(Debug, Clone)]
+pub struct FlakyOptions {
+    /// Phase 1: number of full-suite iterations.
+    pub iterations: usize,
+    /// Phase 2: number of stress iterations over the suspect set.
+    pub stress_iterations: usize,
+    /// Phase 3: per-test isolated iterations.
+    pub isolation_iterations: usize,
+    /// `--test-threads` for phases 1 and 2. `None` lets nextest auto-detect.
+    pub threads: Option<usize>,
+    /// Clean the workspace and prebuild before running.
+    pub clean: bool,
+    /// Skip the stress phase.
+    pub no_stress: bool,
+    /// Skip the isolation phase.
+    pub no_isolation: bool,
+    /// Number of genuinely-flaky tests to tolerate before exiting non-zero.
+    pub tolerable_failures: usize,
+    /// `RUST_LOG` value to set during the isolation phase (for richer logs).
+    pub isolation_log: Option<String>,
+    /// Passthrough args forwarded to the phase-1 nextest invocation.
+    pub args: Vec<String>,
+}
+
+/// Outcome of a single test within a single run.
+#[derive(Debug, Clone, Copy)]
+struct Outcome {
+    passed: bool,
+    timed_out: bool,
+    duration_ms: u64,
+}
+
+/// Aggregated pass/fail counters for one test across one phase.
+#[derive(Debug, Clone, Copy, Default, Serialize)]
+struct PhaseCounts {
+    runs: usize,
+    fails: usize,
+    timeouts: usize,
+    min_ms: u64,
+    max_ms: u64,
+    total_ms: u64,
+}
+
+impl PhaseCounts {
+    fn record(&mut self, o: Outcome) {
+        self.runs += 1;
+        if !o.passed {
+            self.fails += 1;
+        }
+        if o.timed_out {
+            self.timeouts += 1;
+        }
+        if self.runs == 1 || o.duration_ms < self.min_ms {
+            self.min_ms = o.duration_ms;
+        }
+        if o.duration_ms > self.max_ms {
+            self.max_ms = o.duration_ms;
+        }
+        self.total_ms += o.duration_ms;
+    }
+
+    fn avg_ms(&self) -> u64 {
+        if self.runs == 0 {
+            0
+        } else {
+            self.total_ms / self.runs as u64
+        }
+    }
+}
+
+/// How a suspect test is ultimately classified.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum Classification {
+    /// Failed in isolation every single time — not flaky, just broken.
+    Broken,
+    /// Failed in isolation sometimes — a genuine flake.
+    GenuineFlaky,
+    /// Passed in isolation but failed when the suspect set ran together.
+    PeerContention,
+    /// Passed in isolation and under stress, but failed under full-suite load.
+    SuiteContention,
+    /// Failed only via timeouts (no assertion failures observed).
+    TimeoutBound,
+    /// Isolation was skipped, so we can't distinguish genuine from contention.
+    Unverified,
+}
+
+impl Classification {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Broken => "BROKEN (fails every isolated run)",
+            Self::GenuineFlaky => "GENUINE FLAKY (fails in isolation)",
+            Self::PeerContention => "CONTENTION (fails only alongside peers)",
+            Self::SuiteContention => "CONTENTION (fails only under full-suite load)",
+            Self::TimeoutBound => "TIMEOUT-BOUND (failures are timeouts)",
+            Self::Unverified => "UNVERIFIED (isolation skipped)",
+        }
+    }
+
+    /// Whether this classification represents a genuine (non-contention) flake
+    /// that should count toward the CI failure gate.
+    fn is_genuine(self) -> bool {
+        matches!(self, Self::Broken | Self::GenuineFlaky | Self::TimeoutBound)
+    }
+}
+
+/// Per-test aggregated report across all phases.
+#[derive(Debug, Clone, Serialize)]
+struct TestReport {
+    name: String,
+    phase1: PhaseCounts,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stress: Option<PhaseCounts>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    isolation: Option<PhaseCounts>,
+    classification: Classification,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    log_dir: Option<String>,
+}
+
+impl TestReport {
+    fn classify(&self) -> Classification {
+        // Isolation is the strongest signal when available.
+        if let Some(iso) = self.isolation {
+            if iso.fails > 0 {
+                // All failures were timeouts → distinct, actionable category.
+                if iso.timeouts == iso.fails {
+                    return Classification::TimeoutBound;
+                }
+                if iso.fails == iso.runs && iso.runs > 0 {
+                    return Classification::Broken;
+                }
+                return Classification::GenuineFlaky;
+            }
+            // Passed every isolated run — so failures earlier were contention.
+            if let Some(stress) = self.stress
+                && stress.fails > 0
+            {
+                return Classification::PeerContention;
+            }
+            return Classification::SuiteContention;
+        }
+
+        // No isolation data: fall back to stress, then to timeout heuristic.
+        if let Some(stress) = self.stress
+            && stress.fails > 0
+        {
+            return Classification::PeerContention;
+        }
+        if self.phase1.timeouts == self.phase1.fails && self.phase1.fails > 0 {
+            return Classification::TimeoutBound;
+        }
+        Classification::Unverified
+    }
+}
+
+/// Full flaky run report, serialized to `report.json`.
+#[derive(Debug, Serialize)]
+struct Report {
+    started_at: String,
+    iterations: usize,
+    stress_iterations: usize,
+    isolation_iterations: usize,
+    total_suspects: usize,
+    genuine_flakes: usize,
+    tests: Vec<TestReport>,
+}
+
+/// Load per-test outcomes from a wrapper stats base path (reads `<base>.d/`).
+fn load_outcomes(base: &Path) -> HashMap<String, Outcome> {
+    let stats = AggregatedStats::load_or_default(base);
+    let mut map = HashMap::new();
+    for t in stats.tests {
+        if let Some(name) = t.test_name {
+            // With retries=0 there should be one entry per test; last wins.
+            map.insert(
+                name,
+                Outcome {
+                    passed: t.passed,
+                    timed_out: t.timed_out.unwrap_or(false),
+                    duration_ms: t.duration_ms,
+                },
+            );
+        }
+    }
+    map
+}
+
+/// Sanitize a test name into a filesystem-safe directory component.
+fn sanitize(name: &str) -> String {
+    name.replace(['/', '\\', ':', ' '], "_")
+}
+
+/// Run a nextest invocation that streams to the terminal *and* tees to a log
+/// file, with the given wrapper output base and env. Test failures are expected
+/// and do not abort — pass/fail is read from the wrapper stats afterwards.
+fn run_teed(
+    sh: &Shell,
+    cargo_args: &[String],
+    stats_base: &Path,
+    log_path: &Path,
+) -> eyre::Result<()> {
+    if let Some(parent) = log_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let quoted: Vec<String> = cargo_args.iter().map(|a| shell_quote(a)).collect();
+    let inner = format!("cargo {}", quoted.join(" "));
+    let quoted_log = shell_quote(&log_path.to_string_lossy());
+    // tee exits 0, so a failing test suite won't surface as an error here — we
+    // intentionally read results from the wrapper stats instead.
+    let full = format!("{inner} 2>&1 | tee {quoted_log}");
+
+    remove_ring_env_vars(cmd!(sh, "bash -c {full}"))
+        .env("RUST_BACKTRACE", "1")
+        .env("NEXTEST_MONITOR_OUTPUT", stats_base)
+        .env("NEXTEST_MONITOR_CPU", "0")
+        .env("NEXTEST_MONITOR_MEMORY", "0")
+        .run()?;
+    Ok(())
+}
+
+/// Result of a single isolated test invocation.
+enum IsoResult {
+    Passed,
+    Failed {
+        timed_out: bool,
+        duration_ms: u64,
+    },
+    /// The filter matched no tests — surfaced as a hard error, not a flake.
+    NoMatch,
+}
+
+/// Run a single test in isolation (single-threaded, one process), capturing all
+/// output to `log_path`. Pass/fail comes from the process exit code.
+fn run_isolated(
+    test_name: &str,
+    log_path: &Path,
+    isolation_log: Option<&str>,
+) -> eyre::Result<IsoResult> {
+    if let Some(parent) = log_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let filter = format!("test(={test_name})");
+    let start = std::time::Instant::now();
+
+    let mut cmd = std::process::Command::new("cargo");
+    cmd.args([
+        "nextest",
+        "run",
+        "-E",
+        &filter,
+        "--test-threads",
+        "1",
+        "--no-fail-fast",
+    ]);
+    cmd.env("RUST_BACKTRACE", "1");
+    if let Some(log) = isolation_log {
+        cmd.env("RUST_LOG", log);
+    }
+    for k in RING_ENV_VARS {
+        cmd.env_remove(k);
+    }
+
+    let output = cmd.output()?;
+    let duration_ms = start.elapsed().as_millis() as u64;
+
+    let mut combined = Vec::new();
+    combined.extend_from_slice(&output.stdout);
+    combined.extend_from_slice(&output.stderr);
+    fs::write(log_path, &combined)?;
+
+    let text = String::from_utf8_lossy(&combined);
+    // nextest exits with code 4 when no tests match the filter; treat that as a
+    // configuration problem rather than a passing/failing test. The string check
+    // is a fallback in case the code changes across nextest versions.
+    if output.status.code() == Some(4)
+        || text.contains("no tests to run")
+        || text.contains("did not match any")
+    {
+        return Ok(IsoResult::NoMatch);
+    }
+
+    if output.status.success() {
+        Ok(IsoResult::Passed)
+    } else {
+        // A SIGTERM-driven timeout shows up in nextest output; best-effort tag.
+        let timed_out = text.contains("SIGTERM") || text.contains("timed out");
+        Ok(IsoResult::Failed {
+            timed_out,
+            duration_ms,
+        })
+    }
+}
+
+/// Entry point for `cargo xtask flaky`.
+pub fn run_flaky(sh: &Shell, opts: FlakyOptions) -> eyre::Result<()> {
+    // Ensure nextest is available (matches the version pinned by `xtask test`).
+    let _ = cmd!(sh, "cargo install --locked --version 0.9.124 cargo-nextest").run();
+
+    if opts.clean {
+        println!("Cleaning workspace and prebuilding...");
+        cmd!(sh, "cargo build --workspace --tests").run()?;
+    }
+
+    // Build tests once up front so compile time doesn't pollute iteration 1 and
+    // every iteration measures pure test time.
+    println!("Prebuilding tests (cargo nextest run --no-run)...");
+    let _ = remove_ring_env_vars(cmd!(sh, "cargo nextest run --workspace --no-run"))
+        .env("RUST_BACKTRACE", "1")
+        .run();
+
+    // Build the wrapper and generate the phase-1 config (default profile with
+    // the monitoring run-wrapper attached — retries stay at the profile default
+    // of 0 so a nextest-level retry never masks a flake).
+    let wrapper_path = build_wrapper(sh, None)?;
+    let wrapper_str = wrapper_path.to_string_lossy().to_string();
+    let phase1_config = generate_nextest_config(&wrapper_str, None, false)?;
+    let phase1_config_path = phase1_config.path().to_string_lossy().to_string();
+
+    // Per-run output directory.
+    let started = Local::now();
+    let run_id = started.format("%Y-%m-%d_%H-%M-%S").to_string();
+    let run_dir = get_monitor_dir().join("flaky").join(&run_id);
+    fs::create_dir_all(&run_dir)?;
+    println!("Flaky run artifacts: {}", run_dir.display());
+
+    let threads_arg: Option<Vec<String>> = opts
+        .threads
+        .map(|t| vec!["--test-threads".to_string(), t.to_string()]);
+
+    // ---- Phase 1: full suite, N times ----
+    println!(
+        "\n=== Phase 1: full suite × {} ({} threads) ===",
+        opts.iterations,
+        opts.threads
+            .map_or_else(|| "auto".to_string(), |t| t.to_string())
+    );
+
+    // test_name -> counts across phase 1
+    let mut phase1: BTreeMap<String, PhaseCounts> = BTreeMap::new();
+
+    for i in 1..=opts.iterations {
+        println!("\n--- Phase 1 iteration {i}/{} ---", opts.iterations);
+        let stats_base = run_dir.join(format!("phase1/iter-{i}/stats"));
+        let log_path = run_dir.join(format!("phase1/iter-{i}/output.log"));
+
+        let mut args = vec![
+            "nextest".to_string(),
+            "run".to_string(),
+            "--workspace".to_string(),
+            "--tests".to_string(),
+            "--all-targets".to_string(),
+            "--no-fail-fast".to_string(),
+            "--config-file".to_string(),
+            phase1_config_path.clone(),
+        ];
+        if let Some(ref t) = threads_arg {
+            args.extend(t.clone());
+        }
+        args.extend(opts.args.iter().cloned());
+
+        run_teed(sh, &args, &stats_base, &log_path)?;
+
+        let outcomes = load_outcomes(&stats_base);
+        for (name, outcome) in outcomes {
+            phase1.entry(name).or_default().record(outcome);
+        }
+    }
+
+    // Suspects: any test that failed at least once in phase 1.
+    let mut suspects: Vec<String> = phase1
+        .iter()
+        .filter(|(_, c)| c.fails > 0)
+        .map(|(name, _)| name.clone())
+        .collect();
+    suspects.sort();
+
+    println!(
+        "\nPhase 1 complete: {} test(s) failed at least once out of {} observed.",
+        suspects.len(),
+        phase1.len()
+    );
+
+    if suspects.is_empty() {
+        println!("No flaky tests detected. 🎉");
+        write_reports(&run_dir, &started, &opts, Vec::new())?;
+        return Ok(());
+    }
+    for s in &suspects {
+        let c = &phase1[s];
+        println!("  {} — {}/{} failed", s, c.fails, c.runs);
+    }
+
+    // ---- Phase 2: stress the suspect set together ----
+    let mut stress: BTreeMap<String, PhaseCounts> = BTreeMap::new();
+    if !opts.no_stress && opts.stress_iterations > 0 {
+        println!(
+            "\n=== Phase 2: stress suspect set × {} ===",
+            opts.stress_iterations
+        );
+        // Config restricting the run to just the suspect set, wrapper attached.
+        let stress_config = generate_nextest_config(&wrapper_str, Some(&suspects), false)?;
+        let stress_config_path = stress_config.path().to_string_lossy().to_string();
+        // High concurrency to maximize peer contention.
+        let stress_threads = opts
+            .threads
+            .or_else(|| {
+                std::thread::available_parallelism()
+                    .ok()
+                    .map(std::num::NonZero::get)
+            })
+            .unwrap_or(8);
+
+        for i in 1..=opts.stress_iterations {
+            println!("\n--- Stress iteration {i}/{} ---", opts.stress_iterations);
+            let stats_base = run_dir.join(format!("phase2-stress/iter-{i}/stats"));
+            let log_path = run_dir.join(format!("phase2-stress/iter-{i}/output.log"));
+            let args = vec![
+                "nextest".to_string(),
+                "run".to_string(),
+                "--workspace".to_string(),
+                "--tests".to_string(),
+                "--all-targets".to_string(),
+                "--no-fail-fast".to_string(),
+                "--config-file".to_string(),
+                stress_config_path.clone(),
+                "--profile".to_string(),
+                "xtask-rerun-failures".to_string(),
+                "--test-threads".to_string(),
+                stress_threads.to_string(),
+            ];
+            run_teed(sh, &args, &stats_base, &log_path)?;
+            let outcomes = load_outcomes(&stats_base);
+            for (name, outcome) in outcomes {
+                stress.entry(name).or_default().record(outcome);
+            }
+        }
+        drop(stress_config);
+    } else {
+        println!("\n=== Phase 2: stress — skipped ===");
+    }
+
+    // ---- Phase 3: isolation ----
+    let mut isolation: BTreeMap<String, PhaseCounts> = BTreeMap::new();
+    let mut log_dirs: HashMap<String, PathBuf> = HashMap::new();
+    if !opts.no_isolation && opts.isolation_iterations > 0 {
+        println!(
+            "\n=== Phase 3: isolation × {} per test ({} suspects) ===",
+            opts.isolation_iterations,
+            suspects.len()
+        );
+        for (idx, test) in suspects.iter().enumerate() {
+            let test_dir = run_dir.join("phase3-isolation").join(sanitize(test));
+            fs::create_dir_all(&test_dir)?;
+            log_dirs.insert(test.clone(), test_dir.clone());
+            print!("[{}/{}] {} ", idx + 1, suspects.len(), test);
+            std::io::stdout().flush().ok();
+
+            let counts = isolation.entry(test.clone()).or_default();
+            for i in 1..=opts.isolation_iterations {
+                let log_path = test_dir.join(format!("run-{i}.log"));
+                match run_isolated(test, &log_path, opts.isolation_log.as_deref())? {
+                    IsoResult::Passed => {
+                        counts.record(Outcome {
+                            passed: true,
+                            timed_out: false,
+                            duration_ms: 0,
+                        });
+                        print!(".");
+                    }
+                    IsoResult::Failed {
+                        timed_out,
+                        duration_ms,
+                    } => {
+                        counts.record(Outcome {
+                            passed: false,
+                            timed_out,
+                            duration_ms,
+                        });
+                        print!("{}", if timed_out { "T" } else { "F" });
+                    }
+                    IsoResult::NoMatch => {
+                        // Don't count runs that never executed; note and stop.
+                        print!("?");
+                        break;
+                    }
+                }
+                std::io::stdout().flush().ok();
+            }
+            let c = &isolation[test];
+            println!(" → {}/{} failed", c.fails, c.runs);
+        }
+    } else {
+        println!("\n=== Phase 3: isolation — skipped ===");
+    }
+
+    // ---- Assemble report ----
+    let mut reports: Vec<TestReport> = Vec::new();
+    for name in &suspects {
+        let mut tr = TestReport {
+            name: name.clone(),
+            phase1: phase1.get(name).copied().unwrap_or_default(),
+            stress: stress.get(name).copied(),
+            isolation: isolation.get(name).copied(),
+            classification: Classification::Unverified,
+            log_dir: log_dirs.get(name).map(|p| p.to_string_lossy().to_string()),
+        };
+        tr.classification = tr.classify();
+        reports.push(tr);
+    }
+
+    // Order: genuine flakes first (most actionable), then by phase-1 fail rate.
+    reports.sort_by(|a, b| {
+        b.classification
+            .is_genuine()
+            .cmp(&a.classification.is_genuine())
+            .then(b.phase1.fails.cmp(&a.phase1.fails))
+            .then(a.name.cmp(&b.name))
+    });
+
+    let genuine: Vec<&TestReport> = reports
+        .iter()
+        .filter(|r| r.classification.is_genuine())
+        .collect();
+    let genuine_count = genuine.len();
+
+    // Feed genuine flakes into failures.json so `xtask test --rerun-failures`
+    // can pick them up.
+    if genuine_count > 0 {
+        let mut failures = FailuresFile {
+            failed_tests: genuine.iter().map(|r| r.name.clone()).collect(),
+        };
+        failures.failed_tests.sort();
+        if let Err(e) = failures.save() {
+            eprintln!("warning: failed to update failures.json: {e}");
+        }
+    }
+
+    print_summary(&reports);
+    drop(phase1_config);
+
+    let report_paths = write_reports(&run_dir, &started, &opts, reports)?;
+    println!("\nReports written:");
+    println!("  {}", report_paths.0.display());
+    println!("  {}", report_paths.1.display());
+
+    // ---- CI gate ----
+    if genuine_count > opts.tolerable_failures {
+        return Err(eyre::eyre!(
+            "{genuine_count} genuinely-flaky test(s) detected (tolerable: {})",
+            opts.tolerable_failures
+        ));
+    }
+    if genuine_count > 0 {
+        println!(
+            "\n{genuine_count} genuine flake(s) within tolerance ({}).",
+            opts.tolerable_failures
+        );
+    }
+
+    Ok(())
+}
+
+fn print_summary(reports: &[TestReport]) {
+    println!("\n=== Flaky Test Summary ===");
+    for r in reports {
+        let p1 = &r.phase1;
+        print!(
+            "\n{}\n  classification: {}\n  phase1: {}/{} failed",
+            r.name,
+            r.classification.label(),
+            p1.fails,
+            p1.runs
+        );
+        if p1.timeouts > 0 {
+            print!(" ({} timeouts)", p1.timeouts);
+        }
+        if let Some(s) = r.stress {
+            print!("\n  stress: {}/{} failed", s.fails, s.runs);
+            if s.timeouts > 0 {
+                print!(" ({} timeouts)", s.timeouts);
+            }
+        }
+        if let Some(iso) = r.isolation {
+            print!(
+                "\n  isolation: {}/{} failed (avg {}ms)",
+                iso.fails,
+                iso.runs,
+                iso.avg_ms()
+            );
+            if iso.timeouts > 0 {
+                print!(" ({} timeouts)", iso.timeouts);
+            }
+        }
+        if let Some(ref d) = r.log_dir {
+            print!("\n  logs: {d}");
+        }
+        println!();
+    }
+}
+
+/// Write `report.json` and `report.md`, returning their paths.
+fn write_reports(
+    run_dir: &Path,
+    started: &chrono::DateTime<Local>,
+    opts: &FlakyOptions,
+    reports: Vec<TestReport>,
+) -> eyre::Result<(PathBuf, PathBuf)> {
+    let genuine_flakes = reports
+        .iter()
+        .filter(|r| r.classification.is_genuine())
+        .count();
+    let report = Report {
+        started_at: started.to_rfc3339(),
+        iterations: opts.iterations,
+        stress_iterations: if opts.no_stress {
+            0
+        } else {
+            opts.stress_iterations
+        },
+        isolation_iterations: if opts.no_isolation {
+            0
+        } else {
+            opts.isolation_iterations
+        },
+        total_suspects: reports.len(),
+        genuine_flakes,
+        tests: reports,
+    };
+
+    let json_path = run_dir.join("report.json");
+    fs::write(&json_path, serde_json::to_string_pretty(&report)?)?;
+
+    let md_path = run_dir.join("report.md");
+    fs::write(&md_path, render_markdown(&report))?;
+
+    Ok((json_path, md_path))
+}
+
+fn render_markdown(report: &Report) -> String {
+    let mut s = String::new();
+    s.push_str("# Flaky Test Detection Report\n\n");
+    s.push_str(&format!("- **Started:** {}\n", report.started_at));
+    s.push_str(&format!(
+        "- **Phases:** full-suite ×{}, stress ×{}, isolation ×{}\n",
+        report.iterations, report.stress_iterations, report.isolation_iterations
+    ));
+    s.push_str(&format!("- **Suspects:** {}\n", report.total_suspects));
+    s.push_str(&format!(
+        "- **Genuine flakes:** {}\n\n",
+        report.genuine_flakes
+    ));
+
+    if report.tests.is_empty() {
+        s.push_str("No flaky tests detected. 🎉\n");
+        return s;
+    }
+
+    s.push_str("| Test | Classification | Phase 1 | Stress | Isolation |\n");
+    s.push_str("|------|----------------|---------|--------|-----------|\n");
+    for t in &report.tests {
+        let cell = |c: &Option<PhaseCounts>| match c {
+            Some(p) => {
+                let to = if p.timeouts > 0 {
+                    format!(" ({}T)", p.timeouts)
+                } else {
+                    String::new()
+                };
+                format!("{}/{}{}", p.fails, p.runs, to)
+            }
+            None => "—".to_string(),
+        };
+        let p1to = if t.phase1.timeouts > 0 {
+            format!(" ({}T)", t.phase1.timeouts)
+        } else {
+            String::new()
+        };
+        s.push_str(&format!(
+            "| `{}` | {} | {}/{}{} | {} | {} |\n",
+            t.name,
+            t.classification.label(),
+            t.phase1.fails,
+            t.phase1.runs,
+            p1to,
+            cell(&t.stress),
+            cell(&t.isolation),
+        ));
+    }
+
+    s.push_str("\n## Logs\n\n");
+    for t in &report.tests {
+        if let Some(ref d) = t.log_dir {
+            s.push_str(&format!("- `{}` → `{}`\n", t.name, d));
+        }
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn counts(runs: usize, fails: usize, timeouts: usize) -> PhaseCounts {
+        PhaseCounts {
+            runs,
+            fails,
+            timeouts,
+            min_ms: 0,
+            max_ms: 0,
+            total_ms: 0,
+        }
+    }
+
+    fn report(
+        phase1: PhaseCounts,
+        stress: Option<PhaseCounts>,
+        isolation: Option<PhaseCounts>,
+    ) -> TestReport {
+        TestReport {
+            name: "t".to_string(),
+            phase1,
+            stress,
+            isolation,
+            classification: Classification::Unverified,
+            log_dir: None,
+        }
+    }
+
+    #[test]
+    fn classify_broken_when_isolation_always_fails() {
+        let r = report(counts(5, 5, 0), None, Some(counts(10, 10, 0)));
+        assert_eq!(r.classify(), Classification::Broken);
+    }
+
+    #[test]
+    fn classify_genuine_when_isolation_sometimes_fails() {
+        let r = report(counts(5, 3, 0), None, Some(counts(10, 4, 0)));
+        assert_eq!(r.classify(), Classification::GenuineFlaky);
+    }
+
+    #[test]
+    fn classify_timeout_bound_when_all_isolation_failures_are_timeouts() {
+        let r = report(counts(5, 3, 3), None, Some(counts(10, 3, 3)));
+        assert_eq!(r.classify(), Classification::TimeoutBound);
+    }
+
+    #[test]
+    fn classify_peer_contention_when_isolation_clean_but_stress_fails() {
+        let r = report(
+            counts(5, 2, 0),
+            Some(counts(5, 2, 0)),
+            Some(counts(10, 0, 0)),
+        );
+        assert_eq!(r.classify(), Classification::PeerContention);
+    }
+
+    #[test]
+    fn classify_suite_contention_when_only_full_suite_fails() {
+        let r = report(
+            counts(5, 2, 0),
+            Some(counts(5, 0, 0)),
+            Some(counts(10, 0, 0)),
+        );
+        assert_eq!(r.classify(), Classification::SuiteContention);
+    }
+
+    #[test]
+    fn classify_unverified_when_isolation_skipped_and_stress_clean() {
+        let r = report(counts(5, 2, 0), Some(counts(5, 0, 0)), None);
+        assert_eq!(r.classify(), Classification::Unverified);
+    }
+
+    #[test]
+    fn genuine_classifications_gate_ci() {
+        assert!(Classification::Broken.is_genuine());
+        assert!(Classification::GenuineFlaky.is_genuine());
+        assert!(Classification::TimeoutBound.is_genuine());
+        assert!(!Classification::PeerContention.is_genuine());
+        assert!(!Classification::SuiteContention.is_genuine());
+        assert!(!Classification::Unverified.is_genuine());
+    }
+
+    #[test]
+    fn phase_counts_track_min_max_avg() {
+        let mut c = PhaseCounts::default();
+        c.record(Outcome {
+            passed: true,
+            timed_out: false,
+            duration_ms: 100,
+        });
+        c.record(Outcome {
+            passed: false,
+            timed_out: false,
+            duration_ms: 300,
+        });
+        assert_eq!(c.runs, 2);
+        assert_eq!(c.fails, 1);
+        assert_eq!(c.min_ms, 100);
+        assert_eq!(c.max_ms, 300);
+        assert_eq!(c.avg_ms(), 200);
+    }
+
+    #[test]
+    fn sanitize_replaces_path_separators() {
+        assert_eq!(sanitize("a::b::c"), "a__b__c");
+        assert_eq!(sanitize("crate/mod::test name"), "crate_mod__test_name");
+    }
+}

--- a/xtask/src/flaky.rs
+++ b/xtask/src/flaky.rs
@@ -28,7 +28,9 @@ use nextest_monitor::types::AggregatedStats;
 use serde::Serialize;
 use xshell::{Shell, cmd};
 
-use crate::failures::{FailuresFile, generate_nextest_config, get_monitor_dir};
+use crate::failures::{
+    FailuresFile, build_failure_filter, generate_nextest_config, get_monitor_dir,
+};
 use crate::util::{RING_ENV_VARS, build_wrapper, remove_ring_env_vars, shell_quote};
 
 /// Options for the flaky-detection run, parsed from the CLI.
@@ -54,6 +56,15 @@ pub struct FlakyOptions {
     pub isolation_log: Option<String>,
     /// Emit the machine-readable report to stdout (sentinel-wrapped) on completion.
     pub json: bool,
+    /// Known flaky tests to target directly, skipping full-suite discovery.
+    /// Phase 1 is scoped to just these (fast) instead of running the whole suite.
+    pub tests: Vec<String>,
+    /// Read the target test list from a prior `report.json` or `failures.json`
+    /// instead of (or in addition to) `--tests`.
+    pub tests_from: Option<PathBuf>,
+    /// Verify mode: run *only* the isolation phase on the given tests (the
+    /// post-fix "is it fixed?" check). Skips discovery and stress.
+    pub verify: Vec<String>,
     /// Passthrough args forwarded to the phase-1 nextest invocation.
     pub args: Vec<String>,
 }
@@ -64,6 +75,78 @@ struct Outcome {
     passed: bool,
     timed_out: bool,
     duration_ms: u64,
+}
+
+/// A distinct failure fingerprint extracted from an isolated run's log, so the
+/// report tells you *why* a test failed without opening the log files.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct FailureSignature {
+    /// The panic/assertion message (or a timeout note).
+    message: String,
+    /// Source location (`file:line:col`) when available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    location: Option<String>,
+}
+
+/// Strip ANSI escape sequences (tracing colors) so extracted messages are clean.
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c == '\u{1b}' {
+            // Skip until the terminating letter of the CSI sequence (e.g. 'm').
+            for n in chars.by_ref() {
+                if n.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// Collapse internal whitespace so signatures dedupe cleanly.
+fn normalize_msg(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Extract a failure signature from an isolated run's captured output.
+///
+/// Recognizes the standard Rust panic form
+/// `thread '..' panicked at <file:line:col>: <message>` (message may spill to the
+/// next line), falling back to an `assertion .. failed` line. Returns `None`
+/// when nothing recognizable is found (e.g. a bare timeout with no panic).
+fn extract_failure_signature(text: &str) -> Option<FailureSignature> {
+    let lines: Vec<String> = text.lines().map(strip_ansi).collect();
+    for (i, line) in lines.iter().enumerate() {
+        if let Some(pos) = line.find("panicked at ") {
+            let rest = line[pos + "panicked at ".len()..].trim();
+            let (location, inline_msg) = match rest.split_once(": ") {
+                Some((loc, msg)) => (loc.trim().to_string(), Some(msg.trim().to_string())),
+                None => (rest.trim_end_matches(':').trim().to_string(), None),
+            };
+            let message = inline_msg
+                .filter(|m| !m.is_empty())
+                .or_else(|| lines.get(i + 1).map(|l| l.trim().to_string()))
+                .unwrap_or_default();
+            return Some(FailureSignature {
+                message: normalize_msg(&message),
+                location: (!location.is_empty()).then_some(location),
+            });
+        }
+    }
+    for line in &lines {
+        let t = line.trim();
+        if (t.starts_with("assertion") && t.contains("failed")) || t.starts_with("Error:") {
+            return Some(FailureSignature {
+                message: normalize_msg(t),
+                location: None,
+            });
+        }
+    }
+    None
 }
 
 /// Aggregated pass/fail counters for one test across one phase.
@@ -118,6 +201,9 @@ enum Classification {
     SuiteContention,
     /// Failed only via timeouts (no assertion failures observed).
     TimeoutBound,
+    /// Passed every run we performed with no earlier failure evidence — e.g. a
+    /// verify run confirming a fix.
+    Clean,
     /// Isolation was skipped, so we can't distinguish genuine from contention.
     Unverified,
 }
@@ -130,6 +216,7 @@ impl Classification {
             Self::PeerContention => "CONTENTION (fails only alongside peers)",
             Self::SuiteContention => "CONTENTION (fails only under full-suite load)",
             Self::TimeoutBound => "TIMEOUT-BOUND (failures are timeouts)",
+            Self::Clean => "CLEAN (passed all runs)",
             Self::Unverified => "UNVERIFIED (isolation skipped)",
         }
     }
@@ -153,6 +240,9 @@ struct TestReport {
     classification: Classification,
     #[serde(skip_serializing_if = "Option::is_none")]
     log_dir: Option<String>,
+    /// Distinct failure fingerprints observed across isolated runs.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    failure_signatures: Vec<FailureSignature>,
 }
 
 impl TestReport {
@@ -169,13 +259,18 @@ impl TestReport {
                 }
                 return Classification::GenuineFlaky;
             }
-            // Passed every isolated run — so failures earlier were contention.
+            // Passed every isolated run — attribute to contention only when there
+            // is actual earlier failure evidence; otherwise it's clean (e.g. a
+            // verify run confirming a fix).
             if let Some(stress) = self.stress
                 && stress.fails > 0
             {
                 return Classification::PeerContention;
             }
-            return Classification::SuiteContention;
+            if self.phase1.fails > 0 {
+                return Classification::SuiteContention;
+            }
+            return Classification::Clean;
         }
 
         // No isolation data: fall back to stress, then to timeout heuristic.
@@ -262,6 +357,8 @@ enum IsoResult {
     Failed {
         timed_out: bool,
         duration_ms: u64,
+        /// Failure fingerprint parsed from the captured output, when available.
+        signature: Option<FailureSignature>,
     },
     /// The filter matched no tests — surfaced as a hard error, not a flake.
     NoMatch,
@@ -331,12 +428,67 @@ fn run_isolated(
         Ok(IsoResult::Failed {
             timed_out,
             duration_ms,
+            signature: extract_failure_signature(&text),
         })
     }
 }
 
+/// Parse a `--tests-from` file (either a flaky `report.json` or a
+/// `failures.json`) into a list of test names.
+fn parse_tests_from(path: &Path) -> eyre::Result<Vec<String>> {
+    let content = fs::read_to_string(path)
+        .map_err(|e| eyre::eyre!("failed to read {}: {e}", path.display()))?;
+    let json: serde_json::Value = serde_json::from_str(&content)
+        .map_err(|e| eyre::eyre!("failed to parse {} as JSON: {e}", path.display()))?;
+
+    // report.json: { "tests": [ { "name": "..." }, ... ] }
+    if let Some(tests) = json.get("tests").and_then(|t| t.as_array()) {
+        return Ok(tests
+            .iter()
+            .filter_map(|t| t.get("name").and_then(|n| n.as_str()).map(str::to_owned))
+            .collect());
+    }
+    // failures.json: { "failed_tests": [ "...", ... ] }
+    if let Some(failed) = json.get("failed_tests").and_then(|f| f.as_array()) {
+        return Ok(failed
+            .iter()
+            .filter_map(|f| f.as_str().map(str::to_owned))
+            .collect());
+    }
+    eyre::bail!(
+        "{} has neither a `tests` nor a `failed_tests` array",
+        path.display()
+    )
+}
+
+/// Resolve the explicit target-test list from `--tests`, `--tests-from`, and
+/// `--verify`, de-duplicated and sorted. Empty means "discover via full suite".
+fn resolve_target_tests(opts: &FlakyOptions) -> eyre::Result<Vec<String>> {
+    let mut set: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for t in opts.tests.iter().chain(opts.verify.iter()) {
+        let t = t.trim();
+        if !t.is_empty() {
+            set.insert(t.to_owned());
+        }
+    }
+    if let Some(ref path) = opts.tests_from {
+        for t in parse_tests_from(path)? {
+            set.insert(t);
+        }
+    }
+    Ok(set.into_iter().collect())
+}
+
 /// Entry point for `cargo xtask flaky`.
 pub fn run_flaky(sh: &Shell, opts: FlakyOptions) -> eyre::Result<()> {
+    // Resolve the run mode up front (errors early on a bad --tests-from file):
+    //   - verify   : isolation-only over the given tests (post-fix check)
+    //   - targeted : known tests supplied → scope discovery to them (fast)
+    //   - discovery: no tests supplied → run the full suite to find suspects
+    let verify_mode = !opts.verify.is_empty();
+    let target_tests = resolve_target_tests(&opts)?;
+    let targeted = !target_tests.is_empty();
+
     // Ensure nextest is available (matches the version pinned by `xtask test`).
     let _ = cmd!(sh, "cargo install --locked --version 0.9.124 cargo-nextest").run();
 
@@ -371,72 +523,101 @@ pub fn run_flaky(sh: &Shell, opts: FlakyOptions) -> eyre::Result<()> {
         .threads
         .map(|t| vec!["--test-threads".to_string(), t.to_string()]);
 
-    // ---- Phase 1: full suite, N times ----
-    println!(
-        "\n=== Phase 1: full suite × {} ({} threads) ===",
-        opts.iterations,
-        opts.threads
-            .map_or_else(|| "auto".to_string(), |t| t.to_string())
-    );
-
     // test_name -> counts across phase 1
     let mut phase1: BTreeMap<String, PhaseCounts> = BTreeMap::new();
+    let suspects: Vec<String>;
 
-    for i in 1..=opts.iterations {
-        println!("\n--- Phase 1 iteration {i}/{} ---", opts.iterations);
-        let stats_base = run_dir.join(format!("phase1/iter-{i}/stats"));
-        let log_path = run_dir.join(format!("phase1/iter-{i}/output.log"));
+    if verify_mode {
+        // ---- Verify mode: isolation only, over the given tests ----
+        println!(
+            "\n=== Verify mode: isolation only ({} test(s)) ===",
+            target_tests.len()
+        );
+        suspects = target_tests;
+    } else {
+        // ---- Phase 1: run the suite N times ----
+        // Targeted runs scope phase 1 to just the supplied tests (fast); discovery
+        // runs the whole suite to find suspects.
+        let scope_filter = targeted.then(|| build_failure_filter(&target_tests));
+        println!(
+            "\n=== Phase 1: {} × {} ({} threads) ===",
+            if targeted {
+                format!("targeted ({} test(s))", target_tests.len())
+            } else {
+                "full suite".to_string()
+            },
+            opts.iterations,
+            opts.threads
+                .map_or_else(|| "auto".to_string(), |t| t.to_string())
+        );
 
-        let mut args = vec![
-            "nextest".to_string(),
-            "run".to_string(),
-            "--workspace".to_string(),
-            "--tests".to_string(),
-            "--all-targets".to_string(),
-            "--no-fail-fast".to_string(),
-            "--config-file".to_string(),
-            phase1_config_path.clone(),
-        ];
-        if let Some(ref t) = threads_arg {
-            args.extend(t.clone());
+        for i in 1..=opts.iterations {
+            println!("\n--- Phase 1 iteration {i}/{} ---", opts.iterations);
+            let stats_base = run_dir.join(format!("phase1/iter-{i}/stats"));
+            let log_path = run_dir.join(format!("phase1/iter-{i}/output.log"));
+
+            let mut args = vec![
+                "nextest".to_string(),
+                "run".to_string(),
+                "--workspace".to_string(),
+                "--tests".to_string(),
+                "--all-targets".to_string(),
+                "--no-fail-fast".to_string(),
+                "--config-file".to_string(),
+                phase1_config_path.clone(),
+            ];
+            if let Some(ref filter) = scope_filter {
+                args.push("-E".to_string());
+                args.push(filter.clone());
+            }
+            if let Some(ref t) = threads_arg {
+                args.extend(t.clone());
+            }
+            args.extend(opts.args.iter().cloned());
+
+            run_teed(sh, &args, &stats_base, &log_path)?;
+
+            let outcomes = load_outcomes(&stats_base);
+            for (name, outcome) in outcomes {
+                phase1.entry(name).or_default().record(outcome);
+            }
         }
-        args.extend(opts.args.iter().cloned());
 
-        run_teed(sh, &args, &stats_base, &log_path)?;
-
-        let outcomes = load_outcomes(&stats_base);
-        for (name, outcome) in outcomes {
-            phase1.entry(name).or_default().record(outcome);
+        if targeted {
+            // Always investigate every supplied test, even if it happened to pass
+            // in phase 1 — that's the point of naming them.
+            suspects = target_tests;
+        } else {
+            // Suspects: any test that failed at least once in phase 1.
+            let mut s: Vec<String> = phase1
+                .iter()
+                .filter(|(_, c)| c.fails > 0)
+                .map(|(name, _)| name.clone())
+                .collect();
+            s.sort();
+            println!(
+                "\nPhase 1 complete: {} test(s) failed at least once out of {} observed.",
+                s.len(),
+                phase1.len()
+            );
+            if s.is_empty() {
+                println!("No flaky tests detected. 🎉");
+                // Only phase 1 ran on this path.
+                write_reports(&run_dir, &started, &opts, opts.iterations, 0, 0, Vec::new())?;
+                return Ok(());
+            }
+            for name in &s {
+                let c = &phase1[name];
+                println!("  {} — {}/{} failed", name, c.fails, c.runs);
+            }
+            suspects = s;
         }
-    }
-
-    // Suspects: any test that failed at least once in phase 1.
-    let mut suspects: Vec<String> = phase1
-        .iter()
-        .filter(|(_, c)| c.fails > 0)
-        .map(|(name, _)| name.clone())
-        .collect();
-    suspects.sort();
-
-    println!(
-        "\nPhase 1 complete: {} test(s) failed at least once out of {} observed.",
-        suspects.len(),
-        phase1.len()
-    );
-
-    if suspects.is_empty() {
-        println!("No flaky tests detected. 🎉");
-        write_reports(&run_dir, &started, &opts, Vec::new())?;
-        return Ok(());
-    }
-    for s in &suspects {
-        let c = &phase1[s];
-        println!("  {} — {}/{} failed", s, c.fails, c.runs);
     }
 
     // ---- Phase 2: stress the suspect set together ----
+    // Skipped in verify mode (isolation-only).
     let mut stress: BTreeMap<String, PhaseCounts> = BTreeMap::new();
-    if !opts.no_stress && opts.stress_iterations > 0 {
+    if !verify_mode && !opts.no_stress && opts.stress_iterations > 0 {
         println!(
             "\n=== Phase 2: stress suspect set × {} ===",
             opts.stress_iterations
@@ -486,6 +667,8 @@ pub fn run_flaky(sh: &Shell, opts: FlakyOptions) -> eyre::Result<()> {
     // ---- Phase 3: isolation ----
     let mut isolation: BTreeMap<String, PhaseCounts> = BTreeMap::new();
     let mut log_dirs: HashMap<String, PathBuf> = HashMap::new();
+    // Distinct failure fingerprints per test, so the report explains the "why".
+    let mut sig_map: HashMap<String, Vec<FailureSignature>> = HashMap::new();
     if !opts.no_isolation && opts.isolation_iterations > 0 {
         println!(
             "\n=== Phase 3: isolation × {} per test ({} suspects) ===",
@@ -503,6 +686,8 @@ pub fn run_flaky(sh: &Shell, opts: FlakyOptions) -> eyre::Result<()> {
             // Per-test summary of each iteration's outcome, written alongside the
             // logs so a failing test's history is readable at a glance.
             let mut summary = String::new();
+            // Distinct failure fingerprints across this test's iterations.
+            let mut sigs: Vec<FailureSignature> = Vec::new();
             for i in 1..=opts.isolation_iterations {
                 // Write to a temp name, then rename to encode the outcome so the
                 // failing runs' logs are trivially findable (*.FAIL.log).
@@ -522,6 +707,7 @@ pub fn run_flaky(sh: &Shell, opts: FlakyOptions) -> eyre::Result<()> {
                     IsoResult::Failed {
                         timed_out,
                         duration_ms,
+                        signature,
                     } => {
                         counts.record(Outcome {
                             passed: false,
@@ -530,7 +716,21 @@ pub fn run_flaky(sh: &Shell, opts: FlakyOptions) -> eyre::Result<()> {
                         });
                         let tag = if timed_out { "TIMEOUT" } else { "FAIL" };
                         let _ = fs::rename(&tmp_log, test_dir.join(format!("run-{i}.{tag}.log")));
-                        summary.push_str(&format!("run {i}: {tag} ({duration_ms}ms)\n"));
+                        summary.push_str(&format!("run {i}: {tag} ({duration_ms}ms)"));
+                        if let Some(sig) = signature {
+                            summary.push_str(&format!(
+                                " — {}{}",
+                                sig.location
+                                    .as_deref()
+                                    .map(|l| format!("{l}: "))
+                                    .unwrap_or_default(),
+                                sig.message
+                            ));
+                            if !sigs.contains(&sig) {
+                                sigs.push(sig);
+                            }
+                        }
+                        summary.push('\n');
                         print!("{}", if timed_out { "T" } else { "F" });
                     }
                     IsoResult::NoMatch => {
@@ -550,6 +750,9 @@ pub fn run_flaky(sh: &Shell, opts: FlakyOptions) -> eyre::Result<()> {
             if let Err(e) = fs::write(test_dir.join("summary.txt"), header + &summary) {
                 eprintln!("warning: failed to write isolation summary for {test}: {e}");
             }
+            if !sigs.is_empty() {
+                sig_map.insert(test.clone(), sigs);
+            }
             println!(" → {}/{} failed", c.fails, c.runs);
         }
     } else {
@@ -566,6 +769,7 @@ pub fn run_flaky(sh: &Shell, opts: FlakyOptions) -> eyre::Result<()> {
             isolation: isolation.get(name).copied(),
             classification: Classification::Unverified,
             log_dir: log_dirs.get(name).map(|p| p.to_string_lossy().to_string()),
+            failure_signatures: sig_map.get(name).cloned().unwrap_or_default(),
         };
         tr.classification = tr.classify();
         reports.push(tr);
@@ -601,7 +805,27 @@ pub fn run_flaky(sh: &Shell, opts: FlakyOptions) -> eyre::Result<()> {
     print_summary(&reports);
     drop(phase1_config);
 
-    let report_paths = write_reports(&run_dir, &started, &opts, reports)?;
+    // Report the counts that actually ran (verify mode skips phases 1 and 2).
+    let eff_iterations = if verify_mode { 0 } else { opts.iterations };
+    let eff_stress = if verify_mode || opts.no_stress {
+        0
+    } else {
+        opts.stress_iterations
+    };
+    let eff_isolation = if opts.no_isolation {
+        0
+    } else {
+        opts.isolation_iterations
+    };
+    let report_paths = write_reports(
+        &run_dir,
+        &started,
+        &opts,
+        eff_iterations,
+        eff_stress,
+        eff_isolation,
+        reports,
+    )?;
     println!("\nReports written:");
     println!("  {}", report_paths.0.display());
     println!("  {}", report_paths.1.display());
@@ -654,6 +878,16 @@ fn print_summary(reports: &[TestReport]) {
                 print!(" ({} timeouts)", iso.timeouts);
             }
         }
+        for sig in &r.failure_signatures {
+            print!(
+                "\n  ↳ {}{}",
+                sig.location
+                    .as_deref()
+                    .map(|l| format!("{l}: "))
+                    .unwrap_or_default(),
+                sig.message
+            );
+        }
         if let Some(ref d) = r.log_dir {
             print!("\n  logs: {d}");
         }
@@ -661,11 +895,15 @@ fn print_summary(reports: &[TestReport]) {
     }
 }
 
-/// Write `report.json` and `report.md`, returning their paths.
+/// Write `report.json` and `report.md`, returning their paths. The iteration
+/// counts reflect what actually ran (e.g. 0 for phases skipped in verify mode).
 fn write_reports(
     run_dir: &Path,
     started: &chrono::DateTime<Local>,
     opts: &FlakyOptions,
+    iterations: usize,
+    stress_iterations: usize,
+    isolation_iterations: usize,
     reports: Vec<TestReport>,
 ) -> eyre::Result<(PathBuf, PathBuf)> {
     let genuine_flakes = reports
@@ -674,17 +912,9 @@ fn write_reports(
         .count();
     let report = Report {
         started_at: started.to_rfc3339(),
-        iterations: opts.iterations,
-        stress_iterations: if opts.no_stress {
-            0
-        } else {
-            opts.stress_iterations
-        },
-        isolation_iterations: if opts.no_isolation {
-            0
-        } else {
-            opts.isolation_iterations
-        },
+        iterations,
+        stress_iterations,
+        isolation_iterations,
         total_suspects: reports.len(),
         genuine_flakes,
         tests: reports,
@@ -765,6 +995,30 @@ fn render_markdown(report: &Report) -> String {
         ));
     }
 
+    // Failure signatures — the "why", so a reader (or agent) can go straight to
+    // the root cause without opening the logs.
+    if report
+        .tests
+        .iter()
+        .any(|t| !t.failure_signatures.is_empty())
+    {
+        s.push_str("\n## Failure signatures\n\n");
+        for t in &report.tests {
+            if t.failure_signatures.is_empty() {
+                continue;
+            }
+            s.push_str(&format!("- `{}`\n", t.name));
+            for sig in &t.failure_signatures {
+                let loc = sig
+                    .location
+                    .as_deref()
+                    .map(|l| format!("`{l}`: "))
+                    .unwrap_or_default();
+                s.push_str(&format!("  - {loc}{}\n", sig.message));
+            }
+        }
+    }
+
     s.push_str("\n## Logs\n\n");
     for t in &report.tests {
         if let Some(ref d) = t.log_dir {
@@ -801,6 +1055,7 @@ mod tests {
             isolation,
             classification: Classification::Unverified,
             log_dir: None,
+            failure_signatures: Vec::new(),
         }
     }
 
@@ -843,6 +1098,14 @@ mod tests {
     }
 
     #[test]
+    fn classify_clean_when_isolation_passes_with_no_earlier_failures() {
+        // verify mode: phase1/stress empty, isolation all-pass → CLEAN, not contention.
+        let r = report(counts(0, 0, 0), None, Some(counts(10, 0, 0)));
+        assert_eq!(r.classify(), Classification::Clean);
+        assert!(!Classification::Clean.is_genuine());
+    }
+
+    #[test]
     fn classify_unverified_when_isolation_skipped_and_stress_clean() {
         let r = report(counts(5, 2, 0), Some(counts(5, 0, 0)), None);
         assert_eq!(r.classify(), Classification::Unverified);
@@ -882,5 +1145,63 @@ mod tests {
     fn sanitize_replaces_path_separators() {
         assert_eq!(sanitize("a::b::c"), "a__b__c");
         assert_eq!(sanitize("crate/mod::test name"), "crate_mod__test_name");
+    }
+
+    #[test]
+    fn strip_ansi_removes_color_codes() {
+        assert_eq!(strip_ansi("\u{1b}[32m INFO\u{1b}[0m hi"), " INFO hi");
+        assert_eq!(strip_ansi("plain"), "plain");
+    }
+
+    #[test]
+    fn extract_signature_multiline_panic() {
+        let log = "test foo ... FAILED\n\
+            thread 'foo' (123) panicked at crates/chain-tests/src/x.rs:304:5:\n\
+            tx2 should be promoted (chunks uploaded)\n\
+            stack backtrace:\n";
+        let sig = extract_failure_signature(log).unwrap();
+        assert_eq!(
+            sig.location.as_deref(),
+            Some("crates/chain-tests/src/x.rs:304:5")
+        );
+        assert_eq!(sig.message, "tx2 should be promoted (chunks uploaded)");
+    }
+
+    #[test]
+    fn extract_signature_inline_panic() {
+        let log = "thread 'main' panicked at src/lib.rs:10:5: boom happened\n";
+        let sig = extract_failure_signature(log).unwrap();
+        assert_eq!(sig.location.as_deref(), Some("src/lib.rs:10:5"));
+        assert_eq!(sig.message, "boom happened");
+    }
+
+    #[test]
+    fn extract_signature_strips_ansi_from_message() {
+        let log = "thread 'x' panicked at src/a.rs:1:1:\n\u{1b}[31massertion failed: left == right\u{1b}[0m\n";
+        let sig = extract_failure_signature(log).unwrap();
+        assert_eq!(sig.message, "assertion failed: left == right");
+    }
+
+    #[test]
+    fn extract_signature_none_when_no_panic() {
+        assert!(extract_failure_signature("everything is fine\nPASS\n").is_none());
+    }
+
+    #[test]
+    fn parse_tests_from_report_and_failures() {
+        let dir = irys_testing_utils::TempDirBuilder::new().build();
+
+        let report = dir.path().join("report.json");
+        std::fs::write(&report, r#"{"tests":[{"name":"a::x"},{"name":"b::y"}]}"#).unwrap();
+        let mut got = parse_tests_from(&report).unwrap();
+        got.sort();
+        assert_eq!(got, vec!["a::x".to_string(), "b::y".to_string()]);
+
+        let failures = dir.path().join("failures.json");
+        std::fs::write(&failures, r#"{"failed_tests":["c::z"]}"#).unwrap();
+        assert_eq!(
+            parse_tests_from(&failures).unwrap(),
+            vec!["c::z".to_string()]
+        );
     }
 }

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -4,3 +4,5 @@
 //! and code checking.
 
 pub mod failures;
+pub mod flaky;
+pub mod util;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -4,14 +4,15 @@ use std::collections::HashSet;
 use std::fs;
 use std::io::Write as _;
 use std::path::PathBuf;
-use xshell::{Cmd, Shell, cmd};
+use xshell::{Shell, cmd};
 
 use xtask::failures::{
     self, FailuresFile, RunResults, generate_nextest_config, get_failures_file_path,
     get_stats_file_path,
 };
+use xtask::flaky::{FlakyOptions, run_flaky};
+use xtask::util::{CmdExt as _, RING_ENV_VARS, build_wrapper};
 
-const CARGO_FLAKE_VERSION: &str = "0.0.5";
 const LLVM_COV_VERSION: &str = "0.6.16";
 const NEXTEST_VERSION: &str = "0.9.124";
 
@@ -155,51 +156,46 @@ enum Commands {
         #[clap(last = true)]
         args: Vec<String>,
     },
+    /// Nextest-based flaky-test detection.
+    ///
+    /// Runs the full suite N times, then stresses the tests that failed, then
+    /// runs each of those in isolation to distinguish genuine flakes from
+    /// contention-sensitive tests. See `xtask::flaky` for the phase details.
     Flaky {
-        #[clap(short, long, help = "Number of iterations to run")]
-        iterations: Option<usize>,
-        #[clap(short, long, help = "Clean workspace before running")]
-        clean: bool,
-        #[clap(short, long, help = "Number of threads to use")]
+        /// Phase 1: number of full-suite iterations
+        #[clap(short, long, default_value_t = 5)]
+        iterations: usize,
+        /// Phase 2: number of stress iterations over the suspect set
+        #[clap(long, default_value_t = 5)]
+        stress_iterations: usize,
+        /// Phase 3: per-test isolated iterations
+        #[clap(short = 'y', long, default_value_t = 10)]
+        isolation_iterations: usize,
+        /// `--test-threads` for phases 1 & 2 (default: nextest auto)
+        #[clap(short, long)]
         threads: Option<usize>,
-        #[clap(short, long, help = "Save output to timestamped file")]
+        /// Clean & prebuild the workspace before running
+        #[clap(short, long, default_value_t = false)]
+        clean: bool,
+        /// Skip the stress phase (phase 2)
+        #[clap(long, default_value_t = false)]
+        no_stress: bool,
+        /// Skip the isolation phase (phase 3)
+        #[clap(long, default_value_t = false)]
+        no_isolation: bool,
+        /// Number of genuinely-flaky tests to tolerate before exiting non-zero
+        #[clap(short = 'f', long, default_value_t = 0)]
+        tolerable_failures: usize,
+        /// `RUST_LOG` value to set during the isolation phase (for richer logs)
+        #[clap(long)]
+        isolation_log: Option<String>,
+        /// Accepted for backwards-compat; reports are always saved
+        #[clap(short, long, default_value_t = false, hide = true)]
         save: bool,
-        #[clap(short = 'f', long, help = "Number of tolerable failures")]
-        tolerable_failures: Option<usize>,
-        #[clap(last = true, help = "Arguments to pass to cargo-flake")]
+        /// Passthrough args forwarded to the phase-1 nextest invocation
+        #[clap(last = true)]
         args: Vec<String>,
     },
-}
-
-/// Build the nextest-wrapper binary, optionally with additional features
-fn build_wrapper(sh: &Shell, features: Option<&str>) -> eyre::Result<PathBuf> {
-    println!("Building nextest-wrapper...");
-    let mut build_args = vec![
-        "build".to_string(),
-        "--package".to_string(),
-        "nextest-monitor".to_string(),
-        "--bin".to_string(),
-        "nextest-wrapper".to_string(),
-    ];
-    if let Some(feat) = features {
-        build_args.push("--features".to_string());
-        build_args.push(feat.to_string());
-    }
-    cmd!(sh, "cargo {build_args...}").remove_and_run()?;
-
-    // Get the target directory
-    let metadata = MetadataCommand::new().exec()?;
-    let target_dir = metadata.target_directory.as_std_path();
-    let wrapper_path = target_dir.join("debug").join("nextest-wrapper");
-
-    if !wrapper_path.exists() {
-        return Err(eyre::eyre!(
-            "Failed to find built wrapper at {}",
-            wrapper_path.display()
-        ));
-    }
-
-    Ok(wrapper_path)
 }
 
 fn run_command(command: Commands, sh: &Shell) -> eyre::Result<()> {
@@ -861,169 +857,32 @@ fn run_command(command: Commands, sh: &Shell) -> eyre::Result<()> {
         }
         Commands::Flaky {
             iterations,
-            clean,
+            stress_iterations,
+            isolation_iterations,
             threads,
-            save,
+            clean,
+            no_stress,
+            no_isolation,
             tolerable_failures,
+            isolation_log,
+            save: _,
             args,
         } => {
-            // Clean workspace if requested
-            if clean {
-                run_command(Commands::CleanWorkspace, sh)?;
-
-                // Prebuild the project after cleaning
-                println!("Prebuilding the project");
-                cmd!(sh, "cargo build --workspace --tests").remove_and_run()?;
-            }
-
-            // Build command arguments
-            let mut command_args = vec!["flake".to_string()];
-
-            // Add iterations (default to 5 if not specified)
-            let iters = iterations.unwrap_or(5);
-            command_args.push("--iterations".to_string());
-            command_args.push(iters.to_string());
-
-            // Add threads if specified
-            if let Some(thread_count) = threads {
-                command_args.push("--threads".to_string());
-                command_args.push(thread_count.to_string());
-            }
-
-            // Add tolerable failures if specified
-            if let Some(failures) = tolerable_failures {
-                command_args.push("--tolerable-failures".to_string());
-                command_args.push(failures.to_string());
-            }
-
-            // Add any additional arguments after --
-            let args_for_header = args.clone();
-            if !args.is_empty() {
-                command_args.push("--".to_string());
-                command_args.extend(args);
-            }
-
-            if save {
-                // Create target directory if it doesn't exist
-                fs::create_dir_all("target")?;
-
-                // Generate timestamp for output file
-                let now = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)?
-                    .as_secs();
-                let timestamp = chrono::DateTime::from_timestamp(now as i64, 0)
-                    .unwrap()
-                    .format("%Y-%m-%d-%H-%M-%S");
-                let output_file = format!("target/flaky-test-output-{timestamp}.txt");
-
-                // Create output file and write header
-                let mut file = fs::File::create(&output_file)?;
-                writeln!(file, "=== Flaky Test Run - {timestamp} ===")?;
-                write!(file, "Command: cargo flake --iterations {iters}")?;
-                if let Some(thread_count) = threads {
-                    write!(file, " --threads {thread_count}")?;
-                }
-                if let Some(failures) = tolerable_failures {
-                    write!(file, " --tolerable-failures {failures}")?;
-                }
-                if !args_for_header.is_empty() {
-                    write!(file, " -- {}", args_for_header.join(" "))?;
-                }
-                writeln!(file)?;
-                writeln!(file)?;
-                file.flush()?;
-                drop(file);
-
-                // Use script to preserve TTY behavior for progress bars
-                println!("Running cargo-flake to detect flaky tests");
-                println!("Streaming output to: {output_file}");
-
-                // Install cargo-flake first
-                cmd!(
-                    sh,
-                    "cargo install --locked --version {CARGO_FLAKE_VERSION} cargo-flake"
-                )
-                .remove_and_run()?;
-
-                // Shell-quote each arg — these strings are interpreted by
-                // `bash -c`, so unquoted args with spaces/metacharacters
-                // would be re-split or executed
-                let quoted_args = command_args
-                    .iter()
-                    .map(|a| shell_quote(a))
-                    .collect::<Vec<_>>()
-                    .join(" ");
-                let quoted_output = shell_quote(&output_file);
-
-                // Use script command to preserve TTY and tee to save output.
-                // `set -o pipefail` so a cargo/script failure isn't masked by
-                // tee's (successful) exit status. Commands go through
-                // remove_ring_env_vars like every other cargo invocation here.
-                // Handle different script syntax between platforms
-                let script_result = if cfg!(target_os = "macos") {
-                    // macOS script syntax
-                    let script_command = format!(
-                        "set -o pipefail; script -q /dev/stdout cargo {quoted_args} | tee -a {quoted_output}"
-                    );
-                    remove_ring_env_vars(cmd!(sh, "bash -c {script_command}"))
-                        .env("RUST_BACKTRACE", "1")
-                        .run()
-                } else if cfg!(target_os = "linux") {
-                    // Linux script syntax (-c takes the whole command as one
-                    // argument, so quote the assembled cargo invocation again)
-                    let inner = shell_quote(&format!("cargo {quoted_args}"));
-                    let script_command = format!(
-                        "set -o pipefail; script -q -e -c {inner} /dev/stdout | tee -a {quoted_output}"
-                    );
-                    remove_ring_env_vars(cmd!(sh, "bash -c {script_command}"))
-                        .env("RUST_BACKTRACE", "1")
-                        .run()
-                } else {
-                    // Fallback for other platforms - try basic tee without script
-                    eprintln!(
-                        "Warning: script command may not be available on this platform, progress bars may not display correctly"
-                    );
-                    let tee_command = format!(
-                        "set -o pipefail; cargo {quoted_args} 2>&1 | tee -a {quoted_output}"
-                    );
-                    remove_ring_env_vars(cmd!(sh, "bash -c {tee_command}"))
-                        .env("RUST_BACKTRACE", "1")
-                        .run()
-                };
-
-                // If the `script` command itself is unavailable, fall back to
-                // basic tee. Only retry in that case — with pipefail a cargo
-                // failure also surfaces here, and rerunning the whole flaky
-                // suite on a genuine test failure would be very expensive.
-                let script_missing = cmd!(sh, "which script").quiet().run().is_err();
-                if script_result.is_err() && script_missing {
-                    eprintln!(
-                        "Warning: script command unavailable, falling back to basic output capture"
-                    );
-                    let tee_command = format!(
-                        "set -o pipefail; cargo {quoted_args} 2>&1 | tee -a {quoted_output}"
-                    );
-                    remove_ring_env_vars(cmd!(sh, "bash -c {tee_command}"))
-                        .env("RUST_BACKTRACE", "1")
-                        .run()?;
-                } else {
-                    script_result?;
-                }
-            } else {
-                // Run command without file output - show output in terminal
-                println!("Running cargo-flake to detect flaky tests");
-
-                // Install cargo-flake if not already installed
-                cmd!(
-                    sh,
-                    "cargo install --locked --version {CARGO_FLAKE_VERSION} cargo-flake"
-                )
-                .remove_and_run()?;
-
-                remove_ring_env_vars(cmd!(sh, "cargo {command_args...}"))
-                    .env("RUST_BACKTRACE", "1")
-                    .run()?;
-            }
+            run_flaky(
+                sh,
+                FlakyOptions {
+                    iterations,
+                    stress_iterations,
+                    isolation_iterations,
+                    threads,
+                    clean,
+                    no_stress,
+                    no_isolation,
+                    tolerable_failures,
+                    isolation_log,
+                    args,
+                },
+            )?;
         }
     };
     Ok(())
@@ -1034,12 +893,6 @@ fn main() -> eyre::Result<()> {
     let sh = Shell::new()?;
     let args = Args::parse();
     run_command(args.command, &sh)
-}
-
-/// Quote a string for safe inclusion in a `bash -c` command line.
-/// Wraps in single quotes; embedded single quotes become `'\''`.
-fn shell_quote(s: &str) -> String {
-    format!("'{}'", s.replace('\'', "'\\''"))
 }
 
 /// Scans per-test `.status` marker files and writes an aggregate `status.txt`.
@@ -1330,51 +1183,6 @@ fn log_coverage_mismatches(sh: &Shell, scope_args: &[String]) -> eyre::Result<()
     }
 
     Ok(())
-}
-
-/// Env vars that Ring's build.rs emits rerun conditions for, many of which are
-/// absent under a regular `cargo check`, causing unnecessary rebuilds when
-/// alternating between `cargo check` and xtask commands.
-// TODO: remove once briansmith/ring#2454 is resolved and released; that issue
-// tracks spurious rebuilds caused by ring's build.rs rerun conditions
-const RING_ENV_VARS: &[&str] = &[
-    "CARGO_MANIFEST_DIR",
-    "CARGO_PKG_NAME",
-    "CARGO_PKG_VERSION_MAJOR",
-    "CARGO_PKG_VERSION_MINOR",
-    "CARGO_PKG_VERSION_PATCH",
-    "CARGO_PKG_VERSION_PRE",
-    "CARGO_MANIFEST_LINKS",
-    "RING_PREGENERATE_ASM",
-    // "OUT_DIR",
-    "CARGO_CFG_TARGET_ARCH",
-    "CARGO_CFG_TARGET_OS",
-    "CARGO_CFG_TARGET_ENV",
-    "CARGO_CFG_TARGET_ENDIAN",
-    // "DEBUG",
-];
-
-fn remove_ring_env_vars(cmd: Cmd<'_>) -> Cmd<'_> {
-    let mut c = cmd;
-    for k in RING_ENV_VARS {
-        c = c.env_remove(k);
-    }
-    c
-}
-
-pub trait CmdExt {
-    fn remove_and_run(self) -> Result<(), xshell::Error>;
-    fn remove_and_read(self) -> Result<String, xshell::Error>;
-}
-
-impl CmdExt for Cmd<'_> {
-    fn remove_and_run(self) -> Result<(), xshell::Error> {
-        remove_ring_env_vars(self).run()
-    }
-
-    fn remove_and_read(self) -> Result<String, xshell::Error> {
-        remove_ring_env_vars(self).read()
-    }
 }
 
 #[cfg(test)]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -11,10 +11,9 @@ use xtask::failures::{
     get_stats_file_path,
 };
 use xtask::flaky::{FlakyOptions, run_flaky};
-use xtask::util::{CmdExt as _, RING_ENV_VARS, build_wrapper};
+use xtask::util::{CmdExt as _, NEXTEST_VERSION, RING_ENV_VARS, build_wrapper};
 
 const LLVM_COV_VERSION: &str = "0.6.16";
-const NEXTEST_VERSION: &str = "0.9.124";
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -189,6 +189,9 @@ enum Commands {
         /// `RUST_LOG` value to set during the isolation phase (for richer logs)
         #[clap(long)]
         isolation_log: Option<String>,
+        /// Emit the machine-readable report to stdout (sentinel-wrapped) for CI/tooling
+        #[clap(long, default_value_t = false)]
+        json: bool,
         /// Accepted for backwards-compat; reports are always saved
         #[clap(short, long, default_value_t = false, hide = true)]
         save: bool,
@@ -865,6 +868,7 @@ fn run_command(command: Commands, sh: &Shell) -> eyre::Result<()> {
             no_isolation,
             tolerable_failures,
             isolation_log,
+            json,
             save: _,
             args,
         } => {
@@ -880,6 +884,7 @@ fn run_command(command: Commands, sh: &Shell) -> eyre::Result<()> {
                     no_isolation,
                     tolerable_failures,
                     isolation_log,
+                    json,
                     args,
                 },
             )?;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -192,6 +192,17 @@ enum Commands {
         /// Emit the machine-readable report to stdout (sentinel-wrapped) for CI/tooling
         #[clap(long, default_value_t = false)]
         json: bool,
+        /// Target known flaky tests directly (comma-separated), skipping
+        /// full-suite discovery. Phase 1 is scoped to just these.
+        #[clap(long, value_delimiter = ',')]
+        tests: Vec<String>,
+        /// Read the target test list from a prior report.json or failures.json
+        #[clap(long)]
+        tests_from: Option<std::path::PathBuf>,
+        /// Verify mode: run only the isolation phase on these tests
+        /// (comma-separated) — the post-fix "is it fixed?" check
+        #[clap(long, value_delimiter = ',')]
+        verify: Vec<String>,
         /// Accepted for backwards-compat; reports are always saved
         #[clap(short, long, default_value_t = false, hide = true)]
         save: bool,
@@ -869,6 +880,9 @@ fn run_command(command: Commands, sh: &Shell) -> eyre::Result<()> {
             tolerable_failures,
             isolation_log,
             json,
+            tests,
+            tests_from,
+            verify,
             save: _,
             args,
         } => {
@@ -885,6 +899,9 @@ fn run_command(command: Commands, sh: &Shell) -> eyre::Result<()> {
                     tolerable_failures,
                     isolation_log,
                     json,
+                    tests,
+                    tests_from,
+                    verify,
                     args,
                 },
             )?;

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -4,6 +4,10 @@ use cargo_metadata::MetadataCommand;
 use std::path::PathBuf;
 use xshell::{Cmd, Shell, cmd};
 
+/// Pinned cargo-nextest version, shared by `xtask test` and `xtask flaky` so the
+/// two install the same binary whenever the version changes.
+pub const NEXTEST_VERSION: &str = "0.9.124";
+
 /// Env vars that Ring's build.rs emits rerun conditions for, many of which are
 /// absent under a regular `cargo check`, causing unnecessary rebuilds when
 /// alternating between `cargo check` and xtask commands.

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -1,0 +1,88 @@
+//! Shared helpers used across xtask commands.
+
+use cargo_metadata::MetadataCommand;
+use std::path::PathBuf;
+use xshell::{Cmd, Shell, cmd};
+
+/// Env vars that Ring's build.rs emits rerun conditions for, many of which are
+/// absent under a regular `cargo check`, causing unnecessary rebuilds when
+/// alternating between `cargo check` and xtask commands.
+// TODO: remove once briansmith/ring#2454 is resolved and released; that issue
+// tracks spurious rebuilds caused by ring's build.rs rerun conditions
+pub const RING_ENV_VARS: &[&str] = &[
+    "CARGO_MANIFEST_DIR",
+    "CARGO_PKG_NAME",
+    "CARGO_PKG_VERSION_MAJOR",
+    "CARGO_PKG_VERSION_MINOR",
+    "CARGO_PKG_VERSION_PATCH",
+    "CARGO_PKG_VERSION_PRE",
+    "CARGO_MANIFEST_LINKS",
+    "RING_PREGENERATE_ASM",
+    // "OUT_DIR",
+    "CARGO_CFG_TARGET_ARCH",
+    "CARGO_CFG_TARGET_OS",
+    "CARGO_CFG_TARGET_ENV",
+    "CARGO_CFG_TARGET_ENDIAN",
+    // "DEBUG",
+];
+
+pub fn remove_ring_env_vars(cmd: Cmd<'_>) -> Cmd<'_> {
+    let mut c = cmd;
+    for k in RING_ENV_VARS {
+        c = c.env_remove(k);
+    }
+    c
+}
+
+pub trait CmdExt {
+    fn remove_and_run(self) -> Result<(), xshell::Error>;
+    fn remove_and_read(self) -> Result<String, xshell::Error>;
+}
+
+impl CmdExt for Cmd<'_> {
+    fn remove_and_run(self) -> Result<(), xshell::Error> {
+        remove_ring_env_vars(self).run()
+    }
+
+    fn remove_and_read(self) -> Result<String, xshell::Error> {
+        remove_ring_env_vars(self).read()
+    }
+}
+
+/// Quote a string for safe inclusion in a `bash -c` command line.
+/// Wraps in single quotes; embedded single quotes become `'\''`.
+pub fn shell_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// Build the nextest-wrapper binary, optionally with additional features.
+/// Returns the path to the built binary.
+pub fn build_wrapper(sh: &Shell, features: Option<&str>) -> eyre::Result<PathBuf> {
+    println!("Building nextest-wrapper...");
+    let mut build_args = vec![
+        "build".to_string(),
+        "--package".to_string(),
+        "nextest-monitor".to_string(),
+        "--bin".to_string(),
+        "nextest-wrapper".to_string(),
+    ];
+    if let Some(feat) = features {
+        build_args.push("--features".to_string());
+        build_args.push(feat.to_string());
+    }
+    cmd!(sh, "cargo {build_args...}").remove_and_run()?;
+
+    // Get the target directory
+    let metadata = MetadataCommand::new().exec()?;
+    let target_dir = metadata.target_directory.as_std_path();
+    let wrapper_path = target_dir.join("debug").join("nextest-wrapper");
+
+    if !wrapper_path.exists() {
+        return Err(eyre::eyre!(
+            "Failed to find built wrapper at {}",
+            wrapper_path.display()
+        ));
+    }
+
+    Ok(wrapper_path)
+}


### PR DESCRIPTION
## Summary

Replaces the old `cargo-flake` wrapper with a nextest-native flaky-test detector (`cargo xtask flaky`) built on the existing nextest-wrapper stats infrastructure. It distinguishes **genuine flakes** (which should gate CI) from **contention-sensitive** tests (which only fail under full-suite parallelism), captures rich per-failure logs, and exposes a machine-readable report so an agent can run a tight "diagnose these flaky tests → fix → verify" loop.

## How it works

Three phases:

1. **Full suite ×N** under normal parallelism → *suspects* (any test that fails at least once). Pass/fail read from per-iteration wrapper stats.
2. **Stress** the suspect set together at high concurrency ×K to cheaply reproduce peer contention.
3. **Isolation** — run each suspect single-threaded, one process, ×Y with `--no-capture` + `RUST_BACKTRACE=full`; pass/fail from the process exit code.

Suspects are classified as **GENUINE FLAKY / BROKEN / TIMEOUT-BOUND** (gate CI) vs **CONTENTION** (peers / full-suite only — warn only). Retries are forced to `0`, tests are built once up front, and no phase fail-fasts so every iteration observes the whole suite.

## Highlights

- **Targeted mode** — `--tests 'a,b'` or `--tests-from <report.json|failures.json>` skip the ~40-min full-suite discovery; phase 1 is scoped to just those tests (still gets the contention signal) before stress + isolation.
- **Verify fast-path** — `--verify 'a,b'` runs isolation only; a test that passes every isolated run is classified CLEAN (exit 0). This is the post-fix "is it fixed?" check.
- **Failure signatures** — each isolated run's captured output is parsed for the panic/assertion message + `file:line`, deduped per test, and surfaced in the report — the "why" without opening logs.
- **Rich per-test logs** — log files named by outcome (`run-N.FAIL.log` / `.TIMEOUT.log` / `.pass.log`) plus a per-test `summary.txt` of each iteration's result.
- **Machine-readable output** — `--json` emits the report as a single compact JSON line on stdout, bracketed by `<<<FLAKY_REPORT_JSON_BEGIN>>>` / `<<<FLAKY_REPORT_JSON_END>>>` sentinels for downstream tooling. Full `report.md` + `report.json` are always saved under `target/nextest-monitor/flaky/<ts>/`, and genuine flakes feed into `failures.json`.

## CI (`flaky.yml`)

- Runs with `--json`; extracts the payload as the authoritative source for `genuine_flakes` / `total_suspects` metrics (falling back to `report.json`), and uploads `run-output.log`.
- The run step keeps `continue-on-error` so reporting/upload still happen, but a final step re-raises the captured exit code — non-zero only when genuine flakes exceed `-f/--tolerable-failures` or on a run error. A red job triggers GitHub's native scheduled-failure email and any Slack GitHub-app subscription — no webhook secret required.

## Other

- `fix: tests using testnet() consensus config`.
- `debugging-flaky-tests` skill updated to route agents through the targeted / `--verify` / `--json` path with the report schema.
- Shared xtask helpers extracted into a new `xtask::util` module.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added phase-based flaky-test detection (full-suite, stress, isolation) with JSON/markdown reports and bundled per-test logs.
  * Updated the CI flaky workflow to support separate stress/isolation iteration controls and improved artifact output.
* **Bug Fixes**
  * Updated testnet consensus Borealis activation timestamp expectations.
* **Documentation**
  * Expanded local flaky-test debugging guidance and clarified `cargo xtask flaky` phase behavior.
* **Tests**
  * Updated coverage for canonicalization and flaky classification/handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->