### PR TITLE
fix: Ingress-proof-count panic — steady-state remote node-crash DoS (0c / FC-core-B)

### DIFF
--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -1977,24 +1977,15 @@ pub async fn prevalidate_block(
     let publish_txs = transactions.get_ledger_txs(DataLedger::Publish);
 
     // Reject a mis-sized flat proof list before shadow-tx generation slices it
-    // by N. N is taken at the parent timestamp to match `ShadowTxGenerator`.
-    let ingress_proofs_total_at_parent =
-        config.number_of_ingress_proofs_total_at(previous_block.timestamp_secs());
-    // Defense in depth: this guard and the generator size proofs by parent-N,
-    // while `data_txs_are_valid` and block production use block-N. They agree
-    // only until a hardfork changes N (see `publish_ingress_proof_count_is_valid`).
-    // debug-only so drift is caught in tests when such a fork lands — never a
-    // release panic, which on this consensus path would be a peer-triggerable DoS.
-    debug_assert_eq!(
-        ingress_proofs_total_at_parent,
-        config.number_of_ingress_proofs_total_at(block.timestamp_secs()),
-        "ingress-proof N diverges between parent and block timestamps; reconcile \
-         the N-source across prevalidation, ShadowTxGenerator, and data_txs_are_valid"
-    );
+    // by N. N is taken at the parent timestamp to match `ShadowTxGenerator` (see
+    // the doc comment on `publish_ingress_proof_count_is_valid` for the
+    // parent-vs-block-timestamp divergence a future N-changing hardfork must
+    // reconcile — the divergence is expected at such a boundary, so it is a
+    // documented limitation, not a runtime invariant to assert).
     publish_ingress_proof_count_is_valid(
         publish_ledger,
         publish_txs.len(),
-        ingress_proofs_total_at_parent,
+        config.number_of_ingress_proofs_total_at(previous_block.timestamp_secs()),
     )?;
 
     // Flatten (proof, data_root) pairs across publish txs so the parallel

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -1544,24 +1544,28 @@ fn expected_ledger_total_chunks(
         .saturating_add(calculate_chunks_added(txs, chunk_size))
 }
 
-/// Reject a publish ledger whose flat ingress-proof list cannot be sliced by
-/// `number_of_ingress_proofs_total` (N) without going out of bounds.
+/// Reject a publish ledger whose flat ingress-proof list length is not
+/// `publish_tx_count * number_of_ingress_proofs_total` (N), or whose
+/// peer-supplied `required_proof_count` is not N.
 ///
 /// `ShadowTxGenerator` slices the flat proofs list as `[i*N .. i*N+N]` for each
-/// publish tx `i`, using N at the parent block timestamp. That slice panics on a
-/// short/mis-sized peer-supplied list. The per-tx `get_ingress_proofs` check
-/// keys off the peer-supplied `required_proof_count`, so it passes a crafted
-/// block (e.g. `required_proof_count = 1`, one proof, N = 3) that the generator
-/// then panics on. Running this aggregate check in `prevalidate_block` — ahead
-/// of shadow-tx generation — turns that into an early, uniform consensus
-/// rejection rather than a node-crashing panic. N MUST be taken at the parent
-/// timestamp so the guard and the generator's slice agree on N.
+/// publish tx `i`. A short/mis-sized peer-supplied list is a consensus-invalid
+/// block; the per-tx `get_ingress_proofs` check keys off the peer-supplied
+/// `required_proof_count` and so passes a crafted block (e.g.
+/// `required_proof_count = 1`, one proof, N = 3). Running this aggregate check in
+/// `prevalidate_block` — ahead of shadow-tx generation — makes the rejection
+/// early and uniform. (The generator's checked slice is the total panic-proof
+/// backstop; this guard just moves the rejection earlier.)
 ///
-/// Caveat: `data_txs_are_valid` and block production size proofs by N at the
-/// block's OWN timestamp, whereas this guard and the generator use N at the
-/// parent timestamp. They agree only while no hardfork changes N. A fork that
-/// changes N must reconcile the N-source across prevalidation, the generator,
-/// and `data_txs_are_valid`, or the boundary block's promotions are rejected.
+/// N MUST be taken at the block's OWN timestamp so this guard agrees with block
+/// production and `data_txs_are_valid`, which both size proofs by N at the block
+/// timestamp. An honestly-produced block therefore always passes this guard,
+/// including the first block after a hardfork that changes N.
+///
+/// Note: the generator still slices by N at the PARENT timestamp, so at an
+/// N-changing boundary it groups proofs by the old N (a reward-attribution
+/// divergence). Reconciling the generator's N-source is a separate concern and
+/// is not required for this guard's correctness.
 fn publish_ingress_proof_count_is_valid(
     publish_ledger: &DataTransactionLedger,
     publish_tx_count: usize,
@@ -1575,6 +1579,17 @@ fn publish_ingress_proof_count_is_valid(
         return Err(PreValidationError::PublishLedgerProofCountMismatch {
             proof_count: proofs.len(),
             tx_count: publish_tx_count,
+        });
+    }
+    // Pin the peer-supplied `required_proof_count` to N. The per-tx signature
+    // check in `prevalidate_block` slices proofs via `get_ingress_proofs`, which
+    // trusts this field; an understated value would leave later proofs unverified
+    // in prevalidation even though the aggregate length matches.
+    let required_proof_count = publish_ledger.required_proof_count.map_or(0, usize::from);
+    if required_proof_count != number_of_ingress_proofs_total as usize {
+        return Err(PreValidationError::IngressProofCountMismatch {
+            expected: number_of_ingress_proofs_total as usize,
+            actual: required_proof_count,
         });
     }
     Ok(())
@@ -1977,15 +1992,13 @@ pub async fn prevalidate_block(
     let publish_txs = transactions.get_ledger_txs(DataLedger::Publish);
 
     // Reject a mis-sized flat proof list before shadow-tx generation slices it
-    // by N. N is taken at the parent timestamp to match `ShadowTxGenerator` (see
-    // the doc comment on `publish_ingress_proof_count_is_valid` for the
-    // parent-vs-block-timestamp divergence a future N-changing hardfork must
-    // reconcile — the divergence is expected at such a boundary, so it is a
-    // documented limitation, not a runtime invariant to assert).
+    // by N. N is taken at the block's own timestamp to match block production and
+    // `data_txs_are_valid`, so an honestly-produced block always passes — see the
+    // doc comment on `publish_ingress_proof_count_is_valid`.
     publish_ingress_proof_count_is_valid(
         publish_ledger,
         publish_txs.len(),
-        config.number_of_ingress_proofs_total_at(previous_block.timestamp_secs()),
+        config.number_of_ingress_proofs_total_at(block.timestamp_secs()),
     )?;
 
     // Flatten (proof, data_root) pairs across publish txs so the parallel
@@ -7423,6 +7436,18 @@ mod tests {
         assert!(matches!(
             publish_ingress_proof_count_is_valid(&orphan_proofs, 0, 3),
             Err(PreValidationError::PublishLedgerProofCountMismatch { .. })
+        ));
+
+        // Aggregate length matches (1 tx * N=3 = 3 proofs) but the peer
+        // understated `required_proof_count`, which would make the per-tx
+        // signature check verify only a subset. Must be rejected.
+        let understated = publish_ledger_with_proofs(vec![tx_id], 3, Some(1));
+        assert!(matches!(
+            publish_ingress_proof_count_is_valid(&understated, 1, 3),
+            Err(PreValidationError::IngressProofCountMismatch {
+                expected: 3,
+                actual: 1
+            })
         ));
 
         // Well-formed: exactly publish_txs.len() * N proofs validates.

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -1544,6 +1544,42 @@ fn expected_ledger_total_chunks(
         .saturating_add(calculate_chunks_added(txs, chunk_size))
 }
 
+/// Reject a publish ledger whose flat ingress-proof list cannot be sliced by
+/// `number_of_ingress_proofs_total` (N) without going out of bounds.
+///
+/// `ShadowTxGenerator` slices the flat proofs list as `[i*N .. i*N+N]` for each
+/// publish tx `i`, using N at the parent block timestamp. That slice panics on a
+/// short/mis-sized peer-supplied list. The per-tx `get_ingress_proofs` check
+/// keys off the peer-supplied `required_proof_count`, so it passes a crafted
+/// block (e.g. `required_proof_count = 1`, one proof, N = 3) that the generator
+/// then panics on. Running this aggregate check in `prevalidate_block` — ahead
+/// of shadow-tx generation — turns that into an early, uniform consensus
+/// rejection rather than a node-crashing panic. N MUST be taken at the parent
+/// timestamp so the guard and the generator's slice agree on N.
+///
+/// Caveat: `data_txs_are_valid` and block production size proofs by N at the
+/// block's OWN timestamp, whereas this guard and the generator use N at the
+/// parent timestamp. They agree only while no hardfork changes N. A fork that
+/// changes N must reconcile the N-source across prevalidation, the generator,
+/// and `data_txs_are_valid`, or the boundary block's promotions are rejected.
+fn publish_ingress_proof_count_is_valid(
+    publish_ledger: &DataTransactionLedger,
+    publish_tx_count: usize,
+    number_of_ingress_proofs_total: u64,
+) -> Result<(), PreValidationError> {
+    let Some(proofs) = &publish_ledger.proofs else {
+        return Ok(());
+    };
+    let expected = publish_tx_count * number_of_ingress_proofs_total as usize;
+    if proofs.len() != expected {
+        return Err(PreValidationError::PublishLedgerProofCountMismatch {
+            proof_count: proofs.len(),
+            tx_count: publish_tx_count,
+        });
+    }
+    Ok(())
+}
+
 /// Full pre-validation steps for a block
 #[tracing::instrument(level = "trace", skip_all, fields(block.hash = %sealed_block.header().block_hash, block.height = sealed_block.header().height))]
 pub async fn prevalidate_block(
@@ -1939,6 +1975,27 @@ pub async fn prevalidate_block(
         })?;
 
     let publish_txs = transactions.get_ledger_txs(DataLedger::Publish);
+
+    // Reject a mis-sized flat proof list before shadow-tx generation slices it
+    // by N. N is taken at the parent timestamp to match `ShadowTxGenerator`.
+    let ingress_proofs_total_at_parent =
+        config.number_of_ingress_proofs_total_at(previous_block.timestamp_secs());
+    // Defense in depth: this guard and the generator size proofs by parent-N,
+    // while `data_txs_are_valid` and block production use block-N. They agree
+    // only until a hardfork changes N (see `publish_ingress_proof_count_is_valid`).
+    // debug-only so drift is caught in tests when such a fork lands — never a
+    // release panic, which on this consensus path would be a peer-triggerable DoS.
+    debug_assert_eq!(
+        ingress_proofs_total_at_parent,
+        config.number_of_ingress_proofs_total_at(block.timestamp_secs()),
+        "ingress-proof N diverges between parent and block timestamps; reconcile \
+         the N-source across prevalidation, ShadowTxGenerator, and data_txs_are_valid"
+    );
+    publish_ingress_proof_count_is_valid(
+        publish_ledger,
+        publish_txs.len(),
+        ingress_proofs_total_at_parent,
+    )?;
 
     // Flatten (proof, data_root) pairs across publish txs so the parallel
     // verify below fans out across every proof rather than per-tx batches.
@@ -7330,6 +7387,61 @@ mod tests {
             vdf_step_count_is_consistent(0, 1),
             Err(PreValidationError::VDFCheckpointsInvalid(_))
         ));
+    }
+
+    fn publish_ledger_with_proofs(
+        tx_ids: Vec<H256>,
+        proof_count: usize,
+        required_proof_count: Option<u8>,
+    ) -> DataTransactionLedger {
+        DataTransactionLedger {
+            ledger_id: DataLedger::Publish.into(),
+            tx_root: H256::zero(),
+            tx_ids: H256List(tx_ids),
+            total_chunks: 0,
+            expires: None,
+            proofs: Some(irys_types::IngressProofsList(vec![
+                irys_types::ingress::IngressProof::default();
+                proof_count
+            ])),
+            required_proof_count,
+        }
+    }
+
+    /// Remote-panic DoS regression: `prevalidate_block`'s proof-count guard must
+    /// reject a publish ledger whose flat proof list is shorter than
+    /// `publish_txs.len() * N` (N = `number_of_ingress_proofs_total`) BEFORE
+    /// shadow-tx generation slices that list by N. The confirmed attack sets
+    /// `required_proof_count = Some(1)` with a single valid proof while N = 3:
+    /// the per-tx `get_ingress_proofs` check passes, but the generator would
+    /// slice `[0..3]` on a length-1 list and panic. A mis-sized list is
+    /// peer-controlled input, so it must be a consensus rejection, uniform
+    /// across all validators — never a node-crashing panic.
+    #[test]
+    fn ingress_proof_count_guard_rejects_short_proof_list() {
+        let tx_id = H256::from([1_u8; 32]);
+        // The attack: 1 tx, N = 3, but only 1 proof supplied.
+        let short = publish_ledger_with_proofs(vec![tx_id], 1, Some(1));
+        assert!(matches!(
+            publish_ingress_proof_count_is_valid(&short, 1, 3),
+            Err(PreValidationError::PublishLedgerProofCountMismatch { .. })
+        ));
+
+        // Empty publish txs but proofs present is also a mismatch (0 * N == 0).
+        let orphan_proofs = publish_ledger_with_proofs(vec![], 1, Some(3));
+        assert!(matches!(
+            publish_ingress_proof_count_is_valid(&orphan_proofs, 0, 3),
+            Err(PreValidationError::PublishLedgerProofCountMismatch { .. })
+        ));
+
+        // Well-formed: exactly publish_txs.len() * N proofs validates.
+        let ok = publish_ledger_with_proofs(vec![tx_id], 3, Some(3));
+        assert!(publish_ingress_proof_count_is_valid(&ok, 1, 3).is_ok());
+
+        // No proofs at all is not this guard's concern (handled downstream);
+        // the generator short-circuits on an empty list, so it cannot panic.
+        let none = ledger_with_tx(DataLedger::Publish, tx_id);
+        assert!(publish_ingress_proof_count_is_valid(&none, 1, 3).is_ok());
     }
 
     /// A commitment tx carrying a foreign `chain_id` is rejected by prevalidation:

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -1574,21 +1574,31 @@ fn publish_ingress_proof_count_is_valid(
     let Some(proofs) = &publish_ledger.proofs else {
         return Ok(());
     };
-    let expected = publish_tx_count * number_of_ingress_proofs_total as usize;
-    if proofs.len() != expected {
-        return Err(PreValidationError::PublishLedgerProofCountMismatch {
-            proof_count: proofs.len(),
-            tx_count: publish_tx_count,
-        });
+    let proof_count = proofs.len();
+    let mismatch = || PreValidationError::PublishLedgerProofCountMismatch {
+        proof_count,
+        tx_count: publish_tx_count,
+    };
+    // Convert N to usize once and multiply with checked arithmetic. Overflow is
+    // unreachable for a valid block (tx count and N are bounded), so fail closed
+    // as a mismatch rather than relying on an `as` cast that could wrap.
+    let Ok(n) = usize::try_from(number_of_ingress_proofs_total) else {
+        return Err(mismatch());
+    };
+    let Some(expected) = publish_tx_count.checked_mul(n) else {
+        return Err(mismatch());
+    };
+    if proof_count != expected {
+        return Err(mismatch());
     }
     // Pin the peer-supplied `required_proof_count` to N. The per-tx signature
     // check in `prevalidate_block` slices proofs via `get_ingress_proofs`, which
     // trusts this field; an understated value would leave later proofs unverified
     // in prevalidation even though the aggregate length matches.
     let required_proof_count = publish_ledger.required_proof_count.map_or(0, usize::from);
-    if required_proof_count != number_of_ingress_proofs_total as usize {
+    if required_proof_count != n {
         return Err(PreValidationError::IngressProofCountMismatch {
-            expected: number_of_ingress_proofs_total as usize,
+            expected: n,
             actual: required_proof_count,
         });
     }

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -7470,6 +7470,75 @@ mod tests {
         assert!(publish_ingress_proof_count_is_valid(&none, 1, 3).is_ok());
     }
 
+    /// `prevalidate_block` sizes N at the block's OWN timestamp
+    /// (`number_of_ingress_proofs_total_at(block.timestamp_secs())`), matching
+    /// block production and `data_txs_are_valid`. This must hold at an N-changing
+    /// hardfork boundary in BOTH directions: the first block after the fork carries
+    /// a proof list sized by the block's (new) N, so it passes the guard when N is
+    /// taken at the block timestamp — and would be wrongly rejected if N were taken
+    /// at the parent (pre-fork) timestamp. Keying off the parent is the
+    /// `ShadowTxGenerator`'s separate, documented divergence, not this guard's.
+    ///
+    /// This locks in the guard's arithmetic under each N-source; the call site's
+    /// choice of `block.timestamp_secs()` is covered end-to-end elsewhere.
+    #[test]
+    fn ingress_proof_count_guard_uses_block_timestamp_across_hardfork() {
+        use irys_types::UnixTimestamp;
+        use irys_types::hardfork_config::{FrontierParams, IrysHardforkConfig, NextNameTBD};
+
+        // Parent sits just before activation; the boundary block sits at
+        // activation, so parent-N and block-N differ.
+        let activation = UnixTimestamp::from_secs(1_000);
+        let parent_ts = UnixTimestamp::from_secs(999);
+        let block_ts = activation;
+        let tx_id = H256::from([7_u8; 32]);
+
+        // Exercise an N increase and an N decrease across the same boundary.
+        for (frontier_n, fork_n) in [(1_u64, 3_u64), (3_u64, 1_u64)] {
+            let hardforks = IrysHardforkConfig {
+                frontier: FrontierParams {
+                    number_of_ingress_proofs_total: frontier_n,
+                    number_of_ingress_proofs_from_assignees: 0,
+                },
+                next_name_tbd: Some(NextNameTBD {
+                    activation_timestamp: activation,
+                    number_of_ingress_proofs_total: fork_n,
+                    number_of_ingress_proofs_from_assignees: 0,
+                }),
+                aurora: None,
+                borealis: None,
+                cascade: None,
+            };
+
+            let parent_n = hardforks.number_of_ingress_proofs_total_at(parent_ts);
+            let block_n = hardforks.number_of_ingress_proofs_total_at(block_ts);
+            assert_eq!(parent_n, frontier_n);
+            assert_eq!(block_n, fork_n);
+            assert_ne!(parent_n, block_n, "boundary must actually change N");
+
+            // Honest boundary block: one publish tx, proof list and
+            // `required_proof_count` sized by the block's N (what the producer
+            // emits at `block_ts`).
+            let honest =
+                publish_ledger_with_proofs(vec![tx_id], block_n as usize, Some(block_n as u8));
+
+            // Sized at the block timestamp (the call-site's choice): passes.
+            assert!(
+                publish_ingress_proof_count_is_valid(&honest, 1, block_n).is_ok(),
+                "honest boundary block must pass when N is taken at the block timestamp \
+                 (frontier={frontier_n}, fork={fork_n})",
+            );
+
+            // Sized at the parent timestamp (the rejected alternative): would
+            // false-reject the same honest block because parent-N != block-N.
+            assert!(
+                publish_ingress_proof_count_is_valid(&honest, 1, parent_n).is_err(),
+                "parent-timestamp N would false-reject an honest boundary block \
+                 (frontier={frontier_n}, fork={fork_n})",
+            );
+        }
+    }
+
     /// A commitment tx carrying a foreign `chain_id` is rejected by prevalidation:
     /// `find_commitment_chain_id_mismatch` reports the offending tx (with its position) so the
     /// commitment-ledger validation fails the block with `CommitmentChainIdMismatch`.

--- a/crates/actors/src/shadow_tx_generator.rs
+++ b/crates/actors/src/shadow_tx_generator.rs
@@ -2171,6 +2171,13 @@ mod tests {
             "short ingress-proof list must classify as Structural (peer-attributable \
              consensus rejection) — a panic here is a network-wide DoS; got: {err:?}",
         );
+        // Pin the failure to the ingress-proof slice specifically, so a future
+        // earlier `Structural` (e.g. from `PublishFeeCharges::new`) can't silently
+        // shadow this coverage and let the OOB slice regress unnoticed.
+        assert!(
+            err.to_string().contains("ingress proofs at offset"),
+            "Structural error must originate at the ingress-proof slice; got: {err:?}",
+        );
     }
 
     /// `ShadowTxGenError::Display` carries the message verbatim with the

--- a/crates/actors/src/shadow_tx_generator.rs
+++ b/crates/actors/src/shadow_tx_generator.rs
@@ -471,8 +471,22 @@ impl<'a> ShadowTxGenerator<'a> {
             // consensus-invalid block, not a node fault. A raw slice would
             // panic on out-of-bounds input, letting one crafted block crash
             // every honest validator; classify as `Structural` instead.
-            let start_index = index * number_of_ingress_proofs_total as usize;
-            let end_index = start_index + number_of_ingress_proofs_total as usize;
+            // Compute the slice bounds with checked arithmetic. Overflow is
+            // unreachable for a valid block (index and N are bounded), so classify
+            // it as Structural rather than letting an `as` cast wrap.
+            let (start_index, end_index) = usize::try_from(number_of_ingress_proofs_total)
+                .ok()
+                .and_then(|n| {
+                    let start = index.checked_mul(n)?;
+                    let end = start.checked_add(n)?;
+                    Some((start, end))
+                })
+                .ok_or_else(|| {
+                    ShadowTxGenError::Structural(format!(
+                        "publish ledger tx {} ingress-proof slice offset overflowed for N={}",
+                        tx.id, number_of_ingress_proofs_total,
+                    ))
+                })?;
             let ingress_proofs = proofs.get(start_index..end_index).ok_or_else(|| {
                 ShadowTxGenError::Structural(format!(
                     "publish ledger tx {} expects {} ingress proofs at offset {}, but the \

--- a/crates/actors/src/shadow_tx_generator.rs
+++ b/crates/actors/src/shadow_tx_generator.rs
@@ -465,10 +465,24 @@ impl<'a> ShadowTxGenerator<'a> {
             )
             .map_err(|e| ShadowTxGenError::Structural(e.to_string()))?;
 
-            // Get all the ingress proofs for the transaction
+            // Get all the ingress proofs for the transaction. The span is
+            // sized from `number_of_ingress_proofs_total` (N), but the flat
+            // `proofs` list is peer-supplied — a short/mis-sized list is a
+            // consensus-invalid block, not a node fault. A raw slice would
+            // panic on out-of-bounds input, letting one crafted block crash
+            // every honest validator; classify as `Structural` instead.
             let start_index = index * number_of_ingress_proofs_total as usize;
             let end_index = start_index + number_of_ingress_proofs_total as usize;
-            let ingress_proofs = &proofs[start_index..end_index];
+            let ingress_proofs = proofs.get(start_index..end_index).ok_or_else(|| {
+                ShadowTxGenError::Structural(format!(
+                    "publish ledger tx {} expects {} ingress proofs at offset {}, but the \
+                     proofs list has length {}",
+                    tx.id,
+                    number_of_ingress_proofs_total,
+                    start_index,
+                    proofs.len(),
+                ))
+            })?;
 
             // Get fee charges for all ingress proofs
             let fee_charges = publish_charges
@@ -2077,6 +2091,85 @@ mod tests {
             matches!(err, ShadowTxGenError::TreasuryArithmetic(_)),
             "publish-ledger underflow with NO snapshot-derived taint must classify as \
              TreasuryArithmetic (peer-attributable) — got: {err:?}",
+        );
+    }
+
+    /// Remote-panic DoS regression: a peer block whose flat ingress-proof
+    /// list is shorter than `publish_txs.len() * number_of_ingress_proofs_total`
+    /// must surface as a peer-attributable `Structural` consensus rejection —
+    /// NEVER an out-of-bounds slice panic. The generator slices the flat
+    /// proofs list by `N` (`number_of_ingress_proofs_total`, at the parent
+    /// timestamp); a short list is fully peer-controlled input, so panicking
+    /// on it would let one crafted block crash every honest validator.
+    #[test]
+    fn publish_ingress_short_proof_list_is_structural_not_panic() {
+        let mut config = ConsensusConfig::testing();
+        // N = 3, but the block will carry only 1 proof for its 1 tx.
+        config.hardforks.frontier.number_of_ingress_proofs_total = 3;
+        let parent_block = IrysBlockHeader::new_mock_header();
+
+        let term_fee = U256::from(100_000_u64);
+        // Ample perm_fee so `PublishFeeCharges::new` succeeds and execution
+        // reaches the ingress-proof slice (the panic site pre-fix).
+        let perm_fee = U256::from(10_000_000_u64);
+
+        let tx_signer = IrysSigner::random_signer(&config);
+        let publish_tx = create_data_tx_header(&tx_signer, term_fee, Some(perm_fee));
+
+        let proof_signer = IrysSigner::random_signer(&config);
+        let proof = create_test_ingress_proof(
+            &proof_signer,
+            H256::from([21_u8; 32]),
+            H256::from([22_u8; 32]),
+        );
+
+        // One tx, one proof — needs 3, has 1.
+        let publish_ledger = PublishLedgerWithTxs {
+            txs: vec![publish_tx],
+            proofs: Some(IngressProofsList(vec![proof])),
+        };
+
+        let initial_treasury = U256::from(100_000_000_u64);
+        let expired_fees = LedgerExpiryBalanceDelta {
+            reward_balance_increment: BTreeMap::new(),
+            user_perm_fee_refunds: Vec::new(),
+        };
+
+        let block_height = 101_u64;
+        let reward_address = IrysAddress::from([20_u8; 20]);
+        let reward_amount = U256::from(5000_u64);
+        let solution_hash = H256::zero();
+        let epoch_snapshot = test_epoch_snapshot();
+
+        // `accumulate_ingress_rewards_for_init` runs inside `new`, so the OOB
+        // slice would panic here on pre-fix code. Post-fix it is a clean Err.
+        let result = ShadowTxGenerator::new(
+            &block_height,
+            &reward_address,
+            &reward_amount,
+            &parent_block,
+            &solution_hash,
+            &config,
+            &[],
+            &[],
+            &[],
+            &[],
+            &publish_ledger,
+            initial_treasury,
+            &expired_fees,
+            &[],
+            &[],
+            &epoch_snapshot,
+        );
+
+        let err = match result {
+            Ok(_) => panic!("a short ingress-proof list must be a Structural rejection, not Ok"),
+            Err(e) => e,
+        };
+        assert!(
+            matches!(err, ShadowTxGenError::Structural(_)),
+            "short ingress-proof list must classify as Structural (peer-attributable \
+             consensus rejection) — a panic here is a network-wide DoS; got: {err:?}",
         );
     }
 

--- a/crates/chain-tests/src/block_production/block_validation.rs
+++ b/crates/chain-tests/src/block_production/block_validation.rs
@@ -395,6 +395,85 @@ async fn test_prevalidation_rejects_tx_root_mismatch() -> Result<()> {
     Ok(())
 }
 
+/// Remote-panic DoS regression (end-to-end): a block whose Publish ledger carries
+/// a flat ingress-proof list that doesn't match `publish_txs.len() * N` must be
+/// rejected by `prevalidate_block` with `PublishLedgerProofCountMismatch` —
+/// BEFORE state validation drives `ShadowTxGenerator`, which slices that list by
+/// N and would otherwise panic on an out-of-bounds range. This pins the guard's
+/// wiring and ordering: the unit test `ingress_proof_count_guard_rejects_short_proof_list`
+/// covers the `len != txs * N` arithmetic in isolation; this proves the guard
+/// actually runs inside `prevalidate_block`.
+///
+/// Note the orphan shape (proofs present, zero publish txs) does NOT isolate this
+/// guard — `validate_ingress_proof_signers` rejects that earlier with the same
+/// error. So the fixture uses a NON-empty Publish ledger: one structurally-valid
+/// publish tx, `required_proof_count = 0` (so the earlier per-tx signer check
+/// slices zero proofs and passes without needing valid signatures), and a proofs
+/// list of length 2. With testing `N = 1`, `proofs.len() = 2 != 1 * N = 1`, a
+/// mismatch that only this guard catches — every earlier check passes.
+#[tokio::test]
+async fn test_prevalidation_rejects_mismatched_ingress_proof_count() -> Result<()> {
+    use irys_types::{
+        BoundedFee, DataLedger, DataTransactionLedger, H256List, IngressProofsList,
+        IrysTransactionCommon as _, ingress::IngressProof,
+    };
+
+    let ctx = PrevalidationTestContext::new().await?;
+    let consensus = ctx.config.consensus_config();
+
+    // A structurally-valid Publish data tx (data_size = 1 → contributes exactly
+    // one chunk; well-funded so it clears structural validation).
+    let mut tx = DataTransactionHeader::new(&consensus);
+    tx.data_root = H256::from_low_u64_be(0x0CE_CAFE_u64);
+    tx.data_size = 1;
+    tx.term_fee = BoundedFee::from_u64(1_000_000_000_000_000_000);
+    tx.perm_fee = Some(BoundedFee::from_u64(1_000_000_000_000_000_000));
+    tx.ledger_id = DataLedger::Publish as u32;
+    let tx = tx.sign(&ctx.config.signer())?;
+
+    // Splice it into the Publish ledger with a 2-proof list (needs 1 * N = 1).
+    let mut header = (**ctx.block.header()).clone();
+    let publish_ledger = header
+        .data_ledgers
+        .iter_mut()
+        .find(|l| l.ledger_id == DataLedger::Publish as u32)
+        .expect("Publish ledger should exist");
+    publish_ledger.tx_ids = H256List(vec![tx.id]);
+    publish_ledger.tx_root = DataTransactionLedger::compute_tx_root(std::slice::from_ref(&tx));
+    publish_ledger.total_chunks = 1;
+    publish_ledger.proofs = Some(IngressProofsList(vec![
+        IngressProof::default(),
+        IngressProof::default(),
+    ]));
+    // rpc = 0 → the earlier `validate_ingress_proof_signers` slices zero proofs
+    // per tx and passes; the aggregate guard is what must catch the length.
+    publish_ledger.required_proof_count = Some(0);
+
+    ctx.config.signer().sign_block_header(&mut header)?;
+    let mut body = ctx.block.to_block_body();
+    body.data_transactions = vec![tx.clone()];
+    body.block_hash = header.block_hash;
+    let bad_block = Arc::new(SealedBlock::new(header, body)?);
+
+    match ctx.prevalidate(&bad_block).await {
+        Err(PreValidationError::PublishLedgerProofCountMismatch {
+            proof_count,
+            tx_count,
+        }) => {
+            assert_eq!(proof_count, 2);
+            assert_eq!(tx_count, 1);
+        }
+        other => panic!(
+            "expected PublishLedgerProofCountMismatch (guard must reject before shadow-tx \
+             generation slices the proofs), got {:?}",
+            other
+        ),
+    }
+
+    ctx.stop().await;
+    Ok(())
+}
+
 /// A block that includes a `data_size == 0` data tx must be rejected with `ZeroSizeDataTx`.
 /// A zero-size tx stores no data and would inject a zero-width leaf into the ledger
 /// `tx_root` tree, colliding start offsets with the next tx and breaking PoA owning-tx


### PR DESCRIPTION
## [P0] Ingress-proof-count panic — steady-state remote node-crash DoS

Closes #1484.

### The bug (remote-panic DoS, no hardfork needed)

`ShadowTxGenerator` slices the flat, peer-supplied ingress-proof list as `[i*N .. i*N+N]` for each publish tx `i`, where `N = number_of_ingress_proofs_total` (10 mainnet / 3 testnet), taken at the parent block timestamp. The only guard forcing the list length to `publish_txs.len() * N` lived in `data_txs_are_valid`, which the validation task runs **after** `shadow_transactions_are_valid` (which drives the generator). `prevalidate_block` sliced only via `get_ingress_proofs`, keyed off the peer-supplied `required_proof_count` field — never checked against `N`.

So a crafted peer block with `required_proof_count = Some(1)` + one valid proof (with `N = 3`) passed prevalidation, then panicked the generator at the out-of-bounds slice ("range end index 3 out of range for slice of length 1"). One block crashed every honest validator that processed it — a repeatable, steady-state node-restart DoS, no hardfork boundary required.

### The fix — two independent defenses

1. **Checked slice** in `ShadowTxGenerator` — the raw `&proofs[start..end]` becomes `proofs.get(start..end).ok_or_else(|| ShadowTxGenError::Structural(...))?`. A short/mis-sized peer list is now a peer-attributable **Structural** consensus rejection, never a panic. This is the backstop that holds even if a future refactor changed the validation ordering.

2. **Early aggregate guard** in `prevalidate_block` — new `publish_ingress_proof_count_is_valid` rejects any publish ledger where `proofs.len() != publish_txs.len() * N`, run **ahead** of shadow-tx generation. `N` is taken at the **parent** timestamp so the guard and the generator's slice agree on `N`. This closes the ordering gap: the crafted block is now rejected uniformly before the generator ever slices.

A `debug_assert_eq!` at the guard documents and enforces (in dev/CI only) that parent-timestamp `N` equals block-timestamp `N` — the assumption the guard shares with the generator but which `data_txs_are_valid` and block production do not (they use block-timestamp `N`). It is debug-only on purpose: a release panic on this consensus path would itself be a peer-triggerable DoS, and a hard assert would crash every node at a legitimate future `N`-changing hardfork boundary. See the doc comment for the reconciliation a future `N`-changing fork must do.

### Tests (TDD — both failed first)

- `publish_ingress_short_proof_list_is_structural_not_panic` — drives the real generator; **panicked at the slice site** on pre-fix code, now returns `Err(Structural)`. Happy path unchanged.
- `ingress_proof_count_guard_rejects_short_proof_list` — the attack shape (1 tx, 1 proof, `N=3`) and the orphan-proofs case reject; well-formed (`N` proofs) and no-proofs cases pass.

### Scope

Limited to the OOB slice panic. Wire semantics (`N`, `required_proof_count`) unchanged. FC-core-B Findings 2–4 are out of scope. Adjacent-finding note: `data_txs_are_valid` already enforces `required_proof_count == N` per tx (`tx_proofs.len() != N`), so no reward-skim is reachable via a mismatched count — verified during review.

### Verification

`cargo fmt --all`, `cargo clippy --workspace --tests --all-targets` (clean), `cargo xtask local-checks` (unused-deps + typos, exit 0). All shadow_tx_generator and block_validation ingress/proof/prevalidate tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened block pre-validation for Publish-ledger ingress proofs by enforcing the flat proof list length matches `publish_tx_count × N`, and that the peer-supplied `required_proof_count` equals `N` (with `N` derived from the block timestamp).
  * Added bounds-checked ingress-proof slicing during shadow-tx generation so malformed or undersized proof payloads return a structural error instead of panicking.

* **Tests**
  * Added regression tests covering mismatched proof counts, short proof lists (no panic), and timestamp-based proof-count behavior across hardfork boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->