### PR TITLE
fix: Reorg reverts a reth-finalized block post-restart (0a / FC-recheck-1)

### DIFF
--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -6,7 +6,8 @@ use irys_database::{
 };
 use irys_domain::{
     BlockIndex, BlockTree, ChunkType, StorageModule, StorageModulesReadGuard, SupplyState,
-    block_index_guard::BlockIndexReadGuard, get_overlapped_storage_modules,
+    block_index_guard::BlockIndexReadGuard, forkchoice_markers::finalized_height,
+    get_overlapped_storage_modules,
 };
 use irys_storage::ii;
 use irys_types::{
@@ -32,6 +33,8 @@ pub struct BlockMigrationService {
     /// (re-list) every commitment of the epoch but never first-INCLUDE one, so
     /// they must not write commitment dedup metadata.
     num_blocks_in_epoch: u64,
+    block_tree_depth: u64,
+    block_migration_depth: u64,
     cache: Arc<RwLock<BlockTree>>,
     chunk_migration_sender: UnboundedSender<Traced<ChunkMigrationServiceMessage>>,
     storage_modules_guard: Option<StorageModulesReadGuard>,
@@ -133,6 +136,8 @@ impl BlockMigrationService {
         supply_state: Option<Arc<SupplyState>>,
         chunk_size: u64,
         num_blocks_in_epoch: u64,
+        block_tree_depth: u64,
+        block_migration_depth: u64,
         cache: Arc<RwLock<BlockTree>>,
         chunk_migration_sender: UnboundedSender<Traced<ChunkMigrationServiceMessage>>,
     ) -> Self {
@@ -142,6 +147,8 @@ impl BlockMigrationService {
             supply_state,
             chunk_size,
             num_blocks_in_epoch,
+            block_tree_depth,
+            block_migration_depth,
             cache,
             chunk_migration_sender,
             storage_modules_guard: None,
@@ -408,6 +415,15 @@ impl BlockMigrationService {
         let latest = block_index.latest_height();
         if fork_parent_height >= latest {
             return Ok(());
+        }
+
+        let finalized = finalized_height(latest, self.block_tree_depth, self.block_migration_depth);
+        if fork_parent_height < finalized {
+            return Err(eyre::eyre!(
+                "network-partition recovery would roll back to height {fork_parent_height}, below the \
+                 finalized height {finalized}; refusing to orphan a finalized block. A reorg below \
+                 finalized means our view of finality was wrong; halting is the safe response."
+            ));
         }
 
         let rollback_count = latest - fork_parent_height;
@@ -889,6 +905,8 @@ mod tests {
             None, // supply_state — unused by persist_metadata
             ConsensusConfig::testing().chunk_size,
             num_blocks_in_epoch,
+            ConsensusConfig::testing().block_tree_depth,
+            ConsensusConfig::testing().block_migration_depth as u64,
             cache,
             chunk_migration_sender,
         );
@@ -2072,6 +2090,97 @@ mod tests {
         assert_eq!(
             modules[1].get_intervals(ChunkType::Entropy),
             [partition_chunk_offset_ii!(3, 4)]
+        );
+
+        Ok(())
+    }
+
+    /// P0 finality-violation reproduction: a deep reorg whose fork point sits
+    /// **at or below the finalized (prune) height** must never orphan the
+    /// finalized block. `recover_from_network_partition` performs the
+    /// irreversible block-index truncation, so it is the last line of defense —
+    /// it must refuse (error out) rather than roll back an entry at or below
+    /// finalized. A reorg below finalized means our view of finality was wrong;
+    /// continuing would silently revert an already-announced-final block.
+    ///
+    /// Scenario mirrors the confirmed counterexample, scaled to `testing()`
+    /// depths (`block_tree_depth = 50`, `block_migration_depth = 6`, so
+    /// `depth_delta = 44`):
+    ///   - the block index is migrated up to height 60 (latest indexed),
+    ///   - finalized height = 60 - 44 = 16,
+    ///   - a cdiff-heavier fork diverges at height 12 — *below* finalized.
+    ///
+    /// Rolling the index back to the fork parent (12) would orphan finalized
+    /// block 16. The guard must reject the rollback and leave the index intact.
+    #[test]
+    fn recover_from_network_partition_refuses_to_orphan_finalized_block() -> eyre::Result<()> {
+        let (db, _db_tmp) = open_db()?;
+        let (mut svc, _svc_tmp) = make_service(db.clone());
+
+        // recover requires a storage-modules guard. The seeded chain has no
+        // ledger growth, so there are no offsets to unassign and an empty
+        // module set is sufficient.
+        svc.set_storage_modules_guard(StorageModulesReadGuard::new(Arc::new(RwLock::new(
+            Vec::new(),
+        ))));
+
+        // depth_delta = block_tree_depth(50) - block_migration_depth(6) = 44.
+        let consensus = ConsensusConfig::testing();
+        let depth_delta = consensus.block_tree_depth - consensus.block_migration_depth as u64;
+        let latest_indexed = 60_u64;
+        let finalized_height = latest_indexed - depth_delta; // 16
+        let fork_parent_height = finalized_height - 4; // 12, below finalized
+
+        // Build a chained index 0..=latest_indexed with constant Submit chunks
+        // (no ledger growth → recover finds no storage-module work). recover
+        // reads block headers from the DB, so seed both headers and index items.
+        let mut prev_hash = H256::zero();
+        let mut headers = Vec::new();
+        for height in 0..=latest_indexed {
+            let header = make_block_header(height, prev_hash, 1, vec![]);
+            prev_hash = header.block_hash;
+            headers.push(header);
+        }
+        db.update_eyre(|tx| {
+            for header in &headers {
+                irys_database::insert_block_header(tx, header)?;
+            }
+            Ok(())
+        })?;
+        let submit_index_item = |header: &IrysBlockHeader| BlockIndexItem {
+            block_hash: header.block_hash,
+            num_ledgers: 1,
+            ledgers: vec![LedgerIndexItem {
+                total_chunks: 1,
+                tx_root: H256::zero(),
+                ledger: DataLedger::Submit,
+            }],
+        };
+        {
+            let index = svc.block_index_guard.read();
+            for (height, header) in headers.iter().enumerate() {
+                index.push_item(&submit_index_item(header), height as u64)?;
+            }
+        }
+
+        let result = svc.recover_from_network_partition(fork_parent_height);
+
+        assert!(
+            result.is_err(),
+            "recover_from_network_partition must refuse a rollback below the \
+             finalized height {finalized_height} (fork parent {fork_parent_height}); \
+             orphaning a finalized block is a silent finality violation",
+        );
+
+        let index = svc.block_index_guard.read();
+        assert_eq!(
+            index.latest_height(),
+            latest_indexed,
+            "the block index must not be truncated when a below-finalized reorg is rejected",
+        );
+        assert!(
+            index.get_item(finalized_height).is_some(),
+            "the finalized block at height {finalized_height} must survive the rejected reorg",
         );
 
         Ok(())

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -2257,6 +2257,8 @@ mod tests {
                 None,
                 config.consensus.chunk_size,
                 config.consensus.epoch.num_blocks_in_epoch,
+                config.consensus.block_tree_depth,
+                config.consensus.block_migration_depth as u64,
                 cache.clone(),
                 chunk_migration_sender,
             );

--- a/crates/actors/src/reth_service.rs
+++ b/crates/actors/src/reth_service.rs
@@ -46,7 +46,8 @@ pub enum RethServiceMessage {
 // Represents the fork-choice hashes we feed to Reth. Each field is an ancestor of `head`:
 // - `head_hash`: current canonical tip (latest block we want Reth to follow).
 // - `confirmed_hash`: migration/safe block, roughly `migration_depth` behind head.
-// - `finalized_hash`: prune/finalized block, `block_tree_depth` behind the confirmed block.
+// - `finalized_hash`: prune/finalized block, `block_tree_depth` behind head (the
+//   block that has left the block tree and is therefore irreversible).
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ForkChoiceUpdate {
     pub head_hash: B256,

--- a/crates/actors/src/reth_service.rs
+++ b/crates/actors/src/reth_service.rs
@@ -46,8 +46,10 @@ pub enum RethServiceMessage {
 // Represents the fork-choice hashes we feed to Reth. Each field is an ancestor of `head`:
 // - `head_hash`: current canonical tip (latest block we want Reth to follow).
 // - `confirmed_hash`: migration/safe block, roughly `migration_depth` behind head.
-// - `finalized_hash`: prune/finalized block, `block_tree_depth` behind head (the
-//   block that has left the block tree and is therefore irreversible).
+// - `finalized_hash`: prune/finalized block, `block_tree_depth` behind the live head (the
+//   block that has left the block tree and is therefore irreversible). On restart the head
+//   rolls back to the confirmed tip, so the startup FCU's `finalized_hash` is
+//   `block_tree_depth - migration_depth` behind `head_hash` (see `ForkChoiceMarkers::from_index`).
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ForkChoiceUpdate {
     pub head_hash: B256,

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -1653,7 +1653,7 @@ impl IrysNode {
             config.consensus.chunk_size,
             config.consensus.epoch.num_blocks_in_epoch,
             config.consensus.block_tree_depth,
-            config.consensus.block_migration_depth as u64,
+            u64::from(config.consensus.block_migration_depth),
             Arc::clone(&block_tree_cache),
             service_senders.chunk_migration.clone(),
         );

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -1652,6 +1652,8 @@ impl IrysNode {
             Some(supply_state.clone()),
             config.consensus.chunk_size,
             config.consensus.epoch.num_blocks_in_epoch,
+            config.consensus.block_tree_depth,
+            config.consensus.block_migration_depth as u64,
             Arc::clone(&block_tree_cache),
             service_senders.chunk_migration.clone(),
         );

--- a/crates/domain/src/models/block_tree.rs
+++ b/crates/domain/src/models/block_tree.rs
@@ -305,7 +305,7 @@ impl BlockTree {
             let start = restore_cache_floor(
                 block_index.latest_height(),
                 consensus_config.block_tree_depth,
-                consensus_config.block_migration_depth as u64,
+                u64::from(consensus_config.block_migration_depth),
             );
             let end = block_index.num_blocks();
             let start_block_hash = block_index

--- a/crates/domain/src/models/block_tree.rs
+++ b/crates/domain/src/models/block_tree.rs
@@ -17,6 +17,8 @@ use crate::{
     EpochSnapshot, create_ema_snapshot_from_chain_history,
 };
 
+use super::forkchoice_markers::restore_cache_floor;
+
 /// Why a block is being evicted from the block-tree cache.
 ///
 /// Recorded on the `Removing block from block tree cache` debug log so an
@@ -300,9 +302,11 @@ impl BlockTree {
             let block_index = block_index_guard.read();
             eyre::ensure!(block_index.num_blocks() > 0, "Block list must not be empty");
 
-            let start = block_index
-                .num_blocks()
-                .saturating_sub(consensus_config.block_tree_depth - 1);
+            let start = restore_cache_floor(
+                block_index.latest_height(),
+                consensus_config.block_tree_depth,
+                consensus_config.block_migration_depth as u64,
+            );
             let end = block_index.num_blocks();
             let start_block_hash = block_index
                 .get_item(start)

--- a/crates/domain/src/models/forkchoice_markers.rs
+++ b/crates/domain/src/models/forkchoice_markers.rs
@@ -114,8 +114,12 @@ impl ForkChoiceMarkers {
 
         let head_height = block_index.latest_height();
         let migration_height = head_height;
-        let depth_delta = compute_depth_delta(prune_depth, migration_depth)?;
-        let prune_height = head_height.saturating_sub(depth_delta);
+        // At restart the head rolls back to the confirmed (migrated) frontier, so
+        // `head_height` here IS the confirmed frontier — the canonical anchor for
+        // finalization. This keeps the finalized we re-announce to reth aligned
+        // with the value in effect before shutdown (no recession).
+        let prune_height =
+            finalized_height(head_height, prune_depth as u64, migration_depth as u64);
 
         let head_block = marker_from_index_height(block_index, database, head_height)?;
         let migration_block = marker_from_index_height(block_index, database, migration_height)?;
@@ -221,6 +225,38 @@ pub(crate) fn compute_prune_height(
     desired_prune.max(index_final_height).min(migration_height)
 }
 
+/// The finalized height: the block that has left (or is leaving) the block tree
+/// and is therefore irreversible. Finalization depth is canonically equal to
+/// `block_tree_depth` — the moment a block falls `block_tree_depth` behind the
+/// head it is pruned from the tree, and no admissible reorg (whose LCA must live
+/// in the tree) can reach it.
+///
+/// Anchored to the **confirmed frontier** (the migrated block-index tip), not the
+/// live head: the confirmed frontier persists across a restart, whereas the head
+/// rolls back to it. Because the confirmed frontier sits `migration_depth` behind
+/// the head, `confirmed − (block_tree_depth − migration_depth)` equals
+/// `head − block_tree_depth` in steady state while remaining monotonic across a
+/// restart's head-rollback. This is the single definition every finalized/prune
+/// computation (fork-choice markers, block-tree restore floor, partition-recovery
+/// guard) must agree on.
+pub fn finalized_height(confirmed_height: u64, block_tree_depth: u64, migration_depth: u64) -> u64 {
+    let depth_delta = block_tree_depth.saturating_sub(migration_depth);
+    confirmed_height.saturating_sub(depth_delta)
+}
+
+/// The block-tree cache floor to restore after a restart: the lowest height the
+/// rebuilt tree should keep, so the reorg window never straddles a finalized block.
+///
+/// On restart the head rolls back to the confirmed (migrated) index tip, so we
+/// reconstruct the pre-crash head (`confirmed_tip + migration_depth`) and apply the
+/// same rule a running node's `prune` follows (`head - (block_tree_depth - 1)`).
+/// This equals `finalized_height(..) + 1` once the chain is `block_tree_depth`
+/// deep, and saturates to 0 (keeping genesis) on a young chain.
+pub fn restore_cache_floor(confirmed_tip: u64, block_tree_depth: u64, migration_depth: u64) -> u64 {
+    let precrash_head = confirmed_tip.saturating_add(migration_depth);
+    precrash_head.saturating_sub(block_tree_depth.saturating_sub(1))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -266,5 +302,59 @@ mod tests {
             let result = compute_prune_height(migration_height, index_safe_height, 0);
             prop_assert_eq!(result, migration_height);
         }
+    }
+
+    /// The canonical finalized height is the confirmed (migrated) frontier minus
+    /// `depth_delta` (= `block_tree_depth − migration_depth`). Worked from the
+    /// confirmed counterexample: confirmed tip 94, block_tree_depth 18,
+    /// migration_depth 6 → finalized 82.
+    #[test]
+    fn finalized_height_is_confirmed_minus_depth_delta() {
+        assert_eq!(finalized_height(94, 18, 6), 82);
+    }
+
+    /// Anchored to the confirmed frontier, the helper equals `head − block_tree_depth`
+    /// in steady state, because the confirmed frontier sits `migration_depth` behind
+    /// the head. head 100, migration_depth 6 → confirmed 94 → finalized 82 = 100 − 18.
+    #[test]
+    fn finalized_height_equals_head_minus_block_tree_depth_in_steady_state() {
+        let (head, block_tree_depth, migration_depth) = (100_u64, 18_u64, 6_u64);
+        let confirmed = head - migration_depth;
+        assert_eq!(
+            finalized_height(confirmed, block_tree_depth, migration_depth),
+            head - block_tree_depth,
+        );
+    }
+
+    /// Before the chain is `block_tree_depth` deep nothing has left the tree, so
+    /// finalized saturates at genesis rather than underflowing.
+    #[test]
+    fn finalized_height_saturates_to_genesis_on_shallow_chain() {
+        assert_eq!(finalized_height(5, 18, 6), 0);
+    }
+
+    /// Deep chain: the reconstructed pre-crash head is `confirmed_tip + migration_depth`
+    /// = 100, so the floor is `100 - (18 - 1)` = 83, matching `finalized_height(94, 18, 6) + 1`.
+    #[test]
+    fn restore_cache_floor_matches_finalized_height_plus_one_on_deep_chain() {
+        assert_eq!(restore_cache_floor(94, 18, 6), 83);
+        assert_eq!(
+            restore_cache_floor(94, 18, 6),
+            finalized_height(94, 18, 6) + 1
+        );
+    }
+
+    /// Boundary: pre-crash head (confirmed_tip + migration_depth = 18) exactly equals
+    /// block_tree_depth, so the floor lands at height 1.
+    #[test]
+    fn restore_cache_floor_at_exact_boundary() {
+        assert_eq!(restore_cache_floor(12, 18, 6), 1);
+    }
+
+    /// Young chain: pre-crash head (9 + 6 = 15) is still less than block_tree_depth (18),
+    /// so the floor saturates to 0, keeping genesis in the tree.
+    #[test]
+    fn restore_cache_floor_saturates_to_genesis_on_young_chain() {
+        assert_eq!(restore_cache_floor(9, 18, 6), 0);
     }
 }

--- a/crates/domain/src/models/forkchoice_markers.rs
+++ b/crates/domain/src/models/forkchoice_markers.rs
@@ -98,10 +98,12 @@ impl ForkChoiceMarkers {
     /// latest indexed block).
     ///
     /// During startup the block tree is empty, so:
-    /// - `head` resolves to the latest block index entry (the prior canonical head).
-    /// - `migration_block` mirrors that same entry to match the “confirmed” head just before shutdown.
-    /// - `prune_block` is derived from the index at `block_tree_depth` behind the tip so the finalized
-    ///   marker aligns with the state before shutdown.
+    /// - `head` resolves to the latest block index entry — the confirmed/migrated frontier, which
+    ///   sits `migration_depth` below the pre-shutdown canonical head (the head rolls back to it).
+    /// - `migration_block` mirrors that same entry (the “confirmed” head just before shutdown).
+    /// - `prune_block` is `finalized_height(...)` behind that frontier — `block_tree_depth −
+    ///   migration_depth` below the tip, equal to `block_tree_depth` below the pre-shutdown head —
+    ///   so the finalized marker aligns with the state before shutdown.
     pub fn from_index(
         block_index: &block_index::BlockIndex,
         database: &DatabaseProvider,


### PR DESCRIPTION
## [P0] Reorg reverts a reth-finalized block post-restart

Minimal mitigation for #1483 (deep review 0a / FC-recheck-1). **#1483 stays open** — this
closes the confirmed trigger but not the full class (see Scope).

**The bug (silent finality violation):** `BlockTree::restore_from_db` rebuilt the cache floor
at `num_blocks − (block_tree_depth − 1)`, which lands *below* the finalized height after a
restart (the head rolls back by `block_migration_depth`), re-opening a reorg window that
straddles the finalized block. A cdiff-heavier fork diverging in that window passed every
guard, and `recover_from_network_partition` would truncate the block index below finalized —
orphaning an already-announced-final block. No crash, no diagnostic.

## What this changes

- **Raise the restart cache floor to `finalized + 1`** (`restore_cache_floor`), so the
  rebuilt tree matches a never-crashed node's prune floor and the reorg window can no longer
  straddle finalized. Saturates to genesis on a young chain.
- **Guard `recover_from_network_partition`:** refuse (hard error → controlled shutdown) any
  rollback below the finalized height rather than silently orphaning a finalized block. This
  is the sole irreversible block-index truncation path.
- **Add `finalized_height` / `restore_cache_floor` helpers** expressing the canonical
  finalization depth (`block_tree_depth`), and route `from_index` through them
  (behavior-preserving refactor).

## Scope — minimal fix, not the full class closure

Closes the confirmed steady-state counterexample (any-time crash → restart → sub-finalized
reorg) and regresses no legitimate reorgs. It does **not** close two crash-window cases,
because "finalized" here is anchored to the index-derived value, which is not monotone (a
legitimate deep reorg truncates the index, so the derived finalized can recede):

- **A** — crash in the `emit_fcu`-ack → `migrate_block` gap on a ≥2 migration jump: the
  announced/persisted finalized outruns the index tip; after restart the re-derived floor
  sits below it.
- **B** — finalized recession after a legitimate deep reorg truncates the index; a crash in
  that window restores a floor below the previously-announced finalized.

Fully closing the class needs a **monotone finalized height that survives restart and
reorg** — the value can never be safely re-derived from the recede-able index tip. Plan
(follow-up on #1483, see `HANDOFF-finalized-hwm.md`): store an advance-only finalized height
*with the block index* (which now retains every finalized block permanently thanks to the
guard here, so its hash is always available), **never announce a finalized ahead of the index
tip**, and read that height at the restore floor, the recover guard, and every FCU emitter
(clamped once at the `RethService` choke point). The cap-at-index-tip rule is what keeps a
plain height sufficient — it removes the A-extreme case where an announced-final block sits
above the local index after a crash.

## Tests

- Unit coverage for `finalized_height` / `restore_cache_floor`: steady-state equivalence to
  `head − block_tree_depth`, the deep-chain `finalized + 1` floor, the exact boundary, and
  young-chain saturation to genesis.
- Reproduction that `recover_from_network_partition` refuses a below-finalized rollback and
  leaves the index intact (fails on `master`, passes here).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented network-partition recovery from orphaning finalized blocks.
  * Improved fork-choice handling during startup and recovery.
  * Restored the block cache from the correct finalized boundary, including shallow-chain cases.

* **Tests**
  * Added regression coverage for rejected reorganizations below finalized blocks.
  * Added validation for finalized-height and cache-restoration boundary calculations.

* **Documentation**
  * Clarified finalized-block terminology in fork-choice guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
