### PR TITLE
ci(release): changelog range fix + green-CI gate hardening

### DIFF
--- a/.config/cliff.toml
+++ b/.config/cliff.toml
@@ -30,10 +30,11 @@ sort_commits = "oldest"
 # Releases live on diverged branches (deployment/testnet/<major>.x vs
 # deployment/mainnet/<major>.x), each with its own tag lineage. Restrict version
 # boundaries to tags reachable on the branch being released so a tag from another
-# release line can't be picked as the previous-release boundary. release.yml
-# additionally overrides this pattern per env via GIT_CLIFF_TAG_PATTERN, so each
-# release's changelog is bounded by the previous release of the SAME env (testnet
-# vs mainnet) rather than whichever stream tagged most recently.
+# release line can't be picked as the previous-release boundary in a standalone
+# `git cliff` run. The release workflow does not rely on this: because release
+# commits live on sibling branches where the previous tag is not an ancestor, it
+# computes an explicit previous-release..commit range itself (see release.yml
+# "Determine changelog range").
 use_branch_tags = true
 
 commit_preprocessors = [

--- a/.github/actions/require-green-ci/action.yaml
+++ b/.github/actions/require-green-ci/action.yaml
@@ -21,6 +21,20 @@ inputs:
   github-token:
     description: "Token with checks:read and statuses:read on this repo."
     required: true
+  wait-timeout-seconds:
+    description: >-
+      Max seconds to wait for still-running CI to finish before evaluating.
+      0 (the default) preserves the original fail-fast behavior: any check
+      still running is an immediate failure. A positive value polls until every
+      check has settled (or the timeout elapses). A commit that concludes with a
+      real failure/cancellation fails immediately regardless of this value —
+      only in-progress checks are waited on.
+    required: false
+    default: "0"
+  poll-interval-seconds:
+    description: "Seconds to sleep between polls while waiting for in-progress CI."
+    required: false
+    default: "30"
 
 runs:
   using: "composite"
@@ -31,6 +45,8 @@ runs:
         GH_TOKEN: ${{ inputs.github-token }}
         REPO: ${{ github.repository }}
         SHA: ${{ inputs.commit }}
+        WAIT_TIMEOUT: ${{ inputs.wait-timeout-seconds }}
+        POLL_INTERVAL: ${{ inputs.poll-interval-seconds }}
       run: |
         set -euo pipefail
         if [ -z "${SHA}" ]; then
@@ -38,63 +54,105 @@ runs:
           exit 1
         fi
 
-        # GitHub Actions jobs surface as "check runs"; external CI / bots surface
-        # as legacy "commit statuses". A fully passing CI result must satisfy both.
-        # filter=latest (the API default) collapses re-runs to the most recent run
-        # per check name, so a red run that was later re-run green is not counted.
-        runs_tsv=$(gh api --paginate \
-          "repos/${REPO}/commits/${SHA}/check-runs?per_page=100" \
-          -q '.check_runs[] | [.name, .status, (.conclusion // "")] | @tsv')
+        # Link to GitHub's checks view for this commit so the log has a clickable
+        # jump to the live CI runs being gated on.
+        CHECKS_URL="${GITHUB_SERVER_URL:-https://github.com}/${REPO}/commit/${SHA}/checks"
+        echo "Gating release on CI for ${SHA}"
+        echo "  checks: ${CHECKS_URL}"
 
-        fail=0
-        successes=0
-        total_runs=0
-        if [ -n "${runs_tsv}" ]; then
-          while IFS=$'\t' read -r name status conclusion; do
-            [ -z "${name}" ] && continue
-            total_runs=$((total_runs + 1))
-            if [ "${status}" != "completed" ]; then
-              echo "::error::Check '${name}' has not completed (status=${status}); CI is still running on ${SHA}."
-              fail=1
-              continue
-            fi
-            case "${conclusion}" in
+        # SECONDS is bash's monotonic elapsed-seconds counter since shell start;
+        # the poll loop below waits until SECONDS exceeds this deadline.
+        deadline=$((SECONDS + WAIT_TIMEOUT))
+
+        while true; do
+          # GitHub Actions jobs surface as "check runs"; external CI / bots surface
+          # as legacy "commit statuses". A fully passing CI result must satisfy both.
+          # filter=latest (the API default) collapses re-runs to the most recent run
+          # per check name, so a red run that was later re-run green is not counted.
+          runs_tsv=$(gh api --paginate \
+            "repos/${REPO}/commits/${SHA}/check-runs?per_page=100" \
+            -q '.check_runs[] | [.name, .status, (.conclusion // "")] | @tsv')
+
+          fail=0        # a check reached a real, terminal non-pass conclusion
+          pending=0     # a check is still running (waitable)
+          successes=0
+          total_runs=0
+          if [ -n "${runs_tsv}" ]; then
+            while IFS=$'\t' read -r name status conclusion; do
+              [ -z "${name}" ] && continue
+              total_runs=$((total_runs + 1))
+              if [ "${status}" != "completed" ]; then
+                echo "Check '${name}' is still running (status=${status}) on ${SHA}."
+                pending=$((pending + 1))
+                continue
+              fi
+              case "${conclusion}" in
+                success)
+                  successes=$((successes + 1))
+                  ;;
+                skipped|neutral)
+                  # Non-blocking, mirrors GitHub's required-status-check semantics.
+                  ;;
+                *)
+                  echo "::error::Check '${name}' did not pass (conclusion=${conclusion}) on ${SHA}."
+                  fail=1
+                  ;;
+              esac
+            done <<< "${runs_tsv}"
+          fi
+
+          # Combined legacy status: the .state field is aggregated server-side across
+          # every context, so one read is authoritative regardless of context count.
+          # One call returns both fields as a TSV (via gh's embedded jq, so no system
+          # jq dependency); splitting it into two `gh api` calls would risk reading an
+          # inconsistent state/total across a status update mid-poll.
+          IFS=$'\t' read -r status_state status_total < <(
+            gh api "repos/${REPO}/commits/${SHA}/status" -q '[.state, .total_count] | @tsv'
+          )
+          if [ "${status_total}" -gt 0 ]; then
+            case "${status_state}" in
               success)
                 successes=$((successes + 1))
                 ;;
-              skipped|neutral)
-                # Non-blocking, mirrors GitHub's required-status-check semantics.
+              pending)
+                echo "Combined commit status for ${SHA} is still pending."
+                pending=$((pending + 1))
                 ;;
               *)
-                echo "::error::Check '${name}' did not pass (conclusion=${conclusion}) on ${SHA}."
+                echo "::error::Combined commit status for ${SHA} is '${status_state}' (expected success)."
                 fail=1
                 ;;
             esac
-          done <<< "${runs_tsv}"
-        fi
-
-        # Combined legacy status: the .state field is aggregated server-side across
-        # every context, so one read is authoritative regardless of context count.
-        status_state=$(gh api "repos/${REPO}/commits/${SHA}/status" -q '.state')
-        status_total=$(gh api "repos/${REPO}/commits/${SHA}/status" -q '.total_count')
-        if [ "${status_total}" -gt 0 ]; then
-          if [ "${status_state}" = "success" ]; then
-            successes=$((successes + 1))
-          else
-            echo "::error::Combined commit status for ${SHA} is '${status_state}' (expected success)."
-            fail=1
           fi
-        fi
 
-        if [ "${total_runs}" -eq 0 ] && [ "${status_total}" -eq 0 ]; then
-          echo "::error::No CI check runs or commit statuses found for ${SHA}. Cannot prove the release base passed CI. (Emergency hotfixes can bypass with force=true.)"
-          exit 1
-        fi
+          if [ "${total_runs}" -eq 0 ] && [ "${status_total}" -eq 0 ]; then
+            echo "::error::No CI check runs or commit statuses found for ${SHA}. Cannot prove the release base passed CI. (Emergency hotfixes can bypass with force=true.)"
+            exit 1
+          fi
 
-        if [ "${fail}" -ne 0 ]; then
-          echo "::error::CI for ${SHA} is not fully green; refusing to release. (Emergency hotfixes can bypass with force=true.)"
-          exit 1
-        fi
+          # A real failure is terminal — waiting cannot turn it green, so fail fast
+          # even if other checks are still in flight.
+          if [ "${fail}" -ne 0 ]; then
+            echo "::error::CI for ${SHA} is not fully green; refusing to release. (Emergency hotfixes can bypass with force=true.)"
+            exit 1
+          fi
+
+          # No failures, but something is still running. Wait and re-poll until the
+          # deadline, then give up. With WAIT_TIMEOUT=0 the deadline is already past
+          # so this is the original fail-fast behavior.
+          if [ "${pending}" -ne 0 ]; then
+            if [ "${SECONDS}" -ge "${deadline}" ]; then
+              echo "::error::Timed out after ${WAIT_TIMEOUT}s waiting for ${pending} in-progress CI check(s) on ${SHA} to finish (${CHECKS_URL}). (Emergency hotfixes can bypass with force=true.)"
+              exit 1
+            fi
+            echo "Waiting ${POLL_INTERVAL}s for ${pending} in-progress CI check(s) on ${SHA} to finish (elapsed ${SECONDS}s / timeout ${WAIT_TIMEOUT}s) — ${CHECKS_URL}"
+            sleep "${POLL_INTERVAL}"
+            continue
+          fi
+
+          # Settled with no failures and nothing pending — exit the poll loop.
+          break
+        done
 
         # Every check was skipped/neutral and no green status exists: CI never
         # actually ran (e.g. a #disable-ci gate short-circuit), so there is no

--- a/.github/actions/require-green-ci/action.yaml
+++ b/.github/actions/require-green-ci/action.yaml
@@ -60,6 +60,32 @@ runs:
         echo "Gating release on CI for ${SHA}"
         echo "  checks: ${CHECKS_URL}"
 
+        # gh has no built-in retry for transient API failures. Under `set -e` a
+        # single network blip / 5xx would otherwise abort the whole gate — and the
+        # poll loop below makes ~120 calls over a 60-min window, so one such blip
+        # anywhere would force a full release re-run. Retry with backoff; only a
+        # persistent failure (all attempts exhausted) fails the step, still closed.
+        gh_api() {
+          local attempt=1 max_attempts=3 out
+          while true; do
+            # Buffer the attempt's output and emit only on success, so a failure
+            # part-way through pagination is discarded rather than concatenated
+            # onto the retry's (re-fetched-from-page-1) output.
+            if out=$(gh api "$@"); then
+              # Re-add the trailing newline `$(...)` strips: gh's `-q @tsv` output is
+              # newline-terminated and the downstream `read` relies on that delimiter.
+              printf '%s\n' "${out}"
+              return 0
+            fi
+            if [ "${attempt}" -ge "${max_attempts}" ]; then
+              return 1
+            fi
+            echo "gh api call failed (attempt ${attempt}/${max_attempts}); retrying in $((attempt * 2))s..." >&2
+            sleep "$((attempt * 2))"
+            attempt=$((attempt + 1))
+          done
+        }
+
         # SECONDS is bash's monotonic elapsed-seconds counter since shell start;
         # the poll loop below waits until SECONDS exceeds this deadline.
         deadline=$((SECONDS + WAIT_TIMEOUT))
@@ -69,12 +95,14 @@ runs:
           # as legacy "commit statuses". A fully passing CI result must satisfy both.
           # filter=latest (the API default) collapses re-runs to the most recent run
           # per check name, so a red run that was later re-run green is not counted.
-          runs_tsv=$(gh api --paginate \
+          runs_tsv=$(gh_api --paginate \
             "repos/${REPO}/commits/${SHA}/check-runs?per_page=100" \
             -q '.check_runs[] | [.name, .status, (.conclusion // "")] | @tsv')
 
-          fail=0        # a check reached a real, terminal non-pass conclusion
-          pending=0     # a check is still running (waitable)
+          fail=0          # a check reached a real, terminal non-pass conclusion
+          pending=0       # a check is still running (waitable)
+          no_results=0    # no checks/statuses registered yet (also waitable)
+          pending_names=""
           successes=0
           total_runs=0
           if [ -n "${runs_tsv}" ]; then
@@ -84,6 +112,7 @@ runs:
               if [ "${status}" != "completed" ]; then
                 echo "Check '${name}' is still running (status=${status}) on ${SHA}."
                 pending=$((pending + 1))
+                pending_names="${pending_names:+${pending_names}, }${name}"
                 continue
               fi
               case "${conclusion}" in
@@ -107,7 +136,7 @@ runs:
           # jq dependency); splitting it into two `gh api` calls would risk reading an
           # inconsistent state/total across a status update mid-poll.
           IFS=$'\t' read -r status_state status_total < <(
-            gh api "repos/${REPO}/commits/${SHA}/status" -q '[.state, .total_count] | @tsv'
+            gh_api "repos/${REPO}/commits/${SHA}/status" -q '[.state, .total_count] | @tsv'
           )
           if [ "${status_total}" -gt 0 ]; then
             case "${status_state}" in
@@ -117,6 +146,7 @@ runs:
               pending)
                 echo "Combined commit status for ${SHA} is still pending."
                 pending=$((pending + 1))
+                pending_names="${pending_names:+${pending_names}, }combined commit status"
                 ;;
               *)
                 echo "::error::Combined commit status for ${SHA} is '${status_state}' (expected success)."
@@ -125,9 +155,15 @@ runs:
             esac
           fi
 
+          # No checks/statuses observed yet. When waiting is enabled this is likely a
+          # race — the release was dispatched just as the merge-base landed, before CI
+          # registered — so treat it as waitable and let later polls see them appear.
+          # With WAIT_TIMEOUT=0 the deadline is already past, so the pending branch
+          # below still fails fast on the first poll, preserving the original behavior.
           if [ "${total_runs}" -eq 0 ] && [ "${status_total}" -eq 0 ]; then
-            echo "::error::No CI check runs or commit statuses found for ${SHA}. Cannot prove the release base passed CI. (Emergency hotfixes can bypass with force=true.)"
-            exit 1
+            echo "No CI check runs or commit statuses found yet for ${SHA}."
+            no_results=1
+            pending=$((pending + 1))
           fi
 
           # A real failure is terminal — waiting cannot turn it green, so fail fast
@@ -137,15 +173,25 @@ runs:
             exit 1
           fi
 
-          # No failures, but something is still running. Wait and re-poll until the
-          # deadline, then give up. With WAIT_TIMEOUT=0 the deadline is already past
-          # so this is the original fail-fast behavior.
+          # No failures, but something is still settling (in-progress checks, a
+          # pending combined status, or checks not registered yet). Wait and re-poll
+          # until the deadline, then give up. With WAIT_TIMEOUT=0 the deadline is
+          # already past so this is the original fail-fast behavior.
           if [ "${pending}" -ne 0 ]; then
+            if [ "${no_results}" -ne 0 ]; then
+              waiting_for="CI to register on ${SHA}"
+            else
+              waiting_for="${pending} in-progress CI check(s) on ${SHA} to finish (${pending_names})"
+            fi
             if [ "${SECONDS}" -ge "${deadline}" ]; then
-              echo "::error::Timed out after ${WAIT_TIMEOUT}s waiting for ${pending} in-progress CI check(s) on ${SHA} to finish (${CHECKS_URL}). (Emergency hotfixes can bypass with force=true.)"
+              if [ "${no_results}" -ne 0 ]; then
+                echo "::error::Timed out after ${WAIT_TIMEOUT}s: no CI check runs or commit statuses ever appeared for ${SHA}. Cannot prove the release base passed CI (${CHECKS_URL}). (Emergency hotfixes can bypass with force=true.)"
+              else
+                echo "::error::Timed out after ${WAIT_TIMEOUT}s waiting for ${waiting_for} (${CHECKS_URL}). (Emergency hotfixes can bypass with force=true.)"
+              fi
               exit 1
             fi
-            echo "Waiting ${POLL_INTERVAL}s for ${pending} in-progress CI check(s) on ${SHA} to finish (elapsed ${SECONDS}s / timeout ${WAIT_TIMEOUT}s) — ${CHECKS_URL}"
+            echo "Waiting ${POLL_INTERVAL}s for ${waiting_for} (elapsed ${SECONDS}s / timeout ${WAIT_TIMEOUT}s) — ${CHECKS_URL}"
             sleep "${POLL_INTERVAL}"
             continue
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,11 @@ on:
         required: false
         type: boolean
         default: false
+      previous_tag:
+        description: 'Optional changelog range lower bound (tag or commit SHA). Overrides the auto-detected previous same-env release. Leave empty for automatic semver detection.'
+        required: false
+        type: string
+        default: ''
       dry_run:
         description: 'Build and validate without tagging or publishing'
         required: false
@@ -261,13 +266,60 @@ jobs:
           image: ${{ steps.image.outputs.name }}
           tag: ${{ env.DOCKER_TAG }}
 
+      # Bound the changelog to (previous same-env release, this release]. The
+      # boundary is the highest <env>-X.Y.Z tag strictly BELOW the version being
+      # released in SEMVER order — not tag-creation order — so a back-port tagged
+      # after a newer release (e.g. testnet-3.1.1 cut after testnet-4.0.0) is
+      # bounded by its own predecessor (testnet-3.1.0), never the newer tag.
+      #
+      # Releases live on diverged sibling deployment branches, so the predecessor
+      # tag is generally NOT an ancestor of the release commit. git-cliff's own
+      # --unreleased boundary detection is ancestry/time-based and would anchor to
+      # the oldest reachable tag here (spanning the entire history); instead we
+      # compute the boundary and hand cliff an explicit <prev>..<commit> range,
+      # whose set-difference is correct regardless of ancestry. First release of an
+      # env (no lower tag) has no lower bound and spans full history.
+      - name: Determine changelog range
+        id: changelog_range
+        env:
+          INPUT_RELEASE_TYPE: ${{ inputs.release_type }}
+          INPUT_COMMIT: ${{ inputs.commit }}
+          INPUT_PREVIOUS_TAG: ${{ inputs.previous_tag }}
+          GIT_TAG: ${{ env.GIT_TAG }}
+        run: |
+          # An explicit previous_tag override wins over auto-detection, to
+          # re-anchor the range when tag history is irregular. It may be any ref
+          # git can resolve; require that it resolves so a typo fails loudly
+          # rather than feeding git-cliff a bogus range.
+          if [ -n "$INPUT_PREVIOUS_TAG" ]; then
+            if ! git rev-parse --verify --quiet "${INPUT_PREVIOUS_TAG}^{commit}" >/dev/null; then
+              echo "::error::previous_tag override '${INPUT_PREVIOUS_TAG}' does not resolve to a commit"
+              exit 1
+            fi
+            echo "Changelog range: ${INPUT_PREVIOUS_TAG}..${GIT_TAG} (previous_tag override)"
+            echo "cliff_args=--tag ${GIT_TAG} ${INPUT_PREVIOUS_TAG}..${INPUT_COMMIT}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          PATTERN="^${INPUT_RELEASE_TYPE}-[0-9]+\.[0-9]+\.[0-9]+$"
+          # Insert the not-yet-created release tag into the version-sorted list of
+          # same-env release tags; its predecessor is the entry immediately before
+          # it. `sort -V` gives semver order; grep -B1 pulls the preceding line.
+          SORTED=$( { git tag --list | grep -E "$PATTERN"; echo "$GIT_TAG"; } | sort -V -u )
+          PREV=$(printf '%s\n' "$SORTED" | grep -B1 -xF "$GIT_TAG" | head -n1)
+          [ "$PREV" = "$GIT_TAG" ] && PREV=""
+          if [ -n "$PREV" ]; then
+            echo "Changelog range: ${PREV}..${GIT_TAG} (commit ${INPUT_COMMIT})"
+            echo "cliff_args=--tag ${GIT_TAG} ${PREV}..${INPUT_COMMIT}" >> "$GITHUB_OUTPUT"
+          else
+            echo "Changelog range: full history (first ${INPUT_RELEASE_TYPE} release)"
+            echo "cliff_args=--tag ${GIT_TAG}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Generate changelog
         uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
         with:
           config: .config/cliff.toml
-          args: >-
-            --unreleased
-            --tag ${{ env.GIT_TAG }}
+          args: ${{ steps.changelog_range.outputs.cliff_args }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OUTPUT: /tmp/cliff-changelog.md
@@ -280,11 +332,11 @@ jobs:
           # action) does not auto-detect the repo from origin, so omitting GITHUB_REPO
           # disables the fetch. The action still injects a token for its binary download.
           #
-          # Bound the changelog to the previous release of THIS env: restrict the
-          # release-tag pattern to the env's own tags so --unreleased anchors to the
-          # last <env>-X.Y.Z (testnet-3.0.0 spans since testnet-0.2.0, not the newer
-          # mainnet-0.1.3). --ignore-tags only relabels "previous"; --tag-pattern moves
-          # the range. First release of an env (no prior tag) spans the full history.
+          # Restrict recognised version tags to THIS env so cliff never treats a
+          # tag from the other env as a release boundary. The explicit range above
+          # already scopes normal releases; this matters for an env's first release
+          # (full history), where the other env's tags would otherwise split the
+          # output into spurious version sections.
           GIT_CLIFF_TAG_PATTERN: ${{ inputs.release_type == 'mainnet' && '^mainnet-[0-9]+\.[0-9]+\.[0-9]+$' || '^testnet-[0-9]+\.[0-9]+\.[0-9]+$' }}
           # Log each skipped/non-conventional commit (the "N commit(s) skipped due to
           # parse error" warning) without the global -vv flood.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,6 +284,7 @@ jobs:
         env:
           INPUT_RELEASE_TYPE: ${{ inputs.release_type }}
           INPUT_COMMIT: ${{ inputs.commit }}
+          INPUT_VERSION: ${{ inputs.version }}
           INPUT_PREVIOUS_TAG: ${{ inputs.previous_tag }}
           GIT_TAG: ${{ env.GIT_TAG }}
         run: |
@@ -295,12 +296,27 @@ jobs:
           # shell metacharacters could smuggle extra arguments. Both accepted
           # forms are metacharacter-free. Then require that it resolves, so a
           # typo fails loudly rather than feeding git-cliff a bogus range.
+          #
+          # A tag-form override must additionally be a STRICTLY LOWER semver than
+          # the version being released, mirroring auto-detection (which always
+          # picks a predecessor below GIT_TAG). An equal or forward tag would
+          # yield an inverted/empty prev..commit range and a bogus changelog. SHA
+          # overrides are exempt: an arbitrary commit has no comparable version,
+          # and that is the intended escape hatch for irregular history.
           if [ -n "$INPUT_PREVIOUS_TAG" ]; then
             SHA_RE='^[0-9a-f]{40}$'
             TAG_RE="^${INPUT_RELEASE_TYPE}-[0-9]+\.[0-9]+\.[0-9]+$"
             if ! [[ "$INPUT_PREVIOUS_TAG" =~ $SHA_RE || "$INPUT_PREVIOUS_TAG" =~ $TAG_RE ]]; then
               echo "::error::previous_tag override '${INPUT_PREVIOUS_TAG}' must be a full 40-char commit SHA or a ${INPUT_RELEASE_TYPE}-X.Y.Z tag"
               exit 1
+            fi
+            if [[ "$INPUT_PREVIOUS_TAG" =~ $TAG_RE ]]; then
+              OVERRIDE_VER="${INPUT_PREVIOUS_TAG#"${INPUT_RELEASE_TYPE}-"}"
+              LOWER=$(printf '%s\n%s\n' "$OVERRIDE_VER" "$INPUT_VERSION" | sort -V | head -n1)
+              if [ "$OVERRIDE_VER" = "$INPUT_VERSION" ] || [ "$LOWER" != "$OVERRIDE_VER" ]; then
+                echo "::error::previous_tag override '${INPUT_PREVIOUS_TAG}' (${OVERRIDE_VER}) must be a lower version than the release being cut (${INPUT_VERSION})"
+                exit 1
+              fi
             fi
             if ! git rev-parse --verify --quiet "${INPUT_PREVIOUS_TAG}^{commit}" >/dev/null; then
               echo "::error::previous_tag override '${INPUT_PREVIOUS_TAG}' does not resolve to a commit"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release
+run-name: Release - ${{ inputs.release_type }} - ${{ inputs.version }}${{ inputs.dry_run && ' (dry-run)' || '' }}
 
 concurrency:
   group: release
@@ -14,6 +15,10 @@ on:
         description: 'Release type / environment'
         required: true
         type: choice
+        # testnet is the normal first step of a release; mainnet follows once the
+        # testnet tag exists. (workflow_dispatch defaults are static literals — they
+        # can't be derived, which is why version/commit below have no default.)
+        default: testnet
         options:
           - testnet
           - mainnet
@@ -114,6 +119,11 @@ jobs:
         with:
           commit: ${{ steps.base.outputs.sha }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Wait for in-progress CI on the release base to finish rather than
+          # failing immediately, so a release kicked off while its base CI is
+          # still running blocks until the result is known (up to 60 min).
+          wait-timeout-seconds: "3600"
+          poll-interval-seconds: "30"
 
       - name: Determine tag name
         id: tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ on:
         type: boolean
         default: false
       previous_tag:
-        description: 'Optional changelog range lower bound (tag or commit SHA). Overrides the auto-detected previous same-env release. Leave empty for automatic semver detection.'
+        description: 'Optional changelog range lower bound: a full 40-char commit SHA or an <env>-X.Y.Z tag for this release_type. Overrides the auto-detected previous same-env release. Leave empty for automatic semver detection.'
         required: false
         type: string
         default: ''
@@ -288,10 +288,20 @@ jobs:
           GIT_TAG: ${{ env.GIT_TAG }}
         run: |
           # An explicit previous_tag override wins over auto-detection, to
-          # re-anchor the range when tag history is irregular. It may be any ref
-          # git can resolve; require that it resolves so a typo fails loudly
-          # rather than feeding git-cliff a bogus range.
+          # re-anchor the range when tag history is irregular. Restrict it to a
+          # full 40-char commit SHA or an <env>-X.Y.Z tag for THIS release_type:
+          # the value is interpolated into cliff_args below (and thence into the
+          # git-cliff action's arg string), so a form admitting whitespace or
+          # shell metacharacters could smuggle extra arguments. Both accepted
+          # forms are metacharacter-free. Then require that it resolves, so a
+          # typo fails loudly rather than feeding git-cliff a bogus range.
           if [ -n "$INPUT_PREVIOUS_TAG" ]; then
+            SHA_RE='^[0-9a-f]{40}$'
+            TAG_RE="^${INPUT_RELEASE_TYPE}-[0-9]+\.[0-9]+\.[0-9]+$"
+            if ! [[ "$INPUT_PREVIOUS_TAG" =~ $SHA_RE || "$INPUT_PREVIOUS_TAG" =~ $TAG_RE ]]; then
+              echo "::error::previous_tag override '${INPUT_PREVIOUS_TAG}' must be a full 40-char commit SHA or a ${INPUT_RELEASE_TYPE}-X.Y.Z tag"
+              exit 1
+            fi
             if ! git rev-parse --verify --quiet "${INPUT_PREVIOUS_TAG}^{commit}" >/dev/null; then
               echo "::error::previous_tag override '${INPUT_PREVIOUS_TAG}' does not resolve to a commit"
               exit 1


### PR DESCRIPTION
Improvements to the release workflow, focused on correctness of the auto-generated changelog and robustness of the release gates.

## Changelog range (main fix)
The generated changelog was spanning the entire history instead of just the previous same-env release. Root cause: git-cliff's `--unreleased` boundary detection is ancestry/time-based, but releases live on diverged sibling deployment branches, so the previous `<env>-X.Y.Z` tag is not an ancestor of the release commit — cliff fell back to the oldest reachable tag.

- Compute the boundary in the workflow: the highest `<env>-X.Y.Z` tag strictly below the version being released in **semver** order (not tag-creation order, so a back-port tagged after a newer release is bounded by its own predecessor), then hand cliff an explicit `<prev>..<commit>` range whose set-difference is correct regardless of ancestry.
- First release of an env (no lower tag) spans full history.
- New optional `previous_tag` dispatch input to override the auto-detected boundary for irregular tag histories; it must resolve to a commit or the run fails.
- Corrected the now-stale `cliff.toml` comment about how the range is bounded.

Verified with the pinned git-cliff v2.13.1 against a pre-tag snapshot: `testnet-4.0.1` went from 251 → 21 changes (the intended `testnet-4.0.0..testnet-4.0.1` range).

## Green-CI gate hardening
- Retry transient errors and handle unregistered checks in the release-base CI gate.

## Run-name / dispatch ergonomics
- Descriptive `run-name`, wait for in-progress base CI rather than failing immediately, sensible dispatch default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release workflow run names now show “(dry-run)” and `release_type` defaults to `testnet`.
  * Added optional `previous_tag` to override the changelog start point.
  * Release CI gating can now wait/poll for checks to finish (configurable timeout and polling interval) instead of failing right away.
* **Bug Fixes**
  * Changelog generation is now deterministic, using an explicit semver-ordered tag/commit range with same-environment boundary handling and auto-detection when `previous_tag` isn’t set.
  * CI gating more accurately differentiates pending/no-results-yet vs true failures and settles without requiring a successful result count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->