### PR TITLE
feat: expiry tests

### DIFF
--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -105,9 +105,11 @@ pub async fn calculate_expired_ledger_fees(
     // rescued by the `last_height` touch and must not be settled here).
     new_total_chunks: u64,
     // Cascade status of the epoch block being produced/validated (its own
-    // timestamp — NOT the parent snapshot's). Gates the write-window exclusion
-    // so it mirrors the Cascade-gated `touch_active_ledger_slots`. When false,
-    // settlement matches pre-Cascade master exactly (no exclusion).
+    // timestamp — NOT the parent snapshot's). Gates ONLY the write-window
+    // exclusion, mirroring the Cascade-gated `touch_active_ledger_slots`. The
+    // slot-keyed minerless-slot refund (empty-`partitions` expired slots) is
+    // unconditional, so for such a slot the settled set differs from pre-Cascade
+    // master.
     cascade_active: bool,
 ) -> eyre::Result<LedgerExpiryBalanceDelta> {
     // Fee distribution is only implemented for Submit ledger. Publish expiry

--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -4148,4 +4148,212 @@ mod tests {
 
         Ok(())
     }
+
+    /// An expired Submit slot with ZERO written chunks (pre-Cascade
+    /// allocation-anchored recycle of an unwritten slot) yields `range_end == 0`:
+    /// `expired_submit_range` must return `None` — nothing was ever written into
+    /// the expired range, so there is nothing to block or walk — rather than
+    /// erroring or fabricating a range.
+    #[test]
+    fn expired_submit_range_none_when_expired_slots_hold_no_chunks() -> eyre::Result<()> {
+        // No Cascade config: the pre-Cascade gate is transparent, so an
+        // unwritten, aged, non-last slot recycles by allocation age alone.
+        let node_config = NodeConfig::testing();
+        let config = Config::new_with_random_peer_id(node_config);
+        let mut epoch = empty_epoch_snapshot(&config);
+        epoch.ledgers[DataLedger::Submit].allocate_slots(2, 1);
+
+        let ep = &config.consensus.epoch;
+        let min_blocks = ep.submit_ledger_epoch_length * ep.num_blocks_in_epoch;
+        let expiry_epoch = min_blocks + 50;
+
+        // Recycle slot 0 (unwritten, partition-less): marks `is_expired`; with
+        // no partitions there are no expiring-partition infos to report.
+        let infos = epoch.ledgers.expire_partitions(
+            expiry_epoch,
+            false,
+            |_| 0,
+            config.consensus.num_chunks_in_partition,
+        );
+        assert!(
+            infos.is_empty(),
+            "a partition-less slot recycles without partition infos"
+        );
+        assert!(
+            epoch.ledgers.get_slots(DataLedger::Submit)[0].is_expired,
+            "slot 0 must have recycled"
+        );
+        // The inclusive (non-promotability) set still contains the slot...
+        assert_eq!(
+            epoch.get_all_expired_term_slot_indexes(DataLedger::Submit, expiry_epoch + 1, false, 0),
+            vec![0],
+            "the recycled slot stays in the inclusive set"
+        );
+
+        // ...but with zero chunks written as of the parent, there is no expired
+        // chunk range at all.
+        let mut parent = IrysBlockHeader::new_mock_header();
+        parent.data_ledgers[DataLedger::Submit].total_chunks = 0;
+        let range = expired_submit_range(expiry_epoch + 1, &epoch, &parent, &config, false)?;
+        assert!(
+            range.is_none(),
+            "an expired-but-never-written slot yields no expired chunk range"
+        );
+        Ok(())
+    }
+
+    /// A candidate promoted BELOW the by-hash walk window must be resolved as
+    /// promoted through the finalized `canonical_promoted_height` fallback —
+    /// refund suppressed — not silently missed. The by-hash walk covers only
+    /// the reorg window, and a Submit slot can expire long after its txs were
+    /// promoted (the promotion then sits below the walk floor, where MBH is
+    /// branch-invariant).
+    #[test]
+    fn resolve_promoted_below_walk_window_uses_finalized_fallback() -> eyre::Result<()> {
+        use irys_database::{
+            IrysDatabaseArgs as _, insert_block_header, insert_tx_header, open_or_create_db,
+            tables::IrysTables,
+        };
+        use irys_domain::{
+            BlockTree, BlockTreeReadGuard, CommitmentSnapshot, EpochSnapshot, dummy_ema_snapshot,
+        };
+        use irys_testing_utils::IrysBlockHeaderTestExt as _;
+        use irys_types::{
+            BlockTransactions, DataTransactionHeaderV1, DataTransactionHeaderV1WithMetadata,
+            DataTransactionMetadata, SealedBlock,
+        };
+        use reth_db::{mdbx::DatabaseArguments, transaction::DbTxMut as _};
+        use std::sync::RwLock;
+
+        fn with_publish(height: u64, publish_tx_ids: Vec<H256>) -> IrysBlockHeader {
+            let ledger = |id: DataLedger, tx_ids: Vec<H256>| irys_types::DataTransactionLedger {
+                ledger_id: id as u32,
+                tx_root: H256::zero(),
+                tx_ids: irys_types::H256List(tx_ids),
+                total_chunks: 0,
+                expires: None,
+                proofs: None,
+                required_proof_count: None,
+            };
+            let mut h = IrysBlockHeader::new_mock_header();
+            h.height = height;
+            h.data_ledgers = vec![
+                ledger(DataLedger::Publish, publish_tx_ids),
+                ledger(DataLedger::Submit, vec![]),
+            ];
+            h
+        }
+
+        // Small walk window so the promotion height sits strictly below it:
+        // walk_depth = max(tx_anchor_expiry_depth, block_tree_depth) = 5, and
+        // the settlement block at height 20 walks only [15, 19].
+        let mut node_config = NodeConfig::testing();
+        {
+            let c = node_config.consensus.get_mut();
+            c.block_tree_depth = 5;
+            c.mempool.tx_anchor_expiry_depth = 5;
+        }
+        let config = Config::new_with_random_peer_id(node_config);
+        let block_height = 20_u64;
+        let promote_height = 2_u64;
+
+        let target = H256::random();
+
+        // Chain 0..=19: the block at height 2 promotes `target`; every block
+        // inside the walk window [15, 19] does not.
+        let mut headers: Vec<IrysBlockHeader> = (0..block_height)
+            .map(|h| {
+                with_publish(
+                    h,
+                    if h == promote_height {
+                        vec![target]
+                    } else {
+                        vec![]
+                    },
+                )
+            })
+            .collect();
+        let guard = {
+            let mut iter = headers.iter_mut();
+            let genesis = iter.next().expect("chain has a genesis");
+            genesis.cumulative_diff = 0.into();
+            genesis.test_sign();
+            let mut prev = genesis.block_hash;
+            let mut tree = BlockTree::new(genesis, irys_types::ConsensusConfig::testing());
+            tree.mark_tip(&prev).unwrap();
+            for h in iter {
+                h.previous_block_hash = prev;
+                h.cumulative_diff = h.height.into();
+                h.test_sign();
+                prev = h.block_hash;
+                let sealed = Arc::new(SealedBlock::new_unchecked(
+                    Arc::new(h.clone()),
+                    BlockTransactions::default(),
+                ));
+                tree.add_block(
+                    &sealed,
+                    Arc::new(CommitmentSnapshot::default()),
+                    Arc::new(EpochSnapshot::default()),
+                    dummy_ema_snapshot(),
+                )?;
+            }
+            BlockTreeReadGuard::new(Arc::new(RwLock::new(tree)))
+        };
+
+        // Finalized promotion record: tx metadata + the canonical (MBH-agreed)
+        // promoting block whose Publish ledger carries the tx — everything
+        // `canonical_promoted_height`'s content check requires.
+        let tx_header = DataTransactionHeader::V1(DataTransactionHeaderV1WithMetadata {
+            tx: DataTransactionHeaderV1 {
+                id: target,
+                ..Default::default()
+            },
+            metadata: DataTransactionMetadata::new(),
+        });
+        let temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db_env = open_or_create_db(
+            &temp_dir,
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        let db = DatabaseProvider(Arc::new(db_env));
+        db.update_eyre(|wtx| {
+            insert_tx_header(wtx, &tx_header)?;
+            // promoted_height requires the Submit inclusion height to exist first.
+            irys_database::db_index::set_data_tx_included_height(wtx, &target, 1)?;
+            irys_database::db_index::set_data_tx_promoted_height(wtx, &target, promote_height)?;
+            insert_block_header(wtx, &headers[promote_height as usize])?;
+            wtx.put::<irys_database::tables::MigratedBlockHashes>(
+                promote_height,
+                headers[promote_height as usize].block_hash,
+            )?;
+            Ok(())
+        })?;
+
+        let parent_hash = headers[(block_height - 1) as usize].block_hash;
+        let promoted =
+            resolve_promoted_on_branch(&[target], parent_hash, block_height, &config, &guard, &db)?;
+        assert!(
+            promoted.contains(&target),
+            "a promotion below the walk floor must be found via the finalized fallback \
+             (refund suppressed)"
+        );
+
+        // Control: a tx with no promotion record anywhere stays unpromoted.
+        let unknown = H256::random();
+        let not_promoted = resolve_promoted_on_branch(
+            &[unknown],
+            parent_hash,
+            block_height,
+            &config,
+            &guard,
+            &db,
+        )?;
+        assert!(
+            not_promoted.is_empty(),
+            "a tx never promoted on the branch or below it must not be suppressed"
+        );
+
+        Ok(())
+    }
 }

--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -467,9 +467,10 @@ pub async fn expired_submit_tx_ids(
         return Ok(std::collections::BTreeSet::new());
     }
 
-    // Sentinel miner: `find_block_range` / `filter_transactions_by_chunk_range`
-    // require a non-empty miner list to include a slot's txs, but we only need the
-    // tx ids here. The address value is never read (we take `.keys()`).
+    // Miners are irrelevant here — only the tx-id keys are read. The walk
+    // includes a slot's txs whenever the slot is present in the map (an empty
+    // miner list works too — see the minerless-slot settlement path); the
+    // sentinel address is never read.
     let expired_slots: BTreeMap<SlotIndex, Vec<IrysAddress>> = slot_indexes
         .into_iter()
         .map(|i| (SlotIndex::new(i as u64), vec![IrysAddress::ZERO]))
@@ -1194,61 +1195,51 @@ fn collect_expired_partitions(
     // touch) is not paid here and then again when it later recycles. Pre-Cascade
     // the touch is gated off, so `cascade_active=false` disables the exclusion
     // and settlement matches the original master set.
-    let expired_partition_info = &parent_epoch_snapshot.get_expiring_partition_info(
+    //
+    // Slot-keyed, NOT partition-keyed: a slot whose replicas were all unpledged
+    // before expiry (and never backfilled) recycles with an empty `partitions`
+    // vec. It must still settle — its unpromoted txs are refunded — even though
+    // there are no miners to pay term fees to. A partition-keyed walk would
+    // never see the slot, stranding the refunds while the slot's txs stay
+    // promotion-blocked forever (`get_all_expired_slot_indexes`).
+    let expiring_slots = parent_epoch_snapshot.get_expiring_slot_partitions(
         block_height,
         target_ledger_type,
         new_total_chunks,
         cascade_active,
     );
     let mut expired_ledger_slot_indexes = BTreeMap::new();
-    if expired_partition_info.is_empty() {
-        return Ok(expired_ledger_slot_indexes);
-    }
 
     tracing::debug!(
-        "collect_expired_partitions: block_height={}, target_ledger={:?}, found {} expired partition hashes",
+        "collect_expired_partitions: block_height={}, target_ledger={:?}, found {} expiring slots",
         block_height,
         target_ledger_type,
-        expired_partition_info.len()
+        expiring_slots.len()
     );
 
-    for expired_partition in expired_partition_info {
-        let ledger_id = expired_partition.ledger_id;
-        let slot_index = SlotIndex::new(expired_partition.slot_index as u64);
-
-        // Filter by ledger type FIRST — before any lookup that could fail.
-        // This prevents a Publish partition state inconsistency from blocking
-        // Submit fee distribution (or vice versa).
-        if ledger_id != target_ledger_type {
-            tracing::debug!(
-                "Skipping partition with ledger_id={:?} (looking for {:?})",
-                ledger_id,
-                target_ledger_type
-            );
-            continue;
-        }
-
-        let partition = partition_assignments
-            .get_assignment(expired_partition.partition_hash)
-            .ok_or_eyre("could not get expired partition")?;
-
-        tracing::info!(
-            "Found expired partition for {:?} ledger at slot_index={}, miner={:?}",
-            ledger_id,
-            slot_index.0,
-            partition.miner_address
-        );
+    for (slot_index, partition_hashes) in expiring_slots {
+        let slot_index = SlotIndex::new(slot_index as u64);
 
         // Store miner_address (not reward_address) to preserve unique miner identities
         // for correct fee distribution. Reward address resolution is deferred to
         // aggregate_balance_deltas to ensure pooled miners (sharing a reward address)
         // are counted individually for fee splitting.
-        expired_ledger_slot_indexes
-            .entry(slot_index)
-            .and_modify(|miners: &mut Vec<IrysAddress>| {
-                miners.push(partition.miner_address);
-            })
-            .or_insert(vec![partition.miner_address]);
+        let mut miners = Vec::with_capacity(partition_hashes.len());
+        for partition_hash in partition_hashes {
+            let partition = partition_assignments
+                .get_assignment(partition_hash)
+                .ok_or_eyre("could not get expired partition")?;
+
+            tracing::info!(
+                "Found expired partition for {:?} ledger at slot_index={}, miner={:?}",
+                target_ledger_type,
+                slot_index.0,
+                partition.miner_address
+            );
+            miners.push(partition.miner_address);
+        }
+
+        expired_ledger_slot_indexes.insert(slot_index, miners);
     }
 
     Ok(expired_ledger_slot_indexes)
@@ -1709,7 +1700,10 @@ fn aggregate_balance_deltas(
             .ok_or_else(|| eyre!("Missing miner list for transaction {}", data_tx.id))?;
 
         // process miner balance increments for storing the term tx
-        {
+        // (skipped when the expired slot has NO miners — every replica unpledged
+        // before expiry. There is no one to distribute term fees to, so they
+        // stay in the treasury; the user perm-fee refunds below still settle.)
+        if !miners_that_stored_this_tx.is_empty() {
             // Deduplicate miners - each address should only get one share.
             // BTreeSet ensures deterministic iteration order across all nodes,
             // which is critical because the fee remainder is assigned to the
@@ -3913,6 +3907,243 @@ mod tests {
             ),
             vec![0],
             "the refilled slot stays out of the expired set for a fresh term"
+        );
+
+        Ok(())
+    }
+
+    /// An expired Submit slot with an EMPTY `partitions` vec — its sole replica
+    /// unpledged before expiry and never backfilled — must still settle: its
+    /// unpromoted txs are perm-fee refunded even though there are no miners to
+    /// pay term fees to (those stay in the treasury). Settlement must be
+    /// slot-keyed, not partition-keyed: the slot is marked `is_expired` and its
+    /// txs are promotion-blocked forever (`get_all_expired_slot_indexes`), so a
+    /// partition-keyed settlement walk that never sees the slot would leave its
+    /// users charged, non-promotable, and unsettled.
+    #[test_log::test(tokio::test)]
+    async fn empty_partition_expired_slot_still_refunds_unpromoted_txs() -> eyre::Result<()> {
+        use irys_database::{
+            IrysDatabaseArgs as _, insert_block_header, insert_tx_header, open_or_create_db,
+            tables::IrysTables,
+        };
+        use irys_domain::{BlockIndex, BlockTree, BlockTreeReadGuard};
+        use irys_testing_utils::{IrysBlockHeaderTestExt as _, utils::TempDirBuilder};
+        use irys_types::{
+            ConsensusConfig, DataTransactionHeaderV1, DataTransactionHeaderV1WithMetadata,
+            DataTransactionMetadata, H256List, LedgerIndexItem, app_state::DatabaseProvider,
+        };
+        use reth_db::{mdbx::DatabaseArguments, transaction::DbTxMut as _};
+        use std::sync::{Arc, RwLock};
+
+        fn submit_chain_header(
+            height: u64,
+            total_chunks: u64,
+            tx_ids: Vec<H256>,
+        ) -> IrysBlockHeader {
+            let mut h = IrysBlockHeader::new_mock_header();
+            h.height = height;
+            h.data_ledgers[DataLedger::Submit].total_chunks = total_chunks;
+            h.data_ledgers[DataLedger::Submit].tx_ids = H256List(tx_ids);
+            h
+        }
+
+        let config = config_with_cascade();
+        let num_blocks_in_epoch = config.consensus.epoch.num_blocks_in_epoch;
+        let blocks_per_cycle =
+            config.consensus.epoch.submit_ledger_epoch_length * num_blocks_in_epoch;
+        // Slot 0 is written (and its expiry clock stamped) at the first epoch;
+        // it expires a full slot lifetime later.
+        let write_epoch_height = num_blocks_in_epoch;
+        let expiry_height = write_epoch_height + blocks_per_cycle;
+        let submit_total = config.consensus.num_chunks_in_partition; // slot 0 exactly full
+
+        // --- Epoch snapshot: slot 0 fully written at the first epoch, then aged
+        //     through the cycle WITHOUT ever holding a partition assignment (no
+        //     pledges in this fixture — the state an unpledged sole replica
+        //     leaves behind). Evolution stops at the last epoch BEFORE expiry:
+        //     the parent snapshot of the expiry epoch block. ---
+        let mut epoch = empty_epoch_snapshot(&config);
+        let mut prev_epoch = submit_epoch_header(0, 0);
+        prev_epoch.test_sign();
+        epoch.perform_epoch_tasks(&None, &prev_epoch, vec![])?;
+        for height in (num_blocks_in_epoch..expiry_height).step_by(num_blocks_in_epoch as usize) {
+            let mut next = submit_epoch_header(height, submit_total);
+            next.test_sign();
+            epoch.perform_epoch_tasks(&Some(prev_epoch.clone()), &next, vec![])?;
+            prev_epoch = next;
+        }
+
+        {
+            let slots = epoch.ledgers.get_slots(DataLedger::Submit);
+            assert!(
+                slots.len() >= 2,
+                "fixture: slot 0 must be non-last (got {} slots)",
+                slots.len()
+            );
+            let slot0 = &slots[0];
+            assert!(slot0.has_been_written && !slot0.is_expired);
+            assert!(
+                slot0.partitions.is_empty(),
+                "fixture: slot 0 must have no partition assignment"
+            );
+        }
+        // The slot IS in the non-promotability set at the expiry epoch (its txs
+        // are blocked) ...
+        assert_eq!(
+            epoch.get_all_expired_term_slot_indexes(
+                DataLedger::Submit,
+                expiry_height,
+                true,
+                submit_total
+            ),
+            vec![0],
+            "the minerless slot must be in the blocked set at its expiry epoch"
+        );
+        // ... while the partition-keyed view is blind to it, so settlement must
+        // not be derived from partition infos.
+        assert!(
+            epoch
+                .get_expiring_partition_info(expiry_height, DataLedger::Submit, submit_total, true)
+                .is_empty(),
+            "partition-keyed expiring set has no entry for a partition-less slot"
+        );
+
+        // --- Two unpromoted Submit txs exactly fill slot 0 (chunk_size = 1). ---
+        let mk_tx = |data_size: u64, perm_fee: u64| {
+            DataTransactionHeader::V1(DataTransactionHeaderV1WithMetadata {
+                tx: DataTransactionHeaderV1 {
+                    id: H256::random(),
+                    signer: IrysAddress::random(),
+                    data_size,
+                    term_fee: U256::from(1000).into(),
+                    perm_fee: Some(U256::from(perm_fee).into()),
+                    ..Default::default()
+                },
+                metadata: DataTransactionMetadata::new(),
+            })
+        };
+        let tx_a = mk_tx(6, 7001); // chunks [0,6)
+        let tx_b = mk_tx(4, 7002); // chunks [6,10)
+
+        let mut inclusion_genesis = submit_chain_header(0, 0, vec![]);
+        inclusion_genesis.cumulative_diff = 0.into();
+        inclusion_genesis.test_sign();
+        let mut inclusion_block = submit_chain_header(1, submit_total, vec![tx_a.id, tx_b.id]);
+        inclusion_block.previous_block_hash = inclusion_genesis.block_hash;
+        inclusion_block.cumulative_diff = 1.into();
+        inclusion_block.test_sign();
+
+        let temp_dir = TempDirBuilder::new().build();
+        let db_env = open_or_create_db(
+            &temp_dir,
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        let db = DatabaseProvider(Arc::new(db_env));
+        db.update_eyre(|wtx| {
+            insert_tx_header(wtx, &tx_a)?;
+            insert_tx_header(wtx, &tx_b)?;
+            insert_block_header(wtx, &inclusion_genesis)?;
+            insert_block_header(wtx, &inclusion_block)?;
+            wtx.put::<irys_database::tables::MigratedBlockHashes>(0, inclusion_genesis.block_hash)?;
+            wtx.put::<irys_database::tables::MigratedBlockHashes>(1, inclusion_block.block_hash)?;
+            Ok(())
+        })?;
+
+        let block_index = BlockIndex::new_for_testing(db.clone());
+        for (height, (hash, total)) in [
+            (inclusion_genesis.block_hash, 0_u64),
+            (inclusion_block.block_hash, submit_total),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            block_index.push_item(
+                &BlockIndexItem {
+                    block_hash: hash,
+                    num_ledgers: 2,
+                    ledgers: vec![
+                        LedgerIndexItem {
+                            total_chunks: 0,
+                            tx_root: H256::random(),
+                            ledger: DataLedger::Publish,
+                        },
+                        LedgerIndexItem {
+                            total_chunks: total,
+                            tx_root: H256::random(),
+                            ledger: DataLedger::Submit,
+                        },
+                    ],
+                },
+                height as u64,
+            )?;
+        }
+
+        // Parent-ancestry chain for the promotion-suppression walk
+        // (`resolve_promoted_on_branch` descends by hash from the parent to the
+        // walk floor; none of these blocks promotes anything).
+        let walk_floor = expiry_height
+            .saturating_sub(crate::block_validation::prior_inclusion_walk_depth(&config))
+            .saturating_sub(2);
+        let mut walk_prev: Option<H256> = None;
+        let mut parent_header: Option<IrysBlockHeader> = None;
+        for height in walk_floor..expiry_height {
+            let mut hdr = submit_chain_header(height, submit_total, vec![]);
+            if let Some(prev_hash) = walk_prev {
+                hdr.previous_block_hash = prev_hash;
+            }
+            hdr.cumulative_diff = height.into();
+            hdr.test_sign();
+            db.update_eyre(|wtx| {
+                insert_block_header(wtx, &hdr)?;
+                Ok(())
+            })?;
+            walk_prev = Some(hdr.block_hash);
+            parent_header = Some(hdr);
+        }
+        let parent_header = parent_header.expect("walk chain is non-empty");
+
+        let tree = BlockTree::new(&inclusion_genesis, ConsensusConfig::testing());
+        let guard = BlockTreeReadGuard::new(Arc::new(RwLock::new(tree)));
+
+        let delta = calculate_expired_ledger_fees(
+            &epoch,
+            &parent_header,
+            expiry_height,
+            DataLedger::Submit,
+            &config,
+            block_index,
+            &guard,
+            &MempoolReadGuard::stub(),
+            &db,
+            true, // Submit: refund the perm fee for unpromoted txs
+            submit_total,
+            true,
+        )
+        .await?;
+
+        let refunds: std::collections::BTreeMap<_, _> = delta
+            .user_perm_fee_refunds
+            .iter()
+            .map(|(id, amount, addr)| (*id, (*amount, *addr)))
+            .collect();
+        assert_eq!(
+            refunds.len(),
+            2,
+            "both unpromoted txs in the minerless expired slot must be refunded, got {:?}",
+            delta.user_perm_fee_refunds
+        );
+        for tx in [&tx_a, &tx_b] {
+            assert_eq!(
+                refunds.get(&tx.id).copied(),
+                Some((tx.perm_fee.expect("fixture sets perm_fee").get(), tx.signer)),
+                "tx {} must be refunded exactly its perm_fee to its signer",
+                tx.id
+            );
+        }
+        assert!(
+            delta.reward_balance_increment.is_empty(),
+            "no miners stored the slot, so no term-fee rewards may be distributed"
         );
 
         Ok(())

--- a/crates/chain-tests/src/perm_ledger_expiry/mod.rs
+++ b/crates/chain-tests/src/perm_ledger_expiry/mod.rs
@@ -1386,6 +1386,15 @@ async fn slow_heavy_perm_partial_frontier_survives_cascade() -> eyre::Result<()>
         !publish_slots[1].partitions.is_empty(),
         "the surviving partial frontier slot's partition assignment must be retained"
     );
+    // Discriminating anchor: slot 0 (fully written at batch 1, non-last, mined far past
+    // its allocation-anchored expiry) MUST have expired. Without this, slot 1's survival
+    // could pass on a dead or over-strong gate that never expires anything — this proves
+    // the expiry machinery is live, so slot 1 surviving is the fully-written gate at work.
+    assert!(
+        publish_slots[0].is_expired,
+        "slot 0 (fully written, non-last, aged well past its window) must expire — else \
+         slot 1's survival is not discriminating"
+    );
 
     // --- Fixture hygiene: no term-ledger settlement shadow txs leaked into the
     //     window. (Publish recycle never emits these tx types, so this does not

--- a/crates/chain-tests/src/perm_ledger_expiry/mod.rs
+++ b/crates/chain-tests/src/perm_ledger_expiry/mod.rs
@@ -1,8 +1,11 @@
 use crate::utils::IrysNodeTest;
 use alloy_genesis::GenesisAccount;
 use alloy_rpc_types_eth::TransactionTrait as _;
+use irys_config::submodules::StorageSubmodulesConfig;
 use irys_reth_node_bridge::irys_reth::shadow_tx::{ShadowTransaction, TransactionPacket};
-use irys_types::{DataLedger, NodeConfig, U256, irys::IrysSigner};
+use irys_types::{
+    DataLedger, NodeConfig, U256, UnixTimestamp, hardfork_config::Cascade, irys::IrysSigner,
+};
 use tracing::info;
 
 /// Tests that publish ledger slots expire when publish_ledger_epoch_length is configured.
@@ -1169,6 +1172,232 @@ async fn heavy_perm_expiry_disabled_nothing_expires() -> eyre::Result<()> {
     info!("Verified all Publish partition assignments remain active");
 
     info!("Perm expiry disabled (mainnet safety) test passed!");
+    node.stop().await;
+    Ok(())
+}
+
+/// End-to-end proof that a partially-written PERMANENT (Publish) frontier slot is
+/// never recycled past its allocation window under Cascade — the live
+/// epoch-snapshot complement to the pure-function coverage.
+///
+/// Post-Cascade `cascade_expiry_gate` only lets a slot recycle once it is *fully
+/// written* (`slot_index < total_chunks / num_chunks_in_partition`). A slot whose
+/// write frontier still sits inside it is structurally non-expirable, independent
+/// of age or last-slot protection. This drives a real node so:
+/// - Publish slot 0 is fully filled (fully written → may legitimately recycle),
+/// - Publish slot 1 is partially filled (the frontier sits inside it),
+/// - Publish slot 2 is preallocated headroom (so slot 1 is NOT the last slot,
+///   ruling out last-slot protection as the reason it survives).
+///
+/// Then it mines far past where slot 1's allocation-anchored — and even its
+/// last-write-anchored — age would recycle it under the pre-gate behavior, and
+/// asserts slot 1 survives with its partition assignment, and that no Publish
+/// expiry fee/refund shadow txs were produced for the slot that never recycles.
+#[test_log::test(tokio::test)]
+async fn slow_heavy_perm_partial_frontier_survives_cascade() -> eyre::Result<()> {
+    let num_blocks_in_epoch = 2_u64;
+    let activation_height = num_blocks_in_epoch;
+    let publish_ledger_epoch_length = 2_u64; // k
+    let chunk_size = 32_u64;
+    let num_chunks_in_partition = 4_u64; // perm slot capacity = 4 chunks
+    let window = publish_ledger_epoch_length * num_blocks_in_epoch; // 4
+    let full_slot_bytes = (num_chunks_in_partition * chunk_size) as usize; // fills one slot (4 chunks)
+    let half_slot_bytes = (2 * chunk_size) as usize; // partial fill (2 of 4 chunks)
+
+    let mut config = NodeConfig::testing().with_consensus(|c| {
+        c.block_migration_depth = 1;
+        c.epoch.num_blocks_in_epoch = num_blocks_in_epoch;
+        c.epoch.publish_ledger_epoch_length = Some(publish_ledger_epoch_length);
+        // Keep Submit far from expiry so the only ledger under test is Publish;
+        // any expiry fee/refund shadow tx observed is then unambiguously a perm defect.
+        c.epoch.submit_ledger_epoch_length = 100;
+        c.chunk_size = chunk_size;
+        c.num_chunks_in_partition = num_chunks_in_partition;
+        c.num_chunks_in_recall_range = 1;
+        // 1 partition per slot keeps partition demand low so the partial frontier
+        // slot deterministically retains its assignment across recycles.
+        c.num_partitions_per_slot = 1;
+        c.hardforks.cascade = Some(Cascade {
+            activation_timestamp: UnixTimestamp::from_secs(0),
+            one_year_epoch_length: 8,
+            thirty_day_epoch_length: 2,
+            annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
+        });
+    });
+
+    let signer = config.new_random_signer();
+    config.fund_genesis_accounts(vec![&signer]);
+
+    let test_node = IrysNodeTest::new_genesis(config);
+    // Cascade activates all four data ledgers; pre-configure enough submodules so
+    // every ledger (plus capacity) has partitions available.
+    StorageSubmodulesConfig::load_for_test(test_node.cfg.base_directory.clone(), 5)?;
+    let node = test_node.start_and_wait_for_packing("test", 30).await;
+
+    // Post and fully promote one publish-data tx (Submit -> Publish), growing the
+    // Publish ledger's `total_chunks` by `bytes`-worth of chunks.
+    async fn promote_publish(
+        node: &IrysNodeTest<irys_chain::IrysNodeCtx>,
+        signer: &IrysSigner,
+        bytes: usize,
+        tag: u8,
+    ) -> eyre::Result<()> {
+        let mut data = vec![7_u8; bytes];
+        data[0] = tag;
+        let anchor = node.get_anchor().await?;
+        let tx = node.post_data_tx(anchor, data, signer).await;
+        node.wait_for_mempool(tx.header.id, 30).await?;
+        node.upload_chunks(&tx).await?;
+        node.mine_block().await?; // confirm in Submit, trigger ingress-proof generation
+        node.wait_for_ingress_proofs_no_mining(vec![tx.header.id], 30)
+            .await?;
+        node.mine_block().await?; // promote Submit -> Publish
+        Ok(())
+    }
+
+    // Counts Publish-expiry fee/refund shadow txs in the block at `height`.
+    // Publish expiry emits no fee distribution and perm fees are never refunded,
+    // so both counts must be zero for a slot that never recycles.
+    async fn count_publish_expiry_shadow_txs(
+        node: &IrysNodeTest<irys_chain::IrysNodeCtx>,
+        height: u64,
+    ) -> eyre::Result<usize> {
+        let block = node.get_block_by_height(height).await?;
+        let evm = node.wait_for_evm_block(block.evm_block_hash, 30).await?;
+        let mut count = 0_usize;
+        for tx in evm.body.transactions {
+            let mut input = tx.input().as_ref();
+            if let Ok(shadow) = ShadowTransaction::decode(&mut input)
+                && let Some(packet) = shadow.as_v1()
+                && matches!(
+                    packet,
+                    TransactionPacket::TermFeeReward(_) | TransactionPacket::PermFeeRefund(_)
+                )
+            {
+                count += 1;
+            }
+        }
+        Ok(count)
+    }
+
+    // Mine past Cascade activation so the perm/term expiry machinery is live.
+    while node.get_canonical_chain_height().await <= activation_height {
+        node.mine_block().await?;
+    }
+
+    // --- Fill perm slot 0 fully; the epoch allocates headroom slots. ---
+    promote_publish(&node, &signer, full_slot_bytes, 1).await?;
+    node.mine_until_next_epoch().await?;
+    let a1 = node.get_canonical_chain_height().await;
+    {
+        let snapshot = node.get_canonical_epoch_snapshot();
+        let slots = snapshot.ledgers.get_slots(DataLedger::Publish);
+        assert!(
+            slots.len() >= 2,
+            "expected >=2 perm slots after filling slot 0 (got {})",
+            slots.len()
+        );
+    }
+
+    // --- Partially fill perm slot 1 (the frontier); slot 2 stays headroom. ---
+    promote_publish(&node, &signer, half_slot_bytes, 2).await?;
+    let a2 = node.mine_until_next_epoch().await?.1;
+    assert!(
+        a2 > a1,
+        "batch 2 epoch (a2={a2}) must be after batch 1 epoch (a1={a1})"
+    );
+
+    // Verify the intended fixture state: slot 0 fully written, slot 1 the partial
+    // frontier, slot 2 headroom — i.e. exactly one fully-written slot.
+    let fixture_block = node.get_block_by_height(a2).await?;
+    let publish_total = fixture_block.ledger_total_chunks(DataLedger::Publish);
+    assert_eq!(
+        publish_total / num_chunks_in_partition,
+        1,
+        "exactly one Publish slot must be fully written (total_chunks={publish_total}, C={num_chunks_in_partition})"
+    );
+    assert_ne!(
+        publish_total % num_chunks_in_partition,
+        0,
+        "slot 1 must be a PARTIAL frontier (total_chunks={publish_total} should not be a slot multiple)"
+    );
+    {
+        let snapshot = node.get_canonical_epoch_snapshot();
+        let slots = snapshot.ledgers.get_slots(DataLedger::Publish);
+        assert!(
+            slots.len() >= 3,
+            "slot 1 must be non-last (slot 2 headroom) so survival is the fully-written \
+             gate, not last-slot protection (got {} slots)",
+            slots.len()
+        );
+        assert!(
+            !slots[1].is_expired,
+            "partial frontier slot 1 must not be expired right after being written"
+        );
+        assert!(
+            !slots[1].partitions.is_empty(),
+            "partial frontier slot 1 must have a partition assignment"
+        );
+    }
+
+    // --- Mine far past where slot 1 would recycle under age-anchored behavior. ---
+    // Allocation-anchored expiry would be a1+window; last-write-anchored a2+window.
+    // Mine well past BOTH (5x its own write window) to prove survival is the
+    // fully-written gate — the frontier still sits inside slot 1 — not age.
+    let target_height = a2 + 5 * window;
+    let alloc_anchored_expiry = a1 + window;
+    assert!(
+        target_height > alloc_anchored_expiry && target_height > a2 + window,
+        "target {target_height} must exceed both allocation ({alloc_anchored_expiry}) \
+         and last-write ({}) anchored expiry",
+        a2 + window
+    );
+    let current_height = node.get_canonical_chain_height().await;
+    for _ in current_height..target_height {
+        node.mine_block().await?;
+    }
+    let final_height = node.get_canonical_chain_height().await;
+    assert!(
+        final_height >= target_height,
+        "should have reached target height {target_height} (got {final_height})"
+    );
+
+    // --- Load-bearing assertions on the tip snapshot. ---
+    let snapshot = node.get_canonical_epoch_snapshot();
+    let publish_slots = snapshot.ledgers.get_slots(DataLedger::Publish);
+    assert!(
+        publish_slots.len() >= 3,
+        "slot 1 must remain non-last at the tip (got {} slots)",
+        publish_slots.len()
+    );
+    assert!(
+        !publish_slots[1].is_expired,
+        "partial Publish frontier slot must not expire at height {final_height}: its write \
+         frontier still sits inside it, so the fully-written gate keeps it alive even past \
+         its age-anchored expiry"
+    );
+    assert!(
+        !publish_slots[1].partitions.is_empty(),
+        "the surviving partial frontier slot's partition assignment must be retained"
+    );
+
+    // --- No Publish expiry fee/refund shadow txs for the slot that never recycles. ---
+    let mut epoch_height = a2;
+    while epoch_height <= final_height {
+        let count = count_publish_expiry_shadow_txs(&node, epoch_height).await?;
+        assert_eq!(
+            count, 0,
+            "no Publish expiry fee/refund shadow txs may be generated for a non-recycling \
+             perm slot (found {count} at epoch height {epoch_height})"
+        );
+        epoch_height += num_blocks_in_epoch;
+    }
+
+    info!(
+        "Partial Publish frontier slot survived to height {} with its partition assignment; \
+         zero perm expiry shadow txs",
+        final_height
+    );
     node.stop().await;
     Ok(())
 }

--- a/crates/chain-tests/src/perm_ledger_expiry/mod.rs
+++ b/crates/chain-tests/src/perm_ledger_expiry/mod.rs
@@ -1191,8 +1191,10 @@ async fn heavy_perm_expiry_disabled_nothing_expires() -> eyre::Result<()> {
 ///
 /// Then it mines far past where slot 1's allocation-anchored — and even its
 /// last-write-anchored — age would recycle it under the pre-gate behavior, and
-/// asserts slot 1 survives with its partition assignment, and that no Publish
-/// expiry fee/refund shadow txs were produced for the slot that never recycles.
+/// asserts slot 1 survives with its partition assignment, plus a fixture-hygiene
+/// guard that no term-ledger settlement shadow txs leaked into the window (Publish
+/// recycle never emits these tx types, so this does not test the Publish gate
+/// itself — that's covered by the is_expired/partitions assertions above).
 #[test_log::test(tokio::test)]
 async fn slow_heavy_perm_partial_frontier_survives_cascade() -> eyre::Result<()> {
     let num_blocks_in_epoch = 2_u64;
@@ -1255,9 +1257,13 @@ async fn slow_heavy_perm_partial_frontier_survives_cascade() -> eyre::Result<()>
         Ok(())
     }
 
-    // Counts Publish-expiry fee/refund shadow txs in the block at `height`.
-    // Publish expiry emits no fee distribution and perm fees are never refunded,
-    // so both counts must be zero for a slot that never recycles.
+    // Counts TermFeeReward / PermFeeRefund shadow txs in the block at `height`.
+    // Publish-ledger recycle never emits either of these tx types (perm fees are
+    // never refunded and Publish expiry emits no fee distribution), so this cannot
+    // discriminate a recycling Publish slot from a non-recycling one — it does not
+    // test the Publish frontier gate. Its value is fixture hygiene: guarding that
+    // no term-ledger (Submit/OneYear/ThirtyDay) settlement leaked into the window,
+    // since Submit is configured far from expiry.
     async fn count_publish_expiry_shadow_txs(
         node: &IrysNodeTest<irys_chain::IrysNodeCtx>,
         height: u64,
@@ -1381,14 +1387,19 @@ async fn slow_heavy_perm_partial_frontier_survives_cascade() -> eyre::Result<()>
         "the surviving partial frontier slot's partition assignment must be retained"
     );
 
-    // --- No Publish expiry fee/refund shadow txs for the slot that never recycles. ---
+    // --- Fixture hygiene: no term-ledger settlement shadow txs leaked into the
+    //     window. (Publish recycle never emits these tx types, so this does not
+    //     test the Publish frontier gate — that's covered by the
+    //     is_expired/partitions assertions above.) ---
     let mut epoch_height = a2;
     while epoch_height <= final_height {
         let count = count_publish_expiry_shadow_txs(&node, epoch_height).await?;
         assert_eq!(
             count, 0,
-            "no Publish expiry fee/refund shadow txs may be generated for a non-recycling \
-             perm slot (found {count} at epoch height {epoch_height})"
+            "no term-ledger (Submit/OneYear/ThirtyDay) expiry settlement shadow txs should \
+             appear while Submit is held non-expiring (found {count} at epoch height \
+             {epoch_height}); Publish recycle never emits these tx types, so this is a \
+             fixture-hygiene guard, not a check on the Publish frontier slot"
         );
         epoch_height += num_blocks_in_epoch;
     }

--- a/crates/chain-tests/src/term_ledger_expiry/mod.rs
+++ b/crates/chain-tests/src/term_ledger_expiry/mod.rs
@@ -1,3 +1,4 @@
+mod multi_replica_expiry;
 mod perm_refund;
 mod perm_refund_multi_miner;
 mod perm_refund_unpledged_slot;

--- a/crates/chain-tests/src/term_ledger_expiry/mod.rs
+++ b/crates/chain-tests/src/term_ledger_expiry/mod.rs
@@ -1,5 +1,6 @@
 mod perm_refund;
 mod perm_refund_multi_miner;
+mod perm_refund_unpledged_slot;
 
 use crate::utils::IrysNodeTest;
 use alloy_core::primitives::B256;

--- a/crates/chain-tests/src/term_ledger_expiry/multi_replica_expiry.rs
+++ b/crates/chain-tests/src/term_ledger_expiry/multi_replica_expiry.rs
@@ -1,0 +1,257 @@
+//! Multi-replica (`num_partitions_per_slot = 2`) Submit-slot expiry settlement,
+//! produced-block coverage: ONE expired slot held by TWO DISTINCT miners must
+//! split the slot's term-fee treasury between them and refund each unpromoted
+//! tx exactly ONCE — never once per replica.
+//!
+//! Every other expiry E2E runs with 1 partition per slot (production profiles
+//! use 10), so the per-slot multi-miner settlement path — the slot's miner
+//! list carrying more than one address into `aggregate_balance_deltas` — was
+//! exercised only by in-memory unit tests
+//! (`test_aggregate_balance_deltas_with_pooled_miners`,
+//! `test_aggregate_miner_fees_handles_duplicates`). No produced-block test
+//! decoded the on-chain shadow txs for a two-owner slot.
+//!
+//! Getting two DISTINCT owners into one slot is deterministic here (no RNG
+//! dependence on the owner): `process_slot_needs` filters a slot's candidate
+//! capacity partitions by the miners already assigned to it, so the genesis
+//! miner can fill only ONE replica of each slot no matter how many spare
+//! partitions it has. The second replica stays empty until the second miner's
+//! pledged capacity exists, at which point it is the only eligible candidate.
+
+use crate::utils::IrysNodeTest;
+use alloy_genesis::GenesisAccount;
+use irys_config::submodules::StorageSubmodulesConfig;
+use irys_reth_node_bridge::irys_reth::shadow_tx::{ShadowTransaction, TransactionPacket};
+use irys_types::{
+    DataLedger, IrysAddress, NodeConfig, U256, fee_distribution::TermFeeCharges, irys::IrysSigner,
+};
+use reth::rpc::types::TransactionTrait as _;
+use std::collections::BTreeMap;
+use tracing::info;
+
+#[test_log::test(tokio::test)]
+async fn heavy_multi_replica_slot_expiry_splits_reward_and_refunds_once() -> eyre::Result<()> {
+    const CHUNK_SIZE: u64 = 32;
+    const NUM_CHUNKS_IN_PARTITION: u64 = 4;
+    const DATA_SIZE: usize = (NUM_CHUNKS_IN_PARTITION * CHUNK_SIZE) as usize; // fills slot 0
+    const INITIAL_BALANCE: u128 = 30_000_000_000_000_000_000_000; // covers stake (20k) + pledges
+    const SUBMIT_LEDGER_EPOCH_LENGTH: u64 = 5;
+    const BLOCKS_PER_EPOCH: u64 = 3;
+    // Pre-Cascade: Submit slot 0 (allocated at genesis) is allocation-anchored
+    // and expires at exactly SUBMIT_LEDGER_EPOCH_LENGTH * BLOCKS_PER_EPOCH,
+    // regardless of when it was written. Multi-replica settlement is
+    // Cascade-independent. The window leaves room for the second miner's
+    // commitment activation + slot backfill (a few epochs) plus the inclusion,
+    // all strictly before expiry.
+    const EXPIRY_HEIGHT: u64 = SUBMIT_LEDGER_EPOCH_LENGTH * BLOCKS_PER_EPOCH; // 15
+
+    let mut config = NodeConfig::testing();
+    {
+        let c = config.consensus.get_mut();
+        c.block_migration_depth = 1;
+        c.chunk_size = CHUNK_SIZE;
+        c.num_chunks_in_partition = NUM_CHUNKS_IN_PARTITION;
+        c.epoch.submit_ledger_epoch_length = SUBMIT_LEDGER_EPOCH_LENGTH;
+        c.epoch.num_blocks_in_epoch = BLOCKS_PER_EPOCH;
+        // The property under test: every slot holds TWO replicas.
+        c.num_partitions_per_slot = 2;
+        c.num_partitions_per_term_ledger_slot = 2;
+    }
+
+    let user_signer = IrysSigner::random_signer(&config.consensus_config());
+    let user_address = user_signer.address();
+    // The second miner only posts commitments (stake + pledges); it never runs
+    // a node or mines — settlement needs its partitions assigned, not packed.
+    let miner2_signer = IrysSigner::random_signer(&config.consensus_config());
+    let miner2_address = miner2_signer.address();
+    config.consensus.extend_genesis_accounts(vec![
+        (
+            user_address,
+            GenesisAccount {
+                balance: U256::from(INITIAL_BALANCE).into(),
+                ..Default::default()
+            },
+        ),
+        (
+            miner2_address,
+            GenesisAccount {
+                balance: U256::from(INITIAL_BALANCE).into(),
+                ..Default::default()
+            },
+        ),
+    ]);
+
+    let genesis_address = config.miner_address();
+    let test_node = IrysNodeTest::new_genesis(config.clone());
+    StorageSubmodulesConfig::load_for_test(test_node.cfg.base_directory.clone(), 3)?;
+    let node = test_node
+        .start_and_wait_for_packing("multi_replica", 30)
+        .await;
+
+    // --- 1. Second miner stakes and pledges two partitions; the next epoch
+    //        assigns them to the empty second replicas (Submit slot 0 and
+    //        Publish slot 0 — the genesis miner is filtered out of both). ---
+    let stake = node
+        .post_stake_commitment_with_signer(&miner2_signer)
+        .await?;
+    let pledge_a = node
+        .post_pledge_commitment_with_signer(&miner2_signer)
+        .await;
+    let pledge_b = node
+        .post_pledge_commitment_with_signer(&miner2_signer)
+        .await;
+    node.wait_for_mempool_commitment_txs(vec![stake.id(), pledge_a.id(), pledge_b.id()], 20)
+        .await?;
+    // Observed (not hardcoded) assignment: Submit slot 0 must hold two replicas
+    // owned by the two distinct miners. Commitment activation and the capacity
+    // -> slot backfill land across epoch boundaries, so allow a few epochs —
+    // but they must all complete BEFORE the slot's expiry epoch (asserted via
+    // `inclusion.height < EXPIRY_HEIGHT` below, which this loop precedes).
+    let mut slot0_owners: Vec<IrysAddress> = Vec::new();
+    for _ in 0..3 {
+        node.mine_until_next_epoch().await?;
+        let snapshot = node.get_canonical_epoch_snapshot();
+        let slots = snapshot.ledgers.get_slots(DataLedger::Submit);
+        slot0_owners = slots[0]
+            .partitions
+            .iter()
+            .map(|hash| {
+                snapshot
+                    .partition_assignments
+                    .get_assignment(*hash)
+                    .expect("assigned partition must have an assignment entry")
+                    .miner_address
+            })
+            .collect();
+        if slot0_owners.len() == 2 {
+            break;
+        }
+    }
+    assert_eq!(
+        slot0_owners.len(),
+        2,
+        "Submit slot 0 must hold both replicas (got owners {slot0_owners:?})"
+    );
+    assert!(
+        slot0_owners.contains(&genesis_address) && slot0_owners.contains(&miner2_address),
+        "the two replicas must belong to the two distinct miners (got {slot0_owners:?})"
+    );
+
+    // --- 2. One unpromoted tx (no chunks uploaded) exactly fills slot 0. ---
+    let anchor = node.get_anchor().await?;
+    let tx = node
+        .post_data_tx(anchor, vec![7_u8; DATA_SIZE], &user_signer)
+        .await;
+    let perm_fee = tx.header.perm_fee.expect("data tx must carry a perm_fee");
+    node.wait_for_mempool(tx.header.id, 20).await?;
+    let inclusion = node.mine_block().await?;
+    assert!(
+        inclusion.height < EXPIRY_HEIGHT,
+        "the tx must be included before slot 0 expires"
+    );
+    assert_eq!(
+        inclusion.ledger_total_chunks(DataLedger::Submit),
+        NUM_CHUNKS_IN_PARTITION,
+        "the tx must exactly fill Submit slot 0"
+    );
+
+    // --- 3. Mine to the expiry epoch and decode the settlement shadow txs. ---
+    while node.get_canonical_chain_height().await < EXPIRY_HEIGHT {
+        node.mine_block().await?;
+    }
+    {
+        let snapshot = node.get_canonical_epoch_snapshot();
+        let slots = snapshot.ledgers.get_slots(DataLedger::Submit);
+        assert!(
+            slots.len() >= 2,
+            "slot 0 must be non-last at expiry (got {} slots)",
+            slots.len()
+        );
+        assert!(
+            slots[0].is_expired,
+            "Submit slot 0 must recycle at its expiry epoch {EXPIRY_HEIGHT}"
+        );
+    }
+
+    let expiry_block = node.get_block_by_height(EXPIRY_HEIGHT).await?;
+    let evm_block = node
+        .wait_for_evm_block(expiry_block.evm_block_hash, 20)
+        .await?;
+    let mut refund_count = 0_usize;
+    let mut refund_total = U256::from(0);
+    let mut rewards: BTreeMap<IrysAddress, U256> = BTreeMap::new();
+    for evm_tx in evm_block.body.transactions {
+        if evm_tx.input().len() < 4 {
+            continue;
+        }
+        let Ok(shadow_tx) = ShadowTransaction::decode(&mut evm_tx.input().as_ref()) else {
+            continue;
+        };
+        match shadow_tx.as_v1() {
+            Some(TransactionPacket::PermFeeRefund(refund))
+                if refund.target == user_address.to_alloy_address() =>
+            {
+                refund_count += 1;
+                refund_total =
+                    refund_total.saturating_add(U256::from_le_bytes(refund.amount.to_le_bytes()));
+            }
+            Some(TransactionPacket::TermFeeReward(reward)) => {
+                let target = IrysAddress::from(reward.target);
+                let amount = U256::from_le_bytes(reward.amount.to_le_bytes());
+                assert!(
+                    rewards.insert(target, amount).is_none(),
+                    "each miner must receive at most one TermFeeReward per settlement block"
+                );
+            }
+            _ => {}
+        }
+    }
+
+    // Refund: exactly once (per tx, NOT per replica), for the full perm_fee.
+    assert_eq!(
+        refund_count, 1,
+        "the unpromoted tx must be refunded exactly once, not once per replica"
+    );
+    assert_eq!(
+        refund_total, perm_fee,
+        "the single refund must be the tx's full perm_fee"
+    );
+
+    // Reward: the slot's term-fee treasury is SPLIT between the two owners —
+    // both credited, amounts summing exactly to the treasury, neither getting
+    // the whole pot. (Split shape: floor(treasury/2) each, remainder to the
+    // first miner in deterministic order.)
+    let treasury =
+        TermFeeCharges::new(tx.header.term_fee, &config.consensus_config())?.term_fee_treasury;
+    let base_share = treasury
+        .checked_div(U256::from(2))
+        .expect("division by two");
+    assert_eq!(
+        rewards.keys().copied().collect::<Vec<_>>(),
+        {
+            let mut owners = vec![genesis_address, miner2_address];
+            owners.sort();
+            owners
+        },
+        "both distinct owners of the expired slot must be rewarded (got {rewards:?})"
+    );
+    let sum = rewards
+        .values()
+        .fold(U256::from(0), |acc, v| acc.saturating_add(*v));
+    assert_eq!(
+        sum, treasury,
+        "the two shares must sum exactly to the slot's term-fee treasury"
+    );
+    for (miner, amount) in &rewards {
+        assert!(
+            *amount >= base_share && *amount < treasury,
+            "miner {miner} must get a genuine share (got {amount}, treasury {treasury})"
+        );
+    }
+
+    info!(
+        "multi-replica slot settled: refund={refund_total}, rewards={rewards:?}, treasury={treasury}"
+    );
+    node.stop().await;
+    Ok(())
+}

--- a/crates/chain-tests/src/term_ledger_expiry/multi_replica_expiry.rs
+++ b/crates/chain-tests/src/term_ledger_expiry/multi_replica_expiry.rs
@@ -242,12 +242,14 @@ async fn heavy_multi_replica_slot_expiry_splits_reward_and_refunds_once() -> eyr
         sum, treasury,
         "the two shares must sum exactly to the slot's term-fee treasury"
     );
-    for (miner, amount) in &rewards {
-        assert!(
-            *amount >= base_share && *amount < treasury,
-            "miner {miner} must get a genuine share (got {amount}, treasury {treasury})"
-        );
-    }
+    let mut shares: Vec<U256> = rewards.values().copied().collect();
+    shares.sort_unstable();
+    let mut expected = vec![base_share, treasury - base_share];
+    expected.sort_unstable();
+    assert_eq!(
+        shares, expected,
+        "the two shares must be exactly floor/ceil of treasury/2 (got {rewards:?}, treasury {treasury})"
+    );
 
     info!(
         "multi-replica slot settled: refund={refund_total}, rewards={rewards:?}, treasury={treasury}"

--- a/crates/chain-tests/src/term_ledger_expiry/perm_refund_unpledged_slot.rs
+++ b/crates/chain-tests/src/term_ledger_expiry/perm_refund_unpledged_slot.rs
@@ -1,0 +1,213 @@
+//! A Submit slot whose SOLE partition replica is unpledged before expiry (and
+//! never backfilled — no spare capacity) reaches its expiry epoch with an empty
+//! `partitions` vec. Slot-expiry marking and the non-promotability set are
+//! slot-keyed, so the slot still recycles and its txs stay blocked — and fee
+//! settlement must be slot-keyed too: the unpromoted tx's perm fee is refunded
+//! even though there is no miner to distribute term fees to (those stay in the
+//! treasury). A partition-keyed settlement walk never sees the minerless slot,
+//! leaving its users charged, non-promotable, and unsettled forever.
+//!
+//! End-to-end proof of reachability: the honest unpledge flow (no last-replica
+//! guard) + capacity starvation produce the state on a real node, and the
+//! expiry epoch block must carry the refund.
+
+use crate::utils::{IrysNodeTest, gossip_commitment_to_node};
+use alloy_genesis::GenesisAccount;
+use irys_config::submodules::StorageSubmodulesConfig;
+use irys_reth_node_bridge::irys_reth::shadow_tx::{ShadowTransaction, TransactionPacket};
+use irys_types::{CommitmentTransaction, DataLedger, NodeConfig, U256, irys::IrysSigner};
+use reth::rpc::types::TransactionTrait as _;
+use tracing::info;
+
+#[test_log::test(tokio::test)]
+async fn heavy_unpledged_minerless_slot_still_refunds_at_expiry() -> eyre::Result<()> {
+    const CHUNK_SIZE: u64 = 32;
+    const NUM_CHUNKS_IN_PARTITION: u64 = 4;
+    const DATA_SIZE: usize = (NUM_CHUNKS_IN_PARTITION * CHUNK_SIZE) as usize; // fills slot 0 exactly
+    const INITIAL_BALANCE: u128 = 10_000_000_000_000_000_000; // 10 IRYS
+    const SUBMIT_LEDGER_EPOCH_LENGTH: u64 = 3;
+    const BLOCKS_PER_EPOCH: u64 = 3;
+    // Pre-Cascade (no cascade config): slot 0 is allocation-anchored, so it
+    // expires at exactly SUBMIT_LEDGER_EPOCH_LENGTH * BLOCKS_PER_EPOCH. The
+    // minerless-settlement path under test is Cascade-independent (the
+    // post-Cascade gate variant is pinned at unit level by
+    // `empty_partition_expired_slot_still_refunds_unpromoted_txs`).
+    const EXPIRY_HEIGHT: u64 = SUBMIT_LEDGER_EPOCH_LENGTH * BLOCKS_PER_EPOCH; // 9
+
+    let mut config = NodeConfig::testing();
+    {
+        let c = config.consensus.get_mut();
+        c.block_migration_depth = 1;
+        c.chunk_size = CHUNK_SIZE;
+        c.num_chunks_in_partition = NUM_CHUNKS_IN_PARTITION;
+        c.epoch.submit_ledger_epoch_length = SUBMIT_LEDGER_EPOCH_LENGTH;
+        c.epoch.num_blocks_in_epoch = BLOCKS_PER_EPOCH;
+    }
+
+    let user_signer = IrysSigner::random_signer(&config.consensus_config());
+    let user_address = user_signer.address();
+    let initial_balance = U256::from(INITIAL_BALANCE);
+    config.consensus.extend_genesis_accounts(vec![(
+        user_address,
+        GenesisAccount {
+            balance: initial_balance.into(),
+            ..Default::default()
+        },
+    )]);
+
+    // 3 submodules (the genesis minimum): Publish slot 0 + Submit slot 0 take
+    // two of the pledged partitions at genesis; the growth epoch's newly
+    // allocated Submit slot takes the third BEFORE the unpledge applies. From
+    // then on the capacity pool is empty, so nothing can backfill the unpledged
+    // slot — the "no spare capacity" leg of the fixture (asserted below via the
+    // slot staying minerless).
+    let test_node = IrysNodeTest::new_genesis(config.clone());
+    StorageSubmodulesConfig::load_for_test(test_node.cfg.base_directory.clone(), 3)?;
+    let node = test_node
+        .start_and_wait_for_packing("unpledged_slot", 30)
+        .await;
+    let anchor = node.get_block_by_height(0).await?.block_hash;
+
+    // --- 1. One unpromoted tx (no chunks uploaded) exactly fills Submit slot 0.
+    //        Filling it crosses the capacity-growth threshold so the next epoch
+    //        allocates more Submit slots: slot 0 becomes non-last (expirable). ---
+    let tx = node
+        .post_data_tx(anchor, vec![7_u8; DATA_SIZE], &user_signer)
+        .await;
+    let perm_fee = tx.header.perm_fee.expect("data tx must carry a perm_fee");
+    node.wait_for_mempool(tx.header.id, 20).await?;
+    let inclusion = node.mine_block().await?;
+    assert_eq!(
+        inclusion.ledger_total_chunks(DataLedger::Submit),
+        NUM_CHUNKS_IN_PARTITION,
+        "the tx must exactly fill Submit slot 0"
+    );
+
+    // Reach the first epoch so slot 0's write is processed and growth slots are
+    // allocated (slot 0 becomes non-last).
+    node.mine_until_next_epoch().await?;
+    let slot0_partition = {
+        let snapshot = node.get_canonical_epoch_snapshot();
+        let slots = snapshot.ledgers.get_slots(DataLedger::Submit);
+        assert!(
+            slots.len() >= 2,
+            "growth must allocate more Submit slots so slot 0 is non-last (got {})",
+            slots.len()
+        );
+        *slots[0]
+            .partitions
+            .first()
+            .expect("Submit slot 0 must hold its genesis-assigned partition")
+    };
+
+    // --- 2. Unpledge slot 0's sole replica via the honest flow (accepted: there
+    //        is no last-replica guard), applied at the next epoch boundary. ---
+    let genesis_signer = config.signer();
+    let unpledge_anchor = node.get_anchor().await?;
+    let mut unpledge = CommitmentTransaction::new_unpledge(
+        &node.node_ctx.config.consensus,
+        unpledge_anchor,
+        node.node_ctx.mempool_pledge_provider.as_ref(),
+        genesis_signer.address(),
+        slot0_partition,
+    )
+    .await;
+    genesis_signer.sign_commitment(&mut unpledge)?;
+    gossip_commitment_to_node(&node, &unpledge).await?;
+    node.wait_for_mempool_commitment_txs(vec![unpledge.id()], 20)
+        .await?;
+
+    let (_, unpledge_epoch) = node.mine_until_next_epoch().await?;
+    assert!(
+        unpledge_epoch < EXPIRY_HEIGHT,
+        "the unpledge must apply before slot 0 expires (applied at {unpledge_epoch}, expiry {EXPIRY_HEIGHT})"
+    );
+    {
+        let snapshot = node.get_canonical_epoch_snapshot();
+        let slot0 = &snapshot.ledgers.get_slots(DataLedger::Submit)[0];
+        assert!(
+            slot0.partitions.is_empty(),
+            "slot 0 must be minerless after the unpledge epoch (and must stay so: \
+             the capacity pool is empty, nothing can backfill it)"
+        );
+        assert!(
+            !slot0.is_expired,
+            "slot 0 must not have expired yet at the unpledge epoch {unpledge_epoch}"
+        );
+    }
+
+    // --- 3. Mine to the expiry epoch: the minerless slot recycles and its
+    //        unpromoted tx is refunded — the settlement the partition-keyed walk
+    //        used to strand. ---
+    while node.get_canonical_chain_height().await < EXPIRY_HEIGHT {
+        node.mine_block().await?;
+    }
+    {
+        let snapshot = node.get_canonical_epoch_snapshot();
+        let slot0 = &snapshot.ledgers.get_slots(DataLedger::Submit)[0];
+        assert!(
+            slot0.partitions.is_empty(),
+            "slot 0 must still be minerless at its expiry epoch"
+        );
+        assert!(
+            slot0.is_expired,
+            "the minerless slot 0 must recycle at its expiry epoch {EXPIRY_HEIGHT}"
+        );
+    }
+
+    let expiry_block = node.get_block_by_height(EXPIRY_HEIGHT).await?;
+    let evm_block = node
+        .wait_for_evm_block(expiry_block.evm_block_hash, 20)
+        .await?;
+    let (mut refund_total, mut reward_count) = (U256::from(0), 0_usize);
+    for evm_tx in evm_block.body.transactions {
+        if evm_tx.input().len() < 4 {
+            continue;
+        }
+        let Ok(shadow_tx) = ShadowTransaction::decode(&mut evm_tx.input().as_ref()) else {
+            continue;
+        };
+        match shadow_tx.as_v1() {
+            Some(TransactionPacket::PermFeeRefund(refund))
+                if refund.target == user_address.to_alloy_address() =>
+            {
+                refund_total =
+                    refund_total.saturating_add(U256::from_le_bytes(refund.amount.to_le_bytes()));
+            }
+            Some(TransactionPacket::TermFeeReward(_)) => reward_count += 1,
+            _ => {}
+        }
+    }
+    assert_eq!(
+        refund_total, perm_fee,
+        "the unpromoted tx in the minerless expired slot must be refunded its full perm_fee"
+    );
+    assert_eq!(
+        reward_count, 0,
+        "no miner stored the expired slot, so no TermFeeReward may be emitted \
+         (its term fees stay in the treasury)"
+    );
+
+    // Balance: the user paid total_cost at inclusion and gets exactly the
+    // perm_fee back at expiry.
+    let user_final = U256::from_be_bytes(
+        node.get_balance(user_address, expiry_block.evm_block_hash)
+            .await
+            .to_be_bytes(),
+    );
+    let user_expected = initial_balance
+        .saturating_sub(tx.header.total_cost().into())
+        .saturating_add(perm_fee.into());
+    assert_eq!(
+        user_final, user_expected,
+        "user balance must reflect exactly one full perm_fee refund"
+    );
+
+    // --- 4. Liveness: the chain keeps producing epoch blocks past the
+    //        minerless-slot expiry. ---
+    node.mine_until_next_epoch().await?;
+
+    info!("minerless expired slot settled: refund={refund_total}, no term-fee rewards");
+    node.stop().await;
+    Ok(())
+}

--- a/crates/chain-tests/src/validation/cascade_submit_expiry_promotion.rs
+++ b/crates/chain-tests/src/validation/cascade_submit_expiry_promotion.rs
@@ -44,20 +44,16 @@
 // crashes BlockTreeService, per the notes in the pre-Cascade tests).
 
 use crate::utils::{IrysNodeTest, assert_validation_error, solution_context};
-use crate::validation::send_block_and_read_state;
-use irys_actors::block_validation::ValidationError;
-use irys_actors::{
-    BlockProdStrategy, BlockProducerInner, ProductionStrategy, async_trait,
-    block_producer::ledger_expiry::LedgerExpiryBalanceDelta,
-    shadow_tx_generator::PublishLedgerWithTxs,
+use crate::validation::{
+    EvilPublishStrategy, is_nc_0042_expiry_rejection, next_epoch_boundary,
+    send_block_and_read_state,
 };
+use irys_actors::{BlockProdStrategy as _, ProductionStrategy};
 use irys_config::submodules::StorageSubmodulesConfig;
-use irys_domain::BlockTreeReadGuard;
 use irys_reth_node_bridge::irys_reth::shadow_tx::{ShadowTransaction, TransactionPacket};
 use irys_types::ingress::generate_ingress_proof;
 use irys_types::{
-    DataLedger, DataTransactionHeader, H256, IngressProofsList, IrysBlockHeader, NodeConfig, U256,
-    UnixTimestamp, UnixTimestampMs, hardfork_config::Cascade,
+    DataLedger, H256, IngressProofsList, NodeConfig, U256, UnixTimestamp, hardfork_config::Cascade,
 };
 use reth::rpc::types::TransactionTrait as _;
 use std::collections::BTreeSet;
@@ -65,50 +61,6 @@ use std::collections::BTreeSet;
 #[test_log::test(tokio::test)]
 async fn heavy_cascade_block_promoting_already_expired_submit_tx_gets_rejected() -> eyre::Result<()>
 {
-    /// Forces an already-expired Submit tx into the Publish ledger, with a valid
-    /// ingress proof so the block fails validation *only* on the §4c expiry rule
-    /// (not on a missing/invalid proof). No refund is scheduled in the bundle, so
-    /// the in-constructor defence-in-depth guard does not fire during production —
-    /// the block is built and must be caught at validation time.
-    struct EvilPublishStrategy {
-        prod: ProductionStrategy,
-        expired_tx: DataTransactionHeader,
-        proofs: IngressProofsList,
-        block_tree_guard: BlockTreeReadGuard,
-    }
-
-    #[async_trait::async_trait]
-    impl BlockProdStrategy for EvilPublishStrategy {
-        fn inner(&self) -> &BlockProducerInner {
-            &self.prod.inner
-        }
-
-        async fn get_mempool_txs(
-            &self,
-            _prev_block_header: &IrysBlockHeader,
-            _block_timestamp: UnixTimestampMs,
-        ) -> Result<
-            irys_actors::block_producer::MempoolTxsBundle,
-            irys_actors::tx_selector::TxSelectorError,
-        > {
-            Ok(irys_actors::block_producer::MempoolTxsBundle {
-                commitment_txs: vec![],
-                commitment_txs_to_bill: vec![],
-                submit_txs: vec![],
-                one_year_txs: vec![],
-                thirty_day_txs: vec![],
-                publish_txs: PublishLedgerWithTxs {
-                    txs: vec![self.expired_tx.clone()],
-                    proofs: Some(self.proofs.clone()),
-                },
-                aggregated_miner_fees: LedgerExpiryBalanceDelta::default(),
-                commitment_refund_events: vec![],
-                unstake_refund_events: vec![],
-                epoch_snapshot: self.block_tree_guard.read().canonical_epoch_snapshot(),
-            })
-        }
-    }
-
     // --- 1. Config: Cascade ACTIVE from genesis + Submit-expiry aging params ---
     let num_blocks_in_epoch: u64 = 2;
     let submit_ledger_epoch_length: u64 = 2;
@@ -189,14 +141,7 @@ async fn heavy_cascade_block_promoting_already_expired_submit_tx_gets_rejected()
     //         2nd Submit slot (genesis slot 0 becomes non-last) and the Cascade
     //         last-write touch stamps slot 0's `last_height` at the epoch that
     //         processes its writes. ---
-    let next_epoch_boundary = |h: u64| -> u64 {
-        if h.is_multiple_of(num_blocks_in_epoch) {
-            h
-        } else {
-            h + (num_blocks_in_epoch - (h % num_blocks_in_epoch))
-        }
-    };
-    let alloc_epoch = next_epoch_boundary(data_block.height + 1);
+    let alloc_epoch = next_epoch_boundary(data_block.height + 1, num_blocks_in_epoch);
     while genesis_node.get_canonical_chain_height().await < alloc_epoch {
         genesis_node.mine_block().await?;
     }
@@ -223,7 +168,7 @@ async fn heavy_cascade_block_promoting_already_expired_submit_tx_gets_rejected()
     // `last_height + window`. Pipeline B refunds slot-0's unpromoted txs at that
     // epoch and the honest producer drops them from promotion (§4b). The loop
     // terminating proves the producer did NOT panic.
-    let expiry_height = next_epoch_boundary(slot0_last_height + expiry_window);
+    let expiry_height = next_epoch_boundary(slot0_last_height + expiry_window, num_blocks_in_epoch);
     assert_eq!(
         expiry_height % num_blocks_in_epoch,
         0,
@@ -457,7 +402,7 @@ async fn heavy_cascade_block_promoting_already_expired_submit_tx_gets_rejected()
     )?;
 
     let evil_strategy = EvilPublishStrategy {
-        expired_tx: expired_tx.clone(),
+        publish_tx: expired_tx.clone(),
         proofs: IngressProofsList(vec![proof]),
         prod: ProductionStrategy {
             inner: genesis_node.node_ctx.block_producer_inner.clone(),
@@ -477,13 +422,9 @@ async fn heavy_cascade_block_promoting_already_expired_submit_tx_gets_rejected()
         "evil block must promote the expired tx"
     );
 
-    // The §4c rejection message includes "NC-0042" — match on that to ensure the
-    // block is rejected for the right reason, not an unrelated shadow-tx error.
-    let is_nc_0042_expiry_rejection = |e: &ValidationError| match e {
-        ValidationError::ShadowTransactionInvalid(msg) => msg.contains("NC-0042"),
-        _ => false,
-    };
-
+    // The §4c rejection message includes "NC-0042" — the shared
+    // `is_nc_0042_expiry_rejection` matches on that so we assert the block is
+    // rejected for the right reason, not an unrelated shadow-tx error.
     // Genesis must reject it.
     let genesis_outcome =
         send_block_and_read_state(&genesis_node.node_ctx, block.clone(), false).await?;

--- a/crates/chain-tests/src/validation/cascade_term_expiry.rs
+++ b/crates/chain-tests/src/validation/cascade_term_expiry.rs
@@ -886,6 +886,10 @@ async fn heavy_cascade_expiry_fee_model_matches_actual_recycle() -> eyre::Result
     // block — the property the fully-written-gate fix guarantees by feeding all three
     // the same write-frontier inputs. Uses the snapshot wrapper (chunks_per_slot is
     // supplied internally).
+    // Note: this feeds the epoch block's own total (e_total); the production §4c
+    // promotion validator passes the PARENT header's total. They are equal here because
+    // no data is written in the expiry epoch, so this stays a faithful gate-family
+    // consistency check (blocked vs recycle computed from one snapshot's inputs).
     let blocked: std::collections::BTreeSet<usize> = parent_snap
         .get_all_expired_term_slot_indexes(DataLedger::ThirtyDay, e, true, e_total)
         .into_iter()
@@ -1078,6 +1082,14 @@ async fn heavy_cascade_expiry_blocked_set_surplus_is_previously_expired() -> eyr
     assert!(
         recycled.is_subset(&blocked),
         "every recycled slot must be in the non-promotability set: recycled={recycled:?} blocked={blocked:?}"
+    );
+    // Pin the newly-recycled set exactly, so the surplus checks below cannot silently
+    // degrade to a vacuous form if fixture drift ever stops slot B(1) recycling at E2
+    // (recycled={} would satisfy subset, strict-surplus, and the surplus checks trivially).
+    assert_eq!(
+        recycled,
+        std::collections::BTreeSet::from([1]),
+        "slot B(1) must be the sole newly-recycled slot at E2 (got {recycled:?})"
     );
     // Non-vacuity: the blocked set STRICTLY exceeds the newly-recycled set — this
     // is the surplus the sibling fixture never produces.

--- a/crates/chain-tests/src/validation/cascade_term_expiry.rs
+++ b/crates/chain-tests/src/validation/cascade_term_expiry.rs
@@ -867,12 +867,14 @@ async fn heavy_cascade_expiry_fee_model_matches_actual_recycle() -> eyre::Result
     // block — the property the fully-written-gate fix guarantees by feeding all three
     // the same write-frontier inputs. Uses the snapshot wrapper (chunks_per_slot is
     // supplied internally).
-    // Note: this feeds the epoch block's own total (e_total); the production §4c
-    // promotion validator passes the PARENT header's total. They are equal here because
-    // no data is written in the expiry epoch, so this stays a faithful gate-family
-    // consistency check (blocked vs recycle computed from one snapshot's inputs).
+    // Feed the PARENT header's ThirtyDay total — the exact input the production §4c
+    // promotion validator uses (it keys off the parent header, pre-this-epoch-touch).
+    // The rescue write lands in epoch block E, so parent_total (pre-write) differs from
+    // e_total; using the parent keeps this a faithful check of the consensus input
+    // contract rather than the post-touch epoch-block total.
+    let parent_total = parent_block.ledger_total_chunks(DataLedger::ThirtyDay);
     let blocked: std::collections::BTreeSet<usize> = parent_snap
-        .get_all_expired_term_slot_indexes(DataLedger::ThirtyDay, e, true, e_total)
+        .get_all_expired_term_slot_indexes(DataLedger::ThirtyDay, e, true, parent_total)
         .into_iter()
         .collect();
     let recycled: std::collections::BTreeSet<usize> = actual_set.iter().copied().collect();
@@ -1279,6 +1281,15 @@ async fn heavy_cascade_rescued_slot_defers_reward_and_refund() -> eyre::Result<(
         3,
         "exactly the three unpromoted rescued-slot txs must be refunded at recycle, \
          got {refunds:?}"
+    );
+    // Settlement side of the same deferral: the TermFeeReward the rescued slot was
+    // denied at the skipped epoch E (Phase A asserted zero there) must now be emitted
+    // when the slot actually recycles — the term fees are distributed, not lost.
+    let (rewards_at_recycle, _) = expiry_shadow_counts(&ctx, recycle).await?;
+    assert!(
+        rewards_at_recycle >= 1,
+        "the deferred TermFeeReward must be emitted when slot 0 actually recycles at \
+         F+{window}={recycle} (got {rewards_at_recycle})"
     );
 
     ctx.stop().await;

--- a/crates/chain-tests/src/validation/cascade_term_expiry.rs
+++ b/crates/chain-tests/src/validation/cascade_term_expiry.rs
@@ -839,14 +839,16 @@ async fn heavy_cascade_expiry_fee_model_matches_actual_recycle() -> eyre::Result
     // Fee-predicted expiring set: the PARENT epoch snapshot (as the producer
     // sees it) asked which ThirtyDay slots will actually recycle at height E.
     let parent_block = ctx.get_block_by_height(e - 1).await?;
-    let mut fee_set = {
+    let parent_snap = {
         let tree = ctx.node_ctx.block_tree_guard.read();
-        let snap = tree
-            .get_epoch_snapshot(&parent_block.block_hash)
-            .expect("parent epoch snapshot");
+        tree.get_epoch_snapshot(&parent_block.block_hash)
+            .expect("parent epoch snapshot")
+    };
+    let mut fee_set = {
         // cascade_active=true: this scenario runs post-activation (cascade
         // activated at timestamp 0), matching the producer/validator gate.
-        snap.get_expiring_partition_info(e, DataLedger::ThirtyDay, e_total, true)
+        parent_snap
+            .get_expiring_partition_info(e, DataLedger::ThirtyDay, e_total, true)
             .into_iter()
             .map(|p| p.slot_index)
             .collect::<Vec<_>>()
@@ -877,6 +879,29 @@ async fn heavy_cascade_expiry_fee_model_matches_actual_recycle() -> eyre::Result
          equal the actual recycle set (expired_partition_infos) at epoch E={e}; \
          a mismatch means fees are distributed for a slot that did not recycle"
     );
+
+    // Third leg: the inclusive non-promotability set (get_all_expired_...) must
+    // contain every slot that actually recycled at E, and may exceed it only by
+    // slots already is_expired from a prior epoch. Pins all three expiry sets on one
+    // block — the property the fully-written-gate fix guarantees by feeding all three
+    // the same write-frontier inputs. Uses the snapshot wrapper (chunks_per_slot is
+    // supplied internally).
+    let blocked: std::collections::BTreeSet<usize> = parent_snap
+        .get_all_expired_term_slot_indexes(DataLedger::ThirtyDay, e, true, e_total)
+        .into_iter()
+        .collect();
+    let recycled: std::collections::BTreeSet<usize> = actual_set.iter().copied().collect();
+    assert!(
+        recycled.is_subset(&blocked),
+        "every recycled slot must be in the non-promotability set: recycled={recycled:?} blocked={blocked:?}"
+    );
+    let parent_slots = parent_snap.ledgers.get_slots(DataLedger::ThirtyDay);
+    for extra in blocked.difference(&recycled) {
+        assert!(
+            parent_slots[*extra].is_expired,
+            "blocked slot {extra} not in the recycle set must be a previously-expired slot"
+        );
+    }
 
     ctx.stop().await;
     Ok(())

--- a/crates/chain-tests/src/validation/cascade_term_expiry.rs
+++ b/crates/chain-tests/src/validation/cascade_term_expiry.rs
@@ -993,15 +993,7 @@ async fn heavy_cascade_expiry_blocked_set_surplus_is_previously_expired() -> eyr
         ctx.mine_block().await?;
     }
 
-    // ThirtyDay cumulative total_chunks at E2 (the value fed to the expiry calc).
     let epoch_block = ctx.get_block_by_height(e2).await?;
-    let e_total = epoch_block
-        .data_ledgers
-        .iter()
-        .find(|dl| dl.ledger_id == DataLedger::ThirtyDay as u32)
-        .map(|dl| dl.total_chunks)
-        .unwrap_or(0);
-
     let parent_block = ctx.get_block_by_height(e2 - 1).await?;
     let parent_snap = {
         let tree = ctx.node_ctx.block_tree_guard.read();
@@ -1024,9 +1016,13 @@ async fn heavy_cascade_expiry_blocked_set_surplus_is_previously_expired() -> eyr
             .collect()
     };
 
-    // Inclusive non-promotability set from the parent snapshot.
+    // Inclusive non-promotability set from the parent snapshot. Feed the PARENT
+    // header's ThirtyDay total — the exact input the production §4c promotion
+    // validator keys off (pre-this-epoch-touch), matching the sibling
+    // heavy_cascade_expiry_fee_model_matches_actual_recycle fixture.
+    let parent_total = parent_block.ledger_total_chunks(DataLedger::ThirtyDay);
     let blocked: std::collections::BTreeSet<usize> = parent_snap
-        .get_all_expired_term_slot_indexes(DataLedger::ThirtyDay, e2, true, e_total)
+        .get_all_expired_term_slot_indexes(DataLedger::ThirtyDay, e2, true, parent_total)
         .into_iter()
         .collect();
 

--- a/crates/chain-tests/src/validation/cascade_term_expiry.rs
+++ b/crates/chain-tests/src/validation/cascade_term_expiry.rs
@@ -2,7 +2,7 @@ use crate::utils::IrysNodeTest;
 use irys_config::submodules::StorageSubmodulesConfig;
 use irys_reth_node_bridge::irys_reth::shadow_tx::{ShadowTransaction, TransactionPacket};
 use irys_types::{
-    BoundedFee, DataLedger, NodeConfig, U256, UnixTimestamp, hardfork_config::Cascade,
+    BoundedFee, DataLedger, H256, NodeConfig, U256, UnixTimestamp, hardfork_config::Cascade,
 };
 use reth::rpc::types::TransactionTrait as _;
 
@@ -1187,6 +1187,33 @@ async fn heavy_cascade_rescued_slot_defers_reward_and_refund() -> eyre::Result<(
         Ok((rewards, refunds))
     }
 
+    // Maps each PermFeeRefund in the block at `height` to its CL tx id -> amount.
+    // Keys on the refund's `irys_ref` (the CL tx id), NOT `target`: every tx in
+    // this test shares one signer, so address keying cannot tell them apart.
+    // Asserts each CL tx is refunded at most once per block (no double-settlement).
+    async fn refund_amounts_by_tx(
+        ctx: &IrysNodeTest<irys_chain::IrysNodeCtx>,
+        height: u64,
+    ) -> eyre::Result<std::collections::HashMap<H256, U256>> {
+        let block = ctx.get_block_by_height(height).await?;
+        let evm = ctx.wait_for_evm_block(block.evm_block_hash, 30).await?;
+        let mut refunds = std::collections::HashMap::new();
+        for tx in evm.body.transactions {
+            let mut input = tx.input().as_ref();
+            if let Ok(shadow) = ShadowTransaction::decode(&mut input)
+                && let Some(TransactionPacket::PermFeeRefund(refund)) = shadow.as_v1()
+            {
+                let tx_id = H256::from_slice(refund.irys_ref.as_slice());
+                let amount = U256::from_le_bytes(refund.amount.to_le_bytes());
+                assert!(
+                    refunds.insert(tx_id, amount).is_none(),
+                    "duplicate PermFeeRefund for CL tx {tx_id} in block {height}"
+                );
+            }
+        }
+        Ok(refunds)
+    }
+
     while ctx.get_canonical_chain_height().await <= activation_height {
         ctx.mine_block().await?;
     }
@@ -1256,6 +1283,14 @@ async fn heavy_cascade_rescued_slot_defers_reward_and_refund() -> eyre::Result<(
             slot0.last_height, f,
             "the fill must refresh slot 0's expiry clock to F={f}"
         );
+        // Interim promotability: while live (after the rescued-slot tx was
+        // appended, before the recycle epoch), slot 0 must retain a partition
+        // assignment — the third bug leg (permanently non-promotable rescued
+        // slot) does not recur.
+        assert!(
+            !slot0.partitions.is_empty(),
+            "rescued slot 0 must retain its partition assignment while live at F={f}"
+        );
     }
 
     // Phase B: when the slot ACTUALLY recycles (F + window), the deferred refund
@@ -1264,11 +1299,33 @@ async fn heavy_cascade_rescued_slot_defers_reward_and_refund() -> eyre::Result<(
     while ctx.get_canonical_chain_height().await < recycle {
         ctx.mine_block().await?;
     }
-    let (_, refunds_at_recycle) = expiry_shadow_counts(&ctx, recycle).await?;
-    assert!(
-        refunds_at_recycle >= 1,
-        "deferred PermFeeRefund for the unpromoted txs must land when slot 0 \
-         actually recycles at F+{window}={recycle} (got {refunds_at_recycle})"
+    // The deferred refunds settle exactly once per unpromoted tx in the rescued
+    // slot, each for its full perm_fee — the outcome the fully-written-gate fix
+    // preserves: charged txs are honored, never stranded, never doubled. All three
+    // txs (tx1/tx2/tx3) are unpromoted here (chunks never uploaded), so each must
+    // be refunded; a promoted tx would instead be absent from the refund set.
+    let refunds = refund_amounts_by_tx(&ctx, recycle).await?;
+    for tx in [&tx1, &tx2, &tx3] {
+        let perm_fee: U256 = tx
+            .header
+            .perm_fee
+            .expect("unpromoted data tx must carry a perm_fee")
+            .into();
+        let tx_id = tx.header.id;
+        assert_eq!(
+            refunds.get(&tx_id).copied(),
+            Some(perm_fee),
+            "unpromoted tx {tx_id} must be refunded exactly its perm_fee once when \
+             slot 0 recycles at F+{window}={recycle}"
+        );
+    }
+    // Exactly the three rescued-slot txs are refunded: no spurious or duplicate
+    // settlement of any other tx.
+    assert_eq!(
+        refunds.len(),
+        3,
+        "exactly the three unpromoted rescued-slot txs must be refunded at recycle, \
+         got {refunds:?}"
     );
 
     ctx.stop().await;

--- a/crates/chain-tests/src/validation/cascade_term_expiry.rs
+++ b/crates/chain-tests/src/validation/cascade_term_expiry.rs
@@ -895,6 +895,198 @@ async fn heavy_cascade_expiry_fee_model_matches_actual_recycle() -> eyre::Result
         recycled.is_subset(&blocked),
         "every recycled slot must be in the non-promotability set: recycled={recycled:?} blocked={blocked:?}"
     );
+    // blocked ⊇ recycled is the safety-critical (double-pay) direction, cross-checked
+    // here between two independently-computed functions. The complementary
+    // "surplus is only previously-expired slots" direction needs a prior-epoch-expired
+    // slot, which this fixture never produces — it is exercised by
+    // heavy_cascade_expiry_blocked_set_surplus_is_previously_expired (below) and by the
+    // data_ledger proptest invariant (d) / get_all_expired_slot_indexes_includes_already_expired_slots.
+
+    ctx.stop().await;
+    Ok(())
+}
+
+/// Non-vacuous companion to `heavy_cascade_expiry_fee_model_matches_actual_recycle`:
+/// drives the ThirtyDay ledger through TWO expiry epochs so the inclusive
+/// non-promotability set (`get_all_expired_term_slot_indexes`) STRICTLY exceeds
+/// the set that newly recycles at the second expiry, and the surplus is exactly
+/// the slot that already recycled at the first expiry.
+///
+/// Scenario (nbe=2, thirty_day_epoch_length=2 -> window=4 blocks, C=10 chunks):
+/// 1. Epoch E_a: write 12 chunks -> slot A(=0) fully written (chunks 0-9), slot
+///    B(=1) partial frontier (10-11); extra empty slots so slot 0 is non-last.
+///    Both get last_height=E_a.
+/// 2. Epoch E1 = E_a + window: slot A (fully written, aged) recycles. It is now
+///    `is_expired` and drops OUT of every later newly-recycling set.
+/// 3. Epoch E_b (> E_a): write more ThirtyDay data so slot B fills fully (chunks
+///    10-19) and spills into slot C(=2) (the new frontier / trailing headroom).
+///    The touch advances slots B and C to E_b; slot A is frozen (frontier long
+///    past it) so it stays expired.
+/// 4. Epoch E2 = E_b + window: slot B recycles.
+///
+/// At E2 the inclusive blocked set = {A, B} but the newly-recycled set = {B}, so
+/// the surplus {A} is non-empty AND is a previously-expired slot — the direction
+/// the sibling test's fixture cannot reach.
+#[test_log::test(tokio::test)]
+async fn heavy_cascade_expiry_blocked_set_surplus_is_previously_expired() -> eyre::Result<()> {
+    let num_blocks_in_epoch = 2_u64;
+    let activation_height = num_blocks_in_epoch;
+    let one_year_epoch_length = 8_u64;
+    let thirty_day_epoch_length = 2_u64;
+    let chunk_size = 32_u64;
+    let num_chunks_in_partition = 10_u64;
+    let window = thirty_day_epoch_length * num_blocks_in_epoch; // 4
+
+    let mut config = NodeConfig::testing().with_consensus(|c| {
+        c.block_migration_depth = 1;
+        c.epoch.num_blocks_in_epoch = num_blocks_in_epoch;
+        c.chunk_size = chunk_size;
+        c.num_chunks_in_partition = num_chunks_in_partition;
+        c.hardforks.cascade = Some(Cascade {
+            activation_timestamp: UnixTimestamp::from_secs(0),
+            one_year_epoch_length,
+            thirty_day_epoch_length,
+            annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
+        });
+    });
+
+    let signer = config.new_random_signer();
+    config.fund_genesis_accounts(vec![&signer]);
+
+    let test_node = IrysNodeTest::new_genesis(config);
+    StorageSubmodulesConfig::load_for_test(test_node.cfg.base_directory.clone(), 5)?;
+    let ctx = test_node.start_and_wait_for_packing("test", 30).await;
+
+    let next_epoch_boundary = |h: u64| -> u64 {
+        if h.is_multiple_of(num_blocks_in_epoch) {
+            h
+        } else {
+            h + (num_blocks_in_epoch - (h % num_blocks_in_epoch))
+        }
+    };
+
+    async fn post_thirty_day(
+        ctx: &IrysNodeTest<irys_chain::IrysNodeCtx>,
+        signer: &irys_types::irys::IrysSigner,
+        tag: u8,
+        bytes: usize,
+    ) -> eyre::Result<()> {
+        let mut data = vec![9_u8; bytes];
+        data[0] = tag;
+        let price = ctx
+            .get_data_price(DataLedger::ThirtyDay, bytes as u64)
+            .await?;
+        let tx = signer.create_transaction_with_fees(
+            data,
+            ctx.get_anchor().await?,
+            DataLedger::ThirtyDay,
+            BoundedFee::new(price.term_fee),
+            None,
+        )?;
+        let tx = signer.sign_transaction(tx)?;
+        ctx.ingest_data_tx(tx.header.clone()).await?;
+        ctx.wait_for_mempool(tx.header.id, 30).await?;
+        Ok(())
+    }
+
+    while ctx.get_canonical_chain_height().await <= activation_height {
+        ctx.mine_block().await?;
+    }
+
+    // Epoch E_a: 4 txs × 3 chunks = 12 chunks -> slot A(0) full, slot B(1) partial.
+    for i in 0_u8..4 {
+        post_thirty_day(&ctx, &signer, i, 96).await?;
+    }
+    let e_a = next_epoch_boundary(ctx.mine_block().await?.height);
+    while ctx.get_canonical_chain_height().await < e_a {
+        ctx.mine_block().await?;
+    }
+
+    // Epoch E1 = E_a + window: the fully-written aged slot A recycles.
+    let e1 = e_a + window;
+    while ctx.get_canonical_chain_height().await < e1 {
+        ctx.mine_block().await?;
+    }
+    {
+        let e1_block = ctx.get_block_by_height(e1).await?;
+        let tree = ctx.node_ctx.block_tree_guard.read();
+        let snap = tree
+            .get_epoch_snapshot(&e1_block.block_hash)
+            .expect("epoch snapshot at E1");
+        assert!(
+            snap.ledgers.get_slots(DataLedger::ThirtyDay)[0].is_expired,
+            "slot A(0) must have recycled at E1={e1}"
+        );
+    }
+
+    // Epoch E_b (> E_a): fill slot B fully and spill into slot C(2) so B is a
+    // fully-written non-last slot, and its expiry clock is refreshed to E_b.
+    // 4 txs × 3 chunks brings total 12 -> 24: slot B(10-19) full, slot C(20-23)
+    // partial frontier / trailing headroom.
+    for i in 0_u8..4 {
+        post_thirty_day(&ctx, &signer, 100 + i, 96).await?;
+    }
+    let e_b = next_epoch_boundary(ctx.mine_block().await?.height);
+    while ctx.get_canonical_chain_height().await < e_b {
+        ctx.mine_block().await?;
+    }
+    assert!(e_b > e_a, "E_b({e_b}) must be after E_a({e_a})");
+
+    // Epoch E2 = E_b + window: slot B recycles while slot A is already expired.
+    let e2 = e_b + window;
+    while ctx.get_canonical_chain_height().await < e2 {
+        ctx.mine_block().await?;
+    }
+
+    // ThirtyDay cumulative total_chunks at E2 (the value fed to the expiry calc).
+    let epoch_block = ctx.get_block_by_height(e2).await?;
+    let e_total = epoch_block
+        .data_ledgers
+        .iter()
+        .find(|dl| dl.ledger_id == DataLedger::ThirtyDay as u32)
+        .map(|dl| dl.total_chunks)
+        .unwrap_or(0);
+
+    let parent_block = ctx.get_block_by_height(e2 - 1).await?;
+    let parent_snap = {
+        let tree = ctx.node_ctx.block_tree_guard.read();
+        tree.get_epoch_snapshot(&parent_block.block_hash)
+            .expect("parent epoch snapshot")
+    };
+
+    // Newly-recycled set at E2 (post-touch epoch snapshot).
+    let recycled: std::collections::BTreeSet<usize> = {
+        let tree = ctx.node_ctx.block_tree_guard.read();
+        let snap = tree
+            .get_epoch_snapshot(&epoch_block.block_hash)
+            .expect("epoch snapshot at E2");
+        snap.expired_partition_infos
+            .clone()
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|p| p.ledger_id == DataLedger::ThirtyDay)
+            .map(|p| p.slot_index)
+            .collect()
+    };
+
+    // Inclusive non-promotability set from the parent snapshot.
+    let blocked: std::collections::BTreeSet<usize> = parent_snap
+        .get_all_expired_term_slot_indexes(DataLedger::ThirtyDay, e2, true, e_total)
+        .into_iter()
+        .collect();
+
+    assert!(
+        recycled.is_subset(&blocked),
+        "every recycled slot must be in the non-promotability set: recycled={recycled:?} blocked={blocked:?}"
+    );
+    // Non-vacuity: the blocked set STRICTLY exceeds the newly-recycled set — this
+    // is the surplus the sibling fixture never produces.
+    assert!(
+        blocked.len() > recycled.len(),
+        "blocked set must strictly exceed the recycle set (surplus non-empty): \
+         recycled={recycled:?} blocked={blocked:?}"
+    );
+    // Every surplus slot must be a previously-expired slot.
     let parent_slots = parent_snap.ledgers.get_slots(DataLedger::ThirtyDay);
     for extra in blocked.difference(&recycled) {
         assert!(
@@ -902,6 +1094,12 @@ async fn heavy_cascade_expiry_fee_model_matches_actual_recycle() -> eyre::Result
             "blocked slot {extra} not in the recycle set must be a previously-expired slot"
         );
     }
+    // Slot A(0) specifically is the surplus: expired at E1, not newly recycling at E2.
+    assert!(
+        blocked.contains(&0) && !recycled.contains(&0),
+        "slot A(0) must be in the blocked surplus (expired at E1, not recycling at E2): \
+         recycled={recycled:?} blocked={blocked:?}"
+    );
 
     ctx.stop().await;
     Ok(())

--- a/crates/chain-tests/src/validation/cascade_term_expiry.rs
+++ b/crates/chain-tests/src/validation/cascade_term_expiry.rs
@@ -1,10 +1,38 @@
 use crate::utils::IrysNodeTest;
+use crate::validation::next_epoch_boundary;
 use irys_config::submodules::StorageSubmodulesConfig;
 use irys_reth_node_bridge::irys_reth::shadow_tx::{ShadowTransaction, TransactionPacket};
 use irys_types::{
     BoundedFee, DataLedger, H256, NodeConfig, U256, UnixTimestamp, hardfork_config::Cascade,
 };
 use reth::rpc::types::TransactionTrait as _;
+
+/// Posts one ThirtyDay data tx (`bytes` of data, first byte tagged with `tag` for
+/// a unique tx id) at the fee oracle's quoted `term_fee`, and waits for it to land
+/// in the mempool. Shared by the fee-model / blocked-set expiry tests.
+async fn post_thirty_day(
+    ctx: &IrysNodeTest<irys_chain::IrysNodeCtx>,
+    signer: &irys_types::irys::IrysSigner,
+    tag: u8,
+    bytes: usize,
+) -> eyre::Result<()> {
+    let mut data = vec![9_u8; bytes];
+    data[0] = tag;
+    let price = ctx
+        .get_data_price(DataLedger::ThirtyDay, bytes as u64)
+        .await?;
+    let tx = signer.create_transaction_with_fees(
+        data,
+        ctx.get_anchor().await?,
+        DataLedger::ThirtyDay,
+        BoundedFee::new(price.term_fee),
+        None,
+    )?;
+    let tx = signer.sign_transaction(tx)?;
+    ctx.ingest_data_tx(tx.header.clone()).await?;
+    ctx.wait_for_mempool(tx.header.id, 30).await?;
+    Ok(())
+}
 
 /// Verify that OneYear and ThirtyDay term ledgers expire at different rates
 /// based on their distinct epoch_length values from the Cascade hardfork config.
@@ -110,19 +138,14 @@ async fn heavy_cascade_term_ledger_expiry_respects_distinct_epoch_lengths() -> e
         treasury_after_inclusion
     );
 
-    let next_epoch_boundary = |h: u64| -> u64 {
-        if h.is_multiple_of(num_blocks_in_epoch) {
-            h
-        } else {
-            h + (num_blocks_in_epoch - (h % num_blocks_in_epoch))
-        }
-    };
-
     let thirty_day_expiry_blocks = thirty_day_epoch_length * num_blocks_in_epoch;
     let one_year_expiry_blocks = one_year_epoch_length * num_blocks_in_epoch;
 
     // Mine to the epoch boundary where ThirtyDay expires but OneYear does not
-    let mid_boundary = next_epoch_boundary(inclusion_height + thirty_day_expiry_blocks);
+    let mid_boundary = next_epoch_boundary(
+        inclusion_height + thirty_day_expiry_blocks,
+        num_blocks_in_epoch,
+    );
     while ctx.get_canonical_chain_height().await < mid_boundary {
         ctx.mine_block().await?;
     }
@@ -188,7 +211,10 @@ async fn heavy_cascade_term_ledger_expiry_respects_distinct_epoch_lengths() -> e
     );
 
     // Mine to the epoch boundary where OneYear also expires
-    let late_boundary = next_epoch_boundary(inclusion_height + one_year_expiry_blocks);
+    let late_boundary = next_epoch_boundary(
+        inclusion_height + one_year_expiry_blocks,
+        num_blocks_in_epoch,
+    );
     while ctx.get_canonical_chain_height().await < late_boundary {
         ctx.mine_block().await?;
     }
@@ -315,14 +341,6 @@ async fn heavy_cascade_spanning_tx_last_write_expiry() -> eyre::Result<()> {
     StorageSubmodulesConfig::load_for_test(test_node.cfg.base_directory.clone(), 5)?;
     let ctx = test_node.start_and_wait_for_packing("test", 30).await;
 
-    let next_epoch_boundary = |h: u64| -> u64 {
-        if h.is_multiple_of(num_blocks_in_epoch) {
-            h
-        } else {
-            h + (num_blocks_in_epoch - (h % num_blocks_in_epoch))
-        }
-    };
-
     // Reads (slot0_last_height, slot0_expired, slot1_last_height, slot1_expired,
     // slot_count, first_unexpired) for the ThirtyDay ledger at `height`.
     async fn thirty_day_slots(
@@ -368,7 +386,7 @@ async fn heavy_cascade_spanning_tx_last_write_expiry() -> eyre::Result<()> {
         ctx.wait_for_mempool(tx.header.id, 30).await?;
     }
     let h1 = ctx.mine_block().await?.height;
-    let epoch_a = next_epoch_boundary(h1);
+    let epoch_a = next_epoch_boundary(h1, num_blocks_in_epoch);
     while ctx.get_canonical_chain_height().await < epoch_a {
         ctx.mine_block().await?;
     }
@@ -414,7 +432,7 @@ async fn heavy_cascade_spanning_tx_last_write_expiry() -> eyre::Result<()> {
         ctx.wait_for_mempool(tx.header.id, 30).await?;
     }
     let h2 = ctx.mine_block().await?.height;
-    let epoch_b = next_epoch_boundary(h2);
+    let epoch_b = next_epoch_boundary(h2, num_blocks_in_epoch);
     assert!(
         epoch_b > epoch_a,
         "E_b ({epoch_b}) must be after E_a ({epoch_a})"
@@ -501,7 +519,7 @@ async fn heavy_cascade_spanning_tx_last_write_expiry() -> eyre::Result<()> {
         ctx.wait_for_mempool(tx.header.id, 30).await?;
     }
     let h3 = ctx.mine_block().await?.height;
-    let epoch_c = next_epoch_boundary(h3);
+    let epoch_c = next_epoch_boundary(h3, num_blocks_in_epoch);
     while ctx.get_canonical_chain_height().await < epoch_c {
         ctx.mine_block().await?;
     }
@@ -591,14 +609,6 @@ async fn slow_heavy_cascade_midchain_activation_submit_last_height_transition() 
     StorageSubmodulesConfig::load_for_test(test_node.cfg.base_directory.clone(), 5)?;
     let node = test_node.start_and_wait_for_packing("test", 30).await;
 
-    let next_epoch_boundary = |h: u64| -> u64 {
-        if h.is_multiple_of(num_blocks_in_epoch) {
-            h
-        } else {
-            h + (num_blocks_in_epoch - (h % num_blocks_in_epoch))
-        }
-    };
-
     // Post one 1-chunk data tx. The Submit ledger is not user-targetable
     // directly; published data lands in Submit (pre-promotion), so a Publish
     // data tx is what grows Submit's `total_chunks`.
@@ -640,7 +650,10 @@ async fn slow_heavy_cascade_midchain_activation_submit_last_height_transition() 
     // allocation last_height (0) despite receiving data.
     for tag in 0_u8..2 {
         post_submit_chunk(&node, &signer, chunk_size, tag).await?;
-        let boundary = next_epoch_boundary(node.get_canonical_chain_height().await + 1);
+        let boundary = next_epoch_boundary(
+            node.get_canonical_chain_height().await + 1,
+            num_blocks_in_epoch,
+        );
         while node.get_canonical_chain_height().await < boundary {
             node.mine_block().await?;
         }
@@ -693,7 +706,7 @@ async fn slow_heavy_cascade_midchain_activation_submit_last_height_transition() 
     // === Post-activation write: the touch now advances last_height ===
     post_submit_chunk(&node, &signer, chunk_size, 200).await?;
     let write_height = node.mine_block().await?.height;
-    let boundary = next_epoch_boundary(write_height);
+    let boundary = next_epoch_boundary(write_height, num_blocks_in_epoch);
     while node.get_canonical_chain_height().await < boundary {
         node.mine_block().await?;
     }
@@ -769,38 +782,6 @@ async fn heavy_cascade_expiry_fee_model_matches_actual_recycle() -> eyre::Result
     StorageSubmodulesConfig::load_for_test(test_node.cfg.base_directory.clone(), 5)?;
     let ctx = test_node.start_and_wait_for_packing("test", 30).await;
 
-    let next_epoch_boundary = |h: u64| -> u64 {
-        if h.is_multiple_of(num_blocks_in_epoch) {
-            h
-        } else {
-            h + (num_blocks_in_epoch - (h % num_blocks_in_epoch))
-        }
-    };
-
-    async fn post_thirty_day(
-        ctx: &IrysNodeTest<irys_chain::IrysNodeCtx>,
-        signer: &irys_types::irys::IrysSigner,
-        tag: u8,
-        bytes: usize,
-    ) -> eyre::Result<()> {
-        let mut data = vec![9_u8; bytes];
-        data[0] = tag;
-        let price = ctx
-            .get_data_price(DataLedger::ThirtyDay, bytes as u64)
-            .await?;
-        let tx = signer.create_transaction_with_fees(
-            data,
-            ctx.get_anchor().await?,
-            DataLedger::ThirtyDay,
-            BoundedFee::new(price.term_fee),
-            None,
-        )?;
-        let tx = signer.sign_transaction(tx)?;
-        ctx.ingest_data_tx(tx.header.clone()).await?;
-        ctx.wait_for_mempool(tx.header.id, 30).await?;
-        Ok(())
-    }
-
     while ctx.get_canonical_chain_height().await <= activation_height {
         ctx.mine_block().await?;
     }
@@ -809,7 +790,7 @@ async fn heavy_cascade_expiry_fee_model_matches_actual_recycle() -> eyre::Result
     for i in 0_u8..4 {
         post_thirty_day(&ctx, &signer, i, 96).await?;
     }
-    let l = next_epoch_boundary(ctx.mine_block().await?.height);
+    let l = next_epoch_boundary(ctx.mine_block().await?.height, num_blocks_in_epoch);
     while ctx.get_canonical_chain_height().await < l {
         ctx.mine_block().await?;
     }
@@ -961,38 +942,6 @@ async fn heavy_cascade_expiry_blocked_set_surplus_is_previously_expired() -> eyr
     StorageSubmodulesConfig::load_for_test(test_node.cfg.base_directory.clone(), 5)?;
     let ctx = test_node.start_and_wait_for_packing("test", 30).await;
 
-    let next_epoch_boundary = |h: u64| -> u64 {
-        if h.is_multiple_of(num_blocks_in_epoch) {
-            h
-        } else {
-            h + (num_blocks_in_epoch - (h % num_blocks_in_epoch))
-        }
-    };
-
-    async fn post_thirty_day(
-        ctx: &IrysNodeTest<irys_chain::IrysNodeCtx>,
-        signer: &irys_types::irys::IrysSigner,
-        tag: u8,
-        bytes: usize,
-    ) -> eyre::Result<()> {
-        let mut data = vec![9_u8; bytes];
-        data[0] = tag;
-        let price = ctx
-            .get_data_price(DataLedger::ThirtyDay, bytes as u64)
-            .await?;
-        let tx = signer.create_transaction_with_fees(
-            data,
-            ctx.get_anchor().await?,
-            DataLedger::ThirtyDay,
-            BoundedFee::new(price.term_fee),
-            None,
-        )?;
-        let tx = signer.sign_transaction(tx)?;
-        ctx.ingest_data_tx(tx.header.clone()).await?;
-        ctx.wait_for_mempool(tx.header.id, 30).await?;
-        Ok(())
-    }
-
     while ctx.get_canonical_chain_height().await <= activation_height {
         ctx.mine_block().await?;
     }
@@ -1001,7 +950,7 @@ async fn heavy_cascade_expiry_blocked_set_surplus_is_previously_expired() -> eyr
     for i in 0_u8..4 {
         post_thirty_day(&ctx, &signer, i, 96).await?;
     }
-    let e_a = next_epoch_boundary(ctx.mine_block().await?.height);
+    let e_a = next_epoch_boundary(ctx.mine_block().await?.height, num_blocks_in_epoch);
     while ctx.get_canonical_chain_height().await < e_a {
         ctx.mine_block().await?;
     }
@@ -1030,7 +979,7 @@ async fn heavy_cascade_expiry_blocked_set_surplus_is_previously_expired() -> eyr
     for i in 0_u8..4 {
         post_thirty_day(&ctx, &signer, 100 + i, 96).await?;
     }
-    let e_b = next_epoch_boundary(ctx.mine_block().await?.height);
+    let e_b = next_epoch_boundary(ctx.mine_block().await?.height, num_blocks_in_epoch);
     while ctx.get_canonical_chain_height().await < e_b {
         ctx.mine_block().await?;
     }
@@ -1168,14 +1117,6 @@ async fn heavy_cascade_rescued_slot_defers_reward_and_refund() -> eyre::Result<(
     StorageSubmodulesConfig::load_for_test(test_node.cfg.base_directory.clone(), 5)?;
     let ctx = test_node.start_and_wait_for_packing("test", 30).await;
 
-    let next_epoch_boundary = |h: u64| -> u64 {
-        if h.is_multiple_of(num_blocks_in_epoch) {
-            h
-        } else {
-            h + (num_blocks_in_epoch - (h % num_blocks_in_epoch))
-        }
-    };
-
     // Counts (TermFeeReward, PermFeeRefund) shadow txs in the block at `height`.
     async fn expiry_shadow_counts(
         ctx: &IrysNodeTest<irys_chain::IrysNodeCtx>,
@@ -1236,7 +1177,7 @@ async fn heavy_cascade_rescued_slot_defers_reward_and_refund() -> eyre::Result<(
         .post_data_tx(anchor, vec![1_u8; 6 * chunk_size as usize], &signer)
         .await;
     ctx.wait_for_mempool(tx1.header.id, 30).await?;
-    let l = next_epoch_boundary(ctx.mine_block().await?.height);
+    let l = next_epoch_boundary(ctx.mine_block().await?.height, num_blocks_in_epoch);
     while ctx.get_canonical_chain_height().await < l {
         ctx.mine_block().await?;
     }
@@ -1275,7 +1216,7 @@ async fn heavy_cascade_rescued_slot_defers_reward_and_refund() -> eyre::Result<(
         .post_data_tx(anchor, vec![3_u8; 3 * chunk_size as usize], &signer)
         .await;
     ctx.wait_for_mempool(tx3.header.id, 30).await?;
-    let f = next_epoch_boundary(ctx.mine_block().await?.height);
+    let f = next_epoch_boundary(ctx.mine_block().await?.height, num_blocks_in_epoch);
     while ctx.get_canonical_chain_height().await < f {
         ctx.mine_block().await?;
     }
@@ -1397,14 +1338,6 @@ async fn heavy_pre_cascade_submit_expiry_fee_model_matches_actual_recycle() -> e
     StorageSubmodulesConfig::load_for_test(test_node.cfg.base_directory.clone(), 5)?;
     let ctx = test_node.start_and_wait_for_packing("test", 30).await;
 
-    let next_epoch_boundary = |h: u64| -> u64 {
-        if h.is_multiple_of(num_blocks_in_epoch) {
-            h
-        } else {
-            h + (num_blocks_in_epoch - (h % num_blocks_in_epoch))
-        }
-    };
-
     // Post one unpromoted publish-data tx (chunks never uploaded) -> grows the
     // Submit ledger's `total_chunks`. `chunks` controls how many chunks it spans.
     async fn post_submit(
@@ -1431,7 +1364,7 @@ async fn heavy_pre_cascade_submit_expiry_fee_model_matches_actual_recycle() -> e
     for i in 0_u8..4 {
         post_submit(&ctx, &signer, chunk_size, i, 3).await?;
     }
-    let l = next_epoch_boundary(ctx.mine_block().await?.height);
+    let l = next_epoch_boundary(ctx.mine_block().await?.height, num_blocks_in_epoch);
     while ctx.get_canonical_chain_height().await < l {
         ctx.mine_block().await?;
     }
@@ -1737,14 +1670,6 @@ async fn slow_heavy_cascade_midchain_thirty_day_expiry_resolves_through_index() 
     StorageSubmodulesConfig::load_for_test(test_node.cfg.base_directory.clone(), 5)?;
     let node = test_node.start_and_wait_for_packing("test", 30).await;
 
-    let next_epoch_boundary = |h: u64| -> u64 {
-        if h.is_multiple_of(num_blocks_in_epoch) {
-            h
-        } else {
-            h + (num_blocks_in_epoch - (h % num_blocks_in_epoch))
-        }
-    };
-
     // === Pre-activation phase: keep it the MAJORITY of the chain ===
     // The index binary search's first probe is `latest_height / 2`; making the
     // pre-activation span exceed half the chain at expiry guarantees that probe
@@ -1801,7 +1726,7 @@ async fn slow_heavy_cascade_midchain_thirty_day_expiry_resolves_through_index() 
         node.wait_for_mempool(tx.header.id, 30).await?;
     }
     let write_height = node.mine_block().await?.height;
-    let write_epoch = next_epoch_boundary(write_height);
+    let write_epoch = next_epoch_boundary(write_height, num_blocks_in_epoch);
     while node.get_canonical_chain_height().await < write_epoch {
         node.mine_block().await?;
     }

--- a/crates/chain-tests/src/validation/mid_epoch_promotability.rs
+++ b/crates/chain-tests/src/validation/mid_epoch_promotability.rs
@@ -1,0 +1,518 @@
+// NC-0042 §4b/§4c: the mid-epoch fully-written-boundary-crossing promotability
+// window, pinned end-to-end for producer/validator determinism plus the
+// next-epoch rescue.
+//
+// The rule lives (only) as a comment in `block_validation.rs`: the inclusive
+// all-expired Submit slot set is recomputed EVERY block from the *parent's*
+// advancing Submit total, while a slot's `last_height` is refreshed only by the
+// next epoch `touch`. So a stale slot (aged `last_height`) whose fully-written
+// boundary is crossed by mid-epoch appends re-enters the blocked set the instant
+// the parent total passes it — and stays there until the next epoch `touch`
+// bumps its `last_height` (the rescue). A tx appended into such a slot is held
+// non-promotable for up to ~one epoch, then rescued (NOT refunded). If the
+// producer and the validator ever disagreed inside this window (one keying off
+// the tip total, the other the parent total), it would be a consensus fork; this
+// test pins that they agree, from the SAME parent state.
+//
+// Fixture (Cascade active from genesis; num_blocks_in_epoch=5,
+// submit_ledger_epoch_length=2 -> Submit slot lifetime = 10 blocks; slot size
+// C = 10 chunks, chunk_size = 32 so one 32-byte tx == one Submit chunk):
+//   1. Write 15 single-chunk txs -> Submit slot 0 fully written (chunks [0,10))
+//      and slot 1 the partial frontier (chunks [10,15)); allocation adds slot 2
+//      as headroom so slot 1 is non-last. At the first epoch touch (E_w) both
+//      slots 0 and 1 get `last_height = E_w`.
+//   2. Age WITHOUT Submit writes. Slot 0 (fully written) recycles a full slot
+//      lifetime after E_w; slot 1 (partial frontier) survives — only fully
+//      written slots may expire — and keeps its stale `last_height = E_w`.
+//   3. MID-EPOCH, append 5 more single-chunk txs pushing the frontier past slot
+//      1's end (Submit total -> 20), so slot 1 is now fully written THIS epoch.
+//      A chosen tx `T` lands in slot 1; inject T's ingress proof so it is a
+//      promotion candidate.
+// Because slot 0 is already expired (a contiguous prefix), slot 1 now joins the
+// inclusive all-expired set: `expired_submit_range` extends to slot 1's end and
+// T maps inside it -> T is non-promotable, even though slot 1's `last_height` is
+// not yet refreshed.
+//
+// Assertions (all from the SAME parent — the load-bearing consensus checks):
+//   - Producer: the honest producer mines the window block and does NOT promote
+//     T (T absent from the block's Publish ledger).
+//   - Validator: an "evil" block built on the SAME parent that DOES promote T is
+//     rejected by the peer (and genesis) with `ShadowTransactionInvalid`
+//     carrying the NC-0042 marker.
+// Then across the epoch boundary:
+//   - Rescue: at the epoch block the `touch` refreshes slot 1's `last_height`
+//     and the write-window exclusion drops it from the refund set, so NO
+//     perm-fee refund is emitted for T's slot, and T becomes promotable
+//     afterwards (eventually promoted).
+//
+// We drive everything through the real Submit flow (no MigratedBlockHashes
+// seeding — that collides with the chain's real migration writes and crashes
+// BlockTreeService, per the notes in the pre-Cascade §4b/§4c tests).
+
+use crate::utils::{IrysNodeTest, assert_validation_error, solution_context};
+use crate::validation::send_block_and_read_state;
+use irys_actors::block_validation::ValidationError;
+use irys_actors::{
+    BlockProdStrategy, BlockProducerInner, ProductionStrategy, async_trait,
+    block_producer::ledger_expiry::LedgerExpiryBalanceDelta,
+    shadow_tx_generator::PublishLedgerWithTxs,
+};
+use irys_config::submodules::StorageSubmodulesConfig;
+use irys_database::{db::IrysDatabaseExt as _, store_external_ingress_proof_checked};
+use irys_domain::BlockTreeReadGuard;
+use irys_reth_node_bridge::irys_reth::shadow_tx::{ShadowTransaction, TransactionPacket};
+use irys_types::ingress::generate_ingress_proof;
+use irys_types::{
+    DataLedger, DataTransaction, DataTransactionHeader, H256, IngressProofsList, IrysBlockHeader,
+    NodeConfig, UnixTimestamp, UnixTimestampMs, hardfork_config::Cascade,
+};
+use reth::rpc::types::TransactionTrait as _;
+use std::collections::BTreeSet;
+
+#[test_log::test(tokio::test)]
+async fn heavy_mid_epoch_boundary_crossing_defers_then_rescues() -> eyre::Result<()> {
+    /// Promotes a chosen tx into the Publish ledger with a valid ingress proof so
+    /// the block fails validation ONLY on the §4c expiry rule (not on a
+    /// missing/invalid proof). No refund is scheduled in the bundle, so the
+    /// in-constructor defence-in-depth guard does not fire during production — the
+    /// block is built and must be caught at validation time.
+    struct EvilPublishStrategy {
+        prod: ProductionStrategy,
+        target_tx: DataTransactionHeader,
+        proofs: IngressProofsList,
+        block_tree_guard: BlockTreeReadGuard,
+    }
+
+    #[async_trait::async_trait]
+    impl BlockProdStrategy for EvilPublishStrategy {
+        fn inner(&self) -> &BlockProducerInner {
+            &self.prod.inner
+        }
+
+        async fn get_mempool_txs(
+            &self,
+            _prev_block_header: &IrysBlockHeader,
+            _block_timestamp: UnixTimestampMs,
+        ) -> Result<
+            irys_actors::block_producer::MempoolTxsBundle,
+            irys_actors::tx_selector::TxSelectorError,
+        > {
+            Ok(irys_actors::block_producer::MempoolTxsBundle {
+                commitment_txs: vec![],
+                commitment_txs_to_bill: vec![],
+                submit_txs: vec![],
+                one_year_txs: vec![],
+                thirty_day_txs: vec![],
+                publish_txs: PublishLedgerWithTxs {
+                    txs: vec![self.target_tx.clone()],
+                    proofs: Some(self.proofs.clone()),
+                },
+                aggregated_miner_fees: LedgerExpiryBalanceDelta::default(),
+                commitment_refund_events: vec![],
+                unstake_refund_events: vec![],
+                epoch_snapshot: self.block_tree_guard.read().canonical_epoch_snapshot(),
+            })
+        }
+    }
+
+    // --- 1. Config: Cascade active from genesis + tight Submit-expiry aging ---
+    let num_blocks_in_epoch: u64 = 5;
+    let submit_ledger_epoch_length: u64 = 2;
+    let chunk_size: u64 = 32;
+    let num_chunks_in_partition: u64 = 10; // slot size C = 10 chunks
+    let slot_lifetime = submit_ledger_epoch_length * num_blocks_in_epoch; // 10 blocks
+    let seconds_to_wait = 40_usize;
+
+    let mut genesis_config = NodeConfig::testing_with_epochs(num_blocks_in_epoch as usize);
+    {
+        let c = genesis_config.consensus.get_mut();
+        c.chunk_size = chunk_size;
+        c.num_chunks_in_partition = num_chunks_in_partition;
+        // Fast migration so a Submit inclusion resolves promptly (fast path); the
+        // un-migrated tip still resolves via the branch-correct by-hash walk.
+        c.block_migration_depth = 1;
+        c.epoch.submit_ledger_epoch_length = submit_ledger_epoch_length;
+        // One ingress proof from the genesis signer makes a tx promotable.
+        c.hardforks.frontier.number_of_ingress_proofs_total = 1;
+        // Cascade active from genesis -> last-write anchoring + written-this-epoch
+        // rescue, the semantics this window depends on.
+        c.hardforks.cascade = Some(Cascade {
+            activation_timestamp: UnixTimestamp::from_secs(0),
+            one_year_epoch_length: 8,
+            thirty_day_epoch_length: 2,
+            annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
+        });
+    }
+
+    let user_signer = genesis_config.new_random_signer();
+    genesis_config.fund_genesis_accounts(vec![&user_signer]);
+
+    // Enough submodules for the Submit data slots (0,1,2) + the other Cascade
+    // ledgers (Publish/OneYear/ThirtyDay) + capacity headroom.
+    let genesis_node = IrysNodeTest::new_genesis(genesis_config.clone());
+    StorageSubmodulesConfig::load_for_test(genesis_node.cfg.base_directory.clone(), 10)?;
+    let genesis_node = genesis_node
+        .start_and_wait_for_packing("GENESIS", seconds_to_wait)
+        .await;
+    let peer_node = {
+        let peer_config = genesis_node.testing_peer_with_signer(&user_signer);
+        IrysNodeTest::new(peer_config).start_with_name("PEER").await
+    };
+
+    let next_epoch_boundary = |h: u64| -> u64 {
+        if h.is_multiple_of(num_blocks_in_epoch) {
+            h
+        } else {
+            h + (num_blocks_in_epoch - (h % num_blocks_in_epoch))
+        }
+    };
+
+    // Reads (slot0_last_height, slot0_expired, slot1_last_height, slot1_expired,
+    // slot_count) for the Submit ledger from `height`'s epoch snapshot.
+    async fn submit_slots(
+        ctx: &IrysNodeTest<irys_chain::IrysNodeCtx>,
+        height: u64,
+    ) -> eyre::Result<(u64, bool, u64, bool, usize)> {
+        let block = ctx.get_block_by_height(height).await?;
+        let tree = ctx.node_ctx.block_tree_guard.read();
+        let snapshot = tree
+            .get_epoch_snapshot(&block.block_hash)
+            .expect("epoch snapshot should exist");
+        let slots = snapshot.ledgers.get_slots(DataLedger::Submit);
+        Ok((
+            slots[0].last_height,
+            slots[0].is_expired,
+            slots[1].last_height,
+            slots[1].is_expired,
+            slots.len(),
+        ))
+    }
+
+    // Posts `n` single-chunk (one Submit chunk each) txs and waits for the mempool.
+    async fn post_single_chunk_txs(
+        ctx: &IrysNodeTest<irys_chain::IrysNodeCtx>,
+        signer: &irys_types::irys::IrysSigner,
+        n: usize,
+        marker_base: u8,
+        chunk_size: usize,
+        seconds_to_wait: usize,
+    ) -> eyre::Result<Vec<DataTransaction>> {
+        let mut out = Vec::with_capacity(n);
+        for i in 0..n {
+            let mut data = vec![7_u8; chunk_size];
+            data[0] = marker_base.wrapping_add(i as u8);
+            let anchor = ctx.get_anchor().await?;
+            let tx = ctx.post_data_tx(anchor, data, signer).await;
+            ctx.wait_for_mempool(tx.header.id, seconds_to_wait).await?;
+            out.push(tx);
+        }
+        Ok(out)
+    }
+
+    // --- 2. Write slot 0 full (10 chunks) + slot 1 partial (5 chunks) ---
+    let initial_txs = post_single_chunk_txs(
+        &genesis_node,
+        &user_signer,
+        (num_chunks_in_partition + num_chunks_in_partition / 2) as usize, // 15
+        100,
+        chunk_size as usize,
+        seconds_to_wait,
+    )
+    .await?;
+    let data_block = genesis_node.mine_block().await?;
+    assert_eq!(
+        data_block.ledger_total_chunks(DataLedger::Submit),
+        15,
+        "one 32-byte tx must equal one Submit chunk (15 txs -> 15 chunks: slot 0 full + slot 1 partial)"
+    );
+
+    // Mine to the first epoch touch E_w so slots 0 and 1 get `last_height = E_w`
+    // and allocation adds slot 2 (so slot 1 is non-last).
+    let ew = next_epoch_boundary(data_block.height);
+    while genesis_node.get_canonical_chain_height().await < ew {
+        genesis_node.mine_block().await?;
+    }
+    let (s0_lh, s0_exp, s1_lh, s1_exp, slot_count) = submit_slots(&genesis_node, ew).await?;
+    assert!(
+        slot_count >= 3,
+        "capacity allocation must add slot 2 so slot 1 is non-last (got {slot_count} slots)"
+    );
+    assert_eq!(
+        s0_lh, ew,
+        "slot 0 last_height should be the write epoch E_w"
+    );
+    assert_eq!(
+        s1_lh, ew,
+        "slot 1 last_height should be the write epoch E_w"
+    );
+    assert!(!s0_exp, "slot 0 must not be expired yet at E_w");
+    assert!(!s1_exp, "slot 1 must not be expired yet at E_w");
+
+    // --- 3. Age WITHOUT Submit writes. Slot 0 recycles a full slot lifetime after
+    //         E_w; slot 1 (partial frontier) survives with its stale last_height. ---
+    let slot0_expiry_epoch = next_epoch_boundary(ew + slot_lifetime);
+    while genesis_node.get_canonical_chain_height().await < slot0_expiry_epoch {
+        genesis_node.mine_block().await?;
+    }
+    let (s0_lh2, s0_exp2, s1_lh2, s1_exp2, _) =
+        submit_slots(&genesis_node, slot0_expiry_epoch).await?;
+    assert_eq!(s0_lh2, ew, "slot 0 last_height stays stale (no rewrite)");
+    assert!(
+        s0_exp2,
+        "the fully-written aged slot 0 must recycle at E_w + slot_lifetime"
+    );
+    assert_eq!(s1_lh2, ew, "slot 1 last_height stays stale (no rewrite)");
+    assert!(
+        !s1_exp2,
+        "the partially-written frontier slot 1 must NOT expire (only fully-written slots may)"
+    );
+
+    // Peer follows the honest chain up to the recycle epoch.
+    peer_node
+        .wait_until_height(slot0_expiry_epoch, seconds_to_wait)
+        .await?;
+
+    // --- 4. MID-EPOCH: append 5 more single-chunk txs pushing the frontier past
+    //         slot 1's end (Submit total -> 20). Slot 1 is now fully written THIS
+    //         epoch; T (the first appended tx) lands in slot 1. ---
+    let mid_txs = post_single_chunk_txs(
+        &genesis_node,
+        &user_signer,
+        (num_chunks_in_partition / 2) as usize, // 5 -> slot 1 filled to [10,20)
+        200,
+        chunk_size as usize,
+        seconds_to_wait,
+    )
+    .await?;
+    let target = mid_txs
+        .first()
+        .cloned()
+        .expect("must have appended at least one mid-epoch tx");
+    let append_block = genesis_node.mine_block().await?;
+    assert_eq!(
+        append_block.ledger_total_chunks(DataLedger::Submit),
+        20,
+        "mid-epoch append must fill slot 1 exactly (Submit total -> 20 chunks)"
+    );
+    // The append is a mid-epoch (non-epoch) block, on top of the recycle epoch.
+    assert!(
+        !append_block.height.is_multiple_of(num_blocks_in_epoch),
+        "the append must be a mid-epoch block, not an epoch block"
+    );
+
+    // Inject T's ingress proof (from the staked genesis signer) so it is a
+    // promotion candidate — the only reason it can be dropped/rejected is expiry.
+    let genesis_signer = genesis_config.signer();
+    let chain_id = genesis_config.consensus_config().chain_id;
+    let proof_anchor = genesis_node.get_anchor().await?;
+    let target_chunks: Vec<Vec<u8>> = vec![
+        target
+            .data
+            .clone()
+            .expect("posted tx must carry data bytes")
+            .into(),
+    ];
+    let proof = generate_ingress_proof(
+        &genesis_signer,
+        target.header.data_root,
+        target_chunks.iter().map(|c| Ok(c.as_slice())),
+        chain_id,
+        proof_anchor,
+    )?;
+    genesis_node.node_ctx.db.update_eyre(|rw_tx| {
+        store_external_ingress_proof_checked(rw_tx, &proof, genesis_signer.address())?;
+        Ok(())
+    })?;
+
+    // --- 5. The window: T must be non-promotable at the next (mid-epoch) block,
+    //         computed from the SAME parent (the append block). ---
+    let window_height = append_block.height + 1;
+    assert!(
+        !window_height.is_multiple_of(num_blocks_in_epoch),
+        "the window block must be mid-epoch (before the rescuing epoch boundary)"
+    );
+    let parent_snapshot = genesis_node
+        .node_ctx
+        .block_tree_guard
+        .read()
+        .get_epoch_snapshot(&append_block.block_hash)
+        .expect("epoch snapshot for the append (parent) block");
+    let cascade_active_for_block = genesis_node
+        .node_ctx
+        .config
+        .consensus
+        .hardforks
+        .is_cascade_active_at(append_block.timestamp_secs());
+
+    // Oracle (anti-vacuity): T really is inside the boundary-crossed-but-unrescued
+    // window as of the block we are about to produce.
+    let t_expired = irys_actors::block_producer::ledger_expiry::is_submit_storage_expired(
+        target.header.id,
+        window_height,
+        &parent_snapshot,
+        &append_block,
+        &genesis_node.node_ctx.config,
+        cascade_active_for_block,
+        &genesis_node.node_ctx.block_producer_inner.block_index,
+        &genesis_node.node_ctx.block_tree_guard,
+        &genesis_node.node_ctx.mempool_guard,
+        &genesis_node.node_ctx.db,
+    )
+    .await?;
+    assert!(
+        t_expired,
+        "T must map into a boundary-crossed-but-unrescued slot at the window block \
+         (else the producer-drop / validator-reject checks would be vacuous)"
+    );
+
+    // Validator check FIRST (while the tip is still the append block, T's parent):
+    // an evil block that DOES promote T, built on the SAME parent, must be
+    // rejected with ShadowTransactionInvalid carrying the NC-0042 marker.
+    peer_node
+        .wait_until_height(append_block.height, seconds_to_wait)
+        .await?;
+    let evil_strategy = EvilPublishStrategy {
+        target_tx: target.header.clone(),
+        proofs: IngressProofsList(vec![proof.clone()]),
+        prod: ProductionStrategy {
+            inner: genesis_node.node_ctx.block_producer_inner.clone(),
+        },
+        block_tree_guard: genesis_node.node_ctx.block_tree_guard.clone(),
+    };
+    let (evil_block, _adj, _payload) = evil_strategy
+        .fully_produce_new_block_without_gossip(&solution_context(&genesis_node.node_ctx).await?)
+        .await?
+        .expect("evil block should be produced (the guard fires at validation, not production)");
+    assert_eq!(
+        evil_block.header().height,
+        window_height,
+        "evil block must be at the window height (same parent as the honest block)"
+    );
+    assert_eq!(
+        evil_block.header().previous_block_hash,
+        append_block.block_hash,
+        "evil block must build on the same parent state the producer uses"
+    );
+    assert!(
+        evil_block.header().data_ledgers[DataLedger::Publish]
+            .tx_ids
+            .contains(&target.header.id),
+        "evil block must promote T"
+    );
+
+    let is_nc_0042_expiry_rejection = |e: &ValidationError| match e {
+        ValidationError::ShadowTransactionInvalid(msg) => msg.contains("NC-0042"),
+        _ => false,
+    };
+    let genesis_outcome =
+        send_block_and_read_state(&genesis_node.node_ctx, evil_block.clone(), false).await?;
+    assert_validation_error(
+        genesis_outcome,
+        is_nc_0042_expiry_rejection,
+        "Genesis must reject a block promoting a boundary-crossed-but-unrescued Submit tx (NC-0042)",
+    );
+    let peer_outcome =
+        send_block_and_read_state(&peer_node.node_ctx, evil_block.clone(), false).await?;
+    assert_validation_error(
+        peer_outcome,
+        is_nc_0042_expiry_rejection,
+        "Peer must reject a block promoting a boundary-crossed-but-unrescued Submit tx (NC-0042)",
+    );
+    genesis_node
+        .assert_evm_block_absent(evil_block.header().evm_block_hash, 2)
+        .await?;
+
+    // Producer check: the honest producer mines the window block on the SAME
+    // parent and does NOT promote T.
+    let window_block = genesis_node.mine_block().await?;
+    assert_eq!(
+        window_block.height, window_height,
+        "honest window block at the expected height"
+    );
+    assert_eq!(
+        window_block.previous_block_hash, append_block.block_hash,
+        "honest window block builds on the same parent as the evil block"
+    );
+    let window_publish_ids: BTreeSet<H256> = window_block
+        .get_data_ledger_tx_ids()
+        .get(&DataLedger::Publish)
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .collect();
+    assert!(
+        !window_publish_ids.contains(&target.header.id),
+        "the honest producer must NOT promote T inside the boundary-crossed-but-unrescued window"
+    );
+
+    // --- 6. Rescue: advance across the epoch boundary. The `touch` refreshes slot
+    //         1's last_height and the write-window exclusion drops it from refunds,
+    //         so NO perm-fee refund is emitted for T's slot at the epoch block. ---
+    let rescue_epoch = next_epoch_boundary(window_height);
+    while genesis_node.get_canonical_chain_height().await < rescue_epoch {
+        genesis_node.mine_block().await?;
+    }
+    let (_, _, s1_lh_r, s1_exp_r, _) = submit_slots(&genesis_node, rescue_epoch).await?;
+    assert_eq!(
+        s1_lh_r, rescue_epoch,
+        "the epoch touch must refresh slot 1's last_height (rescue)"
+    );
+    assert!(
+        !s1_exp_r,
+        "slot 1 must be rescued (not recycled) because it was written this epoch"
+    );
+
+    // No perm-fee refund for T's slot at the epoch block (it was rescued, not
+    // settled).
+    let epoch_block = genesis_node.get_block_by_height(rescue_epoch).await?;
+    let user_addr = user_signer.address().to_alloy_address();
+    let evm_block = genesis_node
+        .wait_for_evm_block(epoch_block.evm_block_hash, seconds_to_wait)
+        .await?;
+    let refunded_tx_ids: BTreeSet<H256> = evm_block
+        .body
+        .transactions
+        .into_iter()
+        .filter(|tx| tx.input().len() >= 4)
+        .filter_map(|tx| {
+            let shadow_tx = ShadowTransaction::decode(&mut tx.input().as_ref()).ok()?;
+            let packet = shadow_tx.as_v1()?;
+            match packet {
+                TransactionPacket::PermFeeRefund(refund) if refund.target == user_addr => {
+                    Some(H256(refund.irys_ref.into()))
+                }
+                _ => None,
+            }
+        })
+        .collect();
+    assert!(
+        !refunded_tx_ids.contains(&target.header.id),
+        "no perm-fee refund may be emitted for a rescued-slot tx at the epoch block (NC-0042)"
+    );
+
+    // --- 7. After the rescue, T becomes promotable (eventually promoted). ---
+    let mut promoted = false;
+    for _ in 0..num_blocks_in_epoch {
+        let block = genesis_node.mine_block().await?;
+        let publish_ids: BTreeSet<H256> = block
+            .get_data_ledger_tx_ids()
+            .get(&DataLedger::Publish)
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .collect();
+        if publish_ids.contains(&target.header.id) {
+            promoted = true;
+            break;
+        }
+    }
+    assert!(
+        promoted,
+        "a rescued-slot tx must become promotable after the epoch (eventually promoted)"
+    );
+
+    let _ = initial_txs;
+    peer_node.stop().await;
+    genesis_node.stop().await;
+    Ok(())
+}

--- a/crates/chain-tests/src/validation/mid_epoch_promotability.rs
+++ b/crates/chain-tests/src/validation/mid_epoch_promotability.rs
@@ -427,9 +427,14 @@ async fn heavy_mid_epoch_boundary_crossing_defers_then_rescues() -> eyre::Result
             }
         })
         .collect();
+    // No perm-fee refund at all for the user at this epoch: slot 0 already recycled
+    // (and settled) at its own earlier expiry epoch, and slot 1 is rescued (written
+    // this epoch), so nothing recycles here. A non-empty set would mean either T's
+    // rescued slot was wrongly refunded or a sibling slot leaked a refund (NC-0042).
     assert!(
-        !refunded_tx_ids.contains(&target.header.id),
-        "no perm-fee refund may be emitted for a rescued-slot tx at the epoch block (NC-0042)"
+        refunded_tx_ids.is_empty(),
+        "no perm-fee refund may be emitted for the user at the rescue epoch block \
+         (rescued slot 1, slot 0 settled earlier) (NC-0042); got {refunded_tx_ids:?}"
     );
 
     // --- 7. After the rescue, T becomes promotable (eventually promoted). ---

--- a/crates/chain-tests/src/validation/mid_epoch_promotability.rs
+++ b/crates/chain-tests/src/validation/mid_epoch_promotability.rs
@@ -50,71 +50,24 @@
 // BlockTreeService, per the notes in the pre-Cascade §4b/§4c tests).
 
 use crate::utils::{IrysNodeTest, assert_validation_error, solution_context};
-use crate::validation::send_block_and_read_state;
-use irys_actors::block_validation::ValidationError;
-use irys_actors::{
-    BlockProdStrategy, BlockProducerInner, ProductionStrategy, async_trait,
-    block_producer::ledger_expiry::LedgerExpiryBalanceDelta,
-    shadow_tx_generator::PublishLedgerWithTxs,
+use crate::validation::{
+    EvilPublishStrategy, is_nc_0042_expiry_rejection, next_epoch_boundary,
+    send_block_and_read_state,
 };
+use irys_actors::{BlockProdStrategy as _, ProductionStrategy};
 use irys_config::submodules::StorageSubmodulesConfig;
 use irys_database::{db::IrysDatabaseExt as _, store_external_ingress_proof_checked};
-use irys_domain::BlockTreeReadGuard;
 use irys_reth_node_bridge::irys_reth::shadow_tx::{ShadowTransaction, TransactionPacket};
 use irys_types::ingress::generate_ingress_proof;
 use irys_types::{
-    DataLedger, DataTransaction, DataTransactionHeader, H256, IngressProofsList, IrysBlockHeader,
-    NodeConfig, UnixTimestamp, UnixTimestampMs, hardfork_config::Cascade,
+    DataLedger, DataTransaction, H256, IngressProofsList, NodeConfig, UnixTimestamp,
+    hardfork_config::Cascade,
 };
 use reth::rpc::types::TransactionTrait as _;
 use std::collections::BTreeSet;
 
 #[test_log::test(tokio::test)]
 async fn heavy_mid_epoch_boundary_crossing_defers_then_rescues() -> eyre::Result<()> {
-    /// Promotes a chosen tx into the Publish ledger with a valid ingress proof so
-    /// the block fails validation ONLY on the §4c expiry rule (not on a
-    /// missing/invalid proof). No refund is scheduled in the bundle, so the
-    /// in-constructor defence-in-depth guard does not fire during production — the
-    /// block is built and must be caught at validation time.
-    struct EvilPublishStrategy {
-        prod: ProductionStrategy,
-        target_tx: DataTransactionHeader,
-        proofs: IngressProofsList,
-        block_tree_guard: BlockTreeReadGuard,
-    }
-
-    #[async_trait::async_trait]
-    impl BlockProdStrategy for EvilPublishStrategy {
-        fn inner(&self) -> &BlockProducerInner {
-            &self.prod.inner
-        }
-
-        async fn get_mempool_txs(
-            &self,
-            _prev_block_header: &IrysBlockHeader,
-            _block_timestamp: UnixTimestampMs,
-        ) -> Result<
-            irys_actors::block_producer::MempoolTxsBundle,
-            irys_actors::tx_selector::TxSelectorError,
-        > {
-            Ok(irys_actors::block_producer::MempoolTxsBundle {
-                commitment_txs: vec![],
-                commitment_txs_to_bill: vec![],
-                submit_txs: vec![],
-                one_year_txs: vec![],
-                thirty_day_txs: vec![],
-                publish_txs: PublishLedgerWithTxs {
-                    txs: vec![self.target_tx.clone()],
-                    proofs: Some(self.proofs.clone()),
-                },
-                aggregated_miner_fees: LedgerExpiryBalanceDelta::default(),
-                commitment_refund_events: vec![],
-                unstake_refund_events: vec![],
-                epoch_snapshot: self.block_tree_guard.read().canonical_epoch_snapshot(),
-            })
-        }
-    }
-
     // --- 1. Config: Cascade active from genesis + tight Submit-expiry aging ---
     let num_blocks_in_epoch: u64 = 5;
     let submit_ledger_epoch_length: u64 = 2;
@@ -157,14 +110,6 @@ async fn heavy_mid_epoch_boundary_crossing_defers_then_rescues() -> eyre::Result
     let peer_node = {
         let peer_config = genesis_node.testing_peer_with_signer(&user_signer);
         IrysNodeTest::new(peer_config).start_with_name("PEER").await
-    };
-
-    let next_epoch_boundary = |h: u64| -> u64 {
-        if h.is_multiple_of(num_blocks_in_epoch) {
-            h
-        } else {
-            h + (num_blocks_in_epoch - (h % num_blocks_in_epoch))
-        }
     };
 
     // Reads (slot0_last_height, slot0_expired, slot1_last_height, slot1_expired,
@@ -210,7 +155,8 @@ async fn heavy_mid_epoch_boundary_crossing_defers_then_rescues() -> eyre::Result
     }
 
     // --- 2. Write slot 0 full (10 chunks) + slot 1 partial (5 chunks) ---
-    let initial_txs = post_single_chunk_txs(
+    // Held only to keep the posted txs alive for the run; not referenced again.
+    let _initial_txs = post_single_chunk_txs(
         &genesis_node,
         &user_signer,
         (num_chunks_in_partition + num_chunks_in_partition / 2) as usize, // 15
@@ -228,7 +174,7 @@ async fn heavy_mid_epoch_boundary_crossing_defers_then_rescues() -> eyre::Result
 
     // Mine to the first epoch touch E_w so slots 0 and 1 get `last_height = E_w`
     // and allocation adds slot 2 (so slot 1 is non-last).
-    let ew = next_epoch_boundary(data_block.height);
+    let ew = next_epoch_boundary(data_block.height, num_blocks_in_epoch);
     while genesis_node.get_canonical_chain_height().await < ew {
         genesis_node.mine_block().await?;
     }
@@ -250,7 +196,7 @@ async fn heavy_mid_epoch_boundary_crossing_defers_then_rescues() -> eyre::Result
 
     // --- 3. Age WITHOUT Submit writes. Slot 0 recycles a full slot lifetime after
     //         E_w; slot 1 (partial frontier) survives with its stale last_height. ---
-    let slot0_expiry_epoch = next_epoch_boundary(ew + slot_lifetime);
+    let slot0_expiry_epoch = next_epoch_boundary(ew + slot_lifetime, num_blocks_in_epoch);
     while genesis_node.get_canonical_chain_height().await < slot0_expiry_epoch {
         genesis_node.mine_block().await?;
     }
@@ -372,7 +318,7 @@ async fn heavy_mid_epoch_boundary_crossing_defers_then_rescues() -> eyre::Result
         .wait_until_height(append_block.height, seconds_to_wait)
         .await?;
     let evil_strategy = EvilPublishStrategy {
-        target_tx: target.header.clone(),
+        publish_tx: target.header.clone(),
         proofs: IngressProofsList(vec![proof.clone()]),
         prod: ProductionStrategy {
             inner: genesis_node.node_ctx.block_producer_inner.clone(),
@@ -400,10 +346,6 @@ async fn heavy_mid_epoch_boundary_crossing_defers_then_rescues() -> eyre::Result
         "evil block must promote T"
     );
 
-    let is_nc_0042_expiry_rejection = |e: &ValidationError| match e {
-        ValidationError::ShadowTransactionInvalid(msg) => msg.contains("NC-0042"),
-        _ => false,
-    };
     let genesis_outcome =
         send_block_and_read_state(&genesis_node.node_ctx, evil_block.clone(), false).await?;
     assert_validation_error(
@@ -448,7 +390,7 @@ async fn heavy_mid_epoch_boundary_crossing_defers_then_rescues() -> eyre::Result
     // --- 6. Rescue: advance across the epoch boundary. The `touch` refreshes slot
     //         1's last_height and the write-window exclusion drops it from refunds,
     //         so NO perm-fee refund is emitted for T's slot at the epoch block. ---
-    let rescue_epoch = next_epoch_boundary(window_height);
+    let rescue_epoch = next_epoch_boundary(window_height, num_blocks_in_epoch);
     while genesis_node.get_canonical_chain_height().await < rescue_epoch {
         genesis_node.mine_block().await?;
     }
@@ -511,7 +453,6 @@ async fn heavy_mid_epoch_boundary_crossing_defers_then_rescues() -> eyre::Result
         "a rescued-slot tx must become promotable after the epoch (eventually promoted)"
     );
 
-    let _ = initial_txs;
     peer_node.stop().await;
     genesis_node.stop().await;
     Ok(())

--- a/crates/chain-tests/src/validation/mod.rs
+++ b/crates/chain-tests/src/validation/mod.rs
@@ -41,10 +41,11 @@ use irys_actors::{
     shadow_tx_generator::PublishLedgerWithTxs,
 };
 use irys_chain::IrysNodeCtx;
+use irys_domain::BlockTreeReadGuard;
 use irys_types::{
     BlockBody, CommitmentTransaction, DataTransaction, DataTransactionHeader,
-    DataTransactionHeaderV1, H256, H256List, IrysBlockHeader, IrysTransactionCommon as _,
-    NodeConfig, SealedBlock, SystemTransactionLedger,
+    DataTransactionHeaderV1, H256, H256List, IngressProofsList, IrysBlockHeader,
+    IrysTransactionCommon as _, NodeConfig, SealedBlock, SystemTransactionLedger, UnixTimestampMs,
 };
 use irys_types::{DataLedger, SendTraced as _, SystemLedger};
 
@@ -206,6 +207,67 @@ fn send_block_to_block_validation(
         })
         .unwrap();
     Ok(())
+}
+
+/// Rounds `height` UP to the next `num_blocks_in_epoch` boundary, returning
+/// `height` unchanged when it already sits on a boundary. Shared by the expiry
+/// tests, which repeatedly compute "the epoch block that will process this write".
+pub(crate) fn next_epoch_boundary(height: u64, num_blocks_in_epoch: u64) -> u64 {
+    height.div_ceil(num_blocks_in_epoch) * num_blocks_in_epoch
+}
+
+/// True iff `e` is the NC-0042 expiry rejection: a `ShadowTransactionInvalid`
+/// whose message carries the "NC-0042" marker. The expiry-promotion tests match
+/// on it so they assert the block was rejected for the expiry rule specifically,
+/// not for an unrelated shadow-tx error.
+pub(crate) fn is_nc_0042_expiry_rejection(e: &ValidationError) -> bool {
+    matches!(e, ValidationError::ShadowTransactionInvalid(msg) if msg.contains("NC-0042"))
+}
+
+/// "Evil" block-production strategy shared by the Submit/Publish expiry tests:
+/// forces a single data tx into the Publish ledger with the given ingress
+/// proofs, leaving every other bundle field empty. No refund is scheduled in the
+/// bundle, so the in-constructor defence-in-depth guard does NOT fire during
+/// production — the block is built and must be caught at validation time, which
+/// is exactly what these tests exercise.
+pub(crate) struct EvilPublishStrategy {
+    pub prod: ProductionStrategy,
+    /// The tx illegally promoted into Publish (an expired / non-promotable Submit tx).
+    pub publish_tx: DataTransactionHeader,
+    pub proofs: IngressProofsList,
+    pub block_tree_guard: BlockTreeReadGuard,
+}
+
+#[async_trait::async_trait]
+impl BlockProdStrategy for EvilPublishStrategy {
+    fn inner(&self) -> &BlockProducerInner {
+        &self.prod.inner
+    }
+
+    async fn get_mempool_txs(
+        &self,
+        _prev_block_header: &IrysBlockHeader,
+        _block_timestamp: UnixTimestampMs,
+    ) -> Result<
+        irys_actors::block_producer::MempoolTxsBundle,
+        irys_actors::tx_selector::TxSelectorError,
+    > {
+        Ok(irys_actors::block_producer::MempoolTxsBundle {
+            commitment_txs: vec![],
+            commitment_txs_to_bill: vec![],
+            submit_txs: vec![],
+            one_year_txs: vec![],
+            thirty_day_txs: vec![],
+            publish_txs: PublishLedgerWithTxs {
+                txs: vec![self.publish_tx.clone()],
+                proofs: Some(self.proofs.clone()),
+            },
+            aggregated_miner_fees: LedgerExpiryBalanceDelta::default(),
+            commitment_refund_events: vec![],
+            unstake_refund_events: vec![],
+            epoch_snapshot: self.block_tree_guard.read().canonical_epoch_snapshot(),
+        })
+    }
 }
 
 // This test creates a malicious block producer that includes a stake commitment with invalid value.

--- a/crates/chain-tests/src/validation/mod.rs
+++ b/crates/chain-tests/src/validation/mod.rs
@@ -13,6 +13,7 @@ mod invalid_perm_fee_refund;
 mod ledger_expiry_with_unstake;
 mod mempool_gossip_shape;
 mod mempool_ingress_proof_dedup;
+mod mid_epoch_promotability;
 mod poa_cases;
 mod promote_after_submit_expiry;
 mod publish_after_submit_expiry_filtered;

--- a/crates/chain-tests/src/validation/mod.rs
+++ b/crates/chain-tests/src/validation/mod.rs
@@ -15,6 +15,7 @@ mod mempool_gossip_shape;
 mod mempool_ingress_proof_dedup;
 mod mid_epoch_promotability;
 mod poa_cases;
+mod promote_after_activation_straddle;
 mod promote_after_submit_expiry;
 mod publish_after_submit_expiry_filtered;
 mod reorg_submit_expiry;

--- a/crates/chain-tests/src/validation/promote_after_activation_straddle.rs
+++ b/crates/chain-tests/src/validation/promote_after_activation_straddle.rs
@@ -33,69 +33,20 @@
 //     its full perm_fee pre-Cascade.
 
 use crate::utils::{IrysNodeTest, assert_validation_error, solution_context};
-use crate::validation::send_block_and_read_state;
-use irys_actors::block_validation::ValidationError;
-use irys_actors::{
-    BlockProdStrategy, BlockProducerInner, ProductionStrategy, async_trait,
-    block_producer::ledger_expiry::LedgerExpiryBalanceDelta,
-    shadow_tx_generator::PublishLedgerWithTxs,
+use crate::validation::{
+    EvilPublishStrategy, is_nc_0042_expiry_rejection, send_block_and_read_state,
 };
+use irys_actors::{BlockProdStrategy as _, ProductionStrategy};
 use irys_config::submodules::StorageSubmodulesConfig;
-use irys_domain::BlockTreeReadGuard;
 use irys_reth_node_bridge::irys_reth::shadow_tx::{ShadowTransaction, TransactionPacket};
 use irys_types::ingress::generate_ingress_proof;
 use irys_types::{
-    DataLedger, DataTransactionHeader, IngressProofsList, IrysBlockHeader, NodeConfig, U256,
-    UnixTimestamp, UnixTimestampMs, hardfork_config::Cascade,
+    DataLedger, IngressProofsList, NodeConfig, U256, UnixTimestamp, hardfork_config::Cascade,
 };
 use reth::rpc::types::TransactionTrait as _;
 
 #[test_log::test(tokio::test)]
 async fn slow_heavy_promote_after_activation_straddle_rejected() -> eyre::Result<()> {
-    /// Forces an already-expired+refunded Submit tx into the Publish ledger with a
-    /// valid ingress proof, so the block fails validation ONLY on the §4c expiry
-    /// rule. No refund is scheduled in the bundle, so the in-constructor guard does
-    /// not fire during production — the block is built and must be caught at
-    /// validation time.
-    struct EvilPublishStrategy {
-        prod: ProductionStrategy,
-        expired_tx: DataTransactionHeader,
-        proofs: IngressProofsList,
-        block_tree_guard: BlockTreeReadGuard,
-    }
-
-    #[async_trait::async_trait]
-    impl BlockProdStrategy for EvilPublishStrategy {
-        fn inner(&self) -> &BlockProducerInner {
-            &self.prod.inner
-        }
-
-        async fn get_mempool_txs(
-            &self,
-            _prev_block_header: &IrysBlockHeader,
-            _block_timestamp: UnixTimestampMs,
-        ) -> Result<
-            irys_actors::block_producer::MempoolTxsBundle,
-            irys_actors::tx_selector::TxSelectorError,
-        > {
-            Ok(irys_actors::block_producer::MempoolTxsBundle {
-                commitment_txs: vec![],
-                commitment_txs_to_bill: vec![],
-                submit_txs: vec![],
-                one_year_txs: vec![],
-                thirty_day_txs: vec![],
-                publish_txs: PublishLedgerWithTxs {
-                    txs: vec![self.expired_tx.clone()],
-                    proofs: Some(self.proofs.clone()),
-                },
-                aggregated_miner_fees: LedgerExpiryBalanceDelta::default(),
-                commitment_refund_events: vec![],
-                unstake_refund_events: vec![],
-                epoch_snapshot: self.block_tree_guard.read().canonical_epoch_snapshot(),
-            })
-        }
-    }
-
     // --- 1. Config: Cascade OFF (activated mid-chain below), small partitions so
     //         a single sub-partition tx leaves slot 0 partial. ---
     let num_blocks_in_epoch = 2_u64;
@@ -305,7 +256,7 @@ async fn slow_heavy_promote_after_activation_straddle_rejected() -> eyre::Result
     )?;
 
     let evil_strategy = EvilPublishStrategy {
-        expired_tx: tx.header.clone(),
+        publish_tx: tx.header.clone(),
         proofs: IngressProofsList(vec![proof]),
         prod: ProductionStrategy {
             inner: node.node_ctx.block_producer_inner.clone(),
@@ -325,13 +276,9 @@ async fn slow_heavy_promote_after_activation_straddle_rejected() -> eyre::Result
         "evil block must promote the already-refunded tx"
     );
 
-    // The §4c rejection message carries the "NC-0042" marker — match on it so we
-    // reject for the right reason, not an unrelated shadow-tx error.
-    let is_nc_0042_expiry_rejection = |e: &ValidationError| match e {
-        ValidationError::ShadowTransactionInvalid(msg) => msg.contains("NC-0042"),
-        _ => false,
-    };
-
+    // The §4c rejection message carries the "NC-0042" marker — match on it (via the
+    // shared `is_nc_0042_expiry_rejection`) so we reject for the right reason, not an
+    // unrelated shadow-tx error.
     let outcome = send_block_and_read_state(&node.node_ctx, block.clone(), false).await?;
     assert_validation_error(
         outcome,

--- a/crates/chain-tests/src/validation/promote_after_activation_straddle.rs
+++ b/crates/chain-tests/src/validation/promote_after_activation_straddle.rs
@@ -173,6 +173,21 @@ async fn slow_heavy_promote_after_activation_straddle_rejected() -> eyre::Result
         .await?;
     let evil_height = evil_parent_block.height + 1;
     let parent_submit_total = evil_parent_block.ledger_total_chunks(DataLedger::Submit);
+    // Derive Cascade status from the parent tip's timestamp against the activation
+    // boundary (set to the pre-restart tip + 1s), as production does — don't hardcode
+    // it. Assert it holds so the oracle checks below genuinely run on the post-activation
+    // gate and can't silently pass on a pre-activation (transparent-gate) parent.
+    let cascade_active = node
+        .node_ctx
+        .config
+        .consensus
+        .hardforks
+        .is_cascade_active_at(evil_parent_block.timestamp_secs());
+    assert!(
+        cascade_active,
+        "evil block's parent tip must be cascade-active post-activation \
+         (activation anchored at the pre-restart tip + 1s)"
+    );
     let tip_snapshot = node
         .node_ctx
         .block_tree_guard
@@ -207,7 +222,7 @@ async fn slow_heavy_promote_after_activation_straddle_rejected() -> eyre::Result
     let inclusive_expired = tip_snapshot.get_all_expired_term_slot_indexes(
         DataLedger::Submit,
         evil_height,
-        true, // cascade active
+        cascade_active,
         parent_submit_total,
     );
     assert!(
@@ -225,7 +240,7 @@ async fn slow_heavy_promote_after_activation_straddle_rejected() -> eyre::Result
         &tip_snapshot,
         &evil_parent_block,
         &node.node_ctx.config,
-        true, // cascade active
+        cascade_active,
         &node.node_ctx.block_producer_inner.block_index,
         &node.node_ctx.block_tree_guard,
         &node.node_ctx.mempool_guard,
@@ -246,7 +261,21 @@ async fn slow_heavy_promote_after_activation_straddle_rejected() -> eyre::Result
     let target_data = tx.data.clone().expect(
         "posted tx payload must be retained to build the ingress proof (fixture invariant)",
     );
-    let chunks: Vec<Vec<u8>> = vec![target_data.into()];
+    // Split into chunk_size leaves so the ingress-proof root matches the real
+    // multi-chunk tx (data_size=96, chunk_size=32 -> 3 chunks). Passing the whole
+    // payload as one leaf would compute a root that never matches tx.data_root, so
+    // the block could be rejected for a bad proof instead of only the §4c rule.
+    let target_bytes: Vec<u8> = target_data.into();
+    let chunks: Vec<Vec<u8>> = target_bytes
+        .chunks(chunk_size as usize)
+        .map(<[u8]>::to_vec)
+        .collect();
+    assert_eq!(
+        chunks.len(),
+        3,
+        "fixture expects a 3-chunk (96B / 32B) payload, got {} chunks",
+        chunks.len()
+    );
     let proof = generate_ingress_proof(
         &genesis_signer,
         tx.header.data_root,

--- a/crates/chain-tests/src/validation/promote_after_activation_straddle.rs
+++ b/crates/chain-tests/src/validation/promote_after_activation_straddle.rs
@@ -1,0 +1,360 @@
+// NC-0042 Gap C (activation-straddle double-pay guard): a Submit slot that was
+// recycled + perm-fee-REFUNDED while only PARTIALLY written *pre-Cascade* must
+// stay in the inclusive non-promotability set after Cascade activates — otherwise
+// its already-refunded txs could be promoted again post-activation (refund +
+// permanent storage = double-pay).
+//
+// This is enforced by the `is_expired` short-circuit in
+// `TermLedger::get_all_expired_slot_indexes` (data_ledger.rs): an already-recycled
+// slot is included forever, independent of the post-Cascade fully-written gate.
+// Without that override a partial slot (write frontier still inside it) drops out
+// of the inclusive set the instant Cascade activates, because
+// `cascade_expiry_gate` requires `slot_index < fully_written_slots` and a partial
+// slot is not fully written.
+//
+// The one mid-chain E2E (`slow_heavy_cascade_midchain_submit_expiry_refunds_across_activation`)
+// fills all Submit slots, so the fully-written gate always passes and the override
+// never bites. This test constructs the state where it DOES bite: a partial,
+// non-last Submit slot 0 that expires + refunds pre-Cascade, then Cascade
+// activates. It proves both consequences of the override end-to-end:
+//   1. an evil block promoting the already-refunded tx is REJECTED post-activation
+//      with `ShadowTransactionInvalid` (NC-0042) — no double-pay;
+//   2. the chain stays LIVE past the expiry epoch — the expired set stays a
+//      contiguous prefix {0}, so `expired_submit_range`'s fail-loud bail never
+//      trips.
+//
+// Fixture (partial slot 0, so the fully-written gate would exclude it):
+//   - num_chunks_in_partition = 4; a single 3-chunk (96B) Submit tx never fills a
+//     partition, so the write frontier stays inside slot 0 (slot 0 is PARTIAL).
+//   - the 3-chunk tx crosses the capacity-growth threshold, so the epoch allocates
+//     +2 slots — slot 0 becomes NON-LAST (and therefore expiry-eligible) while
+//     still being partial. This is the exact combination the override guards.
+//   - the tx is never promoted (no chunks uploaded), so its slot expiry refunds
+//     its full perm_fee pre-Cascade.
+
+use crate::utils::{IrysNodeTest, assert_validation_error, solution_context};
+use crate::validation::send_block_and_read_state;
+use irys_actors::block_validation::ValidationError;
+use irys_actors::{
+    BlockProdStrategy, BlockProducerInner, ProductionStrategy, async_trait,
+    block_producer::ledger_expiry::LedgerExpiryBalanceDelta,
+    shadow_tx_generator::PublishLedgerWithTxs,
+};
+use irys_config::submodules::StorageSubmodulesConfig;
+use irys_domain::BlockTreeReadGuard;
+use irys_reth_node_bridge::irys_reth::shadow_tx::{ShadowTransaction, TransactionPacket};
+use irys_types::ingress::generate_ingress_proof;
+use irys_types::{
+    DataLedger, DataTransactionHeader, IngressProofsList, IrysBlockHeader, NodeConfig, U256,
+    UnixTimestamp, UnixTimestampMs, hardfork_config::Cascade,
+};
+use reth::rpc::types::TransactionTrait as _;
+
+#[test_log::test(tokio::test)]
+async fn slow_heavy_promote_after_activation_straddle_rejected() -> eyre::Result<()> {
+    /// Forces an already-expired+refunded Submit tx into the Publish ledger with a
+    /// valid ingress proof, so the block fails validation ONLY on the §4c expiry
+    /// rule. No refund is scheduled in the bundle, so the in-constructor guard does
+    /// not fire during production — the block is built and must be caught at
+    /// validation time.
+    struct EvilPublishStrategy {
+        prod: ProductionStrategy,
+        expired_tx: DataTransactionHeader,
+        proofs: IngressProofsList,
+        block_tree_guard: BlockTreeReadGuard,
+    }
+
+    #[async_trait::async_trait]
+    impl BlockProdStrategy for EvilPublishStrategy {
+        fn inner(&self) -> &BlockProducerInner {
+            &self.prod.inner
+        }
+
+        async fn get_mempool_txs(
+            &self,
+            _prev_block_header: &IrysBlockHeader,
+            _block_timestamp: UnixTimestampMs,
+        ) -> Result<
+            irys_actors::block_producer::MempoolTxsBundle,
+            irys_actors::tx_selector::TxSelectorError,
+        > {
+            Ok(irys_actors::block_producer::MempoolTxsBundle {
+                commitment_txs: vec![],
+                commitment_txs_to_bill: vec![],
+                submit_txs: vec![],
+                one_year_txs: vec![],
+                thirty_day_txs: vec![],
+                publish_txs: PublishLedgerWithTxs {
+                    txs: vec![self.expired_tx.clone()],
+                    proofs: Some(self.proofs.clone()),
+                },
+                aggregated_miner_fees: LedgerExpiryBalanceDelta::default(),
+                commitment_refund_events: vec![],
+                unstake_refund_events: vec![],
+                epoch_snapshot: self.block_tree_guard.read().canonical_epoch_snapshot(),
+            })
+        }
+    }
+
+    // --- 1. Config: Cascade OFF (activated mid-chain below), small partitions so
+    //         a single sub-partition tx leaves slot 0 partial. ---
+    let num_blocks_in_epoch = 2_u64;
+    let submit_ledger_epoch_length = 2_u64;
+    let one_year_epoch_length = 8_u64;
+    let thirty_day_epoch_length = 2_u64;
+    let chunk_size = 32_u64;
+    let num_chunks_in_partition = 4_u64;
+    // 3 chunks < 4-chunk partition -> the write frontier stays inside slot 0
+    // (slot 0 is PARTIAL) but still crosses the capacity-growth threshold so the
+    // epoch allocates a 2nd/3rd slot and slot 0 becomes non-last.
+    let data_size = 96_usize;
+
+    let mut config = NodeConfig::testing().with_consensus(|c| {
+        c.block_migration_depth = 1;
+        c.epoch.num_blocks_in_epoch = num_blocks_in_epoch;
+        c.epoch.submit_ledger_epoch_length = submit_ledger_epoch_length;
+        c.chunk_size = chunk_size;
+        c.num_chunks_in_partition = num_chunks_in_partition;
+        // One ingress proof from the (staked) genesis signer makes a tx promotable.
+        c.hardforks.frontier.number_of_ingress_proofs_total = 1;
+        // Cascade intentionally NOT configured yet — activated mid-chain below.
+    });
+
+    let user = config.new_random_signer();
+    let user_addr = user.address();
+    config.fund_genesis_accounts(vec![&user]);
+
+    let genesis_config = config.clone();
+    let test_node = IrysNodeTest::new_genesis(config);
+    StorageSubmodulesConfig::load_for_test(test_node.cfg.base_directory.clone(), 8)?;
+    let node = test_node.start_and_wait_for_packing("straddle", 30).await;
+
+    // --- 2. Pre-Cascade: include ONE unpromoted 3-chunk Submit tx (no chunks
+    //         uploaded -> never promoted -> refundable). Its 3 chunks stay inside
+    //         slot 0 (partial), and the capacity-growth threshold allocates extra
+    //         slots so slot 0 is non-last and can expire. ---
+    let anchor = node.get_block_by_height(0).await?.block_hash;
+    let tx = node
+        .post_data_tx(anchor, vec![7_u8; data_size], &user)
+        .await;
+    let tx_perm_fee = tx.header.perm_fee.expect("data tx must carry a perm_fee");
+    node.wait_for_mempool(tx.header.id, 20).await?;
+    node.mine_block().await?;
+
+    // --- 3. Mine (still pre-Cascade) until slot 0 expires and `tx` is perm-fee
+    //         refunded. Detected data-driven by scanning epoch blocks for a
+    //         PermFeeRefund to the user. A refund proves slot 0 became non-last and
+    //         aged out normally pre-Cascade. ---
+    let mut refund_amount = U256::from(0);
+    let mut refund_height = 0_u64;
+    const MAX_EPOCHS: usize = 12;
+    'mine: for _ in 0..MAX_EPOCHS {
+        let (_, height) = node.mine_until_next_epoch().await?;
+        let block = node.get_block_by_height(height).await?;
+        let evm_block = node.wait_for_evm_block(block.evm_block_hash, 20).await?;
+        for evm_tx in evm_block.body.transactions {
+            if evm_tx.input().len() < 4 {
+                continue;
+            }
+            let Ok(shadow_tx) = ShadowTransaction::decode(&mut evm_tx.input().as_ref()) else {
+                continue;
+            };
+            let Some(TransactionPacket::PermFeeRefund(refund)) = shadow_tx.as_v1() else {
+                continue;
+            };
+            if refund.target == user_addr.to_alloy_address() {
+                refund_amount = U256::from_le_bytes(refund.amount.to_le_bytes());
+                refund_height = height;
+                break 'mine;
+            }
+        }
+    }
+    assert!(
+        refund_height > 0,
+        "slot 0 must have expired + refunded pre-Cascade (no PermFeeRefund seen) — the \
+         fixture failed to produce the partial-pre-Cascade-refund state the override guards"
+    );
+    assert_eq!(
+        refund_amount, tx_perm_fee,
+        "an unpromoted tx whose partial Submit slot expired pre-Cascade must be refunded \
+         its full perm_fee"
+    );
+    // Bury the pre-Cascade expiry epoch below the restart durability floor. The
+    // restart drops the unmigrated chain tip, so the epoch block that set slot 0's
+    // is_expired must be a durable (migrated) block before we stop — otherwise the
+    // restart discards it and slot 0's pre-Cascade expiry is lost, re-mined instead
+    // as a cascade-active epoch (where the partial slot never expires). Still
+    // pre-Cascade (cascade=None), so the expiry stays allocation-anchored.
+    let durable_target = refund_height + 8;
+    while node.get_canonical_chain_height().await < durable_target {
+        node.mine_block().await?;
+    }
+    let pre_activation_height = node.get_canonical_chain_height().await;
+
+    // --- 4. Activate Cascade mid-chain: stop -> set activation = tip+1 -> restart.
+    //         Anchored to the tip timestamp (not wall-clock) so historical blocks
+    //         stay pre-activation and only newly-mined blocks are cascade-active
+    //         (deterministic; immune to a backward CLOCK_REALTIME lurch). ---
+    let tip_block = node.get_block_by_height(pre_activation_height).await?;
+    let activation_timestamp = tip_block.timestamp_secs().as_secs() + 1;
+    let mut stopped = node.stop().await;
+    stopped.cfg.consensus.get_mut().hardforks.cascade = Some(Cascade {
+        activation_timestamp: UnixTimestamp::from_secs(activation_timestamp),
+        one_year_epoch_length,
+        thirty_day_epoch_length,
+        annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
+    });
+    let node = stopped.start().await;
+
+    // Mine a couple cascade-active epochs so `activate_cascade` runs (OneYear /
+    // ThirtyDay ledgers come into existence) and the evil block's parent is
+    // cascade-active.
+    for _ in 0..(2 * num_blocks_in_epoch) {
+        node.mine_block().await?;
+    }
+
+    // --- 5. NON-VACUITY: confirm slot 0 is genuinely PARTIAL and NON-LAST
+    //         post-activation, and that the fully-written gate WOULD exclude it —
+    //         so the `is_expired` override is exactly what keeps it in the
+    //         inclusive non-promotability set. ---
+    let evil_parent_block = node
+        .get_block_by_height(node.get_canonical_chain_height().await)
+        .await?;
+    let evil_height = evil_parent_block.height + 1;
+    let parent_submit_total = evil_parent_block.ledger_total_chunks(DataLedger::Submit);
+    let tip_snapshot = node
+        .node_ctx
+        .block_tree_guard
+        .read()
+        .get_epoch_snapshot(&evil_parent_block.block_hash)
+        .expect("epoch snapshot for the current tip");
+
+    let (submit_slot_count, slot0_is_expired, slot0_has_been_written) = {
+        let slots = tip_snapshot.ledgers.get_slots(DataLedger::Submit);
+        (slots.len(), slots[0].is_expired, slots[0].has_been_written)
+    };
+    assert!(
+        submit_slot_count >= 2,
+        "slot 0 must be NON-LAST post-activation (got {submit_slot_count} Submit slots) — else \
+         the never-expire-the-last-slot rule, not the override, keeps the tx non-promotable"
+    );
+    // Partial <=> fully_written_slot_count(parent_total, chunks_per_slot) == 0
+    //         <=> parent_total < num_chunks_in_partition.
+    assert!(
+        parent_submit_total < num_chunks_in_partition,
+        "slot 0 must be PARTIAL post-activation (write frontier inside it): Submit total \
+         {parent_submit_total} must be < chunks_per_slot {num_chunks_in_partition}; otherwise \
+         the fully-written gate passes and the override is not what keeps the tx non-promotable"
+    );
+    assert!(
+        slot0_is_expired,
+        "slot 0 must carry is_expired from the pre-Cascade refund (the override keys on it)"
+    );
+    // The fully-written gate (has_been_written && slot_index < fully_written) is
+    // FALSE for slot 0 (fully_written == 0), so the inclusive set can only contain
+    // slot 0 via the is_expired override.
+    let inclusive_expired = tip_snapshot.get_all_expired_term_slot_indexes(
+        DataLedger::Submit,
+        evil_height,
+        true, // cascade active
+        parent_submit_total,
+    );
+    assert!(
+        inclusive_expired.contains(&0),
+        "the is_expired override must keep partial slot 0 in the inclusive non-promotability \
+         set post-activation (has_been_written={slot0_has_been_written}, fully_written=0, so the \
+         Cascade gate alone would exclude it); got {inclusive_expired:?}"
+    );
+
+    // Confirm the per-candidate (§4c) verdict marks our tx expired at the evil
+    // block's height under the Cascade gate — the exact predicate validation uses.
+    let per_candidate = irys_actors::block_producer::ledger_expiry::is_submit_storage_expired(
+        tx.header.id,
+        evil_height,
+        &tip_snapshot,
+        &evil_parent_block,
+        &node.node_ctx.config,
+        true, // cascade active
+        &node.node_ctx.block_producer_inner.block_index,
+        &node.node_ctx.block_tree_guard,
+        &node.node_ctx.mempool_guard,
+        &node.node_ctx.db,
+    )
+    .await?;
+    assert!(
+        per_candidate,
+        "the already-refunded tx must be non-promotable post-activation (per-candidate §4c \
+         verdict) — this is the double-pay the override prevents"
+    );
+    drop(tip_snapshot);
+
+    // --- 6. §4c: build an evil block at tip+1 that promotes the already-refunded
+    //         tx, with a valid ingress proof so it fails ONLY on the expiry rule. ---
+    let genesis_signer = genesis_config.signer();
+    let proof_anchor = node.get_anchor().await?;
+    let target_data = tx.data.clone().expect(
+        "posted tx payload must be retained to build the ingress proof (fixture invariant)",
+    );
+    let chunks: Vec<Vec<u8>> = vec![target_data.into()];
+    let proof = generate_ingress_proof(
+        &genesis_signer,
+        tx.header.data_root,
+        chunks.iter().map(|c| Ok(c.as_slice())),
+        genesis_config.consensus_config().chain_id,
+        proof_anchor,
+    )?;
+
+    let evil_strategy = EvilPublishStrategy {
+        expired_tx: tx.header.clone(),
+        proofs: IngressProofsList(vec![proof]),
+        prod: ProductionStrategy {
+            inner: node.node_ctx.block_producer_inner.clone(),
+        },
+        block_tree_guard: node.node_ctx.block_tree_guard.clone(),
+    };
+    let (block, _adj, _payload) = evil_strategy
+        .fully_produce_new_block_without_gossip(&solution_context(&node.node_ctx).await?)
+        .await?
+        .expect("evil block should be produced (the guard fires at validation, not production)");
+
+    assert_eq!(block.header().height, evil_height, "evil block at tip+1");
+    assert!(
+        block.header().data_ledgers[DataLedger::Publish]
+            .tx_ids
+            .contains(&tx.header.id),
+        "evil block must promote the already-refunded tx"
+    );
+
+    // The §4c rejection message carries the "NC-0042" marker — match on it so we
+    // reject for the right reason, not an unrelated shadow-tx error.
+    let is_nc_0042_expiry_rejection = |e: &ValidationError| match e {
+        ValidationError::ShadowTransactionInvalid(msg) => msg.contains("NC-0042"),
+        _ => false,
+    };
+
+    let outcome = send_block_and_read_state(&node.node_ctx, block.clone(), false).await?;
+    assert_validation_error(
+        outcome,
+        is_nc_0042_expiry_rejection,
+        "a block promoting a pre-Cascade-refunded straddle tx must be rejected post-activation \
+         (NC-0042 §4c — the is_expired override keeps partial slot 0 non-promotable)",
+    );
+    node.assert_evm_block_absent(block.header().evm_block_hash, 2)
+        .await?;
+
+    // --- 7. Liveness: honest epoch blocks keep being produced past the expiry
+    //         epoch. The override keeps the expired set a contiguous prefix {0}, so
+    //         `expired_submit_range`'s fail-loud bail never trips (which would halt
+    //         the chain). ---
+    let before = node.get_canonical_chain_height().await;
+    node.mine_until_next_epoch().await?;
+    node.mine_until_next_epoch().await?;
+    let after = node.get_canonical_chain_height().await;
+    assert!(
+        after > before,
+        "chain must progress past the activation-straddle expiry (before={before}, after={after})"
+    );
+
+    node.stop().await;
+    Ok(())
+}

--- a/crates/chain-tests/src/validation/promote_after_activation_straddle.rs
+++ b/crates/chain-tests/src/validation/promote_after_activation_straddle.rs
@@ -20,8 +20,8 @@
 //   1. an evil block promoting the already-refunded tx is REJECTED post-activation
 //      with `ShadowTransactionInvalid` (NC-0042) — no double-pay;
 //   2. the chain stays LIVE past the expiry epoch — the expired set stays a
-//      contiguous prefix {0}, so `expired_submit_range`'s fail-loud bail never
-//      trips.
+//      contiguous prefix {0, 1}, so `expired_submit_range`'s fail-loud bail
+//      never trips.
 //
 // Fixture (partial slot 0, so the fully-written gate would exclude it):
 //   - num_chunks_in_partition = 4; a single 3-chunk (96B) Submit tx never fills a
@@ -343,7 +343,7 @@ async fn slow_heavy_promote_after_activation_straddle_rejected() -> eyre::Result
         .await?;
 
     // --- 7. Liveness: honest epoch blocks keep being produced past the expiry
-    //         epoch. The override keeps the expired set a contiguous prefix {0}, so
+    //         epoch. The override keeps the expired set a contiguous prefix {0, 1}, so
     //         `expired_submit_range`'s fail-loud bail never trips (which would halt
     //         the chain). ---
     let before = node.get_canonical_chain_height().await;

--- a/crates/chain-tests/src/validation/promote_after_submit_expiry.rs
+++ b/crates/chain-tests/src/validation/promote_after_submit_expiry.rs
@@ -20,65 +20,16 @@
 // BlockTreeService. We drive the tx through the real Submit flow instead.
 
 use crate::utils::{assert_validation_error, solution_context};
-use crate::validation::{send_block_and_read_state, submit_expiry_two_node_setup};
-use irys_actors::block_validation::ValidationError;
-use irys_actors::{
-    BlockProdStrategy, BlockProducerInner, ProductionStrategy, async_trait,
-    block_producer::ledger_expiry::LedgerExpiryBalanceDelta,
-    shadow_tx_generator::PublishLedgerWithTxs,
+use crate::validation::{
+    EvilPublishStrategy, is_nc_0042_expiry_rejection, send_block_and_read_state,
+    submit_expiry_two_node_setup,
 };
-use irys_domain::BlockTreeReadGuard;
+use irys_actors::{BlockProdStrategy as _, ProductionStrategy};
 use irys_types::ingress::generate_ingress_proof;
-use irys_types::{
-    DataLedger, DataTransactionHeader, IngressProofsList, IrysBlockHeader, UnixTimestampMs,
-};
+use irys_types::{DataLedger, IngressProofsList};
 
 #[test_log::test(tokio::test)]
 async fn heavy_block_promoting_already_expired_submit_tx_gets_rejected() -> eyre::Result<()> {
-    /// Forces an already-expired Submit tx into the Publish ledger, with a valid
-    /// ingress proof so the block fails validation *only* on the §4c expiry rule
-    /// (not on a missing/invalid proof). No refund is scheduled in the bundle, so
-    /// the in-constructor defence-in-depth guard does not fire during production —
-    /// the block is built and must be caught at validation time.
-    struct EvilPublishStrategy {
-        prod: ProductionStrategy,
-        expired_tx: DataTransactionHeader,
-        proofs: IngressProofsList,
-        block_tree_guard: BlockTreeReadGuard,
-    }
-
-    #[async_trait::async_trait]
-    impl BlockProdStrategy for EvilPublishStrategy {
-        fn inner(&self) -> &BlockProducerInner {
-            &self.prod.inner
-        }
-
-        async fn get_mempool_txs(
-            &self,
-            _prev_block_header: &IrysBlockHeader,
-            _block_timestamp: UnixTimestampMs,
-        ) -> Result<
-            irys_actors::block_producer::MempoolTxsBundle,
-            irys_actors::tx_selector::TxSelectorError,
-        > {
-            Ok(irys_actors::block_producer::MempoolTxsBundle {
-                commitment_txs: vec![],
-                commitment_txs_to_bill: vec![],
-                submit_txs: vec![],
-                one_year_txs: vec![],
-                thirty_day_txs: vec![],
-                publish_txs: PublishLedgerWithTxs {
-                    txs: vec![self.expired_tx.clone()],
-                    proofs: Some(self.proofs.clone()),
-                },
-                aggregated_miner_fees: LedgerExpiryBalanceDelta::default(),
-                commitment_refund_events: vec![],
-                unstake_refund_events: vec![],
-                epoch_snapshot: self.block_tree_guard.read().canonical_epoch_snapshot(),
-            })
-        }
-    }
-
     // --- 1 + 2. Shared config + two-node startup + overflow data posting ---
     let setup = submit_expiry_two_node_setup(1).await?;
     let genesis_config = setup.genesis_config;
@@ -201,7 +152,7 @@ async fn heavy_block_promoting_already_expired_submit_tx_gets_rejected() -> eyre
 
     // --- 6. Evil producer builds a block at E+1 that promotes the expired tx ---
     let evil_strategy = EvilPublishStrategy {
-        expired_tx: expired_tx.clone(),
+        publish_tx: expired_tx.clone(),
         proofs: IngressProofsList(vec![proof]),
         prod: ProductionStrategy {
             inner: genesis_node.node_ctx.block_producer_inner.clone(),
@@ -221,13 +172,9 @@ async fn heavy_block_promoting_already_expired_submit_tx_gets_rejected() -> eyre
         "evil block must promote the expired tx"
     );
 
-    // The §4c rejection message includes "See NC-0042." — match on that to ensure
-    // the block is rejected for the right reason and not an unrelated shadow-tx error.
-    let is_nc_0042_expiry_rejection = |e: &ValidationError| match e {
-        ValidationError::ShadowTransactionInvalid(msg) => msg.contains("NC-0042"),
-        _ => false,
-    };
-
+    // The §4c rejection message includes "See NC-0042." — the shared
+    // `is_nc_0042_expiry_rejection` matches on that so we assert the block is
+    // rejected for the right reason and not an unrelated shadow-tx error.
     // --- 7. Both nodes must reject it with ShadowTransactionInvalid (§4c) ---
     let genesis_outcome =
         send_block_and_read_state(&genesis_node.node_ctx, block.clone(), false).await?;

--- a/crates/chain-tests/src/validation/slow_path_submit_expiry.rs
+++ b/crates/chain-tests/src/validation/slow_path_submit_expiry.rs
@@ -15,66 +15,17 @@
 // by-hash walk resolved the un-migrated inclusion to the correct offsets.
 
 use crate::utils::{assert_validation_error, solution_context};
-use crate::validation::{send_block_and_read_state, submit_expiry_two_node_setup};
-use irys_actors::block_validation::ValidationError;
-use irys_actors::{
-    BlockProdStrategy, BlockProducerInner, ProductionStrategy, async_trait,
-    block_producer::ledger_expiry::LedgerExpiryBalanceDelta,
-    shadow_tx_generator::PublishLedgerWithTxs,
+use crate::validation::{
+    EvilPublishStrategy, is_nc_0042_expiry_rejection, send_block_and_read_state,
+    submit_expiry_two_node_setup,
 };
+use irys_actors::{BlockProdStrategy as _, ProductionStrategy};
 use irys_database::{canonical_submit_height, db::IrysDatabaseExt as _};
-use irys_domain::BlockTreeReadGuard;
 use irys_types::ingress::generate_ingress_proof;
-use irys_types::{
-    DataLedger, DataTransactionHeader, IngressProofsList, IrysBlockHeader, UnixTimestampMs,
-};
+use irys_types::{DataLedger, IngressProofsList};
 
 #[test_log::test(tokio::test)]
 async fn heavy_submit_expiry_resolves_unmigrated_inclusion_via_slow_path() -> eyre::Result<()> {
-    /// Same evil producer as the §4c test: promotes an already-expired tx with a
-    /// valid ingress proof and schedules NO refund, so the block is built (the
-    /// in-constructor guard does not fire) and must be caught at validation by the
-    /// §4c rule — which here can only succeed if the SLOW path resolved the
-    /// un-migrated Submit inclusion correctly.
-    struct EvilPublishStrategy {
-        prod: ProductionStrategy,
-        expired_tx: DataTransactionHeader,
-        proofs: IngressProofsList,
-        block_tree_guard: BlockTreeReadGuard,
-    }
-
-    #[async_trait::async_trait]
-    impl BlockProdStrategy for EvilPublishStrategy {
-        fn inner(&self) -> &BlockProducerInner {
-            &self.prod.inner
-        }
-
-        async fn get_mempool_txs(
-            &self,
-            _prev_block_header: &IrysBlockHeader,
-            _block_timestamp: UnixTimestampMs,
-        ) -> Result<
-            irys_actors::block_producer::MempoolTxsBundle,
-            irys_actors::tx_selector::TxSelectorError,
-        > {
-            Ok(irys_actors::block_producer::MempoolTxsBundle {
-                commitment_txs: vec![],
-                commitment_txs_to_bill: vec![],
-                submit_txs: vec![],
-                one_year_txs: vec![],
-                thirty_day_txs: vec![],
-                publish_txs: PublishLedgerWithTxs {
-                    txs: vec![self.expired_tx.clone()],
-                    proofs: Some(self.proofs.clone()),
-                },
-                aggregated_miner_fees: LedgerExpiryBalanceDelta::default(),
-                commitment_refund_events: vec![],
-                unstake_refund_events: vec![],
-                epoch_snapshot: self.block_tree_guard.read().canonical_epoch_snapshot(),
-            })
-        }
-    }
-
     // --- 1 + 2. Shared setup, but with a LARGE block_migration_depth. The data
     //         block sits at height 1 and the slot expires at blocks_per_cycle (10),
     //         so a depth > (expiry_height - 1) keeps the inclusion un-migrated
@@ -176,7 +127,7 @@ async fn heavy_submit_expiry_resolves_unmigrated_inclusion_via_slow_path() -> ey
         proof_anchor,
     )?;
     let evil_strategy = EvilPublishStrategy {
-        expired_tx: expired_tx.clone(),
+        publish_tx: expired_tx.clone(),
         proofs: IngressProofsList(vec![proof]),
         prod: ProductionStrategy {
             inner: genesis_node.node_ctx.block_producer_inner.clone(),
@@ -196,11 +147,9 @@ async fn heavy_submit_expiry_resolves_unmigrated_inclusion_via_slow_path() -> ey
     );
 
     // --- 7. Both nodes must reject it (§4c) — only possible if the slow path
-    //         resolved the un-migrated inclusion to the correct offsets. ---
-    let is_nc_0042_expiry_rejection = |e: &ValidationError| match e {
-        ValidationError::ShadowTransactionInvalid(msg) => msg.contains("NC-0042"),
-        _ => false,
-    };
+    //         resolved the un-migrated inclusion to the correct offsets. The
+    //         shared `is_nc_0042_expiry_rejection` keys on the NC-0042 marker so
+    //         we reject for the expiry rule, not an unrelated shadow-tx error. ---
     let genesis_outcome =
         send_block_and_read_state(&genesis_node.node_ctx, block.clone(), false).await?;
     assert_validation_error(

--- a/crates/database/src/data_ledger.rs
+++ b/crates/database/src/data_ledger.rs
@@ -54,6 +54,11 @@ fn fully_written_slot_count(total_chunks: u64, chunks_per_slot: u64) -> u64 {
 /// written — the write frontier has moved past it (`slot_index < fully_written`),
 /// which also implies it has been written at all. Pre-Cascade the gate is
 /// transparent so replay stays bit-identical to the allocation-anchored behavior.
+///
+/// Per-branch recompute of this gate is sound only because expiry is committed at
+/// epoch blocks and no reorg can straddle a finalized epoch block; the config
+/// invariant `num_blocks_in_epoch > block_tree_depth` (see `Config::validate`)
+/// keeps at most one epoch transition unfinalized at a time.
 fn cascade_expiry_gate(
     cascade_active: bool,
     slot: &LedgerSlot,

--- a/crates/database/src/data_ledger.rs
+++ b/crates/database/src/data_ledger.rs
@@ -1804,8 +1804,8 @@ mod tests {
             // (a) both sets are strictly ascending & contiguous. The inclusive set
             // starts at 0 (already-expired slots always pass). The newly-expiring set
             // may start ABOVE 0 because get_expired_slot_indexes filters out
-            // is_expired slots (data_ledger.rs:180) — so instead assert every slot
-            // below its first entry is already expired (a contiguous expired prefix).
+            // is_expired slots — so instead assert every slot below its first
+            // entry is already expired (a contiguous expired prefix).
             for w in newly.windows(2) { prop_assert_eq!(w[1], w[0] + 1); }
             for w in inclusive.windows(2) { prop_assert_eq!(w[1], w[0] + 1); }
             if let Some(&first) = inclusive.first() { prop_assert_eq!(first, 0); }

--- a/crates/database/src/data_ledger.rs
+++ b/crates/database/src/data_ledger.rs
@@ -897,6 +897,7 @@ mod tests {
     use irys_types::{
         DataLedger, UnixTimestamp, config::consensus::ConsensusConfig, hardfork_config::Cascade,
     };
+    use proptest::prelude::*;
 
     fn config_with_cascade() -> ConsensusConfig {
         let mut config = ConsensusConfig::testing();
@@ -1749,5 +1750,89 @@ mod tests {
             slot.is_expired = true;
         }
         assert_eq!(ledgers.expiry_frontier_for(DataLedger::Submit), 3);
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(512))]
+
+        /// For any canonical (prefix-written, prefix-expired) term ledger state, the
+        /// newly-expiring set and the inclusive set must satisfy the invariants the
+        /// three consumers rely on. chunks_per_slot is fixed; total_chunks and the
+        /// written/expired/aged prefixes vary.
+        #[test]
+        fn expiry_sets_are_mutually_consistent(
+            num_slots in 2_usize..=8,
+            // frontier: how many chunks written, in [0, num_slots*CPS]
+            total_chunks in 0_u64..=80,
+            // how many leading slots are already is_expired (prefix), capped later
+            already_expired in 0_usize..=8,
+            // how many leading slots are aged at-or-below expiry_height (prefix)
+            aged_prefix in 0_usize..=8,
+        ) {
+            const CPS: u64 = 10;
+            let config = ConsensusConfig::testing();
+            // epoch_length=1, num_blocks_in_epoch from config; pick epoch_height well
+            // above min_blocks so the aging gate is satisfiable.
+            let epoch_length = 1_u64;
+            let mut ledger = TermLedger::new(DataLedger::Submit, &config, epoch_length);
+            let min_blocks = epoch_length * config.epoch.num_blocks_in_epoch;
+            let epoch_height = min_blocks + 1_000;
+            let expiry_height = epoch_height - min_blocks;
+
+            ledger.allocate_slots(num_slots as u64, epoch_height); // default: unaged, unwritten
+
+            let frontier = fully_written_slot_count(total_chunks, CPS) as usize;
+            let aged = aged_prefix.min(num_slots);
+            let exp = already_expired.min(num_slots);
+
+            for (i, slot) in ledger.slots.iter_mut().enumerate() {
+                // canonical: a slot is written iff it is at or below the write frontier
+                slot.has_been_written = i < frontier;
+                if i < aged {
+                    slot.last_height = expiry_height; // aged: last_height <= expiry_height
+                } else {
+                    slot.last_height = epoch_height;  // fresh
+                }
+                // is_expired is a prefix and only ever set on slots the expiry path
+                // could have expired (written + non-last); model it as a leading run.
+                slot.is_expired = i < exp && i < frontier && i != num_slots - 1;
+            }
+
+            let newly = ledger.get_expired_slot_indexes(epoch_height, true, total_chunks, CPS);
+            let inclusive = ledger.get_all_expired_slot_indexes(epoch_height, true, total_chunks, CPS);
+
+            // (a) both sets are strictly ascending & contiguous. The inclusive set
+            // starts at 0 (already-expired slots always pass). The newly-expiring set
+            // may start ABOVE 0 because get_expired_slot_indexes filters out
+            // is_expired slots (data_ledger.rs:180) — so instead assert every slot
+            // below its first entry is already expired (a contiguous expired prefix).
+            for w in newly.windows(2) { prop_assert_eq!(w[1], w[0] + 1); }
+            for w in inclusive.windows(2) { prop_assert_eq!(w[1], w[0] + 1); }
+            if let Some(&first) = inclusive.first() { prop_assert_eq!(first, 0); }
+            if let Some(&first) = newly.first() {
+                for i in 0..first {
+                    prop_assert!(ledger.slots[i].is_expired,
+                        "slot {i} below the first newly-expiring slot must already be expired");
+                }
+            }
+
+            // (b) newly-expiring is a subset of the inclusive (non-promotability) set
+            for idx in &newly { prop_assert!(inclusive.contains(idx)); }
+
+            // (c) post-Cascade no NEWLY expired slot may sit at or beyond the frontier,
+            //     and the last slot never newly expires
+            for &idx in &newly {
+                prop_assert!(idx < frontier, "newly-expired slot {idx} must be fully written (frontier={frontier})");
+                prop_assert_ne!(idx, num_slots - 1, "last slot must never newly expire");
+            }
+
+            // (d) the inclusive set exceeds `newly` only by already-`is_expired` slots
+            for &idx in &inclusive {
+                let is_newly = newly.contains(&idx);
+                let was_expired = ledger.slots[idx].is_expired;
+                prop_assert!(is_newly || was_expired,
+                    "inclusive slot {idx} is neither newly-expiring nor previously is_expired");
+            }
+        }
     }
 }

--- a/crates/database/src/data_ledger.rs
+++ b/crates/database/src/data_ledger.rs
@@ -1348,6 +1348,18 @@ mod tests {
     }
 
     #[test]
+    fn test_touch_filled_slots_noop_when_window_beyond_allocated_slots() {
+        // The write window STARTS past every allocated slot (allocation lagging
+        // ingress by more than a full slot, so even `first` is out of range):
+        // the touch must be a no-op — no panic, no slot marked written or
+        // refreshed.
+        let mut ledgers = ledgers_with_submit_slots(2, 1);
+        ledgers.touch_filled_slots(DataLedger::Submit, 30, 35, 10, 100, true);
+        assert_eq!(submit_last_heights(&ledgers), vec![1, 1]);
+        assert_eq!(submit_written_flags(&ledgers), vec![false, false]);
+    }
+
+    #[test]
     fn test_touch_filled_slots_refreshes_publish_perm_ledger() {
         // `touch_active_ledger_slots` iterates `active_ledgers()`, which INCLUDES
         // Publish. When `publish_ledger_epoch_length` makes perm slots expirable,

--- a/crates/database/src/data_ledger.rs
+++ b/crates/database/src/data_ledger.rs
@@ -557,19 +557,23 @@ impl Ledgers {
         expired_partitions
     }
 
-    /// Get all partition hashes that would expire at this epoch height (read-only).
-    /// Unlike `expire_partitions`, this does NOT mark slots as expired.
+    /// All slots that would expire at this epoch height (read-only), each with
+    /// its partition hashes — INCLUDING slots whose `partitions` vec is empty
+    /// (every replica unpledged before expiry and never backfilled). Fee
+    /// settlement keys on this slot-keyed view: a partition-less slot still
+    /// recycles and its unpromoted txs must still be refunded, but the
+    /// flattened per-partition view below is structurally blind to it.
     ///
     /// `total_chunks` / `chunks_per_slot`: see [`Self::expire_partitions`] — pass
     /// the same per-ledger totals so the two sets cannot diverge.
-    pub fn get_expiring_partitions(
+    pub fn get_expiring_slots(
         &self,
         epoch_height: u64,
         cascade_active: bool,
         total_chunks: impl Fn(DataLedger) -> u64,
         chunks_per_slot: u64,
-    ) -> Vec<ExpiringPartitionInfo> {
-        let mut expired_partitions: Vec<ExpiringPartitionInfo> = Vec::new();
+    ) -> Vec<(DataLedger, usize, Vec<PartitionHash>)> {
+        let mut expiring_slots = Vec::new();
 
         // Check perm ledger slots using shared helper
         for (slot_index, partition_hashes, ledger_id) in self.get_perm_expiring_slots(
@@ -578,16 +582,10 @@ impl Ledgers {
             total_chunks(DataLedger::Publish),
             chunks_per_slot,
         ) {
-            for partition_hash in partition_hashes {
-                expired_partitions.push(ExpiringPartitionInfo {
-                    partition_hash,
-                    ledger_id,
-                    slot_index,
-                });
-            }
+            expiring_slots.push((ledger_id, slot_index, partition_hashes));
         }
 
-        // Collect from term ledgers (existing logic)
+        // Collect from term ledgers
         for term_ledger in &self.term {
             let ledger_id = DataLedger::try_from(term_ledger.ledger_id)
                 .expect("term ledger_id is always constructed from a valid DataLedger variant");
@@ -597,17 +595,42 @@ impl Ledgers {
                 total_chunks(ledger_id),
                 chunks_per_slot,
             ) {
-                for partition_hash in term_ledger.slots[expiring_slot_index].partitions.iter() {
-                    expired_partitions.push(ExpiringPartitionInfo {
-                        partition_hash: *partition_hash,
-                        ledger_id,
-                        slot_index: expiring_slot_index,
-                    });
-                }
+                expiring_slots.push((
+                    ledger_id,
+                    expiring_slot_index,
+                    term_ledger.slots[expiring_slot_index].partitions.clone(),
+                ));
             }
         }
 
-        expired_partitions
+        expiring_slots
+    }
+
+    /// Get all partition hashes that would expire at this epoch height (read-only).
+    /// Unlike `expire_partitions`, this does NOT mark slots as expired.
+    ///
+    /// Flattened per-partition view of [`Self::get_expiring_slots`] (a slot with
+    /// no partitions contributes nothing here — settlement must use the
+    /// slot-keyed view).
+    pub fn get_expiring_partitions(
+        &self,
+        epoch_height: u64,
+        cascade_active: bool,
+        total_chunks: impl Fn(DataLedger) -> u64,
+        chunks_per_slot: u64,
+    ) -> Vec<ExpiringPartitionInfo> {
+        self.get_expiring_slots(epoch_height, cascade_active, total_chunks, chunks_per_slot)
+            .into_iter()
+            .flat_map(|(ledger_id, slot_index, partition_hashes)| {
+                partition_hashes
+                    .into_iter()
+                    .map(move |partition_hash| ExpiringPartitionInfo {
+                        partition_hash,
+                        ledger_id,
+                        slot_index,
+                    })
+            })
+            .collect()
     }
 
     /// Slot indexes of the given term `ledger` whose storage has expired as of

--- a/crates/database/src/data_ledger.rs
+++ b/crates/database/src/data_ledger.rs
@@ -606,33 +606,6 @@ impl Ledgers {
         expiring_slots
     }
 
-    /// Get all partition hashes that would expire at this epoch height (read-only).
-    /// Unlike `expire_partitions`, this does NOT mark slots as expired.
-    ///
-    /// Flattened per-partition view of [`Self::get_expiring_slots`] (a slot with
-    /// no partitions contributes nothing here — settlement must use the
-    /// slot-keyed view).
-    pub fn get_expiring_partitions(
-        &self,
-        epoch_height: u64,
-        cascade_active: bool,
-        total_chunks: impl Fn(DataLedger) -> u64,
-        chunks_per_slot: u64,
-    ) -> Vec<ExpiringPartitionInfo> {
-        self.get_expiring_slots(epoch_height, cascade_active, total_chunks, chunks_per_slot)
-            .into_iter()
-            .flat_map(|(ledger_id, slot_index, partition_hashes)| {
-                partition_hashes
-                    .into_iter()
-                    .map(move |partition_hash| ExpiringPartitionInfo {
-                        partition_hash,
-                        ledger_id,
-                        slot_index,
-                    })
-            })
-            .collect()
-    }
-
     /// Slot indexes of the given term `ledger` whose storage has expired as of
     /// `epoch_height`, inclusive of already-expired slots. Used by the NC-0042
     /// publish-candidate filter (producer) and validator check, which must treat
@@ -1206,10 +1179,11 @@ mod tests {
         ledgers.perm.slots[1].has_been_written = true;
 
         // Read-only: should report slot 0 as expiring without marking it
-        let expiring = ledgers.get_expiring_partitions(30, true, |_| 20, 10);
+        let expiring = ledgers.get_expiring_slots(30, true, |_| 20, 10);
         let perm_expiring: Vec<_> = expiring
             .iter()
-            .filter(|e| e.ledger_id == DataLedger::Publish)
+            .filter(|(ledger_id, _, _)| *ledger_id == DataLedger::Publish)
+            .flat_map(|(_, _, partition_hashes)| partition_hashes)
             .collect();
         assert_eq!(perm_expiring.len(), 1);
         // Verify NOT marked as expired (read-only)
@@ -1241,8 +1215,12 @@ mod tests {
         ledgers.perm.allocate_slots(1, 1);
         ledgers.perm.slots[0].partitions.push(H256::random());
 
-        let expiring = ledgers.get_expiring_partitions(1000, true, |_| 10, 10);
-        assert!(expiring.iter().all(|e| e.ledger_id != DataLedger::Publish));
+        let expiring = ledgers.get_expiring_slots(1000, true, |_| 10, 10);
+        assert!(
+            expiring
+                .iter()
+                .all(|(ledger_id, _, _)| *ledger_id != DataLedger::Publish)
+        );
     }
 
     /// Allocate `count` Submit slots, all stamped with `last_height = alloc_height`.
@@ -1830,6 +1808,8 @@ mod tests {
                 }
                 // is_expired is a prefix and only ever set on slots the expiry path
                 // could have expired (written + non-last); model it as a leading run.
+                // (Excludes the pre-Cascade legacy state — is_expired on an unwritten
+                // slot — which the runtime is_expired short-circuit still handles.)
                 slot.is_expired = i < exp && i < frontier && i != num_slots - 1;
             }
 

--- a/crates/database/src/data_ledger.rs
+++ b/crates/database/src/data_ledger.rs
@@ -1062,6 +1062,116 @@ mod tests {
     }
 
     #[test]
+    fn perm_partial_frontier_slot_does_not_expire_post_cascade() {
+        // 3 perm slots: slot 0 full, slot 1 the partially-written frontier, slot 2
+        // empty headroom (last). With Publish total_chunks=15 and chunks_per_slot=10,
+        // fully_written_slots = 1, so only slot 0 (index 0 < 1) may expire. Slot 1 is
+        // the write frontier — aged and written, not the last slot — yet must survive
+        // because it is not fully written. This is the perm-ledger analogue of the
+        // Submit frontier protection.
+        let config = make_test_config(Some(2)); // publish expiry enabled; min_blocks = 2*10 = 20
+        let mut ledgers = Ledgers::new(&config, false);
+        ledgers.perm.allocate_slots(3, 1); // slots 0,1,2 all allocated at height 1
+        for i in 0..2 {
+            ledgers.perm.slots[i].partitions.push(H256::random());
+            ledgers.perm.slots[i].has_been_written = true;
+            ledgers.perm.slots[i].last_height = 1; // aged well below expiry_height
+        }
+        // slot 2 stays unwritten headroom (the last slot)
+
+        // epoch_height = 100 -> expiry_height = 100 - 20 = 80; slots 0 and 1 are aged.
+        // Publish total = 15 (frontier inside slot 1); a term ledger reports 100 so a
+        // ledger-swap bug that read the wrong total would make the gate permissive.
+        let expired = ledgers.expire_partitions(
+            100,
+            true,
+            |l| if l == DataLedger::Publish { 15 } else { 100 },
+            10,
+        );
+        let perm_expired: Vec<_> = expired
+            .iter()
+            .filter(|e| e.ledger_id == DataLedger::Publish)
+            .map(|e| e.slot_index)
+            .collect();
+        assert_eq!(
+            perm_expired,
+            vec![0],
+            "only the fully-written slot 0 may expire"
+        );
+        assert!(ledgers.perm.slots[0].is_expired);
+        assert!(
+            !ledgers.perm.slots[1].is_expired,
+            "partial frontier perm slot must survive"
+        );
+        assert!(!ledgers.perm.slots[2].is_expired);
+    }
+
+    #[test]
+    fn perm_frontier_slot_expires_once_fully_written_post_cascade() {
+        // Same layout, but now the frontier has moved past slot 1 (Publish total=20 ->
+        // fully_written_slots=2). Slot 1 (index 1 < 2) is now fully written and aged,
+        // and slot 2 is the protected last slot, so slot 1 becomes eligible.
+        let config = make_test_config(Some(2));
+        let mut ledgers = Ledgers::new(&config, false);
+        ledgers.perm.allocate_slots(3, 1);
+        for i in 0..2 {
+            ledgers.perm.slots[i].partitions.push(H256::random());
+            ledgers.perm.slots[i].has_been_written = true;
+            ledgers.perm.slots[i].last_height = 1;
+        }
+        let expired = ledgers.expire_partitions(
+            100,
+            true,
+            |l| if l == DataLedger::Publish { 20 } else { 100 },
+            10,
+        );
+        let mut perm_expired: Vec<_> = expired
+            .iter()
+            .filter(|e| e.ledger_id == DataLedger::Publish)
+            .map(|e| e.slot_index)
+            .collect();
+        perm_expired.sort_unstable();
+        assert_eq!(
+            perm_expired,
+            vec![0, 1],
+            "both fully-written non-last slots expire"
+        );
+    }
+
+    #[test]
+    fn perm_partial_frontier_pre_cascade_replay_identity() {
+        // Pre-Cascade (cascade_active=false) the gate is transparent: the partial
+        // frontier slot still ages out by last_height, preserving replay identity with
+        // the allocation-anchored behavior. Locks that Task-2's post-Cascade change did
+        // not alter pre-Cascade expiry.
+        let config = make_test_config(Some(2));
+        let mut ledgers = Ledgers::new(&config, false);
+        ledgers.perm.allocate_slots(3, 1);
+        for i in 0..2 {
+            ledgers.perm.slots[i].partitions.push(H256::random());
+            ledgers.perm.slots[i].has_been_written = true;
+            ledgers.perm.slots[i].last_height = 1;
+        }
+        let expired = ledgers.expire_partitions(
+            100,
+            false, // pre-Cascade
+            |l| if l == DataLedger::Publish { 15 } else { 100 },
+            10,
+        );
+        let mut perm_expired: Vec<_> = expired
+            .iter()
+            .filter(|e| e.ledger_id == DataLedger::Publish)
+            .map(|e| e.slot_index)
+            .collect();
+        perm_expired.sort_unstable();
+        assert_eq!(
+            perm_expired,
+            vec![0, 1],
+            "pre-Cascade: aged non-last slots expire regardless of fill"
+        );
+    }
+
+    #[test]
     fn test_get_expiring_partitions_includes_perm() {
         let config = make_test_config(Some(2));
         let mut ledgers = Ledgers::new(&config, false);

--- a/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
+++ b/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
@@ -1340,6 +1340,9 @@ impl EpochSnapshot {
     /// the new epoch block. When false, the window exclusion is skipped and the
     /// result reproduces the original (pre-Cascade) master set, so pre-activation
     /// history replays bit-identically.
+    ///
+    /// Flattened (per-partition) diagnostic/test view; the settlement path uses
+    /// the slot-keyed `get_expiring_slot_partitions` instead.
     pub fn get_expiring_partition_info(
         &self,
         epoch_height: u64,

--- a/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
+++ b/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
@@ -1347,6 +1347,36 @@ impl EpochSnapshot {
         new_total_chunks: u64,
         cascade_active: bool,
     ) -> Vec<ExpiringPartitionInfo> {
+        // Flattened per-partition view of the slot-keyed set, so the two can
+        // never diverge. A slot with no partitions contributes nothing here.
+        self.get_expiring_slot_partitions(epoch_height, ledger, new_total_chunks, cascade_active)
+            .into_iter()
+            .flat_map(|(slot_index, partition_hashes)| {
+                partition_hashes
+                    .into_iter()
+                    .map(move |partition_hash| ExpiringPartitionInfo {
+                        partition_hash,
+                        ledger_id: ledger,
+                        slot_index,
+                    })
+            })
+            .collect()
+    }
+
+    /// Slot-keyed sibling of [`Self::get_expiring_partition_info`] (same
+    /// write-window rescue exclusion): the slots of `ledger` that will actually
+    /// recycle at `epoch_height`, each with its partition hashes — INCLUDING
+    /// slots whose `partitions` vec is empty (every replica unpledged before
+    /// expiry, never backfilled). Fee settlement keys on this so a
+    /// partition-less expired slot still refunds its unpromoted txs; the
+    /// flattened per-partition view is structurally blind to such slots.
+    pub fn get_expiring_slot_partitions(
+        &self,
+        epoch_height: u64,
+        ledger: DataLedger,
+        new_total_chunks: u64,
+        cascade_active: bool,
+    ) -> Vec<(usize, Vec<PartitionHash>)> {
         let chunks_per_slot = self.config.consensus.num_chunks_in_partition;
         let prev_total_chunks = self.epoch_block.ledger_total_chunks(ledger);
 
@@ -1371,7 +1401,7 @@ impl EpochSnapshot {
         };
 
         self.ledgers
-            .get_expiring_partitions(
+            .get_expiring_slots(
                 epoch_height,
                 cascade_active,
                 // LOCKSTEP with `expire_ledger_slots`: the target ledger uses the
@@ -1389,7 +1419,10 @@ impl EpochSnapshot {
                 chunks_per_slot,
             )
             .into_iter()
-            .filter(|info| info.ledger_id == ledger && !written_this_epoch(info.slot_index))
+            .filter(|(ledger_id, slot_index, _)| {
+                *ledger_id == ledger && !written_this_epoch(*slot_index)
+            })
+            .map(|(_, slot_index, partition_hashes)| (slot_index, partition_hashes))
             .collect()
     }
 

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -1535,6 +1535,25 @@ mod tests {
             err.contains("straddle"),
             "expected the reorg-window guard, got: {err}"
         );
+
+        // Boundary: EQUAL must also be rejected — the guard is strict `>`, since an
+        // epoch exactly as long as the reorg window still leaves the transition
+        // unfinalized. Guards against a future weakening of `>` to `>=`.
+        let mut equal_config = NodeConfig::testing().with_run_mode(RunMode::Production);
+        {
+            let c = equal_config.consensus.get_mut();
+            c.epoch.num_blocks_in_epoch = 50;
+            c.block_tree_depth = 50; // 50 == 50 must still be rejected (strict >)
+            c.epoch.submit_ledger_epoch_length = 6; // 6*50=300 > 50 so NC-0042 passes first
+        }
+        let equal_err = Config::new_with_random_peer_id(equal_config)
+            .validate()
+            .expect_err("epoch equal to block_tree_depth must be rejected in production")
+            .to_string();
+        assert!(
+            equal_err.contains("straddle"),
+            "expected the reorg-window guard for the equality case, got: {equal_err}"
+        );
     }
 
     #[test]

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -451,6 +451,21 @@ impl Config {
                 );
             }
 
+            // Real networks only (test fixtures deliberately use tiny epochs).
+            // Expiry and settlement are committed at epoch blocks. An epoch block is
+            // irreversible only once it falls block_tree_depth behind the head and is
+            // pruned from the tree (finalized_height in forkchoice_markers). Requiring
+            // the epoch to span more blocks than the reorg window keeps at most one
+            // epoch transition unfinalized at a time, so no admissible reorg can
+            // straddle a settled expiry and the per-branch expiry recompute only ever
+            // spans a single epoch.
+            ensure!(
+                self.consensus.epoch.num_blocks_in_epoch > self.consensus.block_tree_depth,
+                "num_blocks_in_epoch ({}) must be > block_tree_depth ({}) so no reorg can straddle a finalized epoch-block expiry",
+                self.consensus.epoch.num_blocks_in_epoch,
+                self.consensus.block_tree_depth,
+            );
+
             // Tx anchors must resolve INSIDE the reorg window so prevalidation's
             // inclusion/anchor walks can confirm them branch-correctly by-hash. A
             // tx anchored older than the tree would fall to the by-height index/MBH
@@ -1494,6 +1509,46 @@ mod tests {
             err.contains("overflows u64"),
             "expected the slot-lifetime overflow guard, got: {err}"
         );
+    }
+
+    #[test]
+    fn validate_rejects_epoch_shorter_than_reorg_window() {
+        // Expiry+settlement is committed at epoch blocks; a finalized epoch block is
+        // irreversible only because it falls block_tree_depth behind head (see
+        // forkchoice_markers::finalized_height). If an epoch spans fewer blocks than
+        // the reorg window, more than one epoch transition can be unfinalized at once
+        // and a single reorg could straddle a settled expiry. Production-only invariant.
+        let mut node_config = NodeConfig::testing().with_run_mode(RunMode::Production);
+        {
+            let c = node_config.consensus.get_mut();
+            c.epoch.num_blocks_in_epoch = 10;
+            c.block_tree_depth = 50; // 10 <= 50 must be rejected
+            c.epoch.submit_ledger_epoch_length = 6; // 6*10=60 > 50 so the NC-0042 slot-lifetime guard passes first
+        }
+        let err = Config::new_with_random_peer_id(node_config)
+            .validate()
+            .expect_err("epoch shorter than block_tree_depth must be rejected in production")
+            .to_string();
+        // Assert on a substring UNIQUE to this guard: the NC-0042 message also contains
+        // "num_blocks_in_epoch", so keying on that would false-pass without the guard.
+        assert!(
+            err.contains("straddle"),
+            "expected the reorg-window guard, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_epoch_longer_than_reorg_window() {
+        let mut node_config = NodeConfig::testing().with_run_mode(RunMode::Production);
+        {
+            let c = node_config.consensus.get_mut();
+            c.epoch.num_blocks_in_epoch = 100; // 100 > 50 is fine
+            c.block_tree_depth = 50;
+            c.epoch.submit_ledger_epoch_length = 6; // 6*100 > 50, NC-0042 also satisfied
+        }
+        Config::new_with_random_peer_id(node_config)
+            .validate()
+            .expect("epoch longer than block_tree_depth must validate in production");
     }
 
     #[test]

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -452,13 +452,13 @@ impl Config {
             }
 
             // Real networks only (test fixtures deliberately use tiny epochs).
-            // Expiry and settlement are committed at epoch blocks. An epoch block is
-            // irreversible only once it falls block_tree_depth behind the head and is
-            // pruned from the tree (finalized_height in forkchoice_markers). Requiring
-            // the epoch to span more blocks than the reorg window keeps at most one
-            // epoch transition unfinalized at a time, so no admissible reorg can
-            // straddle a settled expiry and the per-branch expiry recompute only ever
-            // spans a single epoch.
+            // Expiry/settlement is committed at epoch blocks. The reorg-mutable
+            // window is exactly block_tree_depth heights (finalized_height =
+            // head - block_tree_depth in forkchoice_markers). Epoch boundaries are
+            // num_blocks_in_epoch apart, so num_blocks_in_epoch >= block_tree_depth
+            // already leaves at most one boundary reorg-mutable — no reorg can
+            // straddle a settled expiry. `>=` is the exact bound; the strict `>`
+            // below keeps one extra block of margin.
             ensure!(
                 self.consensus.epoch.num_blocks_in_epoch > self.consensus.block_tree_depth,
                 "num_blocks_in_epoch ({}) must be > block_tree_depth ({}) so no reorg can straddle a finalized epoch-block expiry",
@@ -1536,9 +1536,10 @@ mod tests {
             "expected the reorg-window guard, got: {err}"
         );
 
-        // Boundary: EQUAL must also be rejected — the guard is strict `>`, since an
-        // epoch exactly as long as the reorg window still leaves the transition
-        // unfinalized. Guards against a future weakening of `>` to `>=`.
+        // Boundary: EQUAL must also be rejected — the guard is strict `>`. At
+        // num_blocks_in_epoch == block_tree_depth at most one epoch transition is
+        // reorg-mutable (so `>=` would already be safe); the strict `>` keeps one
+        // block of margin, and this pins that we don't weaken it without intent.
         let mut equal_config = NodeConfig::testing().with_run_mode(RunMode::Production);
         {
             let c = equal_config.consensus.get_mut();

--- a/docker/agent_cluster/configs/irys-1.toml
+++ b/docker/agent_cluster/configs/irys-1.toml
@@ -93,7 +93,7 @@ annual_cost_per_gb = 0.01
 decay_rate = 0.01
 chunk_size = 262144
 block_migration_depth = 6
-block_tree_depth = 50
+block_tree_depth = 20
 num_chunks_in_partition = 100
 num_chunks_in_recall_range = 10
 num_partitions_per_slot = 1
@@ -166,7 +166,7 @@ half_life_secs = 126144000
 
 [consensus.Custom.epoch]
 capacity_scalar = 200
-num_blocks_in_epoch = 4
+num_blocks_in_epoch = 21
 submit_ledger_epoch_length = 200
 num_capacity_partitions = 30
 

--- a/docker/agent_cluster/configs/irys-2.toml
+++ b/docker/agent_cluster/configs/irys-2.toml
@@ -94,7 +94,7 @@ annual_cost_per_gb = 0.01
 decay_rate = 0.01
 chunk_size = 262144
 block_migration_depth = 6
-block_tree_depth = 50
+block_tree_depth = 20
 num_chunks_in_partition = 100
 num_chunks_in_recall_range = 10
 num_partitions_per_slot = 1
@@ -167,7 +167,7 @@ half_life_secs = 126144000
 
 [consensus.Custom.epoch]
 capacity_scalar = 200
-num_blocks_in_epoch = 4
+num_blocks_in_epoch = 21
 submit_ledger_epoch_length = 200
 num_capacity_partitions = 30
 

--- a/docker/agent_cluster/configs/irys-3.toml
+++ b/docker/agent_cluster/configs/irys-3.toml
@@ -94,7 +94,7 @@ annual_cost_per_gb = 0.01
 decay_rate = 0.01
 chunk_size = 262144
 block_migration_depth = 6
-block_tree_depth = 50
+block_tree_depth = 20
 num_chunks_in_partition = 100
 num_chunks_in_recall_range = 10
 num_partitions_per_slot = 1
@@ -167,7 +167,7 @@ half_life_secs = 126144000
 
 [consensus.Custom.epoch]
 capacity_scalar = 200
-num_blocks_in_epoch = 4
+num_blocks_in_epoch = 21
 submit_ledger_epoch_length = 200
 num_capacity_partitions = 30
 

--- a/docker/tests/data-sync/configs/irys-1.toml
+++ b/docker/tests/data-sync/configs/irys-1.toml
@@ -97,7 +97,7 @@ annual_cost_per_gb = 0.01
 decay_rate = 0.01
 chunk_size = 262144
 block_migration_depth = 6
-block_tree_depth = 50
+block_tree_depth = 20
 num_chunks_in_partition = 60
 num_chunks_in_recall_range = 10
 num_partitions_per_slot = 3
@@ -175,7 +175,7 @@ half_life_secs = 126144000
 
 [consensus.Custom.epoch]
 capacity_scalar = 200
-num_blocks_in_epoch = 4
+num_blocks_in_epoch = 21
 submit_ledger_epoch_length = 200
 num_capacity_partitions = 30
 

--- a/docker/tests/data-sync/configs/irys-2.toml
+++ b/docker/tests/data-sync/configs/irys-2.toml
@@ -98,7 +98,7 @@ annual_cost_per_gb = 0.01
 decay_rate = 0.01
 chunk_size = 262144
 block_migration_depth = 6
-block_tree_depth = 50
+block_tree_depth = 20
 num_chunks_in_partition = 60
 num_chunks_in_recall_range = 10
 num_partitions_per_slot = 3
@@ -176,7 +176,7 @@ half_life_secs = 126144000
 
 [consensus.Custom.epoch]
 capacity_scalar = 200
-num_blocks_in_epoch = 4
+num_blocks_in_epoch = 21
 submit_ledger_epoch_length = 200
 num_capacity_partitions = 30
 

--- a/docker/tests/data-sync/configs/irys-3.toml
+++ b/docker/tests/data-sync/configs/irys-3.toml
@@ -98,7 +98,7 @@ annual_cost_per_gb = 0.01
 decay_rate = 0.01
 chunk_size = 262144
 block_migration_depth = 6
-block_tree_depth = 50
+block_tree_depth = 20
 num_chunks_in_partition = 60
 num_chunks_in_recall_range = 10
 num_partitions_per_slot = 3
@@ -176,7 +176,7 @@ half_life_secs = 126144000
 
 [consensus.Custom.epoch]
 capacity_scalar = 200
-num_blocks_in_epoch = 4
+num_blocks_in_epoch = 21
 submit_ledger_epoch_length = 200
 num_capacity_partitions = 30
 


### PR DESCRIPTION
This PR adds and refines expiry test cases to hopefully prevent any further bugs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cascade expiry/recycling to correctly handle partial-frontier, mid-epoch promotability, and activation-straddle edge cases.
  * Fixed expired-slot fee distribution: unpromoted tx perm-fee refunds remain correct, while miner/term-fee rewards are suppressed when there are no miners/replicas (including minerless and unpledged cases).
  * Tightened blocked/expired-set and multi-replica accounting so refunds/rewards are emitted exactly once per expected slot/replica.
* **Validation**
  * Added a production-only consensus invariant to prevent finalized-epoch expiry reorg straddling (`num_blocks_in_epoch > block_tree_depth`).
* **Tests**
  * Added/expanded end-to-end and property-based coverage for NC-0042 rejection, Cascade permanent frontier recycling, mid-epoch boundary behavior, multi-replica expiry, and minerless refund behavior.
* **Chores**
  * Updated cluster/test consensus timing parameters to the new epoch/tree-depth values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->