### PR TITLE
feat(api): add network-wide epoch partition assignment roster endpoint

### DIFF
--- a/crates/api-server/src/lib.rs
+++ b/crates/api-server/src/lib.rs
@@ -177,6 +177,10 @@ pub fn routes() -> impl HttpServiceFactory {
         )
         // Epoch endpoints
         .route("/epoch/current", web::get().to(ledger::get_current_epoch))
+        .route(
+            "/epoch/current/partition-assignments",
+            web::get().to(ledger::get_current_partition_assignments),
+        )
         // Storage endpoints
         .route(
             storage::INTERVALS_ROUTE,

--- a/crates/api-server/src/routes/ledger.rs
+++ b/crates/api-server/src/routes/ledger.rs
@@ -277,6 +277,57 @@ pub async fn get_current_epoch(
     }))
 }
 
+/// Network-wide roster from the canonical epoch snapshot.
+/// Capacity (no ledger slot) is separate from data-ledger assignments;
+/// unassigned partitions (active but owned by no miner, e.g. after an
+/// unpledge) are bare hashes. The three arrays together cover every active
+/// partition the epoch knows about.
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct EpochPartitionAssignmentsResponse {
+    #[serde(with = "string_u64")]
+    pub epoch_height: u64,
+    #[serde(with = "string_u64")]
+    pub epoch_block_height: u64,
+    pub assignments: Vec<PartitionAssignment>,
+    pub capacity_assignments: Vec<PartitionAssignment>,
+    pub unassigned_partitions: Vec<H256>,
+}
+
+/// Consensus-only projection; all rosters are hash-ascending (BTreeMap order
+/// for the assignment maps, an explicit sort for the insertion-ordered
+/// unassigned list). No ledger filter.
+fn build_epoch_partition_assignments(
+    epoch_snapshot: &irys_domain::EpochSnapshot,
+) -> EpochPartitionAssignmentsResponse {
+    let mut unassigned_partitions = epoch_snapshot.unassigned_partitions.clone();
+    unassigned_partitions.sort_unstable();
+    EpochPartitionAssignmentsResponse {
+        epoch_height: epoch_snapshot.epoch_height,
+        epoch_block_height: epoch_snapshot.epoch_block.height,
+        assignments: epoch_snapshot
+            .partition_assignments
+            .data_partitions
+            .values()
+            .copied()
+            .collect(),
+        capacity_assignments: epoch_snapshot
+            .partition_assignments
+            .capacity_partitions
+            .values()
+            .copied()
+            .collect(),
+        unassigned_partitions,
+    }
+}
+
+pub async fn get_current_partition_assignments(
+    app_state: Data<ApiState>,
+) -> Result<Json<EpochPartitionAssignmentsResponse>, ApiError> {
+    let epoch_snapshot = get_canonical_epoch_snapshot(&app_state);
+    Ok(Json(build_epoch_partition_assignments(&epoch_snapshot)))
+}
+
 // === Ledger offset → transaction attribution ===
 
 /// Response for the `/ledger/{ledger_id}/offset/{ledger_offset}/tx` endpoints.
@@ -736,6 +787,211 @@ mod tests {
             count_assignments_by_ledger_type(miner, &assignments, DataLedger::Submit).unwrap(),
             1
         );
+    }
+
+    // === Epoch-wide partition assignment roster ===
+
+    fn ledger_assignment(seed: u8, ledger_id: u32, slot_index: usize) -> PartitionAssignment {
+        PartitionAssignment {
+            partition_hash: nonzero_hash(seed),
+            miner_address: IrysAddress::ZERO,
+            ledger_id: Some(ledger_id),
+            slot_index: Some(slot_index),
+        }
+    }
+
+    fn capacity_assignment(seed: u8) -> PartitionAssignment {
+        PartitionAssignment {
+            partition_hash: nonzero_hash(seed),
+            miner_address: IrysAddress::ZERO,
+            ledger_id: None,
+            slot_index: None,
+        }
+    }
+
+    fn snapshot_with_assignments(
+        data: &[PartitionAssignment],
+        capacity: &[PartitionAssignment],
+    ) -> irys_domain::EpochSnapshot {
+        let mut snapshot = irys_domain::EpochSnapshot {
+            epoch_height: 9,
+            ..Default::default()
+        };
+        snapshot.epoch_block.height = 1080;
+        for assignment in data {
+            snapshot
+                .partition_assignments
+                .data_partitions
+                .insert(assignment.partition_hash, *assignment);
+        }
+        for assignment in capacity {
+            snapshot
+                .partition_assignments
+                .capacity_partitions
+                .insert(assignment.partition_hash, *assignment);
+        }
+        snapshot
+    }
+
+    #[test]
+    fn epoch_assignments_cover_every_data_ledger_and_exclude_capacity() {
+        // All data ledger ids pass through (incl. Cascade + unknown 42); capacity separate.
+        let data = vec![
+            ledger_assignment(1, DataLedger::Publish.get_id(), 0),
+            ledger_assignment(2, DataLedger::Submit.get_id(), 0),
+            ledger_assignment(3, DataLedger::OneYear.get_id(), 0),
+            ledger_assignment(4, DataLedger::ThirtyDay.get_id(), 1),
+            ledger_assignment(5, 42, 3),
+        ];
+        let capacity = vec![capacity_assignment(6), capacity_assignment(7)];
+        let mut snapshot = snapshot_with_assignments(&data, &capacity);
+        // Insertion-ordered in the snapshot; the response sorts by hash.
+        snapshot.unassigned_partitions = vec![nonzero_hash(9), nonzero_hash(8)];
+
+        let response = build_epoch_partition_assignments(&snapshot);
+
+        assert_eq!(response.assignments.len(), data.len());
+        for expected_ledger in [0, 1, 10, 20, 42] {
+            assert!(
+                response
+                    .assignments
+                    .iter()
+                    .any(|a| a.ledger_id == Some(expected_ledger)),
+                "ledger {expected_ledger} missing from the roster"
+            );
+        }
+        for cap in &capacity {
+            assert!(
+                !response
+                    .assignments
+                    .iter()
+                    .any(|a| a.partition_hash == cap.partition_hash),
+                "capacity partition {} must not appear in the roster",
+                cap.partition_hash
+            );
+        }
+        assert_eq!(response.capacity_assignments, capacity);
+        // Unassigned partitions (no miner, no slot) are bare hashes, sorted,
+        // and never mix into the assignment arrays.
+        assert_eq!(
+            response.unassigned_partitions,
+            vec![nonzero_hash(8), nonzero_hash(9)]
+        );
+    }
+
+    #[test]
+    fn epoch_assignments_are_ordered_by_partition_hash() {
+        // Scrambled insert order; BTreeMap yields ascending hash in both arrays.
+        let data = vec![
+            ledger_assignment(9, 1, 0),
+            ledger_assignment(3, 0, 0),
+            ledger_assignment(7, 20, 0),
+            ledger_assignment(1, 10, 0),
+        ];
+        let capacity = vec![capacity_assignment(8), capacity_assignment(2)];
+        let snapshot = snapshot_with_assignments(&data, &capacity);
+
+        let response = build_epoch_partition_assignments(&snapshot);
+
+        let hashes: Vec<H256> = response
+            .assignments
+            .iter()
+            .map(|a| a.partition_hash)
+            .collect();
+        assert_eq!(
+            hashes,
+            vec![
+                nonzero_hash(1),
+                nonzero_hash(3),
+                nonzero_hash(7),
+                nonzero_hash(9)
+            ]
+        );
+        let capacity_hashes: Vec<H256> = response
+            .capacity_assignments
+            .iter()
+            .map(|a| a.partition_hash)
+            .collect();
+        assert_eq!(capacity_hashes, vec![nonzero_hash(2), nonzero_hash(8)]);
+    }
+
+    #[test]
+    fn epoch_assignments_empty_when_no_data_partitions() {
+        let snapshot = snapshot_with_assignments(&[], &[capacity_assignment(1)]);
+
+        let response = build_epoch_partition_assignments(&snapshot);
+
+        assert!(response.assignments.is_empty());
+        assert_eq!(response.capacity_assignments.len(), 1);
+        let json = serde_json::to_value(&response).unwrap();
+        assert_eq!(json["assignments"], serde_json::json!([]));
+        assert_eq!(json["epochHeight"], "9");
+
+        let empty = build_epoch_partition_assignments(&snapshot_with_assignments(&[], &[]));
+        let json = serde_json::to_value(&empty).unwrap();
+        assert_eq!(json["assignments"], serde_json::json!([]));
+        assert_eq!(json["capacityAssignments"], serde_json::json!([]));
+        assert_eq!(json["unassignedPartitions"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn epoch_assignments_metadata_comes_from_the_snapshot() {
+        let mut snapshot = snapshot_with_assignments(&[ledger_assignment(1, 0, 0)], &[]);
+        snapshot.epoch_height = 9;
+        snapshot.epoch_block.height = 1080;
+
+        let response = build_epoch_partition_assignments(&snapshot);
+
+        assert_eq!(response.epoch_height, 9);
+        assert_eq!(response.epoch_block_height, 1080);
+    }
+
+    #[test]
+    fn epoch_assignments_serialization_contract() {
+        let response = EpochPartitionAssignmentsResponse {
+            epoch_height: 9,
+            epoch_block_height: 1080,
+            assignments: vec![PartitionAssignment {
+                partition_hash: nonzero_hash(1),
+                miner_address: IrysAddress::ZERO,
+                ledger_id: Some(DataLedger::OneYear.get_id()),
+                slot_index: Some(2),
+            }],
+            capacity_assignments: vec![capacity_assignment(3)],
+            unassigned_partitions: vec![nonzero_hash(4)],
+        };
+
+        let json = serde_json::to_value(&response).unwrap();
+
+        // Outer camelCase + string u64s; nested PartitionAssignment stays snake_case.
+        assert_eq!(json["epochHeight"], "9");
+        assert_eq!(json["epochBlockHeight"], "1080");
+        let row = &json["assignments"][0];
+        assert!(row["partition_hash"].is_string());
+        assert!(row["miner_address"].is_string());
+        assert_eq!(row["ledger_id"], 10);
+        assert_eq!(row["slot_index"], 2);
+        // Consensus fields only — no storage/chunk/peer leakage.
+        let mut keys: Vec<&String> = row.as_object().unwrap().keys().collect();
+        keys.sort();
+        assert_eq!(
+            keys,
+            ["ledger_id", "miner_address", "partition_hash", "slot_index"]
+        );
+        // Capacity: same shape; nulls are present (not omitted).
+        let capacity_row = &json["capacityAssignments"][0];
+        assert!(capacity_row["partition_hash"].is_string());
+        assert!(capacity_row["miner_address"].is_string());
+        assert!(capacity_row["ledger_id"].is_null());
+        assert!(capacity_row["slot_index"].is_null());
+        let mut capacity_keys: Vec<&String> = capacity_row.as_object().unwrap().keys().collect();
+        capacity_keys.sort();
+        assert_eq!(
+            capacity_keys,
+            ["ledger_id", "miner_address", "partition_hash", "slot_index"]
+        );
+        // Unassigned entries are bare hash strings, not assignment objects.
+        assert!(json["unassignedPartitions"][0].is_string());
     }
 
     // === Ledger offset → transaction attribution ===

--- a/crates/chain-tests/src/api/epoch_partition_assignments_endpoint.rs
+++ b/crates/chain-tests/src/api/epoch_partition_assignments_endpoint.rs
@@ -1,0 +1,250 @@
+//! Integration tests for `GET /v1/epoch/current/partition-assignments`.
+
+use crate::utils::IrysNodeTest;
+use actix_web::body::MessageBody;
+use actix_web::dev::{Service, ServiceResponse};
+use actix_web::http::StatusCode;
+use actix_web::test::{TestRequest, call_service, read_body_json};
+use irys_config::submodules::StorageSubmodulesConfig;
+use irys_domain::EpochSnapshot;
+use irys_types::{
+    DataLedger, H256, NodeConfig, UnixTimestamp, hardfork_config::Cascade,
+    partition::PartitionAssignment,
+};
+
+async fn get_json<T, B>(app: &T, uri: &str) -> (StatusCode, serde_json::Value)
+where
+    T: Service<actix_http::Request, Response = ServiceResponse<B>, Error = actix_web::Error>,
+    B: MessageBody,
+{
+    let req = TestRequest::get().uri(uri).to_request();
+    let resp = call_service(app, req).await;
+    let status = resp.status();
+    assert_eq!(status, StatusCode::OK, "GET {uri} should succeed");
+    (status, read_body_json(resp).await)
+}
+
+fn assignment_rows(body: &serde_json::Value) -> Vec<PartitionAssignment> {
+    serde_json::from_value(body["assignments"].clone())
+        .expect("assignments should deserialize as PartitionAssignment rows")
+}
+
+/// GETs the global roster and asserts it mirrors `snapshot` exactly:
+/// string epoch metadata, data assignments, capacity assignments, and
+/// unassigned hashes (sorted). Returns the data + capacity rows.
+async fn assert_roster_mirrors_snapshot<T, B>(
+    app: &T,
+    snapshot: &EpochSnapshot,
+) -> (Vec<PartitionAssignment>, Vec<PartitionAssignment>)
+where
+    T: Service<actix_http::Request, Response = ServiceResponse<B>, Error = actix_web::Error>,
+    B: MessageBody,
+{
+    let (_, body) = get_json(app, "/v1/epoch/current/partition-assignments").await;
+
+    assert_eq!(
+        body["epochHeight"].as_str(),
+        Some(snapshot.epoch_height.to_string().as_str()),
+        "epochHeight must be a string matching the canonical snapshot"
+    );
+    assert_eq!(
+        body["epochBlockHeight"].as_str(),
+        Some(snapshot.epoch_block.height.to_string().as_str()),
+        "epochBlockHeight must be a string matching the canonical snapshot"
+    );
+
+    let rows = assignment_rows(&body);
+    let expected: Vec<PartitionAssignment> = snapshot
+        .partition_assignments
+        .data_partitions
+        .values()
+        .copied()
+        .collect();
+    assert_eq!(
+        rows, expected,
+        "global roster must mirror the canonical snapshot's data partitions"
+    );
+
+    let capacity_rows: Vec<PartitionAssignment> =
+        serde_json::from_value(body["capacityAssignments"].clone())
+            .expect("capacityAssignments should deserialize as PartitionAssignment rows");
+    let expected_capacity: Vec<PartitionAssignment> = snapshot
+        .partition_assignments
+        .capacity_partitions
+        .values()
+        .copied()
+        .collect();
+    assert_eq!(
+        capacity_rows, expected_capacity,
+        "capacity roster must mirror the canonical snapshot's capacity partitions"
+    );
+
+    let unassigned: Vec<H256> = serde_json::from_value(body["unassignedPartitions"].clone())
+        .expect("unassignedPartitions should deserialize as hashes");
+    let mut expected_unassigned = snapshot.unassigned_partitions.clone();
+    expected_unassigned.sort_unstable();
+    assert_eq!(
+        unassigned, expected_unassigned,
+        "unassigned roster must mirror the canonical snapshot's unassigned partitions"
+    );
+
+    (rows, capacity_rows)
+}
+
+/// Cascade active from genesis: all four data ledgers in the global roster;
+/// capacity separate; per-miner views keep their existing contracts; the
+/// roster follows the canonical snapshot across an epoch boundary.
+#[test_log::test(tokio::test)]
+async fn heavy_epoch_partition_assignments_endpoint() -> eyre::Result<()> {
+    let num_blocks_in_epoch = 2_u64;
+    let mut config = NodeConfig::testing().with_consensus(|c| {
+        c.block_migration_depth = 1;
+        c.epoch.num_blocks_in_epoch = num_blocks_in_epoch;
+        c.chunk_size = 32;
+        c.num_chunks_in_partition = 10;
+        c.entropy_packing_iterations = 1_000;
+        c.hardforks.cascade = Some(Cascade {
+            activation_timestamp: UnixTimestamp::from_secs(0),
+            one_year_epoch_length: 8,
+            thirty_day_epoch_length: 2,
+            annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
+        });
+    });
+    let signer = config.new_random_signer();
+    config.fund_genesis_accounts(vec![&signer]);
+
+    // 5 SMs: enough for all 4 data ledger slots + ≥1 capacity leftover.
+    let test_node = IrysNodeTest::new_genesis(config);
+    StorageSubmodulesConfig::load_for_test(test_node.cfg.base_directory.clone(), 5)?;
+    let node = test_node.start_and_wait_for_packing("test", 30).await;
+    let app = node.start_public_api().await;
+    let miner = node.node_ctx.config.node_config.miner_address();
+
+    // Cascade activates at timestamp 0, i.e. from genesis: all four data
+    // ledgers already have partitions assigned in the genesis epoch snapshot.
+    let all_data_ledgers = [
+        DataLedger::Publish,
+        DataLedger::Submit,
+        DataLedger::OneYear,
+        DataLedger::ThirtyDay,
+    ];
+    let snapshot = node.get_canonical_epoch_snapshot();
+    for ledger in all_data_ledgers {
+        assert!(
+            snapshot
+                .partition_assignments
+                .data_partitions
+                .values()
+                .any(|a| a.ledger_id == Some(ledger.get_id())),
+            "genesis snapshot missing an assignment for {ledger:?} (id {})",
+            ledger.get_id()
+        );
+    }
+
+    let (rows, capacity_rows) = assert_roster_mirrors_snapshot(&app, &snapshot).await;
+    assert!(
+        rows.windows(2)
+            .all(|pair| pair[0].partition_hash < pair[1].partition_hash),
+        "roster must be strictly ordered by partition hash"
+    );
+
+    for ledger in all_data_ledgers {
+        assert!(
+            rows.iter().any(|a| a.ledger_id == Some(ledger.get_id())),
+            "roster missing an assignment for {ledger:?} (id {})",
+            ledger.get_id()
+        );
+    }
+    for row in &rows {
+        assert_eq!(row.miner_address, miner);
+        assert!(
+            row.ledger_id.is_some() && row.slot_index.is_some(),
+            "data partition rows must carry a ledger id and slot index"
+        );
+    }
+
+    let capacity = &snapshot.partition_assignments.capacity_partitions;
+    assert!(
+        !capacity.is_empty(),
+        "test setup should leave at least one capacity partition"
+    );
+    for capacity_hash in capacity.keys() {
+        assert!(
+            !rows.iter().any(|a| a.partition_hash == *capacity_hash),
+            "capacity partition {capacity_hash} must not appear in the roster"
+        );
+    }
+    for capacity_row in &capacity_rows {
+        assert_eq!(capacity_row.miner_address, miner);
+        assert!(
+            capacity_row.ledger_id.is_none() && capacity_row.slot_index.is_none(),
+            "capacity rows must not claim a ledger slot"
+        );
+    }
+
+    // Per-miner generic view: all data ledgers + capacity.
+    let (_, miner_body) = get_json(&app, &format!("/v1/ledger/{miner}/assignments")).await;
+    let miner_rows = assignment_rows(&miner_body);
+    let miner_expected = snapshot.get_partition_assignments(miner);
+    assert_eq!(
+        miner_rows, miner_expected,
+        "generic per-miner endpoint must return the miner's data + capacity assignments"
+    );
+    for ledger in [DataLedger::OneYear, DataLedger::ThirtyDay] {
+        assert!(
+            miner_rows
+                .iter()
+                .any(|a| a.ledger_id == Some(ledger.get_id())),
+            "per-miner endpoint missing {ledger:?} assignments"
+        );
+    }
+    assert!(
+        miner_rows.iter().any(|a| a.ledger_id.is_none()),
+        "per-miner endpoint must retain capacity assignments"
+    );
+
+    // Submit/Publish views stay ledger-filtered; summary fields unchanged.
+    for (route, ledger) in [
+        ("submit", DataLedger::Submit),
+        ("publish", DataLedger::Publish),
+    ] {
+        let (_, filtered_body) =
+            get_json(&app, &format!("/v1/ledger/{route}/{miner}/assignments")).await;
+        let filtered_rows = assignment_rows(&filtered_body);
+        assert!(
+            !filtered_rows.is_empty(),
+            "{route} view should have assignments"
+        );
+        assert!(
+            filtered_rows
+                .iter()
+                .all(|a| a.ledger_id == Some(ledger.get_id())),
+            "{route} view must only contain {ledger:?} assignments"
+        );
+        for field in ["minerAddress", "assignmentStatus", "hashAnalysis"] {
+            assert!(
+                !filtered_body[field].is_null(),
+                "{route} view lost its {field} field"
+            );
+        }
+    }
+
+    let (_, epoch_body) = get_json(&app, "/v1/epoch/current").await;
+    assert_eq!(
+        epoch_body["currentEpoch"].as_str(),
+        Some(snapshot.epoch_height.to_string().as_str())
+    );
+
+    // Cross a real epoch boundary and verify the endpoint tracks the new
+    // canonical snapshot rather than a stale one.
+    node.mine_until_next_epoch().await?;
+    let next_snapshot = node.get_canonical_epoch_snapshot();
+    assert!(
+        next_snapshot.epoch_height > snapshot.epoch_height,
+        "canonical epoch snapshot must advance past genesis"
+    );
+    assert_roster_mirrors_snapshot(&app, &next_snapshot).await;
+
+    node.stop().await;
+    Ok(())
+}

--- a/crates/chain-tests/src/api/mod.rs
+++ b/crates/chain-tests/src/api/mod.rs
@@ -2,6 +2,7 @@ use irys_types::DataLedger;
 mod api;
 mod client;
 mod commitment_anchor_window;
+mod epoch_partition_assignments_endpoint;
 mod external_api;
 mod hardfork_tests;
 mod ledger_offset_endpoint;


### PR DESCRIPTION
## Summary

Adds `GET /v1/epoch/current/partition-assignments` — a read-only projection of the **canonical epoch snapshot** partition roster for operators/indexers.

| Field | Source | Notes |
|---|---|---|
| `epochHeight` / `epochBlockHeight` | snapshot | string u64s |
| `assignments` | `data_partitions` | all ledgers (Publish, Submit, **OneYear**, **ThirtyDay**, future ids) |
| `capacityAssignments` | `capacity_partitions` | miner pledged, no ledger slot |
| `unassignedPartitions` | `unassigned_partitions` | bare hashes, free pool (new / after unpledge at epoch), **sorted** |

- Consensus assignment state only (not local SMs, peers, or chunk data)
- Deterministic order: BTreeMap for assignment maps; explicit sort for unassigned
- Complements existing per-miner `/ledger/.../assignments` (Submit/Publish filters unchanged)
- No pagination (same as other assignment list endpoints)

## Test plan

- [x] Unit tests: multi-ledger coverage (incl. Cascade + unknown ledger id), capacity/unassigned separation, hash order, empty, serde contract
- [x] Heavy integration: Cascade from genesis, all four data ledgers, capacity leftover, per-miner regression, roster tracks epoch boundary
- [ ] `cargo nextest run -p irys-api-server epoch_assignments`
- [ ] `cargo nextest run -p irys-chain-tests heavy_epoch_partition_assignments`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an API endpoint for retrieving current epoch partition assignments.
  - Responses include epoch metadata, data-ledger assignments, capacity assignments, and unassigned partitions.
  - Partition results are consistently ordered and include relevant ledger, slot, miner, and status details.

- **Bug Fixes**
  - Improved assignment reporting to reflect the latest canonical epoch snapshot and avoid stale data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->