### PR TITLE
feat(api): partition-hash intervals endpoint for capacity storage modules

### DIFF
--- a/crates/api-server/src/lib.rs
+++ b/crates/api-server/src/lib.rs
@@ -191,6 +191,10 @@ pub fn routes() -> impl HttpServiceFactory {
             web::get().to(storage::get_chunk_counts),
         )
         .route(
+            storage::PARTITION_INTERVALS_ROUTE,
+            web::get().to(storage::get_partition_intervals),
+        )
+        .route(
             "/mempool/status",
             web::get().to(mempool::get_mempool_status),
         )

--- a/crates/api-server/src/routes/storage.rs
+++ b/crates/api-server/src/routes/storage.rs
@@ -1,9 +1,11 @@
 use crate::ApiState;
 use crate::error::ApiError;
 use actix_web::web::{Data, Json, Path};
-use irys_domain::ChunkType;
-use irys_types::DataLedger;
+use awc::http::StatusCode;
+use irys_domain::{ChunkType, StorageModule};
+use irys_types::{DataLedger, H256};
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 /// Route path templates registered in [`crate::routes()`]. actix-web matches placeholders to
 /// `Path`-extracted struct fields by their serde-visible names; a mismatch rejects every
@@ -12,6 +14,8 @@ use serde::{Deserialize, Serialize};
 /// correct — the camelCase JSON contract lives on the `*Response` structs.
 pub const INTERVALS_ROUTE: &str = "/storage/intervals/{ledger}/{slot_index}/{chunk_type}";
 pub const COUNTS_ROUTE: &str = "/storage/counts/{ledger}/{slot_index}";
+pub const PARTITION_INTERVALS_ROUTE: &str =
+    "/storage/partition/{partition_hash}/intervals/{chunk_type}";
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct StorageIntervalsParams {
@@ -73,6 +77,22 @@ impl ChunkCountsResponse {
     }
 }
 
+/// Maps a storage module's coalesced interval set for one [`ChunkType`] to
+/// the wire shape. Bounds are partition-relative chunk offsets with an
+/// INCLUSIVE `end` (a fully covered 10-chunk partition reads `[0, 9]`);
+/// touching/overlapping runs arrive already merged and sorted from
+/// [`StorageModule::get_intervals`]. Both interval endpoints go through
+/// here so their semantics cannot drift apart.
+fn module_intervals(sm: &StorageModule, chunk_type: ChunkType) -> Vec<ChunkInterval> {
+    sm.get_intervals(chunk_type)
+        .into_iter()
+        .map(|interval| ChunkInterval {
+            start: interval.start().into(),
+            end: interval.end().into(),
+        })
+        .collect()
+}
+
 pub async fn get_intervals(
     params: Path<StorageIntervalsParams>,
     app_state: Data<ApiState>,
@@ -89,18 +109,96 @@ pub async fn get_intervals(
                 })
                 .unwrap_or(false)
         })
-        .map(|sm| {
-            sm.get_intervals(params.chunk_type)
-                .into_iter()
-                .map(|interval| ChunkInterval {
-                    start: interval.start().into(),
-                    end: interval.end().into(),
-                })
-                .collect()
-        })
+        .map(|sm| module_intervals(sm, params.chunk_type))
         .unwrap_or_default();
 
     Ok(Json(StorageIntervalsResponse::new(&params, intervals)))
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PartitionIntervalsParams {
+    // Kept as a String so a malformed hash maps to an explicit 400 instead
+    // of the extractor's opaque 404
+    partition_hash: String,
+    chunk_type: ChunkType,
+}
+
+/// Response for `/storage/partition/{partition_hash}/intervals/{chunk_type}`:
+/// the intervals this node has locally recorded for the partition. Works for
+/// any locally hosted partition — including capacity partitions, which have
+/// no ledger/slot coordinates and so cannot be addressed by
+/// [`INTERVALS_ROUTE`].
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct PartitionIntervalsResponse {
+    partition_hash: H256,
+    chunk_type: ChunkType,
+    intervals: Vec<ChunkInterval>,
+}
+
+fn parse_partition_hash(raw: &str) -> Result<H256, ApiError> {
+    H256::from_base58_result(raw).map_err(|e| {
+        ApiError::CustomWithStatus(
+            format!("Invalid partition hash '{raw}': {e}"),
+            StatusCode::BAD_REQUEST,
+        )
+    })
+}
+
+/// Resolves the one local storage module hosting `partition_hash` from the
+/// node's authoritative in-memory module registry.
+///
+/// `Ok(None)` means the partition is not hosted by this node. More than one
+/// module claiming the same hash is a storage-registry invariant violation
+/// and surfaces as an error rather than silently answering from an
+/// arbitrary module.
+fn find_module_by_partition_hash(
+    modules: &[Arc<StorageModule>],
+    partition_hash: H256,
+) -> Result<Option<Arc<StorageModule>>, ApiError> {
+    let mut matches = modules.iter().filter(|sm| {
+        sm.partition_assignment()
+            .is_some_and(|pa| pa.partition_hash == partition_hash)
+    });
+    let first = matches.next().cloned();
+    let extra = matches.count();
+    if extra > 0 {
+        return Err(ApiError::CustomWithStatus(
+            format!(
+                "{} local storage modules claim partition hash {partition_hash}; \
+                 the storage-module registry violates its one-module-per-partition invariant",
+                extra + 1
+            ),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        ));
+    }
+    Ok(first)
+}
+
+pub async fn get_partition_intervals(
+    params: Path<PartitionIntervalsParams>,
+    app_state: Data<ApiState>,
+) -> Result<Json<PartitionIntervalsResponse>, ApiError> {
+    let partition_hash = parse_partition_hash(&params.partition_hash)?;
+
+    // Clone the module Arc out of the registry lock; the interval read below
+    // only takes the module's own intervals read lock
+    let module = {
+        let storage_modules = app_state.chunk_provider.storage_modules_guard.read();
+        find_module_by_partition_hash(&storage_modules, partition_hash)?
+    };
+    let Some(module) = module else {
+        return Err(ApiError::CustomWithStatus(
+            format!("Partition {partition_hash} is not hosted by this node"),
+            StatusCode::NOT_FOUND,
+        ));
+    };
+
+    Ok(Json(PartitionIntervalsResponse {
+        partition_hash,
+        chunk_type: params.chunk_type,
+        intervals: module_intervals(&module, params.chunk_type),
+    }))
 }
 
 pub async fn get_chunk_counts(
@@ -171,12 +269,22 @@ mod tests {
         Json(params.into_inner())
     }
 
+    async fn echo_partition_intervals(
+        params: Path<PartitionIntervalsParams>,
+    ) -> Json<PartitionIntervalsParams> {
+        Json(params.into_inner())
+    }
+
     async fn call(uri: &str) -> ServiceResponse {
         let app = test::init_service(
             App::new().service(
                 web::scope(crate::API_VERSION)
                     .route(INTERVALS_ROUTE, web::get().to(echo_intervals))
-                    .route(COUNTS_ROUTE, web::get().to(echo_counts)),
+                    .route(COUNTS_ROUTE, web::get().to(echo_counts))
+                    .route(
+                        PARTITION_INTERVALS_ROUTE,
+                        web::get().to(echo_partition_intervals),
+                    ),
             ),
         )
         .await;
@@ -256,6 +364,197 @@ mod tests {
         assert_eq!(object["chunkType"], "Data");
         assert_eq!(object["intervals"][0]["start"], 0);
         assert_eq!(object["intervals"][0]["end"], 3);
+    }
+
+    // === Partition-hash-keyed intervals ===
+
+    use actix_web::ResponseError as _;
+    use irys_domain::StorageModuleInfo;
+    use irys_testing_utils::utils::TempDirBuilder;
+    use irys_types::{
+        Config, ConsensusConfig, ConsensusOptions, NodeConfig, PartitionChunkOffset, ii,
+        partition::PartitionAssignment, partition_chunk_offset_ii,
+    };
+
+    const PARTITION_CHUNKS: u64 = 20;
+
+    fn storage_test_config(base_path: std::path::PathBuf) -> Config {
+        let mut node_config = NodeConfig::testing();
+        node_config.consensus = ConsensusOptions::Custom(ConsensusConfig {
+            chunk_size: 32,
+            num_chunks_in_partition: PARTITION_CHUNKS,
+            entropy_packing_iterations: 1,
+            ..node_config.consensus_config()
+        });
+        node_config.base_directory = base_path;
+        Config::new_with_random_peer_id(node_config)
+    }
+
+    fn capacity_assignment_for(config: &Config, partition_hash: H256) -> PartitionAssignment {
+        PartitionAssignment {
+            partition_hash,
+            miner_address: config.node_config.miner_address(),
+            ledger_id: None,
+            slot_index: None,
+        }
+    }
+
+    fn module_with_assignment(
+        id: usize,
+        config: &Config,
+        assignment: PartitionAssignment,
+    ) -> Arc<StorageModule> {
+        let info = StorageModuleInfo {
+            id,
+            partition_assignment: Some(assignment),
+            submodules: vec![(
+                partition_chunk_offset_ii!(0, PARTITION_CHUNKS as u32 - 1),
+                format!("submodule_{id}").into(),
+            )],
+        };
+        Arc::new(StorageModule::new(&info, config).expect("test storage module"))
+    }
+
+    #[actix_web::test]
+    async fn partition_intervals_path_reaches_handler() {
+        assert_extracted(
+            "/v1/storage/partition/2fu2ar8SLem6ykDT8k7pjWM74qxiFEr4X2vBBjJHnLR/intervals/Entropy",
+            serde_json::json!({
+                "partition_hash": "2fu2ar8SLem6ykDT8k7pjWM74qxiFEr4X2vBBjJHnLR",
+                "chunk_type": "Entropy",
+            }),
+        )
+        .await;
+    }
+
+    #[actix_web::test]
+    async fn parse_partition_hash_maps_malformed_input_to_bad_request() {
+        // Invalid base58 alphabet, valid base58 of the wrong length, empty
+        for raw in ["!!!not-base58!!!", "abc", ""] {
+            let err = parse_partition_hash(raw).expect_err("must reject malformed hash");
+            assert_eq!(
+                err.status_code(),
+                StatusCode::BAD_REQUEST,
+                "wrong status for input {raw:?}"
+            );
+        }
+        // The API's own base58 rendering round-trips
+        let hash = H256::random();
+        assert_eq!(parse_partition_hash(&hash.to_string()).unwrap(), hash);
+    }
+
+    /// Full lifecycle against a real capacity-assigned storage module (no
+    /// ledger id, no slot index): resolvable by hash, empty before packing,
+    /// real coalesced intervals when partially packed, full inclusive range
+    /// when fully packed.
+    #[actix_web::test]
+    async fn capacity_partition_entropy_intervals_lifecycle() {
+        let tmp_dir = TempDirBuilder::new()
+            .prefix("partition_intervals_api")
+            .build();
+        let config = storage_test_config(tmp_dir.path().to_path_buf());
+        let capacity_hash = H256::random();
+        let module =
+            module_with_assignment(0, &config, capacity_assignment_for(&config, capacity_hash));
+        let modules = vec![module];
+
+        // Capacity assignments carry no ledger/slot coordinates yet still
+        // resolve by hash
+        let found = find_module_by_partition_hash(&modules, capacity_hash)
+            .expect("single module cannot violate the registry invariant")
+            .expect("locally hosted capacity partition must resolve");
+        let assignment = found.partition_assignment().expect("assignment");
+        assert!(assignment.ledger_id.is_none() && assignment.slot_index.is_none());
+
+        // Known but unpacked: empty interval list, not an error
+        assert!(module_intervals(&found, ChunkType::Entropy).is_empty());
+
+        // Partially packed, written out of order: intervals come back sorted
+        // by start with touching chunks coalesced and inclusive ends
+        for offset in [5_u32, 2, 0, 1] {
+            found.write_chunk(
+                PartitionChunkOffset::from(offset),
+                vec![0xff; 32],
+                ChunkType::Entropy,
+            );
+        }
+        let partial: Vec<(u32, u32)> = module_intervals(&found, ChunkType::Entropy)
+            .iter()
+            .map(|i| (i.start, i.end))
+            .collect();
+        assert_eq!(partial, vec![(0, 2), (5, 5)]);
+
+        // Fully packed: one interval spanning the whole partition,
+        // 0 ..= num_chunks_in_partition - 1
+        found.pack_with_zeros();
+        let full: Vec<(u32, u32)> = module_intervals(&found, ChunkType::Entropy)
+            .iter()
+            .map(|i| (i.start, i.end))
+            .collect();
+        assert_eq!(full, vec![(0, PARTITION_CHUNKS as u32 - 1)]);
+
+        // A valid hash this node does not host resolves to None (→ 404)
+        assert!(
+            find_module_by_partition_hash(&modules, H256::random())
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[actix_web::test]
+    async fn duplicate_partition_hash_is_an_invariant_violation() {
+        let tmp_dir = TempDirBuilder::new()
+            .prefix("partition_intervals_dup")
+            .build();
+        let config = storage_test_config(tmp_dir.path().to_path_buf());
+        let hash = H256::random();
+        let modules = vec![
+            module_with_assignment(0, &config, capacity_assignment_for(&config, hash)),
+            module_with_assignment(1, &config, capacity_assignment_for(&config, hash)),
+        ];
+
+        let err = find_module_by_partition_hash(&modules, hash)
+            .expect_err("duplicate hash claims must not silently pick a module");
+        assert_eq!(err.status_code(), StatusCode::INTERNAL_SERVER_ERROR);
+        let message = err.to_string();
+        assert!(
+            message.contains("2 local storage modules") && message.contains("invariant"),
+            "unexpected error message: {message}"
+        );
+    }
+
+    #[actix_web::test]
+    async fn partition_intervals_response_serialises_camel_case_keys() {
+        let empty = PartitionIntervalsResponse {
+            partition_hash: H256::from([7; 32]),
+            chunk_type: ChunkType::Entropy,
+            intervals: vec![],
+        };
+        let value = serde_json::to_value(&empty).expect("serialise");
+        let object = value.as_object().expect("object");
+        assert!(
+            object.contains_key("partitionHash") && !object.contains_key("partition_hash"),
+            "expected camelCase partitionHash, got keys {:?}",
+            object.keys().collect::<Vec<_>>()
+        );
+        assert_eq!(object["partitionHash"], H256::from([7; 32]).to_string());
+        assert_eq!(object["chunkType"], "Entropy");
+        // Known-but-unpacked serialises an explicit empty array
+        assert_eq!(object["intervals"], serde_json::json!([]));
+
+        // Same ChunkInterval wire shape as the ledger/slot endpoint,
+        // inclusive end included
+        let full = PartitionIntervalsResponse {
+            partition_hash: H256::from([7; 32]),
+            chunk_type: ChunkType::Entropy,
+            intervals: vec![ChunkInterval {
+                start: 0,
+                end: 2138,
+            }],
+        };
+        let value = serde_json::to_value(&full).expect("serialise");
+        assert_eq!(value["intervals"][0]["start"], 0);
+        assert_eq!(value["intervals"][0]["end"], 2138);
     }
 
     #[actix_web::test]

--- a/crates/chain-tests/src/api/mod.rs
+++ b/crates/chain-tests/src/api/mod.rs
@@ -7,6 +7,7 @@ mod external_api;
 mod hardfork_tests;
 mod ledger_offset_endpoint;
 mod mempool_txs;
+mod partition_intervals_endpoint;
 mod pricing_endpoint;
 mod supply_endpoint;
 mod tx;

--- a/crates/chain-tests/src/api/partition_intervals_endpoint.rs
+++ b/crates/chain-tests/src/api/partition_intervals_endpoint.rs
@@ -1,0 +1,136 @@
+//! Integration tests for the partition-hash-keyed local interval endpoint:
+//! `GET /v1/storage/partition/{partition_hash}/intervals/{chunk_type}`.
+//!
+//! Capacity partitions have no ledger/slot coordinates, so this route is the
+//! only way to observe their locally stored entropy intervals.
+
+use crate::utils::IrysNodeTest;
+use actix_web::body::MessageBody;
+use actix_web::dev::{Service, ServiceResponse};
+use actix_web::http::StatusCode;
+use actix_web::test::{TestRequest, call_service, read_body_json};
+use irys_config::submodules::StorageSubmodulesConfig;
+use irys_types::{DataLedger, H256, NodeConfig};
+
+async fn get<T, B>(app: &T, uri: &str) -> (StatusCode, serde_json::Value)
+where
+    T: Service<actix_http::Request, Response = ServiceResponse<B>, Error = actix_web::Error>,
+    B: MessageBody,
+{
+    let req = TestRequest::get().uri(uri).to_request();
+    let resp = call_service(app, req).await;
+    let status = resp.status();
+    let body = if status == StatusCode::OK {
+        read_body_json(resp).await
+    } else {
+        serde_json::Value::Null
+    };
+    (status, body)
+}
+
+/// A fully packed node: the capacity partition's entropy intervals are
+/// readable by hash and cover the whole partition; the hash-keyed route
+/// agrees byte-for-byte with the ledger/slot route on data partitions;
+/// malformed and unknown hashes map to 400/404.
+#[test_log::test(tokio::test)]
+async fn heavy_partition_intervals_endpoint() -> eyre::Result<()> {
+    let num_chunks_in_partition = 10_u64;
+    let config = NodeConfig::testing().with_consensus(|c| {
+        c.chunk_size = 32;
+        c.num_chunks_in_partition = num_chunks_in_partition;
+        c.entropy_packing_iterations = 1_000;
+    });
+
+    // 5 storage submodules: Publish slot 0 + Submit slot 0 stay data
+    // partitions, the rest remain capacity
+    let test_node = IrysNodeTest::new_genesis(config);
+    StorageSubmodulesConfig::load_for_test(test_node.cfg.base_directory.clone(), 5)?;
+    let node = test_node.start_and_wait_for_packing("test", 30).await;
+    let app = node.start_public_api().await;
+
+    let snapshot = node.get_canonical_epoch_snapshot();
+    let capacity_hash = *snapshot
+        .partition_assignments
+        .capacity_partitions
+        .keys()
+        .next()
+        .expect("test setup should leave at least one capacity partition");
+
+    // The acceptance scenario: a capacity assignment (no ledger id, no slot
+    // index) resolved directly against the hosting miner by partition hash
+    let (status, body) = get(
+        &app,
+        &format!("/v1/storage/partition/{capacity_hash}/intervals/Entropy"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["partitionHash"], capacity_hash.to_string());
+    assert_eq!(body["chunkType"], "Entropy");
+    // Fully packed after start_and_wait_for_packing: one interval covering
+    // 0 ..= num_chunks_in_partition - 1 (inclusive end convention)
+    assert_eq!(
+        body["intervals"],
+        serde_json::json!([{"start": 0, "end": num_chunks_in_partition - 1}]),
+        "fully packed capacity partition must cover the whole partition"
+    );
+
+    // Intervals are sorted by start and bounded by the partition size
+    let intervals = body["intervals"].as_array().expect("intervals array");
+    for pair in intervals.windows(2) {
+        assert!(pair[0]["start"].as_u64() < pair[1]["start"].as_u64());
+    }
+    for interval in intervals {
+        assert!(interval["end"].as_u64().unwrap() < num_chunks_in_partition);
+    }
+
+    // The hash-keyed route and the ledger/slot route answer identically for
+    // a data partition — same serialization, same inclusive end bound
+    let submit_hash = snapshot
+        .partition_assignments
+        .data_partitions
+        .values()
+        .find(|pa| pa.ledger_id == Some(DataLedger::Submit.get_id()) && pa.slot_index == Some(0))
+        .expect("Submit slot 0 must be assigned")
+        .partition_hash;
+    let (status_by_hash, by_hash) = get(
+        &app,
+        &format!("/v1/storage/partition/{submit_hash}/intervals/Entropy"),
+    )
+    .await;
+    let (status_by_slot, by_slot) = get(&app, "/v1/storage/intervals/Submit/0/Entropy").await;
+    assert_eq!(status_by_hash, StatusCode::OK);
+    assert_eq!(status_by_slot, StatusCode::OK);
+    assert_eq!(
+        by_hash["intervals"], by_slot["intervals"],
+        "hash-keyed and ledger/slot routes must share interval semantics"
+    );
+
+    // A well-formed hash this node does not host: 404
+    let (status, _) = get(
+        &app,
+        &format!("/v1/storage/partition/{}/intervals/Entropy", H256::random()),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    // Malformed hashes: 400 (bad alphabet, and valid base58 of wrong length)
+    for bad in ["!!!not-base58!!!", "abc"] {
+        let (status, _) = get(
+            &app,
+            &format!("/v1/storage/partition/{bad}/intervals/Entropy"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "input {bad:?}");
+    }
+
+    // Garbage chunk type follows the API-wide Path-extractor convention: 404
+    let (status, _) = get(
+        &app,
+        &format!("/v1/storage/partition/{capacity_hash}/intervals/NotAChunkType"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    node.stop().await;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adds `GET /v1/storage/partition/{partition_hash}/intervals/{chunk_type}` for this node’s **local** coalesced intervals, keyed by partition hash.

Capacity partitions have no ledger/slot, so they cannot use `/storage/intervals/{ledger}/{slot}/{chunk_type}`. Both routes share `module_intervals` so wire semantics (partition-relative offsets, **inclusive** end) cannot drift.

| Case | Response |
|---|---|
| Hosted partition (any packing state) | `200` + intervals (empty array if unpacked) |
| Not hosted on this node | `404` |
| Malformed partition hash | `400` (path param is a string; base58 parse is explicit) |
| Bad `chunk_type` | `404` (actix Path extractor, same as other storage routes) |
| Multiple modules claim the same hash | `500` (registry invariant) |

**Note:** the ledger/slot route still returns `200` + `[]` when no module matches. The hash-keyed route uses `404` for “not hosted” so clients can distinguish empty packing from missing ownership.

## Test plan

- [x] Unit: path extraction, bad hash → 400, capacity lifecycle (empty → partial coalesce → full pack), duplicate hash → 500, camelCase serde
- [x] Heavy: packed capacity full-range intervals, hash vs ledger/slot agreement on Submit slot 0, 400/404/bad chunk type
- [ ] `cargo nextest run -p irys-api-server partition_intervals`
- [ ] `cargo nextest run -p irys-chain-tests heavy_partition_intervals_endpoint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint to retrieve chunk intervals by partition hash and chunk type.
  * Responses include the partition hash, chunk type, and inclusive interval ranges.
  * Added validation for malformed hashes, unavailable partitions, unknown chunk types, and duplicate partition ownership.

* **Bug Fixes**
  * Standardized interval conversion and JSON field formatting for storage responses.

* **Tests**
  * Added coverage for packed, partially packed, and unpacked partition states, along with endpoint error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->