### PR TITLE
fix(data-sync): separate fetch from durable store; block missing data_root index

### DIFF
--- a/crates/actors/src/data_sync_service.rs
+++ b/crates/actors/src/data_sync_service.rs
@@ -24,7 +24,7 @@ use tracing::{Instrument as _, debug, error, warn};
 /// Local write outcome after a successful peer fetch.
 #[derive(Debug, PartialEq, Eq)]
 enum DataSyncWriteOutcome {
-    /// Offset is now (or is about to be observed as) [`ChunkType::Data`].
+    /// Offset is durably [`ChunkType::Data`] after pending flush + fsync.
     Stored,
     /// SM has no `DataRootInfos` entry for this data_root — needs index rebuild.
     MissingDataRootIndex,
@@ -43,11 +43,22 @@ fn attempt_data_sync_write(
         Err(WriteDataChunkError::DataRootNotFound) => DataSyncWriteOutcome::MissingDataRootIndex,
         Err(e) => DataSyncWriteOutcome::Other(e.to_string()),
         Ok(()) => {
-            // write_data_chunk can return Ok(()) without writing when there are
-            // no Entropy targets at the resolved offsets — verify the requested
-            // offset actually became Data.
+            // write_data_chunk only enqueues into pending_writes; get_chunk_type
+            // can report Data before persistence. Do not mark Stored (or
+            // Completed in the orchestrator) until force_sync flushes + fsyncs.
+            // On flush failure we return Other → requeue; the request stays
+            // Requested until this function returns an outcome that advances it.
             if matches!(sm.get_chunk_type(&expected_offset), Some(ChunkType::Data)) {
-                DataSyncWriteOutcome::Stored
+                if let Err(e) = sm.force_sync_pending_chunks() {
+                    return DataSyncWriteOutcome::Other(e.to_string());
+                }
+                if matches!(sm.get_chunk_type(&expected_offset), Some(ChunkType::Data)) {
+                    DataSyncWriteOutcome::Stored
+                } else {
+                    DataSyncWriteOutcome::Other(
+                        "chunk not Data after force_sync_pending_chunks".into(),
+                    )
+                }
             } else if matches!(
                 sm.collect_data_root_infos(unpacked.data_root),
                 Ok(infos) if infos.0.is_empty()

--- a/crates/actors/src/data_sync_service.rs
+++ b/crates/actors/src/data_sync_service.rs
@@ -4,12 +4,12 @@ pub mod peer_bandwidth_manager;
 pub mod peer_stats;
 
 use crate::{chunk_fetcher::ChunkFetcherFactory, metrics, services::ServiceSenders};
-use chunk_orchestrator::ChunkOrchestrator;
+use chunk_orchestrator::{ChunkBlockReason, ChunkOrchestrator};
 use irys_domain::{BlockTreeReadGuard, ChunkType, PeerList, StorageModule};
 use irys_packing::unpack;
 use irys_types::{
     Config, IrysAddress, PackedChunk, PartitionChunkOffset, SendTraced as _, TokioServiceHandle,
-    Traced,
+    Traced, UnpackedChunk,
 };
 use peer_bandwidth_manager::PeerBandwidthManager;
 use reth::tasks::shutdown::Shutdown;
@@ -20,6 +20,66 @@ use std::{
 };
 use tokio::sync::{mpsc::UnboundedReceiver, oneshot};
 use tracing::{Instrument as _, debug, error, warn};
+
+/// Local write outcome after a successful peer fetch.
+#[derive(Debug)]
+enum DataSyncWriteOutcome {
+    /// Offset is now (or is about to be observed as) [`ChunkType::Data`].
+    Stored,
+    /// SM has no `DataRootInfos` entry for this data_root — needs index rebuild.
+    MissingDataRootIndex,
+    /// data_root is indexed but no Entropy target at the expected offsets.
+    NoWriteableOffset,
+    /// Other write error.
+    Other(String),
+}
+
+fn attempt_data_sync_write(
+    sm: &StorageModule,
+    unpacked: &UnpackedChunk,
+    expected_offset: PartitionChunkOffset,
+) -> DataSyncWriteOutcome {
+    match sm.write_data_chunk(unpacked) {
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("data_root not found") {
+                DataSyncWriteOutcome::MissingDataRootIndex
+            } else {
+                DataSyncWriteOutcome::Other(msg)
+            }
+        }
+        Ok(()) => {
+            // write_data_chunk can return Ok(()) without writing when there are
+            // no Entropy targets at the resolved offsets — verify the requested
+            // offset actually became Data.
+            if matches!(
+                sm.get_chunk_type(&expected_offset),
+                Some(ChunkType::Data)
+            ) {
+                DataSyncWriteOutcome::Stored
+            } else if matches!(
+                sm.collect_data_root_infos(unpacked.data_root),
+                Ok(infos) if infos.0.is_empty()
+            ) {
+                // Defensive: empty infos should have been Err, but classify if not.
+                DataSyncWriteOutcome::MissingDataRootIndex
+            } else {
+                DataSyncWriteOutcome::NoWriteableOffset
+            }
+        }
+    }
+}
+
+fn try_send_chunk_to_ingress(service_senders: &ServiceSenders, unpacked: UnpackedChunk) {
+    if let Err(e) = service_senders.chunk_ingress.send_traced(
+        crate::chunk_ingress_service::ChunkIngressMessage::IngestChunk(unpacked, None),
+    ) {
+        warn!(
+            error = %e,
+            "Failed to send ChunkIngressMessage to chunk ingress channel after data_sync write failure"
+        );
+    }
+}
 
 pub struct DataSyncService {
     shutdown: Shutdown,
@@ -103,13 +163,16 @@ impl DataSyncServiceInner {
                 peer_address: peer_addr,
                 chunk,
             } => {
-                metrics::record_data_sync_chunk_completed();
+                // Fetch succeeded — record that separately from durable store.
+                metrics::record_data_sync_chunk_fetched();
                 if let Err(e) =
                     self.on_chunk_completed(storage_module_id, chunk_offset, peer_addr, chunk)
                 {
                     error!(
-                        "Failed to handle chunk completion for storage_module {} chunk_offset {} from peer {}: {e:?}",
-                        storage_module_id, chunk_offset, peer_addr
+                        storage_module.id = storage_module_id,
+                        chunk.offset = %chunk_offset,
+                        peer.address = %peer_addr,
+                        "Failed to handle chunk completion: {e:?}"
                     );
                 }
             }
@@ -228,7 +291,9 @@ impl DataSyncServiceInner {
     #[tracing::instrument(level = "trace", skip_all, fields(
         chunk.storage_module_id = storage_module_id,
         chunk.offset = %chunk_offset,
-        peer.address = %peer_addr
+        peer.address = %peer_addr,
+        chunk.data_root = %chunk.data_root,
+        chunk.partition_hash = %chunk.partition_hash,
     ))]
     fn on_chunk_completed(
         &mut self,
@@ -237,12 +302,11 @@ impl DataSyncServiceInner {
         peer_addr: IrysAddress,
         chunk: PackedChunk,
     ) -> eyre::Result<()> {
-        // Update the orchestrator with completion tracking
+        // Peer delivery success: credit bandwidth stats, leave Requested until write outcome.
         if let Some(orchestrator) = self.chunk_orchestrators.get_mut(&storage_module_id) {
-            orchestrator.on_chunk_completed(chunk_offset, peer_addr)?;
+            orchestrator.on_chunk_fetched(chunk_offset, peer_addr)?;
         }
 
-        // Unpack and store the chunk data
         let consensus = &self.config.consensus;
         let unpacked_chunk = unpack(
             &chunk,
@@ -251,27 +315,104 @@ impl DataSyncServiceInner {
             consensus.chain_id,
         );
 
-        // Attempt to write the chunk directly to the sm, if it doesn't succeed
-        // for a variety of reasons, indexes not initialized, no packing etc etc...
         let sm = self
             .storage_modules
             .read()
             .unwrap()
             .get(storage_module_id)
-            .unwrap()
+            .ok_or_else(|| eyre::eyre!("storage_module_id {storage_module_id} not found"))?
             .clone();
-        if sm.write_data_chunk(&unpacked_chunk).is_err() {
-            // ..then, send the unpacked chunk to the mempool and let the it do it's thing.
-            if let Err(e) = self.service_senders.chunk_ingress.send_traced(
-                crate::chunk_ingress_service::ChunkIngressMessage::IngestChunk(
-                    unpacked_chunk,
-                    None,
-                ),
-            ) {
-                tracing::warn!(
-                    "Failed to send ChunkIngressMessage to chunk ingress channel: {:?}",
-                    e
+
+        let pa = sm.partition_assignment();
+        let ledger_id = pa.and_then(|p| p.ledger_id);
+        let slot_index = pa.and_then(|p| p.slot_index);
+        let partition_hash = pa.map(|p| p.partition_hash);
+
+        let write_outcome = attempt_data_sync_write(&sm, &unpacked_chunk, chunk_offset);
+
+        match write_outcome {
+            DataSyncWriteOutcome::Stored => {
+                metrics::record_data_sync_chunk_stored();
+                if let Some(orchestrator) = self.chunk_orchestrators.get_mut(&storage_module_id) {
+                    orchestrator.mark_chunk_stored(chunk_offset)?;
+                }
+                debug!(
+                    storage_module.id = storage_module_id,
+                    chunk.offset = %chunk_offset,
+                    chunk.data_root = %unpacked_chunk.data_root,
+                    ?ledger_id,
+                    ?slot_index,
+                    ?partition_hash,
+                    peer.address = %peer_addr,
+                    "data_sync chunk stored"
                 );
+            }
+            DataSyncWriteOutcome::MissingDataRootIndex => {
+                metrics::record_data_sync_chunk_write_failed("data_root_missing");
+                metrics::record_data_sync_chunk_blocked(
+                    ChunkBlockReason::MissingDataRootIndex.as_metric_label(),
+                );
+                warn!(
+                    storage_module.id = storage_module_id,
+                    chunk.offset = %chunk_offset,
+                    chunk.data_root = %unpacked_chunk.data_root,
+                    chunk.tx_offset = %unpacked_chunk.tx_offset,
+                    ?ledger_id,
+                    ?slot_index,
+                    ?partition_hash,
+                    peer.address = %peer_addr,
+                    reason = "data_root_missing",
+                    "data_sync write blocked: data_root not indexed in storage module; \
+                     stopping hot re-fetch for this offset (needs index rebuild)"
+                );
+                if let Some(orchestrator) = self.chunk_orchestrators.get_mut(&storage_module_id) {
+                    orchestrator.mark_chunk_blocked(
+                        chunk_offset,
+                        ChunkBlockReason::MissingDataRootIndex,
+                    )?;
+                }
+                // Best-effort: mempool/ingress may still place the chunk if another
+                // path holds indexes; do not treat handoff as durable success.
+                try_send_chunk_to_ingress(&self.service_senders, unpacked_chunk);
+            }
+            DataSyncWriteOutcome::NoWriteableOffset => {
+                metrics::record_data_sync_chunk_write_failed("no_writeable_offset");
+                warn!(
+                    storage_module.id = storage_module_id,
+                    chunk.offset = %chunk_offset,
+                    chunk.data_root = %unpacked_chunk.data_root,
+                    chunk.tx_offset = %unpacked_chunk.tx_offset,
+                    ?ledger_id,
+                    ?slot_index,
+                    ?partition_hash,
+                    peer.address = %peer_addr,
+                    reason = "no_writeable_offset",
+                    "data_sync write had no Entropy target at expected offsets; re-queueing"
+                );
+                if let Some(orchestrator) = self.chunk_orchestrators.get_mut(&storage_module_id) {
+                    orchestrator.requeue_after_local_write_failure(chunk_offset)?;
+                }
+                try_send_chunk_to_ingress(&self.service_senders, unpacked_chunk);
+            }
+            DataSyncWriteOutcome::Other(err) => {
+                metrics::record_data_sync_chunk_write_failed("other");
+                warn!(
+                    storage_module.id = storage_module_id,
+                    chunk.offset = %chunk_offset,
+                    chunk.data_root = %unpacked_chunk.data_root,
+                    chunk.tx_offset = %unpacked_chunk.tx_offset,
+                    ?ledger_id,
+                    ?slot_index,
+                    ?partition_hash,
+                    peer.address = %peer_addr,
+                    reason = "other",
+                    error = %err,
+                    "data_sync write failed; re-queueing and forwarding to chunk ingress"
+                );
+                if let Some(orchestrator) = self.chunk_orchestrators.get_mut(&storage_module_id) {
+                    orchestrator.requeue_after_local_write_failure(chunk_offset)?;
+                }
+                try_send_chunk_to_ingress(&self.service_senders, unpacked_chunk);
             }
         }
 

--- a/crates/actors/src/data_sync_service.rs
+++ b/crates/actors/src/data_sync_service.rs
@@ -5,7 +5,7 @@ pub mod peer_stats;
 
 use crate::{chunk_fetcher::ChunkFetcherFactory, metrics, services::ServiceSenders};
 use chunk_orchestrator::{ChunkBlockReason, ChunkOrchestrator};
-use irys_domain::{BlockTreeReadGuard, ChunkType, PeerList, StorageModule};
+use irys_domain::{BlockTreeReadGuard, ChunkType, PeerList, StorageModule, WriteDataChunkError};
 use irys_packing::unpack;
 use irys_types::{
     Config, IrysAddress, PackedChunk, PartitionChunkOffset, SendTraced as _, TokioServiceHandle,
@@ -34,27 +34,14 @@ enum DataSyncWriteOutcome {
     Other(String),
 }
 
-/// Substring of `StorageModule::write_data_chunk`'s eyre message when
-/// `DataRootInfosByDataRoot` has no entry. Keep in sync with domain
-/// `storage_module.rs` (`"Chunks data_root not found in storage module"`).
-/// Prefer a typed error in a follow-up; until then this pin + unit test
-/// prevents silent thrash if the message is reworded.
-const DATA_ROOT_NOT_FOUND_MSG: &str = "data_root not found";
-
 fn attempt_data_sync_write(
     sm: &StorageModule,
     unpacked: &UnpackedChunk,
     expected_offset: PartitionChunkOffset,
 ) -> DataSyncWriteOutcome {
     match sm.write_data_chunk(unpacked) {
-        Err(e) => {
-            let msg = e.to_string();
-            if msg.contains(DATA_ROOT_NOT_FOUND_MSG) {
-                DataSyncWriteOutcome::MissingDataRootIndex
-            } else {
-                DataSyncWriteOutcome::Other(msg)
-            }
-        }
+        Err(WriteDataChunkError::DataRootNotFound) => DataSyncWriteOutcome::MissingDataRootIndex,
+        Err(e) => DataSyncWriteOutcome::Other(e.to_string()),
         Ok(()) => {
             // write_data_chunk can return Ok(()) without writing when there are
             // no Entropy targets at the resolved offsets — verify the requested
@@ -65,7 +52,7 @@ fn attempt_data_sync_write(
                 sm.collect_data_root_infos(unpacked.data_root),
                 Ok(infos) if infos.0.is_empty()
             ) {
-                // Defensive: empty infos should have been Err, but classify if not.
+                // Defensive: empty infos should have been DataRootNotFound Err.
                 DataSyncWriteOutcome::MissingDataRootIndex
             } else {
                 DataSyncWriteOutcome::NoWriteableOffset
@@ -851,8 +838,8 @@ impl DataSyncService {
 
 #[cfg(test)]
 mod write_outcome_tests {
-    use super::{DATA_ROOT_NOT_FOUND_MSG, DataSyncWriteOutcome, attempt_data_sync_write};
-    use irys_domain::{StorageModule, StorageModuleInfo};
+    use super::{DataSyncWriteOutcome, attempt_data_sync_write};
+    use irys_domain::{StorageModule, StorageModuleInfo, WriteDataChunkError};
     use irys_testing_utils::TempDirBuilder;
     use irys_types::{
         Config, ConsensusConfig, DataLedger, H256, IrysAddress, NodeConfig, PartitionChunkOffset,
@@ -860,8 +847,7 @@ mod write_outcome_tests {
     };
     use std::sync::Arc;
 
-    /// Pins the load-bearing string coupling: unindexed data_root must classify
-    /// as MissingDataRootIndex (not Other/requeue thrash).
+    /// Unindexed data_root must classify as MissingDataRootIndex (not Other/requeue thrash).
     #[test]
     fn unindexed_data_root_classifies_as_missing_index() {
         let tmp = TempDirBuilder::new().with_tracing().build();
@@ -908,14 +894,12 @@ mod write_outcome_tests {
             tx_offset: TxChunkOffset::from(0_u32),
         };
 
-        // Domain error must still contain the substring we classify on.
         let err = sm
             .write_data_chunk(&chunk)
             .expect_err("unindexed data_root must fail write");
         assert!(
-            err.to_string().contains(DATA_ROOT_NOT_FOUND_MSG),
-            "write_data_chunk message changed; update DATA_ROOT_NOT_FOUND_MSG and \
-             classification. got: {err}"
+            matches!(err, WriteDataChunkError::DataRootNotFound),
+            "expected DataRootNotFound, got: {err:?}"
         );
 
         let outcome = attempt_data_sync_write(&sm, &chunk, PartitionChunkOffset::from(0_u32));

--- a/crates/actors/src/data_sync_service.rs
+++ b/crates/actors/src/data_sync_service.rs
@@ -22,7 +22,7 @@ use tokio::sync::{mpsc::UnboundedReceiver, oneshot};
 use tracing::{Instrument as _, debug, error, warn};
 
 /// Local write outcome after a successful peer fetch.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 enum DataSyncWriteOutcome {
     /// Offset is now (or is about to be observed as) [`ChunkType::Data`].
     Stored,
@@ -34,6 +34,13 @@ enum DataSyncWriteOutcome {
     Other(String),
 }
 
+/// Substring of `StorageModule::write_data_chunk`'s eyre message when
+/// `DataRootInfosByDataRoot` has no entry. Keep in sync with domain
+/// `storage_module.rs` (`"Chunks data_root not found in storage module"`).
+/// Prefer a typed error in a follow-up; until then this pin + unit test
+/// prevents silent thrash if the message is reworded.
+const DATA_ROOT_NOT_FOUND_MSG: &str = "data_root not found";
+
 fn attempt_data_sync_write(
     sm: &StorageModule,
     unpacked: &UnpackedChunk,
@@ -42,7 +49,7 @@ fn attempt_data_sync_write(
     match sm.write_data_chunk(unpacked) {
         Err(e) => {
             let msg = e.to_string();
-            if msg.contains("data_root not found") {
+            if msg.contains(DATA_ROOT_NOT_FOUND_MSG) {
                 DataSyncWriteOutcome::MissingDataRootIndex
             } else {
                 DataSyncWriteOutcome::Other(msg)
@@ -52,10 +59,7 @@ fn attempt_data_sync_write(
             // write_data_chunk can return Ok(()) without writing when there are
             // no Entropy targets at the resolved offsets — verify the requested
             // offset actually became Data.
-            if matches!(
-                sm.get_chunk_type(&expected_offset),
-                Some(ChunkType::Data)
-            ) {
+            if matches!(sm.get_chunk_type(&expected_offset), Some(ChunkType::Data)) {
                 DataSyncWriteOutcome::Stored
             } else if matches!(
                 sm.collect_data_root_infos(unpacked.data_root),
@@ -71,9 +75,10 @@ fn attempt_data_sync_write(
 }
 
 fn try_send_chunk_to_ingress(service_senders: &ServiceSenders, unpacked: UnpackedChunk) {
-    if let Err(e) = service_senders.chunk_ingress.send_traced(
-        crate::chunk_ingress_service::ChunkIngressMessage::IngestChunk(unpacked, None),
-    ) {
+    if let Err(e) = service_senders
+        .chunk_ingress
+        .send_traced(crate::chunk_ingress_service::ChunkIngressMessage::IngestChunk(unpacked, None))
+    {
         warn!(
             error = %e,
             "Failed to send ChunkIngressMessage to chunk ingress channel after data_sync write failure"
@@ -348,10 +353,9 @@ impl DataSyncServiceInner {
                 );
             }
             DataSyncWriteOutcome::MissingDataRootIndex => {
-                metrics::record_data_sync_chunk_write_failed("data_root_missing");
-                metrics::record_data_sync_chunk_blocked(
-                    ChunkBlockReason::MissingDataRootIndex.as_metric_label(),
-                );
+                let reason = ChunkBlockReason::MissingDataRootIndex.as_metric_label();
+                metrics::record_data_sync_chunk_write_failed(reason);
+                metrics::record_data_sync_chunk_blocked(reason);
                 warn!(
                     storage_module.id = storage_module_id,
                     chunk.offset = %chunk_offset,
@@ -361,15 +365,13 @@ impl DataSyncServiceInner {
                     ?slot_index,
                     ?partition_hash,
                     peer.address = %peer_addr,
-                    reason = "data_root_missing",
+                    reason,
                     "data_sync write blocked: data_root not indexed in storage module; \
                      stopping hot re-fetch for this offset (needs index rebuild)"
                 );
                 if let Some(orchestrator) = self.chunk_orchestrators.get_mut(&storage_module_id) {
-                    orchestrator.mark_chunk_blocked(
-                        chunk_offset,
-                        ChunkBlockReason::MissingDataRootIndex,
-                    )?;
+                    orchestrator
+                        .mark_chunk_blocked(chunk_offset, ChunkBlockReason::MissingDataRootIndex)?;
                 }
                 // Best-effort: mempool/ingress may still place the chunk if another
                 // path holds indexes; do not treat handoff as durable success.
@@ -844,5 +846,79 @@ impl DataSyncService {
 
         tracing::info!("shutting down DataSync Service gracefully");
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod write_outcome_tests {
+    use super::{DATA_ROOT_NOT_FOUND_MSG, DataSyncWriteOutcome, attempt_data_sync_write};
+    use irys_domain::{StorageModule, StorageModuleInfo};
+    use irys_testing_utils::TempDirBuilder;
+    use irys_types::{
+        Config, ConsensusConfig, DataLedger, H256, IrysAddress, NodeConfig, PartitionChunkOffset,
+        TxChunkOffset, UnpackedChunk, partition::PartitionAssignment, partition_chunk_offset_ie,
+    };
+    use std::sync::Arc;
+
+    /// Pins the load-bearing string coupling: unindexed data_root must classify
+    /// as MissingDataRootIndex (not Other/requeue thrash).
+    #[test]
+    fn unindexed_data_root_classifies_as_missing_index() {
+        let tmp = TempDirBuilder::new().with_tracing().build();
+        let num_chunks = 4_u64;
+        let chunk_size = 32_u64;
+        let node_config = NodeConfig {
+            consensus: irys_types::ConsensusOptions::Custom(ConsensusConfig {
+                chunk_size,
+                num_chunks_in_partition: num_chunks,
+                num_chunks_in_recall_range: 2,
+                num_partitions_per_slot: 1,
+                entropy_packing_iterations: 1,
+                chain_id: 1,
+                ..ConsensusConfig::testing()
+            }),
+            base_directory: tmp.path().to_path_buf(),
+            ..NodeConfig::testing()
+        };
+        let config = Config::new_with_random_peer_id(node_config);
+
+        let pa = PartitionAssignment {
+            ledger_id: Some(DataLedger::Publish.into()),
+            slot_index: Some(0),
+            miner_address: IrysAddress::from([7_u8; 20]),
+            partition_hash: H256::random(),
+        };
+        let info = StorageModuleInfo {
+            id: 0,
+            partition_assignment: Some(pa),
+            submodules: vec![(
+                partition_chunk_offset_ie!(0, num_chunks as u32),
+                "chunks".into(),
+            )],
+        };
+        let sm = Arc::new(StorageModule::new(&info, &config).expect("storage module"));
+        // Packed entropy, but deliberately no index_transaction_data — peer-4 hole case.
+        sm.pack_with_zeros();
+
+        let chunk = UnpackedChunk {
+            data_root: H256::random(),
+            data_size: chunk_size,
+            data_path: vec![1, 2, 3, 4].into(),
+            bytes: vec![0xcd; chunk_size as usize].into(),
+            tx_offset: TxChunkOffset::from(0_u32),
+        };
+
+        // Domain error must still contain the substring we classify on.
+        let err = sm
+            .write_data_chunk(&chunk)
+            .expect_err("unindexed data_root must fail write");
+        assert!(
+            err.to_string().contains(DATA_ROOT_NOT_FOUND_MSG),
+            "write_data_chunk message changed; update DATA_ROOT_NOT_FOUND_MSG and \
+             classification. got: {err}"
+        );
+
+        let outcome = attempt_data_sync_write(&sm, &chunk, PartitionChunkOffset::from(0_u32));
+        assert_eq!(outcome, DataSyncWriteOutcome::MissingDataRootIndex);
     }
 }

--- a/crates/actors/src/data_sync_service/chunk_orchestrator.rs
+++ b/crates/actors/src/data_sync_service/chunk_orchestrator.rs
@@ -47,7 +47,8 @@ pub enum ChunkRequestState {
 
     /// Chunk was successfully fetched **and** durably written as [`ChunkType::Data`].
     ///
-    /// Fetch alone is not enough — see [`DataSyncServiceInner::on_chunk_completed`].
+    /// Fetch alone is not enough — see [`Self::on_chunk_fetched`] then
+    /// [`Self::mark_chunk_stored`].
     Completed,
 
     /// Locally blocked from hot re-fetch (index gap, etc.). Still retained while
@@ -469,9 +470,7 @@ impl ChunkOrchestrator {
                     },
                 };
 
-                // Send the message to the DataSyncService so it can update the PeerBandwidthManagers and
-                // then call back into the orchestrator using `on_chunk_completed(...)` to mark the request as
-                // completed
+                // Service handles fetch credit + local write outcome (store / block / requeue).
                 let _ = tx.send_traced(message);
             }
             .instrument(tracing::Span::current()),
@@ -490,7 +489,10 @@ impl ChunkOrchestrator {
         peer_addr: IrysAddress,
     ) -> eyre::Result<ChunkTimeRecord> {
         let request = self.chunk_requests.get_mut(&chunk_offset).ok_or_else(|| {
-            eyre::eyre!("Chunk fetch completion for unknown offset: {:?}", chunk_offset)
+            eyre::eyre!(
+                "Chunk fetch completion for unknown offset: {:?}",
+                chunk_offset
+            )
         })?;
 
         let (expected_peer, start_instant) = match request.request_state {
@@ -590,18 +592,6 @@ impl ChunkOrchestrator {
         request.request_state = ChunkRequestState::Pending;
         // Do not add the delivering peer to `excluded` — they succeeded.
         Ok(())
-    }
-
-    /// Backward-compatible name: treat as fetch success + immediate store mark.
-    /// Prefer the explicit fetch/store helpers from data-sync write path.
-    pub fn on_chunk_completed(
-        &mut self,
-        chunk_offset: PartitionChunkOffset,
-        peer_addr: IrysAddress,
-    ) -> eyre::Result<ChunkTimeRecord> {
-        let record = self.on_chunk_fetched(chunk_offset, peer_addr)?;
-        self.mark_chunk_stored(chunk_offset)?;
-        Ok(record)
     }
 
     #[tracing::instrument(level = "trace", skip_all, fields(
@@ -718,4 +708,270 @@ pub struct OrchestrationMetrics {
     pub completed_requests: usize,
     pub blocked_requests: usize,
     pub total_throughput_bps: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{chunk_fetcher::MockChunkFetcher, test_helpers::build_test_service_senders};
+    use irys_domain::{BlockTree, StorageModuleInfo};
+    use irys_testing_utils::TempDirBuilder;
+    use irys_types::{
+        Config, ConsensusConfig, DataLedger, H256, IrysAddress, NodeConfig,
+        partition::PartitionAssignment, partition_chunk_offset_ie,
+    };
+
+    fn test_config(base_directory: std::path::PathBuf, num_chunks: u64) -> Config {
+        let node_config = NodeConfig {
+            consensus: irys_types::ConsensusOptions::Custom(ConsensusConfig {
+                chunk_size: 32,
+                num_chunks_in_partition: num_chunks,
+                num_chunks_in_recall_range: 2,
+                num_partitions_per_slot: 1,
+                entropy_packing_iterations: 1,
+                block_migration_depth: 1,
+                chain_id: 1,
+                ..ConsensusConfig::testing()
+            }),
+            base_directory,
+            ..NodeConfig::testing()
+        };
+        Config::new_with_random_peer_id(node_config)
+    }
+
+    fn packed_sm(config: &Config, num_chunks: u64) -> Arc<StorageModule> {
+        let pa = PartitionAssignment {
+            ledger_id: Some(DataLedger::Publish.into()),
+            slot_index: Some(0),
+            miner_address: IrysAddress::from([1_u8; 20]),
+            partition_hash: H256::random(),
+        };
+        let info = StorageModuleInfo {
+            id: 0,
+            partition_assignment: Some(pa),
+            submodules: vec![(
+                partition_chunk_offset_ie!(0, num_chunks as u32),
+                "chunks".into(),
+            )],
+        };
+        let sm = Arc::new(StorageModule::new(&info, config).expect("storage module"));
+        sm.pack_with_zeros();
+        sm
+    }
+
+    fn make_orchestrator(sm: Arc<StorageModule>, config: &Config) -> ChunkOrchestrator {
+        let genesis = irys_testing_utils::new_mock_signed_header();
+        let block_tree = BlockTree::new(&genesis, config.consensus.clone());
+        let block_tree_guard = BlockTreeReadGuard::new(Arc::new(RwLock::new(block_tree)));
+        let (service_senders, _receivers) = build_test_service_senders();
+        let ledger_id: u32 = DataLedger::Publish.into();
+        ChunkOrchestrator::new(
+            sm,
+            Arc::new(RwLock::new(HashMap::new())),
+            block_tree_guard,
+            &service_senders,
+            Arc::new(MockChunkFetcher::new(ledger_id as usize)),
+            config.node_config.clone(),
+            tokio::runtime::Handle::current(),
+        )
+    }
+
+    fn insert_requested(
+        orch: &mut ChunkOrchestrator,
+        offset: PartitionChunkOffset,
+        peer: IrysAddress,
+    ) {
+        orch.chunk_requests.insert(
+            offset,
+            ChunkRequest {
+                ledger_id: 0,
+                slot_index: 0,
+                chunk_offset: offset,
+                excluded: None,
+                request_state: ChunkRequestState::Requested(peer, Instant::now()),
+            },
+        );
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn mark_helpers_require_requested_state() {
+        let tmp = TempDirBuilder::new().with_tracing().build();
+        let num_chunks = 4;
+        let config = test_config(tmp.path().to_path_buf(), num_chunks);
+        let sm = packed_sm(&config, num_chunks);
+        let mut orch = make_orchestrator(sm, &config);
+        let peer = IrysAddress::from([2_u8; 20]);
+        let offset = PartitionChunkOffset::from(0_u32);
+
+        // Unknown offset
+        assert!(orch.mark_chunk_stored(offset).is_err());
+        assert!(
+            orch.mark_chunk_blocked(offset, ChunkBlockReason::MissingDataRootIndex)
+                .is_err()
+        );
+        assert!(orch.requeue_after_local_write_failure(offset).is_err());
+
+        // Pending is not Requested
+        orch.chunk_requests.insert(
+            offset,
+            ChunkRequest {
+                ledger_id: 0,
+                slot_index: 0,
+                chunk_offset: offset,
+                excluded: None,
+                request_state: ChunkRequestState::Pending,
+            },
+        );
+        assert!(orch.mark_chunk_stored(offset).is_err());
+        assert!(
+            orch.mark_chunk_blocked(offset, ChunkBlockReason::MissingDataRootIndex)
+                .is_err()
+        );
+        assert!(orch.requeue_after_local_write_failure(offset).is_err());
+
+        // Requested accepts each transition
+        insert_requested(&mut orch, offset, peer);
+        orch.mark_chunk_stored(offset).expect("store");
+        assert_eq!(
+            orch.chunk_requests[&offset].request_state,
+            ChunkRequestState::Completed
+        );
+
+        insert_requested(&mut orch, offset, peer);
+        orch.mark_chunk_blocked(offset, ChunkBlockReason::MissingDataRootIndex)
+            .expect("block");
+        assert_eq!(
+            orch.chunk_requests[&offset].request_state,
+            ChunkRequestState::Blocked(ChunkBlockReason::MissingDataRootIndex)
+        );
+
+        insert_requested(&mut orch, offset, peer);
+        orch.requeue_after_local_write_failure(offset)
+            .expect("requeue");
+        assert_eq!(
+            orch.chunk_requests[&offset].request_state,
+            ChunkRequestState::Pending
+        );
+        // Requeue must not blame the delivering peer.
+        assert!(orch.chunk_requests[&offset].excluded.is_none());
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn on_chunk_fetched_does_not_mark_stored() {
+        let tmp = TempDirBuilder::new().with_tracing().build();
+        let num_chunks = 4;
+        let config = test_config(tmp.path().to_path_buf(), num_chunks);
+        let sm = packed_sm(&config, num_chunks);
+        let mut orch = make_orchestrator(sm, &config);
+        let peer = IrysAddress::from([3_u8; 20]);
+        let offset = PartitionChunkOffset::from(1_u32);
+        insert_requested(&mut orch, offset, peer);
+
+        orch.on_chunk_fetched(offset, peer).expect("fetched");
+        assert!(
+            matches!(
+                orch.chunk_requests[&offset].request_state,
+                ChunkRequestState::Requested(..)
+            ),
+            "fetch success must not imply durable store (Completed)"
+        );
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn blocked_retained_while_entropy_dropped_when_data() {
+        let tmp = TempDirBuilder::new().with_tracing().build();
+        let num_chunks = 4;
+        let config = test_config(tmp.path().to_path_buf(), num_chunks);
+        let sm = packed_sm(&config, num_chunks);
+        let mut orch = make_orchestrator(sm.clone(), &config);
+        let peer = IrysAddress::from([4_u8; 20]);
+        let offset = PartitionChunkOffset::from(0_u32);
+
+        insert_requested(&mut orch, offset, peer);
+        orch.mark_chunk_blocked(offset, ChunkBlockReason::MissingDataRootIndex)
+            .unwrap();
+
+        // Still Entropy → retain Blocked
+        orch.populate_request_queue();
+        assert!(
+            matches!(
+                orch.chunk_requests[&offset].request_state,
+                ChunkRequestState::Blocked(ChunkBlockReason::MissingDataRootIndex)
+            ),
+            "Blocked must stay while offset is Entropy"
+        );
+
+        // Become Data (e.g. gossip/heal) → drop request
+        let data_bytes = vec![0xab; config.consensus.chunk_size as usize];
+        sm.write_chunk(offset, data_bytes, ChunkType::Data);
+        sm.sync_pending_chunks().unwrap();
+        assert!(matches!(sm.get_chunk_type(&offset), Some(ChunkType::Data)));
+
+        orch.populate_request_queue();
+        assert!(
+            !orch.chunk_requests.contains_key(&offset),
+            "Blocked must drop once offset is Data"
+        );
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn blocked_excluded_from_pending_budget_and_dispatch_selection() {
+        let tmp = TempDirBuilder::new().with_tracing().build();
+        let num_chunks = 4;
+        let config = test_config(tmp.path().to_path_buf(), num_chunks);
+        let sm = packed_sm(&config, num_chunks);
+        let mut orch = make_orchestrator(sm, &config);
+        let peer = IrysAddress::from([5_u8; 20]);
+
+        // Fill with Blocked offsets — must not count as pending budget consumers.
+        for i in 0..3_u32 {
+            let offset = PartitionChunkOffset::from(i);
+            insert_requested(&mut orch, offset, peer);
+            orch.mark_chunk_blocked(offset, ChunkBlockReason::MissingDataRootIndex)
+                .unwrap();
+        }
+
+        let metrics = orch.get_metrics();
+        assert_eq!(metrics.blocked_requests, 3);
+        assert_eq!(metrics.pending_requests, 0);
+        assert_eq!(metrics.active_requests, 0);
+
+        // Only Pending is eligible for dispatch.
+        let pending_for_dispatch: Vec<_> = orch
+            .chunk_requests
+            .iter()
+            .filter_map(|(&offset, req)| {
+                matches!(req.request_state, ChunkRequestState::Pending).then_some(offset)
+            })
+            .collect();
+        assert!(
+            pending_for_dispatch.is_empty(),
+            "Blocked offsets must not be selected for re-dispatch"
+        );
+
+        // Pending budget counts only Pending, so a fresh Pending can still be inserted
+        // even when many offsets are Blocked (Vacant entries only — offset 3 is free).
+        let offset3 = PartitionChunkOffset::from(3_u32);
+        orch.chunk_requests.insert(
+            offset3,
+            ChunkRequest {
+                ledger_id: 0,
+                slot_index: 0,
+                chunk_offset: offset3,
+                excluded: None,
+                request_state: ChunkRequestState::Pending,
+            },
+        );
+        let metrics = orch.get_metrics();
+        assert_eq!(metrics.pending_requests, 1);
+        assert_eq!(metrics.blocked_requests, 3);
+    }
+
+    #[test]
+    fn metric_label_stable() {
+        assert_eq!(
+            ChunkBlockReason::MissingDataRootIndex.as_metric_label(),
+            "missing_data_root_index"
+        );
+    }
 }

--- a/crates/actors/src/data_sync_service/chunk_orchestrator.rs
+++ b/crates/actors/src/data_sync_service/chunk_orchestrator.rs
@@ -16,6 +16,26 @@ use std::{
 };
 use tracing::{Instrument as _, debug, warn};
 
+/// Why a chunk offset is blocked from the hot re-fetch loop.
+///
+/// These are local progress blockers (not peer-delivery failures). Peers may
+/// have delivered the bytes; we still cannot place them until the underlying
+/// issue is repaired (e.g. SM data_root index rebuild).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChunkBlockReason {
+    /// `write_data_chunk` failed because `DataRootInfosByDataRoot` has no entry
+    /// for the chunk's data_root. Needs index rebuild / backfill.
+    MissingDataRootIndex,
+}
+
+impl ChunkBlockReason {
+    pub const fn as_metric_label(self) -> &'static str {
+        match self {
+            Self::MissingDataRootIndex => "missing_data_root_index",
+        }
+    }
+}
+
 #[derive(Debug, PartialEq)]
 pub enum ChunkRequestState {
     /// Chunk needs to be requested.
@@ -25,8 +45,15 @@ pub enum ChunkRequestState {
     /// Used for tracking timeouts and preventing duplicate requests.
     Requested(IrysAddress, Instant),
 
-    /// Chunk has been successfully retrieved and stored.
+    /// Chunk was successfully fetched **and** durably written as [`ChunkType::Data`].
+    ///
+    /// Fetch alone is not enough — see [`DataSyncServiceInner::on_chunk_completed`].
     Completed,
+
+    /// Locally blocked from hot re-fetch (index gap, etc.). Still retained while
+    /// the offset is Entropy so we do not thrash peers; not auto-cleared until
+    /// the offset becomes Data (gossip/heal) or the process restarts.
+    Blocked(ChunkBlockReason),
 }
 
 type ExcludedPeerAddresses = HashSet<IrysAddress>;
@@ -127,14 +154,20 @@ impl ChunkOrchestrator {
                 return true;
             }
 
-            // For non-requested states, only retain if the chunk is still Entropy
-            // and not Completed
-            matches!(
+            // Drop once the offset is no longer Entropy (stored as Data, or invalidated).
+            if !matches!(
                 self.storage_module.get_chunk_type(offset),
                 Some(ChunkType::Entropy)
-            ) && cr.request_state != ChunkRequestState::Completed
+            ) {
+                return false;
+            }
+
+            // Keep Pending / Blocked while still Entropy. Drop Completed.
+            !matches!(cr.request_state, ChunkRequestState::Completed)
         });
 
+        // Pending only — Blocked offsets intentionally do not consume the
+        // pending budget or get re-dispatched.
         let pending_count: usize = self
             .chunk_requests
             .values()
@@ -445,20 +478,26 @@ impl ChunkOrchestrator {
         );
     }
 
-    pub fn on_chunk_completed(
+    /// Peer delivered the chunk body. Credits peer bandwidth stats but leaves
+    /// the request in [`ChunkRequestState::Requested`] until
+    /// [`Self::mark_chunk_stored`] / [`Self::mark_chunk_blocked`] /
+    /// [`Self::requeue_after_local_write_failure`] decides the local outcome.
+    ///
+    /// Peer delivery success must not be conflated with durable local storage.
+    pub fn on_chunk_fetched(
         &mut self,
         chunk_offset: PartitionChunkOffset,
         peer_addr: IrysAddress,
     ) -> eyre::Result<ChunkTimeRecord> {
         let request = self.chunk_requests.get_mut(&chunk_offset).ok_or_else(|| {
-            eyre::eyre!("Chunk completion for unknown offset: {:?}", chunk_offset)
+            eyre::eyre!("Chunk fetch completion for unknown offset: {:?}", chunk_offset)
         })?;
 
         let (expected_peer, start_instant) = match request.request_state {
             ChunkRequestState::Requested(addr, started) => (addr, started),
             ref invalid_state => {
                 return Err(eyre::eyre!(
-                    "Invalid state for chunk request completion at offset {}: expected Requested, got {:?}",
+                    "Invalid state for chunk fetch at offset {}: expected Requested, got {:?}",
                     chunk_offset,
                     invalid_state
                 ));
@@ -472,8 +511,6 @@ impl ChunkOrchestrator {
         let completion_time = Instant::now();
         let duration = completion_time.duration_since(start_instant);
 
-        request.request_state = ChunkRequestState::Completed;
-
         let completion_record = ChunkTimeRecord {
             chunk_offset,
             start_time: start_instant,
@@ -483,6 +520,7 @@ impl ChunkOrchestrator {
 
         self.recent_chunk_times.push(completion_record.clone());
 
+        // Credit the peer for successful delivery regardless of local write outcome.
         if let Ok(mut peers) = self.active_sync_peers.write()
             && let Some(peer_manager) = peers.get_mut(&peer_addr)
         {
@@ -490,6 +528,80 @@ impl ChunkOrchestrator {
         }
 
         Ok(completion_record)
+    }
+
+    /// Durable local store succeeded — offset is (or will be observed as) Data.
+    pub fn mark_chunk_stored(&mut self, chunk_offset: PartitionChunkOffset) -> eyre::Result<()> {
+        let request = self.chunk_requests.get_mut(&chunk_offset).ok_or_else(|| {
+            eyre::eyre!("mark_chunk_stored for unknown offset: {:?}", chunk_offset)
+        })?;
+        if !matches!(request.request_state, ChunkRequestState::Requested(..)) {
+            return Err(eyre::eyre!(
+                "mark_chunk_stored expected Requested state at {:?}, got {:?}",
+                chunk_offset,
+                request.request_state
+            ));
+        }
+        request.request_state = ChunkRequestState::Completed;
+        Ok(())
+    }
+
+    /// Locally blocked; stop hot re-fetching this offset.
+    pub fn mark_chunk_blocked(
+        &mut self,
+        chunk_offset: PartitionChunkOffset,
+        reason: ChunkBlockReason,
+    ) -> eyre::Result<()> {
+        let request = self.chunk_requests.get_mut(&chunk_offset).ok_or_else(|| {
+            eyre::eyre!("mark_chunk_blocked for unknown offset: {:?}", chunk_offset)
+        })?;
+        if !matches!(request.request_state, ChunkRequestState::Requested(..)) {
+            return Err(eyre::eyre!(
+                "mark_chunk_blocked expected Requested state at {:?}, got {:?}",
+                chunk_offset,
+                request.request_state
+            ));
+        }
+        request.request_state = ChunkRequestState::Blocked(reason);
+        // Clear peer exclusions — the failure is local, not peer-specific.
+        request.excluded = None;
+        Ok(())
+    }
+
+    /// Local write failed for a non-blocking reason; re-queue without blaming the peer
+    /// that just delivered the bytes.
+    pub fn requeue_after_local_write_failure(
+        &mut self,
+        chunk_offset: PartitionChunkOffset,
+    ) -> eyre::Result<()> {
+        let request = self.chunk_requests.get_mut(&chunk_offset).ok_or_else(|| {
+            eyre::eyre!(
+                "requeue_after_local_write_failure for unknown offset: {:?}",
+                chunk_offset
+            )
+        })?;
+        if !matches!(request.request_state, ChunkRequestState::Requested(..)) {
+            return Err(eyre::eyre!(
+                "requeue_after_local_write_failure expected Requested at {:?}, got {:?}",
+                chunk_offset,
+                request.request_state
+            ));
+        }
+        request.request_state = ChunkRequestState::Pending;
+        // Do not add the delivering peer to `excluded` — they succeeded.
+        Ok(())
+    }
+
+    /// Backward-compatible name: treat as fetch success + immediate store mark.
+    /// Prefer the explicit fetch/store helpers from data-sync write path.
+    pub fn on_chunk_completed(
+        &mut self,
+        chunk_offset: PartitionChunkOffset,
+        peer_addr: IrysAddress,
+    ) -> eyre::Result<ChunkTimeRecord> {
+        let record = self.on_chunk_fetched(chunk_offset, peer_addr)?;
+        self.mark_chunk_stored(chunk_offset)?;
+        Ok(record)
     }
 
     #[tracing::instrument(level = "trace", skip_all, fields(
@@ -565,14 +677,15 @@ impl ChunkOrchestrator {
     }
 
     pub fn get_metrics(&self) -> OrchestrationMetrics {
-        let (pending, active, completed) =
+        let (pending, active, completed, blocked) =
             self.chunk_requests
                 .values()
-                .fold((0, 0, 0), |(p, a, c), request| {
+                .fold((0, 0, 0, 0), |(p, a, c, b), request| {
                     match request.request_state {
-                        ChunkRequestState::Pending => (p + 1, a, c),
-                        ChunkRequestState::Requested(_, _) => (p, a + 1, c),
-                        ChunkRequestState::Completed => (p, a, c + 1),
+                        ChunkRequestState::Pending => (p + 1, a, c, b),
+                        ChunkRequestState::Requested(_, _) => (p, a + 1, c, b),
+                        ChunkRequestState::Completed => (p, a, c + 1, b),
+                        ChunkRequestState::Blocked(_) => (p, a, c, b + 1),
                     }
                 });
 
@@ -591,6 +704,7 @@ impl ChunkOrchestrator {
             pending_requests: pending,
             active_requests: active,
             completed_requests: completed,
+            blocked_requests: blocked,
             total_throughput_bps,
         }
     }
@@ -602,5 +716,6 @@ pub struct OrchestrationMetrics {
     pub pending_requests: usize,
     pub active_requests: usize,
     pub completed_requests: usize,
+    pub blocked_requests: usize,
     pub total_throughput_bps: u64,
 }

--- a/crates/actors/src/metrics.rs
+++ b/crates/actors/src/metrics.rs
@@ -261,13 +261,6 @@ pub(crate) fn record_producer_parent_wait_target_switch() {
     PRODUCER_PARENT_WAIT_TARGET_SWITCHES.add(1, &[]);
 }
 
-/// Legacy alias: counts durable store success (not mere fetch). Prefer
-/// [`record_data_sync_chunk_stored`]. Kept for call sites / bisect friendliness.
-#[allow(dead_code)]
-pub(crate) fn record_data_sync_chunk_completed() {
-    record_data_sync_chunk_stored();
-}
-
 pub(crate) fn record_data_sync_chunk_fetched() {
     DATA_SYNC_CHUNKS_FETCHED.add(1, &[]);
 }
@@ -281,12 +274,13 @@ pub(crate) fn record_data_sync_chunk_failure() {
     DATA_SYNC_CHUNK_FAILURES.add(1, &[]);
 }
 
-/// `reason` values: `data_root_missing`, `no_writeable_offset`, `other`.
+/// `reason` values: `missing_data_root_index` (via `ChunkBlockReason::as_metric_label`),
+/// `no_writeable_offset`, `other`.
 pub(crate) fn record_data_sync_chunk_write_failed(reason: &'static str) {
     DATA_SYNC_CHUNK_WRITE_FAILED.add(1, &[KeyValue::new("reason", reason)]);
 }
 
-/// `reason` values: `missing_data_root_index`.
+/// `reason` values: `missing_data_root_index` (via `ChunkBlockReason::as_metric_label`).
 pub(crate) fn record_data_sync_chunk_blocked(reason: &'static str) {
     DATA_SYNC_CHUNK_BLOCKED.add(1, &[KeyValue::new("reason", reason)]);
 }

--- a/crates/actors/src/metrics.rs
+++ b/crates/actors/src/metrics.rs
@@ -21,8 +21,14 @@ irys_utils::define_metrics! {
     gauge CACHE_CHUNK_SIZE_BYTES("irys.cache.chunk_size_bytes", "Total size of cached chunks in bytes");
     counter BLOCK_DISCOVERY_ERRORS("irys.block_discovery.errors_total", "Block discovery errors by type");
     counter BLOCK_DISCOVERY_SUCCESS("irys.block_discovery.success_total", "Successful block pre-validations");
-    counter DATA_SYNC_CHUNKS_COMPLETED("irys.data_sync.chunks_completed_total", "Data sync chunks completed");
-    counter DATA_SYNC_CHUNK_FAILURES("irys.data_sync.chunk_failures_total", "Data sync chunk failures");
+    // `chunks_completed_total` is kept as a durable-store success counter (historical name).
+    // Prefer `chunks_fetched_total` / `chunks_stored_total` for new dashboards.
+    counter DATA_SYNC_CHUNKS_COMPLETED("irys.data_sync.chunks_completed_total", "Data sync chunks durably stored as Data (legacy name; same as chunks_stored_total)");
+    counter DATA_SYNC_CHUNKS_FETCHED("irys.data_sync.chunks_fetched_total", "Data sync chunks successfully fetched from a peer (HTTP/body OK; not yet written)");
+    counter DATA_SYNC_CHUNKS_STORED("irys.data_sync.chunks_stored_total", "Data sync chunks durably written (interval is Data)");
+    counter DATA_SYNC_CHUNK_FAILURES("irys.data_sync.chunk_failures_total", "Data sync peer fetch failures/timeouts");
+    counter DATA_SYNC_CHUNK_WRITE_FAILED("irys.data_sync.chunk_write_failed_total", "Data sync local write failures after a successful fetch (labelled by reason)");
+    counter DATA_SYNC_CHUNK_BLOCKED("irys.data_sync.chunk_blocked_total", "Data sync offsets blocked from hot re-fetch (labelled by reason)");
     gauge DATA_SYNC_ACTIVE_PEERS("irys.data_sync.active_peers", "Number of active data sync peers");
     counter MINING_SOLUTIONS_FOUND("irys.mining.solutions_found_total", "Mining solutions found");
     gauge PACKING_ACTIVE_WORKERS("irys.packing.active_workers", "Number of active packing workers");
@@ -255,12 +261,34 @@ pub(crate) fn record_producer_parent_wait_target_switch() {
     PRODUCER_PARENT_WAIT_TARGET_SWITCHES.add(1, &[]);
 }
 
+/// Legacy alias: counts durable store success (not mere fetch). Prefer
+/// [`record_data_sync_chunk_stored`]. Kept for call sites / bisect friendliness.
+#[allow(dead_code)]
 pub(crate) fn record_data_sync_chunk_completed() {
+    record_data_sync_chunk_stored();
+}
+
+pub(crate) fn record_data_sync_chunk_fetched() {
+    DATA_SYNC_CHUNKS_FETCHED.add(1, &[]);
+}
+
+pub(crate) fn record_data_sync_chunk_stored() {
+    DATA_SYNC_CHUNKS_STORED.add(1, &[]);
     DATA_SYNC_CHUNKS_COMPLETED.add(1, &[]);
 }
 
 pub(crate) fn record_data_sync_chunk_failure() {
     DATA_SYNC_CHUNK_FAILURES.add(1, &[]);
+}
+
+/// `reason` values: `data_root_missing`, `no_writeable_offset`, `other`.
+pub(crate) fn record_data_sync_chunk_write_failed(reason: &'static str) {
+    DATA_SYNC_CHUNK_WRITE_FAILED.add(1, &[KeyValue::new("reason", reason)]);
+}
+
+/// `reason` values: `missing_data_root_index`.
+pub(crate) fn record_data_sync_chunk_blocked(reason: &'static str) {
+    DATA_SYNC_CHUNK_BLOCKED.add(1, &[KeyValue::new("reason", reason)]);
 }
 
 pub(crate) fn record_data_sync_active_peers(count: u64) {

--- a/crates/actors/tests/data_sync_test.rs
+++ b/crates/actors/tests/data_sync_test.rs
@@ -529,6 +529,12 @@ impl TestSetup {
         // Make sure the genesis block track the ledger size
         let mut fake_genesis = IrysBlockHeader::new_mock_header();
         fake_genesis.data_ledgers[DataLedger::Publish].total_chunks = num_chunks;
+        // Sign AFTER mutating: BlockTree::new seals genesis and rejects
+        // invalid signatures (test stays #[ignore]d; this keeps it runnable)
+        {
+            use irys_testing_utils::IrysBlockHeaderTestExt as _;
+            fake_genesis.test_sign();
+        }
 
         let data_tx = signer
             .create_transaction(data, fake_genesis.block_hash)

--- a/crates/domain/src/models/storage_module.rs
+++ b/crates/domain/src/models/storage_module.rs
@@ -261,6 +261,17 @@ pub enum ChunkType {
     Interrupted,
 }
 
+/// Errors from [`StorageModule::write_data_chunk`].
+#[derive(Debug, thiserror::Error)]
+pub enum WriteDataChunkError {
+    /// No `DataRootInfos` entry for this chunk's data_root (needs index rebuild).
+    #[error("Chunks data_root not found in storage module")]
+    DataRootNotFound,
+    /// Any other write failure (IO, index update, packing, etc.).
+    #[error(transparent)]
+    Other(#[from] eyre::Report),
+}
+
 // we can't put this in `types` due to dependency cycles
 #[derive(Debug, Clone, Deref, DerefMut)]
 pub struct StorageModules(pub StorageModuleVec);
@@ -1293,7 +1304,7 @@ impl StorageModule {
     }
 
     /// Writes chunk data and its data_path to relevant storage locations
-    pub fn write_data_chunk(&self, chunk: &UnpackedChunk) -> eyre::Result<()> {
+    pub fn write_data_chunk(&self, chunk: &UnpackedChunk) -> Result<(), WriteDataChunkError> {
         let data_path = &chunk.data_path.0;
         let data_path_hash = UnpackedChunk::hash_data_path(data_path);
 
@@ -1301,7 +1312,7 @@ impl StorageModule {
         let data_root_infos = self.collect_data_root_infos(chunk.data_root)?;
 
         if data_root_infos.0.is_empty() {
-            return Err(eyre::eyre!("Chunks data_root not found in storage module"));
+            return Err(WriteDataChunkError::DataRootNotFound);
         }
 
         // Lists for both types of offsets to process


### PR DESCRIPTION
## Summary

PR1 from the testnet-peer-4 data-sync investigation: **fetch ≠ stored**.

On peer-4, data-sync thrashed offsets `0..1138` of Publish/0 while metrics looked healthy because `chunks_completed` fired on HTTP fetch success, **before** `write_data_chunk`. Writes failed with `Chunks data_root not found in storage module`, then the offset was re-queued forever.

### Changes

| Area | Behavior |
|---|---|
| **Metrics** | `chunks_fetched_total` on peer delivery; `chunks_stored_total` (+ `chunks_completed_total`) only after durable Data write; `chunk_write_failed_total{reason}` / `chunk_blocked_total{reason}` with shared labels via `ChunkBlockReason::as_metric_label()` (`missing_data_root_index`, `no_writeable_offset`, `other`) |
| **Orchestrator states** | `Pending` → `Requested` → `Completed` (stored) or `Blocked(MissingDataRootIndex)` or re-`Pending` on non-blocking local write failure. Explicit `on_chunk_fetched` / `mark_chunk_*` / `requeue_*` — no combined fetch+store helper |
| **Peer scoring** | Successful delivery still credits the peer even when local write fails (don’t punish peers for local index gaps) |
| **Logging** | Structured warn with `storage_module.id`, offsets, `data_root`, ledger/slot/partition_hash, reason |
| **Classification** | Missing index via `WriteDataChunkError::DataRootNotFound` (not string match); unit-tested. Other write errors still map to `Other(msg)` |

`Blocked` offsets stay out of the hot re-fetch loop while still Entropy (avoids fetch storms). Clearing them after index repair is a follow-up (heal/rebuild PR).

### Out of scope (later PRs)

- Index rebuild on assign / fix `find_first_unindexed_chunk` binary search
- Proactive detect + `StorageIndexRepair` job
- Bounded retries / block for `NoWriteableOffset` residual requeue thrash
- Gauge of current blocked count per SM (counter only today)

## Test plan

- [x] `cargo check -p irys-actors`
- [x] `cargo clippy -p irys-actors --tests --all-targets`
- [x] Unit: classification pin + orchestrator block/requeue/retain/metrics (`cargo nextest run -p irys-actors -E 'test(data_sync) + test(term_ledger_orchestrator)'`)
- [ ] Manual / deploy: missing data_root path logs `reason=missing_data_root_index`, increments blocked/write_failed, stops re-fetch thrash; successful write increments stored/completed