### PR TITLE
fix: repack orphaned ranges after reorg rollback + correct PoA offset over Uninitialized holes

### DIFF
--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -421,8 +421,9 @@ impl BlockMigrationService {
         let block_index = self.block_index_guard.read();
         // HAZARD: `latest_height()` maps a transient DB read error to 0. If that
         // happens the `fork_parent_height >= latest` guard trips and the whole
-        // rollback is silently skipped; recovery then relies on a later reorg
-        // tick retrying. There is no fallible public variant to propagate.
+        // rollback is silently skipped for this invocation, with no self-retry —
+        // it only reruns if a later reorg happens to re-invoke recovery. There is
+        // no fallible public variant to propagate.
         let latest = block_index.latest_height();
         if fork_parent_height >= latest {
             return Ok(());
@@ -563,9 +564,12 @@ impl BlockMigrationService {
                     let range_end = *partition_range.end();
 
                     // Drop queued (not-yet-synced) writes in the orphaned range
-                    // first: otherwise a later `sync_pending_chunks` would replay
+                    // first: a later `sync_pending_chunks` would otherwise replay
                     // them and flip the intervals we clear below back to `Data`
-                    // over a now-empty offset index.
+                    // over a now-empty offset index. This closes the queued-write
+                    // path; a sync already mid-flush (its batch snapshotted before
+                    // this drop) can still replay, but that window is transient and
+                    // healed by the repack enqueued below.
                     module.drop_pending_writes_in_range(
                         PartitionChunkOffset::from(range_start),
                         PartitionChunkOffset::from(range_end),

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -419,12 +419,13 @@ impl BlockMigrationService {
         })?;
 
         let block_index = self.block_index_guard.read();
-        // HAZARD: `latest_height()` maps a transient DB read error to 0. If that
-        // happens the `fork_parent_height >= latest` guard trips and the whole
-        // rollback is silently skipped for this invocation, with no self-retry —
-        // it only reruns if a later reorg happens to re-invoke recovery. There is
-        // no fallible public variant to propagate.
-        let latest = block_index.latest_height();
+        // Use the fallible height read so a transient DB error propagates rather
+        // than masquerading as height 0 — which would trip the guard below and
+        // silently skip the rollback. An empty index (`None`) is a genuine
+        // nothing-to-roll-back case and returns early.
+        let Some(latest) = block_index.try_latest_height()? else {
+            return Ok(());
+        };
         if fork_parent_height >= latest {
             return Ok(());
         }

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -1,4 +1,5 @@
 use crate::chunk_migration_service::ChunkMigrationServiceMessage;
+use crate::packing_service::{PackingRequest, PackingSender};
 use eyre::{OptionExt as _, ensure};
 use irys_database::{
     block_header_by_hash, db::IrysDatabaseExt as _, insert_commitment_tx, insert_tx_header,
@@ -12,8 +13,8 @@ use irys_domain::{
 use irys_storage::ii;
 use irys_types::{
     DataLedger, DataTransactionHeader, H256, IrysBlockHeader, LedgerChunkOffset, LedgerChunkRange,
-    PartitionChunkOffset, SealedBlock, SendTraced as _, SystemLedger, Traced, U256,
-    app_state::DatabaseProvider,
+    PartitionChunkOffset, PartitionChunkRange, SealedBlock, SendTraced as _, SystemLedger, Traced,
+    U256, app_state::DatabaseProvider,
 };
 use std::{
     collections::HashMap,
@@ -37,6 +38,10 @@ pub struct BlockMigrationService {
     block_migration_depth: u64,
     cache: Arc<RwLock<BlockTree>>,
     chunk_migration_sender: UnboundedSender<Traced<ChunkMigrationServiceMessage>>,
+    /// Used by `recover_from_network_partition` to re-request packing for
+    /// offsets re-marked `Uninitialized` during a deep-reorg rollback (packing
+    /// is otherwise only requested at startup / assignment transitions).
+    packing_sender: PackingSender,
     storage_modules_guard: Option<StorageModulesReadGuard>,
 }
 
@@ -140,6 +145,7 @@ impl BlockMigrationService {
         block_migration_depth: u64,
         cache: Arc<RwLock<BlockTree>>,
         chunk_migration_sender: UnboundedSender<Traced<ChunkMigrationServiceMessage>>,
+        packing_sender: PackingSender,
     ) -> Self {
         Self {
             db,
@@ -151,6 +157,7 @@ impl BlockMigrationService {
             block_migration_depth,
             cache,
             chunk_migration_sender,
+            packing_sender,
             storage_modules_guard: None,
         }
     }
@@ -412,6 +419,10 @@ impl BlockMigrationService {
         })?;
 
         let block_index = self.block_index_guard.read();
+        // HAZARD: `latest_height()` maps a transient DB read error to 0. If that
+        // happens the `fork_parent_height >= latest` guard trips and the whole
+        // rollback is silently skipped; recovery then relies on a later reorg
+        // tick retrying. There is no fallible public variant to propagate.
         let latest = block_index.latest_height();
         if fork_parent_height >= latest {
             return Ok(());
@@ -475,13 +486,15 @@ impl BlockMigrationService {
                 }
             }
 
-            // Collect data_roots from orphaned block's transactions
+            // Collect data_roots from orphaned block's transactions. Propagate
+            // DB read errors rather than swallowing them — a swallowed error
+            // would silently drop the tx's data_root from the clear set,
+            // leaving its orphaned placement in the offset index.
             let mut data_roots = Vec::new();
             let tx_id_map = header.get_data_ledger_tx_ids();
             for tx_ids in tx_id_map.values() {
                 for txid in tx_ids {
-                    if let Ok(Some(tx_header)) = self.db.view_eyre(|tx| tx_header_by_txid(tx, txid))
-                    {
+                    if let Some(tx_header) = self.db.view_eyre(|tx| tx_header_by_txid(tx, txid))? {
                         data_roots.push(tx_header.data_root);
                     }
                 }
@@ -546,37 +559,37 @@ impl BlockMigrationService {
                         }
                     };
 
-                    // Clear offset index entries and data_root mappings for orphaned txs
-                    for offset in *partition_range.start()..=*partition_range.end() {
-                        let part_offset = PartitionChunkOffset::from(offset);
-                        let (_, submodule) = module.get_submodule_for_offset(part_offset)?;
-                        submodule.db.update_eyre(|tx| {
-                            irys_database::submodule::add_tx_path_hash_to_offset_index(
-                                tx,
-                                part_offset,
-                                None,
-                            )?;
-                            irys_database::submodule::add_data_path_hash_to_offset_index(
-                                tx,
-                                part_offset,
-                                None,
-                            )?;
-                            // Clear DataRootInfosByDataRoot for orphaned txs' data_roots
-                            for data_root in &info.data_roots {
-                                irys_database::submodule::set_data_root_infos_for_data_root(
-                                    tx,
-                                    *data_root,
-                                    irys_database::submodule::tables::DataRootInfos(Vec::new()),
-                                )?;
-                            }
-                            Ok(())
-                        })?;
-                    }
+                    let range_start = *partition_range.start();
+                    let range_end = *partition_range.end();
+
+                    // Drop queued (not-yet-synced) writes in the orphaned range
+                    // first: otherwise a later `sync_pending_chunks` would replay
+                    // them and flip the intervals we clear below back to `Data`
+                    // over a now-empty offset index.
+                    module.drop_pending_writes_in_range(
+                        PartitionChunkOffset::from(range_start),
+                        PartitionChunkOffset::from(range_end),
+                    );
+
+                    // Clear per-offset tx/data path index entries for orphaned txs.
+                    module.clear_offset_index_in_range(
+                        PartitionChunkOffset::from(range_start),
+                        PartitionChunkOffset::from(range_end),
+                    )?;
+
+                    // Scope the DataRootInfos clear to the orphaned placements so
+                    // a data_root shared with a still-canonical block keeps its
+                    // canonical placement.
+                    module.clear_data_root_infos_in_range(
+                        PartitionChunkOffset::from(range_start),
+                        PartitionChunkOffset::from(range_end),
+                        &info.data_roots,
+                    )?;
 
                     // Mark offsets as Uninitialized (not Entropy — on-disk bytes are packed data)
                     {
                         let mut intervals = module.intervals().write().unwrap();
-                        for offset in *partition_range.start()..=*partition_range.end() {
+                        for offset in range_start..=range_end {
                             let part_offset = PartitionChunkOffset::from(offset);
                             StorageModule::cut_then_insert_interval_if_touching(
                                 &mut intervals,
@@ -586,6 +599,48 @@ impl BlockMigrationService {
                         }
                     }
                     module.write_intervals_to_submodules()?;
+
+                    // Re-request packing for the re-marked range. These offsets
+                    // are now `Uninitialized` with no entropy on disk; packing is
+                    // otherwise only requested at startup / assignment
+                    // transitions, so without this the canonical fork's
+                    // re-migrated chunks would have no entropy to XOR against and
+                    // silently fail to write. The packing channel is buffered and
+                    // a rollback enqueues only a handful of ranges, so a
+                    // non-blocking `try_send` from this sync path suffices; warn
+                    // (don't fail the module) if it can't be enqueued.
+                    //
+                    // Known limitation: packing is asynchronous, so canonical
+                    // chunks re-migrated into this range *before* packing
+                    // completes still find no entropy and are silently skipped by
+                    // `write_data_chunk`. This is not permanent — the range stays
+                    // `Uninitialized` and is recovered by the startup repack plus
+                    // data-sync. Closing the window (gating re-migration on
+                    // entropy presence) is left to the packing-reconciler rework.
+                    match PackingRequest::new(
+                        module.clone(),
+                        PartitionChunkRange(ii(
+                            PartitionChunkOffset::from(*partition_range.start()),
+                            PartitionChunkOffset::from(*partition_range.end()),
+                        )),
+                    ) {
+                        Ok(req) => {
+                            if let Err(err) = self.packing_sender.try_send(req) {
+                                warn!(
+                                    module_id = module.id,
+                                    %err,
+                                    "failed to enqueue repacking request during partition recovery"
+                                );
+                            }
+                        }
+                        Err(err) => {
+                            warn!(
+                                module_id = module.id,
+                                %err,
+                                "failed to build repacking request during partition recovery"
+                            );
+                        }
+                    }
                 }
             }
         }
@@ -848,11 +903,12 @@ mod tests {
     };
     use irys_domain::{BlockTree, StorageModuleInfo};
     use irys_testing_utils::IrysBlockHeaderTestExt as _;
+    use irys_types::partition::PartitionAssignment;
     use irys_types::{
         BlockIndexItem, BlockTransactions, ConsensusConfig, DataTransactionHeader,
         DataTransactionHeaderV1, DataTransactionHeaderV1WithMetadata, DataTransactionMetadata,
         H256, H256List, IrysBlockHeader, LedgerIndexItem, NodeConfig, U256,
-        partition::PartitionAssignment, partition_chunk_offset_ii,
+        partition_chunk_offset_ii,
     };
     use reth_db::Database as _;
     use reth_db::mdbx::DatabaseArguments;
@@ -895,6 +951,10 @@ mod tests {
         let cache = Arc::new(RwLock::new(tree));
 
         let (chunk_migration_sender, _rx) = tokio::sync::mpsc::unbounded_channel();
+        // Packing sender: these tests don't assert on packing, so a buffered
+        // channel whose receiver is held (not dropped) is sufficient (enqueue
+        // failures are warn-and-continue).
+        let (packing_sender, _packing_rx) = tokio::sync::mpsc::channel(16);
 
         // Return a dummy tempdir alongside so callers can keep it alive if
         // they want; in practice the test owns its own tempdir for the DB.
@@ -909,6 +969,7 @@ mod tests {
             ConsensusConfig::testing().block_migration_depth as u64,
             cache,
             chunk_migration_sender,
+            packing_sender,
         );
         (svc, tmp)
     }
@@ -2181,6 +2242,124 @@ mod tests {
         assert!(
             index.get_item(finalized_height).is_some(),
             "the finalized block at height {finalized_height} must survive the rejected reorg",
+        );
+
+        Ok(())
+    }
+
+    /// Regression test: the rollback must clear only the orphaned
+    /// `DataRootInfo` placements, not wipe the whole list for a data_root that
+    /// is also placed by a still-canonical block.
+    #[test]
+    fn recover_from_network_partition_scopes_data_root_infos_clear() -> eyre::Result<()> {
+        use irys_database::submodule::{add_data_root_info, tables::DataRootInfo};
+        use irys_types::RelativeChunkOffset;
+
+        let (db, _db_tmp) = open_db()?;
+        let (mut svc, _svc_tmp) = make_service(db.clone());
+
+        let sm_tmp = irys_testing_utils::utils::TempDirBuilder::new()
+            .prefix("recover_scoped_dri")
+            .build();
+        let node_config = NodeConfig {
+            consensus: irys_types::ConsensusOptions::Custom(ConsensusConfig {
+                chunk_size: 32,
+                num_chunks_in_partition: 10,
+                ..ConsensusConfig::testing()
+            }),
+            base_directory: sm_tmp.path().to_path_buf(),
+            ..NodeConfig::testing()
+        };
+        let config = irys_types::Config::new_with_random_peer_id(node_config);
+        let info = StorageModuleInfo {
+            id: 0,
+            partition_assignment: Some(PartitionAssignment {
+                ledger_id: Some(DataLedger::Submit as u32),
+                slot_index: Some(0),
+                ..PartitionAssignment::default()
+            }),
+            submodules: vec![(partition_chunk_offset_ii!(0, 9), "submodule-0".into())],
+        };
+        let module = Arc::new(StorageModule::new(&info, &config)?);
+        module.pack_with_zeros();
+        svc.set_storage_modules_guard(StorageModulesReadGuard::new(Arc::new(RwLock::new(vec![
+            module.clone(),
+        ]))));
+
+        // The same data_root placed twice: a canonical placement at partition
+        // offset 0 (below the orphaned range) and an orphaned placement at
+        // offset 3 (inside it).
+        let shared_data_root = H256::random();
+        let orphan_txid = H256::random();
+        {
+            let (_, submodule) = module.get_submodule_for_offset(PartitionChunkOffset::from(3))?;
+            submodule.db.update_eyre(|tx| {
+                add_data_root_info(
+                    tx,
+                    shared_data_root,
+                    &DataRootInfo {
+                        start_offset: RelativeChunkOffset(0),
+                        data_size: 32,
+                    },
+                )?;
+                add_data_root_info(
+                    tx,
+                    shared_data_root,
+                    &DataRootInfo {
+                        start_offset: RelativeChunkOffset(3),
+                        data_size: 32,
+                    },
+                )
+            })?;
+        }
+
+        // The orphaned block carries the tx whose data_root is shared; its
+        // header must be resolvable so recovery adds it to the clear set.
+        let orphan_tx = DataTransactionHeader::V1(DataTransactionHeaderV1WithMetadata {
+            tx: DataTransactionHeaderV1 {
+                id: orphan_txid,
+                data_root: shared_data_root,
+                ledger_id: DataLedger::Submit as u32,
+                ..Default::default()
+            },
+            metadata: DataTransactionMetadata::new(),
+        });
+
+        // Genesis leaves Submit at 3 chunks; the orphan takes it to 6, so the
+        // orphaned range is ledger/partition [3, 5].
+        let genesis = make_block_header(0, H256::zero(), 3, vec![]);
+        let orphan = make_block_header(1, genesis.block_hash, 6, vec![orphan_txid]);
+        db.update_eyre(|tx| {
+            irys_database::insert_block_header(tx, &genesis)?;
+            irys_database::insert_block_header(tx, &orphan)?;
+            insert_tx_header(tx, &orphan_tx)
+        })?;
+        let submit_index_item = |header: &IrysBlockHeader, total_chunks| BlockIndexItem {
+            block_hash: header.block_hash,
+            num_ledgers: 1,
+            ledgers: vec![LedgerIndexItem {
+                total_chunks,
+                tx_root: H256::zero(),
+                ledger: DataLedger::Submit,
+            }],
+        };
+        {
+            let index = svc.block_index_guard.read();
+            index.push_item(&submit_index_item(&genesis, 3), 0)?;
+            index.push_item(&submit_index_item(&orphan, 6), 1)?;
+        }
+
+        svc.recover_from_network_partition(0)?;
+
+        let infos = module.collect_data_root_infos(shared_data_root)?;
+        assert_eq!(
+            infos.0,
+            vec![DataRootInfo {
+                start_offset: RelativeChunkOffset(0),
+                data_size: 32,
+            }],
+            "canonical placement (start_offset 0, below the orphaned range) survives; \
+             orphaned placement (start_offset 3, inside it) is removed"
         );
 
         Ok(())

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -509,156 +509,178 @@ impl BlockMigrationService {
             });
         }
 
-        // Phase 2: Unassign storage module offsets and clear orphaned index entries
-        for info in &rollback_infos {
-            for (ledger, range) in &info.ledger_ranges {
-                let modules = get_overlapped_storage_modules(storage_modules_guard, *ledger, range);
+        // Phases 2-4 mutate three stores that cannot share a transaction — the
+        // per-submodule DBs, the block index, and in-memory supply state — so a
+        // failure partway leaves them inconsistent. Once mutation begins we abort
+        // the node rather than return an error and keep running on a
+        // partially-rolled-back state; a clean restart re-runs the (idempotent)
+        // rollback. Crash-safe journaled recovery is the proper fix, tracked for
+        // the storage-module rework. Everything above this point is read-only, so
+        // its failures propagate normally.
+        let apply_rollback = || -> eyre::Result<()> {
+            // Phase 2: Unassign storage module offsets and clear orphaned index entries
+            for info in &rollback_infos {
+                for (ledger, range) in &info.ledger_ranges {
+                    let modules =
+                        get_overlapped_storage_modules(storage_modules_guard, *ledger, range);
 
-                for module in modules {
-                    // `modules` merely overlap `range`: clip to each module's own
-                    // ledger range before converting (as `index_transaction_data`
-                    // does), otherwise partially covered modules are skipped and
-                    // their orphaned offsets never unassigned.
-                    let module_range = match module.get_storage_module_ledger_offsets() {
-                        Ok(r) => r,
-                        Err(err) => {
-                            warn!(
-                                module_id = module.id,
-                                ?ledger,
-                                %err,
-                                "skipping storage module with no ledger offsets during rollback"
-                            );
-                            continue;
-                        }
-                    };
-                    // Fully qualified method call: importing `InclusiveInterval`
-                    // module-wide breaks inference on `PartitionChunkRange`,
-                    // which implements the trait for two point types.
-                    let Some(overlap) =
-                        nodit::InclusiveInterval::intersection(&module_range, range)
-                    else {
-                        warn!(
-                            module_id = module.id,
-                            ?ledger,
-                            ?range,
-                            ?module_range,
-                            "skipping storage module: orphaned range no longer overlaps during rollback"
-                        );
-                        continue;
-                    };
-                    // The clipped range is contained by construction, so this
-                    // only fails if the module's assignment changed mid-loop.
-                    let partition_range = match module.make_range_partition_relative(overlap) {
-                        Ok(r) => r,
-                        Err(err) => {
-                            warn!(
-                                module_id = module.id,
-                                ?ledger,
-                                %err,
-                                "skipping storage module: clipped range conversion failed during rollback"
-                            );
-                            continue;
-                        }
-                    };
-
-                    let range_start = *partition_range.start();
-                    let range_end = *partition_range.end();
-
-                    // Drop queued (not-yet-synced) writes in the orphaned range
-                    // first: a later `sync_pending_chunks` would otherwise replay
-                    // them and flip the intervals we clear below back to `Data`
-                    // over a now-empty offset index. This closes the queued-write
-                    // path; a sync already mid-flush (its batch snapshotted before
-                    // this drop) can still replay, but that window is transient and
-                    // healed by the repack enqueued below.
-                    module.drop_pending_writes_in_range(
-                        PartitionChunkOffset::from(range_start),
-                        PartitionChunkOffset::from(range_end),
-                    );
-
-                    // Clear per-offset tx/data path index entries for orphaned txs.
-                    module.clear_offset_index_in_range(
-                        PartitionChunkOffset::from(range_start),
-                        PartitionChunkOffset::from(range_end),
-                    )?;
-
-                    // Scope the DataRootInfos clear to the orphaned placements so
-                    // a data_root shared with a still-canonical block keeps its
-                    // canonical placement.
-                    module.clear_data_root_infos_in_range(
-                        PartitionChunkOffset::from(range_start),
-                        PartitionChunkOffset::from(range_end),
-                        &info.data_roots,
-                    )?;
-
-                    // Mark offsets as Uninitialized (not Entropy — on-disk bytes are packed data)
-                    {
-                        let mut intervals = module.intervals().write().unwrap();
-                        for offset in range_start..=range_end {
-                            let part_offset = PartitionChunkOffset::from(offset);
-                            StorageModule::cut_then_insert_interval_if_touching(
-                                &mut intervals,
-                                part_offset,
-                                ChunkType::Uninitialized,
-                            );
-                        }
-                    }
-                    module.write_intervals_to_submodules()?;
-
-                    // Re-request packing for the re-marked range. These offsets
-                    // are now `Uninitialized` with no entropy on disk; packing is
-                    // otherwise only requested at startup / assignment
-                    // transitions, so without this the canonical fork's
-                    // re-migrated chunks would have no entropy to XOR against and
-                    // silently fail to write. The packing channel is buffered and
-                    // a rollback enqueues only a handful of ranges, so a
-                    // non-blocking `try_send` from this sync path suffices; warn
-                    // (don't fail the module) if it can't be enqueued.
-                    //
-                    // Known limitation: packing is asynchronous, so canonical
-                    // chunks re-migrated into this range *before* packing
-                    // completes still find no entropy and are silently skipped by
-                    // `write_data_chunk`. This is not permanent — the range stays
-                    // `Uninitialized` and is recovered by the startup repack plus
-                    // data-sync. Closing the window (gating re-migration on
-                    // entropy presence) is left to the packing-reconciler rework.
-                    match PackingRequest::new(
-                        module.clone(),
-                        PartitionChunkRange(ii(
-                            PartitionChunkOffset::from(*partition_range.start()),
-                            PartitionChunkOffset::from(*partition_range.end()),
-                        )),
-                    ) {
-                        Ok(req) => {
-                            if let Err(err) = self.packing_sender.try_send(req) {
+                    for module in modules {
+                        // `modules` merely overlap `range`: clip to each module's own
+                        // ledger range before converting (as `index_transaction_data`
+                        // does), otherwise partially covered modules are skipped and
+                        // their orphaned offsets never unassigned.
+                        let module_range = match module.get_storage_module_ledger_offsets() {
+                            Ok(r) => r,
+                            Err(err) => {
                                 warn!(
                                     module_id = module.id,
+                                    ?ledger,
                                     %err,
-                                    "failed to enqueue repacking request during partition recovery"
+                                    "skipping storage module with no ledger offsets during rollback"
+                                );
+                                continue;
+                            }
+                        };
+                        // Fully qualified method call: importing `InclusiveInterval`
+                        // module-wide breaks inference on `PartitionChunkRange`,
+                        // which implements the trait for two point types.
+                        let Some(overlap) =
+                            nodit::InclusiveInterval::intersection(&module_range, range)
+                        else {
+                            warn!(
+                                module_id = module.id,
+                                ?ledger,
+                                ?range,
+                                ?module_range,
+                                "skipping storage module: orphaned range no longer overlaps during rollback"
+                            );
+                            continue;
+                        };
+                        // The clipped range is contained by construction, so this
+                        // only fails if the module's assignment changed mid-loop.
+                        let partition_range = match module.make_range_partition_relative(overlap) {
+                            Ok(r) => r,
+                            Err(err) => {
+                                warn!(
+                                    module_id = module.id,
+                                    ?ledger,
+                                    %err,
+                                    "skipping storage module: clipped range conversion failed during rollback"
+                                );
+                                continue;
+                            }
+                        };
+
+                        let range_start = *partition_range.start();
+                        let range_end = *partition_range.end();
+
+                        // Drop queued (not-yet-synced) writes in the orphaned range
+                        // first: a later `sync_pending_chunks` would otherwise replay
+                        // them and flip the intervals we clear below back to `Data`
+                        // over a now-empty offset index. This closes the queued-write
+                        // path; a sync already mid-flush (its batch snapshotted before
+                        // this drop) can still replay, but that window is transient and
+                        // healed by the repack enqueued below.
+                        module.drop_pending_writes_in_range(
+                            PartitionChunkOffset::from(range_start),
+                            PartitionChunkOffset::from(range_end),
+                        );
+
+                        // Clear per-offset tx/data path index entries for orphaned txs.
+                        module.clear_offset_index_in_range(
+                            PartitionChunkOffset::from(range_start),
+                            PartitionChunkOffset::from(range_end),
+                        )?;
+
+                        // Scope the DataRootInfos clear to the orphaned placements so
+                        // a data_root shared with a still-canonical block keeps its
+                        // canonical placement.
+                        module.clear_data_root_infos_in_range(
+                            PartitionChunkOffset::from(range_start),
+                            PartitionChunkOffset::from(range_end),
+                            &info.data_roots,
+                        )?;
+
+                        // Mark offsets as Uninitialized (not Entropy — on-disk bytes are packed data)
+                        {
+                            let mut intervals = module.intervals().write().unwrap();
+                            for offset in range_start..=range_end {
+                                let part_offset = PartitionChunkOffset::from(offset);
+                                StorageModule::cut_then_insert_interval_if_touching(
+                                    &mut intervals,
+                                    part_offset,
+                                    ChunkType::Uninitialized,
                                 );
                             }
                         }
-                        Err(err) => {
-                            warn!(
-                                module_id = module.id,
-                                %err,
-                                "failed to build repacking request during partition recovery"
-                            );
+                        module.write_intervals_to_submodules()?;
+
+                        // Re-request packing for the re-marked range. These offsets
+                        // are now `Uninitialized` with no entropy on disk; packing is
+                        // otherwise only requested at startup / assignment
+                        // transitions, so without this the canonical fork's
+                        // re-migrated chunks would have no entropy to XOR against and
+                        // silently fail to write. The packing channel is buffered and
+                        // a rollback enqueues only a handful of ranges, so a
+                        // non-blocking `try_send` from this sync path suffices; warn
+                        // (don't fail the module) if it can't be enqueued.
+                        //
+                        // Known limitation: packing is asynchronous, so canonical
+                        // chunks re-migrated into this range *before* packing
+                        // completes still find no entropy and are silently skipped by
+                        // `write_data_chunk`. This is not permanent — the range stays
+                        // `Uninitialized` and is recovered by the startup repack plus
+                        // data-sync. Closing the window (gating re-migration on
+                        // entropy presence) is left to the packing-reconciler rework.
+                        match PackingRequest::new(
+                            module.clone(),
+                            PartitionChunkRange(ii(
+                                PartitionChunkOffset::from(*partition_range.start()),
+                                PartitionChunkOffset::from(*partition_range.end()),
+                            )),
+                        ) {
+                            Ok(req) => {
+                                if let Err(err) = self.packing_sender.try_send(req) {
+                                    warn!(
+                                        module_id = module.id,
+                                        %err,
+                                        "failed to enqueue repacking request during partition recovery"
+                                    );
+                                }
+                            }
+                            Err(err) => {
+                                warn!(
+                                    module_id = module.id,
+                                    %err,
+                                    "failed to build repacking request during partition recovery"
+                                );
+                            }
                         }
                     }
                 }
             }
-        }
 
-        // Phase 3: Truncate block index
-        block_index.truncate_to_height(fork_parent_height)?;
+            // Phase 3: Truncate block index
+            block_index.truncate_to_height(fork_parent_height)?;
 
-        // Phase 4: Roll back supply state
-        if let Some(supply_state) = &self.supply_state {
-            let reward_sum: U256 = rollback_infos.iter().fold(U256::zero(), |acc, info| {
-                acc.saturating_add(info.reward_amount)
-            });
-            supply_state.rollback_reward(fork_parent_height, reward_sum);
+            // Phase 4: Roll back supply state
+            if let Some(supply_state) = &self.supply_state {
+                let reward_sum: U256 = rollback_infos.iter().fold(U256::zero(), |acc, info| {
+                    acc.saturating_add(info.reward_amount)
+                });
+                supply_state.rollback_reward(fork_parent_height, reward_sum);
+            }
+
+            Ok(())
+        };
+
+        if let Err(err) = apply_rollback() {
+            panic!(
+                "network-partition rollback failed after mutation began; aborting the \
+                 node to avoid running on partially-rolled-back state (storage modules \
+                 and the block index may be left inconsistent until a restart re-runs \
+                 recovery): {err:#}"
+            );
         }
 
         info!(

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -2261,6 +2261,7 @@ mod tests {
                 config.consensus.block_migration_depth as u64,
                 cache.clone(),
                 chunk_migration_sender,
+                service_senders.packing_sender(),
             );
 
             // Real (not mocked) VDF state pinned at `live_step`; the gate only

--- a/crates/actors/src/partition_mining_service.rs
+++ b/crates/actors/src/partition_mining_service.rs
@@ -256,10 +256,8 @@ impl PartitionMiningServiceInner {
             );
         }
 
-        for (index, (_chunk_offset, (chunk_bytes, chunk_type))) in chunks.iter().enumerate() {
+        for (&partition_chunk_offset, (chunk_bytes, chunk_type)) in chunks.iter() {
             // TODO: check if difficulty higher now. Will look in DB for latest difficulty info and update difficulty
-            let partition_chunk_offset =
-                PartitionChunkOffset::from(start_chunk_offset + index as u32);
 
             // Only include the tx_path and data_path for chunks that contain data
             let (tx_path, data_path) = match chunk_type {
@@ -288,7 +286,7 @@ impl PartitionMiningServiceInner {
                     self.storage_module.id,
                     partition_chunk_offset,
                     self.config.consensus.num_chunks_in_partition,
-                    index,
+                    *partition_chunk_offset - start_chunk_offset,
                     chunks.len(),
                     self.difficulty
                 );

--- a/crates/actors/src/partition_mining_service.rs
+++ b/crates/actors/src/partition_mining_service.rs
@@ -287,7 +287,7 @@ impl PartitionMiningServiceInner {
                     partition_chunk_offset,
                     self.config.consensus.num_chunks_in_partition,
                     *partition_chunk_offset - start_chunk_offset,
-                    chunks.len(),
+                    self.config.consensus.num_chunks_in_recall_range,
                     self.difficulty
                 );
                 metrics::record_mining_solution_found();

--- a/crates/actors/src/partition_mining_service.rs
+++ b/crates/actors/src/partition_mining_service.rs
@@ -393,6 +393,19 @@ impl PartitionMiningServiceInner {
         self.get_recall_range(step, &seed, &partition_hash)
             .expect("test_get_recall_range failed")
     }
+
+    /// Test-only helper to drive the mining loop directly (bypassing the
+    /// service event loop) so a sparse recall range with an `Uninitialized`
+    /// hole can be exercised.
+    pub fn test_mine_partition_with_seed(
+        &mut self,
+        mining_seed: irys_types::H256,
+        vdf_step: u64,
+        checkpoints: &H256List,
+    ) -> Option<SolutionContext> {
+        self.mine_partition_with_seed(mining_seed, vdf_step, checkpoints)
+            .expect("test_mine_partition_with_seed failed")
+    }
 }
 
 /// Tokio service for partition mining
@@ -688,6 +701,104 @@ mod tests {
         assert_eq!(
             got, expected,
             "a behind-the-iterator step must rebuild the rotation, not answer from stale state"
+        );
+    }
+
+    /// Regression test for the sparse-map PoA offset bug. `read_chunks` skips
+    /// `Uninitialized` offsets, so the mining loop must key the solution's
+    /// partition offset off the returned map key, not a dense index. Offset 0
+    /// is left `Uninitialized` (a hole at the start of the recall range), so
+    /// the first returned chunk is offset 1 at dense index 0 — the old
+    /// `start + index` code produced offset 0 and a PoA over the wrong offset.
+    /// Difficulty 0 makes the first chunk win.
+    #[test]
+    fn solution_offset_keys_off_map_over_uninitialized_hole() {
+        let tmp_dir = TempDirBuilder::new().build();
+        let node_config = NodeConfig {
+            consensus: ConsensusOptions::Custom(ConsensusConfig {
+                chunk_size: 32,
+                num_chunks_in_partition: 10,
+                // single recall range spanning the whole partition → index 0,
+                // so get_recall_range needs no VDF reconstruction
+                num_chunks_in_recall_range: 10,
+                ..ConsensusConfig::testing()
+            }),
+            base_directory: tmp_dir.path().to_path_buf(),
+            ..NodeConfig::testing()
+        };
+        let config = Config::new_with_random_peer_id(node_config);
+
+        let partition_hash = H256::repeat_byte(0x77);
+        let info = StorageModuleInfo {
+            id: 0,
+            partition_assignment: Some(PartitionAssignment {
+                partition_hash,
+                miner_address: config.node_config.miner_address(),
+                ledger_id: None,
+                slot_index: None,
+            }),
+            submodules: vec![(partition_chunk_offset_ie!(0, 10), "hdd0".into())],
+        };
+        let storage_module =
+            Arc::new(StorageModule::new(&info, &config).expect("test storage module"));
+
+        // Pack offsets 1..10 as Entropy, leaving offset 0 Uninitialized (the hole).
+        let chunk = vec![0_u8; config.consensus.chunk_size as usize];
+        for offset in 1..10_u32 {
+            storage_module.write_chunk(
+                PartitionChunkOffset::from(offset),
+                chunk.clone(),
+                ChunkType::Entropy,
+            );
+        }
+        storage_module
+            .force_sync_pending_chunks()
+            .expect("sync entropy writes");
+
+        // Sanity: read_chunks skips offset 0, so the first key is 1 at dense index 0.
+        let chunks = storage_module
+            .read_chunks(partition_chunk_offset_ie!(0, 10))
+            .expect("read chunks");
+        assert!(
+            !chunks.contains_key(&PartitionChunkOffset::from(0)),
+            "offset 0 must be an Uninitialized hole"
+        );
+        assert_eq!(
+            *chunks.keys().next().expect("a returned chunk"),
+            PartitionChunkOffset::from(1),
+            "first returned chunk is offset 1"
+        );
+
+        let vdf_state = Arc::new(RwLock::new(VdfState::new(
+            8,
+            0,
+            Arc::new(AtomicBool::new(false)),
+        )));
+        let (service_senders, _receivers) = ServiceSenders::new();
+        let mut inner = PartitionMiningServiceInner::new(
+            &config,
+            service_senders,
+            storage_module,
+            false,
+            VdfStateReadonly::new(Arc::clone(&vdf_state)),
+            U256::zero(), // difficulty 0 → the first chunk wins
+        );
+
+        let seed = H256::repeat_byte(0x11);
+        // step = 1 hits get_recall_range's consecutive fast path (no VDF reads).
+        let solution = inner
+            .test_mine_partition_with_seed(seed, 1, &H256List::default())
+            .expect("a solution at difficulty 0");
+
+        assert_eq!(
+            solution.chunk_offset, 1,
+            "solution offset must be the true map key (1), not the dense index (0)"
+        );
+        // The PoA hash must be computed over that same true offset.
+        assert_eq!(
+            solution.solution_hash,
+            irys_types::compute_solution_hash(&chunk, solution.chunk_offset, &seed),
+            "solution hash must be over the true offset"
         );
     }
 }

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -1656,6 +1656,7 @@ impl IrysNode {
             u64::from(config.consensus.block_migration_depth),
             Arc::clone(&block_tree_cache),
             service_senders.chunk_migration.clone(),
+            service_senders.packing_sender(),
         );
 
         // Create the VDF state before the block tree service: its re-anchor

--- a/crates/domain/src/models/block_index.rs
+++ b/crates/domain/src/models/block_index.rs
@@ -96,6 +96,15 @@ impl BlockIndex {
             .unwrap_or(0)
     }
 
+    /// Fallible variant of [`Self::latest_height`]. `Ok(None)` means the index
+    /// is empty; a DB read error propagates instead of being masked as height
+    /// `0` (which [`Self::latest_height`] cannot distinguish from an empty
+    /// index). Callers that must not treat a read failure as "no blocks" — e.g.
+    /// the deep-reorg rollback guard — should use this.
+    pub fn try_latest_height(&self) -> eyre::Result<Option<u64>> {
+        self.db.view_eyre(block_index_latest_height)
+    }
+
     /// Retrieves a [`BlockIndexItem`] from the block index by block height
     pub fn get_item(&self, block_height: u64) -> Option<BlockIndexItem> {
         self.db
@@ -873,6 +882,27 @@ mod tests {
             block_index.push_item(&item, h).unwrap();
         }
         (tmp_dir, block_index)
+    }
+
+    /// `try_latest_height` must distinguish an empty index (`None`) from a
+    /// populated one (`Some(max_height)`) — the distinction the deep-reorg
+    /// rollback guard relies on to avoid treating "no blocks" and a masked DB
+    /// error alike. `latest_height` collapses both empty and genesis-only to 0.
+    #[test]
+    fn try_latest_height_distinguishes_empty_from_populated() {
+        let (_empty_tmp, empty) = build_uniform_index(0);
+        assert_eq!(
+            empty.try_latest_height().expect("empty index read"),
+            None,
+            "an empty index reports no latest height, not 0"
+        );
+
+        let (_tmp, populated) = build_uniform_index(3);
+        assert_eq!(
+            populated.try_latest_height().expect("populated index read"),
+            Some(2),
+            "3 blocks occupy heights 0..=2"
+        );
     }
 
     /// Builds a `BlockIndex` where the Publish ledger is introduced at

--- a/crates/domain/src/models/storage_module.rs
+++ b/crates/domain/src/models/storage_module.rs
@@ -2477,6 +2477,18 @@ mod tests {
                     start_offset: RelativeChunkOffset(4),
                     data_size: 32,
                 },
+            )?;
+            // Orphaned cross-partition placement anchored in a lower module:
+            // negative start_offset whose extent [-2, 3] (ceil(192 / 32) = 6
+            // chunks) reaches into the range. start_offset alone (-2 < 3) would
+            // wrongly keep it; this exercises the negative-i32 extent path.
+            add_data_root_info(
+                tx,
+                data_root,
+                &DataRootInfo {
+                    start_offset: RelativeChunkOffset(-2),
+                    data_size: 192,
+                },
             )
         })?;
 

--- a/crates/domain/src/models/storage_module.rs
+++ b/crates/domain/src/models/storage_module.rs
@@ -47,6 +47,7 @@ use irys_database::{
         clear_submodule_database, create_or_open_submodule_db, get_data_path_by_offset,
         get_data_root_infos_for_data_root, get_full_data_path, get_full_tx_path,
         get_path_hashes_by_offset, get_tx_leaf_binding, get_tx_path_by_offset,
+        set_data_root_infos_for_data_root,
         tables::{DataRootInfo, DataRootInfos, TxLeafBinding},
     },
 };
@@ -1030,6 +1031,120 @@ impl StorageModule {
     pub fn print_pending_writes(&self) {
         let pending = self.pending_writes.read().unwrap();
         debug!("pending_writes: {:?}", pending);
+    }
+
+    /// Drops any queued (not-yet-synced) chunk writes whose partition offset
+    /// falls in the inclusive range `[start, end]`.
+    ///
+    /// Used by network-partition rollback: after orphaned offsets are cleared
+    /// and re-marked `Uninitialized`, a stale pending write left in the queue
+    /// would be replayed by `sync_pending_chunks` and flip the interval back to
+    /// `Data` with a now-empty offset index.
+    pub fn drop_pending_writes_in_range(
+        &self,
+        start: PartitionChunkOffset,
+        end: PartitionChunkOffset,
+    ) {
+        let mut pending = self.pending_writes.write().unwrap();
+        pending.retain(|offset, _| *offset < start || *offset > end);
+    }
+
+    /// Clears the per-offset tx-path and data-path offset-index entries in the
+    /// inclusive partition range `[start, end]`, so orphaned chunk offsets no
+    /// longer resolve to a tx/data path.
+    ///
+    /// Used by network-partition rollback alongside
+    /// [`Self::clear_data_root_infos_in_range`]. Walks each submodule covering
+    /// the range once, clearing its slice of the range in a single write
+    /// transaction.
+    pub fn clear_offset_index_in_range(
+        &self,
+        start: PartitionChunkOffset,
+        end: PartitionChunkOffset,
+    ) -> eyre::Result<()> {
+        let range_start = *start;
+        let range_end = *end;
+        let mut cursor = range_start;
+        while cursor <= range_end {
+            let (interval, submodule) =
+                self.get_submodule_for_offset(PartitionChunkOffset::from(cursor))?;
+            let submodule_end = *interval.end();
+            let slice_end = submodule_end.min(range_end);
+            submodule.db.update_eyre(|tx| {
+                for offset in cursor..=slice_end {
+                    let part_offset = PartitionChunkOffset::from(offset);
+                    add_tx_path_hash_to_offset_index(tx, part_offset, None)?;
+                    add_data_path_hash_to_offset_index(tx, part_offset, None)?;
+                }
+                Ok(())
+            })?;
+            // Advance to the next submodule covering the range.
+            if submodule_end >= range_end {
+                break;
+            }
+            cursor = submodule_end + 1;
+        }
+        Ok(())
+    }
+
+    /// Removes the `DataRootInfo` placements whose on-disk extent
+    /// `[start_offset, start_offset + ceil(data_size / chunk_size) - 1]`
+    /// intersects the inclusive range `[start, end]`, for each of `data_roots`,
+    /// leaving placements that lie entirely outside the range intact.
+    ///
+    /// Used by network-partition rollback to un-index only the *orphaned*
+    /// placement of a data_root. A data_root shared with a still-canonical
+    /// block (a Submit→Publish promotion, or a duplicate upload of identical
+    /// data) keeps its canonical placement, whose extent sits outside the
+    /// orphaned range. Walks each submodule covering the range once, so it
+    /// does not depend on the per-chunk offset.
+    pub fn clear_data_root_infos_in_range(
+        &self,
+        start: PartitionChunkOffset,
+        end: PartitionChunkOffset,
+        data_roots: &[H256],
+    ) -> eyre::Result<()> {
+        let range_start = *start;
+        let range_end = *end;
+        let mut cursor = range_start;
+        while cursor <= range_end {
+            let (interval, submodule) =
+                self.get_submodule_for_offset(PartitionChunkOffset::from(cursor))?;
+            let submodule_end = *interval.end();
+            submodule.db.update_eyre(|tx| {
+                for data_root in data_roots {
+                    let Some(infos) = get_data_root_infos_for_data_root(tx, *data_root)? else {
+                        continue;
+                    };
+                    let remaining: Vec<_> = infos
+                        .0
+                        .into_iter()
+                        .filter(|di| {
+                            // Keep the placement iff its full on-disk extent
+                            // [start_offset, start_offset + ceil(data_size / chunk_size) - 1]
+                            // does NOT intersect the orphaned range. Matching on
+                            // start_offset alone would leave a stale entry for a
+                            // placement that begins before the range (e.g. a
+                            // cross-partition placement in a higher module, whose
+                            // start_offset is negative) but extends into it.
+                            let extent_start = di.start_offset.0;
+                            let extent_chunks =
+                                di.data_size.div_ceil(self.config.consensus.chunk_size) as i32;
+                            let extent_end = (extent_start + extent_chunks).saturating_sub(1);
+                            extent_end < range_start as i32 || extent_start > range_end as i32
+                        })
+                        .collect();
+                    set_data_root_infos_for_data_root(tx, *data_root, DataRootInfos(remaining))?;
+                }
+                Ok(())
+            })?;
+            // Advance to the next submodule covering the range.
+            if submodule_end >= range_end {
+                break;
+            }
+            cursor = submodule_end + 1;
+        }
+        Ok(())
     }
 
     /// Indexes transaction data by mapping chunks to transaction paths across storage submodules.
@@ -2245,6 +2360,142 @@ mod tests {
             storage_module
                 .make_range_partition_relative(LedgerChunkRange(ledger_chunk_offset_ii!(25, 45)))
                 .is_err()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn drop_pending_writes_in_range_purges_only_the_range() -> eyre::Result<()> {
+        let infos = [StorageModuleInfo {
+            id: 0,
+            partition_assignment: Some(PartitionAssignment::default()),
+            submodules: vec![(partition_chunk_offset_ii!(0, 9), "hdd0-test".into())],
+        }];
+        let tmp_dir = TempDirBuilder::new()
+            .prefix("drop_pending_writes_test")
+            .build();
+        let node_config = NodeConfig {
+            consensus: irys_types::ConsensusOptions::Custom(ConsensusConfig {
+                chunk_size: 32,
+                num_chunks_in_partition: 10,
+                ..ConsensusConfig::testing()
+            }),
+            base_directory: tmp_dir.path().to_path_buf(),
+            ..NodeConfig::testing()
+        };
+        let config = Config::new_with_random_peer_id(node_config);
+        let storage_module = StorageModule::new(&infos[0], &config)?;
+
+        // Queue writes at offsets 0..6.
+        let bytes = vec![0_u8; config.consensus.chunk_size as usize];
+        for offset in 0..6_u32 {
+            storage_module.write_chunk(
+                PartitionChunkOffset::from(offset),
+                bytes.clone(),
+                ChunkType::Entropy,
+            );
+        }
+
+        // Purge the orphaned range [2, 4] (inclusive).
+        storage_module.drop_pending_writes_in_range(
+            PartitionChunkOffset::from(2),
+            PartitionChunkOffset::from(4),
+        );
+
+        let remaining: Vec<u32> = storage_module
+            .pending_writes
+            .read()
+            .unwrap()
+            .keys()
+            .map(|o| **o)
+            .collect();
+        assert_eq!(
+            remaining,
+            vec![0, 1, 5],
+            "only offsets inside [2, 4] are dropped; those outside remain queued"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn clear_data_root_infos_in_range_drops_placements_overlapping_by_extent() -> eyre::Result<()> {
+        use irys_database::submodule::{add_data_root_info, tables::DataRootInfo};
+        use irys_types::RelativeChunkOffset;
+
+        let infos = [StorageModuleInfo {
+            id: 0,
+            partition_assignment: Some(PartitionAssignment::default()),
+            submodules: vec![(partition_chunk_offset_ii!(0, 9), "hdd0-test".into())],
+        }];
+        let tmp_dir = TempDirBuilder::new()
+            .prefix("clear_dri_extent_test")
+            .build();
+        let node_config = NodeConfig {
+            consensus: irys_types::ConsensusOptions::Custom(ConsensusConfig {
+                chunk_size: 32,
+                num_chunks_in_partition: 10,
+                ..ConsensusConfig::testing()
+            }),
+            base_directory: tmp_dir.path().to_path_buf(),
+            ..NodeConfig::testing()
+        };
+        let config = Config::new_with_random_peer_id(node_config);
+        let storage_module = StorageModule::new(&infos[0], &config)?;
+
+        // Three placements of the same (orphaned) data_root; orphaned range is [3, 5].
+        let data_root = H256::random();
+        let (_, submodule) =
+            storage_module.get_submodule_for_offset(PartitionChunkOffset::from(0))?;
+        submodule.db.update_eyre(|tx| {
+            // Canonical: extent [0, 0], entirely below the orphaned range.
+            add_data_root_info(
+                tx,
+                data_root,
+                &DataRootInfo {
+                    start_offset: RelativeChunkOffset(0),
+                    data_size: 32,
+                },
+            )?;
+            // Orphaned: starts at offset 2 (below range_start 3) but spans 3
+            // chunks → extent [2, 4], reaching into the range. `start_offset`
+            // alone (2 < 3) would wrongly keep it; extent overlap drops it.
+            add_data_root_info(
+                tx,
+                data_root,
+                &DataRootInfo {
+                    start_offset: RelativeChunkOffset(2),
+                    data_size: 96,
+                },
+            )?;
+            // Orphaned: extent [4, 4], fully inside the range.
+            add_data_root_info(
+                tx,
+                data_root,
+                &DataRootInfo {
+                    start_offset: RelativeChunkOffset(4),
+                    data_size: 32,
+                },
+            )
+        })?;
+
+        storage_module.clear_data_root_infos_in_range(
+            PartitionChunkOffset::from(3),
+            PartitionChunkOffset::from(5),
+            &[data_root],
+        )?;
+
+        let remaining = storage_module.collect_data_root_infos(data_root)?;
+        assert_eq!(
+            remaining.0,
+            vec![DataRootInfo {
+                start_offset: RelativeChunkOffset(0),
+                data_size: 32,
+            }],
+            "only the canonical placement whose extent lies entirely outside [3, 5] \
+             survives; the placement starting at offset 2 but extending into the \
+             range is dropped by extent overlap"
         );
 
         Ok(())


### PR DESCRIPTION
## What

Two fixes for storage-module behavior around network-partition rollback.

### Repack orphaned ranges + scope rollback clears (`block_migration_service`, `storage_module`)

`recover_from_network_partition` re-marks rolled-back chunk offsets `Uninitialized`, but packing is otherwise only requested at startup and on assignment transitions — so those offsets stayed a dead zone while the node ran, and the canonical fork's re-migrated chunks found no entropy and were silently dropped by `write_data_chunk` until the next restart.

- Enqueue a packing request per re-marked range so the gap heals live.
- Scope the offset-index and `DataRootInfos` clears to the orphaned range — drop a placement iff its on-disk extent `[start, start + ceil(data_size / chunk_size) - 1]` intersects the range — so a `data_root` shared with a still-canonical block keeps its canonical placement.
- Purge stale pending writes in the range so a later `sync_pending_chunks` cannot replay them over the cleared index.

### Correct PoA offset over `Uninitialized` holes (`partition_mining_service`)

`read_chunks` skips `Uninitialized` offsets, so iterating its result with `enumerate()` shifted every offset after a mid-partition hole and produced an invalid PoA solution. Key off the returned map's partition offset instead. Exposed by the rollback path, which now creates such holes.

## Interim / follow-up

Threading a packing sender into the migration service is an interim home for the repack; the intended owner is a per-storage-module packing reconciler. Known limitations tracked for that rework:

- A canonical chunk re-migrated into a range before packing completes is still skipped by `write_data_chunk` (not permanent — recovered by startup repack + data-sync).
- Repack requests use non-blocking `try_send`, so a rollback that saturates the packing channel can drop some — those ranges recover on restart.

## Testing

- `cargo fmt --all --check` and `cargo clippy -p irys-domain -p irys-actors --tests --all-targets` clean.
- `block_migration_service` / `partition_mining_service` / `storage_module` test modules pass (41/41), including a new regression test for the extent-scoped `DataRootInfos` clear (a placement starting below the orphaned range but extending into it).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Network-partition recovery now performs extent-scoped rollback cleanup, clearing `DataRootInfo` only for orphaned overlapping placements while preserving canonical placements for shared data roots.
  * Transient database read issues no longer get treated as “no data,” improving reliability of recovery.
  * Mining now reports correct solution offset/hash when skipping `Uninitialized` gaps.
  * Rollback cleanup ensures affected ranges are requeued for repacking.
* **Tests**
  * Added regression coverage for extent-scoped cleanup, inclusive-range pending-write purging, and correct mining offset/hash computation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->