### PR TITLE
fix(storage): heal path-hash indexes on startup and reconnect data_sync

### DIFF
--- a/crates/actors/src/chunk_migration_service.rs
+++ b/crates/actors/src/chunk_migration_service.rs
@@ -54,6 +54,10 @@ pub enum MigrationError {
     /// Failed to write chunk index data to submodule database
     #[error("Failed to write chunk index data to submodule database")]
     ChunkIndexWrite,
+    /// Block header or tx missing from DB (legacy import / corruption / mixed restore).
+    /// Callers should soft-skip the block rather than panic the service.
+    #[error("Missing block or tx data for migration: {0}")]
+    MissingData(String),
     /// Catch-all variant for other errors.
     #[error("Ingress proof error: {0}")]
     Other(String),
@@ -116,12 +120,16 @@ impl ChunkMigrationServiceInner {
         &mut self,
         block_hash: BlockHash,
     ) -> Result<(), MigrationError> {
-        // Retrieve the block from the db
+        // Soft-fail on missing/corrupt data so startup heal cannot panic-loop the node.
         let block_header = self
             .db
             .view_eyre(|tx| block_header_by_hash(tx, &block_hash, false))
-            .expect("db query to succeed")
-            .expect("header should exist in db");
+            .map_err(|e| {
+                MigrationError::Other(format!("db query for block {block_hash} failed: {e}"))
+            })?
+            .ok_or_else(|| {
+                MigrationError::MissingData(format!("block header not found for {block_hash}"))
+            })?;
 
         // For each data ledger, retrieve the tx headers and build a map
         let data_ledger_txids = block_header.get_data_ledger_tx_ids();
@@ -133,8 +141,14 @@ impl ChunkMigrationServiceInner {
                 let tx = self
                     .db
                     .view_eyre(|tx| tx_header_by_txid(tx, &txid))
-                    .unwrap()
-                    .unwrap();
+                    .map_err(|e| {
+                        MigrationError::Other(format!("db query for tx {txid} failed: {e}"))
+                    })?
+                    .ok_or_else(|| {
+                        MigrationError::MissingData(format!(
+                            "tx {txid} not found for block {block_hash}"
+                        ))
+                    })?;
                 txs.push(tx);
             }
             block_tx_map.insert(ledger, txs);
@@ -240,7 +254,9 @@ pub fn process_ledger_transactions(
     storage_modules_guard: &StorageModulesReadGuard,
     db: &Arc<DatabaseProvider>,
 ) -> Result<(), MigrationError> {
-    let path_pairs = get_tx_path_pairs(block, ledger, txs).unwrap();
+    let path_pairs = get_tx_path_pairs(block, ledger, txs).map_err(|e| {
+        MigrationError::Other(format!("tx path merklization failed for {ledger:?}: {e}"))
+    })?;
     let block_offsets = get_block_offsets_in_ledger(block, ledger, block_index);
     let mut prev_chunk_offset = block_offsets.start();
 
@@ -249,7 +265,12 @@ pub fn process_ledger_transactions(
             .data_size
             .div_ceil(chunk_size as u64)
             .try_into()
-            .expect("Value exceeds u32::MAX");
+            .map_err(|_| {
+                MigrationError::Other(format!(
+                    "tx {} data_size {} exceeds u32 chunk count",
+                    tx.id, tx.data_size
+                ))
+            })?;
 
         let tx_chunk_range = LedgerChunkRange(ie(
             prev_chunk_offset,

--- a/crates/actors/src/data_sync_service.rs
+++ b/crates/actors/src/data_sync_service.rs
@@ -4,7 +4,7 @@ pub mod peer_bandwidth_manager;
 pub mod peer_stats;
 
 use crate::{chunk_fetcher::ChunkFetcherFactory, metrics, services::ServiceSenders};
-use chunk_orchestrator::{ChunkBlockReason, ChunkOrchestrator};
+use chunk_orchestrator::{ChunkBlockReason, ChunkOrchestrator, ChunkRequestState};
 use irys_domain::{BlockTreeReadGuard, ChunkType, PeerList, StorageModule, WriteDataChunkError};
 use irys_packing::unpack;
 use irys_types::{
@@ -105,7 +105,17 @@ pub struct DataSyncServiceInner {
 }
 
 pub enum DataSyncServiceMessage {
-    SyncPartitions,
+    /// Refresh peer/orchestrator membership for current ledger-assigned SMs.
+    ///
+    /// When `unblock_missing_data_root_index` is true, also re-queues
+    /// [`ChunkBlockReason::MissingDataRootIndex`] offsets (capped by free pending
+    /// budget). Only set that after index heal finished with zero issues (every
+    /// SM plan Complete or fully migrated; no plan soft-skips, no migrate
+    /// failures) — otherwise mass-unblock on a still-broken index becomes an
+    /// epoch refetch/re-block thrash.
+    SyncPartitions {
+        unblock_missing_data_root_index: bool,
+    },
     ChunkCompleted {
         storage_module_id: usize,
         chunk_offset: PartitionChunkOffset,
@@ -157,8 +167,13 @@ impl DataSyncServiceInner {
     #[tracing::instrument(level = "trace", skip_all, err)]
     pub fn handle_message(&mut self, msg: DataSyncServiceMessage) -> eyre::Result<()> {
         match msg {
-            DataSyncServiceMessage::SyncPartitions => {
+            DataSyncServiceMessage::SyncPartitions {
+                unblock_missing_data_root_index,
+            } => {
                 self.synchronize_peers_and_orchestrators();
+                if unblock_missing_data_root_index {
+                    self.unblock_missing_data_root_indexes();
+                }
             }
             DataSyncServiceMessage::ChunkCompleted {
                 storage_module_id,
@@ -221,6 +236,34 @@ impl DataSyncServiceInner {
         }
         self.optimize_peer_concurrency();
         Ok(())
+    }
+
+    /// Re-queue offsets blocked on missing data_root indexes, capped per
+    /// orchestrator at free pending-budget slots so one heal cannot flood dispatch.
+    fn unblock_missing_data_root_indexes(&mut self) {
+        let max_pending = self.config.node_config.data_sync.max_pending_chunk_requests as usize;
+        let mut total = 0_usize;
+        for (id, orchestrator) in self.chunk_orchestrators.iter_mut() {
+            let pending = orchestrator
+                .chunk_requests
+                .values()
+                .filter(|r| matches!(r.request_state, ChunkRequestState::Pending))
+                .count();
+            let free_slots = max_pending.saturating_sub(pending);
+            let unblocked = orchestrator.unblock_missing_data_root_index(free_slots);
+            if unblocked > 0 {
+                debug!(
+                    storage_module.id = id,
+                    data_sync.unblocked = unblocked,
+                    data_sync.unblock_cap = free_slots,
+                    "re-queued offsets blocked on missing data_root index"
+                );
+                total += unblocked;
+            }
+        }
+        if total > 0 {
+            metrics::record_data_sync_chunk_unblocked(total as u64);
+        }
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
@@ -365,7 +408,7 @@ impl DataSyncServiceInner {
                     peer.address = %peer_addr,
                     reason,
                     "data_sync write blocked: data_root not indexed in storage module; \
-                     stopping hot re-fetch for this offset (needs index rebuild)"
+                     stopping hot re-fetch until SyncPartitions after a successful index heal"
                 );
                 if let Some(orchestrator) = self.chunk_orchestrators.get_mut(&storage_module_id) {
                     orchestrator

--- a/crates/actors/src/data_sync_service/chunk_orchestrator/mod.rs
+++ b/crates/actors/src/data_sync_service/chunk_orchestrator/mod.rs
@@ -52,8 +52,9 @@ pub enum ChunkRequestState {
     Completed,
 
     /// Locally blocked from hot re-fetch (index gap, etc.). Still retained while
-    /// the offset is Entropy so we do not thrash peers; not auto-cleared until
-    /// the offset becomes Data (gossip/heal) or the process restarts.
+    /// the offset is Entropy so we do not thrash peers. Cleared when the offset
+    /// becomes Data, when `SyncPartitions { unblock_missing_data_root_index: true }`
+    /// re-queues [`ChunkBlockReason::MissingDataRootIndex`], or on process restart.
     Blocked(ChunkBlockReason),
 }
 
@@ -570,6 +571,34 @@ impl ChunkOrchestrator {
         Ok(())
     }
 
+    /// After a successful index heal, re-queue offsets blocked solely on
+    /// [`ChunkBlockReason::MissingDataRootIndex`], up to `max` offsets.
+    ///
+    /// Cap prevents one `SyncPartitions` from flipping an unbounded Blocked
+    /// backlog into Pending and storming the 250ms dispatch tick. Remaining
+    /// Blocked offsets stay until a later successful heal/SyncPartitions.
+    ///
+    /// Returns the number of requests moved to [`ChunkRequestState::Pending`].
+    pub fn unblock_missing_data_root_index(&mut self, max: usize) -> usize {
+        if max == 0 {
+            return 0;
+        }
+        let mut count = 0_usize;
+        for request in self.chunk_requests.values_mut() {
+            if count >= max {
+                break;
+            }
+            if matches!(
+                request.request_state,
+                ChunkRequestState::Blocked(ChunkBlockReason::MissingDataRootIndex)
+            ) {
+                request.request_state = ChunkRequestState::Pending;
+                count += 1;
+            }
+        }
+        count
+    }
+
     /// Local write failed for a non-blocking reason; re-queue without blaming the peer
     /// that just delivered the bytes.
     pub fn requeue_after_local_write_failure(
@@ -711,267 +740,4 @@ pub struct OrchestrationMetrics {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::{chunk_fetcher::MockChunkFetcher, test_helpers::build_test_service_senders};
-    use irys_domain::{BlockTree, StorageModuleInfo};
-    use irys_testing_utils::TempDirBuilder;
-    use irys_types::{
-        Config, ConsensusConfig, DataLedger, H256, IrysAddress, NodeConfig,
-        partition::PartitionAssignment, partition_chunk_offset_ie,
-    };
-
-    fn test_config(base_directory: std::path::PathBuf, num_chunks: u64) -> Config {
-        let node_config = NodeConfig {
-            consensus: irys_types::ConsensusOptions::Custom(ConsensusConfig {
-                chunk_size: 32,
-                num_chunks_in_partition: num_chunks,
-                num_chunks_in_recall_range: 2,
-                num_partitions_per_slot: 1,
-                entropy_packing_iterations: 1,
-                block_migration_depth: 1,
-                chain_id: 1,
-                ..ConsensusConfig::testing()
-            }),
-            base_directory,
-            ..NodeConfig::testing()
-        };
-        Config::new_with_random_peer_id(node_config)
-    }
-
-    fn packed_sm(config: &Config, num_chunks: u64) -> Arc<StorageModule> {
-        let pa = PartitionAssignment {
-            ledger_id: Some(DataLedger::Publish.into()),
-            slot_index: Some(0),
-            miner_address: IrysAddress::from([1_u8; 20]),
-            partition_hash: H256::random(),
-        };
-        let info = StorageModuleInfo {
-            id: 0,
-            partition_assignment: Some(pa),
-            submodules: vec![(
-                partition_chunk_offset_ie!(0, num_chunks as u32),
-                "chunks".into(),
-            )],
-        };
-        let sm = Arc::new(StorageModule::new(&info, config).expect("storage module"));
-        sm.pack_with_zeros();
-        sm
-    }
-
-    fn make_orchestrator(sm: Arc<StorageModule>, config: &Config) -> ChunkOrchestrator {
-        let genesis = irys_testing_utils::new_mock_signed_header();
-        let block_tree = BlockTree::new(&genesis, config.consensus.clone());
-        let block_tree_guard = BlockTreeReadGuard::new(Arc::new(RwLock::new(block_tree)));
-        let (service_senders, _receivers) = build_test_service_senders();
-        let ledger_id: u32 = DataLedger::Publish.into();
-        ChunkOrchestrator::new(
-            sm,
-            Arc::new(RwLock::new(HashMap::new())),
-            block_tree_guard,
-            &service_senders,
-            Arc::new(MockChunkFetcher::new(ledger_id as usize)),
-            config.node_config.clone(),
-            tokio::runtime::Handle::current(),
-        )
-    }
-
-    fn insert_requested(
-        orch: &mut ChunkOrchestrator,
-        offset: PartitionChunkOffset,
-        peer: IrysAddress,
-    ) {
-        orch.chunk_requests.insert(
-            offset,
-            ChunkRequest {
-                ledger_id: 0,
-                slot_index: 0,
-                chunk_offset: offset,
-                excluded: None,
-                request_state: ChunkRequestState::Requested(peer, Instant::now()),
-            },
-        );
-    }
-
-    #[test_log::test(tokio::test)]
-    async fn mark_helpers_require_requested_state() {
-        let tmp = TempDirBuilder::new().with_tracing().build();
-        let num_chunks = 4;
-        let config = test_config(tmp.path().to_path_buf(), num_chunks);
-        let sm = packed_sm(&config, num_chunks);
-        let mut orch = make_orchestrator(sm, &config);
-        let peer = IrysAddress::from([2_u8; 20]);
-        let offset = PartitionChunkOffset::from(0_u32);
-
-        // Unknown offset
-        assert!(orch.mark_chunk_stored(offset).is_err());
-        assert!(
-            orch.mark_chunk_blocked(offset, ChunkBlockReason::MissingDataRootIndex)
-                .is_err()
-        );
-        assert!(orch.requeue_after_local_write_failure(offset).is_err());
-
-        // Pending is not Requested
-        orch.chunk_requests.insert(
-            offset,
-            ChunkRequest {
-                ledger_id: 0,
-                slot_index: 0,
-                chunk_offset: offset,
-                excluded: None,
-                request_state: ChunkRequestState::Pending,
-            },
-        );
-        assert!(orch.mark_chunk_stored(offset).is_err());
-        assert!(
-            orch.mark_chunk_blocked(offset, ChunkBlockReason::MissingDataRootIndex)
-                .is_err()
-        );
-        assert!(orch.requeue_after_local_write_failure(offset).is_err());
-
-        // Requested accepts each transition
-        insert_requested(&mut orch, offset, peer);
-        orch.mark_chunk_stored(offset).expect("store");
-        assert_eq!(
-            orch.chunk_requests[&offset].request_state,
-            ChunkRequestState::Completed
-        );
-
-        insert_requested(&mut orch, offset, peer);
-        orch.mark_chunk_blocked(offset, ChunkBlockReason::MissingDataRootIndex)
-            .expect("block");
-        assert_eq!(
-            orch.chunk_requests[&offset].request_state,
-            ChunkRequestState::Blocked(ChunkBlockReason::MissingDataRootIndex)
-        );
-
-        insert_requested(&mut orch, offset, peer);
-        orch.requeue_after_local_write_failure(offset)
-            .expect("requeue");
-        assert_eq!(
-            orch.chunk_requests[&offset].request_state,
-            ChunkRequestState::Pending
-        );
-        // Requeue must not blame the delivering peer.
-        assert!(orch.chunk_requests[&offset].excluded.is_none());
-    }
-
-    #[test_log::test(tokio::test)]
-    async fn on_chunk_fetched_does_not_mark_stored() {
-        let tmp = TempDirBuilder::new().with_tracing().build();
-        let num_chunks = 4;
-        let config = test_config(tmp.path().to_path_buf(), num_chunks);
-        let sm = packed_sm(&config, num_chunks);
-        let mut orch = make_orchestrator(sm, &config);
-        let peer = IrysAddress::from([3_u8; 20]);
-        let offset = PartitionChunkOffset::from(1_u32);
-        insert_requested(&mut orch, offset, peer);
-
-        orch.on_chunk_fetched(offset, peer).expect("fetched");
-        assert!(
-            matches!(
-                orch.chunk_requests[&offset].request_state,
-                ChunkRequestState::Requested(..)
-            ),
-            "fetch success must not imply durable store (Completed)"
-        );
-    }
-
-    #[test_log::test(tokio::test)]
-    async fn blocked_retained_while_entropy_dropped_when_data() {
-        let tmp = TempDirBuilder::new().with_tracing().build();
-        let num_chunks = 4;
-        let config = test_config(tmp.path().to_path_buf(), num_chunks);
-        let sm = packed_sm(&config, num_chunks);
-        let mut orch = make_orchestrator(sm.clone(), &config);
-        let peer = IrysAddress::from([4_u8; 20]);
-        let offset = PartitionChunkOffset::from(0_u32);
-
-        insert_requested(&mut orch, offset, peer);
-        orch.mark_chunk_blocked(offset, ChunkBlockReason::MissingDataRootIndex)
-            .unwrap();
-
-        // Still Entropy → retain Blocked
-        orch.populate_request_queue();
-        assert!(
-            matches!(
-                orch.chunk_requests[&offset].request_state,
-                ChunkRequestState::Blocked(ChunkBlockReason::MissingDataRootIndex)
-            ),
-            "Blocked must stay while offset is Entropy"
-        );
-
-        // Become Data (e.g. gossip/heal) → drop request
-        let data_bytes = vec![0xab; config.consensus.chunk_size as usize];
-        sm.write_chunk(offset, data_bytes, ChunkType::Data);
-        sm.sync_pending_chunks().unwrap();
-        assert!(matches!(sm.get_chunk_type(&offset), Some(ChunkType::Data)));
-
-        orch.populate_request_queue();
-        assert!(
-            !orch.chunk_requests.contains_key(&offset),
-            "Blocked must drop once offset is Data"
-        );
-    }
-
-    #[test_log::test(tokio::test)]
-    async fn blocked_excluded_from_pending_budget_and_dispatch_selection() {
-        let tmp = TempDirBuilder::new().with_tracing().build();
-        let num_chunks = 4;
-        let config = test_config(tmp.path().to_path_buf(), num_chunks);
-        let sm = packed_sm(&config, num_chunks);
-        let mut orch = make_orchestrator(sm, &config);
-        let peer = IrysAddress::from([5_u8; 20]);
-
-        // Fill with Blocked offsets — must not count as pending budget consumers.
-        for i in 0..3_u32 {
-            let offset = PartitionChunkOffset::from(i);
-            insert_requested(&mut orch, offset, peer);
-            orch.mark_chunk_blocked(offset, ChunkBlockReason::MissingDataRootIndex)
-                .unwrap();
-        }
-
-        let metrics = orch.get_metrics();
-        assert_eq!(metrics.blocked_requests, 3);
-        assert_eq!(metrics.pending_requests, 0);
-        assert_eq!(metrics.active_requests, 0);
-
-        // Only Pending is eligible for dispatch.
-        let pending_for_dispatch: Vec<_> = orch
-            .chunk_requests
-            .iter()
-            .filter_map(|(&offset, req)| {
-                matches!(req.request_state, ChunkRequestState::Pending).then_some(offset)
-            })
-            .collect();
-        assert!(
-            pending_for_dispatch.is_empty(),
-            "Blocked offsets must not be selected for re-dispatch"
-        );
-
-        // Pending budget counts only Pending, so a fresh Pending can still be inserted
-        // even when many offsets are Blocked (Vacant entries only — offset 3 is free).
-        let offset3 = PartitionChunkOffset::from(3_u32);
-        orch.chunk_requests.insert(
-            offset3,
-            ChunkRequest {
-                ledger_id: 0,
-                slot_index: 0,
-                chunk_offset: offset3,
-                excluded: None,
-                request_state: ChunkRequestState::Pending,
-            },
-        );
-        let metrics = orch.get_metrics();
-        assert_eq!(metrics.pending_requests, 1);
-        assert_eq!(metrics.blocked_requests, 3);
-    }
-
-    #[test]
-    fn metric_label_stable() {
-        assert_eq!(
-            ChunkBlockReason::MissingDataRootIndex.as_metric_label(),
-            "missing_data_root_index"
-        );
-    }
-}
+mod tests;

--- a/crates/actors/src/data_sync_service/chunk_orchestrator/tests.rs
+++ b/crates/actors/src/data_sync_service/chunk_orchestrator/tests.rs
@@ -1,0 +1,359 @@
+use super::*;
+use crate::{chunk_fetcher::MockChunkFetcher, test_helpers::build_test_service_senders};
+use irys_domain::{BlockTree, StorageModuleInfo};
+use irys_testing_utils::TempDirBuilder;
+use irys_types::{
+    Config, ConsensusConfig, DataLedger, H256, IrysAddress, NodeConfig,
+    partition::PartitionAssignment, partition_chunk_offset_ie,
+};
+
+fn test_config(base_directory: std::path::PathBuf, num_chunks: u64) -> Config {
+    let node_config = NodeConfig {
+        consensus: irys_types::ConsensusOptions::Custom(ConsensusConfig {
+            chunk_size: 32,
+            num_chunks_in_partition: num_chunks,
+            num_chunks_in_recall_range: 2,
+            num_partitions_per_slot: 1,
+            entropy_packing_iterations: 1,
+            block_migration_depth: 1,
+            chain_id: 1,
+            ..ConsensusConfig::testing()
+        }),
+        base_directory,
+        ..NodeConfig::testing()
+    };
+    Config::new_with_random_peer_id(node_config)
+}
+
+fn packed_sm(config: &Config, num_chunks: u64) -> Arc<StorageModule> {
+    let pa = PartitionAssignment {
+        ledger_id: Some(DataLedger::Publish.into()),
+        slot_index: Some(0),
+        miner_address: IrysAddress::from([1_u8; 20]),
+        partition_hash: H256::random(),
+    };
+    let info = StorageModuleInfo {
+        id: 0,
+        partition_assignment: Some(pa),
+        submodules: vec![(
+            partition_chunk_offset_ie!(0, num_chunks as u32),
+            "chunks".into(),
+        )],
+    };
+    let sm = Arc::new(StorageModule::new(&info, config).expect("storage module"));
+    sm.pack_with_zeros();
+    sm
+}
+
+fn make_orchestrator(sm: Arc<StorageModule>, config: &Config) -> ChunkOrchestrator {
+    let genesis = irys_testing_utils::new_mock_signed_header();
+    let block_tree = BlockTree::new(&genesis, config.consensus.clone());
+    let block_tree_guard = BlockTreeReadGuard::new(Arc::new(RwLock::new(block_tree)));
+    let (service_senders, _receivers) = build_test_service_senders();
+    let ledger_id: u32 = DataLedger::Publish.into();
+    ChunkOrchestrator::new(
+        sm,
+        Arc::new(RwLock::new(HashMap::new())),
+        block_tree_guard,
+        &service_senders,
+        Arc::new(MockChunkFetcher::new(ledger_id as usize)),
+        config.node_config.clone(),
+        tokio::runtime::Handle::current(),
+    )
+}
+
+fn insert_requested(orch: &mut ChunkOrchestrator, offset: PartitionChunkOffset, peer: IrysAddress) {
+    orch.chunk_requests.insert(
+        offset,
+        ChunkRequest {
+            ledger_id: 0,
+            slot_index: 0,
+            chunk_offset: offset,
+            excluded: None,
+            request_state: ChunkRequestState::Requested(peer, Instant::now()),
+        },
+    );
+}
+
+#[test_log::test(tokio::test)]
+async fn mark_helpers_require_requested_state() {
+    let tmp = TempDirBuilder::new().with_tracing().build();
+    let num_chunks = 4;
+    let config = test_config(tmp.path().to_path_buf(), num_chunks);
+    let sm = packed_sm(&config, num_chunks);
+    let mut orch = make_orchestrator(sm, &config);
+    let peer = IrysAddress::from([2_u8; 20]);
+    let offset = PartitionChunkOffset::from(0_u32);
+
+    // Unknown offset
+    assert!(orch.mark_chunk_stored(offset).is_err());
+    assert!(
+        orch.mark_chunk_blocked(offset, ChunkBlockReason::MissingDataRootIndex)
+            .is_err()
+    );
+    assert!(orch.requeue_after_local_write_failure(offset).is_err());
+
+    // Pending is not Requested
+    orch.chunk_requests.insert(
+        offset,
+        ChunkRequest {
+            ledger_id: 0,
+            slot_index: 0,
+            chunk_offset: offset,
+            excluded: None,
+            request_state: ChunkRequestState::Pending,
+        },
+    );
+    assert!(orch.mark_chunk_stored(offset).is_err());
+    assert!(
+        orch.mark_chunk_blocked(offset, ChunkBlockReason::MissingDataRootIndex)
+            .is_err()
+    );
+    assert!(orch.requeue_after_local_write_failure(offset).is_err());
+
+    // Requested accepts each transition
+    insert_requested(&mut orch, offset, peer);
+    orch.mark_chunk_stored(offset).expect("store");
+    assert_eq!(
+        orch.chunk_requests[&offset].request_state,
+        ChunkRequestState::Completed
+    );
+
+    insert_requested(&mut orch, offset, peer);
+    orch.mark_chunk_blocked(offset, ChunkBlockReason::MissingDataRootIndex)
+        .expect("block");
+    assert_eq!(
+        orch.chunk_requests[&offset].request_state,
+        ChunkRequestState::Blocked(ChunkBlockReason::MissingDataRootIndex)
+    );
+
+    insert_requested(&mut orch, offset, peer);
+    orch.requeue_after_local_write_failure(offset)
+        .expect("requeue");
+    assert_eq!(
+        orch.chunk_requests[&offset].request_state,
+        ChunkRequestState::Pending
+    );
+    // Requeue must not blame the delivering peer.
+    assert!(orch.chunk_requests[&offset].excluded.is_none());
+}
+
+#[test_log::test(tokio::test)]
+async fn on_chunk_fetched_does_not_mark_stored() {
+    let tmp = TempDirBuilder::new().with_tracing().build();
+    let num_chunks = 4;
+    let config = test_config(tmp.path().to_path_buf(), num_chunks);
+    let sm = packed_sm(&config, num_chunks);
+    let mut orch = make_orchestrator(sm, &config);
+    let peer = IrysAddress::from([3_u8; 20]);
+    let offset = PartitionChunkOffset::from(1_u32);
+    insert_requested(&mut orch, offset, peer);
+
+    orch.on_chunk_fetched(offset, peer).expect("fetched");
+    assert!(
+        matches!(
+            orch.chunk_requests[&offset].request_state,
+            ChunkRequestState::Requested(..)
+        ),
+        "fetch success must not imply durable store (Completed)"
+    );
+}
+
+#[test_log::test(tokio::test)]
+async fn blocked_retained_while_entropy_dropped_when_data() {
+    let tmp = TempDirBuilder::new().with_tracing().build();
+    let num_chunks = 4;
+    let config = test_config(tmp.path().to_path_buf(), num_chunks);
+    let sm = packed_sm(&config, num_chunks);
+    let mut orch = make_orchestrator(sm.clone(), &config);
+    let peer = IrysAddress::from([4_u8; 20]);
+    let offset = PartitionChunkOffset::from(0_u32);
+
+    insert_requested(&mut orch, offset, peer);
+    orch.mark_chunk_blocked(offset, ChunkBlockReason::MissingDataRootIndex)
+        .unwrap();
+
+    // Still Entropy → retain Blocked
+    orch.populate_request_queue();
+    assert!(
+        matches!(
+            orch.chunk_requests[&offset].request_state,
+            ChunkRequestState::Blocked(ChunkBlockReason::MissingDataRootIndex)
+        ),
+        "Blocked must stay while offset is Entropy"
+    );
+
+    // Become Data (e.g. gossip/heal) → drop request
+    let data_bytes = vec![0xab; config.consensus.chunk_size as usize];
+    sm.write_chunk(offset, data_bytes, ChunkType::Data);
+    sm.sync_pending_chunks().unwrap();
+    assert!(matches!(sm.get_chunk_type(&offset), Some(ChunkType::Data)));
+
+    orch.populate_request_queue();
+    assert!(
+        !orch.chunk_requests.contains_key(&offset),
+        "Blocked must drop once offset is Data"
+    );
+}
+
+#[test_log::test(tokio::test)]
+async fn blocked_excluded_from_pending_budget_and_dispatch_selection() {
+    let tmp = TempDirBuilder::new().with_tracing().build();
+    let num_chunks = 4;
+    let config = test_config(tmp.path().to_path_buf(), num_chunks);
+    let sm = packed_sm(&config, num_chunks);
+    let mut orch = make_orchestrator(sm, &config);
+    let peer = IrysAddress::from([5_u8; 20]);
+
+    // Fill with Blocked offsets — must not count as pending budget consumers.
+    for i in 0..3_u32 {
+        let offset = PartitionChunkOffset::from(i);
+        insert_requested(&mut orch, offset, peer);
+        orch.mark_chunk_blocked(offset, ChunkBlockReason::MissingDataRootIndex)
+            .unwrap();
+    }
+
+    let metrics = orch.get_metrics();
+    assert_eq!(metrics.blocked_requests, 3);
+    assert_eq!(metrics.pending_requests, 0);
+    assert_eq!(metrics.active_requests, 0);
+
+    // Only Pending is eligible for dispatch.
+    let pending_for_dispatch: Vec<_> = orch
+        .chunk_requests
+        .iter()
+        .filter_map(|(&offset, req)| {
+            matches!(req.request_state, ChunkRequestState::Pending).then_some(offset)
+        })
+        .collect();
+    assert!(
+        pending_for_dispatch.is_empty(),
+        "Blocked offsets must not be selected for re-dispatch"
+    );
+
+    // Pending budget counts only Pending, so a fresh Pending can still be inserted
+    // even when many offsets are Blocked (Vacant entries only — offset 3 is free).
+    let offset3 = PartitionChunkOffset::from(3_u32);
+    orch.chunk_requests.insert(
+        offset3,
+        ChunkRequest {
+            ledger_id: 0,
+            slot_index: 0,
+            chunk_offset: offset3,
+            excluded: None,
+            request_state: ChunkRequestState::Pending,
+        },
+    );
+    let metrics = orch.get_metrics();
+    assert_eq!(metrics.pending_requests, 1);
+    assert_eq!(metrics.blocked_requests, 3);
+}
+
+#[test]
+fn metric_label_stable() {
+    assert_eq!(
+        ChunkBlockReason::MissingDataRootIndex.as_metric_label(),
+        "missing_data_root_index"
+    );
+}
+
+#[test_log::test(tokio::test)]
+async fn unblock_missing_data_root_index_requeues_only_that_reason() {
+    let tmp = TempDirBuilder::new().with_tracing().build();
+    let num_chunks = 4;
+    let config = test_config(tmp.path().to_path_buf(), num_chunks);
+    let sm = packed_sm(&config, num_chunks);
+    let mut orch = make_orchestrator(sm, &config);
+    let peer = IrysAddress::from([6_u8; 20]);
+
+    let blocked = PartitionChunkOffset::from(0_u32);
+    let pending = PartitionChunkOffset::from(1_u32);
+    let completed = PartitionChunkOffset::from(2_u32);
+    let requested = PartitionChunkOffset::from(3_u32);
+
+    insert_requested(&mut orch, blocked, peer);
+    orch.mark_chunk_blocked(blocked, ChunkBlockReason::MissingDataRootIndex)
+        .unwrap();
+
+    orch.chunk_requests.insert(
+        pending,
+        ChunkRequest {
+            ledger_id: 0,
+            slot_index: 0,
+            chunk_offset: pending,
+            excluded: None,
+            request_state: ChunkRequestState::Pending,
+        },
+    );
+
+    insert_requested(&mut orch, completed, peer);
+    orch.mark_chunk_stored(completed).unwrap();
+
+    insert_requested(&mut orch, requested, peer);
+
+    let n = orch.unblock_missing_data_root_index(usize::MAX);
+    assert_eq!(n, 1, "only MissingDataRootIndex Blocked should unblock");
+    assert_eq!(
+        orch.chunk_requests[&blocked].request_state,
+        ChunkRequestState::Pending
+    );
+    assert_eq!(
+        orch.chunk_requests[&pending].request_state,
+        ChunkRequestState::Pending
+    );
+    assert_eq!(
+        orch.chunk_requests[&completed].request_state,
+        ChunkRequestState::Completed
+    );
+    assert!(matches!(
+        orch.chunk_requests[&requested].request_state,
+        ChunkRequestState::Requested(..)
+    ));
+
+    // Idempotent when nothing is blocked.
+    assert_eq!(orch.unblock_missing_data_root_index(usize::MAX), 0);
+}
+
+#[test_log::test(tokio::test)]
+async fn unblock_missing_data_root_index_respects_cap() {
+    let tmp = TempDirBuilder::new().with_tracing().build();
+    let num_chunks = 4;
+    let config = test_config(tmp.path().to_path_buf(), num_chunks);
+    let sm = packed_sm(&config, num_chunks);
+    let mut orch = make_orchestrator(sm, &config);
+    let peer = IrysAddress::from([7_u8; 20]);
+
+    for i in 0..3_u32 {
+        let offset = PartitionChunkOffset::from(i);
+        insert_requested(&mut orch, offset, peer);
+        orch.mark_chunk_blocked(offset, ChunkBlockReason::MissingDataRootIndex)
+            .unwrap();
+    }
+
+    assert_eq!(orch.unblock_missing_data_root_index(0), 0);
+    assert!(orch.chunk_requests.values().all(|r| {
+        matches!(
+            r.request_state,
+            ChunkRequestState::Blocked(ChunkBlockReason::MissingDataRootIndex)
+        )
+    }));
+
+    assert_eq!(orch.unblock_missing_data_root_index(2), 2);
+    let pending = orch
+        .chunk_requests
+        .values()
+        .filter(|r| matches!(r.request_state, ChunkRequestState::Pending))
+        .count();
+    let still_blocked = orch
+        .chunk_requests
+        .values()
+        .filter(|r| {
+            matches!(
+                r.request_state,
+                ChunkRequestState::Blocked(ChunkBlockReason::MissingDataRootIndex)
+            )
+        })
+        .count();
+    assert_eq!(pending, 2);
+    assert_eq!(still_blocked, 1);
+}

--- a/crates/actors/src/metrics.rs
+++ b/crates/actors/src/metrics.rs
@@ -29,6 +29,7 @@ irys_utils::define_metrics! {
     counter DATA_SYNC_CHUNK_FAILURES("irys.data_sync.chunk_failures_total", "Data sync peer fetch failures/timeouts");
     counter DATA_SYNC_CHUNK_WRITE_FAILED("irys.data_sync.chunk_write_failed_total", "Data sync local write failures after a successful fetch (labelled by reason)");
     counter DATA_SYNC_CHUNK_BLOCKED("irys.data_sync.chunk_blocked_total", "Data sync offsets blocked from hot re-fetch (labelled by reason)");
+    counter DATA_SYNC_CHUNK_UNBLOCKED("irys.data_sync.chunk_unblocked_total", "Data sync offsets re-queued on SyncPartitions when unblock_missing_data_root_index is true (MissingDataRootIndex → Pending)");
     gauge DATA_SYNC_ACTIVE_PEERS("irys.data_sync.active_peers", "Number of active data sync peers");
     counter MINING_SOLUTIONS_FOUND("irys.mining.solutions_found_total", "Mining solutions found");
     gauge PACKING_ACTIVE_WORKERS("irys.packing.active_workers", "Number of active packing workers");
@@ -283,6 +284,12 @@ pub(crate) fn record_data_sync_chunk_write_failed(reason: &'static str) {
 /// `reason` values: `missing_data_root_index` (via `ChunkBlockReason::as_metric_label`).
 pub(crate) fn record_data_sync_chunk_blocked(reason: &'static str) {
     DATA_SYNC_CHUNK_BLOCKED.add(1, &[KeyValue::new("reason", reason)]);
+}
+
+pub(crate) fn record_data_sync_chunk_unblocked(count: u64) {
+    if count > 0 {
+        DATA_SYNC_CHUNK_UNBLOCKED.add(count, &[]);
+    }
 }
 
 pub(crate) fn record_data_sync_active_peers(count: u64) {

--- a/crates/actors/src/storage_module_service.rs
+++ b/crates/actors/src/storage_module_service.rs
@@ -29,7 +29,6 @@ use irys_types::{
 use reth::tasks::shutdown::Shutdown;
 use std::{
     collections::{BTreeMap, HashMap},
-    ops::Range,
     path::Path,
     sync::{Arc, RwLock},
     time::Duration,
@@ -138,7 +137,6 @@ impl StorageModuleServiceInner {
                 .map(|module| (module.id, module.clone()))
                 .collect()
         };
-        let mut assigned_modules = Vec::new();
         let mut packing_modules = Vec::new();
 
         debug!("StorageModuleInfos:\n{:#?}", storage_module_info_update);
@@ -261,10 +259,11 @@ impl StorageModuleServiceInner {
                     if ledger_before.is_some() && info_pa.ledger_id.is_none() {
                         // This storage module is expiring from LedgerSlot->Capacity
                         packing_modules.push(existing.clone());
-                    } else if ledger_before.is_none() && info_pa.ledger_id.is_some() {
-                        // This storage module is assigned Capacity->LedgerSlot
-                        assigned_modules.push(existing.clone());
                     }
+                    // Capacity→LedgerSlot and long-lived ledger assigns: index
+                    // repair runs below for *all* ledger-assigned SMs (path-hash
+                    // gap scan). Direct ledger A→B reassignment relies on the
+                    // mining-bus reset path, not this presence scan.
                 }
             }
         }
@@ -301,173 +300,112 @@ impl StorageModuleServiceInner {
             }
         }
 
-        // For each storage module assigned to a data ledger, we need to update the data_root indexes
-        // that may overlap the assigned slot so that it can index chunks
+        // After assignments settle: gap-scan + index backfill for every local SM
+        // currently on a data ledger (not only Capacity→LedgerSlot transitions).
+        self.heal_ledger_data_indexes().await?;
+
+        Ok(())
+    }
+
+    /// Scan ledger-assigned SMs for path-hash index gaps, backfill via
+    /// `UpdateStorageModuleIndexes`, then `SyncPartitions` (membership always;
+    /// unblock only if plan + migrate reported no issues).
+    ///
+    /// Startup and every partition-assignment update. Dense indexes → density
+    /// fast path / no migrate. Soft-skips bounds/index inconsistency and per-block
+    /// migration errors; hard-fails only if the migration channel is closed.
+    ///
+    /// Marker is path-hash completeness; `UpdateStorageModuleIndexes` also writes
+    /// DataRootInfos when it runs. Residual: dense path-hashes with empty
+    /// DataRootInfos will not schedule a migrate.
+    #[tracing::instrument(level = "debug", skip_all, err)]
+    async fn heal_ledger_data_indexes(&self) -> eyre::Result<()> {
+        let ledger_modules: Vec<Arc<StorageModule>> = {
+            let guard = self.storage_modules.read().unwrap();
+            guard
+                .iter()
+                .filter(|sm| {
+                    sm.partition_assignment()
+                        .and_then(|a| a.ledger_id)
+                        .is_some()
+                })
+                .cloned()
+                .collect()
+        };
+
+        debug!(
+            storage_module.ledger_assigned_count = ledger_modules.len(),
+            "healing data indexes for ledger-assigned storage modules"
+        );
+
         let mut blocks_to_migrate: BTreeMap<u64, BlockHash> = BTreeMap::new();
-        for assigned_sm in assigned_modules {
-            // Rebuild indexes
-            let ledger_id = assigned_sm
-                .partition_assignment()
-                .and_then(|a| a.ledger_id)
-                .expect("storage module must be assigned to a data ledger slot");
-
-            let ledger_range = assigned_sm
-                .get_storage_module_ledger_offsets()
-                .expect("storage module should be assigned to a ledger");
-
-            // Get the chunk range in PartitionRelative offsets for the min and max
-            // relative offset of data stored in this partition.
-            let max_partition_offset = self.get_max_partition_offset(assigned_sm.clone());
-            let partition_range = PartitionChunkOffset::from(0)..max_partition_offset;
-
-            // First offset without path hashes (resume after crash / restart).
-            // Cursor gap-scan: correct for non-prefix holes, O(indexed keys).
-            let first_unindexed_chunk_offset =
-                Self::find_first_unindexed_chunk(assigned_sm.clone(), partition_range)?;
-
-            // If we found some unindexed chunks that should be present, let's build a list of blocks to migrate
-            if let Some(chunk_offset) = first_unindexed_chunk_offset {
-                let ledger_chunk_offset =
-                    ledger_range.start() + LedgerChunkOffset::from(*chunk_offset);
-
-                // check max_chunk_offset first
-                let block_index_guard = self.block_index.read();
-                let latest_item = match block_index_guard.get_latest_item() {
-                    Some(item) => item,
-                    None => continue, // No blocks yet, skip
-                };
-
-                let data_ledger = DataLedger::try_from(ledger_id).unwrap();
-                // Frontier for this ledger; an absent entry (e.g. a term
-                // ledger before Cascade activation) means no data yet. Still
-                // read here (not just via the bounds error) because the end
-                // offset is clamped against it below.
-                let max_chunk_offset = latest_item
-                    .ledgers
-                    .iter()
-                    .find(|l| l.ledger == data_ledger)
-                    .map(|l| l.total_chunks)
-                    .unwrap_or(0);
-
-                // Check if start offset is within bounds
-                if *ledger_chunk_offset >= max_chunk_offset {
-                    // This offset is beyond the actual data in the ledger, skip this storage module
-                    continue;
+        let mut heal_issues = 0_usize;
+        for sm in &ledger_modules {
+            match self.plan_index_repair(sm) {
+                IndexRepairPlan::Complete => {}
+                IndexRepairPlan::SoftSkipped => {
+                    heal_issues += 1;
                 }
-
-                let block_bounds =
-                    match block_index_guard.get_block_bounds(data_ledger, ledger_chunk_offset) {
-                        Ok(bounds) => bounds,
-                        // The index shrank between the frontier read and the
-                        // search (reorg truncation) — skip; the next update
-                        // re-evaluates against the new index.
-                        Err(
-                            BlockBoundsError::IndexEmpty
-                            | BlockBoundsError::LedgerInactive { .. }
-                            | BlockBoundsError::OffsetBeyondFrontier { .. },
-                        ) => continue,
-                        Err(BlockBoundsError::Internal(e)) => {
-                            return Err(e.wrap_err("Failed to get start block bounds"));
-                        }
-                    };
-
-                let start_block = block_bounds.height;
-
-                // Inclusive last ledger offset: max_partition_offset is exclusive.
-                if *max_partition_offset == 0 {
-                    continue;
-                }
-                let end_ledger_offset =
-                    ledger_range.start() + LedgerChunkOffset::from(*max_partition_offset - 1);
-
-                // Clamp end offset to actual data bounds
-                let clamped_end_offset = if *end_ledger_offset >= max_chunk_offset {
-                    if max_chunk_offset > 0 {
-                        LedgerChunkOffset::from(max_chunk_offset - 1)
-                    } else {
-                        continue; // No data at all
-                    }
-                } else {
-                    end_ledger_offset
-                };
-
-                // Ensure we have a valid range after clamping
-                if clamped_end_offset < ledger_chunk_offset {
-                    continue; // Skip if the range is invalid
-                }
-
-                // Now get block bounds for the end
-                let end_block_bounds =
-                    match block_index_guard.get_block_bounds(data_ledger, clamped_end_offset) {
-                        Ok(bounds) => bounds,
-                        Err(
-                            BlockBoundsError::IndexEmpty
-                            | BlockBoundsError::LedgerInactive { .. }
-                            | BlockBoundsError::OffsetBeyondFrontier { .. },
-                        ) => continue,
-                        Err(BlockBoundsError::Internal(e)) => {
-                            return Err(e.wrap_err("Failed to get end block bounds"));
-                        }
-                    };
-
-                let end_block = end_block_bounds.height;
-
-                // Drop the guard before the next read
-                let _ = block_index_guard;
-
-                {
+                IndexRepairPlan::NeedsRepair {
+                    start_height,
+                    end_height,
+                } => {
                     let bi = self.block_index.read();
-                    for height in start_block..=end_block {
-                        let block_hash = bi
-                            .get_item(height)
-                            .expect("block item to be present in index")
-                            .block_hash;
-                        blocks_to_migrate.insert(height, block_hash);
+                    let mut planned_any = false;
+                    let mut missing_height = false;
+                    for height in start_height..=end_height {
+                        let Some(item) = bi.get_item(height) else {
+                            // Index shrank / truncated between plan and read (e.g. reorg).
+                            warn!(
+                                storage_module.id = sm.id,
+                                block.height = height,
+                                plan.start_height = start_height,
+                                plan.end_height = end_height,
+                                "block missing from index during heal; counting as heal issue"
+                            );
+                            missing_height = true;
+                            break;
+                        };
+                        blocks_to_migrate.insert(height, item.block_hash);
+                        planned_any = true;
+                    }
+                    // Incomplete materialization (empty span or mid-range gap) —
+                    // count once, not on both the miss and the empty check.
+                    if missing_height || !planned_any {
+                        heal_issues += 1;
                     }
                 }
             }
         }
 
         if !blocks_to_migrate.is_empty() {
-            // If we have blocks to migrate, lets do so. The BTreeSet ensures in-order traversal
-            let migration_service = &self.service_senders.chunk_migration;
-            for (block_height, block_hash) in blocks_to_migrate {
-                // Send migration request
-                let (tx, rx) = tokio::sync::oneshot::channel();
-
-                // Handle send error
-                if let Err(e) = migration_service.send_traced(
-                    ChunkMigrationServiceMessage::UpdateStorageModuleIndexes {
-                        block_hash,
-                        receiver: tx,
-                    },
-                ) {
-                    error!(
-                        "Failed to send migration request for block {} (height {}): {}",
-                        block_hash, block_height, e
-                    );
-                    return Err(eyre!(
-                        "Unable to index storage module chunks do to mpsc send failure: {}",
-                        e
-                    ));
-                }
-
-                // We await responses so we only perform one migration at a time
-                if let Err(e) = rx.await {
-                    error!(
-                        "Failed to receive migration response for block {} (height {}): {}",
-                        block_hash, block_height, e
-                    );
-                }
-            }
+            debug!(
+                index_heal.blocks = blocks_to_migrate.len(),
+                "migrating blocks to repair storage-module data indexes"
+            );
+            heal_issues += self
+                .migrate_storage_module_indexes(blocks_to_migrate)
+                .await?;
         }
 
-        // Only once the storage module partition assignments are updated we can a
-        // safely update the data_sync_service for any necessary data synchronization
-        if let Err(e) = self
-            .service_senders
-            .data_sync
-            .send_traced(DataSyncServiceMessage::SyncPartitions)
+        // Always refresh orchestrator membership. Unblock only when every SM plan
+        // was Complete or fully migrated — plan soft-skips and migrate failures
+        // both suppress unblock to avoid epoch refetch/re-block thrash.
+        let unblock = heal_issues == 0;
+        if !unblock {
+            warn!(
+                index_heal.issues = heal_issues,
+                "index heal incomplete; SyncPartitions without unblock \
+                 to avoid refetch/re-block thrash"
+            );
+        }
+
+        if let Err(e) =
+            self.service_senders
+                .data_sync
+                .send_traced(DataSyncServiceMessage::SyncPartitions {
+                    unblock_missing_data_root_index: unblock,
+                })
         {
             error!(
                 "Failed to send SyncPartitions message to data_sync service: {}",
@@ -476,6 +414,202 @@ impl StorageModuleServiceInner {
         }
 
         Ok(())
+    }
+
+    /// Path-hash gap → inclusive block-height range to re-index, or a soft outcome.
+    ///
+    /// Distinguishes "indexes look complete" from "could not plan / uncertain" so
+    /// heal does not claim success and mass-unblock after a soft-skip.
+    fn plan_index_repair(&self, sm: &Arc<StorageModule>) -> IndexRepairPlan {
+        let ledger_id = sm
+            .partition_assignment()
+            .and_then(|a| a.ledger_id)
+            .expect("storage module must be assigned to a data ledger slot");
+
+        let Ok(ledger_range) = sm.get_storage_module_ledger_offsets() else {
+            warn!(
+                storage_module.id = sm.id,
+                "storage module not assigned to a ledger during index plan; soft-skip"
+            );
+            return IndexRepairPlan::SoftSkipped;
+        };
+
+        let max_partition_offset = self.get_max_partition_offset(sm.clone());
+        if *max_partition_offset == 0 {
+            // No migrated data in range yet — nothing to repair.
+            return IndexRepairPlan::Complete;
+        }
+
+        // First offset without path hashes (density fast path or cursor walk).
+        let chunk_offset = match sm
+            .first_missing_path_hash_offset(PartitionChunkOffset::from(0), max_partition_offset)
+        {
+            Ok(Some(offset)) => offset,
+            Ok(None) => return IndexRepairPlan::Complete,
+            Err(e) => {
+                warn!(
+                    storage_module.id = sm.id,
+                    error = %e,
+                    "path-hash gap scan failed; soft-skipping index repair for this module"
+                );
+                return IndexRepairPlan::SoftSkipped;
+            }
+        };
+
+        debug!(
+            storage_module.id = sm.id,
+            index_heal.first_gap = %chunk_offset,
+            index_heal.max_partition_offset = %max_partition_offset,
+            "path-hash index gap detected; scheduling index repair"
+        );
+
+        let ledger_chunk_offset = ledger_range.start() + LedgerChunkOffset::from(*chunk_offset);
+        let block_index_guard = self.block_index.read();
+        let Some(latest_item) = block_index_guard.get_latest_item() else {
+            // Gap exists but chain index is empty — cannot repair yet.
+            return IndexRepairPlan::SoftSkipped;
+        };
+
+        let Ok(data_ledger) = DataLedger::try_from(ledger_id) else {
+            warn!(
+                storage_module.id = sm.id,
+                ledger_id, "invalid ledger id during index plan; soft-skip"
+            );
+            return IndexRepairPlan::SoftSkipped;
+        };
+        // Frontier for this ledger; absent entry (e.g. term ledger pre-Cascade)
+        // means no data yet — still needed to clamp the end offset below.
+        let max_chunk_offset = latest_item
+            .ledgers
+            .iter()
+            .find(|l| l.ledger == data_ledger)
+            .map(|l| l.total_chunks)
+            .unwrap_or(0);
+
+        if *ledger_chunk_offset >= max_chunk_offset {
+            // Gap is past the ledger frontier — not repairable as missing index.
+            return IndexRepairPlan::Complete;
+        }
+
+        let Some(start_block) = Self::block_height_for_ledger_offset(
+            block_index_guard,
+            data_ledger,
+            ledger_chunk_offset,
+            sm.id,
+            "start",
+        ) else {
+            return IndexRepairPlan::SoftSkipped;
+        };
+
+        // Inclusive last ledger offset: max_partition_offset is exclusive.
+        let end_ledger_offset =
+            ledger_range.start() + LedgerChunkOffset::from(*max_partition_offset - 1);
+        let clamped_end_offset = if *end_ledger_offset >= max_chunk_offset {
+            if max_chunk_offset == 0 {
+                return IndexRepairPlan::Complete;
+            }
+            LedgerChunkOffset::from(max_chunk_offset - 1)
+        } else {
+            end_ledger_offset
+        };
+
+        if clamped_end_offset < ledger_chunk_offset {
+            return IndexRepairPlan::SoftSkipped;
+        }
+
+        let Some(end_block) = Self::block_height_for_ledger_offset(
+            block_index_guard,
+            data_ledger,
+            clamped_end_offset,
+            sm.id,
+            "end",
+        ) else {
+            return IndexRepairPlan::SoftSkipped;
+        };
+
+        IndexRepairPlan::NeedsRepair {
+            start_height: start_block,
+            end_height: end_block,
+        }
+    }
+
+    /// Map a ledger chunk offset to a block height, or soft-skip on bounds errors.
+    fn block_height_for_ledger_offset(
+        block_index: &irys_domain::BlockIndex,
+        data_ledger: DataLedger,
+        offset: LedgerChunkOffset,
+        storage_module_id: usize,
+        bound_label: &'static str,
+    ) -> Option<u64> {
+        match block_index.get_block_bounds(data_ledger, offset) {
+            Ok(bounds) => Some(bounds.height),
+            Err(
+                BlockBoundsError::IndexEmpty
+                | BlockBoundsError::LedgerInactive { .. }
+                | BlockBoundsError::OffsetBeyondFrontier { .. },
+            ) => None,
+            Err(BlockBoundsError::Internal(e)) => {
+                warn!(
+                    storage_module.id = storage_module_id,
+                    error = %e,
+                    bound = bound_label,
+                    "block bounds internal error; soft-skipping index repair"
+                );
+                None
+            }
+        }
+    }
+
+    /// Sequential `UpdateStorageModuleIndexes` for each block (BTreeMap order).
+    ///
+    /// Returns the number of per-block failures (missing data / index write /
+    /// oneshot drop). Hard-fails only if the migration mpsc is closed.
+    async fn migrate_storage_module_indexes(
+        &self,
+        blocks_to_migrate: BTreeMap<u64, BlockHash>,
+    ) -> eyre::Result<usize> {
+        let migration_service = &self.service_senders.chunk_migration;
+        let mut failures = 0_usize;
+        for (block_height, block_hash) in blocks_to_migrate {
+            let (tx, rx) = tokio::sync::oneshot::channel();
+
+            if let Err(e) = migration_service.send_traced(
+                ChunkMigrationServiceMessage::UpdateStorageModuleIndexes {
+                    block_hash,
+                    receiver: tx,
+                },
+            ) {
+                error!(
+                    "Failed to send migration request for block {} (height {}): {}",
+                    block_hash, block_height, e
+                );
+                return Err(eyre!(
+                    "Unable to index storage module chunks due to mpsc send failure: {}",
+                    e
+                ));
+            }
+
+            match rx.await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    warn!(
+                        block.hash = %block_hash,
+                        block.height = block_height,
+                        error = %e,
+                        "UpdateStorageModuleIndexes failed; soft-skipping block"
+                    );
+                    failures += 1;
+                }
+                Err(e) => {
+                    error!(
+                        "Failed to receive migration response for block {} (height {}): {}",
+                        block_hash, block_height, e
+                    );
+                    failures += 1;
+                }
+            }
+        }
+        Ok(failures)
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
@@ -568,18 +702,6 @@ impl StorageModuleServiceInner {
         PartitionChunkOffset::from(exclusive_partition_end(start, end_incl, max_excl))
     }
 
-    /// First partition-relative offset in `range` with no path-hash index entry.
-    ///
-    /// Delegates to [`StorageModule::first_missing_path_hash_offset`] (MDBX cursor
-    /// gap walk). Binary search is wrong for non-prefix holes; dense linear
-    /// point-gets are O(range) and unsafe at production partition sizes.
-    fn find_first_unindexed_chunk(
-        storage_module: Arc<StorageModule>,
-        range: Range<PartitionChunkOffset>,
-    ) -> eyre::Result<Option<PartitionChunkOffset>> {
-        storage_module.first_missing_path_hash_offset(range.start, range.end)
-    }
-
     /// Validates that a storage module's partition assignment matches the on-disk parameters.
     /// Reports an error if there's a mismatch.
     #[tracing::instrument(level = "trace", skip_all, err)]
@@ -662,6 +784,16 @@ impl StorageModuleServiceInner {
     }
 }
 
+/// Outcome of planning path-hash index repair for one ledger-assigned SM.
+enum IndexRepairPlan {
+    /// Path-hash scan found no gap (or no data in range).
+    Complete,
+    /// Inclusive block heights that should be re-indexed.
+    NeedsRepair { start_height: u64, end_height: u64 },
+    /// Gap or bounds uncertainty; heal must not claim success / unblock.
+    SoftSkipped,
+}
+
 /// Exclusive partition-relative end for index scan / backfill.
 ///
 /// - `start` / `end_incl`: SM ledger span as **inclusive** bounds (nodit `ie` storage)
@@ -731,6 +863,13 @@ impl StorageModuleService {
     #[tracing::instrument(name = "storage_module_service_start", level = "trace", skip_all, err)]
     async fn start(mut self) -> eyre::Result<()> {
         tracing::info!("starting StorageModule Service");
+
+        // Crash-resume / long-lived ledger assigns never see Capacity→LedgerSlot
+        // again. Soft-skips per-SM index issues; only migration channel failure is fatal.
+        if let Err(e) = self.inner.heal_ledger_data_indexes().await {
+            error!("startup data-index heal failed: {e:?}");
+            return Err(e);
+        }
 
         let mut interval = tokio::time::interval(Duration::from_secs(1));
         interval.tick().await; // Skip first immediate tick

--- a/crates/actors/src/storage_module_service.rs
+++ b/crates/actors/src/storage_module_service.rs
@@ -36,6 +36,15 @@ use std::{
 use tokio::sync::{mpsc::UnboundedReceiver /*, oneshot*/};
 use tracing::{Instrument as _, debug, error, warn};
 
+/// Max blocks re-indexed in one heal pass. Remaining path-hash holes retry on
+/// the next assignment update / restart so a first-gap→frontier repair cannot
+/// monopolize startup or the assignment path for unbounded wall time.
+const INDEX_HEAL_MAX_BLOCKS_PER_PASS: usize = 128;
+
+/// Per-block wait for `UpdateStorageModuleIndexes`. If migration neither
+/// responds nor drops the oneshot, heal soft-skips and continues.
+const INDEX_HEAL_MIGRATE_RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
+
 // Messages that the StorageModuleService service supports
 #[derive(Debug)]
 pub enum StorageModuleServiceMessage {
@@ -313,7 +322,9 @@ impl StorageModuleServiceInner {
     ///
     /// Startup and every partition-assignment update. Dense indexes → density
     /// fast path / no migrate. Soft-skips bounds/index inconsistency and per-block
-    /// migration errors; hard-fails only if the migration channel is closed.
+    /// migration errors (including response timeouts); hard-fails only if the
+    /// migration channel is closed. Large repairs are chunked
+    /// ([`INDEX_HEAL_MAX_BLOCKS_PER_PASS`]) so startup cannot hang unbounded.
     ///
     /// Marker is path-hash completeness; `UpdateStorageModuleIndexes` also writes
     /// DataRootInfos when it runs. Residual: dense path-hashes with empty
@@ -562,15 +573,40 @@ impl StorageModuleServiceInner {
 
     /// Sequential `UpdateStorageModuleIndexes` for each block (BTreeMap order).
     ///
-    /// Returns the number of per-block failures (missing data / index write /
-    /// oneshot drop). Hard-fails only if the migration mpsc is closed.
+    /// Caps work at [`INDEX_HEAL_MAX_BLOCKS_PER_PASS`] and awaits each response
+    /// with [`INDEX_HEAL_MIGRATE_RESPONSE_TIMEOUT`] so startup / assignment heal
+    /// cannot hang indefinitely if migration stalls. Deferred and failed blocks
+    /// count toward the returned failure total (suppresses unblock).
+    ///
+    /// Hard-fails only if the migration mpsc is closed.
     async fn migrate_storage_module_indexes(
         &self,
         blocks_to_migrate: BTreeMap<u64, BlockHash>,
     ) -> eyre::Result<usize> {
-        let migration_service = &self.service_senders.chunk_migration;
+        let total_planned = blocks_to_migrate.len();
         let mut failures = 0_usize;
-        for (block_height, block_hash) in blocks_to_migrate {
+
+        let blocks_this_pass: BTreeMap<u64, BlockHash> =
+            if total_planned > INDEX_HEAL_MAX_BLOCKS_PER_PASS {
+                let deferred = total_planned - INDEX_HEAL_MAX_BLOCKS_PER_PASS;
+                warn!(
+                    index_heal.planned = total_planned,
+                    index_heal.pass_limit = INDEX_HEAL_MAX_BLOCKS_PER_PASS,
+                    index_heal.deferred = deferred,
+                    "capping index heal migrate pass; remaining holes retry on next heal"
+                );
+                // Count deferred as incomplete heal so we do not mass-unblock early.
+                failures += deferred;
+                blocks_to_migrate
+                    .into_iter()
+                    .take(INDEX_HEAL_MAX_BLOCKS_PER_PASS)
+                    .collect()
+            } else {
+                blocks_to_migrate
+            };
+
+        let migration_service = &self.service_senders.chunk_migration;
+        for (block_height, block_hash) in blocks_this_pass {
             let (tx, rx) = tokio::sync::oneshot::channel();
 
             if let Err(e) = migration_service.send_traced(
@@ -589,9 +625,9 @@ impl StorageModuleServiceInner {
                 ));
             }
 
-            match rx.await {
-                Ok(Ok(())) => {}
-                Ok(Err(e)) => {
+            match tokio::time::timeout(INDEX_HEAL_MIGRATE_RESPONSE_TIMEOUT, rx).await {
+                Ok(Ok(Ok(()))) => {}
+                Ok(Ok(Err(e))) => {
                     warn!(
                         block.hash = %block_hash,
                         block.height = block_height,
@@ -600,10 +636,19 @@ impl StorageModuleServiceInner {
                     );
                     failures += 1;
                 }
-                Err(e) => {
+                Ok(Err(e)) => {
                     error!(
                         "Failed to receive migration response for block {} (height {}): {}",
                         block_hash, block_height, e
+                    );
+                    failures += 1;
+                }
+                Err(_elapsed) => {
+                    warn!(
+                        block.hash = %block_hash,
+                        block.height = block_height,
+                        timeout_secs = INDEX_HEAL_MIGRATE_RESPONSE_TIMEOUT.as_secs(),
+                        "UpdateStorageModuleIndexes response timed out; soft-skipping block"
                     );
                     failures += 1;
                 }
@@ -865,7 +910,9 @@ impl StorageModuleService {
         tracing::info!("starting StorageModule Service");
 
         // Crash-resume / long-lived ledger assigns never see Capacity→LedgerSlot
-        // again. Soft-skips per-SM index issues; only migration channel failure is fatal.
+        // again. Soft-skips per-SM issues; only migration channel closed is fatal.
+        // Migrate is chunked + per-response timeout so first-gap→frontier repair
+        // cannot block this start path indefinitely (see migrate_storage_module_indexes).
         if let Err(e) = self.inner.heal_ledger_data_indexes().await {
             error!("startup data-index heal failed: {e:?}");
             return Err(e);

--- a/crates/actors/tests/data_sync_test.rs
+++ b/crates/actors/tests/data_sync_test.rs
@@ -248,7 +248,9 @@ impl DataSyncServiceTestHarness {
 
     /// Convenience method to start syncing
     fn start_sync(&mut self) -> eyre::Result<()> {
-        self.handle_message(DataSyncServiceMessage::SyncPartitions)
+        self.handle_message(DataSyncServiceMessage::SyncPartitions {
+            unblock_missing_data_root_index: true,
+        })
     }
 
     /// Get peers list

--- a/crates/database/src/submodule/db.rs
+++ b/crates/database/src/submodule/db.rs
@@ -108,7 +108,8 @@ pub fn first_gap_in_sorted_keys(
 
 /// First offset in half-open `[start, end)` with no `ChunkPathHashesByOffset` key.
 ///
-/// Cursor walk over the sorted keyspace (one RO tx): O(#indexed keys in range),
+/// Healthy full indexes take an O(1) density check (`first` + `last` + `entries`).
+/// Otherwise walks the sorted keyspace (one RO tx): O(#indexed keys in range),
 /// correct for non-prefix holes. Dense linear point-gets are not used.
 pub fn first_missing_path_hash_offset_in_tx<T: DbTx>(
     tx: &T,
@@ -117,6 +118,25 @@ pub fn first_missing_path_hash_offset_in_tx<T: DbTx>(
 ) -> eyre::Result<Option<PartitionChunkOffset>> {
     if start >= end {
         return Ok(None);
+    }
+
+    // Density fast path: prove the *entire table* is exactly the dense range
+    // [start, end). Anchors on `cursor.first()` (table minimum), not `seek(start)`:
+    // keys below `start` must not be allowed to pad `entries()` while holes sit
+    // inside the range (e.g. keys {0,5,6,7,9} over [5,10) must not report dense).
+    let expected_len = (*end as u64).saturating_sub(*start as u64);
+    if expected_len > 0 {
+        let mut cursor = tx.cursor_read::<ChunkPathHashesByOffset>()?;
+        let first = cursor.first()?;
+        let last = cursor.last()?;
+        let count = tx.entries::<ChunkPathHashesByOffset>()? as u64;
+        if let (Some((first_key, _)), Some((last_key, _))) = (first, last) {
+            // Compare last == end-1 without wrapping u32::MAX + 1.
+            let last_is_range_end = *end > 0 && last_key == PartitionChunkOffset(*end - 1);
+            if first_key == start && last_is_range_end && count == expected_len {
+                return Ok(None);
+            }
+        }
     }
 
     let mut cursor = tx.cursor_read::<ChunkPathHashesByOffset>()?;
@@ -415,6 +435,94 @@ mod tests {
 
         let head = db.view_eyre(|tx| first_missing_path_hash_offset_in_tx(tx, o(0), o(5)))?;
         assert_eq!(head, Some(o(2)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn first_missing_path_hash_offset_density_fast_path_no_gap() -> eyre::Result<()> {
+        use super::{
+            ChunkPathHashes, first_missing_path_hash_offset_in_tx, set_path_hashes_by_offset,
+        };
+        use crate::submodule::tables::SubmoduleTables;
+        use crate::{IrysDatabaseArgs as _, open_or_create_db};
+        use irys_testing_utils::utils::TempDirBuilder;
+        use irys_types::H256;
+        use reth_db::Database as _;
+        use reth_db::mdbx::DatabaseArguments;
+
+        let temp_dir = TempDirBuilder::new()
+            .prefix("path_hash_dense")
+            .with_tracing()
+            .build();
+        let db = open_or_create_db(
+            temp_dir,
+            SubmoduleTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+
+        let path_hashes = ChunkPathHashes {
+            data_path_hash: Some(H256::random()),
+            tx_path_hash: Some(H256::random()),
+        };
+        {
+            let tx = db.tx_mut()?;
+            for off in 0_u32..10 {
+                set_path_hashes_by_offset(&tx, o(off), path_hashes.clone())?;
+            }
+            tx.commit()?;
+        }
+
+        // Dense [0, 10) — first/last/entries prove completeness without relying on a hole.
+        let none = db.view_eyre(|tx| first_missing_path_hash_offset_in_tx(tx, o(0), o(10)))?;
+        assert_eq!(none, None);
+
+        // Partial dense range with extra keys outside still falls through correctly.
+        let none_mid = db.view_eyre(|tx| first_missing_path_hash_offset_in_tx(tx, o(3), o(7)))?;
+        assert_eq!(none_mid, None);
+
+        Ok(())
+    }
+
+    /// Keys below `start` must not pad `entries()` while a hole sits in-range.
+    /// With `seek(start)` + whole-table count, {0,5,6,7,9} over [5,10) looked dense.
+    #[test]
+    fn first_missing_path_hash_offset_density_not_fooled_by_keys_below_start() -> eyre::Result<()> {
+        use super::{
+            ChunkPathHashes, first_missing_path_hash_offset_in_tx, set_path_hashes_by_offset,
+        };
+        use crate::submodule::tables::SubmoduleTables;
+        use crate::{IrysDatabaseArgs as _, open_or_create_db};
+        use irys_testing_utils::utils::TempDirBuilder;
+        use irys_types::H256;
+        use reth_db::Database as _;
+        use reth_db::mdbx::DatabaseArguments;
+
+        let temp_dir = TempDirBuilder::new()
+            .prefix("path_hash_pad")
+            .with_tracing()
+            .build();
+        let db = open_or_create_db(
+            temp_dir,
+            SubmoduleTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+
+        let path_hashes = ChunkPathHashes {
+            data_path_hash: Some(H256::random()),
+            tx_path_hash: Some(H256::random()),
+        };
+        {
+            let tx = db.tx_mut()?;
+            // 5 keys total; expected_len([5,10))=5. Hole at 8 inside the range.
+            for off in [0_u32, 5, 6, 7, 9] {
+                set_path_hashes_by_offset(&tx, o(off), path_hashes.clone())?;
+            }
+            tx.commit()?;
+        }
+
+        let gap = db.view_eyre(|tx| first_missing_path_hash_offset_in_tx(tx, o(5), o(10)))?;
+        assert_eq!(gap, Some(o(8)), "must not treat padded entries() as dense");
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Closes the gap left after the path-hash gap-scan fix (#1530): index repair now runs on **startup** and for **all ledger-assigned** storage modules (not only Capacity→LedgerSlot), and data_sync can re-open offsets that were blocked on missing data_root indexes **without** crash-looping or thrashing.

Pipeline:

1. **Detect** — path-hash gap scan with O(1) density fast path on healthy modules
2. **Repair** — `UpdateStorageModuleIndexes` with soft-fail (`MigrationError`), no panic on missing header/tx
3. **Reconnect** — `SyncPartitions { unblock_missing_data_root_index }` only when heal has zero issues; unblock capped by free pending budget

## What changed

- **Heal triggers:** storage-module service startup + every partition-assignment update, for every local SM with a ledger assignment
- **Plan tri-state:** `Complete` / `NeedsRepair` / `SoftSkipped` so soft-skips do not claim success
- **Migration soft-fail:** `MissingData` / `Other` instead of `.expect`/`.unwrap` on the Update path; heal honors the oneshot inner `Result`
- **Density fast path:** `first` + `last` + `entries` prove full-table dense range (anchored on table min, not `seek(start)`)
- **Gated unblock:** only when plan + migrate report no issues
- **Capped unblock:** at most free `max_pending_chunk_requests` slots per orchestrator per SyncPartitions
- **Orchestrator tests** moved to `chunk_orchestrator/` so production module stays under 1k lines

## Explicit follow-ups (not merge blockers)

| Item | Notes |
|------|--------|
| **First-gap-only repair span** | Plan migrates from the first path-hash hole through the SM/frontier end. Disjoint holes further in the range cause **redundant tail re-migration**. Substantive efficiency follow-up: migrate only the minimal block span per hole (or multi-gap plan). |
| **DataRootInfos residual** | Marker is **path-hash** completeness. Dense path-hashes with empty `DataRootInfos` still yield `DataRootNotFound` / `MissingDataRootIndex`. Churn is now **bounded** (gated + capped unblock), not unbounded thrash. Detectable later if the orchestrator probes blocked data_roots or a second completeness check is added. |
| Other PLAUSIBLE edges | Stale-dense ledger A→B crash window (mining-bus, not this scan); sync-lag double-indexing; remaining latent expects elsewhere; lock-scope / telemetry-order / test-coverage minors |

## Non-goals

- Full guarantee that every `MissingDataRootIndex` is healed (DataRootInfos residual)
- Optimal multi-hole migrate spans
- Continuous reactive heal on every blocked write

## Test plan

- [x] Density fast path + counterexample (keys below start cannot pad `entries`)
- [x] Unblock reason filter + pending-budget cap
- [x] `cargo clippy` / `fmt` clean on touched crates
- [ ] Canary: restart node with incomplete path-hash indexes → heal migrates → sync stores without crash-loop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented startup and index-repair failures from crashing services by switching to graceful error handling when expected data is missing.
  * Improved recovery when legacy or ledger/index data is incomplete or corrupted.
  * Enhanced data-sync behavior so blocked offsets are safely re-queued only after successful index healing.
* **Performance**
  * Faster detection of fully populated database index ranges using an early “dense” check.
* **Monitoring**
  * Added a metric tracking how many data-sync chunks are unblocked after repair.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->