### PR TITLE
fix(consensus): only fully-written ledger slots may expire post-Cascade

### DIFF
--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -1831,8 +1831,55 @@ struct BlockRange {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use irys_domain::StakeEntry;
-    use irys_types::{CommitmentStatus, DataTransactionHeaderV1};
+    use irys_domain::{CommitmentState, PartitionAssignments, StakeEntry};
+    use irys_types::{
+        CommitmentStatus, DataTransactionHeaderV1, H256List, NodeConfig, UnixTimestamp,
+        hardfork_config::Cascade,
+    };
+
+    /// Shared fixture: an otherwise-empty `EpochSnapshot` seeded from `config`.
+    fn empty_epoch_snapshot(config: &Config) -> EpochSnapshot {
+        EpochSnapshot {
+            ledgers: irys_database::Ledgers::new(&config.consensus, false),
+            partition_assignments: PartitionAssignments::new(),
+            all_active_partitions: Vec::new(),
+            unassigned_partitions: Vec::new(),
+            storage_submodules_config: None,
+            config: config.clone(),
+            commitment_state: CommitmentState::default(),
+            epoch_block: IrysBlockHeader::default(),
+            previous_epoch_block: None,
+            expired_partition_infos: None,
+            epoch_height: 0,
+        }
+    }
+
+    /// Shared fixture: a mock epoch-boundary header carrying only a Submit
+    /// `total_chunks` update (no txs of its own).
+    fn submit_epoch_header(height: u64, total_chunks: u64) -> IrysBlockHeader {
+        let mut h = IrysBlockHeader::new_mock_header();
+        h.height = height;
+        h.timestamp = irys_types::UnixTimestampMs::from_millis((height as u128) * 1000);
+        h.data_ledgers[DataLedger::Submit].total_chunks = total_chunks;
+        h.data_ledgers[DataLedger::Submit].tx_ids = H256List::new();
+        h
+    }
+
+    /// Shared fixture: a `Config` with Cascade active from genesis and small
+    /// chunk/partition sizes so tests can drive slot boundaries with tiny data sizes.
+    fn config_with_cascade() -> Config {
+        let mut node_config = NodeConfig::testing();
+        let consensus = node_config.consensus.get_mut();
+        consensus.chunk_size = 1;
+        consensus.num_chunks_in_partition = 10;
+        consensus.hardforks.cascade = Some(Cascade {
+            activation_timestamp: UnixTimestamp::from_secs(0),
+            one_year_epoch_length: 365,
+            thirty_day_epoch_length: 30,
+            annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
+        });
+        Config::new_with_random_peer_id(node_config)
+    }
 
     #[test]
     fn test_aggregate_miner_fees_handles_duplicates() {
@@ -3449,40 +3496,14 @@ mod tests {
             IrysDatabaseArgs as _, insert_block_header, insert_tx_header, open_or_create_db,
             set_data_tx_included_height, tables::IrysTables,
         };
-        use irys_domain::{
-            BlockIndex, BlockTree, BlockTreeReadGuard, CommitmentState, PartitionAssignments,
-        };
+        use irys_domain::{BlockIndex, BlockTree, BlockTreeReadGuard};
         use irys_testing_utils::{IrysBlockHeaderTestExt as _, utils::TempDirBuilder};
         use irys_types::{
-            Config, ConsensusConfig, DataTransactionHeaderV1, DataTransactionHeaderV1WithMetadata,
-            DataTransactionMetadata, H256List, LedgerIndexItem, NodeConfig, UnixTimestamp,
-            app_state::DatabaseProvider, hardfork_config::Cascade,
+            ConsensusConfig, DataTransactionHeaderV1, DataTransactionHeaderV1WithMetadata,
+            DataTransactionMetadata, H256List, LedgerIndexItem, app_state::DatabaseProvider,
         };
         use reth_db::{mdbx::DatabaseArguments, transaction::DbTxMut as _};
         use std::sync::{Arc, RwLock};
-
-        fn config_with_cascade() -> Config {
-            let mut node_config = NodeConfig::testing();
-            let consensus = node_config.consensus.get_mut();
-            consensus.chunk_size = 1;
-            consensus.num_chunks_in_partition = 10;
-            consensus.hardforks.cascade = Some(Cascade {
-                activation_timestamp: UnixTimestamp::from_secs(0),
-                one_year_epoch_length: 365,
-                thirty_day_epoch_length: 30,
-                annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
-            });
-            Config::new_with_random_peer_id(node_config)
-        }
-
-        fn submit_epoch_header(height: u64, total_chunks: u64) -> IrysBlockHeader {
-            let mut h = IrysBlockHeader::new_mock_header();
-            h.height = height;
-            h.timestamp = irys_types::UnixTimestampMs::from_millis((height as u128) * 1000);
-            h.data_ledgers[DataLedger::Submit].total_chunks = total_chunks;
-            h.data_ledgers[DataLedger::Submit].tx_ids = H256List::new();
-            h
-        }
 
         fn submit_chain_header(
             height: u64,
@@ -3514,19 +3535,7 @@ mod tests {
         //   h=3N..6N : no new data, so the touched/stale heights persist
         // At h=6N+1, slot 0 has expired, slot 1 is still live, and untouched
         // preallocated slots 2/3 must remain unexpired.
-        let mut epoch = EpochSnapshot {
-            ledgers: irys_database::Ledgers::new(&config.consensus, false),
-            partition_assignments: PartitionAssignments::new(),
-            all_active_partitions: Vec::new(),
-            unassigned_partitions: Vec::new(),
-            storage_submodules_config: None,
-            config: config.clone(),
-            commitment_state: CommitmentState::default(),
-            epoch_block: IrysBlockHeader::default(),
-            previous_epoch_block: None,
-            expired_partition_infos: None,
-            epoch_height: 0,
-        };
+        let mut epoch = empty_epoch_snapshot(&config);
         let mut epoch0 = submit_epoch_header(0, 0);
         epoch0.test_sign();
         epoch.perform_epoch_tasks(&None, &epoch0, vec![])?;
@@ -3758,27 +3767,12 @@ mod tests {
     /// would cause the filter to over-approximate real expired txs (NC-0042).
     #[test]
     fn expired_submit_range_bails_on_non_prefix_expired_set() {
-        use irys_domain::{CommitmentState, PartitionAssignments};
-        use irys_types::{Config, NodeConfig};
-
         // Default config: num_blocks_in_epoch=100, submit_ledger_epoch_length=5,
         // num_chunks_in_partition=10. min_blocks = 5 * 100 = 500.
         let node_config = NodeConfig::testing();
         let config = Config::new_with_random_peer_id(node_config);
 
-        let mut epoch = EpochSnapshot {
-            ledgers: irys_database::Ledgers::new(&config.consensus, false),
-            partition_assignments: PartitionAssignments::new(),
-            all_active_partitions: Vec::new(),
-            unassigned_partitions: Vec::new(),
-            storage_submodules_config: None,
-            config: config.clone(),
-            commitment_state: CommitmentState::default(),
-            epoch_block: IrysBlockHeader::default(),
-            previous_epoch_block: None,
-            expired_partition_infos: None,
-            epoch_height: 0,
-        };
+        let mut epoch = empty_epoch_snapshot(&config);
 
         // Allocate 4 Submit slots at height 1 (last_height=1 for all).
         // Slot 3 is the never-expiring last slot.
@@ -3849,50 +3843,15 @@ mod tests {
     /// the only thing keeping the frontier slot alive.
     #[test]
     fn submit_expiry_never_covers_the_partially_written_frontier_slot() -> eyre::Result<()> {
-        use irys_domain::{CommitmentState, PartitionAssignments};
         use irys_testing_utils::IrysBlockHeaderTestExt as _;
-        use irys_types::{Config, H256List, NodeConfig, UnixTimestamp, hardfork_config::Cascade};
 
-        let mut node_config = NodeConfig::testing();
-        {
-            let consensus = node_config.consensus.get_mut();
-            consensus.chunk_size = 1;
-            consensus.num_chunks_in_partition = 10;
-            consensus.hardforks.cascade = Some(Cascade {
-                activation_timestamp: UnixTimestamp::from_secs(0),
-                one_year_epoch_length: 365,
-                thirty_day_epoch_length: 30,
-                annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
-            });
-        }
-        let config = Config::new_with_random_peer_id(node_config);
-
-        fn submit_epoch_header(height: u64, total_chunks: u64) -> IrysBlockHeader {
-            let mut h = IrysBlockHeader::new_mock_header();
-            h.height = height;
-            h.timestamp = irys_types::UnixTimestampMs::from_millis((height as u128) * 1000);
-            h.data_ledgers[DataLedger::Submit].total_chunks = total_chunks;
-            h.data_ledgers[DataLedger::Submit].tx_ids = H256List::new();
-            h
-        }
+        let config = config_with_cascade();
 
         let num_blocks_in_epoch = config.consensus.epoch.num_blocks_in_epoch;
         let blocks_per_cycle =
             config.consensus.epoch.submit_ledger_epoch_length * num_blocks_in_epoch;
 
-        let mut epoch = EpochSnapshot {
-            ledgers: irys_database::Ledgers::new(&config.consensus, false),
-            partition_assignments: PartitionAssignments::new(),
-            all_active_partitions: Vec::new(),
-            unassigned_partitions: Vec::new(),
-            storage_submodules_config: None,
-            config: config.clone(),
-            commitment_state: CommitmentState::default(),
-            epoch_block: IrysBlockHeader::default(),
-            previous_epoch_block: None,
-            expired_partition_infos: None,
-            epoch_height: 0,
-        };
+        let mut epoch = empty_epoch_snapshot(&config);
 
         // h=0: genesis. h=N: data [0, 18) lands — slot 0 full, slot 1 holds the
         // write frontier (8/10), headroom slots preallocated above. Then ingress

--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -461,6 +461,7 @@ pub async fn expired_submit_tx_ids(
         DataLedger::Submit,
         block_height,
         cascade_active,
+        parent_block_header.ledger_total_chunks(DataLedger::Submit),
     );
     if slot_indexes.is_empty() {
         return Ok(std::collections::BTreeSet::new());
@@ -582,21 +583,24 @@ pub fn expired_submit_range(
     config: &Config,
     cascade_active: bool,
 ) -> eyre::Result<Option<ExpiredSubmitRange>> {
+    let parent_total = parent_block_header.ledger_total_chunks(DataLedger::Submit);
     let slot_indexes = parent_epoch_snapshot.get_all_expired_term_slot_indexes(
         DataLedger::Submit,
         block_height,
         cascade_active,
+        parent_total,
     );
     let Some(&max_expired_slot) = slot_indexes.iter().max() else {
         return Ok(None);
     };
 
-    // Expired Submit slots must be a prefix of the written data. Unwritten
-    // preallocated slots never expire, and Submit data is append-only, so once a
-    // higher slot has written data, later writes cannot return to keep a lower
-    // slot live while that higher written slot expires. If this guard ever fires,
-    // the promotion filter would over-approximate real expired txs and must fail
-    // loud rather than silently diverge.
+    // Expired Submit slots must be a prefix of the written data. Post-Cascade
+    // only fully-written slots expire (the write frontier's slot stays live),
+    // unwritten preallocated slots never expire, and Submit data is append-only,
+    // so once a higher slot has written data, later writes cannot return to keep
+    // a lower slot live while that higher written slot expires. If this guard
+    // ever fires, the promotion filter would over-approximate real expired txs
+    // and must fail loud rather than silently diverge.
     if let Some((i, &slot)) = slot_indexes
         .iter()
         .enumerate()
@@ -624,7 +628,6 @@ pub fn expired_submit_range(
     if p == 0 {
         eyre::bail!("num_chunks_in_partition must be non-zero for Submit-expiry range math");
     }
-    let parent_total = parent_block_header.ledger_total_chunks(DataLedger::Submit);
     // `max_expired_slot` is a slot index (usize); the checked conversion documents
     // the invariant and `saturating_add` keeps the lone `+1` from wrapping.
     let max_expired_slot = u64::try_from(max_expired_slot)
@@ -3544,7 +3547,7 @@ mod tests {
         }
 
         assert_eq!(
-            epoch.get_all_expired_term_slot_indexes(DataLedger::Submit, probe_height, true),
+            epoch.get_all_expired_term_slot_indexes(DataLedger::Submit, probe_height, true, 19),
             vec![0],
             "canonical epoch processing must skip unwritten preallocated Submit slots"
         );
@@ -3811,7 +3814,12 @@ mod tests {
 
         // Sanity: fixture produces the non-prefix set before asserting the guard.
         assert_eq!(
-            epoch.get_all_expired_term_slot_indexes(DataLedger::Submit, block_height, true),
+            epoch.get_all_expired_term_slot_indexes(
+                DataLedger::Submit,
+                block_height,
+                true,
+                3 * chunks_per_slot
+            ),
             vec![0, 2],
             "fixture must produce the non-prefix expired set {{0, 2}}"
         );
@@ -3826,5 +3834,128 @@ mod tests {
             err.to_string().contains("not a contiguous prefix"),
             "expected the NC-0042 contiguity guard message, got: {err}"
         );
+    }
+
+    /// The slot holding the write frontier must survive an idle Submit term.
+    /// Chunk offsets are strictly cumulative, so if the partially-written
+    /// frontier slot expired, every tx appended into its unwritten remainder
+    /// afterwards would be charged yet permanently non-promotable (its start
+    /// offset sits inside `[0, range_end)` forever) and never refunded (the
+    /// refund pipeline settles each slot exactly once, at expiry). Post-Cascade
+    /// only fully-written slots may expire, so the expired range can never
+    /// reach the frontier. Unlike `submit_expiry_skips_canonical_unwritten_slots`
+    /// (where the frontier slot is rescued by a later write refreshing its
+    /// clock), here ingress stalls for a full term and the fully-written rule is
+    /// the only thing keeping the frontier slot alive.
+    #[test]
+    fn submit_expiry_never_covers_the_partially_written_frontier_slot() -> eyre::Result<()> {
+        use irys_domain::{CommitmentState, PartitionAssignments};
+        use irys_testing_utils::IrysBlockHeaderTestExt as _;
+        use irys_types::{Config, H256List, NodeConfig, UnixTimestamp, hardfork_config::Cascade};
+
+        let mut node_config = NodeConfig::testing();
+        {
+            let consensus = node_config.consensus.get_mut();
+            consensus.chunk_size = 1;
+            consensus.num_chunks_in_partition = 10;
+            consensus.hardforks.cascade = Some(Cascade {
+                activation_timestamp: UnixTimestamp::from_secs(0),
+                one_year_epoch_length: 365,
+                thirty_day_epoch_length: 30,
+                annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
+            });
+        }
+        let config = Config::new_with_random_peer_id(node_config);
+
+        fn submit_epoch_header(height: u64, total_chunks: u64) -> IrysBlockHeader {
+            let mut h = IrysBlockHeader::new_mock_header();
+            h.height = height;
+            h.timestamp = irys_types::UnixTimestampMs::from_millis((height as u128) * 1000);
+            h.data_ledgers[DataLedger::Submit].total_chunks = total_chunks;
+            h.data_ledgers[DataLedger::Submit].tx_ids = H256List::new();
+            h
+        }
+
+        let num_blocks_in_epoch = config.consensus.epoch.num_blocks_in_epoch;
+        let blocks_per_cycle =
+            config.consensus.epoch.submit_ledger_epoch_length * num_blocks_in_epoch;
+
+        let mut epoch = EpochSnapshot {
+            ledgers: irys_database::Ledgers::new(&config.consensus, false),
+            partition_assignments: PartitionAssignments::new(),
+            all_active_partitions: Vec::new(),
+            unassigned_partitions: Vec::new(),
+            storage_submodules_config: None,
+            config: config.clone(),
+            commitment_state: CommitmentState::default(),
+            epoch_block: IrysBlockHeader::default(),
+            previous_epoch_block: None,
+            expired_partition_infos: None,
+            epoch_height: 0,
+        };
+
+        // h=0: genesis. h=N: data [0, 18) lands — slot 0 full, slot 1 holds the
+        // write frontier (8/10), headroom slots preallocated above. Then ingress
+        // stalls: idle epochs at total 18 until a full term has passed since the
+        // last write.
+        let mut epoch0 = submit_epoch_header(0, 0);
+        epoch0.test_sign();
+        epoch.perform_epoch_tasks(&None, &epoch0, vec![])?;
+        let mut prev_epoch = epoch0;
+        for height in (num_blocks_in_epoch..=blocks_per_cycle + num_blocks_in_epoch)
+            .step_by(num_blocks_in_epoch as usize)
+        {
+            let mut next_epoch = submit_epoch_header(height, 18);
+            next_epoch.test_sign();
+            epoch.perform_epoch_tasks(&Some(prev_epoch.clone()), &next_epoch, vec![])?;
+            prev_epoch = next_epoch;
+        }
+
+        // Both written slots are a full term stale, but only the FULL slot 0 may
+        // expire; the frontier slot 1 must stay live.
+        let probe_height = blocks_per_cycle + num_blocks_in_epoch + 1;
+        assert_eq!(
+            epoch.get_all_expired_term_slot_indexes(DataLedger::Submit, probe_height, true, 18),
+            vec![0],
+            "the write frontier's slot must not expire during an ingress stall"
+        );
+        let slots = epoch.ledgers.get_slots(DataLedger::Submit);
+        assert!(slots[0].is_expired, "the fully-written slot 0 recycles");
+        assert!(!slots[1].is_expired, "the frontier slot 1 must survive");
+
+        // The non-promotability range must stop at slot 0's boundary: the next
+        // append (offset 18) lies outside it and stays promotable/settleable.
+        let mut parent = IrysBlockHeader::new_mock_header();
+        parent.data_ledgers[DataLedger::Submit].total_chunks = 18;
+        let range = expired_submit_range(probe_height, &epoch, &parent, &config, true)?
+            .expect("slot 0 expired, so a range must exist");
+        assert_eq!(
+            range.range_end, 10,
+            "expired range must end at the last full slot's boundary, not the frontier"
+        );
+
+        // Ingress resumes: [18, 25) fills slot 1. Because it never expired, the
+        // touch refreshes its expiry clock instead of freezing it.
+        let resume_height = blocks_per_cycle + 2 * num_blocks_in_epoch;
+        let mut resume_epoch = submit_epoch_header(resume_height, 25);
+        resume_epoch.test_sign();
+        epoch.perform_epoch_tasks(&Some(prev_epoch), &resume_epoch, vec![])?;
+        let slots = epoch.ledgers.get_slots(DataLedger::Submit);
+        assert_eq!(
+            slots[1].last_height, resume_height,
+            "surviving the stall lets the refill refresh the frontier slot's clock"
+        );
+        assert_eq!(
+            epoch.get_all_expired_term_slot_indexes(
+                DataLedger::Submit,
+                resume_height + 1,
+                true,
+                25
+            ),
+            vec![0],
+            "the refilled slot stays out of the expired set for a fresh term"
+        );
+
+        Ok(())
     }
 }

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -4875,9 +4875,17 @@ async fn generate_expected_shadow_transactions(
     // epoch snapshot (pre-`touch_active_ledger_slots`) and cannot see the current
     // epoch's write. That is conservative (never a double-pay) and self-healing:
     // once the epoch `touch` bumps the slot's `last_height` it leaves the blocked
-    // set for the rest of the epoch, so at worst a promotion is delayed one block at
-    // the epoch boundary. Replaces the earlier cycle-math approximation — see
-    // NC-0042 §4b.
+    // set for the rest of the epoch. The delay this imposes is bounded but not
+    // always a single block: this set is recomputed every block from the *parent's*
+    // advancing Submit total, so a slot whose fully-written boundary is crossed by
+    // mid-epoch appends re-enters the blocked set as soon as the parent total passes
+    // it, while its `last_height` is not refreshed until the next epoch `touch`. A tx
+    // appended into a slot that completes mid-epoch can therefore be held
+    // non-promotable until that next epoch block — up to ~one epoch, not one block.
+    // The delay is still deterministic (a pure function of the parent header/snapshot,
+    // so every node agrees), cannot refund within the window (settlement is
+    // epoch-gated), and self-heals at the next epoch. Replaces the earlier cycle-math
+    // approximation — see NC-0042 §4b.
     //
     // This is a strict superset of the old same-block guard: a tx whose Submit
     // slot expires *at* this block (same-block epoch collision) and a tx whose

--- a/crates/chain-tests/src/validation/cascade_term_expiry.rs
+++ b/crates/chain-tests/src/validation/cascade_term_expiry.rs
@@ -275,7 +275,13 @@ async fn heavy_cascade_term_ledger_expiry_respects_distinct_epoch_lengths() -> e
 ///    spanning tx was written (full retention honored, not premature) — while the
 ///    tail slot 1 is still ALIVE (its last write was E_b). The spanning tx's two
 ///    slots expire at different times; the head governs the tx's readable life.
-/// 4. At E_b + 4: the tail slot 1 also expires.
+/// 4. At E_b + 4: the tail slot 1 STILL does not expire — it is the partially
+///    written frontier slot (15/20 chunks), and only fully-written slots may
+///    expire: chunk offsets are cumulative, so expiring the frontier slot would
+///    strand every tx later appended into its remainder (non-promotable forever,
+///    never settled).
+/// 5. Epoch E_c: 5 more chunks fill slot 1 exactly (total 20). A full
+///    `epoch_length` after that write, at E_c + 4, slot 1 finally expires.
 ///
 /// Without the last-write fix slot 0 would keep its genesis `last_height` and be
 /// expired well before E_a + 4 — so this test fails on `master`.
@@ -453,7 +459,10 @@ async fn heavy_cascade_spanning_tx_last_write_expiry() -> eyre::Result<()> {
         "first-unexpired ThirtyDay slot should be 1 (head expired, tail alive)"
     );
 
-    // --- Check 2 @ E_b + 4: the tail slot 1 also expires. ---
+    // --- Check 2 @ E_b + 4: the tail slot 1 is the partially written frontier
+    //     slot (15/20 chunks), so it must NOT expire even a full window after
+    //     its last write — future appends land in its remainder, and expiring
+    //     it would strand them (non-promotable forever, never settled). ---
     let tail_expiry = epoch_b + expiry_blocks;
     while ctx.get_canonical_chain_height().await < tail_expiry {
         ctx.mine_block().await?;
@@ -461,14 +470,69 @@ async fn heavy_cascade_spanning_tx_last_write_expiry() -> eyre::Result<()> {
     let (_, _, _, s1_exp_late, _, first_unexpired_late) =
         thirty_day_slots(&ctx, tail_expiry).await?;
     assert!(
-        s1_exp_late,
-        "tail slot 1 must expire epoch_length after its last write \
-         (E_b+{expiry_blocks}={tail_expiry})"
+        !s1_exp_late,
+        "the partially written frontier slot 1 must NOT expire at \
+         E_b+{expiry_blocks}={tail_expiry} — only fully-written slots may expire"
+    );
+    assert_eq!(
+        first_unexpired_late, 1,
+        "first-unexpired ThirtyDay slot should stay 1 while the frontier slot \
+         remains partially written (got {first_unexpired_late})"
+    );
+
+    // --- Batch 3 @ E_c: 2 + 3 chunks fill slot 1 exactly (chunks 15-19,
+    //     total 20). Because slot 1 never expired, the touch refreshes its
+    //     expiry clock to E_c. ---
+    for (marker, bytes) in [(101_u8, 64_usize), (102, 96)] {
+        let mut tx_data = vec![9_u8; bytes];
+        tx_data[0] = marker;
+        let price = ctx
+            .get_data_price(DataLedger::ThirtyDay, bytes as u64)
+            .await?;
+        let tx = signer.create_transaction_with_fees(
+            tx_data,
+            ctx.get_anchor().await?,
+            DataLedger::ThirtyDay,
+            BoundedFee::new(price.term_fee),
+            None,
+        )?;
+        let tx = signer.sign_transaction(tx)?;
+        ctx.ingest_data_tx(tx.header.clone()).await?;
+        ctx.wait_for_mempool(tx.header.id, 30).await?;
+    }
+    let h3 = ctx.mine_block().await?.height;
+    let epoch_c = next_epoch_boundary(h3);
+    while ctx.get_canonical_chain_height().await < epoch_c {
+        ctx.mine_block().await?;
+    }
+    let (_, _, s1_la_c, s1_exp_c, _, _) = thirty_day_slots(&ctx, epoch_c).await?;
+    assert!(
+        !s1_exp_c,
+        "slot 1 must still be alive at its fill epoch E_c"
+    );
+    assert_eq!(
+        s1_la_c, epoch_c,
+        "surviving as the frontier slot lets the fill refresh slot 1's clock to \
+         E_c={epoch_c}"
+    );
+
+    // --- Check 3 @ E_c + 4: now fully written, slot 1 expires a full window
+    //     after its last write. ---
+    let tail_expiry = epoch_c + expiry_blocks;
+    while ctx.get_canonical_chain_height().await < tail_expiry {
+        ctx.mine_block().await?;
+    }
+    let (_, _, _, s1_exp_final, _, first_unexpired_final) =
+        thirty_day_slots(&ctx, tail_expiry).await?;
+    assert!(
+        s1_exp_final,
+        "once fully written, tail slot 1 must expire epoch_length after its \
+         last write (E_c+{expiry_blocks}={tail_expiry})"
     );
     assert!(
-        first_unexpired_late > 1,
-        "first-unexpired ThirtyDay slot should advance past 1 once the tail \
-         expires (got {first_unexpired_late})"
+        first_unexpired_final > 1,
+        "first-unexpired ThirtyDay slot should advance past 1 once the filled \
+         tail expires (got {first_unexpired_final})"
     );
 
     ctx.stop().await;
@@ -832,7 +896,10 @@ async fn heavy_cascade_expiry_fee_model_matches_actual_recycle() -> eyre::Result
 /// 3. Epoch E: post another (unpromoted) tx into slot 0 -> touch rescues it.
 ///    Assert the epoch block at E has ZERO TermFeeReward and ZERO PermFeeRefund:
 ///    the rescued slot is neither settled nor refunded.
-/// 4. Epoch E + 4: slot 0 (last write E) finally recycles -> the deferred
+/// 4. Epoch F: post a tx that fills slot 0 exactly (10/10 chunks). Only
+///    fully-written slots may recycle — a partially written frontier slot stays
+///    live so later appends never land in an expired slot.
+/// 5. Epoch F + 4: slot 0 (last write F) finally recycles -> the deferred
 ///    PermFeeRefund for its unpromoted txs lands here.
 #[test_log::test(tokio::test)]
 async fn heavy_cascade_rescued_slot_defers_reward_and_refund() -> eyre::Result<()> {
@@ -939,9 +1006,38 @@ async fn heavy_cascade_rescued_slot_defers_reward_and_refund() -> eyre::Result<(
         "rescued Submit slot must not emit a PermFeeRefund at its (skipped) expiry epoch E={e}"
     );
 
-    // Phase B: when the slot ACTUALLY recycles (E + window), the deferred refund
+    // Fill slot 0 exactly (chunks 7-9; total 10/10) in epoch F: only a
+    // fully-written slot may recycle, and the fill refreshes its clock to F.
+    let anchor = ctx.get_anchor().await?;
+    let tx3 = ctx
+        .post_data_tx(anchor, vec![3_u8; 3 * chunk_size as usize], &signer)
+        .await;
+    ctx.wait_for_mempool(tx3.header.id, 30).await?;
+    let f = next_epoch_boundary(ctx.mine_block().await?.height);
+    while ctx.get_canonical_chain_height().await < f {
+        ctx.mine_block().await?;
+    }
+
+    // The fill must have landed: slot 0 survived the rescue window and its
+    // expiry clock now counts from F — otherwise the recycle assertion below
+    // would fail obliquely.
+    {
+        let block = ctx.get_block_by_height(f).await?;
+        let tree = ctx.node_ctx.block_tree_guard.read();
+        let snapshot = tree
+            .get_epoch_snapshot(&block.block_hash)
+            .expect("epoch snapshot should exist");
+        let slot0 = &snapshot.ledgers.get_slots(DataLedger::Submit)[0];
+        assert!(!slot0.is_expired, "slot 0 must still be alive at F={f}");
+        assert_eq!(
+            slot0.last_height, f,
+            "the fill must refresh slot 0's expiry clock to F={f}"
+        );
+    }
+
+    // Phase B: when the slot ACTUALLY recycles (F + window), the deferred refund
     // for its unpromoted txs lands — proving the refund was deferred, not lost.
-    let recycle = e + window;
+    let recycle = f + window;
     while ctx.get_canonical_chain_height().await < recycle {
         ctx.mine_block().await?;
     }
@@ -949,7 +1045,7 @@ async fn heavy_cascade_rescued_slot_defers_reward_and_refund() -> eyre::Result<(
     assert!(
         refunds_at_recycle >= 1,
         "deferred PermFeeRefund for the unpromoted txs must land when slot 0 \
-         actually recycles at E+{window}={recycle} (got {refunds_at_recycle})"
+         actually recycles at F+{window}={recycle} (got {refunds_at_recycle})"
     );
 
     ctx.stop().await;

--- a/crates/database/src/data_ledger.rs
+++ b/crates/database/src/data_ledger.rs
@@ -31,6 +31,23 @@ pub struct LedgerSlot {
     pub last_height: u64,
 }
 
+/// Number of leading slots whose full chunk range lies at or below the write
+/// frontier (`total_chunks`): slots `0..n` are fully written. Post-Cascade a
+/// slot may only expire once it is fully written — i.e. the frontier has moved
+/// past it. Ledger chunk offsets are strictly cumulative, so this makes "no
+/// write ever lands in an expired slot" structural. Without it, data appended
+/// into an expired slot's unwritten remainder would be permanently
+/// non-promotable (the slot stays in the inclusive all-expired set) yet never
+/// settled again (the newly-expiring set acts once per slot) — stranding its
+/// term and perm fees — and its chunks would never get partitions assigned
+/// (`get_slot_needs` skips expired slots).
+///
+/// `chunks_per_slot == 0` (rejected by `Config::validate`) fails safe: no slot
+/// counts as fully written, so nothing expires.
+fn fully_written_slot_count(total_chunks: u64, chunks_per_slot: u64) -> u64 {
+    total_chunks.checked_div(chunks_per_slot).unwrap_or(0)
+}
+
 #[derive(Debug, Clone, Copy, Hash)]
 pub struct ExpiringPartitionInfo {
     pub partition_hash: PartitionHash,
@@ -90,7 +107,13 @@ impl TermLedger {
     }
 
     #[tracing::instrument(level = "trace", skip_all, fields(epoch_height = %epoch_height))]
-    pub fn get_expired_slot_indexes(&self, epoch_height: u64, cascade_active: bool) -> Vec<usize> {
+    pub fn get_expired_slot_indexes(
+        &self,
+        epoch_height: u64,
+        cascade_active: bool,
+        total_chunks: u64,
+        chunks_per_slot: u64,
+    ) -> Vec<usize> {
         let mut expired_slot_indexes = Vec::new();
 
         let min_blocks = self
@@ -119,6 +142,11 @@ impl TermLedger {
         let expiry_height = epoch_height - min_blocks;
         tracing::info!("Calculated expiry_height={}", expiry_height);
 
+        // Post-Cascade, only fully-written slots may expire — the slot holding
+        // the write frontier stays live so future appends never land in an
+        // expired slot (see `fully_written_slot_count`).
+        let fully_written_slots = fully_written_slot_count(total_chunks, chunks_per_slot);
+
         // Collect indices of slots to expire
         for (slot_index, slot) in self.slots.iter().enumerate() {
             tracing::debug!(
@@ -135,7 +163,12 @@ impl TermLedger {
                 continue;
             }
             let written_ok = !cascade_active || slot.has_been_written;
-            if written_ok && slot.last_height <= expiry_height && !slot.is_expired {
+            let fully_written_ok = !cascade_active || (slot_index as u64) < fully_written_slots;
+            if written_ok
+                && fully_written_ok
+                && slot.last_height <= expiry_height
+                && !slot.is_expired
+            {
                 tracing::info!("Slot {} is expired! Adding to expired_indices", slot_index);
                 expired_slot_indexes.push(slot_index);
             }
@@ -156,13 +189,17 @@ impl TermLedger {
     /// block at-or-after the expiry, not just the single epoch block where it
     /// newly expires.
     ///
-    /// Post-Cascade, unwritten preallocated slots are excluded: they never held
-    /// canonical data and therefore must not expire. Pre-Cascade replay stays
-    /// bit-identical to the allocation-anchored behavior.
+    /// Post-Cascade, unwritten preallocated slots are excluded (they never held
+    /// canonical data and therefore must not expire), and so are slots not yet
+    /// fully written (the write frontier still sits inside them — see
+    /// `fully_written_slot_count`). Pre-Cascade replay stays bit-identical to
+    /// the allocation-anchored behavior.
     pub fn get_all_expired_slot_indexes(
         &self,
         epoch_height: u64,
         cascade_active: bool,
+        total_chunks: u64,
+        chunks_per_slot: u64,
     ) -> Vec<usize> {
         let min_blocks = self
             .epoch_length
@@ -175,6 +212,7 @@ impl TermLedger {
 
         let expiry_height = epoch_height - min_blocks;
         let last_slot_index = self.slots.len().saturating_sub(1);
+        let fully_written_slots = fully_written_slot_count(total_chunks, chunks_per_slot);
 
         self.slots
             .iter()
@@ -183,6 +221,7 @@ impl TermLedger {
                 // Never expire the last slot in a ledger (matches get_expired_slot_indexes).
                 *slot_index != last_slot_index
                     && (!cascade_active || slot.has_been_written)
+                    && (!cascade_active || (*slot_index as u64) < fully_written_slots)
                     && slot.last_height <= expiry_height
             })
             .map(|(slot_index, _)| slot_index)
@@ -190,8 +229,19 @@ impl TermLedger {
     }
 
     /// Returns indices of newly expired slots
-    pub fn expire_old_slots(&mut self, epoch_height: u64, cascade_active: bool) -> Vec<usize> {
-        let expired_slot_indexes = self.get_expired_slot_indexes(epoch_height, cascade_active);
+    pub fn expire_old_slots(
+        &mut self,
+        epoch_height: u64,
+        cascade_active: bool,
+        total_chunks: u64,
+        chunks_per_slot: u64,
+    ) -> Vec<usize> {
+        let expired_slot_indexes = self.get_expired_slot_indexes(
+            epoch_height,
+            cascade_active,
+            total_chunks,
+            chunks_per_slot,
+        );
 
         // Mark collected slots as expired
         for &idx in &expired_slot_indexes {
@@ -414,17 +464,27 @@ impl Ledgers {
 
     /// Get all partition hashes that have expired out of both perm and term ledgers.
     /// Perm slots only expire when `publish_ledger_epoch_length` is configured.
+    ///
+    /// `total_chunks` maps each ledger to its cumulative chunk count at the epoch
+    /// block driving this expiry (`IrysBlockHeader::ledger_total_chunks`), and
+    /// `chunks_per_slot` is `num_chunks_in_partition` — the same write-frontier
+    /// model `touch_filled_slots` uses.
     pub fn expire_partitions(
         &mut self,
         epoch_height: u64,
         cascade_active: bool,
+        total_chunks: impl Fn(DataLedger) -> u64,
+        chunks_per_slot: u64,
     ) -> Vec<ExpiringPartitionInfo> {
         let mut expired_partitions: Vec<ExpiringPartitionInfo> = Vec::new();
 
         // Expire perm ledger slots using shared helper
-        for (slot_index, partition_hashes, ledger_id) in
-            self.get_perm_expiring_slots(epoch_height, cascade_active)
-        {
+        for (slot_index, partition_hashes, ledger_id) in self.get_perm_expiring_slots(
+            epoch_height,
+            cascade_active,
+            total_chunks(DataLedger::Publish),
+            chunks_per_slot,
+        ) {
             self.perm.slots[slot_index].is_expired = true;
             for partition_hash in partition_hashes {
                 expired_partitions.push(ExpiringPartitionInfo {
@@ -439,7 +499,12 @@ impl Ledgers {
         for term_ledger in &mut self.term {
             let ledger_id = DataLedger::try_from(term_ledger.ledger_id)
                 .expect("term ledger_id is always constructed from a valid DataLedger variant");
-            for expired_index in term_ledger.expire_old_slots(epoch_height, cascade_active) {
+            for expired_index in term_ledger.expire_old_slots(
+                epoch_height,
+                cascade_active,
+                total_chunks(ledger_id),
+                chunks_per_slot,
+            ) {
                 for partition_hash in term_ledger.slots[expired_index].partitions.iter() {
                     expired_partitions.push(ExpiringPartitionInfo {
                         partition_hash: *partition_hash,
@@ -455,17 +520,25 @@ impl Ledgers {
 
     /// Get all partition hashes that would expire at this epoch height (read-only).
     /// Unlike `expire_partitions`, this does NOT mark slots as expired.
+    ///
+    /// `total_chunks` / `chunks_per_slot`: see [`Self::expire_partitions`] — pass
+    /// the same per-ledger totals so the two sets cannot diverge.
     pub fn get_expiring_partitions(
         &self,
         epoch_height: u64,
         cascade_active: bool,
+        total_chunks: impl Fn(DataLedger) -> u64,
+        chunks_per_slot: u64,
     ) -> Vec<ExpiringPartitionInfo> {
         let mut expired_partitions: Vec<ExpiringPartitionInfo> = Vec::new();
 
         // Check perm ledger slots using shared helper
-        for (slot_index, partition_hashes, ledger_id) in
-            self.get_perm_expiring_slots(epoch_height, cascade_active)
-        {
+        for (slot_index, partition_hashes, ledger_id) in self.get_perm_expiring_slots(
+            epoch_height,
+            cascade_active,
+            total_chunks(DataLedger::Publish),
+            chunks_per_slot,
+        ) {
             for partition_hash in partition_hashes {
                 expired_partitions.push(ExpiringPartitionInfo {
                     partition_hash,
@@ -479,9 +552,12 @@ impl Ledgers {
         for term_ledger in &self.term {
             let ledger_id = DataLedger::try_from(term_ledger.ledger_id)
                 .expect("term ledger_id is always constructed from a valid DataLedger variant");
-            for expiring_slot_index in
-                term_ledger.get_expired_slot_indexes(epoch_height, cascade_active)
-            {
+            for expiring_slot_index in term_ledger.get_expired_slot_indexes(
+                epoch_height,
+                cascade_active,
+                total_chunks(ledger_id),
+                chunks_per_slot,
+            ) {
                 for partition_hash in term_ledger.slots[expiring_slot_index].partitions.iter() {
                     expired_partitions.push(ExpiringPartitionInfo {
                         partition_hash: *partition_hash,
@@ -505,9 +581,15 @@ impl Ledgers {
         ledger: DataLedger,
         epoch_height: u64,
         cascade_active: bool,
+        total_chunks: u64,
+        chunks_per_slot: u64,
     ) -> Vec<usize> {
-        self.get_term_ledger(ledger)
-            .get_all_expired_slot_indexes(epoch_height, cascade_active)
+        self.get_term_ledger(ledger).get_all_expired_slot_indexes(
+            epoch_height,
+            cascade_active,
+            total_chunks,
+            chunks_per_slot,
+        )
     }
 
     // Private helper methods for term ledger lookups
@@ -531,6 +613,8 @@ impl Ledgers {
         &self,
         epoch_height: u64,
         cascade_active: bool,
+        total_chunks: u64,
+        chunks_per_slot: u64,
     ) -> Vec<(usize, Vec<PartitionHash>, DataLedger)> {
         let Some(epoch_length) = self.publish_ledger_epoch_length else {
             return Vec::new();
@@ -549,6 +633,7 @@ impl Ledgers {
             .expect("perm.ledger_id is always DataLedger::Publish");
         let num_slots = self.perm.slots.len();
         let last_slot_index = num_slots.saturating_sub(1);
+        let fully_written_slots = fully_written_slot_count(total_chunks, chunks_per_slot);
 
         let mut result = Vec::new();
         for (slot_index, slot) in self.perm.slots.iter().enumerate() {
@@ -560,9 +645,16 @@ impl Ledgers {
             // `touch_filled_slots`, which `EpochSnapshot::touch_active_ledger_slots`
             // calls unconditionally over `active_ledgers()` (incl. Publish) before
             // expiry runs — so the post-Cascade unwritten-slot exclusion below is
-            // safe for the perm ledger too.
+            // safe for the perm ledger too. Publish offsets are cumulative like
+            // the term ledgers', so the fully-written frontier rule applies the
+            // same way (see `fully_written_slot_count`).
             let written_ok = !cascade_active || slot.has_been_written;
-            if written_ok && slot.last_height <= expiry_height && !slot.is_expired {
+            let fully_written_ok = !cascade_active || (slot_index as u64) < fully_written_slots;
+            if written_ok
+                && fully_written_ok
+                && slot.last_height <= expiry_height
+                && !slot.is_expired
+            {
                 result.push((slot_index, slot.partitions.clone(), perm_ledger_id));
             }
         }
@@ -809,7 +901,7 @@ mod tests {
         ledgers.perm.allocate_slots(1, 1);
         ledgers.perm.slots[0].partitions.push(H256::random());
         // At height 1000, nothing should expire
-        let expired = ledgers.expire_partitions(1000, true);
+        let expired = ledgers.expire_partitions(1000, true, |_| 10, 10);
         assert!(expired.iter().all(|e| e.ledger_id != DataLedger::Publish));
     }
 
@@ -831,7 +923,7 @@ mod tests {
         // At epoch_height = 30: expiry_height = 30 - 20 = 10
         // Slot 0 (last_height=1) <= 10: EXPIRED
         // Slot 1 (last_height=25) > 10: NOT expired (also last slot)
-        let expired = ledgers.expire_partitions(30, true);
+        let expired = ledgers.expire_partitions(30, true, |_| 20, 10);
         let perm_expired: Vec<_> = expired
             .iter()
             .filter(|e| e.ledger_id == DataLedger::Publish)
@@ -851,7 +943,7 @@ mod tests {
         ledgers.perm.slots[0].has_been_written = true;
 
         // At epoch_height = 100: should NOT expire (it's the last slot)
-        let expired = ledgers.expire_partitions(100, true);
+        let expired = ledgers.expire_partitions(100, true, |_| 10, 10);
         let perm_expired: Vec<_> = expired
             .iter()
             .filter(|e| e.ledger_id == DataLedger::Publish)
@@ -871,7 +963,7 @@ mod tests {
         ledgers.perm.slots[1].has_been_written = true;
 
         // At epoch_height = 15 (< 20 minimum): nothing expires
-        let expired = ledgers.expire_partitions(15, true);
+        let expired = ledgers.expire_partitions(15, true, |_| 20, 10);
         let perm_expired: Vec<_> = expired
             .iter()
             .filter(|e| e.ledger_id == DataLedger::Publish)
@@ -890,7 +982,7 @@ mod tests {
         ledgers.perm.slots[1].has_been_written = true;
 
         // Read-only: should report slot 0 as expiring without marking it
-        let expiring = ledgers.get_expiring_partitions(30, true);
+        let expiring = ledgers.get_expiring_partitions(30, true, |_| 20, 10);
         let perm_expiring: Vec<_> = expiring
             .iter()
             .filter(|e| e.ledger_id == DataLedger::Publish)
@@ -925,7 +1017,7 @@ mod tests {
         ledgers.perm.allocate_slots(1, 1);
         ledgers.perm.slots[0].partitions.push(H256::random());
 
-        let expiring = ledgers.get_expiring_partitions(1000, true);
+        let expiring = ledgers.get_expiring_partitions(1000, true, |_| 10, 10);
         assert!(expiring.iter().all(|e| e.ledger_id != DataLedger::Publish));
     }
 
@@ -1079,12 +1171,12 @@ mod tests {
         // never expires — exactly where the cycle-math approximation diverged.
         assert!(
             ledger
-                .get_all_expired_slot_indexes(blocks_per_cycle, true)
+                .get_all_expired_slot_indexes(blocks_per_cycle, true, 10, 10)
                 .is_empty()
         );
         assert!(
             ledger
-                .get_all_expired_slot_indexes(blocks_per_cycle * 10, true)
+                .get_all_expired_slot_indexes(blocks_per_cycle * 10, true, 10, 10)
                 .is_empty()
         );
     }
@@ -1112,25 +1204,33 @@ mod tests {
         // One epoch before: nothing expired yet.
         assert!(
             ledger
-                .get_all_expired_slot_indexes(expiry - num_blocks, true)
+                .get_all_expired_slot_indexes(expiry - num_blocks, true, 20, 10)
                 .is_empty()
         );
 
         // At expiry, slot 0 is in both sets.
-        assert_eq!(ledger.get_all_expired_slot_indexes(expiry, true), vec![0]);
-        assert_eq!(ledger.get_expired_slot_indexes(expiry, true), vec![0]);
+        assert_eq!(
+            ledger.get_all_expired_slot_indexes(expiry, true, 20, 10),
+            vec![0]
+        );
+        assert_eq!(
+            ledger.get_expired_slot_indexes(expiry, true, 20, 10),
+            vec![0]
+        );
 
         // After it is marked expired, the inclusive set still returns it
         // (a tx in slot 0 stays non-promotable at every later block) while the
         // newly-expiring set drops it (it must only be refunded once).
-        ledger.expire_old_slots(expiry, true);
+        ledger.expire_old_slots(expiry, true, 20, 10);
         assert_eq!(
-            ledger.get_all_expired_slot_indexes(expiry + 1, true),
+            ledger.get_all_expired_slot_indexes(expiry + 1, true, 20, 10),
             vec![0],
             "an already-expired slot must remain in the inclusive set (cross-block guard)"
         );
         assert!(
-            ledger.get_expired_slot_indexes(expiry + 1, true).is_empty(),
+            ledger
+                .get_expired_slot_indexes(expiry + 1, true, 20, 10)
+                .is_empty(),
             "get_expired_slot_indexes returns only newly-expiring slots"
         );
     }
@@ -1157,7 +1257,13 @@ mod tests {
         // expiry_height = (min_blocks + 75) - min_blocks = 75 ∈ (50, 100): slot 0
         // expires, slot 1 stays live, and unwritten slots 2/3 stay unexpired.
         assert_eq!(
-            ledgers.get_all_expired_term_slot_indexes(DataLedger::Submit, min_blocks + 75, true),
+            ledgers.get_all_expired_term_slot_indexes(
+                DataLedger::Submit,
+                min_blocks + 75,
+                true,
+                19,
+                10
+            ),
             vec![0],
             "preallocated slots that never held data must not expire"
         );
@@ -1175,9 +1281,146 @@ mod tests {
         ledgers.touch_filled_slots(DataLedger::Submit, 18, 19, 10, 100, true);
 
         assert_eq!(
-            ledgers.get_all_expired_term_slot_indexes(DataLedger::Submit, min_blocks + 75, false),
+            ledgers.get_all_expired_term_slot_indexes(
+                DataLedger::Submit,
+                min_blocks + 75,
+                false,
+                19,
+                10
+            ),
             vec![0, 2],
             "pre-Cascade replay must keep allocation-aged unwritten slots in the expired set"
+        );
+    }
+
+    /// Post-Cascade, a slot the write frontier still sits inside (written but not
+    /// full) must not expire. Ledger chunk offsets are strictly cumulative, so
+    /// data appended after the slot expired would land inside it — permanently
+    /// non-promotable (it stays in the inclusive all-expired set) yet never
+    /// settled (the newly-expiring set acts once per slot), stranding its
+    /// term_fee and perm_fee and leaving the chunks with no partition
+    /// assignment. Only fully-written slots may expire.
+    #[test]
+    fn partially_written_frontier_slot_does_not_expire_post_cascade() {
+        let config = ConsensusConfig::testing();
+        let min_blocks = config.epoch.submit_ledger_epoch_length * config.epoch.num_blocks_in_epoch;
+
+        // 3 slots of 10 chunks. Data [0, 15) at height 50: slot 0 full, slot 1
+        // holds the write frontier (5/10 chunks), slot 2 is unwritten headroom.
+        let mut ledgers = ledgers_with_submit_slots(3, 1);
+        ledgers.touch_filled_slots(DataLedger::Submit, 0, 15, 10, 50, true);
+
+        // Far past both written slots' expiry heights: only the FULL slot 0 may
+        // expire; the frontier slot 1 must stay live in both sets.
+        let height = min_blocks + 100;
+        assert_eq!(
+            ledgers.get_all_expired_term_slot_indexes(DataLedger::Submit, height, true, 15, 10),
+            vec![0],
+            "the slot holding the write frontier must never enter the non-promotability set"
+        );
+        assert_eq!(
+            ledgers
+                .get_term_ledger(DataLedger::Submit)
+                .get_expired_slot_indexes(height, true, 15, 10),
+            vec![0],
+            "the slot holding the write frontier must not be settled/recycled"
+        );
+    }
+
+    /// Lifecycle of the frontier slot across an idle term: it survives the idle
+    /// period (so a later write still refreshes its expiry clock instead of
+    /// landing in a dead slot), and expires only a full term after the write
+    /// that completed it.
+    #[test]
+    fn partially_written_slot_expires_only_once_fully_written() {
+        let config = ConsensusConfig::testing();
+        let min_blocks = config.epoch.submit_ledger_epoch_length * config.epoch.num_blocks_in_epoch;
+
+        let mut ledgers = ledgers_with_submit_slots(3, 1);
+        ledgers.touch_filled_slots(DataLedger::Submit, 0, 15, 10, 50, true);
+
+        // Ingress stalls for well over a full term: slot 1 must survive.
+        let resume = 50 + min_blocks + 200;
+        assert_eq!(
+            ledgers.get_all_expired_term_slot_indexes(DataLedger::Submit, resume, true, 15, 10),
+            vec![0]
+        );
+
+        // Ingress resumes and fills slot 1. Because the slot never expired, the
+        // touch refreshes its expiry clock (an expired slot would stay frozen).
+        ledgers.touch_filled_slots(DataLedger::Submit, 15, 20, 10, resume, true);
+        assert_eq!(
+            ledgers.get_slots(DataLedger::Submit)[1].last_height,
+            resume,
+            "surviving the idle term is what lets the refill refresh the expiry clock"
+        );
+
+        // One block before a full term from the refill: still live.
+        assert_eq!(
+            ledgers.get_all_expired_term_slot_indexes(
+                DataLedger::Submit,
+                resume + min_blocks - 1,
+                true,
+                20,
+                10
+            ),
+            vec![0]
+        );
+        // Fully written and a full term since its last write: now it expires.
+        assert_eq!(
+            ledgers.get_all_expired_term_slot_indexes(
+                DataLedger::Submit,
+                resume + min_blocks,
+                true,
+                20,
+                10
+            ),
+            vec![0, 1]
+        );
+    }
+
+    /// Pre-Cascade replay identity: before the hardfork, a partially-written
+    /// slot still ages out by its allocation-anchored `last_height` regardless
+    /// of the fully-written rule.
+    #[test]
+    fn pre_cascade_partially_written_slot_still_expires() {
+        let config = ConsensusConfig::testing();
+        let min_blocks = config.epoch.submit_ledger_epoch_length * config.epoch.num_blocks_in_epoch;
+
+        let mut ledgers = ledgers_with_submit_slots(3, 1);
+        ledgers.touch_filled_slots(DataLedger::Submit, 0, 15, 10, 50, true);
+
+        // Pre-Cascade the fully-written rule must not apply (slot 1 expires by
+        // age; slot 2 is the last slot and is excluded by the last-slot rule).
+        let height = min_blocks + 100;
+        assert_eq!(
+            ledgers.get_all_expired_term_slot_indexes(DataLedger::Submit, height, false, 15, 10),
+            vec![0, 1],
+            "pre-Cascade replay must keep the allocation-anchored expiry for partial slots"
+        );
+    }
+
+    /// `chunks_per_slot == 0` (rejected by Config::validate; defense in depth)
+    /// must fail safe post-Cascade: no slot counts as fully written, so nothing
+    /// expires — an incorrectly-expired slot is the dangerous outcome — and no
+    /// division panic.
+    #[test]
+    fn zero_chunks_per_slot_expires_nothing_post_cascade() {
+        let mut ledgers = ledgers_with_submit_slots(3, 1);
+        ledgers.touch_filled_slots(DataLedger::Submit, 0, 15, 10, 50, true);
+
+        let config = ConsensusConfig::testing();
+        let min_blocks = config.epoch.submit_ledger_epoch_length * config.epoch.num_blocks_in_epoch;
+        assert!(
+            ledgers
+                .get_all_expired_term_slot_indexes(
+                    DataLedger::Submit,
+                    min_blocks + 100,
+                    true,
+                    15,
+                    0
+                )
+                .is_empty()
         );
     }
 }

--- a/crates/database/src/data_ledger.rs
+++ b/crates/database/src/data_ledger.rs
@@ -48,6 +48,21 @@ fn fully_written_slot_count(total_chunks: u64, chunks_per_slot: u64) -> u64 {
     total_chunks.checked_div(chunks_per_slot).unwrap_or(0)
 }
 
+/// Post-Cascade slot-expiry gate shared by all three expiry scans
+/// (`get_expired_slot_indexes`, `get_all_expired_slot_indexes`,
+/// `Ledgers::get_perm_expiring_slots`): a slot may expire only once it is fully
+/// written — the write frontier has moved past it (`slot_index < fully_written`),
+/// which also implies it has been written at all. Pre-Cascade the gate is
+/// transparent so replay stays bit-identical to the allocation-anchored behavior.
+fn cascade_expiry_gate(
+    cascade_active: bool,
+    slot: &LedgerSlot,
+    slot_index: usize,
+    fully_written_slots: u64,
+) -> bool {
+    !cascade_active || (slot.has_been_written && (slot_index as u64) < fully_written_slots)
+}
+
 #[derive(Debug, Clone, Copy, Hash)]
 pub struct ExpiringPartitionInfo {
     pub partition_hash: PartitionHash,
@@ -142,9 +157,7 @@ impl TermLedger {
         let expiry_height = epoch_height - min_blocks;
         tracing::info!("Calculated expiry_height={}", expiry_height);
 
-        // Post-Cascade, only fully-written slots may expire — the slot holding
-        // the write frontier stays live so future appends never land in an
-        // expired slot (see `fully_written_slot_count`).
+        // Post-Cascade only fully-written slots may expire — see `cascade_expiry_gate`.
         let fully_written_slots = fully_written_slot_count(total_chunks, chunks_per_slot);
 
         // Collect indices of slots to expire
@@ -162,10 +175,7 @@ impl TermLedger {
                 tracing::warn!("Skipping slot {} (last slot)", slot_index);
                 continue;
             }
-            let written_ok = !cascade_active || slot.has_been_written;
-            let fully_written_ok = !cascade_active || (slot_index as u64) < fully_written_slots;
-            if written_ok
-                && fully_written_ok
+            if cascade_expiry_gate(cascade_active, slot, slot_index, fully_written_slots)
                 && slot.last_height <= expiry_height
                 && !slot.is_expired
             {
@@ -218,10 +228,23 @@ impl TermLedger {
             .iter()
             .enumerate()
             .filter(|(slot_index, slot)| {
+                // An already-recycled slot stays in the inclusive (non-promotability)
+                // set forever, independent of the post-Cascade fully-written gate.
+                // Without this, a slot expired+refunded pre-Cascade while only
+                // partially written would drop out of this set the moment Cascade
+                // activates (its frontier still sits inside it, so it is not
+                // fully written), making its already-refunded txs promotable again
+                // — refund + permanent storage. `is_expired` is only ever set by
+                // the expiry path and pre-Cascade expiry is prefix-ordered, so the
+                // set stays a contiguous prefix in practice; a hypothetical
+                // non-prefix pre-Cascade state trips `expired_submit_range`'s
+                // fail-loud guard rather than silently under-approximating.
+                if slot.is_expired {
+                    return true;
+                }
                 // Never expire the last slot in a ledger (matches get_expired_slot_indexes).
                 *slot_index != last_slot_index
-                    && (!cascade_active || slot.has_been_written)
-                    && (!cascade_active || (*slot_index as u64) < fully_written_slots)
+                    && cascade_expiry_gate(cascade_active, slot, *slot_index, fully_written_slots)
                     && slot.last_height <= expiry_height
             })
             .map(|(slot_index, _)| slot_index)
@@ -648,10 +671,7 @@ impl Ledgers {
             // safe for the perm ledger too. Publish offsets are cumulative like
             // the term ledgers', so the fully-written frontier rule applies the
             // same way (see `fully_written_slot_count`).
-            let written_ok = !cascade_active || slot.has_been_written;
-            let fully_written_ok = !cascade_active || (slot_index as u64) < fully_written_slots;
-            if written_ok
-                && fully_written_ok
+            if cascade_expiry_gate(cascade_active, slot, slot_index, fully_written_slots)
                 && slot.last_height <= expiry_height
                 && !slot.is_expired
             {
@@ -1397,6 +1417,35 @@ mod tests {
             ledgers.get_all_expired_term_slot_indexes(DataLedger::Submit, height, false, 15, 10),
             vec![0, 1],
             "pre-Cascade replay must keep the allocation-anchored expiry for partial slots"
+        );
+    }
+
+    /// Activation-boundary containment: a slot recycled while only partially
+    /// written (an allocation-anchored pre-Cascade expiry, per
+    /// `pre_cascade_partially_written_slot_still_expires`) must STAY in the
+    /// inclusive non-promotability set once Cascade activates. The fully-written
+    /// gate alone would drop it (its frontier still sits inside it), making its
+    /// already-refunded txs promotable again — refund + permanent storage. The
+    /// `is_expired` override keeps it in; without it, slot 1 disappears and the
+    /// set is just `[0]`.
+    #[test]
+    fn expired_partial_slot_stays_in_inclusive_set_post_cascade() {
+        let config = ConsensusConfig::testing();
+        let min_blocks = config.epoch.submit_ledger_epoch_length * config.epoch.num_blocks_in_epoch;
+
+        // Data [0, 15): slot 0 full, slot 1 holds the write frontier (5/10).
+        let mut ledgers = ledgers_with_submit_slots(3, 1);
+        ledgers.touch_filled_slots(DataLedger::Submit, 0, 15, 10, 50, true);
+        // The pre-Cascade epoch recycled the partially-written slot 1.
+        ledgers.slots_mut(DataLedger::Submit)[1].is_expired = true;
+
+        // Post-Cascade `fully_written_slots == 15/10 == 1`, so the gate excludes
+        // slot 1 — but `is_expired` keeps the already-recycled slot in the set.
+        let height = min_blocks + 100;
+        assert_eq!(
+            ledgers.get_all_expired_term_slot_indexes(DataLedger::Submit, height, true, 15, 10),
+            vec![0, 1],
+            "a slot recycled while partially written must remain non-promotable post-Cascade"
         );
     }
 

--- a/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
+++ b/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
@@ -510,8 +510,16 @@ impl EpochSnapshot {
     /// the expired partition hashes in the epoch snapshot.
     fn expire_ledger_slots(&mut self, new_epoch_block: &IrysBlockHeader, cascade_active: bool) {
         let epoch_height = new_epoch_block.height;
-        let expired_partitions: Vec<ExpiringPartitionInfo> =
-            self.ledgers.expire_partitions(epoch_height, cascade_active);
+        // Same write-frontier inputs as `touch_active_ledger_slots`: the new
+        // epoch block's cumulative per-ledger totals. Post-Cascade a slot may
+        // only expire once it is fully written, so the write frontier can never
+        // sit inside an expired slot.
+        let expired_partitions: Vec<ExpiringPartitionInfo> = self.ledgers.expire_partitions(
+            epoch_height,
+            cascade_active,
+            |ledger| new_epoch_block.ledger_total_chunks(ledger),
+            self.config.consensus.num_chunks_in_partition,
+        );
 
         // Return early if there's no more work to do
         if expired_partitions.is_empty() {
@@ -1367,7 +1375,23 @@ impl EpochSnapshot {
         };
 
         self.ledgers
-            .get_expiring_partitions(epoch_height, cascade_active)
+            .get_expiring_partitions(
+                epoch_height,
+                cascade_active,
+                // LOCKSTEP with `expire_ledger_slots`: the target ledger uses the
+                // new epoch block's total. Other ledgers fall back to this
+                // (parent) snapshot's totals — their entries are discarded by the
+                // `ledger_id == ledger` filter below, so the fallback never
+                // reaches the returned set.
+                |l| {
+                    if l == ledger {
+                        new_total_chunks
+                    } else {
+                        self.epoch_block.ledger_total_chunks(l)
+                    }
+                },
+                chunks_per_slot,
+            )
             .into_iter()
             .filter(|info| info.ledger_id == ledger && !written_this_epoch(info.slot_index))
             .collect()
@@ -1379,14 +1403,23 @@ impl EpochSnapshot {
     /// refund pipeline), this is the set the NC-0042 publish-candidate filter and
     /// validator check key on: a tx is non-promotable for every block at-or-after
     /// its Submit slot's expiry. See `Ledgers::get_all_expired_term_slot_indexes`.
+    /// `total_chunks` is `ledger`'s cumulative chunk count at the block whose
+    /// view is being computed (callers pass the parent header's total — the same
+    /// value that bounds the expired chunk range).
     pub fn get_all_expired_term_slot_indexes(
         &self,
         ledger: DataLedger,
         epoch_height: u64,
         cascade_active: bool,
+        total_chunks: u64,
     ) -> Vec<usize> {
-        self.ledgers
-            .get_all_expired_term_slot_indexes(ledger, epoch_height, cascade_active)
+        self.ledgers.get_all_expired_term_slot_indexes(
+            ledger,
+            epoch_height,
+            cascade_active,
+            total_chunks,
+            self.config.consensus.num_chunks_in_partition,
+        )
     }
 
     pub fn get_first_unexpired_slot_index(&self, ledger_id: DataLedger) -> usize {

--- a/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
+++ b/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
@@ -511,9 +511,7 @@ impl EpochSnapshot {
     fn expire_ledger_slots(&mut self, new_epoch_block: &IrysBlockHeader, cascade_active: bool) {
         let epoch_height = new_epoch_block.height;
         // Same write-frontier inputs as `touch_active_ledger_slots`: the new
-        // epoch block's cumulative per-ledger totals. Post-Cascade a slot may
-        // only expire once it is fully written, so the write frontier can never
-        // sit inside an expired slot.
+        // epoch block's cumulative per-ledger totals.
         let expired_partitions: Vec<ExpiringPartitionInfo> = self.ledgers.expire_partitions(
             epoch_height,
             cascade_active,

--- a/crates/tooling/multiversion-tests/src/tests/helpers.rs
+++ b/crates/tooling/multiversion-tests/src/tests/helpers.rs
@@ -6,8 +6,16 @@ use crate::binary::ResolvedBinary;
 use crate::cluster::{ClusterSpec, NodeSpec};
 use crate::config::NodeRole;
 
-pub(super) const HEIGHT_TIMEOUT: Duration = Duration::from_secs(120);
-pub(super) const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(120);
+// These bound the post-action waits (chain height advancing, cluster
+// re-converging). The upgrade tests restart real node processes mid-run: after
+// a restart a node must resume its VDF and re-mine, or resync from peers before
+// it can catch back up to the tip. On a shared CI runner those steps contend
+// for CPU with the other node processes and can briefly stall, so the budget
+// has to cover a slow restart, not just steady-state block time. A wait returns
+// as soon as its condition holds, so a generous ceiling only costs wall-clock on
+// a genuinely stuck run — it does not slow the common case.
+pub(super) const HEIGHT_TIMEOUT: Duration = Duration::from_secs(240);
+pub(super) const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(240);
 
 /// Shared run directory for all tests in this invocation.
 /// Set via `IRYS_RUN_ID` env var (xtask sets this to a timestamp).

--- a/crates/tooling/multiversion-tests/src/tests/helpers.rs
+++ b/crates/tooling/multiversion-tests/src/tests/helpers.rs
@@ -6,14 +6,10 @@ use crate::binary::ResolvedBinary;
 use crate::cluster::{ClusterSpec, NodeSpec};
 use crate::config::NodeRole;
 
-// These bound the post-action waits (chain height advancing, cluster
-// re-converging). The upgrade tests restart real node processes mid-run: after
-// a restart a node must resume its VDF and re-mine, or resync from peers before
-// it can catch back up to the tip. On a shared CI runner those steps contend
-// for CPU with the other node processes and can briefly stall, so the budget
-// has to cover a slow restart, not just steady-state block time. A wait returns
-// as soon as its condition holds, so a generous ceiling only costs wall-clock on
-// a genuinely stuck run — it does not slow the common case.
+// Upgrade tests restart real node processes mid-run; a restarted node must
+// resume VDF/re-mine or resync from peers under CI CPU contention before it can
+// catch back up to the tip. A wait returns as soon as its condition holds, so a
+// generous ceiling only costs wall-clock on a genuinely stuck run.
 pub(super) const HEIGHT_TIMEOUT: Duration = Duration::from_secs(240);
 pub(super) const CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(240);
 


### PR DESCRIPTION
## Problem

The Submit ledger's two "expired" sets disagree about slots that receive data *after* expiring, and the write frontier could end up inside such a slot:

- The **refund/settlement pipeline** keys on newly-expiring slots (`get_expired_slot_indexes`, filters `!is_expired`) — each slot settles exactly once, covering the txs present at that moment.
- The **promotion filter** (producer + validator) keys on the inclusive all-expired set (`get_all_expired_slot_indexes`, no such filter) — a slot that ever expired blocks promotion of its txs forever.

Chunk offsets are strictly cumulative and headroom slots are preallocated above the write frontier, so a **partially-written frontier slot** is written ✓, aged ✓ (after a full-term ingress stall), and no longer the protected last slot ✓ — nothing checked whether it was *full*. It expired half-filled: settled once, partitions recycled, `is_expired` set forever (`touch_filled_slots` deliberately never resurrects it).

Every Submit tx appended after that landed at the frontier — inside the dead slot — and was:

1. **charged** term_fee + perm_fee at inclusion,
2. **never promotable** — its start offset sits inside `[0, range_end)` permanently; producer filters it, validators reject blocks promoting it,
3. **never refunded** — the slot's one settlement already happened,
4. **never stored** — no partitions are ever re-assigned to an expired slot.

Reachability: ≥2 allocated slots (i.e. total ingress past the ~half-partition allocation trigger) plus one full Submit-term lull with the frontier mid-slot (testnet: ~5h). The pre-Cascade variant is worse — expiry is allocation-anchored with no touch, so slot 0 expires under the frontier at the very epoch headroom is allocated. Neither mainnet nor testnet has ever expired a slot (no capacity growth yet), so no chain state is affected.

## Fix

**Post-Cascade, a slot may only expire once it is fully written** — its entire chunk range at or below the ledger's cumulative total (`fully_written_slot_count` in `data_ledger.rs`, a hard conjunct in the settlement set, the promotion-blocked set, and the perm-ledger path).

"Never expire the last slot" was always a proxy for "never expire the growth edge"; preallocation broke the proxy by moving the last slot above the write head. This targets the write head directly, making **"no write ever lands in an expired slot" structural** — the stranding chain can't start — and strengthening the contiguous-prefix invariant the promotion filter's `[0, range_end)` math already relies on.

- All three sets receive the same write-frontier inputs (per-ledger cumulative totals from the epoch block + `num_chunks_in_partition`, the same model `touch_filled_slots` uses), so recycle / settlement / promotion-blocking cannot diverge.
- Gated on `cascade_active`, same as the `has_been_written` filter: pre-Cascade replay is bit-identical. Safe because no slot has ever expired on mainnet or testnet.
- `chunks_per_slot == 0` fails safe (nothing counts as fully written).
- Trade-off (bounded, mirrors existing last-slot semantics): a slot that never fills never expires — its data stays live, promotable, and stored; settlement waits for the fill.

## Testing

- **New unit tests** (`data_ledger.rs`): frontier slot survives in both sets; full lifecycle (survive stall → refill refreshes clock → expires a term after fill); pre-Cascade replay identity; zero-`chunks_per_slot` fail-safe. All verified red against the old code.
- **New e2e test** (`ledger_expiry.rs`): canonical `perform_epoch_tasks` epochs through a full-term stall; asserts the frontier slot never expires, `expired_submit_range.range_end` stops at the last full slot's boundary, and the refill refreshes the clock. Verified to fail against the old logic.
- **Two chain-tests re-pinned** — they encoded the old partial-slot recycling: `heavy_cascade_spanning_tx_last_write_expiry` (partial tail slot now survives; fills at E_c; expires at E_c + window) and `heavy_cascade_rescued_slot_defers_reward_and_refund` (slot fills at F; deferred refund lands at F + window).
- **Green**: irys-database (92), irys-domain (156), irys-actors (412), all 29 expiry-related chain-tests — including `slow_heavy_cascade_midchain_submit_expiry_refunds_across_activation` and both promotion-rejection tests — and `cargo xtask local-checks`.

## Deployment notes

- **Mainnet** has no Cascade scheduled; pre-Cascade expiry is untouched by this fix. Cascade needs to activate before Submit ingress crosses ~half a partition (~9.7 TB, the headroom-allocation trigger), or slot 0 expires under the frontier and becomes an unrecoverable dead zone (expired slots are never resurrected).
- **Testnet** is already post-Cascade: during a mixed-version rollout, old/new nodes would disagree the first time a partially-written non-last slot crosses its term (first term-ledger write + one full-term lull), so deploy coordinated.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated transaction expiry handling to account for partially written ledger slots.
  * Prevented the active write-frontier slot from expiring until it is fully written.
  * Corrected deferred refund timing when rescued slots are refilled.
  * Improved expiration behavior across Cascade transitions.

* **Tests**
  * Added coverage for stalled ingress, slot refilling, and frontier expiry scenarios.
  * Expanded validation of expiry ranges and reward/refund timing.

* **Chores**
  * Increased multiversion test wait timeouts for slower environments.
  * Clarified expiration behavior in validation documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->