### PR TITLE
feat(release): enforce branch-tip commit + toggleable CI gate target

### DIFF
--- a/.github/actions/verify-commit-provenance/action.yaml
+++ b/.github/actions/verify-commit-provenance/action.yaml
@@ -29,6 +29,16 @@ inputs:
       'false' when minting a new release tag.
     required: false
     default: "false"
+  allow-non-tip:
+    description: >-
+      If 'true', permit a commit that is behind the tip of the deployment branch
+      (emit a warning instead of failing). Default 'true' preserves the ad-hoc
+      build behavior of the devnet/docker callers, which legitimately target
+      arbitrary commits on the branch. The release workflow passes 'false' so a
+      stale/non-tip SHA — which would silently drop the later commits on the
+      branch — is rejected unless an operator explicitly opts in.
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -40,6 +50,7 @@ runs:
         COMMIT: ${{ inputs.commit }}
         VERSION: ${{ inputs.version }}
         REQUIRE_RELEASE_TAG: ${{ inputs.require-release-tag }}
+        ALLOW_NON_TIP: ${{ inputs.allow-non-tip }}
       run: |
         if ! git cat-file -e "${COMMIT}^{commit}" 2>/dev/null; then
           echo "::error::Commit ${COMMIT} does not exist"
@@ -89,6 +100,24 @@ runs:
             exit 1
           fi
           echo "Commit ${COMMIT} found on $EXPECTED_BRANCH"
+
+          # Releasing a commit that is not the tip of the deployment branch silently
+          # drops the later commits on that branch (see the 4.0.2 revertme case).
+          # By default this is a hard error; allow-non-tip=true downgrades it to a
+          # warning for the deliberate "cut from behind HEAD" case. This is a
+          # provenance guarantee, independent of the release workflow's force/dry_run
+          # gates — so a non-tip release must opt in explicitly, even under force.
+          BRANCH_HEAD=$(git rev-parse "refs/remotes/$EXPECTED_BRANCH")
+          COMMIT_FULL=$(git rev-parse "${COMMIT}^{commit}")
+          if [ "$COMMIT_FULL" != "$BRANCH_HEAD" ]; then
+            BEHIND=$(git rev-list --count "${COMMIT}..refs/remotes/$EXPECTED_BRANCH")
+            if [ "$ALLOW_NON_TIP" = "true" ]; then
+              echo "::warning::Commit ${COMMIT} is not the tip of $EXPECTED_BRANCH (HEAD is ${BRANCH_HEAD}); ${BEHIND} later commit(s) on the branch will NOT be included in this release. Proceeding because allow-non-tip is set."
+            else
+              echo "::error::Commit ${COMMIT} is not the tip of $EXPECTED_BRANCH (HEAD is ${BRANCH_HEAD}); ${BEHIND} commit(s) on the branch after it would NOT be included. Re-dispatch from the branch tip, or set the workflow's non-tip toggle if excluding them is intentional."
+              exit 1
+            fi
+          fi
         fi
 
         if [[ "$ENVIRONMENT" != "devnet" ]]; then

--- a/.github/actions/verify-commit-provenance/action.yaml
+++ b/.github/actions/verify-commit-provenance/action.yaml
@@ -103,10 +103,13 @@ runs:
 
           # Releasing a commit that is not the tip of the deployment branch silently
           # drops the later commits on that branch (see the 4.0.2 revertme case).
-          # By default this is a hard error; allow-non-tip=true downgrades it to a
-          # warning for the deliberate "cut from behind HEAD" case. This is a
-          # provenance guarantee, independent of the release workflow's force/dry_run
-          # gates — so a non-tip release must opt in explicitly, even under force.
+          # allow-non-tip defaults to true, so by default the action warns and
+          # continues — the devnet/docker callers legitimately build non-tip commits.
+          # release.yml passes allow-non-tip=false to make this a hard error, so a
+          # non-tip release there must opt back in via its allow_non_tip_commit
+          # toggle. This is a provenance check, independent of the release workflow's
+          # force/dry_run gates — so a non-tip release must opt in explicitly, even
+          # under force.
           BRANCH_HEAD=$(git rev-parse "refs/remotes/$EXPECTED_BRANCH")
           COMMIT_FULL=$(git rev-parse "${COMMIT}^{commit}")
           if [ "$COMMIT_FULL" != "$BRANCH_HEAD" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ on:
         required: true
         type: string
       force:
-        description: 'Skip testnet-tag validation and release-base CI gate (emergency hotfixes only)'
+        description: 'Skip testnet-tag validation and the CI gate (emergency hotfixes only)'
         required: false
         type: boolean
         default: false
@@ -62,7 +62,7 @@ jobs:
     runs-on: [self-hosted, misc-runner]
     permissions:
       contents: read
-      # Read check runs and commit statuses to CI-gate the release base below.
+      # Read check runs and commit statuses to CI-gate the gate target below.
       checks: read
       statuses: read
     steps:
@@ -127,7 +127,7 @@ jobs:
             MAJOR="${INPUT_VERSION%%.*}"
             RELEASE_BRANCH="origin/release/${MAJOR}.x"
             if ! git rev-parse --verify "$RELEASE_BRANCH" >/dev/null 2>&1; then
-              echo "::error::Release branch $RELEASE_BRANCH does not exist; cannot CI-gate the release base. (Set gate_ci_on_trunk=false to gate the release commit directly.)"
+              echo "::error::Release branch $RELEASE_BRANCH does not exist; cannot CI-gate the trunk merge-base. (Set gate_ci_on_trunk=false to gate the release commit directly.)"
               exit 1
             fi
             if ! MERGE_BASE=$(git merge-base "${INPUT_COMMIT}" "$RELEASE_BRANCH"); then
@@ -147,9 +147,9 @@ jobs:
         with:
           commit: ${{ steps.base.outputs.sha }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          # Wait for in-progress CI on the release base to finish rather than
-          # failing immediately, so a release kicked off while its base CI is
-          # still running blocks until the result is known (up to 60 min).
+          # Wait for in-progress CI on the gate target to finish rather than
+          # failing immediately, so a release kicked off while its gate-target CI
+          # is still running blocks until the result is known (up to 60 min).
           wait-timeout-seconds: "3600"
           poll-interval-seconds: "30"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,16 @@ on:
         required: false
         type: boolean
         default: false
+      gate_ci_on_trunk:
+        description: 'CI gate target. ON (default): require green CI on the release/<major>.x trunk merge-base — the shared upstream code being shipped. OFF: require green CI on the release commit itself — use when the deployment branch is expected to be green in its own right.'
+        required: false
+        type: boolean
+        default: true
+      allow_non_tip_commit:
+        description: 'Allow releasing a commit that is behind the tip of release/<env>/<major>.x. Default OFF: a non-tip commit is rejected, since it silently drops the later commits on the branch. Turn ON only when excluding those commits is intentional.'
+        required: false
+        type: boolean
+        default: false
       previous_tag:
         description: 'Optional changelog range lower bound: a full 40-char commit SHA or an <env>-X.Y.Z tag for this release_type. Overrides the auto-detected previous same-env release. Leave empty for automatic semver detection.'
         required: false
@@ -90,35 +100,48 @@ jobs:
           environment: ${{ inputs.release_type }}
           commit: ${{ inputs.commit }}
           version: ${{ inputs.version }}
+          allow-non-tip: ${{ inputs.allow_non_tip_commit }}
 
-      # Defense-in-depth CI gate. The deployment branch only adds a forward-merge
-      # of release/<major>.x plus env-specific patches on top of it; the
-      # substantive released code is the merge-base on release/<major>.x. Require
-      # that commit's CI to be fully green before releasing. Scoped to real
-      # releases: force=true (emergency hotfixes) and dry_run=true (which may run
-      # before release/<major>.x even exists — see RELEASE_PLAYBOOK.md dry-run
-      # section) both bypass it.
-      - name: Resolve release/<major>.x merge-base
+      # Defense-in-depth CI gate. Which commit we gate on depends on
+      # gate_ci_on_trunk:
+      #   ON  (default): the deployment branch only adds a forward-merge of
+      #     release/<major>.x plus env-specific patches on top of it; the
+      #     substantive released code is the merge-base on release/<major>.x, so we
+      #     gate that trunk commit — which is expected to be green even though the
+      #     deployment branch's own CI may be red from the env patches.
+      #   OFF: gate the release commit directly. Use when the deployment branch is
+      #     expected to pass CI in its own right, so the env-specific patches above
+      #     the trunk merge-base are CI-verified too rather than trusted implicitly.
+      # Scoped to real releases: force=true (emergency hotfixes) and dry_run=true
+      # (which may run before release/<major>.x even exists — see RELEASE_PLAYBOOK.md
+      # dry-run section) both bypass it.
+      - name: Resolve CI-gate commit
         id: base
         if: ${{ !inputs.force && !inputs.dry_run }}
         env:
           INPUT_COMMIT: ${{ inputs.commit }}
           INPUT_VERSION: ${{ inputs.version }}
+          GATE_ON_TRUNK: ${{ inputs.gate_ci_on_trunk }}
         run: |
-          MAJOR="${INPUT_VERSION%%.*}"
-          RELEASE_BRANCH="origin/release/${MAJOR}.x"
-          if ! git rev-parse --verify "$RELEASE_BRANCH" >/dev/null 2>&1; then
-            echo "::error::Release branch $RELEASE_BRANCH does not exist; cannot CI-gate the release base."
-            exit 1
+          if [ "$GATE_ON_TRUNK" = "true" ]; then
+            MAJOR="${INPUT_VERSION%%.*}"
+            RELEASE_BRANCH="origin/release/${MAJOR}.x"
+            if ! git rev-parse --verify "$RELEASE_BRANCH" >/dev/null 2>&1; then
+              echo "::error::Release branch $RELEASE_BRANCH does not exist; cannot CI-gate the release base. (Set gate_ci_on_trunk=false to gate the release commit directly.)"
+              exit 1
+            fi
+            if ! MERGE_BASE=$(git merge-base "${INPUT_COMMIT}" "$RELEASE_BRANCH"); then
+              echo "::error::No common ancestor between ${INPUT_COMMIT} and $RELEASE_BRANCH"
+              exit 1
+            fi
+            echo "CI gate target: trunk merge-base of ${INPUT_COMMIT} and $RELEASE_BRANCH: $MERGE_BASE"
+            echo "sha=$MERGE_BASE" >> "$GITHUB_OUTPUT"
+          else
+            echo "CI gate target: release commit directly (gate_ci_on_trunk=false): ${INPUT_COMMIT}"
+            echo "sha=${INPUT_COMMIT}" >> "$GITHUB_OUTPUT"
           fi
-          if ! MERGE_BASE=$(git merge-base "${INPUT_COMMIT}" "$RELEASE_BRANCH"); then
-            echo "::error::No common ancestor between ${INPUT_COMMIT} and $RELEASE_BRANCH"
-            exit 1
-          fi
-          echo "Release base (merge-base of ${INPUT_COMMIT} and $RELEASE_BRANCH): $MERGE_BASE"
-          echo "sha=$MERGE_BASE" >> "$GITHUB_OUTPUT"
 
-      - name: Require green CI on release base
+      - name: Require green CI on gate target
         if: ${{ !inputs.force && !inputs.dry_run }}
         uses: ./.github/actions/require-green-ci
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -394,6 +394,26 @@ jobs:
       # --- Publish phase: tag, push image, update head-tracking, create release ---
       # If any step here fails, cleanup steps at the bottom delete pushed git tags.
 
+      # Final provenance re-check at the last moment before the first publish write.
+      # The validate job verified provenance at dispatch, but the environment
+      # approval gate (and the Docker build above) can span a long window during
+      # which the deployment branch may advance — publishing a now-behind-tip
+      # release, the 4.0.2 class of bug. The release job's post-approval checkout
+      # (fetch-depth: 0) already captured the branch tip as of job start, so this
+      # re-run of the same read-only branch/tip/version check rejects a branch that
+      # moved out from under the release during the approval wait, unless the
+      # operator opted into a non-tip release (allow-non-tip threaded through, so a
+      # deliberate non-tip release still only warns). It runs before any tag/image
+      # push, so a rejection needs no cleanup.
+      - name: Re-verify commit provenance before publish
+        if: ${{ !inputs.dry_run }}
+        uses: ./.github/actions/verify-commit-provenance
+        with:
+          environment: ${{ inputs.release_type }}
+          commit: ${{ inputs.commit }}
+          version: ${{ inputs.version }}
+          allow-non-tip: ${{ inputs.allow_non_tip_commit }}
+
       - name: Push git tag
         id: push_tag
         if: ${{ !inputs.dry_run }}

--- a/docs/99-reference/RELEASE_PLAYBOOK.md
+++ b/docs/99-reference/RELEASE_PLAYBOOK.md
@@ -97,9 +97,9 @@ Or use the GitHub UI: **Actions → Release → Run workflow**.
 
 The workflow will:
 
-1. Verify the commit is on `release/testnet/<major>.x`.
+1. Verify the commit is on `release/testnet/<major>.x`, **and is the tip of that branch** — releasing a non-tip commit silently drops the later commits on the branch and is a hard error unless you dispatch with `allow_non_tip_commit=true`.
 2. Verify `crates/chain/Cargo.toml` version equals `1.2.3`.
-3. Verify the commit's `release/1.x` merge-base (the upstream code being shipped, env-patches aside) had a fully passing CI run. Skipped with `force=true` or `dry_run=true`.
+3. Verify the CI gate target had a fully passing CI run. By default this is the commit's `release/1.x` merge-base (the upstream code being shipped, env-patches aside); dispatch with `gate_ci_on_trunk=false` to instead gate the release commit itself (use when the deployment branch is expected to be green in its own right). Skipped entirely with `force=true` or `dry_run=true`.
 4. Build `ghcr.io/<owner>/irys-testnet:1.2.3`.
 5. Push git tag `testnet-1.2.3`, push the Docker image, move the `testnet-latest` git tag.
 6. Auto-publish a GitHub **prerelease** with the auto-generated changelog body.
@@ -292,6 +292,8 @@ After publishing, deploy `irys-mainnet:1.2.3` to mainnet.
 | Critical mainnet hotfix without testnet? | Dispatch with `force=true`. See [`RELEASE_PROCESS.md` § Hotfixes](./RELEASE_PROCESS.md#hotfixes). |
 | Wrong changelog scope on mainnet? | Edit the draft before publishing — nothing assumes the auto-generated text is final. |
 | Need to roll back? | Dispatch `docker-retag.yml`. See [`RELEASE_PROCESS.md` § Rollback](./RELEASE_PROCESS.md#rollback). |
+| Intentionally releasing a commit behind the branch tip? | Dispatch with `allow_non_tip_commit=true`. Otherwise the release is rejected — a non-tip commit drops the later commits on `release/<env>/<major>.x` (this is what caused the 4.0.2 `revertme` commit to be excluded). |
+| Deployment branch itself passes CI (env patches don't break it)? | Dispatch with `gate_ci_on_trunk=false` to gate CI on the release commit directly instead of the `release/<major>.x` trunk merge-base — this way the env-specific patches get CI-verified too rather than trusted implicitly. |
 | Want to test the workflow without publishing? | Dispatch with `dry_run=true`. Validates and builds; skips tag/image push and GH Release creation, skips the release-base CI gate, and runs without the environment approval gate (so a mainnet dry-run needs no reviewer and won't block a queued real release). |
 
 ## Hotfixes and emergencies


### PR DESCRIPTION
Two release-workflow safeguards, both prompted by the 4.0.2 release cutting from behind the deployment branch tip and silently dropping later commits:

- verify-commit-provenance now hard-fails when the release commit is not the tip of release/<env>/<major>.x, reporting how many commits would be dropped. Gated by a new allow-non-tip input (default true to preserve devnet/docker ad-hoc builds); release.yml exposes an allow_non_tip_commit dispatch toggle defaulting off, so a stale/non-tip SHA is rejected unless opted in.

- New gate_ci_on_trunk dispatch toggle (default on = current behavior) selects the CI-gate target: the release/<major>.x trunk merge-base, or the release commit directly when the deployment branch is expected to be green itself.

Playbook updated with both toggles.

**Describe the changes**
A clear and concise description of what the bug fix, feature, or improvement is.

**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release workflows now let you control CI gating via `gate_ci_on_trunk` (trunk merge-base vs the release commit SHA).
  * Commit provenance handling now supports non-tip deployment commits through `allow_non_tip_commit`, with default behavior that prevents non-tip releases unless explicitly allowed.
  * The provenance check can be configured to warn-and-proceed or fail when the target commit is not the branch tip.
* **Documentation**
  * Updated the release playbook with clearer guidance on dispatching non-tip releases and selecting the CI gate target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->