### PR TITLE
fix(ci): remove empty GitHub-expression from flaky workflow run block

### DIFF
--- a/.github/workflows/flaky.yml
+++ b/.github/workflows/flaky.yml
@@ -86,8 +86,8 @@ jobs:
           # --json emits the report to stdout wrapped in sentinel lines; tee so we
           # can both stream to the CI log and extract the machine-readable payload.
           # Pass the workflow-level env vars via shell expansion (quoted) rather
-          # than ${{ }} interpolation, so untrusted workflow_dispatch inputs can't
-          # inject into the run script.
+          # than GitHub-expression interpolation, so untrusted workflow_dispatch
+          # inputs can't inject into the run script.
           cargo xtask flaky --clean --json \
             -i "$ITERATIONS" \
             --stress-iterations "$STRESS_ITERATIONS" \


### PR DESCRIPTION
## Problem

CI reported the flaky workflow as invalid:

```
Invalid workflow file: .github/workflows/flaky.yml#L1
(Line: 80, Col: 14): An expression was expected - please fix
```

## Root cause

GitHub Actions performs `${{ }}` expression substitution across the **entire** `run:` block string — including shell `#` comments. A comment in the run block contained a literal empty `${{ }}` written as prose. GitHub tried to evaluate the empty expression and failed. The error anchors to the block-scalar start (line 80, col 14 = the `|`), not the comment line itself.

## Fix

Reworded the comment to drop the literal `${{ }}` token while preserving its meaning. No behavior change — the step already uses the safe env-var + quoted shell-expansion pattern.

(The identical token on the "Generate summary report" step is a genuine YAML comment, stripped before evaluation, so it was never a problem and is left untouched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified a workflow comment to better explain how input values are handled safely during manual runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->