### PR TITLE
fix(consensus): validate data ledger total_chunks in prevalidation

### DIFF
--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -253,8 +253,9 @@ pub async fn calculate_expired_ledger_fees(
 /// epoch-lagging `is_cascade_active_for_epoch`) and `cascade_active_for_epoch`
 /// (gates whether the term ledgers settle at all). The ONLY legitimate difference —
 /// each ledger's cumulative `total_chunks` at this block — is supplied by
-/// `new_total_chunks`: the producer computes `parent + chunks_added`, the validator
-/// reads it straight from the header it is validating.
+/// `new_total_chunks`: the producer computes `parent + chunks_added`; the validator
+/// reads the same value from the header after prevalidation has checked it equals
+/// that formula.
 pub async fn calculate_all_expired_ledger_fees(
     parent_epoch_snapshot: &EpochSnapshot,
     parent_block_header: &IrysBlockHeader,

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -2,7 +2,7 @@ use crate::block_tree_service::{BlockTreeServiceMessage, ValidationResult};
 use crate::data_tx_validation::{DataTxStructuralDefect, data_tx_structural_defect};
 use crate::{
     block_ancestry::walk_ancestors_tree_then_db,
-    block_producer::ledger_expiry,
+    block_producer::{calculate_chunks_added, ledger_expiry},
     mempool_guard::MempoolReadGuard,
     services::ServiceSenders,
     shadow_tx_generator::{PublishLedgerWithTxs, ShadowTxGenerator},
@@ -372,6 +372,19 @@ pub enum PreValidationError {
         recomputed: H256,
     },
 
+    /// The ledger's cumulative `total_chunks` does not equal
+    /// `parent.total_chunks + chunks_added(included txs)`. Producers write this field
+    /// from the same formula; without this check a peer can inflate/deflate the frontier
+    /// and still pass signature + `tx_root` validation.
+    #[error(
+        "total_chunks mismatch for ledger {ledger_id}: header {expected}, recomputed {recomputed}"
+    )]
+    TotalChunksMismatch {
+        ledger_id: u32,
+        expected: u64,
+        recomputed: u64,
+    },
+
     /// The PoA tx_path leaf does not equal the folded `(data_root, prefix_hash)` value of
     /// the recall chunk's owning transaction. The tx_path proof validated against the
     /// block's signed `tx_root`, so this means the owning tx's `data_root`/`prefix_hash`
@@ -612,6 +625,7 @@ impl PreValidationError {
             | Self::TooManyCommitmentTxs { .. }
             | Self::TooManyDataTxs { .. }
             | Self::TxRootMismatch { .. }
+            | Self::TotalChunksMismatch { .. }
             | Self::PoaTxRootLeafMismatch { .. }
             | Self::ZeroSizeDataTx { .. }
             | Self::PrefixSizeExceedsDataSize { .. }
@@ -721,6 +735,7 @@ impl PreValidationError {
             Self::InvalidEpochSnapshot { .. } => "invalid_epoch_snapshot",
             Self::TooManyDataTxs { .. } => "too_many_data_txs",
             Self::TxRootMismatch { .. } => "tx_root_mismatch",
+            Self::TotalChunksMismatch { .. } => "total_chunks_mismatch",
             Self::PoaTxRootLeafMismatch { .. } => "poa_tx_root_leaf_mismatch",
             Self::ZeroSizeDataTx { .. } => "zero_size_data_tx",
             Self::PrefixSizeExceedsDataSize { .. } => "prefix_size_exceeds_data_size",
@@ -1498,6 +1513,23 @@ impl ValidationError {
     }
 }
 
+/// Expected cumulative `total_chunks` for a ledger at the candidate block:
+/// parent frontier + chunks contributed by this block's included txs.
+///
+/// Must stay byte-for-byte identical to the producer formula
+/// (`parent.total_chunks.saturating_add(calculate_chunks_added(...))`) so honest
+/// blocks pass and adversarial frontier inflation/deflation is rejected.
+fn expected_ledger_total_chunks(
+    parent: &IrysBlockHeader,
+    ledger: DataLedger,
+    txs: &[DataTransactionHeader],
+    chunk_size: u64,
+) -> u64 {
+    parent
+        .ledger_total_chunks(ledger)
+        .saturating_add(calculate_chunks_added(txs, chunk_size))
+}
+
 /// Full pre-validation steps for a block
 #[tracing::instrument(level = "trace", skip_all, fields(block.hash = %sealed_block.header().block_hash, block.height = sealed_block.header().height))]
 pub async fn prevalidate_block(
@@ -1793,14 +1825,20 @@ pub async fn prevalidate_block(
         });
     }
 
-    // Recompute each ledger's `tx_root` from the folded `(data_root, prefix_hash)` leaves
-    // of the included transactions and compare against the signed header value. This is
-    // what enforces `prefix_hash` (and `data_root`) through consensus: the block signature
-    // seals `tx_root`, so any tampering with a tx's `data_root`/`prefix_hash` relative to
-    // it changes the recomputed root and rejects the block. `ledger_txs` is in `dl.tx_ids`
-    // order (asserted by `validate_transactions` above), matching the order the fold uses.
-    // The empty-ledger case folds to `H256::zero()`, leaving pre-data-tx blocks unaffected.
-    // Uses `compute_tx_root` (root-only) to avoid building per-leaf proofs validation discards.
+    // Recompute each ledger's sealed integrity fields from the included txs and compare
+    // against the signed header:
+    //   * `tx_root` — merkle root of folded `(data_root, prefix_hash)` leaves. Any
+    //     tampering with a tx's `data_root`/`prefix_hash` relative to the signed root is
+    //     rejected here.
+    //   * `total_chunks` — cumulative chunk frontier = parent total + chunks contributed
+    //     by this block's txs (same formula the producer writes). Without this check a
+    //     peer can inflate/deflate capacity/expiry/PoA bounds while keeping a valid
+    //     `tx_root`.
+    // `ledger_txs` is in `dl.tx_ids` order (asserted by `validate_transactions` above),
+    // matching the order the fold uses. Empty ledgers fold to `H256::zero()` /
+    // `parent.total_chunks + 0`. Uses `compute_tx_root` (root-only) to avoid building
+    // per-leaf proofs validation discards.
+    let chunk_size = config.consensus.chunk_size;
     for dl in &block.data_ledgers {
         let ledger = DataLedger::try_from(dl.ledger_id).map_err(|_| {
             PreValidationError::InvalidLedgerId {
@@ -1846,6 +1884,15 @@ pub async fn prevalidate_block(
                 ledger_id: dl.ledger_id,
                 expected: dl.tx_root,
                 recomputed: recomputed_tx_root,
+            });
+        }
+        let recomputed_total_chunks =
+            expected_ledger_total_chunks(previous_block, ledger, ledger_txs, chunk_size);
+        if recomputed_total_chunks != dl.total_chunks {
+            return Err(PreValidationError::TotalChunksMismatch {
+                ledger_id: dl.ledger_id,
+                expected: dl.total_chunks,
+                recomputed: recomputed_total_chunks,
             });
         }
     }
@@ -2311,6 +2358,86 @@ mod prevalidation_error_classification_tests {
         assert!(
             !PreValidationError::VDFCheckpointsInvalid("bad".to_string()).is_internal_failure()
         );
+        let total_chunks_mismatch = PreValidationError::TotalChunksMismatch {
+            ledger_id: DataLedger::Submit as u32,
+            expected: 10,
+            recomputed: 5,
+        };
+        assert!(!total_chunks_mismatch.is_internal_failure());
+        assert_eq!(
+            total_chunks_mismatch.metric_reason(),
+            "total_chunks_mismatch"
+        );
+    }
+
+    /// Pure formula unit tests for the consensus total_chunks check — no full
+    /// prevalidate harness required.
+    mod expected_ledger_total_chunks_tests {
+        use super::*;
+
+        fn parent_with_submit_total(total_chunks: u64) -> IrysBlockHeader {
+            let mut header = IrysBlockHeader::new_mock_header();
+            header.data_ledgers[DataLedger::Submit as usize].total_chunks = total_chunks;
+            header.data_ledgers[DataLedger::Publish as usize].total_chunks = 0;
+            header
+        }
+
+        fn tx_with_data_size(data_size: u64) -> DataTransactionHeader {
+            let mut tx = DataTransactionHeader::default();
+            tx.data_size = data_size;
+            tx
+        }
+
+        #[test]
+        fn empty_ledger_preserves_parent_total() {
+            let parent = parent_with_submit_total(42);
+            let expected = expected_ledger_total_chunks(
+                &parent,
+                DataLedger::Submit,
+                &[],
+                /*chunk_size*/ 32,
+            );
+            assert_eq!(expected, 42);
+        }
+
+        #[test]
+        fn adds_chunks_from_included_txs() {
+            // chunk_size=32: a 64-byte tx → 2 chunks; a 33-byte tx → 2 chunks (ceil).
+            let parent = parent_with_submit_total(10);
+            let txs = vec![tx_with_data_size(64), tx_with_data_size(33)];
+            let expected = expected_ledger_total_chunks(
+                &parent,
+                DataLedger::Submit,
+                &txs,
+                /*chunk_size*/ 32,
+            );
+            assert_eq!(expected, 10 + 2 + 2);
+        }
+
+        #[test]
+        fn missing_parent_ledger_starts_from_zero() {
+            // Pre-Cascade parent has no OneYear entry → ledger_total_chunks = 0.
+            let parent = parent_with_submit_total(99);
+            assert_eq!(parent.ledger_total_chunks(DataLedger::OneYear), 0);
+            let txs = vec![tx_with_data_size(32)];
+            let expected = expected_ledger_total_chunks(
+                &parent,
+                DataLedger::OneYear,
+                &txs,
+                /*chunk_size*/ 32,
+            );
+            assert_eq!(expected, 1);
+        }
+
+        #[test]
+        fn mismatch_is_detectable() {
+            let parent = parent_with_submit_total(5);
+            let txs = vec![tx_with_data_size(32)];
+            let recomputed = expected_ledger_total_chunks(&parent, DataLedger::Submit, &txs, 32);
+            // Honest header would claim 6; inflated claim must not equal recomputed.
+            assert_ne!(recomputed, 100);
+            assert_eq!(recomputed, 6);
+        }
     }
 
     /// Every `ValidationCancelReason` is a local-side outcome and routes
@@ -4628,12 +4755,13 @@ async fn generate_expected_shadow_transactions(
     // derived (parent epoch snapshot, validator-computed block height, local
     // block index, local mempool, local DB); the only candidate-header values
     // that flow in are the block's own timestamp (the Cascade gate) and each
-    // ledger's `total_chunks` (the write-window bound). Both are validated
-    // independently elsewhere, so here they merely SELECT which slots the fee
-    // calc settles — they cannot make the calc itself fail. The function
-    // produces what the validator EXPECTS the peer's shadow txs to look like;
-    // the peer-vs-expected comparison (where a divergence is attributed to the
-    // peer) happens downstream in `generate_expected_shadow_transactions`.
+    // ledger's `total_chunks` (the write-window bound). `total_chunks` is
+    // prevalidated against parent + included txs, so here it merely SELECTs
+    // which slots the fee calc settles — it cannot make the calc itself fail.
+    // The function produces what the validator EXPECTS the peer's shadow txs
+    // to look like; the peer-vs-expected comparison (where a divergence is
+    // attributed to the peer) happens downstream in
+    // `generate_expected_shadow_transactions`.
     //
     // Consequence: every failure path here is a node-side fault.
     //   - MDBX I/O failure (block-header / data-tx reads) → NodeFault.
@@ -4651,10 +4779,10 @@ async fn generate_expected_shadow_transactions(
     // that split; on audit it was speculative and the TODO was removed.)
     let expired_ledger_fees = if is_epoch_block {
         // `block.ledger_total_chunks(..)` is each ledger's cumulative total_chunks
-        // at this block, read straight from the header (the producer computed the
-        // identical value). Lets the fee calc exclude slots written this epoch —
-        // rescued by the last_height touch — so the settled set matches what
-        // actually recycles.
+        // at this block, read from the header after prevalidation confirmed it
+        // equals parent + chunks_added. Lets the fee calc exclude slots written
+        // this epoch — rescued by the last_height touch — so the settled set
+        // matches what actually recycles.
         //
         // Gate for the write-window exclusion: THIS block's own Cascade status —
         // the same value `perform_epoch_tasks` reads to gate the
@@ -4670,10 +4798,8 @@ async fn generate_expected_shadow_transactions(
             .consensus
             .hardforks
             .is_cascade_active_for_epoch(&parent_epoch_snapshot);
-        // Each ledger's cumulative `total_chunks` is read straight from the header
-        // being validated — the producer computed the identical value, so both
-        // settle the same expiring set. Shared with the producer so the
-        // Submit + Cascade-gated term-ledger settlement cannot drift between sides.
+        // Each ledger's cumulative `total_chunks` is read from the prevalidated
+        // header so producer and validator settle the identical expiring set.
         ledger_expiry::calculate_all_expired_ledger_fees(
             &parent_epoch_snapshot,
             &prev_block,


### PR DESCRIPTION
## Summary

- Consensus now recomputes each data ledger’s cumulative `total_chunks` as `parent.total_chunks + chunks_added(included txs)` during prevalidation and rejects `TotalChunksMismatch` when the signed header value diverges.
- Mirrors the existing `tx_root` integrity check so a peer cannot inflate/deflate capacity expansion, expiry write-windows, or PoA bounds while keeping a valid `tx_root`.
- Uses the same producer formula (`saturating_add` + shared `calculate_chunks_added`) and classifies the failure as a consensus rejection for metrics/peer attribution.

## Context

`total_chunks` is produced and signed into each `DataTransactionLedger`, but was never checked against parent + included txs. Downstream logic (epoch capacity, ledger expiry fees, PoA bounds) trusted the header value; the local block index recomputed its own frontier independently, so a dishonest header could still pass validation.

## Test plan

- [x] Unit tests for `expected_ledger_total_chunks` (empty ledger, chunk ceil, missing parent ledger, mismatch detectability)
- [x] `TotalChunksMismatch` classifies as consensus + metric label `total_chunks_mismatch`
- [x] `cargo clippy -p irys-actors --lib --tests -- -D warnings`
- [ ] CI green on full suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stricter block pre-validation to reject ledger headers when the reported chunk total doesn’t match the expected cumulative value.
  * Improved consensus handling with a new mismatch classification and metric label for easier monitoring.

* **Documentation**
  * Clarified guidance around how chunk totals are verified during validation, making the flow easier to understand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->