### PR TITLE
docs: capture shadow-tx fee-in-packet hardfork follow-up

### DIFF
--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -5002,6 +5002,15 @@ type ActualShadowTx = (ShadowTransaction, u128);
 ///    producer keeps a valid packet but inflates the envelope tip to drain the
 ///    fee-payer. EL charges that tip as raw wei before packet execution; without
 ///    this check the tip was producer-controlled and not consensus-pinned.
+///
+/// # Hardfork follow-up (do not drop this check lightly)
+///
+/// This is an **interim soft-fork** pin of a dual-channel fee model: the tip
+/// still lives on the EIP-1559 envelope, not in the borsh packet. Removing or
+/// bypassing the tip equality re-opens funds theft. The structural fix is a
+/// future hardfork that embeds the fee in the packet (e.g. shadow V2) so CL
+/// packet equality alone is SSOT — see
+/// `design/docs/shadow-tx-priority-fee-in-packet-hardfork.md`.
 #[tracing::instrument(level = "trace", skip_all, err)]
 fn validate_shadow_transactions_match(
     actual: impl Iterator<Item = eyre::Result<ActualShadowTx>>,
@@ -5046,6 +5055,8 @@ fn validate_shadow_transactions_match(
 
         // Consensus tip: must equal the generator's `transaction_fee` (honest
         // producer path sets compose(..., metadata.transaction_fee)).
+        // INTERIM: dual channel (envelope tip). Do not remove without the
+        // hardfork in design/docs/shadow-tx-priority-fee-in-packet-hardfork.md.
         ensure!(
             actual_priority_fee == expected.transaction_fee,
             "Shadow transaction priority fee mismatch at idx {}. expected {}, got {}",

--- a/crates/irys-reth/src/evm.rs
+++ b/crates/irys-reth/src/evm.rs
@@ -697,9 +697,14 @@ where
 
         tracing::trace!("executing shadow transaction");
 
-        // Calculate and distribute priority fee to beneficiary BEFORE executing shadow tx
+        // Calculate and distribute priority fee to beneficiary BEFORE executing shadow tx.
         // note: gas_priority_fee is `max_priority_fee_per_gas`, remapped in `impl FromRecoveredTx<TxEip1559> for TxEnv` in alloy-revm
         // no idea why the name is different though.
+        //
+        // Fee source is the EIP-1559 *envelope* tip (raw wei, not × gas), not the borsh
+        // packet. CL pins this field to the generator fee (interim). HARD FORK follow-up:
+        // charge the fee from the packet so the validated object is SSOT —
+        // design/docs/shadow-tx-priority-fee-in-packet-hardfork.md
         let priority_fee = tx.gas_priority_fee.unwrap_or(0);
         let total_fee = U256::from(priority_fee);
 
@@ -886,6 +891,11 @@ where
     /// - Target account doesn't exist
     /// - Target has insufficient balance
     /// - Database operation failures
+    ///
+    /// ## Consensus note
+    /// The tip amount is not in the borsh packet today; CL must validate the envelope tip
+    /// (interim soft-fork). Future hardfork should take the fee from the packet —
+    /// `design/docs/shadow-tx-priority-fee-in-packet-hardfork.md`.
     pub fn distribute_priority_fee(
         &mut self,
         total_fee: U256,

--- a/crates/irys-reth/src/shadow_tx.rs
+++ b/crates/irys-reth/src/shadow_tx.rs
@@ -193,6 +193,12 @@ impl ShadowTransaction {
     }
 
     /// Compose this shadow transaction into an EIP-1559 transaction for inclusion in a block.
+    ///
+    /// `max_priority_fee_per_gas` is charged by the EL as **raw wei** (not × gas) from the
+    /// packet fee-payer to the miner. It is consensus-critical today: CL must match it to
+    /// the generator's `transaction_fee` (interim soft-fork). The fee is **not** in the borsh
+    /// packet — a future hardfork should embed it so compose cannot diverge from the
+    /// validated object. See `design/docs/shadow-tx-priority-fee-in-packet-hardfork.md`.
     #[must_use]
     pub fn compose(&self, chain_id: u64, max_priority_fee_per_gas: u128) -> TxEip1559 {
         let shadow_tx_buf = encode_prefixed_input(self);

--- a/design/docs/shadow-tx-priority-fee-in-packet-hardfork.md
+++ b/design/docs/shadow-tx-priority-fee-in-packet-hardfork.md
@@ -2,10 +2,12 @@
 
 ## Status
 
-**Accepted intent — deferred hardfork.**  
-Interim soft-fork mitigation has shipped (or is shipping) as PR
-[#1478](https://github.com/Irys-xyz/irys/pull/1478): consensus validates the
-EIP-1559 envelope tip against `ShadowMetadata.transaction_fee`.
+**Accepted intent — deferred hardfork.**
+
+**Interim soft-fork shipped** as PR
+[#1478](https://github.com/Irys-xyz/irys/pull/1478) (merged to `master`):
+consensus validates the EIP-1559 envelope tip against
+`ShadowMetadata.transaction_fee`.
 
 This document captures the **follow-up hardfork** so the dual-channel fee
 model is not re-opened by a future regression that drops the CL tip check.
@@ -19,15 +21,17 @@ then. Implementation steps follow
 
 Shadow transactions carry economic fees in **two places**:
 
-| Channel | Location | Historical consensus check |
+| Channel | Location | Consensus check |
 | --- | --- | --- |
 | Packet body | Borsh `ShadowTransaction` in `tx.input` | Yes — CL regenerates and compares packets |
-| Priority tip | EIP-1559 `max_priority_fee_per_gas` | **No** (until PR #1478) |
+| Priority tip | EIP-1559 `max_priority_fee_per_gas` | Yes **after** [#1478](https://github.com/Irys-xyz/irys/pull/1478); **No** before |
 
 The EL (`IrysEvm::process_shadow_tx`) distributes the tip as **raw wei**
 (`gas_priority_fee` ← `max_priority_fee_per_gas`, not × gas) from
 `packet.fee_payer_address()` to the block beneficiary **before** executing the
-packet body.
+packet body. Shadow txs short-circuit standard revm fee accounting
+(`transact_raw` → `process_shadow_tx`); other envelope fields (`max_fee_per_gas`,
+`gas_limit`) are unread on that path and are **not** the skim vector.
 
 Without pinning the tip, a producer could keep a valid packet and inflate the
 envelope tip to drain the fee-payer. State roots still matched (all nodes
@@ -37,20 +41,24 @@ Honest nonzero tips are intentional for several packet types (commitment
 `tx.fee()`, storage block-producer share of term fee, fee-only unstake/unpledge
 inclusion). Banning all nonzero tips except BlockReward is **not** a valid fix.
 
-## Interim mitigation (soft fork)
+## Interim mitigation (soft fork) — shipped
 
-PR #1478 — `validate_shadow_transactions_match`:
+PR [#1478](https://github.com/Irys-xyz/irys/pull/1478) —
+`validate_shadow_transactions_match`:
 
 ```text
-actual.max_priority_fee_per_gas == expected.transaction_fee
+actual.max_priority_fee_per_gas.unwrap_or(0) == expected.transaction_fee
 ```
 
-- Wire format and EL unchanged.
+- Wire format and EL unchanged; fee still charged from the envelope tip.
 - Strictly fewer valid blocks (soft fork).
-- Dual channel remains: fee is still on the envelope; CL must keep checking it.
+- Legacy / non-dynamic-fee envelopes expose `None` tip → normalized to `0`
+  (must match generator fee `0` for fee-less packets such as BlockReward / refunds).
+- Dual channel remains: CL must keep checking the tip until this hardfork.
 
 **Risk if interim is removed:** skim re-opens. Any refactor of shadow validation
-must preserve the tip equality check until this hardfork activates.
+must preserve the tip equality check until this hardfork activates. Code anchors
+link back here under "Hardfork follow-up / INTERIM".
 
 ## Hardfork goal
 
@@ -68,11 +76,12 @@ Nonzero tips remain valid where the generator sets them; BlockReward stays fee `
 
 | Phase | Behavior |
 | --- | --- |
-| Pre-activation | V1 packets; envelope tip used by EL; CL tip check (PR #1478) required |
+| Pre-activation (today) | V1 packets; EL uses envelope tip; CL tip check (PR #1478) required |
 | Activation | Timestamp hardfork (same pattern as Aurora / Cascade) |
 | Post-activation | V2 (or fee-in-packet) required; EL uses packet fee; V1 rejected (or deprecated path only if explicitly designed) |
 
-Name the hardfork when scheduled; do not invent a stub flag in config until then.
+Name the hardfork when scheduled (next letter after Cascade is open); do not
+invent a stub flag in config until then.
 
 ## Implementation checklist
 
@@ -84,7 +93,7 @@ When implementing (see also authoring hardforks guide):
 - [ ] EL after activation: charge packet fee; reject mismatched envelope if kept as mirror
 - [ ] CL: packet equality covers fee; optional defense-in-depth envelope == packet fee
 - [ ] BlockReward: fee must be 0 (EL + generator)
-- [ ] Pre-activation tests: V1 + CL tip check still works
+- [ ] Pre-activation tests: V1 + CL tip check still works (`shadow_tx_priority_fee_match` suite)
 - [ ] Post-activation tests: inflate envelope with correct packet fee fails if packet is SSOT; wrong packet fee fails
 - [ ] Config: hardfork struct + activation timestamp; defaults for test/main
 - [ ] Update this doc status to **Implemented** and link the HF PR
@@ -103,6 +112,9 @@ When implementing (see also authoring hardforks guide):
 - Ban all nonzero priority fees (breaks honest stake/storage BP paths).
 - Change commitment or term fee *schedules* (only *where* the fee is encoded).
 - Soft-fork-only forever (acceptable interim; not structural end state).
+- Pinning unread envelope fields (`max_fee_per_gas`, `gas_limit`) for skim
+  safety — they do not affect the EL transfer today; the hardfork SSOT is the
+  packet fee, not a fuller EIP-1559 field set.
 
 ## Code anchors (interim dual channel)
 
@@ -111,9 +123,11 @@ Until the hardfork lands, these sites document the dual channel:
 - CL match: `validate_shadow_transactions_match` in `block_validation.rs`
 - EL charge: `process_shadow_tx` priority fee in `evm.rs`
 - Producer compose: `ShadowTransaction::compose` in `shadow_tx.rs`
+- Unit coverage: `shadow_tx_priority_fee_match_tests` in `block_validation.rs`
+  (skim regression, zero-expected, packet-mismatch order, legacy `None` tip)
 
 ## References
 
-- Interim fix: https://github.com/Irys-xyz/irys/pull/1478
+- Interim fix (merged): https://github.com/Irys-xyz/irys/pull/1478
 - Hardfork authoring: `docs/99-reference/06-authoring-hardforks.md`
 - Shadow module overview: `crates/irys-reth/src/shadow_tx.rs` module docs

--- a/design/docs/shadow-tx-priority-fee-in-packet-hardfork.md
+++ b/design/docs/shadow-tx-priority-fee-in-packet-hardfork.md
@@ -1,0 +1,119 @@
+# Hardfork (deferred): Embed shadow-tx priority fee in the borsh packet
+
+## Status
+
+**Accepted intent — deferred hardfork.**  
+Interim soft-fork mitigation has shipped (or is shipping) as PR
+[#1478](https://github.com/Irys-xyz/irys/pull/1478): consensus validates the
+EIP-1559 envelope tip against `ShadowMetadata.transaction_fee`.
+
+This document captures the **follow-up hardfork** so the dual-channel fee
+model is not re-opened by a future regression that drops the CL tip check.
+
+**Do not** add a named hardfork stub to `IrysHardforkConfig` until product
+names and schedules the cut. Use this doc + GitHub issue for tracking until
+then. Implementation steps follow
+[`docs/99-reference/06-authoring-hardforks.md`](../../docs/99-reference/06-authoring-hardforks.md).
+
+## Problem
+
+Shadow transactions carry economic fees in **two places**:
+
+| Channel | Location | Historical consensus check |
+| --- | --- | --- |
+| Packet body | Borsh `ShadowTransaction` in `tx.input` | Yes — CL regenerates and compares packets |
+| Priority tip | EIP-1559 `max_priority_fee_per_gas` | **No** (until PR #1478) |
+
+The EL (`IrysEvm::process_shadow_tx`) distributes the tip as **raw wei**
+(`gas_priority_fee` ← `max_priority_fee_per_gas`, not × gas) from
+`packet.fee_payer_address()` to the block beneficiary **before** executing the
+packet body.
+
+Without pinning the tip, a producer could keep a valid packet and inflate the
+envelope tip to drain the fee-payer. State roots still matched (all nodes
+re-executed the same payload). That is funds theft without a fork.
+
+Honest nonzero tips are intentional for several packet types (commitment
+`tx.fee()`, storage block-producer share of term fee, fee-only unstake/unpledge
+inclusion). Banning all nonzero tips except BlockReward is **not** a valid fix.
+
+## Interim mitigation (soft fork)
+
+PR #1478 — `validate_shadow_transactions_match`:
+
+```text
+actual.max_priority_fee_per_gas == expected.transaction_fee
+```
+
+- Wire format and EL unchanged.
+- Strictly fewer valid blocks (soft fork).
+- Dual channel remains: fee is still on the envelope; CL must keep checking it.
+
+**Risk if interim is removed:** skim re-opens. Any refactor of shadow validation
+must preserve the tip equality check until this hardfork activates.
+
+## Hardfork goal
+
+Make the consensus fee part of the object CL already equality-checks: the
+borsh shadow packet (or a versioned wrapper). After activation:
+
+1. Fee is encoded in the packet (e.g. `ShadowTransaction::V2 { …, priority_fee }`
+   or a field on debit-carrying variants).
+2. EL charges **packet fee** as the SSOT (and/or requires envelope tip ≡ packet fee).
+3. Packet equality alone implies fee equality — no second channel to forget.
+
+Nonzero tips remain valid where the generator sets them; BlockReward stays fee `0`.
+
+## Activation sketch
+
+| Phase | Behavior |
+| --- | --- |
+| Pre-activation | V1 packets; envelope tip used by EL; CL tip check (PR #1478) required |
+| Activation | Timestamp hardfork (same pattern as Aurora / Cascade) |
+| Post-activation | V2 (or fee-in-packet) required; EL uses packet fee; V1 rejected (or deprecated path only if explicitly designed) |
+
+Name the hardfork when scheduled; do not invent a stub flag in config until then.
+
+## Implementation checklist
+
+When implementing (see also authoring hardforks guide):
+
+- [ ] Versioned packet: borsh-stable V2 (or equivalent) with fee field; keep V1 decode for history
+- [ ] `ShadowTxGenerator` / `ShadowMetadata`: write fee into the packet, not only metadata
+- [ ] `compose`: envelope tip mirrors packet fee (or forced 0 if EL ignores envelope post-HF)
+- [ ] EL after activation: charge packet fee; reject mismatched envelope if kept as mirror
+- [ ] CL: packet equality covers fee; optional defense-in-depth envelope == packet fee
+- [ ] BlockReward: fee must be 0 (EL + generator)
+- [ ] Pre-activation tests: V1 + CL tip check still works
+- [ ] Post-activation tests: inflate envelope with correct packet fee fails if packet is SSOT; wrong packet fee fails
+- [ ] Config: hardfork struct + activation timestamp; defaults for test/main
+- [ ] Update this doc status to **Implemented** and link the HF PR
+
+### Blast radius (files)
+
+- `crates/irys-reth/src/shadow_tx.rs` — version, encode/decode, `compose`
+- `crates/irys-reth/src/evm.rs` — fee source in `process_shadow_tx` / `distribute_priority_fee`
+- `crates/actors/src/shadow_tx_generator.rs` — fee into packet
+- `crates/actors/src/block_producer.rs` — compose path
+- `crates/actors/src/block_validation.rs` — expected/actual match
+- Chain-tests / reth shadow-tx tests / fixtures
+
+## Non-goals
+
+- Ban all nonzero priority fees (breaks honest stake/storage BP paths).
+- Change commitment or term fee *schedules* (only *where* the fee is encoded).
+- Soft-fork-only forever (acceptable interim; not structural end state).
+
+## Code anchors (interim dual channel)
+
+Until the hardfork lands, these sites document the dual channel:
+
+- CL match: `validate_shadow_transactions_match` in `block_validation.rs`
+- EL charge: `process_shadow_tx` priority fee in `evm.rs`
+- Producer compose: `ShadowTransaction::compose` in `shadow_tx.rs`
+
+## References
+
+- Interim fix: https://github.com/Irys-xyz/irys/pull/1478
+- Hardfork authoring: `docs/99-reference/06-authoring-hardforks.md`
+- Shadow module overview: `crates/irys-reth/src/shadow_tx.rs` module docs


### PR DESCRIPTION
## Summary

Follow-up to #1478 (interim soft-fork: CL pins shadow-tx envelope tips).

- Adds `design/docs/shadow-tx-priority-fee-in-packet-hardfork.md` — deferred hardfork plan to embed the consensus fee in the borsh packet (structural SSOT).
- Pins dual-channel / “do not drop tip check” notes at:
  - CL `validate_shadow_transactions_match`
  - EL `process_shadow_tx` / `distribute_priority_fee`
  - `ShadowTransaction::compose`

No runtime behavior change. Stacks on #1478.

## Why

The soft-fork leaves fee on the EIP-1559 envelope. Without a tracked hardfork path, a future refactor could drop the tip equality check and re-open the skim. This PR freezes intent, activation sketch, checklist, and code anchors.

## Test plan

- [x] Docs-only + comments (no logic change)
- [ ] Optional: open GitHub issue from design doc for scheduling (product)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how shadow-transaction priority fees are validated, calculated, and sourced during the interim fee model.
  - Documented the requirement for envelope tips and consensus fee values to remain aligned.
  - Added design documentation for a future hardfork that would store priority fees directly in transaction packets.
  - Confirmed that current transaction behavior, wire formats, and fee charging remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->