### PR TITLE
fix: clip orphaned chunk ranges to storage module bounds in deep-reorg recovery

### DIFF
--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -488,8 +488,17 @@ impl BlockMigrationService {
                     // ledger range before converting (as `index_transaction_data`
                     // does), otherwise partially covered modules are skipped and
                     // their orphaned offsets never unassigned.
-                    let Ok(module_range) = module.get_storage_module_ledger_offsets() else {
-                        continue;
+                    let module_range = match module.get_storage_module_ledger_offsets() {
+                        Ok(r) => r,
+                        Err(err) => {
+                            warn!(
+                                module_id = module.id,
+                                ?ledger,
+                                %err,
+                                "skipping storage module with no ledger offsets during rollback"
+                            );
+                            continue;
+                        }
                     };
                     // UFCS: importing `InclusiveInterval` module-wide breaks
                     // inference on `PartitionChunkRange`, which implements the
@@ -499,9 +508,19 @@ impl BlockMigrationService {
                     else {
                         continue;
                     };
+                    // The clipped range is contained by construction, so this
+                    // only fails if the module's assignment changed mid-loop.
                     let partition_range = match module.make_range_partition_relative(overlap) {
                         Ok(r) => r,
-                        Err(_) => continue,
+                        Err(err) => {
+                            warn!(
+                                module_id = module.id,
+                                ?ledger,
+                                %err,
+                                "skipping storage module: clipped range conversion failed during rollback"
+                            );
+                            continue;
+                        }
                     };
 
                     // Clear offset index entries and data_root mappings for orphaned txs

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -500,12 +500,19 @@ impl BlockMigrationService {
                             continue;
                         }
                     };
-                    // UFCS: importing `InclusiveInterval` module-wide breaks
-                    // inference on `PartitionChunkRange`, which implements the
-                    // trait for two point types.
+                    // Fully qualified method call: importing `InclusiveInterval`
+                    // module-wide breaks inference on `PartitionChunkRange`,
+                    // which implements the trait for two point types.
                     let Some(overlap) =
                         nodit::InclusiveInterval::intersection(&module_range, range)
                     else {
+                        warn!(
+                            module_id = module.id,
+                            ?ledger,
+                            ?range,
+                            ?module_range,
+                            "skipping storage module: orphaned range no longer overlaps during rollback"
+                        );
                         continue;
                     };
                     // The clipped range is contained by construction, so this

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -484,7 +484,24 @@ impl BlockMigrationService {
                 let modules = get_overlapped_storage_modules(storage_modules_guard, *ledger, range);
 
                 for module in modules {
-                    let partition_range = match module.make_range_partition_relative(*range) {
+                    // `modules` merely overlap `range`: an orphaned range that
+                    // spans a slot boundary lies partly outside each module, so
+                    // clip it to the module's own ledger range before
+                    // converting (as `index_transaction_data` does), otherwise
+                    // partially covered modules are skipped and their orphaned
+                    // offsets never unassigned.
+                    let Ok(module_range) = module.get_storage_module_ledger_offsets() else {
+                        continue;
+                    };
+                    // UFCS: importing `InclusiveInterval` module-wide breaks
+                    // inference on `PartitionChunkRange`, which implements the
+                    // trait for two point types.
+                    let Some(overlap) =
+                        nodit::InclusiveInterval::intersection(&module_range, range)
+                    else {
+                        continue;
+                    };
+                    let partition_range = match module.make_range_partition_relative(overlap) {
                         Ok(r) => r,
                         Err(_) => continue,
                     };
@@ -770,7 +787,8 @@ mod tests {
     //! reorg-orphan metadata cleanup) and for the migration-time metadata writer
     //! `write_data_ledger_metadata` (`IrysDataTxMetadata` /
     //! `IrysCommitmentTxMetadata`). Canonical metadata is written only at
-    //! migration, never at confirmation.
+    //! migration, never at confirmation. Also covers the
+    //! `recover_from_network_partition` rollback of storage module offsets.
     //!
     //! The function only touches `self.db`; the other service fields
     //! (block_index_guard, cache, chunk_migration_sender, supply_state) are
@@ -780,12 +798,13 @@ mod tests {
         IrysDatabaseArgs as _, cache_data_root, open_or_create_db,
         tables::{CachedDataRoots, IrysTables},
     };
-    use irys_domain::BlockTree;
+    use irys_domain::{BlockTree, StorageModuleInfo};
     use irys_testing_utils::IrysBlockHeaderTestExt as _;
     use irys_types::{
-        BlockTransactions, ConsensusConfig, DataTransactionHeader, DataTransactionHeaderV1,
-        DataTransactionHeaderV1WithMetadata, DataTransactionMetadata, H256, H256List,
-        IrysBlockHeader, U256,
+        BlockIndexItem, BlockTransactions, ConsensusConfig, DataTransactionHeader,
+        DataTransactionHeaderV1, DataTransactionHeaderV1WithMetadata, DataTransactionMetadata,
+        H256, H256List, IrysBlockHeader, LedgerIndexItem, NodeConfig, U256,
+        partition::PartitionAssignment, partition_chunk_offset_ii,
     };
     use reth_db::Database as _;
     use reth_db::mdbx::DatabaseArguments;
@@ -1920,6 +1939,108 @@ mod tests {
         assert!(
             msg.contains("header/body") && msg.contains(&format!("{ledger:?}")),
             "persist_block error must call out the offending ledger; got: {msg}"
+        );
+
+        Ok(())
+    }
+
+    /// Regression test: an orphaned chunk range spanning a storage module
+    /// (slot) boundary only partially overlaps each module, so
+    /// `recover_from_network_partition` must clip the range to each module
+    /// before converting it to partition offsets. The unclipped conversion
+    /// underflowed for the higher module and overshot the lower one.
+    #[test]
+    fn recover_from_network_partition_handles_ranges_spanning_modules() -> eyre::Result<()> {
+        let (db, _db_tmp) = open_db()?;
+        let (mut svc, _svc_tmp) = make_service(db.clone());
+
+        // Two Submit-ledger modules of 5 chunks each: slot 0 covers ledger
+        // offsets [0, 4], slot 1 covers [5, 9].
+        let sm_tmp = irys_testing_utils::utils::TempDirBuilder::new()
+            .prefix("recover_spanning_modules")
+            .build();
+        let node_config = NodeConfig {
+            consensus: irys_types::ConsensusOptions::Custom(ConsensusConfig {
+                chunk_size: 32,
+                num_chunks_in_partition: 5,
+                ..ConsensusConfig::testing()
+            }),
+            base_directory: sm_tmp.path().to_path_buf(),
+            ..NodeConfig::testing()
+        };
+        let config = irys_types::Config::new_with_random_peer_id(node_config);
+        let mut modules = Vec::new();
+        for slot in 0..2_usize {
+            let info = StorageModuleInfo {
+                id: slot,
+                partition_assignment: Some(PartitionAssignment {
+                    ledger_id: Some(DataLedger::Submit as u32),
+                    slot_index: Some(slot),
+                    ..PartitionAssignment::default()
+                }),
+                submodules: vec![(
+                    partition_chunk_offset_ii!(0, 4),
+                    format!("submodule-{slot}").into(),
+                )],
+            };
+            let module = Arc::new(StorageModule::new(&info, &config)?);
+            module.pack_with_zeros();
+            modules.push(module);
+        }
+        svc.set_storage_modules_guard(StorageModulesReadGuard::new(Arc::new(RwLock::new(
+            modules.clone(),
+        ))));
+
+        // Genesis leaves the Submit ledger at 3 chunks; the orphaned block
+        // takes it to 8, so its range [3, 7] crosses the slot boundary at 5.
+        let genesis = make_block_header(0, H256::zero(), 3, vec![]);
+        let orphan = make_block_header(1, genesis.block_hash, 8, vec![]);
+        db.update_eyre(|tx| {
+            irys_database::insert_block_header(tx, &genesis)?;
+            irys_database::insert_block_header(tx, &orphan)
+        })?;
+        let submit_index_item = |header: &IrysBlockHeader, total_chunks| BlockIndexItem {
+            block_hash: header.block_hash,
+            num_ledgers: 1,
+            ledgers: vec![LedgerIndexItem {
+                total_chunks,
+                tx_root: H256::zero(),
+                ledger: DataLedger::Submit,
+            }],
+        };
+        {
+            let index = svc.block_index_guard.read();
+            index.push_item(&submit_index_item(&genesis, 3), 0)?;
+            index.push_item(&submit_index_item(&orphan, 8), 1)?;
+        }
+
+        svc.recover_from_network_partition(0)?;
+
+        // The orphaned block is gone from the index.
+        {
+            let index = svc.block_index_guard.read();
+            assert_eq!(index.num_blocks(), 1);
+            assert_eq!(index.latest_height(), 0);
+        }
+
+        // Each module had exactly its own slice of [3, 7] unassigned: the
+        // genesis chunks [0, 2] stay packed in slot 0, and slot 1's offsets
+        // past the orphaned range (ledger [8, 9]) stay packed.
+        assert_eq!(
+            modules[0].get_intervals(ChunkType::Uninitialized),
+            [partition_chunk_offset_ii!(3, 4)]
+        );
+        assert_eq!(
+            modules[0].get_intervals(ChunkType::Entropy),
+            [partition_chunk_offset_ii!(0, 2)]
+        );
+        assert_eq!(
+            modules[1].get_intervals(ChunkType::Uninitialized),
+            [partition_chunk_offset_ii!(0, 2)]
+        );
+        assert_eq!(
+            modules[1].get_intervals(ChunkType::Entropy),
+            [partition_chunk_offset_ii!(3, 4)]
         );
 
         Ok(())

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -484,12 +484,10 @@ impl BlockMigrationService {
                 let modules = get_overlapped_storage_modules(storage_modules_guard, *ledger, range);
 
                 for module in modules {
-                    // `modules` merely overlap `range`: an orphaned range that
-                    // spans a slot boundary lies partly outside each module, so
-                    // clip it to the module's own ledger range before
-                    // converting (as `index_transaction_data` does), otherwise
-                    // partially covered modules are skipped and their orphaned
-                    // offsets never unassigned.
+                    // `modules` merely overlap `range`: clip to each module's own
+                    // ledger range before converting (as `index_transaction_data`
+                    // does), otherwise partially covered modules are skipped and
+                    // their orphaned offsets never unassigned.
                     let Ok(module_range) = module.get_storage_module_ledger_offsets() else {
                         continue;
                     };
@@ -2016,7 +2014,6 @@ mod tests {
 
         svc.recover_from_network_partition(0)?;
 
-        // The orphaned block is gone from the index.
         {
             let index = svc.block_index_guard.read();
             assert_eq!(index.num_blocks(), 1);

--- a/crates/domain/src/models/storage_module.rs
+++ b/crates/domain/src/models/storage_module.rs
@@ -1690,11 +1690,23 @@ impl StorageModule {
     /// Internal utility function to take a ledger relative range and make it
     /// Partition relative (relative to the partition assigned to the
     /// StorageModule)
+    ///
+    /// Errors if `chunk_range` is not fully contained in this module's ledger
+    /// range: the offset subtraction would otherwise underflow (range starting
+    /// below the module) or yield offsets past the partition end (range ending
+    /// above it). Callers holding a merely overlapping range must intersect it
+    /// with [`Self::get_storage_module_ledger_offsets`] first.
     pub fn make_range_partition_relative(
         &self,
         chunk_range: LedgerChunkRange,
     ) -> eyre::Result<PartitionChunkRange> {
         let storage_module_range = self.get_storage_module_ledger_offsets()?;
+        eyre::ensure!(
+            storage_module_range.contains_interval(&chunk_range),
+            "chunk_range {:?} is not contained in the storage module's ledger range {:?}; intersect it with the module range first",
+            chunk_range,
+            storage_module_range
+        );
         let start = chunk_range.start() - storage_module_range.start();
         let end = chunk_range.end() - storage_module_range.start();
         Ok(PartitionChunkRange(ii(
@@ -2178,6 +2190,63 @@ mod tests {
             let module_intervals = ints.clone().into_iter().collect::<Vec<_>>();
             assert_eq!(file_intervals, module_intervals);
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn make_range_partition_relative_rejects_ranges_outside_the_module() -> eyre::Result<()> {
+        // Slot 1 with 20 chunks per partition: ledger offsets [20, 39].
+        let infos = [StorageModuleInfo {
+            id: 0,
+            partition_assignment: Some(PartitionAssignment {
+                slot_index: Some(1),
+                ..PartitionAssignment::default()
+            }),
+            submodules: vec![(partition_chunk_offset_ii!(0, 19), "hdd0-test".into())],
+        }];
+
+        let tmp_dir = TempDirBuilder::new()
+            .prefix("range_partition_relative_test")
+            .build();
+        let node_config = NodeConfig {
+            consensus: irys_types::ConsensusOptions::Custom(ConsensusConfig {
+                chunk_size: 32,
+                num_chunks_in_partition: 20,
+                ..ConsensusConfig::testing()
+            }),
+            base_directory: tmp_dir.path().to_path_buf(),
+            ..NodeConfig::testing()
+        };
+        let config = Config::new_with_random_peer_id(node_config);
+        let storage_module = StorageModule::new(&infos[0], &config)?;
+
+        // Fully contained ranges convert to partition-relative offsets.
+        let full = storage_module
+            .make_range_partition_relative(LedgerChunkRange(ledger_chunk_offset_ii!(20, 39)))?;
+        assert_eq!(full, PartitionChunkRange(partition_chunk_offset_ii!(0, 19)));
+        let inner = storage_module
+            .make_range_partition_relative(LedgerChunkRange(ledger_chunk_offset_ii!(25, 30)))?;
+        assert_eq!(
+            inner,
+            PartitionChunkRange(partition_chunk_offset_ii!(5, 10))
+        );
+
+        // A range starting below the module used to underflow the offset
+        // subtraction and panic; it must error instead.
+        assert!(
+            storage_module
+                .make_range_partition_relative(LedgerChunkRange(ledger_chunk_offset_ii!(10, 25)))
+                .is_err()
+        );
+
+        // A range ending above the module used to silently produce offsets
+        // past the partition end; it must error instead.
+        assert!(
+            storage_module
+                .make_range_partition_relative(LedgerChunkRange(ledger_chunk_offset_ii!(25, 45)))
+                .is_err()
+        );
 
         Ok(())
     }

--- a/crates/domain/src/models/storage_module.rs
+++ b/crates/domain/src/models/storage_module.rs
@@ -2221,7 +2221,6 @@ mod tests {
         let config = Config::new_with_random_peer_id(node_config);
         let storage_module = StorageModule::new(&infos[0], &config)?;
 
-        // Fully contained ranges convert to partition-relative offsets.
         let full = storage_module
             .make_range_partition_relative(LedgerChunkRange(ledger_chunk_offset_ii!(20, 39)))?;
         assert_eq!(full, PartitionChunkRange(partition_chunk_offset_ii!(0, 19)));


### PR DESCRIPTION
**Describe the changes**
**Before**: Recovery passed un-intersected orphaned ranges to partition-relative conversion → underflow panic (release
  overflow-checks) on higher modules, overshoot abort on lower ones, for any range spanning a slot boundary.
**After**: Per-module intersection before conversion + containment guard in make_range_partition_relative —
  boundary-spanning rollbacks unassign exactly each module's slice.

**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network partition recovery when orphaned ledger ranges span multiple storage modules, ensuring rollback only applies within the correct overlapped portions.
  * Added stricter validation when converting ledger ranges to partition-relative offsets, rejecting ranges that fall outside a storage module’s ledger bounds.
* **Tests**
  * Expanded regression and unit test coverage for spanning-module recovery and for rejecting out-of-range ledger chunk conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->