### PR TITLE
feat(api): add GET /v1/mempool/txs pending transaction list

### DIFF
--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -936,6 +936,95 @@ impl AtomicMempoolState {
         }
     }
 
+    /// Snapshot of unconfirmed pending transactions for the public list API.
+    ///
+    /// Filters out txs that already carry confirmation metadata (`included_height`
+    /// / `promoted_height`) so the list matches "still awaiting inclusion".
+    /// Collects light metadata only (ids, sizes, roots) under a single read lock;
+    /// `limit` caps each returned list (callers should clamp to
+    /// [`MEMPOOL_TXS_MAX_LIMIT`]).
+    ///
+    /// Order is stable by transaction id (base58 `H256` byte order).
+    ///
+    /// Best-effort under contention: returns an empty list when the read lock
+    /// cannot be acquired (same pattern as `get_status`).
+    pub async fn get_pending_txs(
+        &self,
+        config: &NodeConfig,
+        chunk_ingress: &ChunkIngressState,
+        limit: usize,
+    ) -> MempoolPendingTxs {
+        let pending_chunks_count = chunk_ingress.pending_chunks_count().await;
+        let chunk_size = config.consensus_config().chunk_size.max(1);
+
+        let state = match self.read().await {
+            Ok(g) => g,
+            Err(e) => {
+                warn!(
+                    ?e,
+                    "Mempool read lock contention; get_pending_txs returning empty"
+                );
+                return MempoolPendingTxs::empty(pending_chunks_count);
+            }
+        };
+
+        // Unconfirmed data txs only — confirmed ones stay in mempool for reorgs.
+        let mut data_txs: Vec<MempoolPendingDataTx> = state
+            .valid_submit_ledger_tx
+            .values()
+            .filter(|tx| {
+                tx.metadata().included_height.is_none() && tx.promoted_height().is_none()
+            })
+            .map(|tx| {
+                let byte_size = tx.data_size;
+                MempoolPendingDataTx {
+                    id: tx.id,
+                    byte_size,
+                    chunks: byte_size.div_ceil(chunk_size),
+                    data_root: tx.data_root,
+                    ledger_id: tx.ledger_id,
+                }
+            })
+            .collect();
+        data_txs.sort_by(|a, b| a.id.cmp(&b.id));
+
+        let mut commitment_txs: Vec<MempoolPendingCommitmentTx> = state
+            .valid_commitment_tx
+            .values()
+            .flatten()
+            .filter(|tx| tx.metadata().included_height.is_none())
+            .map(|tx| MempoolPendingCommitmentTx {
+                id: tx.id(),
+                address: tx.signer(),
+            })
+            .collect();
+        commitment_txs.sort_by(|a, b| a.id.cmp(&b.id));
+
+        let total_data_tx_count = data_txs.len();
+        let total_commitment_tx_count = commitment_txs.len();
+        let data_truncated = total_data_tx_count > limit;
+        let commitment_truncated = total_commitment_tx_count > limit;
+        let truncated = data_truncated || commitment_truncated;
+
+        if data_truncated {
+            data_txs.truncate(limit);
+        }
+        if commitment_truncated {
+            commitment_txs.truncate(limit);
+        }
+
+        MempoolPendingTxs {
+            data_tx_count: data_txs.len(),
+            commitment_tx_count: commitment_txs.len(),
+            data_txs,
+            commitment_txs,
+            pending_chunks_count,
+            truncated,
+            total_data_tx_count: truncated.then_some(total_data_tx_count),
+            total_commitment_tx_count: truncated.then_some(total_commitment_tx_count),
+        }
+    }
+
     pub async fn mark_fingerprint_as_invalid(&self, fingerprint: H256) {
         match self.write().await {
             Ok(mut g) => {

--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -938,29 +938,29 @@ impl AtomicMempoolState {
 
     /// Unconfirmed pending txs for `GET /v1/mempool/txs`.
     ///
-    /// Omits confirmed metadata (`included_height` / `promoted_height`). Sorted
-    /// ascending by raw `H256` id; `after_id` returns ids strictly greater
-    /// (forward page). `chunk_size` derives `chunks` (clamped to ≥1). Best-effort
-    /// empty on lock contention (same as `get_status`).
+    /// Omits confirmed metadata (`included_height` / `promoted_height`). Each
+    /// list is sorted ascending by raw `H256` id and paged independently via
+    /// [`MempoolTxsCursor`]. `chunk_size` derives `chunks` (clamped to ≥1).
+    /// Best-effort empty on lock contention (same as `get_status`).
     pub async fn get_pending_txs(
         &self,
         chunk_size: u64,
         chunk_ingress: &ChunkIngressState,
         limit: usize,
-        after_id: Option<H256>,
+        cursor: MempoolTxsCursor,
     ) -> MempoolPendingTxs {
-        /// Sort/dedup by id, apply `after_id`, truncate to `limit`.
+        /// Sort/dedup by id, apply list-local `after`, truncate to `limit`.
         /// Returns `(page, full_unconfirmed_total, has_more)`.
         fn paginate_by_id<T>(
             mut items: Vec<T>,
             id_of: impl Fn(&T) -> H256,
-            after_id: Option<H256>,
+            after: Option<H256>,
             limit: usize,
         ) -> (Vec<T>, usize, bool) {
             items.sort_by_key(&id_of);
             items.dedup_by(|a, b| id_of(a) == id_of(b));
             let total = items.len();
-            if let Some(after) = after_id {
+            if let Some(after) = after {
                 items.retain(|t| id_of(t) > after);
             }
             let more = items.len() > limit;
@@ -1018,10 +1018,11 @@ impl AtomicMempoolState {
             .collect();
 
         let (data_txs, total_data_tx_count, data_more) =
-            paginate_by_id(data_txs, |t| t.id, after_id, limit);
+            paginate_by_id(data_txs, |t| t.id, cursor.after_data_id, limit);
         let (commitment_txs, total_commitment_tx_count, commitment_more) =
-            paginate_by_id(commitment_txs, |t| t.id, after_id, limit);
+            paginate_by_id(commitment_txs, |t| t.id, cursor.after_commitment_id, limit);
         let truncated = data_more || commitment_more;
+        let next_cursor = truncated.then(|| cursor.advance(&data_txs, &commitment_txs).encode());
 
         MempoolPendingTxs {
             data_tx_count: data_txs.len(),
@@ -1030,6 +1031,7 @@ impl AtomicMempoolState {
             commitment_txs,
             pending_chunks_count,
             truncated,
+            next_cursor,
             total_data_tx_count: truncated.then_some(total_data_tx_count),
             total_commitment_tx_count: truncated.then_some(total_commitment_tx_count),
         }

--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -972,9 +972,7 @@ impl AtomicMempoolState {
         let mut data_txs: Vec<MempoolPendingDataTx> = state
             .valid_submit_ledger_tx
             .values()
-            .filter(|tx| {
-                tx.metadata().included_height.is_none() && tx.promoted_height().is_none()
-            })
+            .filter(|tx| tx.metadata().included_height.is_none() && tx.promoted_height().is_none())
             .map(|tx| {
                 let byte_size = tx.data_size;
                 MempoolPendingDataTx {

--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -936,26 +936,40 @@ impl AtomicMempoolState {
         }
     }
 
-    /// Snapshot of unconfirmed pending transactions for the public list API.
+    /// Unconfirmed pending txs for `GET /v1/mempool/txs`.
     ///
-    /// Filters out txs that already carry confirmation metadata (`included_height`
-    /// / `promoted_height`) so the list matches "still awaiting inclusion".
-    /// Collects light metadata only (ids, sizes, roots) under a single read lock;
-    /// `limit` caps each returned list (callers should clamp to
-    /// [`MEMPOOL_TXS_MAX_LIMIT`]).
-    ///
-    /// Order is stable by transaction id (base58 `H256` byte order).
-    ///
-    /// Best-effort under contention: returns an empty list when the read lock
-    /// cannot be acquired (same pattern as `get_status`).
+    /// Omits confirmed metadata (`included_height` / `promoted_height`). Sorted
+    /// ascending by raw `H256` id; `after_id` returns ids strictly greater
+    /// (forward page). `chunk_size` derives `chunks` (clamped to ≥1). Best-effort
+    /// empty on lock contention (same as `get_status`).
     pub async fn get_pending_txs(
         &self,
-        config: &NodeConfig,
+        chunk_size: u64,
         chunk_ingress: &ChunkIngressState,
         limit: usize,
+        after_id: Option<H256>,
     ) -> MempoolPendingTxs {
+        /// Sort/dedup by id, apply `after_id`, truncate to `limit`.
+        /// Returns `(page, full_unconfirmed_total, has_more)`.
+        fn paginate_by_id<T>(
+            mut items: Vec<T>,
+            id_of: impl Fn(&T) -> H256,
+            after_id: Option<H256>,
+            limit: usize,
+        ) -> (Vec<T>, usize, bool) {
+            items.sort_by_key(&id_of);
+            items.dedup_by(|a, b| id_of(a) == id_of(b));
+            let total = items.len();
+            if let Some(after) = after_id {
+                items.retain(|t| id_of(t) > after);
+            }
+            let more = items.len() > limit;
+            items.truncate(limit);
+            (items, total, more)
+        }
+
         let pending_chunks_count = chunk_ingress.pending_chunks_count().await;
-        let chunk_size = config.consensus_config().chunk_size.max(1);
+        let chunk_size = chunk_size.max(1);
 
         let state = match self.read().await {
             Ok(g) => g,
@@ -968,8 +982,8 @@ impl AtomicMempoolState {
             }
         };
 
-        // Unconfirmed data txs only — confirmed ones stay in mempool for reorgs.
-        let mut data_txs: Vec<MempoolPendingDataTx> = state
+        // Confirmed txs stay in mempool for reorgs — exclude them here.
+        let data_txs: Vec<MempoolPendingDataTx> = state
             .valid_submit_ledger_tx
             .values()
             .filter(|tx| tx.metadata().included_height.is_none() && tx.promoted_height().is_none())
@@ -984,32 +998,30 @@ impl AtomicMempoolState {
                 }
             })
             .collect();
-        data_txs.sort_by(|a, b| a.id.cmp(&b.id));
 
-        let mut commitment_txs: Vec<MempoolPendingCommitmentTx> = state
+        // Include `pending_pledges` (out-of-order, still unconfirmed).
+        let commitment_txs: Vec<MempoolPendingCommitmentTx> = state
             .valid_commitment_tx
             .values()
             .flatten()
+            .chain(
+                state
+                    .pending_pledges
+                    .iter()
+                    .flat_map(|(_, inner)| inner.iter().map(|(_, tx)| tx)),
+            )
             .filter(|tx| tx.metadata().included_height.is_none())
             .map(|tx| MempoolPendingCommitmentTx {
                 id: tx.id(),
                 address: tx.signer(),
             })
             .collect();
-        commitment_txs.sort_by(|a, b| a.id.cmp(&b.id));
 
-        let total_data_tx_count = data_txs.len();
-        let total_commitment_tx_count = commitment_txs.len();
-        let data_truncated = total_data_tx_count > limit;
-        let commitment_truncated = total_commitment_tx_count > limit;
-        let truncated = data_truncated || commitment_truncated;
-
-        if data_truncated {
-            data_txs.truncate(limit);
-        }
-        if commitment_truncated {
-            commitment_txs.truncate(limit);
-        }
+        let (data_txs, total_data_tx_count, data_more) =
+            paginate_by_id(data_txs, |t| t.id, after_id, limit);
+        let (commitment_txs, total_commitment_tx_count, commitment_more) =
+            paginate_by_id(commitment_txs, |t| t.id, after_id, limit);
+        let truncated = data_more || commitment_more;
 
         MempoolPendingTxs {
             data_tx_count: data_txs.len(),

--- a/crates/actors/src/mempool_service/types.rs
+++ b/crates/actors/src/mempool_service/types.rs
@@ -31,66 +31,48 @@ pub struct MempoolStatus {
     pub commitment_address_capacity_pct: f64,
 }
 
-/// Light metadata for a pending data transaction in the mempool list API.
-///
-/// IDs use the same base58 encoding as block ledger `txIds` and `GET /v1/tx/{id}`.
+/// Pending data-tx entry for `GET /v1/mempool/txs` (id matches ledger / `/v1/tx/{id}`).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MempoolPendingDataTx {
-    /// Transaction id (base58 `H256`).
     pub id: H256,
-    /// Declared payload size in bytes (`data_size`).
     pub byte_size: u64,
-    /// Number of chunks implied by `byte_size` and consensus `chunk_size`
-    /// (`byte_size.div_ceil(chunk_size)`).
+    /// `byte_size.div_ceil(chunk_size)`.
     pub chunks: u64,
-    /// Merkle root of the transaction data chunks.
     pub data_root: H256,
-    /// Destination ledger id (e.g. Submit / term ledgers).
     pub ledger_id: u32,
 }
 
-/// Light metadata for a pending commitment transaction in the mempool list API.
+/// Pending commitment-tx entry for `GET /v1/mempool/txs`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MempoolPendingCommitmentTx {
-    /// Transaction id (base58 `H256`).
     pub id: H256,
-    /// Signer address.
     pub address: IrysAddress,
 }
 
-/// Response body for `GET /v1/mempool/txs`.
+/// `GET /v1/mempool/txs` response: unconfirmed txs only.
 ///
-/// Lists **unconfirmed** mempool transactions only (no `included_height` /
-/// `promoted_height` yet). Confirmed txs may still sit in mempool state for
-/// reorg handling; they are excluded so the list reflects txs still awaiting
-/// inclusion.
-///
-/// When `truncated` is true, `data_txs` / `commitment_txs` are capped by the
-/// request limit and `total_*_tx_count` carries the full unconfirmed totals.
-/// When not truncated, `data_tx_count` / `commitment_tx_count` match the array
-/// lengths (and equal the totals).
+/// When `truncated`, arrays are capped and `total_*_tx_count` holds full totals.
+/// Otherwise counts match array lengths.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MempoolPendingTxs {
     pub data_txs: Vec<MempoolPendingDataTx>,
     pub commitment_txs: Vec<MempoolPendingCommitmentTx>,
-    /// Number of data txs in `data_txs` (always equals `data_txs.len()`).
+    /// Always `data_txs.len()`.
     pub data_tx_count: usize,
-    /// Number of commitment txs in `commitment_txs` (always equals `commitment_txs.len()`).
+    /// Always `commitment_txs.len()`.
     pub commitment_tx_count: usize,
-    /// Pending chunk-ingress entries (same metric as `/v1/mempool/status`).
+    /// Same metric as `/v1/mempool/status`.
     pub pending_chunks_count: usize,
-    /// True when either list was cut short by the limit.
+    /// True when either list has more after the current page.
     pub truncated: bool,
-    /// Full unconfirmed data-tx count when `truncated` is true.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub total_data_tx_count: Option<usize>,
-    /// Full unconfirmed commitment-tx count when `truncated` is true.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub total_commitment_tx_count: Option<usize>,
 }
 
 impl MempoolPendingTxs {
-    /// Empty mempool response (HTTP 200, not 404).
+    /// Empty pool (HTTP 200, not 404).
     #[must_use]
     pub fn empty(pending_chunks_count: usize) -> Self {
         Self {

--- a/crates/actors/src/mempool_service/types.rs
+++ b/crates/actors/src/mempool_service/types.rs
@@ -6,6 +6,72 @@ pub const MEMPOOL_TXS_DEFAULT_LIMIT: usize = 100;
 /// Hard cap on `?limit=` for `GET /v1/mempool/txs` (prevents unbounded responses).
 pub const MEMPOOL_TXS_MAX_LIMIT: usize = 500;
 
+/// Independent forward positions for data and commitment lists.
+///
+/// Opaque wire form: `v1.<data_b58|_>.<commitment_b58|_>` (`_` = no bound).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MempoolTxsCursor {
+    pub after_data_id: Option<H256>,
+    pub after_commitment_id: Option<H256>,
+}
+
+impl MempoolTxsCursor {
+    const PREFIX: &'static str = "v1";
+    const NONE: &'static str = "_";
+
+    /// Encode for `?cursor=` / `next_cursor`.
+    #[must_use]
+    pub fn encode(&self) -> String {
+        format!(
+            "{}.{}.{}",
+            Self::PREFIX,
+            self.after_data_id
+                .map(|id| id.to_string())
+                .unwrap_or_else(|| Self::NONE.to_owned()),
+            self.after_commitment_id
+                .map(|id| id.to_string())
+                .unwrap_or_else(|| Self::NONE.to_owned()),
+        )
+    }
+
+    /// Parse `?cursor=`. Rejects unknown versions / malformed ids.
+    pub fn decode(s: &str) -> Result<Self, String> {
+        let parts: Vec<&str> = s.split('.').collect();
+        if parts.len() != 3 || parts[0] != Self::PREFIX {
+            return Err("expected v1.<data|_>.<commitment|_>".into());
+        }
+        Ok(Self {
+            after_data_id: Self::parse_part(parts[1], "data")?,
+            after_commitment_id: Self::parse_part(parts[2], "commitment")?,
+        })
+    }
+
+    fn parse_part(part: &str, label: &str) -> Result<Option<H256>, String> {
+        if part == Self::NONE || part.is_empty() {
+            return Ok(None);
+        }
+        H256::from_base58_result(part)
+            .map(Some)
+            .map_err(|e| format!("invalid {label} id in cursor: {e}"))
+    }
+
+    /// Advance each side to the last id returned on that page (keep prior if empty).
+    #[must_use]
+    pub fn advance(
+        self,
+        data_page: &[MempoolPendingDataTx],
+        commitment_page: &[MempoolPendingCommitmentTx],
+    ) -> Self {
+        Self {
+            after_data_id: data_page.last().map(|t| t.id).or(self.after_data_id),
+            after_commitment_id: commitment_page
+                .last()
+                .map(|t| t.id)
+                .or(self.after_commitment_id),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct MempoolStatus {
     /// Total number of data transactions
@@ -51,8 +117,8 @@ pub struct MempoolPendingCommitmentTx {
 
 /// `GET /v1/mempool/txs` response: unconfirmed txs only.
 ///
-/// When `truncated`, arrays are capped and `total_*_tx_count` holds full totals.
-/// Otherwise counts match array lengths.
+/// When `truncated`, arrays are capped, `total_*_tx_count` holds full totals, and
+/// `next_cursor` pages each list independently (no shared single-id cursor).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MempoolPendingTxs {
     pub data_txs: Vec<MempoolPendingDataTx>,
@@ -65,6 +131,9 @@ pub struct MempoolPendingTxs {
     pub pending_chunks_count: usize,
     /// True when either list has more after the current page.
     pub truncated: bool,
+    /// Opaque dual-list cursor for the next page (`?cursor=`). Present iff `truncated`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub total_data_tx_count: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -82,8 +151,47 @@ impl MempoolPendingTxs {
             commitment_tx_count: 0,
             pending_chunks_count,
             truncated: false,
+            next_cursor: None,
             total_data_tx_count: None,
             total_commitment_tx_count: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod cursor_tests {
+    use super::*;
+
+    #[test]
+    fn cursor_round_trips_both_bounds() {
+        let c = MempoolTxsCursor {
+            after_data_id: Some(H256([1; 32])),
+            after_commitment_id: Some(H256([2; 32])),
+        };
+        assert_eq!(MempoolTxsCursor::decode(&c.encode()).unwrap(), c);
+    }
+
+    #[test]
+    fn cursor_round_trips_none_markers() {
+        let c = MempoolTxsCursor::default();
+        assert_eq!(c.encode(), "v1._._");
+        assert_eq!(MempoolTxsCursor::decode(&c.encode()).unwrap(), c);
+    }
+
+    #[test]
+    fn cursor_rejects_bad_version() {
+        assert!(MempoolTxsCursor::decode("v0._._").is_err());
+        assert!(MempoolTxsCursor::decode("not-a-cursor").is_err());
+    }
+
+    #[test]
+    fn cursor_advance_keeps_prior_when_page_empty() {
+        let prev = MempoolTxsCursor {
+            after_data_id: Some(H256([9; 32])),
+            after_commitment_id: None,
+        };
+        let advanced = prev.advance(&[], &[]);
+        assert_eq!(advanced.after_data_id, Some(H256([9; 32])));
+        assert_eq!(advanced.after_commitment_id, None);
     }
 }

--- a/crates/actors/src/mempool_service/types.rs
+++ b/crates/actors/src/mempool_service/types.rs
@@ -1,5 +1,10 @@
-use irys_types::MempoolConsensusConfig;
-use serde::Serialize;
+use irys_types::{H256, IrysAddress, MempoolConsensusConfig};
+use serde::{Deserialize, Serialize};
+
+/// Default max entries returned per tx list when the client omits `?limit=`.
+pub const MEMPOOL_TXS_DEFAULT_LIMIT: usize = 100;
+/// Hard cap on `?limit=` for `GET /v1/mempool/txs` (prevents unbounded responses).
+pub const MEMPOOL_TXS_MAX_LIMIT: usize = 500;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct MempoolStatus {
@@ -24,4 +29,79 @@ pub struct MempoolStatus {
     pub data_tx_capacity_pct: f64,
     /// Capacity utilization percentage for commitment addresses (0-100)
     pub commitment_address_capacity_pct: f64,
+}
+
+/// Light metadata for a pending data transaction in the mempool list API.
+///
+/// IDs use the same base58 encoding as block ledger `txIds` and `GET /v1/tx/{id}`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MempoolPendingDataTx {
+    /// Transaction id (base58 `H256`).
+    pub id: H256,
+    /// Declared payload size in bytes (`data_size`).
+    pub byte_size: u64,
+    /// Number of chunks implied by `byte_size` and consensus `chunk_size`
+    /// (`byte_size.div_ceil(chunk_size)`).
+    pub chunks: u64,
+    /// Merkle root of the transaction data chunks.
+    pub data_root: H256,
+    /// Destination ledger id (e.g. Submit / term ledgers).
+    pub ledger_id: u32,
+}
+
+/// Light metadata for a pending commitment transaction in the mempool list API.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MempoolPendingCommitmentTx {
+    /// Transaction id (base58 `H256`).
+    pub id: H256,
+    /// Signer address.
+    pub address: IrysAddress,
+}
+
+/// Response body for `GET /v1/mempool/txs`.
+///
+/// Lists **unconfirmed** mempool transactions only (no `included_height` /
+/// `promoted_height` yet). Confirmed txs may still sit in mempool state for
+/// reorg handling; they are excluded so the list reflects txs still awaiting
+/// inclusion.
+///
+/// When `truncated` is true, `data_txs` / `commitment_txs` are capped by the
+/// request limit and `total_*_tx_count` carries the full unconfirmed totals.
+/// When not truncated, `data_tx_count` / `commitment_tx_count` match the array
+/// lengths (and equal the totals).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MempoolPendingTxs {
+    pub data_txs: Vec<MempoolPendingDataTx>,
+    pub commitment_txs: Vec<MempoolPendingCommitmentTx>,
+    /// Number of data txs in `data_txs` (always equals `data_txs.len()`).
+    pub data_tx_count: usize,
+    /// Number of commitment txs in `commitment_txs` (always equals `commitment_txs.len()`).
+    pub commitment_tx_count: usize,
+    /// Pending chunk-ingress entries (same metric as `/v1/mempool/status`).
+    pub pending_chunks_count: usize,
+    /// True when either list was cut short by the limit.
+    pub truncated: bool,
+    /// Full unconfirmed data-tx count when `truncated` is true.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_data_tx_count: Option<usize>,
+    /// Full unconfirmed commitment-tx count when `truncated` is true.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_commitment_tx_count: Option<usize>,
+}
+
+impl MempoolPendingTxs {
+    /// Empty mempool response (HTTP 200, not 404).
+    #[must_use]
+    pub fn empty(pending_chunks_count: usize) -> Self {
+        Self {
+            data_txs: Vec::new(),
+            commitment_txs: Vec::new(),
+            data_tx_count: 0,
+            commitment_tx_count: 0,
+            pending_chunks_count,
+            truncated: false,
+            total_data_tx_count: None,
+            total_commitment_tx_count: None,
+        }
+    }
 }

--- a/crates/api-server/src/lib.rs
+++ b/crates/api-server/src/lib.rs
@@ -187,6 +187,7 @@ pub fn routes() -> impl HttpServiceFactory {
             "/mempool/status",
             web::get().to(mempool::get_mempool_status),
         )
+        .route("/mempool/txs", web::get().to(mempool::get_mempool_txs))
         // Mining endpoint
         .route("/mining/info", web::get().to(mining::get_mining_info))
         // Supply endpoint

--- a/crates/api-server/src/routes/mempool.rs
+++ b/crates/api-server/src/routes/mempool.rs
@@ -21,19 +21,15 @@ pub async fn get_mempool_status(state: web::Data<ApiState>) -> Result<HttpRespon
 /// Query params for `GET /v1/mempool/txs`.
 #[derive(Debug, Deserialize)]
 pub struct MempoolTxsQuery {
-    /// Max entries per list (`data_txs` and `commitment_txs` each).
-    /// Default: 100. Hard cap: 500.
+    /// Max entries per list (`data_txs` / `commitment_txs`). Default 100, cap 500.
     pub limit: Option<usize>,
+    /// Forward cursor (base58 `H256`): return ids strictly after this value.
+    pub after_id: Option<String>,
 }
 
-/// GET /v1/mempool/txs
+/// GET /v1/mempool/txs — light unconfirmed pending-tx list (empty pool → 200 + `[]`).
 ///
-/// Returns light metadata for **unconfirmed** pending mempool transactions
-/// (ids + sizes; not full headers). Suitable for frequent polling.
-///
-/// Empty mempool → 200 with empty arrays and zero counts (never 404).
-///
-/// See `MempoolPendingTxs` for truncation rules when the pool exceeds `limit`.
+/// Use `?after_id=` when `truncated` is true. See `MempoolPendingTxs`.
 pub async fn get_mempool_txs(
     state: web::Data<ApiState>,
     query: web::Query<MempoolTxsQuery>,
@@ -43,10 +39,26 @@ pub async fn get_mempool_txs(
         .unwrap_or(MEMPOOL_TXS_DEFAULT_LIMIT)
         .clamp(1, MEMPOOL_TXS_MAX_LIMIT);
 
+    let after_id = match query.after_id.as_deref() {
+        Some(s) => match irys_types::H256::from_base58_result(s) {
+            Ok(id) => Some(id),
+            Err(e) => {
+                return Ok(HttpResponse::BadRequest()
+                    .body(format!("invalid after_id (expected base58 H256): {e}")));
+            }
+        },
+        None => None,
+    };
+
     let pending: MempoolPendingTxs = state
         .mempool_guard
         .atomic_state()
-        .get_pending_txs(&state.config.node_config, &state.chunk_ingress_state, limit)
+        .get_pending_txs(
+            state.config.consensus.chunk_size,
+            &state.chunk_ingress_state,
+            limit,
+            after_id,
+        )
         .await;
     Ok(HttpResponse::Ok().json(pending))
 }

--- a/crates/api-server/src/routes/mempool.rs
+++ b/crates/api-server/src/routes/mempool.rs
@@ -1,7 +1,14 @@
 use crate::ApiState;
 use actix_web::{HttpResponse, Result, web};
+use irys_actors::mempool_service::{
+    MEMPOOL_TXS_DEFAULT_LIMIT, MEMPOOL_TXS_MAX_LIMIT, MempoolPendingTxs,
+};
+use serde::Deserialize;
 
 /// GET /v1/mempool/status
+///
+/// Aggregate mempool counters (counts, capacity %). Unchanged for existing
+/// count-only consumers — use `/v1/mempool/txs` for the pending list.
 pub async fn get_mempool_status(state: web::Data<ApiState>) -> Result<HttpResponse> {
     let status = state
         .mempool_guard
@@ -9,4 +16,110 @@ pub async fn get_mempool_status(state: web::Data<ApiState>) -> Result<HttpRespon
         .get_status(&state.config.node_config, &state.chunk_ingress_state)
         .await;
     Ok(HttpResponse::Ok().json(status))
+}
+
+/// Query params for `GET /v1/mempool/txs`.
+#[derive(Debug, Deserialize)]
+pub struct MempoolTxsQuery {
+    /// Max entries per list (`data_txs` and `commitment_txs` each).
+    /// Default: 100. Hard cap: 500.
+    pub limit: Option<usize>,
+}
+
+/// GET /v1/mempool/txs
+///
+/// Returns light metadata for **unconfirmed** pending mempool transactions
+/// (ids + sizes; not full headers). Suitable for frequent polling.
+///
+/// Empty mempool → 200 with empty arrays and zero counts (never 404).
+///
+/// See `MempoolPendingTxs` for truncation rules when the pool exceeds `limit`.
+pub async fn get_mempool_txs(
+    state: web::Data<ApiState>,
+    query: web::Query<MempoolTxsQuery>,
+) -> Result<HttpResponse> {
+    let limit = query
+        .limit
+        .unwrap_or(MEMPOOL_TXS_DEFAULT_LIMIT)
+        .clamp(1, MEMPOOL_TXS_MAX_LIMIT);
+
+    let pending: MempoolPendingTxs = state
+        .mempool_guard
+        .atomic_state()
+        .get_pending_txs(
+            &state.config.node_config,
+            &state.chunk_ingress_state,
+            limit,
+        )
+        .await;
+    Ok(HttpResponse::Ok().json(pending))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use irys_actors::mempool_service::{MempoolPendingCommitmentTx, MempoolPendingDataTx};
+    use irys_types::{H256, IrysAddress};
+
+    #[test]
+    fn mempool_pending_txs_empty_serialises_with_zero_counts() {
+        let body = MempoolPendingTxs::empty(0);
+        let value: serde_json::Value = serde_json::to_value(&body).expect("serialise");
+        let object = value.as_object().expect("top-level JSON object");
+
+        assert_eq!(object["data_txs"], serde_json::json!([]));
+        assert_eq!(object["commitment_txs"], serde_json::json!([]));
+        assert_eq!(object["data_tx_count"], 0);
+        assert_eq!(object["commitment_tx_count"], 0);
+        assert_eq!(object["pending_chunks_count"], 0);
+        assert_eq!(object["truncated"], false);
+        assert!(object.get("total_data_tx_count").is_none());
+        assert!(object.get("total_commitment_tx_count").is_none());
+    }
+
+    #[test]
+    fn mempool_pending_txs_truncation_fields_round_trip() {
+        let id = H256([1; 32]);
+        let body = MempoolPendingTxs {
+            data_txs: vec![MempoolPendingDataTx {
+                id,
+                byte_size: 512,
+                chunks: 1,
+                data_root: H256([2; 32]),
+                ledger_id: 1,
+            }],
+            commitment_txs: vec![MempoolPendingCommitmentTx {
+                id: H256([3; 32]),
+                address: IrysAddress::ZERO,
+            }],
+            data_tx_count: 1,
+            commitment_tx_count: 1,
+            pending_chunks_count: 4,
+            truncated: true,
+            total_data_tx_count: Some(250),
+            total_commitment_tx_count: Some(10),
+        };
+        let json = serde_json::to_string(&body).expect("serialise");
+        let parsed: MempoolPendingTxs = serde_json::from_str(&json).expect("deserialise");
+        assert_eq!(parsed, body);
+        // ids must be base58 strings in JSON (same as /v1/tx/{id})
+        let value: serde_json::Value = serde_json::from_str(&json).expect("value");
+        assert!(value["data_txs"][0]["id"].as_str().is_some());
+        assert_eq!(value["data_txs"][0]["byte_size"], 512);
+        assert_eq!(value["data_txs"][0]["chunks"], 1);
+        assert_eq!(value["total_data_tx_count"], 250);
+    }
+
+    #[test]
+    fn limit_clamp_matches_documented_bounds() {
+        assert_eq!(0_usize.clamp(1, MEMPOOL_TXS_MAX_LIMIT), 1);
+        assert_eq!(
+            MEMPOOL_TXS_DEFAULT_LIMIT.clamp(1, MEMPOOL_TXS_MAX_LIMIT),
+            MEMPOOL_TXS_DEFAULT_LIMIT
+        );
+        assert_eq!(
+            10_000_usize.clamp(1, MEMPOOL_TXS_MAX_LIMIT),
+            MEMPOOL_TXS_MAX_LIMIT
+        );
+    }
 }

--- a/crates/api-server/src/routes/mempool.rs
+++ b/crates/api-server/src/routes/mempool.rs
@@ -1,7 +1,7 @@
 use crate::ApiState;
 use actix_web::{HttpResponse, Result, web};
 use irys_actors::mempool_service::{
-    MEMPOOL_TXS_DEFAULT_LIMIT, MEMPOOL_TXS_MAX_LIMIT, MempoolPendingTxs,
+    MEMPOOL_TXS_DEFAULT_LIMIT, MEMPOOL_TXS_MAX_LIMIT, MempoolPendingTxs, MempoolTxsCursor,
 };
 use serde::Deserialize;
 
@@ -23,13 +23,13 @@ pub async fn get_mempool_status(state: web::Data<ApiState>) -> Result<HttpRespon
 pub struct MempoolTxsQuery {
     /// Max entries per list (`data_txs` / `commitment_txs`). Default 100, cap 500.
     pub limit: Option<usize>,
-    /// Forward cursor (base58 `H256`): return ids strictly after this value.
-    pub after_id: Option<String>,
+    /// Opaque dual-list cursor from a prior `next_cursor` (`v1.<data|_>.<commit|_>`).
+    pub cursor: Option<String>,
 }
 
 /// GET /v1/mempool/txs — light unconfirmed pending-tx list (empty pool → 200 + `[]`).
 ///
-/// Use `?after_id=` when `truncated` is true. See `MempoolPendingTxs`.
+/// When `truncated`, continue with `?cursor=<next_cursor>`. See `MempoolPendingTxs`.
 pub async fn get_mempool_txs(
     state: web::Data<ApiState>,
     query: web::Query<MempoolTxsQuery>,
@@ -39,15 +39,14 @@ pub async fn get_mempool_txs(
         .unwrap_or(MEMPOOL_TXS_DEFAULT_LIMIT)
         .clamp(1, MEMPOOL_TXS_MAX_LIMIT);
 
-    let after_id = match query.after_id.as_deref() {
-        Some(s) => match irys_types::H256::from_base58_result(s) {
-            Ok(id) => Some(id),
+    let cursor = match query.cursor.as_deref() {
+        Some(s) => match MempoolTxsCursor::decode(s) {
+            Ok(c) => c,
             Err(e) => {
-                return Ok(HttpResponse::BadRequest()
-                    .body(format!("invalid after_id (expected base58 H256): {e}")));
+                return Ok(HttpResponse::BadRequest().body(format!("invalid cursor: {e}")));
             }
         },
-        None => None,
+        None => MempoolTxsCursor::default(),
     };
 
     let pending: MempoolPendingTxs = state
@@ -57,7 +56,7 @@ pub async fn get_mempool_txs(
             state.config.consensus.chunk_size,
             &state.chunk_ingress_state,
             limit,
-            after_id,
+            cursor,
         )
         .await;
     Ok(HttpResponse::Ok().json(pending))
@@ -83,6 +82,7 @@ mod tests {
         assert_eq!(object["truncated"], false);
         assert!(object.get("total_data_tx_count").is_none());
         assert!(object.get("total_commitment_tx_count").is_none());
+        assert!(object.get("next_cursor").is_none());
     }
 
     #[test]
@@ -104,18 +104,19 @@ mod tests {
             commitment_tx_count: 1,
             pending_chunks_count: 4,
             truncated: true,
+            next_cursor: Some("v1.a.b".to_owned()),
             total_data_tx_count: Some(250),
             total_commitment_tx_count: Some(10),
         };
         let json = serde_json::to_string(&body).expect("serialise");
         let parsed: MempoolPendingTxs = serde_json::from_str(&json).expect("deserialise");
         assert_eq!(parsed, body);
-        // ids must be base58 strings in JSON (same as /v1/tx/{id})
         let value: serde_json::Value = serde_json::from_str(&json).expect("value");
         assert!(value["data_txs"][0]["id"].as_str().is_some());
         assert_eq!(value["data_txs"][0]["byte_size"], 512);
         assert_eq!(value["data_txs"][0]["chunks"], 1);
         assert_eq!(value["total_data_tx_count"], 250);
+        assert_eq!(value["next_cursor"], "v1.a.b");
     }
 
     #[test]

--- a/crates/api-server/src/routes/mempool.rs
+++ b/crates/api-server/src/routes/mempool.rs
@@ -46,11 +46,7 @@ pub async fn get_mempool_txs(
     let pending: MempoolPendingTxs = state
         .mempool_guard
         .atomic_state()
-        .get_pending_txs(
-            &state.config.node_config,
-            &state.chunk_ingress_state,
-            limit,
-        )
+        .get_pending_txs(&state.config.node_config, &state.chunk_ingress_state, limit)
         .await;
     Ok(HttpResponse::Ok().json(pending))
 }

--- a/crates/chain-tests/src/api/mempool_txs.rs
+++ b/crates/chain-tests/src/api/mempool_txs.rs
@@ -93,10 +93,7 @@ async fn heavy_test_mempool_txs_empty_and_pending_lifecycle() -> eyre::Result<()
     assert_eq!(entry.data_root, tx.header.data_root);
 
     // 4. GET /v1/tx/{id} succeeds for a listed pending id.
-    let tx_resp = client
-        .get(format!("{base}/v1/tx/{tx_id}"))
-        .send()
-        .await?;
+    let tx_resp = client.get(format!("{base}/v1/tx/{tx_id}")).send().await?;
     assert_eq!(tx_resp.status(), StatusCode::OK);
     let fetched: IrysTransactionResponse = tx_resp.json().await?;
     match fetched {

--- a/crates/chain-tests/src/api/mempool_txs.rs
+++ b/crates/chain-tests/src/api/mempool_txs.rs
@@ -1,0 +1,154 @@
+//! Integration tests for `GET /v1/mempool/txs`.
+
+use crate::utils::IrysNodeTest;
+use alloy_core::primitives::U256;
+use alloy_genesis::GenesisAccount;
+use irys_actors::mempool_service::MempoolPendingTxs;
+use irys_types::{IrysTransactionResponse, NodeConfig, irys::IrysSigner};
+use reqwest::StatusCode;
+use std::time::Duration;
+use tokio::time::sleep;
+
+async fn fetch_mempool_txs(
+    client: &reqwest::Client,
+    base: &str,
+    limit: Option<usize>,
+) -> eyre::Result<(StatusCode, MempoolPendingTxs)> {
+    let url = match limit {
+        Some(n) => format!("{base}/v1/mempool/txs?limit={n}"),
+        None => format!("{base}/v1/mempool/txs"),
+    };
+    let response = client.get(&url).send().await?;
+    let status = response.status();
+    let body = response.json::<MempoolPendingTxs>().await?;
+    Ok((status, body))
+}
+
+#[test_log::test(tokio::test)]
+async fn heavy_test_mempool_txs_empty_and_pending_lifecycle() -> eyre::Result<()> {
+    let mut config = NodeConfig::testing();
+    let signer = IrysSigner::random_signer(&config.consensus_config());
+    config.consensus.extend_genesis_accounts(vec![(
+        signer.address(),
+        GenesisAccount {
+            balance: U256::from(10_000_000_000_000_000_000_u128),
+            ..Default::default()
+        },
+    )]);
+    // Fast confirmation so included_height lands quickly after mine.
+    config.consensus.get_mut().block_migration_depth = 1;
+
+    let node = IrysNodeTest::new_genesis(config).start().await;
+    node.node_ctx
+        .packing_waiter
+        .wait_for_idle(Some(Duration::from_secs(10)))
+        .await?;
+
+    let base = format!(
+        "http://127.0.0.1:{}",
+        node.node_ctx.config.node_config.http.bind_port
+    );
+    let client = reqwest::Client::new();
+
+    // 1. Empty mempool → 200 + empty arrays + zero counts (not 404).
+    let (status, empty) = fetch_mempool_txs(&client, &base, None).await?;
+    assert_eq!(status, StatusCode::OK);
+    assert!(empty.data_txs.is_empty());
+    assert!(empty.commitment_txs.is_empty());
+    assert_eq!(empty.data_tx_count, 0);
+    assert_eq!(empty.commitment_tx_count, 0);
+    assert!(!empty.truncated);
+    assert!(empty.total_data_tx_count.is_none());
+
+    // Status endpoint still works and is independent of the list.
+    let status_resp = client
+        .get(format!("{base}/v1/mempool/status"))
+        .send()
+        .await?;
+    assert_eq!(status_resp.status(), StatusCode::OK);
+
+    // 2. Submit a data tx → id appears; counts match.
+    let data = vec![1_u8; 64];
+    let data_size = data.len() as u64;
+    let anchor = node.get_anchor().await?;
+    let tx = node.post_data_tx(anchor, data, &signer).await;
+    let tx_id = tx.header.id;
+    node.wait_for_mempool(tx_id, 10).await?;
+
+    let (status, pending) = fetch_mempool_txs(&client, &base, None).await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(pending.data_tx_count, pending.data_txs.len());
+    assert_eq!(pending.commitment_tx_count, pending.commitment_txs.len());
+    assert!(
+        pending.data_txs.iter().any(|t| t.id == tx_id),
+        "posted data tx should appear in mempool list: {pending:?}"
+    );
+    let entry = pending
+        .data_txs
+        .iter()
+        .find(|t| t.id == tx_id)
+        .expect("entry");
+    assert_eq!(entry.byte_size, data_size);
+    assert!(entry.chunks >= 1);
+    assert_eq!(entry.data_root, tx.header.data_root);
+
+    // 4. GET /v1/tx/{id} succeeds for a listed pending id.
+    let tx_resp = client
+        .get(format!("{base}/v1/tx/{tx_id}"))
+        .send()
+        .await?;
+    assert_eq!(tx_resp.status(), StatusCode::OK);
+    let fetched: IrysTransactionResponse = tx_resp.json().await?;
+    match fetched {
+        IrysTransactionResponse::Storage(header) => {
+            assert_eq!(header.id, tx_id);
+        }
+        IrysTransactionResponse::Commitment(_) => {
+            panic!("expected storage tx for listed data id");
+        }
+    }
+
+    // 3. After inclusion → id leaves the list on subsequent poll.
+    node.mine_block().await?;
+    node.wait_for_tx_included(&tx_id, 15).await?;
+
+    // Poll until the list drops the tx (BlockConfirmed is async).
+    let mut left = false;
+    for _ in 0..50 {
+        let (_, after) = fetch_mempool_txs(&client, &base, None).await?;
+        if !after.data_txs.iter().any(|t| t.id == tx_id) {
+            left = true;
+            break;
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+    assert!(
+        left,
+        "included data tx should leave the pending list after confirmation"
+    );
+
+    // Light poll under load should not hang (typical ~2–3s poll cadence).
+    let start = std::time::Instant::now();
+    for _ in 0..3 {
+        let (status, _) = fetch_mempool_txs(&client, &base, Some(100)).await?;
+        assert_eq!(status, StatusCode::OK);
+    }
+    assert!(
+        start.elapsed() < Duration::from_secs(2),
+        "three list polls should complete well under a 2.5s poll cadence"
+    );
+
+    // Status counts still present after list usage (compat).
+    let status_json: serde_json::Value = client
+        .get(format!("{base}/v1/mempool/status"))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert!(status_json.get("data_tx_count").is_some());
+    assert!(status_json.get("commitment_tx_count").is_some());
+    assert!(status_json.get("pending_chunks_count").is_some());
+
+    node.stop().await;
+    Ok(())
+}

--- a/crates/chain-tests/src/api/mempool_txs.rs
+++ b/crates/chain-tests/src/api/mempool_txs.rs
@@ -13,10 +13,19 @@ async fn fetch_mempool_txs(
     client: &reqwest::Client,
     base: &str,
     limit: Option<usize>,
+    after_id: Option<&str>,
 ) -> eyre::Result<(StatusCode, MempoolPendingTxs)> {
-    let url = match limit {
-        Some(n) => format!("{base}/v1/mempool/txs?limit={n}"),
-        None => format!("{base}/v1/mempool/txs"),
+    let mut params = Vec::new();
+    if let Some(n) = limit {
+        params.push(format!("limit={n}"));
+    }
+    if let Some(a) = after_id {
+        params.push(format!("after_id={a}"));
+    }
+    let url = if params.is_empty() {
+        format!("{base}/v1/mempool/txs")
+    } else {
+        format!("{base}/v1/mempool/txs?{}", params.join("&"))
     };
     let response = client.get(&url).send().await?;
     let status = response.status();
@@ -51,7 +60,7 @@ async fn heavy_test_mempool_txs_empty_and_pending_lifecycle() -> eyre::Result<()
     let client = reqwest::Client::new();
 
     // 1. Empty mempool → 200 + empty arrays + zero counts (not 404).
-    let (status, empty) = fetch_mempool_txs(&client, &base, None).await?;
+    let (status, empty) = fetch_mempool_txs(&client, &base, None, None).await?;
     assert_eq!(status, StatusCode::OK);
     assert!(empty.data_txs.is_empty());
     assert!(empty.commitment_txs.is_empty());
@@ -75,7 +84,7 @@ async fn heavy_test_mempool_txs_empty_and_pending_lifecycle() -> eyre::Result<()
     let tx_id = tx.header.id;
     node.wait_for_mempool(tx_id, 10).await?;
 
-    let (status, pending) = fetch_mempool_txs(&client, &base, None).await?;
+    let (status, pending) = fetch_mempool_txs(&client, &base, None, None).await?;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(pending.data_tx_count, pending.data_txs.len());
     assert_eq!(pending.commitment_tx_count, pending.commitment_txs.len());
@@ -92,7 +101,55 @@ async fn heavy_test_mempool_txs_empty_and_pending_lifecycle() -> eyre::Result<()
     assert!(entry.chunks >= 1);
     assert_eq!(entry.data_root, tx.header.data_root);
 
-    // 4. GET /v1/tx/{id} succeeds for a listed pending id.
+    // 2b. Cursor paging reaches every data tx past `limit`.
+    for i in 0..4_u8 {
+        let anchor = node.get_anchor().await?;
+        // Distinct payload → distinct id (identical bytes can collapse).
+        let extra = node
+            .post_data_tx(anchor, vec![100 + i; 64 + i as usize], &signer)
+            .await;
+        node.wait_for_mempool(extra.header.id, 10).await?;
+    }
+    let (_, full) = fetch_mempool_txs(&client, &base, Some(500), None).await?;
+    let full_ids: std::collections::BTreeSet<_> = full.data_txs.iter().map(|t| t.id).collect();
+    assert!(
+        full_ids.len() >= 5,
+        "expected >=5 pending data txs before paging, got {}",
+        full_ids.len()
+    );
+
+    let mut paged_ids: Vec<irys_types::H256> = Vec::new();
+    let mut cursor: Option<String> = None;
+    for _ in 0..(full_ids.len() + 5) {
+        let (st, page) = fetch_mempool_txs(&client, &base, Some(2), cursor.as_deref()).await?;
+        assert_eq!(st, StatusCode::OK);
+        assert!(page.data_txs.len() <= 2);
+        if page.data_txs.is_empty() {
+            break;
+        }
+        paged_ids.extend(page.data_txs.iter().map(|t| t.id));
+        cursor = Some(page.data_txs.last().unwrap().id.to_string());
+        if !page.truncated {
+            break;
+        }
+    }
+    let mut ascending = paged_ids.clone();
+    ascending.sort();
+    ascending.dedup();
+    assert_eq!(paged_ids, ascending, "pages must be ascending, no dups");
+    let paged_set: std::collections::BTreeSet<_> = paged_ids.into_iter().collect();
+    assert_eq!(
+        paged_set, full_ids,
+        "cursor must reach every pending data tx"
+    );
+
+    let bad = client
+        .get(format!("{base}/v1/mempool/txs?after_id=not-a-valid-id"))
+        .send()
+        .await?;
+    assert_eq!(bad.status(), StatusCode::BAD_REQUEST);
+
+    // 2c. GET /v1/tx/{id} succeeds for a listed pending id.
     let tx_resp = client.get(format!("{base}/v1/tx/{tx_id}")).send().await?;
     assert_eq!(tx_resp.status(), StatusCode::OK);
     let fetched: IrysTransactionResponse = tx_resp.json().await?;
@@ -112,7 +169,7 @@ async fn heavy_test_mempool_txs_empty_and_pending_lifecycle() -> eyre::Result<()
     // Poll until the list drops the tx (BlockConfirmed is async).
     let mut left = false;
     for _ in 0..50 {
-        let (_, after) = fetch_mempool_txs(&client, &base, None).await?;
+        let (_, after) = fetch_mempool_txs(&client, &base, None, None).await?;
         if !after.data_txs.iter().any(|t| t.id == tx_id) {
             left = true;
             break;
@@ -124,16 +181,11 @@ async fn heavy_test_mempool_txs_empty_and_pending_lifecycle() -> eyre::Result<()
         "included data tx should leave the pending list after confirmation"
     );
 
-    // Light poll under load should not hang (typical ~2–3s poll cadence).
-    let start = std::time::Instant::now();
+    // Repeated polls stay functional (no wall-clock bound — flakes under load).
     for _ in 0..3 {
-        let (status, _) = fetch_mempool_txs(&client, &base, Some(100)).await?;
+        let (status, _) = fetch_mempool_txs(&client, &base, Some(100), None).await?;
         assert_eq!(status, StatusCode::OK);
     }
-    assert!(
-        start.elapsed() < Duration::from_secs(2),
-        "three list polls should complete well under a 2.5s poll cadence"
-    );
 
     // Status counts still present after list usage (compat).
     let status_json: serde_json::Value = client

--- a/crates/chain-tests/src/api/mempool_txs.rs
+++ b/crates/chain-tests/src/api/mempool_txs.rs
@@ -4,8 +4,9 @@ use crate::utils::IrysNodeTest;
 use alloy_core::primitives::U256;
 use alloy_genesis::GenesisAccount;
 use irys_actors::mempool_service::MempoolPendingTxs;
-use irys_types::{IrysTransactionResponse, NodeConfig, irys::IrysSigner};
+use irys_types::{H256, IrysTransactionResponse, NodeConfig, irys::IrysSigner};
 use reqwest::StatusCode;
+use std::collections::BTreeSet;
 use std::time::Duration;
 use tokio::time::sleep;
 
@@ -13,14 +14,15 @@ async fn fetch_mempool_txs(
     client: &reqwest::Client,
     base: &str,
     limit: Option<usize>,
-    after_id: Option<&str>,
+    cursor: Option<&str>,
 ) -> eyre::Result<(StatusCode, MempoolPendingTxs)> {
     let mut params = Vec::new();
     if let Some(n) = limit {
         params.push(format!("limit={n}"));
     }
-    if let Some(a) = after_id {
-        params.push(format!("after_id={a}"));
+    if let Some(c) = cursor {
+        // Cursor is base58-safe; no extra encoding required.
+        params.push(format!("cursor={c}"));
     }
     let url = if params.is_empty() {
         format!("{base}/v1/mempool/txs")
@@ -31,6 +33,53 @@ async fn fetch_mempool_txs(
     let status = response.status();
     let body = response.json::<MempoolPendingTxs>().await?;
     Ok((status, body))
+}
+
+/// Drain all pages via `next_cursor`; assert no dups and stable ascending ids.
+async fn collect_all_pages(
+    client: &reqwest::Client,
+    base: &str,
+    limit: usize,
+) -> eyre::Result<(Vec<H256>, Vec<H256>)> {
+    let mut data_ids = Vec::new();
+    let mut commit_ids = Vec::new();
+    let mut cursor: Option<String> = None;
+    for _ in 0..64 {
+        let (st, page) = fetch_mempool_txs(client, base, Some(limit), cursor.as_deref()).await?;
+        assert_eq!(st, StatusCode::OK);
+        assert!(page.data_txs.len() <= limit);
+        assert!(page.commitment_txs.len() <= limit);
+
+        data_ids.extend(page.data_txs.iter().map(|t| t.id));
+        commit_ids.extend(page.commitment_txs.iter().map(|t| t.id));
+
+        if !page.truncated {
+            assert!(page.next_cursor.is_none());
+            break;
+        }
+        let next = page
+            .next_cursor
+            .expect("truncated pages must return next_cursor");
+        cursor = Some(next);
+    }
+
+    let mut data_sorted = data_ids.clone();
+    data_sorted.sort();
+    data_sorted.dedup();
+    assert_eq!(
+        data_ids, data_sorted,
+        "data pages must be ascending, no dups"
+    );
+
+    let mut commit_sorted = commit_ids.clone();
+    commit_sorted.sort();
+    commit_sorted.dedup();
+    assert_eq!(
+        commit_ids, commit_sorted,
+        "commitment pages must be ascending, no dups"
+    );
+
+    Ok((data_ids, commit_ids))
 }
 
 #[test_log::test(tokio::test)]
@@ -67,6 +116,7 @@ async fn heavy_test_mempool_txs_empty_and_pending_lifecycle() -> eyre::Result<()
     assert_eq!(empty.data_tx_count, 0);
     assert_eq!(empty.commitment_tx_count, 0);
     assert!(!empty.truncated);
+    assert!(empty.next_cursor.is_none());
     assert!(empty.total_data_tx_count.is_none());
 
     // Status endpoint still works and is independent of the list.
@@ -104,47 +154,28 @@ async fn heavy_test_mempool_txs_empty_and_pending_lifecycle() -> eyre::Result<()
     // 2b. Cursor paging reaches every data tx past `limit`.
     for i in 0..4_u8 {
         let anchor = node.get_anchor().await?;
-        // Distinct payload → distinct id (identical bytes can collapse).
         let extra = node
             .post_data_tx(anchor, vec![100 + i; 64 + i as usize], &signer)
             .await;
         node.wait_for_mempool(extra.header.id, 10).await?;
     }
     let (_, full) = fetch_mempool_txs(&client, &base, Some(500), None).await?;
-    let full_ids: std::collections::BTreeSet<_> = full.data_txs.iter().map(|t| t.id).collect();
+    let full_ids: BTreeSet<_> = full.data_txs.iter().map(|t| t.id).collect();
     assert!(
         full_ids.len() >= 5,
         "expected >=5 pending data txs before paging, got {}",
         full_ids.len()
     );
 
-    let mut paged_ids: Vec<irys_types::H256> = Vec::new();
-    let mut cursor: Option<String> = None;
-    for _ in 0..(full_ids.len() + 5) {
-        let (st, page) = fetch_mempool_txs(&client, &base, Some(2), cursor.as_deref()).await?;
-        assert_eq!(st, StatusCode::OK);
-        assert!(page.data_txs.len() <= 2);
-        if page.data_txs.is_empty() {
-            break;
-        }
-        paged_ids.extend(page.data_txs.iter().map(|t| t.id));
-        cursor = Some(page.data_txs.last().unwrap().id.to_string());
-        if !page.truncated {
-            break;
-        }
-    }
-    let mut ascending = paged_ids.clone();
-    ascending.sort();
-    ascending.dedup();
-    assert_eq!(paged_ids, ascending, "pages must be ascending, no dups");
-    let paged_set: std::collections::BTreeSet<_> = paged_ids.into_iter().collect();
+    let (paged_data, _) = collect_all_pages(&client, &base, 2).await?;
+    let paged_set: BTreeSet<_> = paged_data.into_iter().collect();
     assert_eq!(
         paged_set, full_ids,
         "cursor must reach every pending data tx"
     );
 
     let bad = client
-        .get(format!("{base}/v1/mempool/txs?after_id=not-a-valid-id"))
+        .get(format!("{base}/v1/mempool/txs?cursor=not-a-valid-cursor"))
         .send()
         .await?;
     assert_eq!(bad.status(), StatusCode::BAD_REQUEST);
@@ -166,7 +197,6 @@ async fn heavy_test_mempool_txs_empty_and_pending_lifecycle() -> eyre::Result<()
     node.mine_block().await?;
     node.wait_for_tx_included(&tx_id, 15).await?;
 
-    // Poll until the list drops the tx (BlockConfirmed is async).
     let mut left = false;
     for _ in 0..50 {
         let (_, after) = fetch_mempool_txs(&client, &base, None, None).await?;
@@ -181,13 +211,11 @@ async fn heavy_test_mempool_txs_empty_and_pending_lifecycle() -> eyre::Result<()
         "included data tx should leave the pending list after confirmation"
     );
 
-    // Repeated polls stay functional (no wall-clock bound — flakes under load).
     for _ in 0..3 {
         let (status, _) = fetch_mempool_txs(&client, &base, Some(100), None).await?;
         assert_eq!(status, StatusCode::OK);
     }
 
-    // Status counts still present after list usage (compat).
     let status_json: serde_json::Value = client
         .get(format!("{base}/v1/mempool/status"))
         .send()
@@ -197,6 +225,86 @@ async fn heavy_test_mempool_txs_empty_and_pending_lifecycle() -> eyre::Result<()
     assert!(status_json.get("data_tx_count").is_some());
     assert!(status_json.get("commitment_tx_count").is_some());
     assert!(status_json.get("pending_chunks_count").is_some());
+
+    node.stop().await;
+    Ok(())
+}
+
+/// Mixed data + commitment pool: dual-list cursor pages both without dups/skips
+/// even when ids interleave and lists empty at different rates.
+#[test_log::test(tokio::test)]
+async fn heavy_test_mempool_txs_mixed_type_cursor_paging() -> eyre::Result<()> {
+    let mut config = NodeConfig::testing();
+    let data_signer = IrysSigner::random_signer(&config.consensus_config());
+    let stake_signers: Vec<_> = (0..3)
+        .map(|_| IrysSigner::random_signer(&config.consensus_config()))
+        .collect();
+    // Stake value is large; use fund helper (not a tiny test balance).
+    let mut all_signers = vec![&data_signer];
+    all_signers.extend(stake_signers.iter());
+    config.fund_genesis_accounts(all_signers);
+    config.consensus.get_mut().block_migration_depth = 1;
+
+    let node = IrysNodeTest::new_genesis(config).start().await;
+    node.node_ctx
+        .packing_waiter
+        .wait_for_idle(Some(Duration::from_secs(10)))
+        .await?;
+
+    let base = format!(
+        "http://127.0.0.1:{}",
+        node.node_ctx.config.node_config.http.bind_port
+    );
+    let client = reqwest::Client::new();
+
+    // Interleave posts: data and stakes so both lists are non-empty together.
+    let mut expected_data = BTreeSet::new();
+    let mut expected_commit = BTreeSet::new();
+    for i in 0..3_u8 {
+        let anchor = node.get_anchor().await?;
+        let tx = node
+            .post_data_tx(anchor, vec![50 + i; 32 + i as usize], &data_signer)
+            .await;
+        node.wait_for_mempool(tx.header.id, 10).await?;
+        expected_data.insert(tx.header.id);
+
+        let stake = node
+            .post_stake_commitment_with_signer(&stake_signers[i as usize])
+            .await?;
+        node.wait_for_mempool_commitment_txs(vec![stake.id()], 10)
+            .await?;
+        expected_commit.insert(stake.id());
+    }
+    // Extra data so data list is longer than commitment (lists exhaust at different rates).
+    for i in 0..3_u8 {
+        let anchor = node.get_anchor().await?;
+        let tx = node
+            .post_data_tx(anchor, vec![200 + i; 48 + i as usize], &data_signer)
+            .await;
+        node.wait_for_mempool(tx.header.id, 10).await?;
+        expected_data.insert(tx.header.id);
+    }
+
+    let (_, full) = fetch_mempool_txs(&client, &base, Some(500), None).await?;
+    let full_data: BTreeSet<_> = full.data_txs.iter().map(|t| t.id).collect();
+    let full_commit: BTreeSet<_> = full.commitment_txs.iter().map(|t| t.id).collect();
+    assert_eq!(full_data, expected_data);
+    assert_eq!(full_commit, expected_commit);
+    assert!(full_data.len() >= 6);
+    assert_eq!(full_commit.len(), 3);
+
+    // limit=1 forces many pages; dual cursor must still cover both lists fully.
+    let (paged_data, paged_commit) = collect_all_pages(&client, &base, 1).await?;
+    assert_eq!(
+        paged_data.into_iter().collect::<BTreeSet<_>>(),
+        full_data,
+        "mixed paging must not omit/dup data txs"
+    );
+    assert_eq!(
+        paged_commit.into_iter().collect::<BTreeSet<_>>(),
+        full_commit,
+        "mixed paging must not omit/dup commitment txs"
+    );
 
     node.stop().await;
     Ok(())

--- a/crates/chain-tests/src/api/mod.rs
+++ b/crates/chain-tests/src/api/mod.rs
@@ -5,6 +5,7 @@ mod commitment_anchor_window;
 mod external_api;
 mod hardfork_tests;
 mod ledger_offset_endpoint;
+mod mempool_txs;
 mod pricing_endpoint;
 mod supply_endpoint;
 mod tx;

--- a/docs/90-services/07-mempool-txs-api.md
+++ b/docs/90-services/07-mempool-txs-api.md
@@ -5,31 +5,27 @@
 ```http
 GET /v1/mempool/txs
 GET /v1/mempool/txs?limit=100
+GET /v1/mempool/txs?limit=100&after_id=<base58 H256>
 ```
 
 Public, unauthenticated HTTP (same CORS model as `/v1/tip` and `/v1/mempool/status`).
 
-| Param   | Default | Cap | Description                                      |
-|---------|---------|-----|--------------------------------------------------|
-| `limit` | `100`   | `500` | Max entries **per list** (`data_txs` and `commitment_txs` each) |
+| Param      | Default | Cap   | Description |
+|------------|---------|-------|-------------|
+| `limit`    | `100`   | `500` | Max entries **per list** (`data_txs` and `commitment_txs`) |
+| `after_id` | —       | —     | Forward cursor: ids strictly after this base58 `H256`. Malformed → **400**. |
 
-Related summary-only endpoint (unchanged count fields):
-
-```http
-GET /v1/mempool/status
-```
+Related count-only endpoint (unchanged): `GET /v1/mempool/status`.
 
 ## Semantics
 
-- **Pending** = present in this node’s mempool **and** not yet confirmed
-  (`included_height` / `promoted_height` unset). Confirmed txs may remain in
-  internal mempool state for reorg handling; they are omitted from this list.
-- **Order**: stable by transaction id (`H256` byte order).
-- **Empty pool**: HTTP **200** with empty arrays and zero counts — never 404.
-- **Ids**: base58-encoded `H256`, same encoding as block ledger `txIds` and
-  `GET /v1/tx/{id}`.
+- **Pending** = in this node’s mempool and unconfirmed (`included_height` /
+  `promoted_height` unset). Includes out-of-order `pending_pledges`.
+- **Order**: ascending by raw `H256` bytes (not base58 string order).
+- **Empty pool**: **200** with empty arrays / zero counts (never 404).
+- **Ids**: base58 `H256`, same as block ledger `txIds` and `GET /v1/tx/{id}`.
 
-## Response schema
+## Response
 
 ```json
 {
@@ -43,10 +39,7 @@ GET /v1/mempool/status
     }
   ],
   "commitment_txs": [
-    {
-      "id": "<base58 H256>",
-      "address": "<base58 address>"
-    }
+    { "id": "<base58 H256>", "address": "<base58 address>" }
   ],
   "data_tx_count": 1,
   "commitment_tx_count": 1,
@@ -55,45 +48,42 @@ GET /v1/mempool/status
 }
 ```
 
-### Truncation
+### Truncation / paging
 
-When either full unconfirmed list exceeds `limit`:
+When more unconfirmed txs remain after `after_id` + `limit`:
 
-- `truncated` is `true`
-- `data_txs` / `commitment_txs` are truncated independently to `limit`
-- `data_tx_count` / `commitment_tx_count` equal the **returned array lengths**
-- `total_data_tx_count` / `total_commitment_tx_count` are set to the full
-  unconfirmed totals
+- `truncated: true` — next page: `after_id=<last returned id for that list>`
+- array counts = returned lengths; `total_*_tx_count` = full unconfirmed totals
+- `truncated` is shared across both lists (true until both are fully paged)
 
-When not truncated, the `total_*` fields are omitted and counts match arrays
-and the full pool.
+`after_id` filters **both** lists by the same id order. Prefer a high enough
+`limit` for simple pollers; use the cursor when you need the full set.
 
-`pending_chunks_count` is the same chunk-ingress metric as `/v1/mempool/status`
-(not truncated).
+`pending_chunks_count` matches `/v1/mempool/status` (not truncated).
 
-### Field notes
+### Data-tx fields
 
-| Field (data tx) | Meaning |
-|-----------------|--------|
-| `id`            | Tx id; matches `GET /v1/tx/{id}` and block ledger `txIds` |
-| `byte_size`     | Header `data_size` |
-| `chunks`        | `byte_size.div_ceil(chunk_size)` using consensus chunk size |
-| `data_root`     | Merkle root of payload chunks |
-| `ledger_id`     | Destination ledger (pre-inclusion) |
+| Field | Meaning |
+|-------|---------|
+| `id` | Tx id (`GET /v1/tx/{id}`, block ledger match) |
+| `byte_size` | Header `data_size` |
+| `chunks` | `byte_size.div_ceil(chunk_size)` |
+| `data_root` | Payload merkle root |
+| `ledger_id` | Destination ledger |
 
-Full headers are **not** embedded; fetch `GET /v1/tx/{id}` for the full body.
+Full headers via `GET /v1/tx/{id}`.
 
 ## Example
 
 ```bash
-# Local / devnet node (default port from node config)
 curl -sS "http://127.0.0.1:1984/v1/mempool/txs" | jq .
-
-# Cap list size for large pools
 curl -sS "http://127.0.0.1:1984/v1/mempool/txs?limit=50" | jq .
 
-# Aggregate counts still come from status
-curl -sS "http://127.0.0.1:1984/v1/mempool/status" | jq '{data_tx_count, commitment_tx_count, pending_chunks_count}'
+last=$(curl -sS "http://127.0.0.1:1984/v1/mempool/txs?limit=50" | jq -r '.data_txs[-1].id')
+curl -sS "http://127.0.0.1:1984/v1/mempool/txs?limit=50&after_id=$last" | jq .
+
+curl -sS "http://127.0.0.1:1984/v1/mempool/status" \
+  | jq '{data_tx_count, commitment_tx_count, pending_chunks_count}'
 ```
 
 ## Out of scope (v1)

--- a/docs/90-services/07-mempool-txs-api.md
+++ b/docs/90-services/07-mempool-txs-api.md
@@ -1,0 +1,103 @@
+# Mempool pending transaction list API
+
+## Endpoint
+
+```http
+GET /v1/mempool/txs
+GET /v1/mempool/txs?limit=100
+```
+
+Public, unauthenticated HTTP (same CORS model as `/v1/tip` and `/v1/mempool/status`).
+
+| Param   | Default | Cap | Description                                      |
+|---------|---------|-----|--------------------------------------------------|
+| `limit` | `100`   | `500` | Max entries **per list** (`data_txs` and `commitment_txs` each) |
+
+Related summary-only endpoint (unchanged count fields):
+
+```http
+GET /v1/mempool/status
+```
+
+## Semantics
+
+- **Pending** = present in this node’s mempool **and** not yet confirmed
+  (`included_height` / `promoted_height` unset). Confirmed txs may remain in
+  internal mempool state for reorg handling; they are omitted from this list.
+- **Order**: stable by transaction id (`H256` byte order).
+- **Empty pool**: HTTP **200** with empty arrays and zero counts — never 404.
+- **Ids**: base58-encoded `H256`, same encoding as block ledger `txIds` and
+  `GET /v1/tx/{id}`.
+
+## Response schema
+
+```json
+{
+  "data_txs": [
+    {
+      "id": "<base58 H256>",
+      "byte_size": 1234,
+      "chunks": 5,
+      "data_root": "<base58 H256>",
+      "ledger_id": 1
+    }
+  ],
+  "commitment_txs": [
+    {
+      "id": "<base58 H256>",
+      "address": "<base58 address>"
+    }
+  ],
+  "data_tx_count": 1,
+  "commitment_tx_count": 1,
+  "pending_chunks_count": 0,
+  "truncated": false
+}
+```
+
+### Truncation
+
+When either full unconfirmed list exceeds `limit`:
+
+- `truncated` is `true`
+- `data_txs` / `commitment_txs` are truncated independently to `limit`
+- `data_tx_count` / `commitment_tx_count` equal the **returned array lengths**
+- `total_data_tx_count` / `total_commitment_tx_count` are set to the full
+  unconfirmed totals
+
+When not truncated, the `total_*` fields are omitted and counts match arrays
+and the full pool.
+
+`pending_chunks_count` is the same chunk-ingress metric as `/v1/mempool/status`
+(not truncated).
+
+### Field notes
+
+| Field (data tx) | Meaning |
+|-----------------|--------|
+| `id`            | Tx id; matches `GET /v1/tx/{id}` and block ledger `txIds` |
+| `byte_size`     | Header `data_size` |
+| `chunks`        | `byte_size.div_ceil(chunk_size)` using consensus chunk size |
+| `data_root`     | Merkle root of payload chunks |
+| `ledger_id`     | Destination ledger (pre-inclusion) |
+
+Full headers are **not** embedded; fetch `GET /v1/tx/{id}` for the full body.
+
+## Example
+
+```bash
+# Local / devnet node (default port from node config)
+curl -sS "http://127.0.0.1:1984/v1/mempool/txs" | jq .
+
+# Cap list size for large pools
+curl -sS "http://127.0.0.1:1984/v1/mempool/txs?limit=50" | jq .
+
+# Aggregate counts still come from status
+curl -sS "http://127.0.0.1:1984/v1/mempool/status" | jq '{data_tx_count, commitment_tx_count, pending_chunks_count}'
+```
+
+## Out of scope (v1)
+
+- WebSocket streaming
+- Full tx body in the list response
+- Historical / departed mempool entries

--- a/docs/90-services/07-mempool-txs-api.md
+++ b/docs/90-services/07-mempool-txs-api.md
@@ -5,15 +5,15 @@
 ```http
 GET /v1/mempool/txs
 GET /v1/mempool/txs?limit=100
-GET /v1/mempool/txs?limit=100&after_id=<base58 H256>
+GET /v1/mempool/txs?limit=100&cursor=<next_cursor>
 ```
 
 Public, unauthenticated HTTP (same CORS model as `/v1/tip` and `/v1/mempool/status`).
 
-| Param      | Default | Cap   | Description |
-|------------|---------|-------|-------------|
-| `limit`    | `100`   | `500` | Max entries **per list** (`data_txs` and `commitment_txs`) |
-| `after_id` | —       | —     | Forward cursor: ids strictly after this base58 `H256`. Malformed → **400**. |
+| Param    | Default | Cap   | Description |
+|----------|---------|-------|-------------|
+| `limit`  | `100`   | `500` | Max entries **per list** (`data_txs` and `commitment_txs`) |
+| `cursor` | —       | —     | Opaque dual-list page token from a prior `next_cursor`. Malformed → **400**. |
 
 Related count-only endpoint (unchanged): `GET /v1/mempool/status`.
 
@@ -21,7 +21,7 @@ Related count-only endpoint (unchanged): `GET /v1/mempool/status`.
 
 - **Pending** = in this node’s mempool and unconfirmed (`included_height` /
   `promoted_height` unset). Includes out-of-order `pending_pledges`.
-- **Order**: ascending by raw `H256` bytes (not base58 string order).
+- **Order**: each list ascending by raw `H256` bytes (not base58 string order).
 - **Empty pool**: **200** with empty arrays / zero counts (never 404).
 - **Ids**: base58 `H256`, same as block ledger `txIds` and `GET /v1/tx/{id}`.
 
@@ -48,16 +48,28 @@ Related count-only endpoint (unchanged): `GET /v1/mempool/status`.
 }
 ```
 
-### Truncation / paging
+When `truncated` is true, also:
 
-When more unconfirmed txs remain after `after_id` + `limit`:
+```json
+{
+  "truncated": true,
+  "next_cursor": "v1.<data_id|_>.<commitment_id|_>",
+  "total_data_tx_count": 250,
+  "total_commitment_tx_count": 12
+}
+```
 
-- `truncated: true` — next page: `after_id=<last returned id for that list>`
-- array counts = returned lengths; `total_*_tx_count` = full unconfirmed totals
-- `truncated` is shared across both lists (true until both are fully paged)
+### Cursor semantics
 
-`after_id` filters **both** lists by the same id order. Prefer a high enough
-`limit` for simple pollers; use the cursor when you need the full set.
+- Data and commitment lists page **independently**. The cursor stores a separate
+  forward bound for each list (`after_data_id`, `after_commitment_id`).
+- Wire format: `v1.<data_base58|_>.<commitment_base58|_>` (`_` = no bound yet).
+- On each truncated page, `next_cursor` advances each side to the last id
+  returned in that list (keeps the prior bound if that list’s page was empty).
+- Client loop: request without `cursor` → while `truncated`, call again with
+  `cursor=<next_cursor>`. No duplicates or omissions across pages for either
+  list (IDs are strictly greater than that list’s bound).
+- Prefer a large enough `limit` for simple pollers; use `cursor` for full dumps.
 
 `pending_chunks_count` matches `/v1/mempool/status` (not truncated).
 
@@ -79,8 +91,13 @@ Full headers via `GET /v1/tx/{id}`.
 curl -sS "http://127.0.0.1:1984/v1/mempool/txs" | jq .
 curl -sS "http://127.0.0.1:1984/v1/mempool/txs?limit=50" | jq .
 
-last=$(curl -sS "http://127.0.0.1:1984/v1/mempool/txs?limit=50" | jq -r '.data_txs[-1].id')
-curl -sS "http://127.0.0.1:1984/v1/mempool/txs?limit=50&after_id=$last" | jq .
+# Page through a large pool
+cursor=$(curl -sS "http://127.0.0.1:1984/v1/mempool/txs?limit=50" | jq -r '.next_cursor // empty')
+while [ -n "$cursor" ]; do
+  resp=$(curl -sS "http://127.0.0.1:1984/v1/mempool/txs?limit=50&cursor=$cursor")
+  echo "$resp" | jq '{data: .data_tx_count, commit: .commitment_tx_count, truncated}'
+  cursor=$(echo "$resp" | jq -r '.next_cursor // empty')
+done
 
 curl -sS "http://127.0.0.1:1984/v1/mempool/status" \
   | jq '{data_tx_count, commitment_tx_count, pending_chunks_count}'


### PR DESCRIPTION
## Summary
- Add `GET /v1/mempool/txs` returning light metadata for unconfirmed pending data and commitment transactions (ids, sizes, roots; optional `limit` with default 100 / cap 500).
- Leave `GET /v1/mempool/status` count fields unchanged for existing consumers.
- Filter confirmed mempool entries (`included_height` / `promoted_height`) so the list matches txs still awaiting inclusion; ids use the same base58 encoding as block ledger `txIds` and `GET /v1/tx/{id}`.

## Test plan
- [x] Unit tests for empty/truncated JSON serialization and limit clamp (`irys-api-server`)
- [x] Integration test: empty list → post data tx appears → `GET /v1/tx/{id}` works → after mine/confirm id leaves list (`heavy_test_mempool_txs_empty_and_pending_lifecycle`)
- [x] Clippy clean on `irys-api-server` / `irys-actors`
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `GET /v1/mempool/txs` to list pending data and commitment transactions.
  * Added cursor-based pagination with configurable limits and validation.
  * Included transaction counts, pending chunk counts, truncation indicators, and transaction details.

* **Documentation**
  * Documented the endpoint, parameters, response format, ordering, and usage examples.

* **Tests**
  * Added coverage for empty pools, pagination, invalid cursors, transaction lookup, and removal after inclusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->