### PR TITLE
fix(api): fix storage Path extraction (drop rename_all on path params)

### DIFF
--- a/crates/api-server/src/lib.rs
+++ b/crates/api-server/src/lib.rs
@@ -176,11 +176,11 @@ pub fn routes() -> impl HttpServiceFactory {
         .route("/epoch/current", web::get().to(ledger::get_current_epoch))
         // Storage endpoints
         .route(
-            "/storage/intervals/{ledger}/{slot_index}/{chunk_type}",
+            storage::INTERVALS_ROUTE,
             web::get().to(storage::get_intervals),
         )
         .route(
-            "/storage/counts/{ledger}/{slot_index}",
+            storage::COUNTS_ROUTE,
             web::get().to(storage::get_chunk_counts),
         )
         .route(

--- a/crates/api-server/src/routes/storage.rs
+++ b/crates/api-server/src/routes/storage.rs
@@ -5,15 +5,15 @@ use irys_domain::ChunkType;
 use irys_types::DataLedger;
 use serde::{Deserialize, Serialize};
 
-/// Route path templates registered in [`crate::routes`]. Placeholder names must match the
-/// serde-visible (camelCase) field names of the `Path`-extracted structs below — actix-web
-/// matches placeholders to struct fields by name, and a mismatch rejects the request with
-/// a "missing field" error before it reaches the handler.
-pub const INTERVALS_ROUTE: &str = "/storage/intervals/{ledger}/{slotIndex}/{chunkType}";
-pub const COUNTS_ROUTE: &str = "/storage/counts/{ledger}/{slotIndex}";
+/// Route path templates registered in [`crate::routes()`]. actix-web matches placeholders to
+/// `Path`-extracted struct fields by their serde-visible names; a mismatch rejects every
+/// request with a 404 ("missing field" in the body) before it reaches the handler. Keep the
+/// params structs below free of `#[serde(rename_all)]` so these snake_case placeholders stay
+/// correct — the camelCase JSON contract lives on the `*Response` structs.
+pub const INTERVALS_ROUTE: &str = "/storage/intervals/{ledger}/{slot_index}/{chunk_type}";
+pub const COUNTS_ROUTE: &str = "/storage/counts/{ledger}/{slot_index}";
 
 #[derive(Serialize, Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
 pub struct StorageIntervalsParams {
     ledger: DataLedger,
     slot_index: usize,
@@ -48,7 +48,6 @@ impl StorageIntervalsResponse {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
 pub struct ChunkCountsParams {
     ledger: DataLedger,
     slot_index: usize,
@@ -203,7 +202,7 @@ mod tests {
     async fn data_intervals_path_reaches_handler() {
         assert_extracted(
             "/v1/storage/intervals/OneYear/0/Data",
-            serde_json::json!({"ledger": "OneYear", "slotIndex": 0, "chunkType": "Data"}),
+            serde_json::json!({"ledger": "OneYear", "slot_index": 0, "chunk_type": "Data"}),
         )
         .await;
     }
@@ -212,7 +211,7 @@ mod tests {
     async fn entropy_intervals_path_reaches_handler() {
         assert_extracted(
             "/v1/storage/intervals/Submit/3/Entropy",
-            serde_json::json!({"ledger": "Submit", "slotIndex": 3, "chunkType": "Entropy"}),
+            serde_json::json!({"ledger": "Submit", "slot_index": 3, "chunk_type": "Entropy"}),
         )
         .await;
     }
@@ -221,7 +220,7 @@ mod tests {
     async fn counts_path_reaches_handler() {
         assert_extracted(
             "/v1/storage/counts/OneYear/7",
-            serde_json::json!({"ledger": "OneYear", "slotIndex": 7}),
+            serde_json::json!({"ledger": "OneYear", "slot_index": 7}),
         )
         .await;
     }

--- a/crates/api-server/src/routes/storage.rs
+++ b/crates/api-server/src/routes/storage.rs
@@ -5,6 +5,13 @@ use irys_domain::ChunkType;
 use irys_types::DataLedger;
 use serde::{Deserialize, Serialize};
 
+/// Route path templates registered in [`crate::routes`]. Placeholder names must match the
+/// serde-visible (camelCase) field names of the `Path`-extracted structs below — actix-web
+/// matches placeholders to struct fields by name, and a mismatch rejects the request with
+/// a "missing field" error before it reaches the handler.
+pub const INTERVALS_ROUTE: &str = "/storage/intervals/{ledger}/{slotIndex}/{chunkType}";
+pub const COUNTS_ROUTE: &str = "/storage/counts/{ledger}/{slotIndex}";
+
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct StorageIntervalsParams {
@@ -144,4 +151,78 @@ pub async fn get_chunk_counts(
         data_chunks,
         packed_chunks,
     )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::dev::{Service as _, ServiceResponse};
+    use actix_web::http::StatusCode;
+    use actix_web::{App, test, web};
+
+    // The real handlers need a full `ApiState`, which is too heavy to construct in a unit
+    // test. Mounting the shared route templates with stub handlers that use the same
+    // `Path` extractors still exercises what regressed: placeholder names resolving to the
+    // serde-visible field names of the param structs.
+    async fn echo_intervals(params: Path<StorageIntervalsParams>) -> Json<StorageIntervalsParams> {
+        Json(params.into_inner())
+    }
+
+    async fn echo_counts(params: Path<ChunkCountsParams>) -> Json<ChunkCountsParams> {
+        Json(params.into_inner())
+    }
+
+    async fn call(uri: &str) -> ServiceResponse {
+        let app = test::init_service(
+            App::new().service(
+                web::scope(crate::API_VERSION)
+                    .route(INTERVALS_ROUTE, web::get().to(echo_intervals))
+                    .route(COUNTS_ROUTE, web::get().to(echo_counts)),
+            ),
+        )
+        .await;
+        let req = test::TestRequest::get().uri(uri).to_request();
+        app.call(req).await.expect("route call failed")
+    }
+
+    async fn assert_extracted(uri: &str, expected: serde_json::Value) {
+        let resp = call(uri).await;
+        let status = resp.status();
+        let body = test::read_body(resp).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "path extraction failed for {uri}: {}",
+            String::from_utf8_lossy(&body)
+        );
+        let parsed: serde_json::Value = serde_json::from_slice(&body).expect("JSON body");
+        assert_eq!(parsed, expected, "extracted params drifted for {uri}");
+    }
+
+    #[actix_web::test]
+    async fn data_intervals_path_reaches_handler() {
+        assert_extracted(
+            "/v1/storage/intervals/OneYear/0/Data",
+            serde_json::json!({"ledger": "OneYear", "slotIndex": 0, "chunkType": "Data"}),
+        )
+        .await;
+    }
+
+    #[actix_web::test]
+    async fn entropy_intervals_path_reaches_handler() {
+        assert_extracted(
+            "/v1/storage/intervals/Submit/3/Entropy",
+            serde_json::json!({"ledger": "Submit", "slotIndex": 3, "chunkType": "Entropy"}),
+        )
+        .await;
+    }
+
+    #[actix_web::test]
+    async fn counts_path_reaches_handler() {
+        assert_extracted(
+            "/v1/storage/counts/OneYear/7",
+            serde_json::json!({"ledger": "OneYear", "slotIndex": 7}),
+        )
+        .await;
+    }
 }

--- a/crates/api-server/src/routes/storage.rs
+++ b/crates/api-server/src/routes/storage.rs
@@ -224,4 +224,60 @@ mod tests {
         )
         .await;
     }
+
+    /// Wire JSON for storage responses must stay camelCase even though path params
+    /// are snake_case (no `rename_all` on the Path structs).
+    #[actix_web::test]
+    async fn intervals_response_serialises_camel_case_keys() {
+        let params: StorageIntervalsParams = serde_json::from_value(serde_json::json!({
+            "ledger": "OneYear",
+            "slot_index": 2,
+            "chunk_type": "Data",
+        }))
+        .expect("params");
+        let intervals: Vec<ChunkInterval> = serde_json::from_value(serde_json::json!([
+            {"start": 0, "end": 3}
+        ]))
+        .expect("intervals");
+        let body = StorageIntervalsResponse::new(&params, intervals);
+        let value = serde_json::to_value(&body).expect("serialise");
+        let object = value.as_object().expect("object");
+        assert!(
+            object.contains_key("slotIndex") && !object.contains_key("slot_index"),
+            "expected camelCase slotIndex, got keys {:?}",
+            object.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            object.contains_key("chunkType") && !object.contains_key("chunk_type"),
+            "expected camelCase chunkType, got keys {:?}",
+            object.keys().collect::<Vec<_>>()
+        );
+        assert_eq!(object["slotIndex"], 2);
+        assert_eq!(object["chunkType"], "Data");
+        assert_eq!(object["intervals"][0]["start"], 0);
+        assert_eq!(object["intervals"][0]["end"], 3);
+    }
+
+    #[actix_web::test]
+    async fn counts_response_serialises_camel_case_keys() {
+        let params: ChunkCountsParams = serde_json::from_value(serde_json::json!({
+            "ledger": "Submit",
+            "slot_index": 5,
+        }))
+        .expect("params");
+        let body = ChunkCountsResponse::new(&params, 10, 20);
+        let value = serde_json::to_value(&body).expect("serialise");
+        let object = value.as_object().expect("object");
+        let keys: Vec<&str> = object.keys().map(String::as_str).collect();
+        for snake in ["slot_index", "data_chunks", "packed_chunks"] {
+            assert!(
+                !keys.contains(&snake),
+                "response must not emit snake_case {snake}, got {keys:?}"
+            );
+        }
+        assert_eq!(object["slotIndex"], 5);
+        assert_eq!(object["dataChunks"], 10);
+        assert_eq!(object["packedChunks"], 20);
+        assert_eq!(object["ledger"], "Submit");
+    }
 }

--- a/crates/chain-tests/src/external/sync_partition_data_remote.rs
+++ b/crates/chain-tests/src/external/sync_partition_data_remote.rs
@@ -252,41 +252,15 @@ async fn sync_partition_data_remote_test() -> Result<()> {
             current_height_for_check
         );
 
-        // Check Publish(0) ledger for data
-        let publish_result = clients[0]
-            .http_client
-            .get(format!("{}/v1/storage/counts/Publish/0", clients[0].url))
-            .send()
-            .await?
-            .json::<serde_json::Value>()
-            .await?;
+        // Check Publish(0) and Submit(0) ledgers for data; the typed response makes a
+        // missing/renamed field a hard error instead of silently reading as 0 chunks
+        let publish_counts = get_chunk_counts(&clients[0], "Publish", 0).await?;
+        let publish_data_chunks = publish_counts.data_chunks;
+        let publish_packed_chunks = publish_counts.packed_chunks;
 
-        let publish_data_chunks = publish_result
-            .get("data_chunks")
-            .and_then(serde_json::Value::as_u64)
-            .unwrap_or(0);
-        let publish_packed_chunks = publish_result
-            .get("packed_chunks")
-            .and_then(serde_json::Value::as_u64)
-            .unwrap_or(0);
-
-        // Check Submit(0) ledger for data
-        let submit_result = clients[0]
-            .http_client
-            .get(format!("{}/v1/storage/counts/Submit/0", clients[0].url))
-            .send()
-            .await?
-            .json::<serde_json::Value>()
-            .await?;
-
-        let submit_data_chunks = submit_result
-            .get("data_chunks")
-            .and_then(serde_json::Value::as_u64)
-            .unwrap_or(0);
-        let submit_packed_chunks = submit_result
-            .get("packed_chunks")
-            .and_then(serde_json::Value::as_u64)
-            .unwrap_or(0);
+        let submit_counts = get_chunk_counts(&clients[0], "Submit", 0).await?;
+        let submit_data_chunks = submit_counts.data_chunks;
+        let submit_packed_chunks = submit_counts.packed_chunks;
 
         if publish_data_chunks == 0 && submit_data_chunks == 0 {
             return Err(eyre::eyre!(

--- a/crates/chain-tests/src/external/utils/types.rs
+++ b/crates/chain-tests/src/external/utils/types.rs
@@ -56,6 +56,7 @@ pub(crate) struct ChunkInterval {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct StorageIntervalsResponse {
     pub ledger: String,
     pub slot_index: usize,
@@ -188,6 +189,7 @@ pub(crate) struct SlotReplicaSummary {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct ChunkCountsResponse {
     pub ledger: String,
     pub slot_index: usize,


### PR DESCRIPTION
## Summary

**Bug:** `GET /v1/storage/intervals/...` and `GET /v1/storage/counts/...` 404'd on every request (`missing field 'slotIndex'`) before hitting the handler.

**Cause:** actix-web matches path placeholders to serde field names. Params structs had `rename_all = "camelCase"`, so extractors expected `slotIndex` / `chunkType` while routes used `{slot_index}` / `{chunk_type}`.

**Fix:** Drop `rename_all` from the path-param structs only. URLs unchanged. Response JSON stays camelCase (`slotIndex`, `dataChunks`, …) via the separate `*Response` structs.

Also:
- Shared `INTERVALS_ROUTE` / `COUNTS_ROUTE` constants so tests use production templates
- External tests: camelCase response types + typed `get_chunk_counts` (no silent `unwrap_or(0)`)

## Test plan

- [x] Unit tests: path extraction (intervals/counts) + response camelCase keys
- [x] `cargo nextest run -p irys-api-server`
- [ ] External docker-cluster tests (`#[ignore]`) still need a manual cluster run