### PR TITLE
fix(tests): wait for mempool promotion instead of asserting instantly

### DIFF
--- a/crates/chain-tests/src/promotion/data_promotion_basic.rs
+++ b/crates/chain-tests/src/promotion/data_promotion_basic.rs
@@ -395,12 +395,12 @@ async fn promotion_validates_submit_inclusion_test() -> eyre::Result<()> {
         .wait_for_ingress_proofs(vec![data_tx.header.id], seconds_to_wait)
         .await?;
 
-    // Mine a block to promote from submit to publish
+    // Mine a block to promote from submit to publish. Mempool reflects
+    // promotion when it processes `BlockConfirmed` (behind production).
     genesis_node.mine_block().await?;
-
-    // ..and now it should be promoted!
-    let is_promoted = genesis_node.get_is_promoted(&data_tx.header.id).await?;
-    assert!(is_promoted);
+    genesis_node
+        .wait_for_promotion(&data_tx.header.id, seconds_to_wait)
+        .await?;
 
     // Wind down test
     genesis_node.stop().await;
@@ -517,20 +517,12 @@ async fn promotion_validates_ingress_proof_anchor() -> eyre::Result<()> {
         .wait_for_ingress_proofs_no_mining(vec![data_tx.header.id], seconds_to_wait)
         .await?;
 
-    // Mine a block - the ingress proof should enable promotion
+    // Mine a block - the ingress proof should enable promotion. Mempool
+    // reflects promotion when it processes `BlockConfirmed` (behind production).
     genesis_node.mine_block().await?;
-
-    // Poll for promotion status - mempool processes BlockConfirmed asynchronously
-    // Use 100ms intervals for faster detection (300 checks over 30 seconds)
-    let mut is_promoted = false;
-    for _ in 0..(seconds_to_wait * 10) {
-        if genesis_node.get_is_promoted(&data_tx.header.id).await? {
-            is_promoted = true;
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    }
-    assert!(is_promoted, "Transaction was not promoted within timeout");
+    genesis_node
+        .wait_for_promotion(&data_tx.header.id, seconds_to_wait)
+        .await?;
 
     // Wind down test
     genesis_node.stop().await;

--- a/crates/chain-tests/src/promotion/promotion_with_multiple_proofs.rs
+++ b/crates/chain-tests/src/promotion/promotion_with_multiple_proofs.rs
@@ -148,26 +148,23 @@ async fn spiky_slow_heavy4_promotion_with_multiple_proofs_test() -> eyre::Result
         .await;
     assert_matches!(res, Ok(()));
 
-    let height = genesis_node.get_canonical_chain_height().await;
+    // Mine the promotion block. Mempool reflects promotion when it processes
+    // `BlockConfirmed` (behind production) — wait for that, don't assert instantly.
     genesis_node.mine_block().await?;
     genesis_node
-        .wait_until_height_confirmed(height + 1, seconds_to_wait)
+        .wait_for_promotion(&data_tx.header.id, seconds_to_wait)
         .await?;
 
-    // Check is promoted state of tx in the mempool
-    let is_promoted = genesis_node.get_is_promoted(&data_tx.header.id).await?;
-    assert!(is_promoted);
-
+    // Advance past migration depth so the promoting block is written to the DB
+    // index, then confirm promotion is still visible via DB/mempool.
+    // (Previously waited for `height + migration_depth`, which with depth=1
+    // equalled the pre-mine height + 1 and never advanced past the promotion
+    // block itself.)
+    let migration_depth = config.consensus_config().block_migration_depth as usize;
+    genesis_node.mine_blocks(migration_depth).await?;
     genesis_node
-        .wait_until_height_confirmed(
-            height + config.consensus_config().block_migration_depth as u64,
-            seconds_to_wait,
-        )
+        .wait_for_promotion(&data_tx.header.id, seconds_to_wait)
         .await?;
-
-    // Check is promoted state of tx after it migrates to DB
-    let is_promoted = genesis_node.get_is_promoted(&data_tx.header.id).await?;
-    assert!(is_promoted);
 
     // Wind down test
     genesis_node.stop().await;


### PR DESCRIPTION
Promotion is applied on BlockConfirmed behind block production, so instant get_is_promoted asserts race that update and flake under CI. Use wait_for_promotion (same pattern as the perm-ledger readiness fix) and mine past migration depth so the multi-proofs path actually advances beyond the promotion block.


**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved promotion test reliability by using consistent asynchronous promotion waiting.
  * Replaced manual polling and height-based checks with dedicated confirmation handling.
  * Updated validation scenarios involving submit inclusion, ingress proof anchors, and multiple proofs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->