### PR TITLE
fix(config): freeze mainnet genesis constants, add golden-pin tests and fail-closed boot guard

### DIFF
--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -782,9 +782,23 @@ impl IrysNode {
         let genesis_hash = genesis_block.block_hash;
         info!("Node starting with genesis hash: {}", genesis_hash);
 
-        // Genesis node: now that the genesis hash is known, set expected_genesis_hash
-        // so our consensus config hash matches peer nodes during P2P handshakes.
-        if self.config.consensus.expected_genesis_hash.is_none() {
+        // Once genesis is known, pin expected_genesis_hash for P2P handshakes.
+        // Pre-set pin must match built/loaded genesis (wrong network preset or DB).
+        if let Some(expected) = self.config.consensus.expected_genesis_hash {
+            eyre::ensure!(
+                genesis_hash == expected,
+                "genesis block hash {} does not match consensus.expected_genesis_hash {}; \
+                 this node's genesis (built or loaded from the database) belongs to a \
+                 different network than its consensus config — refusing to start",
+                genesis_hash,
+                expected,
+            );
+            info!(
+                "expected_genesis_hash already set to {}, consensus hash: {}",
+                expected,
+                self.config.consensus.keccak256_hash()
+            );
+        } else {
             info!(
                 "Setting expected_genesis_hash to {} (was None)",
                 genesis_hash
@@ -792,12 +806,6 @@ impl IrysNode {
             self.config = self.config.clone().with_expected_genesis_hash(genesis_hash);
             info!(
                 "Consensus config hash after update: {}",
-                self.config.consensus.keccak256_hash()
-            );
-        } else {
-            info!(
-                "expected_genesis_hash already set to {:?}, consensus hash: {}",
-                self.config.consensus.expected_genesis_hash,
                 self.config.consensus.keccak256_hash()
             );
         }

--- a/crates/types/src/config/consensus.rs
+++ b/crates/types/src/config/consensus.rs
@@ -702,14 +702,17 @@ impl ConsensusConfig {
                 }),
             },
             genesis: GenesisConfig {
+                // CONSENSUS-FROZEN — do not edit. Baked into keccak256_hash /
+                // expected_genesis_hash. miner_address is overwritten at signing;
+                // genesis reward_amount is 0 (chainspec).
                 // The timestamp in milliseconds used for the genesis block
                 timestamp_millis: 1763749823171,
                 // Address that signs the genesis block
                 miner_address: IrysAddress::from_hex("faf11d0e472d0b2dc4dab8d4817d0854e3f9e03e")
-                    .unwrap(), // todo()
+                    .unwrap(),
                 // Address that receives the genesis block reward
                 reward_address: IrysAddress::from_hex("faf11d0e472d0b2dc4dab8d4817d0854e3f9e03e")
-                    .unwrap(), // todo()
+                    .unwrap(),
                 // The initial last_epoch_hash used by the genesis block
                 last_epoch_hash: H256::from_base58("4eiVupeZoaBgxyDMacRHnvbbzodLRTEcGUG3yjXpAE4i"),
                 // The initial VDF seed used by the genesis block Must be explicitly set for deterministic VDF output at genesis.
@@ -1139,6 +1142,62 @@ mod tests {
             genesis_config.keccak256_hash(),
             peer_config.keccak256_hash(),
             "Genesis and Peer nodes with same expected_genesis_hash must have matching consensus hashes"
+        );
+    }
+
+    /// Pins mainnet genesis inputs + wire-level `keccak256_hash` (signing key
+    /// is private, so a full rebuild golden is impossible).
+    #[test]
+    fn test_mainnet_genesis_constants_are_frozen() {
+        let config = ConsensusConfig::mainnet();
+
+        assert_eq!(config.chain_id, 3282);
+        assert_eq!(
+            config.expected_genesis_hash,
+            Some(H256::from_base58(
+                "2Pgf5vJvvFifTnyJy9gTg31Yba2HFh2hC6imqsmJqdF7"
+            )),
+            "mainnet expected_genesis_hash is consensus-frozen"
+        );
+
+        assert_eq!(config.genesis.timestamp_millis, 1763749823171);
+        let genesis_signer =
+            IrysAddress::from_hex("faf11d0e472d0b2dc4dab8d4817d0854e3f9e03e").unwrap();
+        assert_eq!(config.genesis.miner_address, genesis_signer);
+        assert_eq!(config.genesis.reward_address, genesis_signer);
+        assert_eq!(
+            config.genesis.last_epoch_hash,
+            H256::from_base58("4eiVupeZoaBgxyDMacRHnvbbzodLRTEcGUG3yjXpAE4i")
+        );
+        assert_eq!(
+            config.genesis.vdf_seed,
+            H256::from_base58("3peqVpX6VF8GjEsSeFk6XPN19bSn7fQbjgT6PJMkpzDo")
+        );
+        assert_eq!(config.genesis.vdf_next_seed, None);
+
+        // P2P handshake hash — any mainnet() field or canonical encoding change fails CI.
+        assert_eq!(
+            config.keccak256_hash(),
+            H256::from_base58("3isK1RK4URjA5oYEQhqt3CnGf5TKZTFyC3CgJfFvD9jA"),
+            "mainnet consensus-config hash is consensus-frozen"
+        );
+    }
+
+    /// Pins testnet genesis hash + wire-level `keccak256_hash`.
+    #[test]
+    fn test_testnet_genesis_constants_are_frozen() {
+        let config = ConsensusConfig::testnet();
+        assert_eq!(
+            config.expected_genesis_hash,
+            Some(H256::from_base58(
+                "DoAEJ8R2CZw6QUFVXzAoPNXjGL8m6uQFEBGweagrUMMP" // spellchecker:disable-line
+            )),
+            "testnet expected_genesis_hash is consensus-frozen"
+        );
+        assert_eq!(
+            config.keccak256_hash(),
+            H256::from_base58("GFHyRkCukwbVcWRsQWtHkBiwkyxW7TmyqRHfeoGZZAEv"),
+            "testnet consensus-config hash is consensus-frozen"
         );
     }
 

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -1373,6 +1373,14 @@ mod tests {
         // Check consensus config fields
         let consensus = config.consensus_config();
         assert_eq!(consensus.chain_id, 3282);
+
+        // Peer mode requires this pin (Config::validate).
+        assert_eq!(
+            consensus.expected_genesis_hash,
+            Some(H256::from_base58(
+                "2Pgf5vJvvFifTnyJy9gTg31Yba2HFh2hC6imqsmJqdF7"
+            ))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Mainnet launched with genesis miner/reward addresses that still had `// todo()` comments. Changing them would desync the live network (`keccak256_hash` / `expected_genesis_hash`). CI never pinned these values.

| Guard | What |
|---|---|
| Mainnet genesis fields | `// CONSENSUS-FROZEN` + pin test (timestamp, addresses, seeds, chain id) |
| Mainnet `expected_genesis_hash` | Pin test + mainnet template assert |
| Mainnet `keccak256_hash()` | Wire-level pin (any `mainnet()` / encoding drift fails CI) |
| Testnet genesis hash + `keccak256_hash()` | Same freeze for the live testnet |
| Boot with pre-set pin | Fail closed if ≠ built/loaded genesis (before persist) |

`miner_address` is overwritten at signing; genesis `reward_amount` is 0 — addresses are still frozen because they feed the consensus-config hash. No consensus behavior or serialized shapes change.

## Test plan

- [x] `test_mainnet_genesis_constants_are_frozen` / `test_testnet_genesis_constants_are_frozen`
- [x] Template asserts pinned mainnet genesis hash
- [x] Boot-guard path audit: no legitimate flow boots with a mismatched pre-set pin
- [x] `cargo fmt` / clippy / typos clean