### PR TITLE
feat: consensus-enforced maximum data-tx size (5 TiB mainnet)

### DIFF
--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -424,6 +424,20 @@ pub enum PreValidationError {
         actual: u64,
     },
 
+    /// A data transaction's size exceeds the consensus-enforced maximum. The tx spans
+    /// `chunks = ceil(data_size / chunk_size)` chunks, more than `max_chunks`
+    /// (`max_data_tx_chunks`). Rejected at the authoritative gate so a hand-crafted peer
+    /// block can't smuggle an oversize tx past what ingress rejects.
+    #[error(
+        "data tx {txid} in ledger {ledger_id} spans {chunks} chunks, exceeding the max of {max_chunks}"
+    )]
+    DataSizeExceedsMax {
+        ledger_id: u32,
+        txid: H256,
+        chunks: u64,
+        max_chunks: u64,
+    },
+
     /// A commitment transaction carries a `chain_id` that differs from this node's.
     /// `chain_id` is a signed field, so a mismatch means the tx was signed for another
     /// chain; rejected at consensus so a hand-crafted peer block can't smuggle one in.
@@ -631,6 +645,7 @@ impl PreValidationError {
             | Self::ZeroSizeDataTx { .. }
             | Self::PrefixSizeExceedsDataSize { .. }
             | Self::DataTxChainIdMismatch { .. }
+            | Self::DataSizeExceedsMax { .. }
             | Self::CommitmentChainIdMismatch { .. }
             | Self::TransactionIdMismatch { .. }
             | Self::TxFoundInMultipleBlocks { .. }
@@ -741,6 +756,7 @@ impl PreValidationError {
             Self::ZeroSizeDataTx { .. } => "zero_size_data_tx",
             Self::PrefixSizeExceedsDataSize { .. } => "prefix_size_exceeds_data_size",
             Self::DataTxChainIdMismatch { .. } => "data_tx_chain_id_mismatch",
+            Self::DataSizeExceedsMax { .. } => "data_size_exceeds_max",
             Self::CommitmentChainIdMismatch { .. } => "commitment_chain_id_mismatch",
             Self::TooManyCommitmentTxs { .. } => "too_many_commitment_txs",
             Self::MissingTransactions(_) => "missing_transactions",
@@ -1944,7 +1960,13 @@ pub async fn prevalidate_block(
         // as mempool ingress (`data_tx_structural_defect`) so the two gates can't drift and a
         // hand-crafted peer block can't smuggle past consensus what ingress rejects. One pass.
         if let Some((tx, defect)) = ledger_txs.iter().find_map(|tx| {
-            data_tx_structural_defect(tx, config.consensus.chain_id).map(|d| (tx, d))
+            data_tx_structural_defect(
+                tx,
+                config.consensus.chain_id,
+                chunk_size,
+                config.consensus.mempool.max_data_tx_chunks,
+            )
+            .map(|d| (tx, d))
         }) {
             return Err(match defect {
                 DataTxStructuralDefect::ZeroDataSize => PreValidationError::ZeroSizeDataTx {
@@ -1966,6 +1988,14 @@ pub async fn prevalidate_block(
                         txid: tx.id,
                         expected,
                         actual,
+                    }
+                }
+                DataTxStructuralDefect::DataSizeExceedsMax { chunks, max_chunks } => {
+                    PreValidationError::DataSizeExceedsMax {
+                        ledger_id: dl.ledger_id,
+                        txid: tx.id,
+                        chunks,
+                        max_chunks,
                     }
                 }
             });

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -1956,7 +1956,8 @@ pub async fn prevalidate_block(
         })?;
         let ledger_txs = transactions.get_ledger_txs(ledger);
         // Reject structurally-invalid data txs (zero data_size, prefix_size > data_size,
-        // foreign chain_id) BEFORE recomputing the tx_root, using the same shared predicate
+        // foreign chain_id, or exceeding config.consensus.mempool.max_data_tx_chunks)
+        // BEFORE recomputing the tx_root, using the same shared predicate
         // as mempool ingress (`data_tx_structural_defect`) so the two gates can't drift and a
         // hand-crafted peer block can't smuggle past consensus what ingress rejects. One pass.
         if let Some((tx, defect)) = ledger_txs.iter().find_map(|tx| {

--- a/crates/actors/src/data_tx_validation.rs
+++ b/crates/actors/src/data_tx_validation.rs
@@ -24,6 +24,10 @@ pub enum DataTxStructuralDefect {
     PrefixSizeExceedsDataSize { prefix_size: u64, data_size: u64 },
     /// The tx's signed `chain_id` differs from this node's — it was signed for another chain.
     ChainIdMismatch { expected: u64, actual: u64 },
+    /// `ceil(data_size / chunk_size) > max_data_tx_chunks`: the transaction's data exceeds
+    /// the consensus-enforced maximum size. `chunks` is the tx's chunk count, `max_chunks`
+    /// the configured cap.
+    DataSizeExceedsMax { chunks: u64, max_chunks: u64 },
 }
 
 /// The first structural defect of a data transaction (if any), given the node's
@@ -31,11 +35,13 @@ pub enum DataTxStructuralDefect {
 ///
 /// Shared by mempool ingress and consensus prevalidation so the two gates enforce
 /// byte-identical rules. The check order is load-bearing for which defect is reported
-/// (zero-size, then oversized prefix, then foreign chain_id), though any defect rejects the
-/// transaction either way.
+/// (zero-size, then oversized prefix, then foreign chain_id, then oversized data), though
+/// any defect rejects the transaction either way.
 pub fn data_tx_structural_defect(
     tx: &DataTransactionHeader,
     expected_chain_id: u64,
+    chunk_size: u64,
+    max_data_tx_chunks: u64,
 ) -> Option<DataTxStructuralDefect> {
     if tx.data_size == 0 {
         return Some(DataTxStructuralDefect::ZeroDataSize);
@@ -50,6 +56,14 @@ pub fn data_tx_structural_defect(
         return Some(DataTxStructuralDefect::ChainIdMismatch {
             expected: expected_chain_id,
             actual: tx.chain_id,
+        });
+    }
+    // data_size > 0 is guaranteed above, so chunks >= 1 here.
+    let chunks = tx.data_size.div_ceil(chunk_size);
+    if chunks > max_data_tx_chunks {
+        return Some(DataTxStructuralDefect::DataSizeExceedsMax {
+            chunks,
+            max_chunks: max_data_tx_chunks,
         });
     }
     None
@@ -78,11 +92,21 @@ mod tests {
         let c = ConsensusConfig::testing();
         // prefix_size == data_size (whole-data prefix) and prefix_size == 0 are both valid.
         assert_eq!(
-            data_tx_structural_defect(&header(&c, 100, 100, c.chain_id), c.chain_id),
+            data_tx_structural_defect(
+                &header(&c, 100, 100, c.chain_id),
+                c.chain_id,
+                c.chunk_size,
+                c.mempool.max_data_tx_chunks,
+            ),
             None
         );
         assert_eq!(
-            data_tx_structural_defect(&header(&c, 100, 0, c.chain_id), c.chain_id),
+            data_tx_structural_defect(
+                &header(&c, 100, 0, c.chain_id),
+                c.chain_id,
+                c.chunk_size,
+                c.mempool.max_data_tx_chunks,
+            ),
             None
         );
     }
@@ -91,7 +115,12 @@ mod tests {
     fn flags_zero_data_size() {
         let c = ConsensusConfig::testing();
         assert_eq!(
-            data_tx_structural_defect(&header(&c, 0, 0, c.chain_id), c.chain_id),
+            data_tx_structural_defect(
+                &header(&c, 0, 0, c.chain_id),
+                c.chain_id,
+                c.chunk_size,
+                c.mempool.max_data_tx_chunks,
+            ),
             Some(DataTxStructuralDefect::ZeroDataSize),
         );
     }
@@ -100,7 +129,12 @@ mod tests {
     fn flags_prefix_size_exceeding_data_size() {
         let c = ConsensusConfig::testing();
         assert_eq!(
-            data_tx_structural_defect(&header(&c, 100, 101, c.chain_id), c.chain_id),
+            data_tx_structural_defect(
+                &header(&c, 100, 101, c.chain_id),
+                c.chain_id,
+                c.chunk_size,
+                c.mempool.max_data_tx_chunks,
+            ),
             Some(DataTxStructuralDefect::PrefixSizeExceedsDataSize {
                 prefix_size: 101,
                 data_size: 100,
@@ -112,7 +146,12 @@ mod tests {
     fn flags_foreign_chain_id() {
         let c = ConsensusConfig::testing();
         assert_eq!(
-            data_tx_structural_defect(&header(&c, 100, 0, c.chain_id + 1), c.chain_id),
+            data_tx_structural_defect(
+                &header(&c, 100, 0, c.chain_id + 1),
+                c.chain_id,
+                c.chunk_size,
+                c.mempool.max_data_tx_chunks,
+            ),
             Some(DataTxStructuralDefect::ChainIdMismatch {
                 expected: c.chain_id,
                 actual: c.chain_id + 1,
@@ -125,16 +164,44 @@ mod tests {
         let c = ConsensusConfig::testing();
         // zero data_size wins even when prefix and chain_id are also wrong
         assert_eq!(
-            data_tx_structural_defect(&header(&c, 0, 5, c.chain_id + 1), c.chain_id),
+            data_tx_structural_defect(
+                &header(&c, 0, 5, c.chain_id + 1),
+                c.chain_id,
+                c.chunk_size,
+                c.mempool.max_data_tx_chunks,
+            ),
             Some(DataTxStructuralDefect::ZeroDataSize),
         );
         // oversized prefix wins over a foreign chain_id when data_size > 0
         assert_eq!(
-            data_tx_structural_defect(&header(&c, 10, 11, c.chain_id + 1), c.chain_id),
+            data_tx_structural_defect(
+                &header(&c, 10, 11, c.chain_id + 1),
+                c.chain_id,
+                c.chunk_size,
+                c.mempool.max_data_tx_chunks,
+            ),
             Some(DataTxStructuralDefect::PrefixSizeExceedsDataSize {
                 prefix_size: 11,
                 data_size: 10,
             }),
+        );
+    }
+
+    #[test]
+    fn flags_data_size_exceeding_max() {
+        let c = ConsensusConfig::testing(); // chunk_size = 32
+        // 129 bytes -> ceil(129/32) = 5 chunks > max of 4 -> rejected.
+        assert_eq!(
+            data_tx_structural_defect(&header(&c, 129, 0, c.chain_id), c.chain_id, c.chunk_size, 4),
+            Some(DataTxStructuralDefect::DataSizeExceedsMax {
+                chunks: 5,
+                max_chunks: 4,
+            }),
+        );
+        // Exactly 128 bytes -> 4 chunks == max -> allowed.
+        assert_eq!(
+            data_tx_structural_defect(&header(&c, 128, 0, c.chain_id), c.chain_id, c.chunk_size, 4),
+            None,
         );
     }
 }

--- a/crates/actors/src/mempool_service.rs
+++ b/crates/actors/src/mempool_service.rs
@@ -2427,6 +2427,15 @@ pub enum TxIngressError {
         expected: u64,
         actual: u64,
     },
+    /// A data transaction's size exceeds the consensus-enforced maximum: its chunk count
+    /// `ceil(data_size / chunk_size)` is greater than `max_data_tx_chunks`. Rejected at
+    /// ingress to mirror the `DataSizeExceedsMax` consensus prevalidation check.
+    #[error("Data transaction {tx_id} spans {chunks} chunks, exceeding the max of {max_chunks}")]
+    DataSizeExceedsMax {
+        tx_id: H256,
+        chunks: u64,
+        max_chunks: u64,
+    },
     /// Some database error occurred
     #[error("Database operation failed: {0}")]
     DatabaseError(String),

--- a/crates/actors/src/mempool_service/data_txs.rs
+++ b/crates/actors/src/mempool_service/data_txs.rs
@@ -34,7 +34,12 @@ impl Inner {
         // foreign chain_id) using the same shared predicate as consensus prevalidation
         // (`data_tx_structural_defect`), so ingress and consensus enforce identical rules.
         // Cheap and fork-independent, so it runs before signature/anchor work.
-        if let Some(defect) = data_tx_structural_defect(tx, self.config.consensus.chain_id) {
+        if let Some(defect) = data_tx_structural_defect(
+            tx,
+            self.config.consensus.chain_id,
+            self.config.consensus.chunk_size,
+            self.config.consensus.mempool.max_data_tx_chunks,
+        ) {
             return Err(match defect {
                 DataTxStructuralDefect::ZeroDataSize => TxIngressError::ZeroDataSize(tx.id),
                 DataTxStructuralDefect::PrefixSizeExceedsDataSize { .. } => {
@@ -45,6 +50,13 @@ impl Inner {
                         tx_id: tx.id,
                         expected,
                         actual,
+                    }
+                }
+                DataTxStructuralDefect::DataSizeExceedsMax { chunks, max_chunks } => {
+                    TxIngressError::DataSizeExceedsMax {
+                        tx_id: tx.id,
+                        chunks,
+                        max_chunks,
                     }
                 }
             });

--- a/crates/actors/src/tx_selector/mod.rs
+++ b/crates/actors/src/tx_selector/mod.rs
@@ -502,6 +502,10 @@ pub async fn select_best_txs(
         .max_data_txs_per_block
         .try_into()
         .expect("max_data_txs_per_block to fit into usize");
+    let (max_data_tx_chunks, chunk_size) = {
+        let consensus = ctx.config.node_config.consensus_config();
+        (consensus.mempool.max_data_tx_chunks, consensus.chunk_size)
+    };
 
     balances.extend(
         helpers::fetch_balances_for_transactions(
@@ -524,6 +528,18 @@ pub async fn select_best_txs(
             );
             continue;
         };
+
+        // Never select a tx over the consensus max data size; consensus prevalidation would
+        // reject the resulting block. Ingress already rejects these, so this is defense-in-depth.
+        if tx.data_size.div_ceil(chunk_size) > max_data_tx_chunks {
+            debug!(
+                tx.id = ?tx.id,
+                tx.data_size = tx.data_size,
+                max_data_tx_chunks,
+                "Skipping tx: exceeds max data-tx size"
+            );
+            continue;
+        }
         match ledger {
             irys_types::DataLedger::Publish => {
                 // For Publish ledger, validate both term and perm fees

--- a/crates/actors/src/tx_selector/mod.rs
+++ b/crates/actors/src/tx_selector/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod helpers;
 use crate::block_discovery::{TxLookupResult, get_data_tx_in_parallel_inner};
 use crate::block_validation::get_assigned_ingress_proofs;
 use crate::chunk_ingress_service::{ChunkIngressServiceInner, ChunkIngressState};
+use crate::data_tx_validation::data_tx_structural_defect;
 use crate::mempool_guard::MempoolReadGuard;
 use crate::mempool_service::{AtomicMempoolState, MempoolTxs, validate_commitment_transaction};
 use crate::shadow_tx_generator::PublishLedgerWithTxs;
@@ -502,9 +503,13 @@ pub async fn select_best_txs(
         .max_data_txs_per_block
         .try_into()
         .expect("max_data_txs_per_block to fit into usize");
-    let (max_data_tx_chunks, chunk_size) = {
+    let (chain_id, chunk_size, max_data_tx_chunks) = {
         let consensus = ctx.config.node_config.consensus_config();
-        (consensus.mempool.max_data_tx_chunks, consensus.chunk_size)
+        (
+            consensus.chain_id,
+            consensus.chunk_size,
+            consensus.mempool.max_data_tx_chunks,
+        )
     };
 
     balances.extend(
@@ -529,14 +534,18 @@ pub async fn select_best_txs(
             continue;
         };
 
-        // Never select a tx over the consensus max data size; consensus prevalidation would
-        // reject the resulting block. Ingress already rejects these, so this is defense-in-depth.
-        if tx.data_size.div_ceil(chunk_size) > max_data_tx_chunks {
+        // Never select a structurally-defective tx; consensus prevalidation would reject the
+        // resulting block. Uses the same shared predicate as ingress and prevalidation
+        // (`data_tx_structural_defect`) so block production can't drift from those gates.
+        // Ingress already rejects these, so this is defense-in-depth.
+        if let Some(defect) =
+            data_tx_structural_defect(&tx, chain_id, chunk_size, max_data_tx_chunks)
+        {
             debug!(
                 tx.id = ?tx.id,
                 tx.data_size = tx.data_size,
-                max_data_tx_chunks,
-                "Skipping tx: exceeds max data-tx size"
+                ?defect,
+                "Skipping tx: structural defect"
             );
             continue;
         }

--- a/crates/api-server/src/routes/commitment.rs
+++ b/crates/api-server/src/routes/commitment.rs
@@ -117,7 +117,9 @@ async fn process_commitment_transaction(
             // These variants are only produced by the data-tx ingress path, so they are
             // unreachable here, but the match must stay exhaustive over the shared
             // `TxIngressError`.
-            TxIngressError::ZeroDataSize(_) | TxIngressError::PrefixSizeExceedsDataSize(_) => {
+            TxIngressError::ZeroDataSize(_)
+            | TxIngressError::PrefixSizeExceedsDataSize(_)
+            | TxIngressError::DataSizeExceedsMax { .. } => {
                 Err(ApiError::from((err.to_string(), StatusCode::BAD_REQUEST)))
             }
             TxIngressError::BalanceFetchError { address, reason } => {

--- a/crates/api-server/src/routes/tx.rs
+++ b/crates/api-server/src/routes/tx.rs
@@ -148,6 +148,9 @@ pub async fn post_tx(
             TxIngressError::ChainIdMismatch { .. } => {
                 Err((err.to_string(), StatusCode::BAD_REQUEST).into())
             }
+            TxIngressError::DataSizeExceedsMax { .. } => {
+                Err((err.to_string(), StatusCode::BAD_REQUEST).into())
+            }
         };
     }
 

--- a/crates/chain-tests/src/block_production/block_validation.rs
+++ b/crates/chain-tests/src/block_production/block_validation.rs
@@ -583,6 +583,64 @@ async fn test_prevalidation_rejects_prefix_size_exceeds_data_size() -> Result<()
     Ok(())
 }
 
+/// A block that includes a data tx whose size exceeds the consensus maximum
+/// (`ceil(data_size / chunk_size) > max_data_tx_chunks`) must be rejected with
+/// `DataSizeExceedsMax` at the authoritative gate (`prevalidate_block`), not only at mempool
+/// ingress. Companion to the `data_tx_validation` unit test `flags_data_size_exceeding_max`.
+#[tokio::test]
+async fn test_prevalidation_rejects_oversize_data_tx() -> Result<()> {
+    use irys_types::{DataTransactionLedger, H256List, IrysTransactionCommon as _};
+
+    let ctx = PrevalidationTestContext::new().await?;
+
+    let consensus = ctx.config.consensus_config();
+    let max_chunks = consensus.mempool.max_data_tx_chunks;
+    // One chunk past the limit: (max + 1) * chunk_size bytes -> max + 1 chunks.
+    let oversize_bytes = (max_chunks + 1) * consensus.chunk_size;
+
+    let signer = ctx.config.signer();
+    let mut otx = DataTransactionHeader::new(&consensus);
+    otx.data_size = oversize_bytes;
+    otx.ledger_id = DataLedger::Submit as u32;
+    let otx = otx.sign(&signer)?;
+
+    // Splice into the Submit ledger (tx_ids + matching folded tx_root) and re-sign. The size
+    // guard fires before the tx_root/total_chunks recompute, so the spliced values only keep
+    // SealedBlock construction valid.
+    let mut header = (**ctx.block.header()).clone();
+    let ledger = header
+        .data_ledgers
+        .iter_mut()
+        .find(|l| l.ledger_id == DataLedger::Submit as u32)
+        .expect("Submit ledger should exist");
+    ledger.tx_ids = H256List(vec![otx.id()]);
+    ledger.tx_root = DataTransactionLedger::compute_tx_root(std::slice::from_ref(&otx));
+    ctx.config.signer().sign_block_header(&mut header)?;
+
+    let mut body = ctx.block.to_block_body();
+    body.data_transactions = vec![otx.clone()];
+    body.block_hash = header.block_hash;
+    let bad_block = Arc::new(SealedBlock::new(header, body)?);
+
+    match ctx.prevalidate(&bad_block).await {
+        Err(PreValidationError::DataSizeExceedsMax {
+            ledger_id,
+            txid,
+            chunks,
+            max_chunks: reported_max,
+        }) => {
+            assert_eq!(ledger_id, DataLedger::Submit as u32);
+            assert_eq!(txid, otx.id());
+            assert_eq!(chunks, max_chunks + 1);
+            assert_eq!(reported_max, max_chunks);
+        }
+        other => panic!("expected DataSizeExceedsMax, got {:?}", other),
+    }
+
+    ctx.stop().await;
+    Ok(())
+}
+
 /// A block that includes a data tx carrying a foreign `chain_id` must be rejected with
 /// `DataTxChainIdMismatch`. `chain_id` is a signed field, so a tx signed for another chain
 /// must not be admitted into a block on this one — consensus refuses it at the authoritative

--- a/crates/chain-tests/src/multi_node/api_ingress_validation.rs
+++ b/crates/chain-tests/src/multi_node/api_ingress_validation.rs
@@ -842,6 +842,54 @@ async fn test_api_rejects_prefix_size_exceeds_data_size() -> eyre::Result<()> {
     Ok(())
 }
 
+/// The mempool ingress gate must reject a data tx whose size exceeds the consensus maximum
+/// (`ceil(data_size / chunk_size) > max_data_tx_chunks`), mirroring the `DataSizeExceedsMax`
+/// consensus prevalidation check, so such a tx is never admitted or gossiped onward. The
+/// header is hand-crafted and signed directly.
+#[test_log::test(tokio::test)]
+async fn test_api_rejects_oversize_data_tx() -> eyre::Result<()> {
+    use irys_types::{DataTransactionHeader, IrysTransactionCommon as _};
+
+    let mut genesis_config = NodeConfig::testing();
+    let signer = genesis_config.new_random_signer();
+    genesis_config.fund_genesis_accounts(vec![&signer]);
+
+    let genesis_node = IrysNodeTest::new_genesis(genesis_config.clone())
+        .start()
+        .await;
+
+    let consensus = genesis_config.consensus_config();
+    let anchor = genesis_node.get_anchor().await?;
+
+    // One chunk past the limit: (max + 1) * chunk_size bytes -> max + 1 chunks.
+    let max_chunks = consensus.mempool.max_data_tx_chunks;
+    let oversize_bytes = (max_chunks + 1) * consensus.chunk_size;
+
+    let mut header = DataTransactionHeader::new(&consensus);
+    header.data_size = oversize_bytes;
+    header.ledger_id = DataLedger::Publish as u32;
+    header.anchor = anchor;
+    let header = header.sign(&signer)?;
+
+    let result = genesis_node.ingest_data_tx(header.clone()).await;
+
+    match result {
+        Err(AddTxError::TxIngress(TxIngressError::DataSizeExceedsMax {
+            tx_id,
+            chunks,
+            max_chunks: reported_max,
+        })) => {
+            assert_eq!(tx_id, header.id());
+            assert_eq!(chunks, max_chunks + 1);
+            assert_eq!(reported_max, max_chunks);
+        }
+        other => panic!("expected DataSizeExceedsMax rejection, got: {:?}", other),
+    }
+
+    genesis_node.stop().await;
+    Ok(())
+}
+
 /// The mempool ingress gate must reject a data tx carrying a foreign `chain_id`, mirroring the
 /// `DataTxChainIdMismatch` consensus prevalidation check, so a tx signed for another chain is
 /// never admitted or gossiped onward.

--- a/crates/config/templates/testnet_config.toml
+++ b/crates/config/templates/testnet_config.toml
@@ -127,6 +127,7 @@ balance = "0x152cf4e72a974f1c0000"
 
 [consensus.Custom.mempool]
 max_data_txs_per_block = 100
+max_data_tx_chunks = 20971520
 max_commitment_txs_per_block = 100
 tx_anchor_expiry_depth = 20
 ingress_proof_anchor_expiry_depth = 200

--- a/crates/p2p/src/types.rs
+++ b/crates/p2p/src/types.rs
@@ -180,6 +180,10 @@ impl From<TxIngressError> for GossipError {
                 // Tx signed for another chain, decrease source reputation
                 Self::InvalidData(InvalidDataError::TransactionChainIdMismatch(tx_id))
             }
+            TxIngressError::DataSizeExceedsMax { tx_id, .. } => {
+                // Structurally invalid tx (exceeds max data size), decrease source reputation
+                Self::InvalidData(InvalidDataError::TransactionDataSizeExceedsMax(tx_id))
+            }
         }
     }
 }
@@ -227,6 +231,8 @@ pub enum InvalidDataError {
     TransactionPrefixSizeExceedsDataSize(irys_types::H256),
     #[error("Transaction {0} has a foreign chain_id")]
     TransactionChainIdMismatch(irys_types::H256),
+    #[error("Transaction {0} exceeds the maximum data size")]
+    TransactionDataSizeExceedsMax(irys_types::H256),
     #[error("Invalid chunk proof")]
     ChunkInvalidProof,
     #[error("Invalid chunk data hash")]

--- a/crates/types/src/config/consensus.rs
+++ b/crates/types/src/config/consensus.rs
@@ -1196,10 +1196,9 @@ mod tests {
         assert_eq!(config.genesis.vdf_next_seed, None);
 
         // P2P handshake hash — any mainnet() field or canonical encoding change fails CI.
-        // Re-pinned 2026-07-22: #1517 golden did not match ConsensusConfig::mainnet().keccak256_hash().
         assert_eq!(
             config.keccak256_hash(),
-            H256::from_base58("GsvYvE3kaQTcNKCF5vEtFwzfeJokdbtaGxZnBVmCh8TU"),
+            H256::from_base58("8nKbR4h8hfRPAv3Zh7Fp5TKjAF8MgmnNA6nM5nRdUeF2"), // spellchecker:disable-line
             "mainnet consensus-config hash is consensus-frozen"
         );
     }
@@ -1217,7 +1216,7 @@ mod tests {
         );
         assert_eq!(
             config.keccak256_hash(),
-            H256::from_base58("GFHyRkCukwbVcWRsQWtHkBiwkyxW7TmyqRHfeoGZZAEv"),
+            H256::from_base58("ErtksqJHbWMXGLdw2NYyNa1RiiHEagYwpKuvbm6VWusK"),
             "testnet consensus-config hash is consensus-frozen"
         );
     }

--- a/crates/types/src/config/consensus.rs
+++ b/crates/types/src/config/consensus.rs
@@ -500,6 +500,12 @@ pub struct MempoolConsensusConfig {
     /// Maximum number of data transactions that can be included in a single block
     pub max_data_txs_per_block: u64,
 
+    /// Maximum size of a single data transaction, expressed in chunks.
+    /// A data tx is rejected (at mempool ingress and consensus prevalidation) when
+    /// `ceil(data_size / chunk_size)` exceeds this value. On mainnet this is
+    /// 20_971_520 chunks = 5 TiB at the 256 KiB chunk size.
+    pub max_data_tx_chunks: u64,
+
     /// Maximum number of commitment transactions allowed in a single block
     pub max_commitment_txs_per_block: u64,
 
@@ -727,6 +733,8 @@ impl ConsensusConfig {
             mempool: MempoolConsensusConfig {
                 // Maximum number of data transactions that can be included in a single block
                 max_data_txs_per_block: 100,
+                // Maximum size of a single data transaction: 20_971_520 chunks = 5 TiB at 256 KiB chunks
+                max_data_tx_chunks: 20_971_520,
                 // Maximum number of commitment transactions allowed in a single block
                 max_commitment_txs_per_block: 100,
                 // The number of blocks a given anchor (tx or block hash) is valid for. The anchor must be included within the last X blocks otherwise the transaction it anchors will drop.
@@ -879,6 +887,7 @@ impl ConsensusConfig {
             pledge_decay: Amount::percentage(dec!(0.9)).expect("valid percentage"),
             mempool: MempoolConsensusConfig {
                 max_data_txs_per_block: 100,
+                max_data_tx_chunks: 20_971_520,
                 max_commitment_txs_per_block: 100,
                 tx_anchor_expiry_depth: 20,
                 ingress_proof_anchor_expiry_depth: 200,
@@ -1021,6 +1030,7 @@ impl ConsensusConfig {
 
             mempool: MempoolConsensusConfig {
                 max_data_txs_per_block: 100,
+                max_data_tx_chunks: 20_971_520,
                 max_commitment_txs_per_block: 100,
                 tx_anchor_expiry_depth: 50,
                 ingress_proof_anchor_expiry_depth: 200,
@@ -1408,7 +1418,7 @@ mod tests {
     #[test]
     fn test_consensus_hash_regression() {
         let config = ConsensusConfig::testing();
-        let expected_hash = H256::from_base58("ZRo1XRxuY4bYeuUKy2VPcBDpnuUsDGUBJk4uCYByaLE");
+        let expected_hash = H256::from_base58("65At1ZvKVtUPtR1jLtA8CcFYX2vHf7tT5TbhBEy3u2XE");
         assert_eq!(
             config.keccak256_hash(),
             expected_hash,

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -1026,6 +1026,7 @@ mod tests {
 
         [mempool]
         max_data_txs_per_block = 100
+        max_data_tx_chunks = 20971520
         max_commitment_txs_per_block = 100
         tx_anchor_expiry_depth = 20
         ingress_proof_anchor_expiry_depth = 200

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -126,6 +126,10 @@ impl Config {
         // also panic on a zero recall range. Reject loudly here. (NC-0042)
         ensure!(self.consensus.chunk_size > 0, "chunk_size must be > 0");
         ensure!(
+            self.consensus.mempool.max_data_tx_chunks > 0,
+            "mempool.max_data_tx_chunks must be > 0"
+        );
+        ensure!(
             self.consensus.num_chunks_in_partition > 0,
             "num_chunks_in_partition must be > 0"
         );
@@ -1834,6 +1838,12 @@ mod validate_tests {
             c.difficulty_adjustment.block_time = u64::MAX / 2;
         },
         "overflows u64"
+    )]
+    #[case::zero_max_data_tx_chunks(
+        |c: &mut ConsensusConfig| {
+            c.mempool.max_data_tx_chunks = 0;
+        },
+        "max_data_tx_chunks"
     )]
     fn validate_rejects_runtime_panic_configs(
         #[case] mutate: fn(&mut ConsensusConfig),

--- a/docker/agent_cluster/configs/irys-1.toml
+++ b/docker/agent_cluster/configs/irys-1.toml
@@ -142,6 +142,7 @@ balance = "0x152cf4e72a974f1c0000"
 
 [consensus.Custom.mempool]
 max_data_txs_per_block = 100
+max_data_tx_chunks = 20971520
 max_commitment_txs_per_block = 100
 tx_anchor_expiry_depth = 20
 ingress_proof_anchor_expiry_depth = 200

--- a/docker/agent_cluster/configs/irys-2.toml
+++ b/docker/agent_cluster/configs/irys-2.toml
@@ -143,6 +143,7 @@ balance = "0x152cf4e72a974f1c0000"
 
 [consensus.Custom.mempool]
 max_data_txs_per_block = 100
+max_data_tx_chunks = 20971520
 max_commitment_txs_per_block = 100
 tx_anchor_expiry_depth = 20
 ingress_proof_anchor_expiry_depth = 200

--- a/docker/agent_cluster/configs/irys-3.toml
+++ b/docker/agent_cluster/configs/irys-3.toml
@@ -143,6 +143,7 @@ balance = "0x152cf4e72a974f1c0000"
 
 [consensus.Custom.mempool]
 max_data_txs_per_block = 100
+max_data_tx_chunks = 20971520
 max_commitment_txs_per_block = 100
 tx_anchor_expiry_depth = 20
 ingress_proof_anchor_expiry_depth = 200

--- a/docker/configs/irys-1.toml
+++ b/docker/configs/irys-1.toml
@@ -117,6 +117,7 @@ balance = "0x152cf4e72a974f1c0000"
 
 [consensus.Custom.mempool]
 max_data_txs_per_block = 100
+max_data_tx_chunks = 20971520
 max_commitment_txs_per_block = 100
 tx_anchor_expiry_depth = 20
 ingress_proof_anchor_expiry_depth = 200

--- a/docker/configs/irys-2.toml
+++ b/docker/configs/irys-2.toml
@@ -118,6 +118,7 @@ balance = "0x152cf4e72a974f1c0000"
 
 [consensus.Custom.mempool]
 max_data_txs_per_block = 100
+max_data_tx_chunks = 20971520
 max_commitment_txs_per_block = 100
 tx_anchor_expiry_depth = 20
 ingress_proof_anchor_expiry_depth = 200

--- a/docker/tests/data-sync/configs/irys-1.toml
+++ b/docker/tests/data-sync/configs/irys-1.toml
@@ -151,6 +151,7 @@ balance = "0x152cf4e72a974f1c0000"
 
 [consensus.Custom.mempool]
 max_data_txs_per_block = 100
+max_data_tx_chunks = 20971520
 max_commitment_txs_per_block = 100
 tx_anchor_expiry_depth = 20
 ingress_proof_anchor_expiry_depth = 200

--- a/docker/tests/data-sync/configs/irys-2.toml
+++ b/docker/tests/data-sync/configs/irys-2.toml
@@ -152,6 +152,7 @@ balance = "0x152cf4e72a974f1c0000"
 
 [consensus.Custom.mempool]
 max_data_txs_per_block = 100
+max_data_tx_chunks = 20971520
 max_commitment_txs_per_block = 100
 tx_anchor_expiry_depth = 20
 ingress_proof_anchor_expiry_depth = 200

--- a/docker/tests/data-sync/configs/irys-3.toml
+++ b/docker/tests/data-sync/configs/irys-3.toml
@@ -152,6 +152,7 @@ balance = "0x152cf4e72a974f1c0000"
 
 [consensus.Custom.mempool]
 max_data_txs_per_block = 100
+max_data_tx_chunks = 20971520
 max_commitment_txs_per_block = 100
 tx_anchor_expiry_depth = 20
 ingress_proof_anchor_expiry_depth = 200


### PR DESCRIPTION
## Summary

Adds a consensus-enforced maximum size for a single data transaction. On mainnet the limit is **5 TiB = 20,971,520 chunks** (at the 256 KiB chunk size — an exact divisor). The limit is consensus-configurable via the new `ConsensusConfig.mempool.max_data_tx_chunks` field.

A data tx is rejected when `ceil(data_size / chunk_size) > max_data_tx_chunks`.

## How it works

Enforcement is a single shared predicate — `data_tx_structural_defect()` — so the two gates cannot drift:

- **Mempool ingress** — rejects with `TxIngressError::DataSizeExceedsMax` (HTTP 400; gossip maps to a reputation decrease).
- **Consensus prevalidation** — rejects with `PreValidationError::DataSizeExceedsMax` at the authoritative gate, before the `tx_root` / `total_chunks` recompute. This is the real consensus enforcement.
- **Block production** — the tx selector skips any oversize candidate (defense-in-depth; the comparison is byte-identical to the gates).

The size check runs after the existing zero-size check, so the `div_ceil` divisor is always safe (`chunk_size > 0` is guaranteed by `Config::validate`, which now also rejects `max_data_tx_chunks == 0`).

## Config

`mainnet()`, `testnet()`, and `testing()` all set `max_data_tx_chunks = 20_971_520`. Under testing's 32-byte chunk size this is an unreachable ~640 MiB, so existing data-tx tests are unaffected. The pinned consensus-hash regression test was updated (a new consensus field rotates the canonical hash), and the field was added to the shipped `testnet_config.toml` template, the docker cluster configs, and the config-parse test fixtures (it is a required field under `deny_unknown_fields`).

## Tests

- Unit: `data_tx_structural_defect` flags `max+1` chunks and accepts exactly `max`.
- Integration: mempool ingress rejects an oversize tx; consensus prevalidation rejects a block carrying one.
- Config: `validate()` rejects `max_data_tx_chunks == 0`.
- `irys-types` 740/740, `irys-actors` 512 passed; fmt + clippy clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `consensus.mempool.max_data_tx_chunks` to cap data transaction size by chunk count.
  * Oversized data transactions are now rejected consistently during submission, mempool ingress, block prevalidation, and gossip, with clearer error reporting.
  * Fee-based data transaction selection now skips data transactions that exceed the configured chunk limit.
* **Bug Fixes**
  * Ensures data transactions that exceed the chunk cap can’t slip through earlier validation stages.
* **Configuration**
  * Added `max_data_tx_chunks` to supported configs/presets and validated it must be greater than 0.
* **Tests**
  * Added unit and integration coverage for rejection at the `max + 1` boundary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->