### PR TITLE
fix(storage): per-SM heal unblock, delete-key clears, shutdown-safe backfill

### DIFF
--- a/crates/actors/src/data_sync_service.rs
+++ b/crates/actors/src/data_sync_service.rs
@@ -102,19 +102,35 @@ pub struct DataSyncServiceInner {
     pub service_senders: ServiceSenders,
     pub config: Config,
     pub runtime_handle: tokio::runtime::Handle,
+    /// SM ids whose path-hash index heal was last confirmed clean by
+    /// `SyncPartitions`. Re-armed on the slower re-arm cadence (see
+    /// [`REARM_EVERY_N_TICKS`]) until the set is replaced by a later
+    /// `SyncPartitions` (heal regressed or re-confirmed) or an SM in it
+    /// re-blocks a write on `MissingDataRootIndex` (index regressed).
+    healed_sm_ids: std::collections::HashSet<usize>,
+    /// Dispatch-tick counter, used to run re-arm every [`REARM_EVERY_N_TICKS`]
+    /// ticks instead of on every dispatch tick.
+    rearm_tick: u64,
 }
+
+/// Re-arm the healed-SM Blocked backlog once every N dispatch ticks. Dispatch
+/// runs on a 250ms interval (latency-sensitive), but draining a Blocked backlog
+/// only needs steady progress, so re-arm runs ~1s (4 × 250ms) apart to avoid the
+/// per-tick scan cost without slowing dispatch.
+const REARM_EVERY_N_TICKS: u64 = 4;
 
 pub enum DataSyncServiceMessage {
     /// Refresh peer/orchestrator membership for current ledger-assigned SMs.
     ///
-    /// When `unblock_missing_data_root_index` is true, also re-queues
+    /// `unblock_sm_ids` lists the SM ids whose path-hash index was confirmed
+    /// gap-free this heal pass; each such orchestrator re-queues its
     /// [`ChunkBlockReason::MissingDataRootIndex`] offsets (capped by free pending
-    /// budget). Only set that after index heal finished with zero issues (every
-    /// SM plan Complete or fully migrated; no plan soft-skips, no migrate
-    /// failures) — otherwise mass-unblock on a still-broken index becomes an
+    /// budget). An empty vec unblocks nobody. Per-SM confirmation (a
+    /// post-migration re-verify) prevents one still-broken module from either
+    /// suppressing unblock for healthy modules or being mass-unblocked into an
     /// epoch refetch/re-block thrash.
     SyncPartitions {
-        unblock_missing_data_root_index: bool,
+        unblock_sm_ids: Vec<usize>,
     },
     ChunkCompleted {
         storage_module_id: usize,
@@ -159,6 +175,8 @@ impl DataSyncServiceInner {
             service_senders,
             config,
             runtime_handle,
+            healed_sm_ids: Default::default(),
+            rearm_tick: 0,
         };
         data_sync.synchronize_peers_and_orchestrators();
         data_sync
@@ -167,13 +185,15 @@ impl DataSyncServiceInner {
     #[tracing::instrument(level = "trace", skip_all, err)]
     pub fn handle_message(&mut self, msg: DataSyncServiceMessage) -> eyre::Result<()> {
         match msg {
-            DataSyncServiceMessage::SyncPartitions {
-                unblock_missing_data_root_index,
-            } => {
+            DataSyncServiceMessage::SyncPartitions { unblock_sm_ids } => {
                 self.synchronize_peers_and_orchestrators();
-                if unblock_missing_data_root_index {
-                    self.unblock_missing_data_root_indexes();
+                if !unblock_sm_ids.is_empty() {
+                    self.unblock_missing_data_root_indexes(&unblock_sm_ids);
                 }
+                // Replace (not union) the healed set: an SM that dropped out of
+                // this heal pass's clean set must stop being re-armed by the
+                // tick loop, and an empty vec clears all re-arming.
+                self.healed_sm_ids = unblock_sm_ids.iter().copied().collect();
             }
             DataSyncServiceMessage::ChunkCompleted {
                 storage_module_id,
@@ -235,15 +255,65 @@ impl DataSyncServiceInner {
             orchestrator.tick()?;
         }
         self.optimize_peer_concurrency();
+        // Re-arm on a slower cadence than dispatch to keep dispatch latency-tight
+        // while still draining Blocked backlogs (see REARM_EVERY_N_TICKS).
+        self.rearm_tick = self.rearm_tick.wrapping_add(1);
+        if self.rearm_tick.is_multiple_of(REARM_EVERY_N_TICKS) {
+            self.rearm_healed_storage_modules();
+        }
         Ok(())
     }
 
-    /// Re-queue offsets blocked on missing data_root indexes, capped per
-    /// orchestrator at free pending-budget slots so one heal cannot flood dispatch.
-    fn unblock_missing_data_root_indexes(&mut self) {
+    /// Re-queue offsets blocked on missing data_root indexes for the
+    /// confirmed-clean SMs in `sm_ids`, capped per orchestrator at free
+    /// pending-budget slots so one heal cannot flood dispatch. Orchestrators
+    /// whose SM id is not in `sm_ids` are left untouched (still Blocked).
+    fn unblock_missing_data_root_indexes(&mut self, sm_ids: &[usize]) {
+        let sm_ids: std::collections::HashSet<usize> = sm_ids.iter().copied().collect();
+        let total = self.rearm_missing_data_root_indexes(|id| sm_ids.contains(id));
+        if total > 0 {
+            metrics::record_data_sync_chunk_unblocked(total as u64);
+        }
+    }
+
+    /// Continuous re-arm: every tick, re-queue offsets blocked on missing
+    /// data_root indexes for SMs whose heal is still considered clean
+    /// (`healed_sm_ids`), capped per orchestrator at free pending-budget
+    /// slots. This drains a large Blocked backlog across many ticks instead
+    /// of relying on a single capped pulse from `SyncPartitions`, which is a
+    /// no-op once dispatch is peer-starved (Pending already at cap).
+    // Runs on the slower re-arm cadence (every REARM_EVERY_N_TICKS ticks), so it
+    // no longer scans on every dispatch tick.
+    // FOLLOWUP: still scans each healed orchestrator's requests even when nothing
+    // is Blocked. For an O(1) skip, track a per-orchestrator
+    // Blocked(MissingDataRootIndex) count (inc on mark_chunk_blocked, dec on
+    // unblock and on the populate drop) and skip orchestrators whose count is 0.
+    fn rearm_healed_storage_modules(&mut self) {
+        if self.healed_sm_ids.is_empty() {
+            return;
+        }
+        let healed = self.healed_sm_ids.clone();
+        let total = self.rearm_missing_data_root_indexes(|id| healed.contains(id));
+        if total > 0 {
+            metrics::record_data_sync_chunk_unblocked(total as u64);
+        }
+    }
+
+    /// Shared cap math for re-queuing `MissingDataRootIndex`-blocked offsets:
+    /// for each orchestrator whose id satisfies `should_unblock`, unblock up
+    /// to its free pending-budget slots. Returns the total offsets unblocked
+    /// across all matching orchestrators (metric recording is the caller's
+    /// responsibility, since callers differ in when they consider 0 notable).
+    fn rearm_missing_data_root_indexes(
+        &mut self,
+        should_unblock: impl Fn(&usize) -> bool,
+    ) -> usize {
         let max_pending = self.config.node_config.data_sync.max_pending_chunk_requests as usize;
         let mut total = 0_usize;
         for (id, orchestrator) in self.chunk_orchestrators.iter_mut() {
+            if !should_unblock(id) {
+                continue;
+            }
             let pending = orchestrator
                 .chunk_requests
                 .values()
@@ -261,9 +331,7 @@ impl DataSyncServiceInner {
                 total += unblocked;
             }
         }
-        if total > 0 {
-            metrics::record_data_sync_chunk_unblocked(total as u64);
-        }
+        total
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
@@ -414,6 +482,13 @@ impl DataSyncServiceInner {
                     orchestrator
                         .mark_chunk_blocked(chunk_offset, ChunkBlockReason::MissingDataRootIndex)?;
                 }
+                // Index regressed for this SM after a prior heal marked it clean —
+                // stop the per-tick re-arm for it until the next heal re-confirms it.
+                // FOLLOWUP: one re-block drops the whole SM, freezing drain of its
+                // other still-healthy Blocked offsets until the next heal pass.
+                // Consider an N-reblock threshold or one more requeue before drop,
+                // trading a little anti-thrash strictness for faster backlog drain.
+                self.healed_sm_ids.remove(&storage_module_id);
                 // Best-effort: mempool/ingress may still place the chunk if another
                 // path holds indexes; do not treat handoff as durable success.
                 try_send_chunk_to_ingress(&self.service_senders, unpacked_chunk);
@@ -958,5 +1033,341 @@ mod write_outcome_tests {
 
         let outcome = attempt_data_sync_write(&sm, &chunk, PartitionChunkOffset::from(0_u32));
         assert_eq!(outcome, DataSyncWriteOutcome::MissingDataRootIndex);
+    }
+}
+
+#[cfg(test)]
+mod unblock_filter_tests {
+    use super::*;
+    use crate::chunk_fetcher::{ChunkFetcher, MockChunkFetcher};
+    use crate::chunk_orchestrator::ChunkRequest;
+    use crate::test_helpers::build_test_service_senders;
+    use irys_domain::{BlockTree, StorageModuleInfo};
+    use irys_testing_utils::TempDirBuilder;
+    use irys_types::{
+        ConsensusConfig, DataLedger, H256, NodeConfig, TxChunkOffset,
+        partition::PartitionAssignment, partition_chunk_offset_ie,
+    };
+
+    fn test_config(base_directory: std::path::PathBuf) -> Config {
+        let node_config = NodeConfig {
+            consensus: irys_types::ConsensusOptions::Custom(ConsensusConfig {
+                chunk_size: 32,
+                num_chunks_in_partition: 4,
+                num_chunks_in_recall_range: 2,
+                num_partitions_per_slot: 1,
+                entropy_packing_iterations: 1,
+                block_migration_depth: 1,
+                chain_id: 1,
+                ..ConsensusConfig::testing()
+            }),
+            base_directory,
+            ..NodeConfig::testing()
+        };
+        Config::new_with_random_peer_id(node_config)
+    }
+
+    fn ledger_sm(config: &Config, id: usize, dir: &str) -> Arc<StorageModule> {
+        let pa = PartitionAssignment {
+            ledger_id: Some(DataLedger::Publish.into()),
+            slot_index: Some(0),
+            miner_address: IrysAddress::from([1_u8; 20]),
+            partition_hash: H256::random(),
+        };
+        let info = StorageModuleInfo {
+            id,
+            partition_assignment: Some(pa),
+            submodules: vec![(partition_chunk_offset_ie!(0, 4), dir.into())],
+        };
+        Arc::new(StorageModule::new(&info, config).expect("storage module"))
+    }
+
+    /// `unblock_missing_data_root_indexes(&[id])` must re-queue only the named
+    /// orchestrator's `MissingDataRootIndex` offsets and leave the others Blocked.
+    #[test_log::test(tokio::test)]
+    async fn unblock_targets_only_named_sm_ids() {
+        let tmp = TempDirBuilder::new().with_tracing().build();
+        let config = test_config(tmp.path().to_path_buf());
+
+        let sm0 = ledger_sm(&config, 0, "chunks0");
+        let sm1 = ledger_sm(&config, 1, "chunks1");
+        let storage_modules = Arc::new(RwLock::new(vec![sm0, sm1]));
+
+        let genesis = irys_testing_utils::new_mock_signed_header();
+        let block_tree = BlockTree::new(&genesis, config.consensus.clone());
+        let block_tree_guard = BlockTreeReadGuard::new(Arc::new(RwLock::new(block_tree)));
+
+        let (service_senders, _receivers) = build_test_service_senders();
+        let peer_list = PeerList::from_peers(
+            vec![],
+            service_senders.peer_network.clone(),
+            &config,
+            tokio::sync::broadcast::channel::<irys_domain::PeerEvent>(100).0,
+        )
+        .expect("peer list");
+
+        let factory: ChunkFetcherFactory = Box::new(|ledger_id| {
+            Arc::new(MockChunkFetcher::new(ledger_id as usize)) as Arc<dyn ChunkFetcher>
+        });
+
+        let mut inner = DataSyncServiceInner::new(
+            block_tree_guard,
+            storage_modules,
+            peer_list,
+            factory,
+            service_senders,
+            config,
+            tokio::runtime::Handle::current(),
+        );
+
+        // Both orchestrators should exist (one per ledger-assigned SM).
+        assert!(inner.chunk_orchestrators.contains_key(&0));
+        assert!(inner.chunk_orchestrators.contains_key(&1));
+
+        // Seed each with a MissingDataRootIndex-blocked offset.
+        for id in [0_usize, 1_usize] {
+            let offset = PartitionChunkOffset::from(0_u32);
+            let orch = inner.chunk_orchestrators.get_mut(&id).unwrap();
+            orch.chunk_requests.insert(
+                offset,
+                ChunkRequest {
+                    ledger_id: 0,
+                    slot_index: 0,
+                    chunk_offset: offset,
+                    excluded: None,
+                    request_state: ChunkRequestState::Blocked(
+                        ChunkBlockReason::MissingDataRootIndex,
+                    ),
+                },
+            );
+        }
+
+        // Unblock only SM 0.
+        inner.unblock_missing_data_root_indexes(&[0]);
+
+        let offset = PartitionChunkOffset::from(0_u32);
+        assert_eq!(
+            inner.chunk_orchestrators[&0].chunk_requests[&offset].request_state,
+            ChunkRequestState::Pending,
+            "SM 0 offset should be re-queued to Pending"
+        );
+        assert_eq!(
+            inner.chunk_orchestrators[&1].chunk_requests[&offset].request_state,
+            ChunkRequestState::Blocked(ChunkBlockReason::MissingDataRootIndex),
+            "SM 1 offset must stay Blocked (not in unblock set)"
+        );
+    }
+
+    fn build_test_inner(
+        config: Config,
+        storage_modules: Arc<RwLock<Vec<Arc<StorageModule>>>>,
+    ) -> DataSyncServiceInner {
+        let genesis = irys_testing_utils::new_mock_signed_header();
+        let block_tree = BlockTree::new(&genesis, config.consensus.clone());
+        let block_tree_guard = BlockTreeReadGuard::new(Arc::new(RwLock::new(block_tree)));
+
+        let (service_senders, _receivers) = build_test_service_senders();
+        let peer_list = PeerList::from_peers(
+            vec![],
+            service_senders.peer_network.clone(),
+            &config,
+            tokio::sync::broadcast::channel::<irys_domain::PeerEvent>(100).0,
+        )
+        .expect("peer list");
+
+        let factory: ChunkFetcherFactory = Box::new(|ledger_id| {
+            Arc::new(MockChunkFetcher::new(ledger_id as usize)) as Arc<dyn ChunkFetcher>
+        });
+
+        DataSyncServiceInner::new(
+            block_tree_guard,
+            storage_modules,
+            peer_list,
+            factory,
+            service_senders,
+            config,
+            tokio::runtime::Handle::current(),
+        )
+    }
+
+    /// The tick-driven re-arm must drain a Blocked backlog larger than a single
+    /// pass's free-slot cap across multiple ticks (as Pending drains between
+    /// them), instead of stalling after one capped pulse.
+    #[test_log::test(tokio::test)]
+    async fn rearm_healed_storage_modules_drains_backlog_across_ticks() {
+        let tmp = TempDirBuilder::new().with_tracing().build();
+        let node_config = NodeConfig {
+            consensus: irys_types::ConsensusOptions::Custom(ConsensusConfig {
+                chunk_size: 32,
+                num_chunks_in_partition: 8,
+                num_chunks_in_recall_range: 2,
+                num_partitions_per_slot: 1,
+                entropy_packing_iterations: 1,
+                block_migration_depth: 1,
+                chain_id: 1,
+                ..ConsensusConfig::testing()
+            }),
+            data_sync: irys_types::DataSyncServiceConfig {
+                max_pending_chunk_requests: 2,
+                ..Default::default()
+            },
+            base_directory: tmp.path().to_path_buf(),
+            ..NodeConfig::testing()
+        };
+        let config = Config::new_with_random_peer_id(node_config);
+        let pa = PartitionAssignment {
+            ledger_id: Some(DataLedger::Publish.into()),
+            slot_index: Some(0),
+            miner_address: IrysAddress::from([1_u8; 20]),
+            partition_hash: H256::random(),
+        };
+        let info = StorageModuleInfo {
+            id: 0,
+            partition_assignment: Some(pa),
+            submodules: vec![(partition_chunk_offset_ie!(0, 8), "chunks_backlog".into())],
+        };
+        let sm0 = Arc::new(StorageModule::new(&info, &config).expect("storage module"));
+        let storage_modules = Arc::new(RwLock::new(vec![sm0]));
+
+        let mut inner = build_test_inner(config, storage_modules);
+        assert!(inner.chunk_orchestrators.contains_key(&0));
+
+        // Seed 5 Blocked offsets — more than the free-slot cap (2) per pass.
+        let orch = inner.chunk_orchestrators.get_mut(&0).unwrap();
+        for i in 0..5_u32 {
+            let offset = PartitionChunkOffset::from(i);
+            orch.chunk_requests.insert(
+                offset,
+                ChunkRequest {
+                    ledger_id: 0,
+                    slot_index: 0,
+                    chunk_offset: offset,
+                    excluded: None,
+                    request_state: ChunkRequestState::Blocked(
+                        ChunkBlockReason::MissingDataRootIndex,
+                    ),
+                },
+            );
+        }
+        inner.healed_sm_ids.insert(0);
+
+        fn blocked_count(inner: &DataSyncServiceInner) -> usize {
+            inner.chunk_orchestrators[&0]
+                .chunk_requests
+                .values()
+                .filter(|r| {
+                    matches!(
+                        r.request_state,
+                        ChunkRequestState::Blocked(ChunkBlockReason::MissingDataRootIndex)
+                    )
+                })
+                .count()
+        }
+
+        assert_eq!(blocked_count(&inner), 5);
+
+        let mut backlog_after_each_tick = Vec::new();
+        for _ in 0..4 {
+            inner.rearm_healed_storage_modules();
+
+            // Simulate Pending draining (dispatched + completed/removed) before
+            // the next tick, so free-slot budget is available again.
+            let orch = inner.chunk_orchestrators.get_mut(&0).unwrap();
+            let pending_offsets: Vec<_> = orch
+                .chunk_requests
+                .iter()
+                .filter_map(|(&offset, r)| {
+                    matches!(r.request_state, ChunkRequestState::Pending).then_some(offset)
+                })
+                .collect();
+            for offset in pending_offsets {
+                orch.chunk_requests.remove(&offset);
+            }
+
+            backlog_after_each_tick.push(blocked_count(&inner));
+        }
+
+        assert_eq!(
+            backlog_after_each_tick,
+            vec![3, 1, 0, 0],
+            "backlog must drain monotonically to zero across ticks, not stall after one capped pulse"
+        );
+    }
+
+    /// A prior heal marks SM 0 clean; a subsequent write on that SM re-blocks
+    /// on `MissingDataRootIndex` (index regressed). The id must drop out of
+    /// `healed_sm_ids` so the tick loop stops re-arming it.
+    #[test_log::test(tokio::test)]
+    async fn missing_data_root_index_reblock_clears_healed_sm_id() {
+        let tmp = TempDirBuilder::new().with_tracing().build();
+        let config = test_config(tmp.path().to_path_buf());
+        let sm0 = ledger_sm(&config, 0, "chunks_reblock");
+        let pa = sm0.partition_assignment().expect("partition assignment");
+        sm0.pack_with_zeros();
+        let storage_modules = Arc::new(RwLock::new(vec![sm0]));
+
+        let mut inner = build_test_inner(config.clone(), storage_modules);
+
+        // A heal pass confirms SM 0 clean.
+        inner
+            .handle_message(DataSyncServiceMessage::SyncPartitions {
+                unblock_sm_ids: vec![0],
+            })
+            .expect("handle SyncPartitions");
+        assert!(inner.healed_sm_ids.contains(&0));
+
+        // Simulate an in-flight fetch for offset 0 from `peer`.
+        let peer = IrysAddress::from([9_u8; 20]);
+        let offset = PartitionChunkOffset::from(0_u32);
+        inner
+            .chunk_orchestrators
+            .get_mut(&0)
+            .unwrap()
+            .chunk_requests
+            .insert(
+                offset,
+                ChunkRequest {
+                    ledger_id: 0,
+                    slot_index: 0,
+                    chunk_offset: offset,
+                    excluded: None,
+                    request_state: ChunkRequestState::Requested(peer, std::time::Instant::now()),
+                },
+            );
+
+        // Packed chunk whose data_root was never indexed on SM 0 — the write
+        // must fail with MissingDataRootIndex regardless of packing content.
+        let chunk_size = config.consensus.chunk_size as usize;
+        let mut entropy_chunk = Vec::with_capacity(chunk_size);
+        irys_packing::capacity_single::compute_entropy_chunk(
+            pa.miner_address,
+            0_u64,
+            pa.partition_hash.into(),
+            config.consensus.entropy_packing_iterations,
+            chunk_size,
+            &mut entropy_chunk,
+            config.consensus.chain_id,
+        );
+        let packed_bytes =
+            irys_packing::packing_xor_vec_u8(entropy_chunk, &vec![0xcd_u8; chunk_size]);
+        let packed_chunk = PackedChunk {
+            data_root: H256::random(),
+            data_size: chunk_size as u64,
+            data_path: vec![1, 2, 3, 4].into(),
+            bytes: packed_bytes.into(),
+            packing_address: pa.miner_address,
+            partition_offset: offset,
+            tx_offset: TxChunkOffset::from(0_u32),
+            partition_hash: pa.partition_hash,
+        };
+
+        inner
+            .on_chunk_completed(0, offset, peer, packed_chunk)
+            .expect("on_chunk_completed handles MissingDataRootIndex without erroring");
+
+        assert!(
+            !inner.healed_sm_ids.contains(&0),
+            "index regressed for SM 0 must clear it from healed_sm_ids"
+        );
     }
 }

--- a/crates/actors/src/data_sync_service/chunk_orchestrator/mod.rs
+++ b/crates/actors/src/data_sync_service/chunk_orchestrator/mod.rs
@@ -53,8 +53,9 @@ pub enum ChunkRequestState {
 
     /// Locally blocked from hot re-fetch (index gap, etc.). Still retained while
     /// the offset is Entropy so we do not thrash peers. Cleared when the offset
-    /// becomes Data, when `SyncPartitions { unblock_missing_data_root_index: true }`
-    /// re-queues [`ChunkBlockReason::MissingDataRootIndex`], or on process restart.
+    /// becomes Data, when this SM's id is in `SyncPartitions { unblock_sm_ids }`
+    /// (immediately, and again on each tick while the SM stays healed) re-queues
+    /// [`ChunkBlockReason::MissingDataRootIndex`], or on process restart.
     Blocked(ChunkBlockReason),
 }
 
@@ -572,31 +573,38 @@ impl ChunkOrchestrator {
     }
 
     /// After a successful index heal, re-queue offsets blocked solely on
-    /// [`ChunkBlockReason::MissingDataRootIndex`], up to `max` offsets.
+    /// [`ChunkBlockReason::MissingDataRootIndex`], up to `max` offsets, lowest
+    /// offset first (deterministic — not HashMap iteration order).
     ///
-    /// Cap prevents one `SyncPartitions` from flipping an unbounded Blocked
-    /// backlog into Pending and storming the 250ms dispatch tick. Remaining
-    /// Blocked offsets stay until a later successful heal/SyncPartitions.
+    /// Cap prevents one call from flipping an unbounded Blocked backlog into
+    /// Pending and storming the 250ms dispatch tick. Remaining Blocked offsets
+    /// stay until a later call (immediate `SyncPartitions` unblock or the
+    /// per-tick re-arm) drains them further.
     ///
     /// Returns the number of requests moved to [`ChunkRequestState::Pending`].
     pub fn unblock_missing_data_root_index(&mut self, max: usize) -> usize {
         if max == 0 {
             return 0;
         }
-        let mut count = 0_usize;
-        for request in self.chunk_requests.values_mut() {
-            if count >= max {
-                break;
-            }
-            if matches!(
-                request.request_state,
-                ChunkRequestState::Blocked(ChunkBlockReason::MissingDataRootIndex)
-            ) {
+        let mut offsets: Vec<PartitionChunkOffset> = self
+            .chunk_requests
+            .iter()
+            .filter_map(|(&offset, request)| {
+                matches!(
+                    request.request_state,
+                    ChunkRequestState::Blocked(ChunkBlockReason::MissingDataRootIndex)
+                )
+                .then_some(offset)
+            })
+            .collect();
+        offsets.sort_unstable();
+        offsets.truncate(max);
+        for offset in &offsets {
+            if let Some(request) = self.chunk_requests.get_mut(offset) {
                 request.request_state = ChunkRequestState::Pending;
-                count += 1;
             }
         }
-        count
+        offsets.len()
     }
 
     /// Local write failed for a non-blocking reason; re-queue without blaming the peer
@@ -741,3 +749,104 @@ pub struct OrchestrationMetrics {
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod deterministic_unblock_order_tests {
+    use super::*;
+    use crate::{chunk_fetcher::MockChunkFetcher, test_helpers::build_test_service_senders};
+    use irys_domain::{BlockTree, StorageModuleInfo};
+    use irys_testing_utils::TempDirBuilder;
+    use irys_types::{
+        Config, ConsensusConfig, DataLedger, H256, partition::PartitionAssignment,
+        partition_chunk_offset_ie,
+    };
+
+    /// With Blocked offsets {5, 1, 3} and `max = 2`, the lowest two offsets
+    /// (1, 3) must be unblocked — not an arbitrary HashMap-order pair.
+    #[test_log::test(tokio::test)]
+    async fn unblock_missing_data_root_index_picks_lowest_offsets_first() {
+        let tmp = TempDirBuilder::new().with_tracing().build();
+        let num_chunks = 8_u64;
+        let node_config = NodeConfig {
+            consensus: irys_types::ConsensusOptions::Custom(ConsensusConfig {
+                chunk_size: 32,
+                num_chunks_in_partition: num_chunks,
+                num_chunks_in_recall_range: 2,
+                num_partitions_per_slot: 1,
+                entropy_packing_iterations: 1,
+                block_migration_depth: 1,
+                chain_id: 1,
+                ..ConsensusConfig::testing()
+            }),
+            base_directory: tmp.path().to_path_buf(),
+            ..NodeConfig::testing()
+        };
+        let config = Config::new_with_random_peer_id(node_config);
+
+        let pa = PartitionAssignment {
+            ledger_id: Some(DataLedger::Publish.into()),
+            slot_index: Some(0),
+            miner_address: IrysAddress::from([1_u8; 20]),
+            partition_hash: H256::random(),
+        };
+        let info = StorageModuleInfo {
+            id: 0,
+            partition_assignment: Some(pa),
+            submodules: vec![(
+                partition_chunk_offset_ie!(0, num_chunks as u32),
+                "chunks".into(),
+            )],
+        };
+        let sm = Arc::new(StorageModule::new(&info, &config).expect("storage module"));
+        sm.pack_with_zeros();
+
+        let genesis = irys_testing_utils::new_mock_signed_header();
+        let block_tree = BlockTree::new(&genesis, config.consensus.clone());
+        let block_tree_guard = BlockTreeReadGuard::new(Arc::new(RwLock::new(block_tree)));
+        let (service_senders, _receivers) = build_test_service_senders();
+        let ledger_id: u32 = DataLedger::Publish.into();
+        let mut orch = ChunkOrchestrator::new(
+            sm,
+            Arc::new(RwLock::new(HashMap::new())),
+            block_tree_guard,
+            &service_senders,
+            Arc::new(MockChunkFetcher::new(ledger_id as usize)),
+            config.node_config.clone(),
+            tokio::runtime::Handle::current(),
+        );
+
+        for i in [5_u32, 1_u32, 3_u32] {
+            let offset = PartitionChunkOffset::from(i);
+            orch.chunk_requests.insert(
+                offset,
+                ChunkRequest {
+                    ledger_id: 0,
+                    slot_index: 0,
+                    chunk_offset: offset,
+                    excluded: None,
+                    request_state: ChunkRequestState::Blocked(
+                        ChunkBlockReason::MissingDataRootIndex,
+                    ),
+                },
+            );
+        }
+
+        let n = orch.unblock_missing_data_root_index(2);
+        assert_eq!(n, 2);
+        assert_eq!(
+            orch.chunk_requests[&PartitionChunkOffset::from(1_u32)].request_state,
+            ChunkRequestState::Pending,
+            "lowest offset must be unblocked"
+        );
+        assert_eq!(
+            orch.chunk_requests[&PartitionChunkOffset::from(3_u32)].request_state,
+            ChunkRequestState::Pending,
+            "second-lowest offset must be unblocked"
+        );
+        assert_eq!(
+            orch.chunk_requests[&PartitionChunkOffset::from(5_u32)].request_state,
+            ChunkRequestState::Blocked(ChunkBlockReason::MissingDataRootIndex),
+            "highest offset must remain Blocked when capped below the full backlog"
+        );
+    }
+}

--- a/crates/actors/src/metrics.rs
+++ b/crates/actors/src/metrics.rs
@@ -29,7 +29,8 @@ irys_utils::define_metrics! {
     counter DATA_SYNC_CHUNK_FAILURES("irys.data_sync.chunk_failures_total", "Data sync peer fetch failures/timeouts");
     counter DATA_SYNC_CHUNK_WRITE_FAILED("irys.data_sync.chunk_write_failed_total", "Data sync local write failures after a successful fetch (labelled by reason)");
     counter DATA_SYNC_CHUNK_BLOCKED("irys.data_sync.chunk_blocked_total", "Data sync offsets blocked from hot re-fetch (labelled by reason)");
-    counter DATA_SYNC_CHUNK_UNBLOCKED("irys.data_sync.chunk_unblocked_total", "Data sync offsets re-queued on SyncPartitions when unblock_missing_data_root_index is true (MissingDataRootIndex → Pending)");
+    counter DATA_SYNC_CHUNK_UNBLOCKED("irys.data_sync.chunk_unblocked_total", "Data sync offsets re-queued on SyncPartitions for confirmed-clean SMs (MissingDataRootIndex → Pending)");
+    counter DATA_INDEX_HEAL_UNREPAIRED("irys.storage.index_heal_unrepaired_total", "Ledger SMs still gapped/uncertain after a heal pass (labelled by reason)");
     gauge DATA_SYNC_ACTIVE_PEERS("irys.data_sync.active_peers", "Number of active data sync peers");
     counter MINING_SOLUTIONS_FOUND("irys.mining.solutions_found_total", "Mining solutions found");
     gauge PACKING_ACTIVE_WORKERS("irys.packing.active_workers", "Number of active packing workers");
@@ -286,10 +287,14 @@ pub(crate) fn record_data_sync_chunk_blocked(reason: &'static str) {
     DATA_SYNC_CHUNK_BLOCKED.add(1, &[KeyValue::new("reason", reason)]);
 }
 
+/// `reason` values: `soft_skip` (plan uncertain), `gap_after_heal` (re-verify
+/// still found a gap).
+pub(crate) fn record_index_heal_unrepaired(reason: &'static str) {
+    DATA_INDEX_HEAL_UNREPAIRED.add(1, &[KeyValue::new("reason", reason)]);
+}
+
 pub(crate) fn record_data_sync_chunk_unblocked(count: u64) {
-    if count > 0 {
-        DATA_SYNC_CHUNK_UNBLOCKED.add(count, &[]);
-    }
+    DATA_SYNC_CHUNK_UNBLOCKED.add(count, &[]);
 }
 
 pub(crate) fn record_data_sync_active_peers(count: u64) {

--- a/crates/actors/src/storage_module_service.rs
+++ b/crates/actors/src/storage_module_service.rs
@@ -17,6 +17,7 @@ use crate::{
     packing_service::PackingRequest, services::ServiceSenders,
 };
 use eyre::{OptionExt as _, eyre};
+use futures::FutureExt as _;
 use irys_config::StorageSubmodulesConfig;
 use irys_domain::{
     BlockBoundsError, BlockIndexReadGuard, BlockTreeReadGuard, PACKING_PARAMS_FILE_NAME,
@@ -98,14 +99,22 @@ impl StorageModuleServiceInner {
         }
     }
 
-    async fn handle_message(&mut self, msg: StorageModuleServiceMessage) -> eyre::Result<()> {
+    async fn handle_message(
+        &mut self,
+        msg: StorageModuleServiceMessage,
+        cancel: Option<&Shutdown>,
+    ) -> eyre::Result<()> {
         match msg {
             StorageModuleServiceMessage::PartitionAssignmentsUpdated {
                 storage_module_infos,
                 update_height,
             } => {
-                self.handle_partition_assignments_update(storage_module_infos, update_height)
-                    .await?
+                self.handle_partition_assignments_update(
+                    storage_module_infos,
+                    update_height,
+                    cancel,
+                )
+                .await?
             }
         }
         Ok(())
@@ -136,6 +145,7 @@ impl StorageModuleServiceInner {
         &mut self,
         storage_module_info_update: Arc<Vec<StorageModuleInfo>>,
         update_height: u64,
+        cancel: Option<&Shutdown>,
     ) -> eyre::Result<()> {
         // Read the current storage modules once, outside the loop
         // this is the current state of the storage modules prior of the partition assignments update
@@ -311,26 +321,35 @@ impl StorageModuleServiceInner {
 
         // After assignments settle: gap-scan + index backfill for every local SM
         // currently on a data ledger (not only Capacity→LedgerSlot transitions).
-        self.heal_ledger_data_indexes().await?;
+        // `cancel` is the run loop's shutdown clone, so a long epoch backfill bails
+        // between blocks on shutdown, same as the startup heal.
+        self.heal_ledger_data_indexes(cancel).await?;
 
         Ok(())
     }
 
-    /// Scan ledger-assigned SMs for path-hash index gaps, backfill via
-    /// `UpdateStorageModuleIndexes`, then `SyncPartitions` (membership always;
-    /// unblock only if plan + migrate reported no issues).
+    /// Per-SM path-hash index heal: gap-scan each ledger-assigned SM, backfill the
+    /// covering blocks via `UpdateStorageModuleIndexes`, then `SyncPartitions`
+    /// (membership always; unblock only SMs confirmed gap-free this pass). Runs at
+    /// startup and every partition-assignment update; dense indexes take the
+    /// density fast path (no migrate). Soft-skips bounds/index inconsistency;
+    /// hard-fails only if the migration channel is closed.
     ///
-    /// Startup and every partition-assignment update. Dense indexes → density
-    /// fast path / no migrate. Soft-skips bounds/index inconsistency and per-block
-    /// migration errors (including response timeouts); hard-fails only if the
-    /// migration channel is closed. Large repairs are chunked
+    /// Cleanliness is per SM by a post-migration re-verify, not migrate success:
+    /// a migrate that returns `Ok` without closing the gap (reorg orphan-skip /
+    /// TOCTOU) leaves a real gap, so re-verify withholds that SM's unblock while
+    /// healthy SMs still unblock. Per-block migration errors (including response
+    /// timeouts) count as failures; large repairs are chunked
     /// ([`INDEX_HEAL_MAX_BLOCKS_PER_PASS`]) so startup cannot hang unbounded.
     ///
-    /// Marker is path-hash completeness; `UpdateStorageModuleIndexes` also writes
-    /// DataRootInfos when it runs. Residual: dense path-hashes with empty
-    /// DataRootInfos will not schedule a migrate.
+    /// Marker is path-hash completeness (`UpdateStorageModuleIndexes` writes
+    /// DataRootInfos alongside). Residual: dense path-hashes with empty
+    /// DataRootInfos won't schedule a migrate.
+    ///
+    /// `cancel` (a cheap `Shutdown` clone) lets a long per-block migration bail
+    /// within ~one block when shutdown is requested mid-heal.
     #[tracing::instrument(level = "debug", skip_all, err)]
-    async fn heal_ledger_data_indexes(&self) -> eyre::Result<()> {
+    async fn heal_ledger_data_indexes(&self, cancel: Option<&Shutdown>) -> eyre::Result<()> {
         let ledger_modules: Vec<Arc<StorageModule>> = {
             let guard = self.storage_modules.read().unwrap();
             guard
@@ -349,42 +368,49 @@ impl StorageModuleServiceInner {
             "healing data indexes for ledger-assigned storage modules"
         );
 
+        let mut clean_sm_ids: Vec<usize> = Vec::new();
+        // (SM, plan-time exclusive partition-offset bound) pairs to re-verify
+        // after migration, against the snapshot range — never a re-read frontier.
+        let mut needs_reverify: Vec<(Arc<StorageModule>, PartitionChunkOffset)> = Vec::new();
         let mut blocks_to_migrate: BTreeMap<u64, BlockHash> = BTreeMap::new();
-        let mut heal_issues = 0_usize;
+
         for sm in &ledger_modules {
             match self.plan_index_repair(sm) {
-                IndexRepairPlan::Complete => {}
+                // No gap at plan time, so no migrate. Still re-verified below
+                // (against the dense-prefix bound) so a reorg-recovery clear that
+                // races the plan→send window is caught and the SM is withheld
+                // rather than falsely unblocked.
+                IndexRepairPlan::Complete { reverify_max } => {
+                    needs_reverify.push((sm.clone(), reverify_max));
+                }
+                // Plan uncertain → not clean; leave blocked and signal operators.
                 IndexRepairPlan::SoftSkipped => {
-                    heal_issues += 1;
+                    crate::metrics::record_index_heal_unrepaired("soft_skip");
                 }
                 IndexRepairPlan::NeedsRepair {
                     start_height,
                     end_height,
+                    max_partition_offset,
                 } => {
+                    // Best-effort materialization: a height missing from the index
+                    // (e.g. reorg truncation) just means the gap may remain — the
+                    // post-migration re-verify is the source of truth, so we don't
+                    // count per-block failures here.
                     let bi = self.block_index.read();
-                    let mut planned_any = false;
-                    let mut missing_height = false;
                     for height in start_height..=end_height {
                         let Some(item) = bi.get_item(height) else {
-                            // Index shrank / truncated between plan and read (e.g. reorg).
                             warn!(
                                 storage_module.id = sm.id,
                                 block.height = height,
                                 plan.start_height = start_height,
                                 plan.end_height = end_height,
-                                "block missing from index during heal; counting as heal issue"
+                                "block missing from index during heal; re-verify will decide cleanliness"
                             );
-                            missing_height = true;
                             break;
                         };
                         blocks_to_migrate.insert(height, item.block_hash);
-                        planned_any = true;
                     }
-                    // Incomplete materialization (empty span or mid-range gap) —
-                    // count once, not on both the miss and the empty check.
-                    if missing_height || !planned_any {
-                        heal_issues += 1;
-                    }
+                    needs_reverify.push((sm.clone(), max_partition_offset));
                 }
             }
         }
@@ -394,28 +420,49 @@ impl StorageModuleServiceInner {
                 index_heal.blocks = blocks_to_migrate.len(),
                 "migrating blocks to repair storage-module data indexes"
             );
-            heal_issues += self
-                .migrate_storage_module_indexes(blocks_to_migrate)
+            // Hard-fail only on migration-channel closed (propagated). The
+            // per-block failure count is intentionally ignored — re-verify below
+            // decides which SMs are actually clean.
+            let _ = self
+                .migrate_storage_module_indexes(blocks_to_migrate, cancel)
                 .await?;
         }
 
-        // Always refresh orchestrator membership. Unblock only when every SM plan
-        // was Complete or fully migrated — plan soft-skips and migrate failures
-        // both suppress unblock to avoid epoch refetch/re-block thrash.
-        let unblock = heal_issues == 0;
-        if !unblock {
-            warn!(
-                index_heal.issues = heal_issues,
-                "index heal incomplete; SyncPartitions without unblock \
-                 to avoid refetch/re-block thrash"
-            );
+        // Post-migration re-verify: an SM that needed repair is clean iff the
+        // range it *planned* to repair now has no path-hash gap. Scanning the
+        // plan-time `[0, max_plan)` (not a freshly-read frontier) means a chain
+        // advancing during the heal cannot manufacture a false gap past what this
+        // pass set out to fix. Orphan-skip / TOCTOU / missing-data all leave a
+        // real gap in this range and correctly withhold the SM's unblock.
+        for (sm, max_plan) in &needs_reverify {
+            match sm.first_missing_path_hash_offset(PartitionChunkOffset::from(0), *max_plan) {
+                Ok(None) => clean_sm_ids.push(sm.id),
+                Ok(Some(gap)) => {
+                    warn!(
+                        storage_module.id = sm.id,
+                        index_heal.first_gap = %gap,
+                        index_heal.max_partition_offset = %max_plan,
+                        "path-hash index still gapped after heal; withholding unblock"
+                    );
+                    crate::metrics::record_index_heal_unrepaired("gap_after_heal");
+                }
+                Err(e) => {
+                    warn!(
+                        storage_module.id = sm.id,
+                        error = %e,
+                        "path-hash re-verify scan failed after heal; withholding unblock"
+                    );
+                    crate::metrics::record_index_heal_unrepaired("soft_skip");
+                }
+            }
         }
 
+        // Always refresh orchestrator membership; unblock only confirmed-clean SMs.
         if let Err(e) =
             self.service_senders
                 .data_sync
                 .send_traced(DataSyncServiceMessage::SyncPartitions {
-                    unblock_missing_data_root_index: unblock,
+                    unblock_sm_ids: clean_sm_ids,
                 })
         {
             error!(
@@ -432,10 +479,13 @@ impl StorageModuleServiceInner {
     /// Distinguishes "indexes look complete" from "could not plan / uncertain" so
     /// heal does not claim success and mass-unblock after a soft-skip.
     fn plan_index_repair(&self, sm: &Arc<StorageModule>) -> IndexRepairPlan {
-        let ledger_id = sm
-            .partition_assignment()
-            .and_then(|a| a.ledger_id)
-            .expect("storage module must be assigned to a data ledger slot");
+        let Some(ledger_id) = sm.partition_assignment().and_then(|a| a.ledger_id) else {
+            warn!(
+                storage_module.id = sm.id,
+                "storage module not assigned to a data ledger slot during index plan; soft-skip"
+            );
+            return IndexRepairPlan::SoftSkipped;
+        };
 
         let Ok(ledger_range) = sm.get_storage_module_ledger_offsets() else {
             warn!(
@@ -445,10 +495,15 @@ impl StorageModuleServiceInner {
             return IndexRepairPlan::SoftSkipped;
         };
 
-        let max_partition_offset = self.get_max_partition_offset(sm.clone());
+        let Some(max_partition_offset) = self.get_max_partition_offset(sm) else {
+            // Cannot determine bounds → uncertain, soft-skip.
+            return IndexRepairPlan::SoftSkipped;
+        };
         if *max_partition_offset == 0 {
-            // No migrated data in range yet — nothing to repair.
-            return IndexRepairPlan::Complete;
+            // No migrated data in range yet — nothing to repair or re-verify.
+            return IndexRepairPlan::Complete {
+                reverify_max: PartitionChunkOffset::from(0),
+            };
         }
 
         // First offset without path hashes (density fast path or cursor walk).
@@ -456,7 +511,12 @@ impl StorageModuleServiceInner {
             .first_missing_path_hash_offset(PartitionChunkOffset::from(0), max_partition_offset)
         {
             Ok(Some(offset)) => offset,
-            Ok(None) => return IndexRepairPlan::Complete,
+            // Fully dense over [0, max) — re-verify the whole range.
+            Ok(None) => {
+                return IndexRepairPlan::Complete {
+                    reverify_max: max_partition_offset,
+                };
+            }
             Err(e) => {
                 warn!(
                     storage_module.id = sm.id,
@@ -499,7 +559,10 @@ impl StorageModuleServiceInner {
 
         if *ledger_chunk_offset >= max_chunk_offset {
             // Gap is past the ledger frontier — not repairable as missing index.
-            return IndexRepairPlan::Complete;
+            // The dense prefix [0, chunk_offset) is what to re-verify.
+            return IndexRepairPlan::Complete {
+                reverify_max: chunk_offset,
+            };
         }
 
         let Some(start_block) = Self::block_height_for_ledger_offset(
@@ -517,7 +580,9 @@ impl StorageModuleServiceInner {
             ledger_range.start() + LedgerChunkOffset::from(*max_partition_offset - 1);
         let clamped_end_offset = if *end_ledger_offset >= max_chunk_offset {
             if max_chunk_offset == 0 {
-                return IndexRepairPlan::Complete;
+                return IndexRepairPlan::Complete {
+                    reverify_max: chunk_offset,
+                };
             }
             LedgerChunkOffset::from(max_chunk_offset - 1)
         } else {
@@ -538,9 +603,23 @@ impl StorageModuleServiceInner {
             return IndexRepairPlan::SoftSkipped;
         };
 
+        // Snapshot the re-verify bound from the block-index frontier the plan
+        // clamped to (`clamped_end_offset`), not the looser block-tree-derived
+        // `max_partition_offset`. When migration lags, the block-tree frontier
+        // (tip − depth) overshoots what is locally repairable; re-verifying to
+        // that bound would see a phantom tail gap and needlessly withhold this
+        // SM's unblock for one cycle. `clamped_end_offset >= ledger_chunk_offset
+        // >= ledger_range.start()` and `<= start + max - 1`, so the exclusive
+        // partition-relative bound fits u32 and is ≤ `max_partition_offset`.
+        let max_plan = PartitionChunkOffset::from(
+            u32::try_from(*clamped_end_offset - *ledger_range.start() + 1)
+                .unwrap_or(*max_partition_offset),
+        );
+
         IndexRepairPlan::NeedsRepair {
             start_height: start_block,
             end_height: end_block,
+            max_partition_offset: max_plan,
         }
     }
 
@@ -575,17 +654,20 @@ impl StorageModuleServiceInner {
     ///
     /// Caps work at [`INDEX_HEAL_MAX_BLOCKS_PER_PASS`] and awaits each response
     /// with [`INDEX_HEAL_MIGRATE_RESPONSE_TIMEOUT`] so startup / assignment heal
-    /// cannot hang indefinitely if migration stalls. Deferred and failed blocks
-    /// count toward the returned failure total (suppresses unblock).
+    /// cannot hang if migration stalls. Deferred and failed blocks (missing data /
+    /// index write / oneshot drop / timeout) count toward the returned failure
+    /// total (suppresses unblock).
     ///
-    /// Hard-fails only if the migration mpsc is closed.
+    /// If `cancel` fires (shutdown requested), the loop returns early before the
+    /// next block so a long heal does not stall graceful shutdown. Hard-fails only
+    /// if the migration mpsc is closed.
     async fn migrate_storage_module_indexes(
         &self,
         blocks_to_migrate: BTreeMap<u64, BlockHash>,
+        cancel: Option<&Shutdown>,
     ) -> eyre::Result<usize> {
         let total_planned = blocks_to_migrate.len();
         let mut failures = 0_usize;
-
         let blocks_this_pass: BTreeMap<u64, BlockHash> =
             if total_planned > INDEX_HEAL_MAX_BLOCKS_PER_PASS {
                 let deferred = total_planned - INDEX_HEAL_MAX_BLOCKS_PER_PASS;
@@ -607,6 +689,13 @@ impl StorageModuleServiceInner {
 
         let migration_service = &self.service_senders.chunk_migration;
         for (block_height, block_hash) in blocks_this_pass {
+            if shutdown_requested(cancel) {
+                debug!(
+                    block.height = block_height,
+                    "shutdown requested during index-heal migration; returning early"
+                );
+                return Ok(failures);
+            }
             let (tx, rx) = tokio::sync::oneshot::channel();
 
             if let Err(e) = migration_service.send_traced(
@@ -722,11 +811,20 @@ impl StorageModuleServiceInner {
     /// stores as **inclusive** start/end. `total_chunks` is an **exclusive**
     /// ledger frontier. Mixing those without +1 on the full-SM arm drops the
     /// last chunk from the scan / backfill window.
-    fn get_max_partition_offset(&self, storage_module: Arc<StorageModule>) -> PartitionChunkOffset {
-        let ledger_id = storage_module
+    fn get_max_partition_offset(
+        &self,
+        storage_module: &Arc<StorageModule>,
+    ) -> Option<PartitionChunkOffset> {
+        let Some(ledger_id) = storage_module
             .partition_assignment()
             .and_then(|a| a.ledger_id)
-            .expect("storage module must be assigned to a data ledger slot");
+        else {
+            warn!(
+                storage_module.id = storage_module.id,
+                "storage module not assigned to a data ledger slot; cannot determine max offset"
+            );
+            return None;
+        };
 
         let current_height = self.block_tree.read().get_latest_canonical_entry().height();
         let migration_height =
@@ -736,15 +834,21 @@ impl StorageModuleServiceInner {
             .block_tree
             .get_total_chunks(migration_height, ledger_id);
 
-        let range = storage_module
-            .get_storage_module_ledger_offsets()
-            .expect("storage module should be assigned to a ledger");
+        let Ok(range) = storage_module.get_storage_module_ledger_offsets() else {
+            warn!(
+                storage_module.id = storage_module.id,
+                "storage module not assigned to a ledger; cannot determine max offset"
+            );
+            return None;
+        };
         // Inclusive bounds after nodit `ie` → stored inclusive end.
         let start: u64 = *range.start();
         let end_incl: u64 = *range.end();
         let max_excl = max_ledger_offset.map(|m| *m);
 
-        PartitionChunkOffset::from(exclusive_partition_end(start, end_incl, max_excl))
+        Some(PartitionChunkOffset::from(exclusive_partition_end(
+            start, end_incl, max_excl,
+        )))
     }
 
     /// Validates that a storage module's partition assignment matches the on-disk parameters.
@@ -832,11 +936,30 @@ impl StorageModuleServiceInner {
 /// Outcome of planning path-hash index repair for one ledger-assigned SM.
 enum IndexRepairPlan {
     /// Path-hash scan found no gap (or no data in range).
-    Complete,
-    /// Inclusive block heights that should be re-indexed.
-    NeedsRepair { start_height: u64, end_height: u64 },
+    /// Plan found no repairable gap. `reverify_max` is the dense-prefix bound to
+    /// re-scan before unblocking (0 if there is no data), so a clear racing the
+    /// plan→send window is caught rather than falsely unblocked.
+    Complete { reverify_max: PartitionChunkOffset },
+    /// Inclusive block heights that should be re-indexed, plus the plan-time
+    /// exclusive partition-offset bound. Re-verify uses this snapshot rather than
+    /// re-reading the (moving) frontier, so a chain advancing mid-heal cannot
+    /// manufacture a false post-heal gap past what this pass planned to repair.
+    NeedsRepair {
+        start_height: u64,
+        end_height: u64,
+        max_partition_offset: PartitionChunkOffset,
+    },
     /// Gap or bounds uncertainty; heal must not claim success / unblock.
     SoftSkipped,
+}
+
+/// Whether the service shutdown signal has fired.
+///
+/// Polls a fresh clone of the shared `Shutdown` so the caller's handle (the run
+/// loop's `&mut self.shutdown`) is never consumed. `now_or_never` polls once
+/// with a no-op waker: `Some(())` once the signal fired, `None` while pending.
+fn shutdown_requested(cancel: Option<&Shutdown>) -> bool {
+    cancel.is_some_and(|s| s.clone().now_or_never().is_some())
 }
 
 /// Exclusive partition-relative end for index scan / backfill.
@@ -911,9 +1034,15 @@ impl StorageModuleService {
 
         // Crash-resume / long-lived ledger assigns never see Capacity→LedgerSlot
         // again. Soft-skips per-SM issues; only migration channel closed is fatal.
-        // Migrate is chunked + per-response timeout so first-gap→frontier repair
-        // cannot block this start path indefinitely (see migrate_storage_module_indexes).
-        if let Err(e) = self.inner.heal_ledger_data_indexes().await {
+        //
+        // The heal runs before the select! loop, so its per-block migration can be
+        // long. Pass a cheap clone of the run loop's `Shutdown` so the heal can bail
+        // between blocks if shutdown is requested mid-heal (cloning shares the signal
+        // without consuming the `&mut self.shutdown` the loop polls below). Migrate is
+        // also chunked + per-response-timeout so a first-gap→frontier repair cannot
+        // block startup indefinitely (see migrate_storage_module_indexes).
+        let cancel = self.shutdown.clone();
+        if let Err(e) = self.inner.heal_ledger_data_indexes(Some(&cancel)).await {
             error!("startup data-index heal failed: {e:?}");
             return Err(e);
         }
@@ -936,7 +1065,7 @@ impl StorageModuleService {
                         Some(traced) => {
                             let (msg, parent_span) = traced.into_parts();
                             let span = tracing::trace_span!(parent: &parent_span, "storage_module_handle_message");
-                            self.inner.handle_message(msg).instrument(span).await?;
+                            self.inner.handle_message(msg, Some(&cancel)).instrument(span).await?;
                         }
                         None => {
                             tracing::warn!("Message channel closed unexpectedly");
@@ -955,7 +1084,7 @@ impl StorageModuleService {
         while let Ok(traced) = self.msg_rx.try_recv() {
             let (msg, parent_span) = traced.into_parts();
             let span = tracing::trace_span!(parent: &parent_span, "storage_module_handle_message");
-            self.inner.handle_message(msg).instrument(span).await?
+            self.inner.handle_message(msg, Some(&cancel)).instrument(span).await?
         }
 
         tracing::info!("shutting down StorageModule Service gracefully");
@@ -998,5 +1127,384 @@ mod exclusive_partition_end_tests {
         assert_eq!(exclusive_partition_end(100, 199, Some(150)), 50);
         // Frontier past SM → full length 100.
         assert_eq!(exclusive_partition_end(100, 199, Some(500)), 100);
+    }
+}
+
+#[cfg(test)]
+mod shutdown_requested_tests {
+    use super::shutdown_requested;
+    use reth::tasks::shutdown::signal;
+
+    #[test]
+    fn none_and_pending_are_not_requested() {
+        let (_signal, shutdown) = signal();
+        // No handle to observe → never cancels (epoch call-site behavior).
+        assert!(!shutdown_requested(None));
+        // Signal not yet fired → still running.
+        assert!(!shutdown_requested(Some(&shutdown)));
+    }
+
+    #[test]
+    fn fired_signal_is_requested() {
+        let (signal, shutdown) = signal();
+        assert!(!shutdown_requested(Some(&shutdown)));
+        signal.fire();
+        // The per-block loop check now short-circuits the heal.
+        assert!(shutdown_requested(Some(&shutdown)));
+    }
+
+    #[test]
+    fn dropped_signal_is_requested() {
+        // TokioServiceHandle shutdown also fires by dropping the Signal.
+        let (signal, shutdown) = signal();
+        drop(signal);
+        assert!(shutdown_requested(Some(&shutdown)));
+    }
+}
+
+/// End-to-end coverage of the per-SM heal -> unblock contract:
+///
+///   `heal_ledger_data_indexes` must emit `SyncPartitions { unblock_sm_ids }`
+///   naming ONLY the SM whose path-hash index is confirmed gap-free, and the
+///   data-sync side must then unblock ONLY that SM's `MissingDataRootIndex`
+///   offsets while a still-gapped SM stays blocked.
+///
+/// Two real `StorageModule`s share one registry:
+///   - `HEALTHY_ID`: dense path-hash index over its range -> `plan_index_repair`
+///     classifies `Complete` (no migration) -> added to `clean_sm_ids`.
+///   - `GAPPED_ID`: a real path-hash hole -> `plan_index_repair` classifies
+///     `NeedsRepair` -> a minimal chunk-migration responder answers `Ok(())`
+///     WITHOUT closing the gap (orphan-skip / TOCTOU shape) -> the post-migration
+///     re-verify still finds the hole -> unblock withheld.
+///
+/// Real code paths exercised: `heal_ledger_data_indexes`, `plan_index_repair`
+/// (both the density fast path and the block-index/block-tree-backed repair
+/// plan), `migrate_storage_module_indexes` (message send + oneshot await), the
+/// post-migration path-hash re-verify, the `SyncPartitions` construction/send,
+/// and the real `DataSyncServiceInner` unblock filter over both orchestrators.
+/// Stubbed: only the chunk-migration responder (returns `Ok` without indexing,
+/// exactly the "migrate returned but gap persists" case the contract guards).
+#[cfg(test)]
+mod heal_unblock_contract_tests {
+    use super::*;
+    use crate::DataSyncServiceInner;
+    use crate::chunk_migration_service::ChunkMigrationServiceMessage;
+    use crate::data_sync_service::chunk_fetcher::{
+        ChunkFetcher, ChunkFetcherFactory, MockChunkFetcher,
+    };
+    use crate::data_sync_service::chunk_orchestrator::{
+        ChunkBlockReason, ChunkRequest, ChunkRequestState,
+    };
+    use crate::test_helpers::build_test_service_senders;
+    use irys_config::StorageSubmodulesConfig;
+    use irys_database::db::IrysDatabaseExt as _;
+    use irys_database::submodule::set_path_hashes_by_offset;
+    use irys_database::submodule::tables::ChunkPathHashes;
+    use irys_database::{IrysDatabaseArgs as _, open_or_create_db, tables::IrysTables};
+    use irys_domain::{BlockIndex, BlockTree, PeerList};
+    use irys_testing_utils::IrysBlockHeaderTestExt as _;
+    use irys_testing_utils::utils::TempDirBuilder;
+    use irys_types::{
+        BlockIndexItem, ConsensusConfig, DatabaseProvider, IrysBlockHeader, LedgerIndexItem,
+        NodeConfig, partition::PartitionAssignment, partition_chunk_offset_ie,
+    };
+    use reth_db::mdbx::DatabaseArguments;
+
+    const HEALTHY_ID: usize = 0;
+    const GAPPED_ID: usize = 1;
+    /// Chunks in the partition / SM ledger span and the ledger frontier: keeping
+    /// them equal means the whole SM range is in-frontier and eligible to repair.
+    const NUM_CHUNKS: u32 = 4;
+    /// Partition offset punched out of the gapped SM's otherwise-dense index.
+    const GAP_OFFSET: u32 = 2;
+
+    fn test_config(base_directory: std::path::PathBuf) -> Config {
+        let node_config = NodeConfig {
+            consensus: irys_types::ConsensusOptions::Custom(ConsensusConfig {
+                chunk_size: 32,
+                num_chunks_in_partition: NUM_CHUNKS as u64,
+                num_chunks_in_recall_range: 2,
+                num_partitions_per_slot: 1,
+                entropy_packing_iterations: 1,
+                // Only genesis is in the chain, so migration_height clamps to 0
+                // regardless of depth; genesis is the migrated frontier block.
+                block_migration_depth: 1,
+                chain_id: 1,
+                ..ConsensusConfig::testing()
+            }),
+            base_directory,
+            ..NodeConfig::testing()
+        };
+        Config::new_with_random_peer_id(node_config)
+    }
+
+    fn ledger_sm(config: &Config, id: usize, dir: &str) -> Arc<StorageModule> {
+        let pa = PartitionAssignment {
+            ledger_id: Some(DataLedger::Publish.into()),
+            slot_index: Some(0),
+            miner_address: irys_types::IrysAddress::from([1_u8; 20]),
+            partition_hash: irys_types::H256::random(),
+        };
+        let info = StorageModuleInfo {
+            id,
+            partition_assignment: Some(pa),
+            submodules: vec![(partition_chunk_offset_ie!(0, NUM_CHUNKS), dir.into())],
+        };
+        Arc::new(StorageModule::new(&info, config).expect("storage module"))
+    }
+
+    /// Write a path-hash index entry for every partition offset in `[0, end)`,
+    /// making the module's path-hash index dense over that range.
+    fn seed_dense_path_hashes(sm: &StorageModule, end: u32) {
+        let path_hashes = ChunkPathHashes {
+            data_path_hash: Some(irys_types::H256::random()),
+            tx_path_hash: Some(irys_types::H256::random()),
+        };
+        let (_interval, submodule) = sm
+            .get_submodule_for_offset(PartitionChunkOffset::from(0))
+            .expect("submodule for offset 0");
+        submodule
+            .db
+            .update_eyre(|tx| {
+                for offset in 0..end {
+                    set_path_hashes_by_offset(
+                        tx,
+                        PartitionChunkOffset::from(offset),
+                        path_hashes.clone(),
+                    )?;
+                }
+                Ok(())
+            })
+            .expect("seed dense path hashes");
+    }
+
+    /// A block-tree genesis and an MDBX-backed block index that both report
+    /// `Publish.total_chunks == NUM_CHUNKS`. `plan_index_repair` reads the
+    /// frontier from the block tree (`get_total_chunks`) and resolves repair
+    /// block heights from the block index (`get_block_bounds`); both must agree.
+    fn genesis_block_tree_and_index(
+        config: &Config,
+    ) -> (BlockTreeReadGuard, BlockIndexReadGuard, DatabaseProvider) {
+        let mut genesis = IrysBlockHeader::new_mock_header();
+        genesis.height = 0;
+        genesis.previous_block_hash = irys_types::H256::zero();
+        genesis.data_ledgers[DataLedger::Publish].total_chunks = NUM_CHUNKS as u64;
+        genesis.test_sign();
+
+        let block_tree = BlockTree::new(&genesis, config.consensus.clone());
+        let block_tree_guard = BlockTreeReadGuard::new(Arc::new(RwLock::new(block_tree)));
+
+        let tmp = TempDirBuilder::new().build();
+        let env = open_or_create_db(
+            tmp.path(),
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing().expect("db args"),
+        )
+        .expect("open block index db");
+        let db = DatabaseProvider(Arc::new(env));
+        let block_index = BlockIndex::new_for_testing(db.clone());
+        block_index
+            .push_item(
+                &BlockIndexItem {
+                    block_hash: genesis.block_hash,
+                    num_ledgers: 1,
+                    ledgers: vec![LedgerIndexItem {
+                        total_chunks: NUM_CHUNKS as u64,
+                        tx_root: irys_types::H256::zero(),
+                        ledger: DataLedger::Publish,
+                    }],
+                },
+                0,
+            )
+            .expect("push genesis block index item");
+        // Keep the tempdir alive for the DB's lifetime by leaking it into the
+        // returned provider's scope — the returned `db` keeps the env open, and
+        // the process-scoped test tempdir is cleaned by the harness.
+        std::mem::forget(tmp);
+
+        (block_tree_guard, BlockIndexReadGuard::new(block_index), db)
+    }
+
+    fn mock_fetcher_factory() -> ChunkFetcherFactory {
+        Box::new(|ledger_id| {
+            Arc::new(MockChunkFetcher::new(ledger_id as usize)) as Arc<dyn ChunkFetcher>
+        })
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn heal_unblocks_only_gap_free_storage_module() {
+        let tmp = TempDirBuilder::new().with_tracing().build();
+        let config = test_config(tmp.path().to_path_buf());
+
+        // Healthy SM: dense path-hash index over its whole range.
+        let healthy = ledger_sm(&config, HEALTHY_ID, "chunks_healthy");
+        seed_dense_path_hashes(&healthy, NUM_CHUNKS);
+        assert_eq!(
+            healthy
+                .first_missing_path_hash_offset(
+                    PartitionChunkOffset::from(0),
+                    PartitionChunkOffset::from(NUM_CHUNKS)
+                )
+                .expect("scan healthy"),
+            None,
+            "precondition: healthy SM index must be gap-free"
+        );
+
+        // Gapped SM: dense, then punch a hole so a real gap exists mid-range.
+        let gapped = ledger_sm(&config, GAPPED_ID, "chunks_gapped");
+        seed_dense_path_hashes(&gapped, NUM_CHUNKS);
+        gapped
+            .clear_offset_index_in_range(
+                PartitionChunkOffset::from(GAP_OFFSET),
+                PartitionChunkOffset::from(GAP_OFFSET),
+            )
+            .expect("punch gap");
+        assert_eq!(
+            gapped
+                .first_missing_path_hash_offset(
+                    PartitionChunkOffset::from(0),
+                    PartitionChunkOffset::from(NUM_CHUNKS)
+                )
+                .expect("scan gapped"),
+            Some(PartitionChunkOffset::from(GAP_OFFSET)),
+            "precondition: gapped SM must have a hole at GAP_OFFSET"
+        );
+
+        let storage_modules: Arc<RwLock<Vec<Arc<StorageModule>>>> =
+            Arc::new(RwLock::new(vec![healthy, gapped]));
+
+        let (block_tree_guard, block_index_guard, _db) = genesis_block_tree_and_index(&config);
+
+        let (service_senders, mut service_receivers) = build_test_service_senders();
+
+        // Minimal chunk-migration responder: answer every UpdateStorageModuleIndexes
+        // with Ok(()) WITHOUT writing any index. This is the adversarial case the
+        // per-SM re-verify guards — migration "succeeds" but the gap persists.
+        // A shared counter records how many migration requests the heal issued,
+        // read after the heal without having to join (senders outlive the heal).
+        let mut chunk_migration_rx = std::mem::replace(
+            &mut service_receivers.chunk_migration,
+            tokio::sync::mpsc::unbounded_channel().1,
+        );
+        let migrate_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let migrate_calls_task = migrate_calls.clone();
+        let responder = tokio::spawn(async move {
+            while let Some(traced) = chunk_migration_rx.recv().await {
+                let (msg, _span) = traced.into_parts();
+                if let ChunkMigrationServiceMessage::UpdateStorageModuleIndexes {
+                    receiver, ..
+                } = msg
+                {
+                    // Deliberately do NOT index — leave the gap in place.
+                    let _ = receiver.send(Ok(()));
+                    migrate_calls_task.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                }
+            }
+        });
+
+        let submodules_config =
+            StorageSubmodulesConfig::load_for_test(config.node_config.base_directory.clone(), 2)
+                .expect("submodules config");
+
+        let inner = StorageModuleServiceInner {
+            storage_modules: storage_modules.clone(),
+            block_index: block_index_guard.clone(),
+            block_tree: block_tree_guard.clone(),
+            submodules_config,
+            service_senders: service_senders.clone(),
+            config: config.clone(),
+        };
+
+        // Drive the real heal pass (plan -> migrate -> re-verify -> SyncPartitions).
+        inner
+            .heal_ledger_data_indexes(None)
+            .await
+            .expect("heal_ledger_data_indexes");
+
+        // Capture the SyncPartitions the heal emitted.
+        let traced = service_receivers
+            .data_sync
+            .try_recv()
+            .expect("heal must emit a SyncPartitions message");
+        let (msg, _span) = traced.into_parts();
+        let unblock_sm_ids = match msg {
+            DataSyncServiceMessage::SyncPartitions { unblock_sm_ids } => unblock_sm_ids,
+            _ => panic!("expected a SyncPartitions message from the heal pass"),
+        };
+
+        assert!(
+            unblock_sm_ids.contains(&HEALTHY_ID),
+            "gap-free SM must be in unblock_sm_ids, got {unblock_sm_ids:?}"
+        );
+        assert!(
+            !unblock_sm_ids.contains(&GAPPED_ID),
+            "still-gapped SM must NOT be in unblock_sm_ids, got {unblock_sm_ids:?}"
+        );
+
+        // ---- data-sync half: the captured message must unblock only HEALTHY ----
+        let peer_list = PeerList::from_peers(
+            vec![],
+            service_senders.peer_network.clone(),
+            &config,
+            tokio::sync::broadcast::channel::<irys_domain::PeerEvent>(100).0,
+        )
+        .expect("peer list");
+
+        let mut data_sync = DataSyncServiceInner::new(
+            block_tree_guard,
+            storage_modules,
+            peer_list,
+            mock_fetcher_factory(),
+            service_senders,
+            config,
+            tokio::runtime::Handle::current(),
+        );
+
+        // One orchestrator per ledger-assigned SM.
+        assert!(data_sync.chunk_orchestrators.contains_key(&HEALTHY_ID));
+        assert!(data_sync.chunk_orchestrators.contains_key(&GAPPED_ID));
+
+        // Seed each orchestrator with a MissingDataRootIndex-blocked offset.
+        let blocked_offset = PartitionChunkOffset::from(0_u32);
+        for id in [HEALTHY_ID, GAPPED_ID] {
+            let orch = data_sync.chunk_orchestrators.get_mut(&id).unwrap();
+            orch.chunk_requests.insert(
+                blocked_offset,
+                ChunkRequest {
+                    ledger_id: DataLedger::Publish as usize,
+                    slot_index: 0,
+                    chunk_offset: blocked_offset,
+                    excluded: None,
+                    request_state: ChunkRequestState::Blocked(
+                        ChunkBlockReason::MissingDataRootIndex,
+                    ),
+                },
+            );
+        }
+
+        // Feed the exact message the heal produced.
+        data_sync
+            .handle_message(DataSyncServiceMessage::SyncPartitions { unblock_sm_ids })
+            .expect("handle SyncPartitions");
+
+        assert_eq!(
+            data_sync.chunk_orchestrators[&HEALTHY_ID].chunk_requests[&blocked_offset]
+                .request_state,
+            ChunkRequestState::Pending,
+            "healthy SM's blocked offset must be re-queued to Pending"
+        );
+        assert_eq!(
+            data_sync.chunk_orchestrators[&GAPPED_ID].chunk_requests[&blocked_offset].request_state,
+            ChunkRequestState::Blocked(ChunkBlockReason::MissingDataRootIndex),
+            "gapped SM's offset must stay Blocked (withheld by re-verify)"
+        );
+
+        // The gapped SM's repair plan must have driven at least one migration
+        // request (proving it reached NeedsRepair, not a trivial Complete/SoftSkip).
+        assert!(
+            migrate_calls.load(std::sync::atomic::Ordering::SeqCst) >= 1,
+            "gapped SM must have triggered a migration request (reached NeedsRepair)"
+        );
+        responder.abort();
     }
 }

--- a/crates/actors/tests/data_sync_test.rs
+++ b/crates/actors/tests/data_sync_test.rs
@@ -246,11 +246,11 @@ impl DataSyncServiceTestHarness {
         self.inner.handle_message(message)
     }
 
-    /// Convenience method to start syncing
+    /// Convenience method to start syncing. Unblocks every current orchestrator
+    /// (initial-sync behavior: all local ledger SMs are treated as clean).
     fn start_sync(&mut self) -> eyre::Result<()> {
-        self.handle_message(DataSyncServiceMessage::SyncPartitions {
-            unblock_missing_data_root_index: true,
-        })
+        let unblock_sm_ids: Vec<usize> = self.inner.chunk_orchestrators.keys().copied().collect();
+        self.handle_message(DataSyncServiceMessage::SyncPartitions { unblock_sm_ids })
     }
 
     /// Get peers list

--- a/crates/database/src/submodule/db.rs
+++ b/crates/database/src/submodule/db.rs
@@ -111,6 +111,12 @@ pub fn first_gap_in_sorted_keys(
 /// Healthy full indexes take an O(1) density check (`first` + `last` + `entries`).
 /// Otherwise walks the sorted keyspace (one RO tx): O(#indexed keys in range),
 /// correct for non-prefix holes. Dense linear point-gets are not used.
+///
+/// FOLLOWUP: this is key-presence only. Legacy `{tx_path_hash: None,
+/// data_path_hash: None}` tombstones written by pre-fix clears (before clears
+/// switched to deleting the key) read as present → dense → invisible to heal,
+/// while their `DataRootInfos` are gone. A one-shot upgrade scrub deleting all
+/// entries whose both hashes are `None` converts them to real, healable gaps.
 pub fn first_missing_path_hash_offset_in_tx<T: DbTx>(
     tx: &T,
     start: PartitionChunkOffset,
@@ -124,13 +130,16 @@ pub fn first_missing_path_hash_offset_in_tx<T: DbTx>(
     // [start, end). Anchors on `cursor.first()` (table minimum), not `seek(start)`:
     // keys below `start` must not be allowed to pad `entries()` while holes sit
     // inside the range (e.g. keys {0,5,6,7,9} over [5,10) must not report dense).
-    let expected_len = (*end as u64).saturating_sub(*start as u64);
+    let expected_len = u64::from(*end).saturating_sub(u64::from(*start));
     if expected_len > 0 {
         let mut cursor = tx.cursor_read::<ChunkPathHashesByOffset>()?;
         let first = cursor.first()?;
         let last = cursor.last()?;
-        let count = tx.entries::<ChunkPathHashesByOffset>()? as u64;
-        if let (Some((first_key, _)), Some((last_key, _))) = (first, last) {
+        if let (Ok(count), Some((first_key, _)), Some((last_key, _))) = (
+            u64::try_from(tx.entries::<ChunkPathHashesByOffset>()?),
+            first,
+            last,
+        ) {
             // Compare last == end-1 without wrapping u32::MAX + 1.
             let last_is_range_end = *end > 0 && last_key == PartitionChunkOffset(*end - 1);
             if first_key == start && last_is_range_end && count == expected_len {
@@ -223,6 +232,16 @@ pub fn set_path_hashes_by_offset<T: DbTxMut>(
     path_hashes: ChunkPathHashes,
 ) -> eyre::Result<()> {
     Ok(tx.put::<ChunkPathHashesByOffset>(offset, path_hashes)?)
+}
+
+/// Delete the entire `ChunkPathHashesByOffset` entry for `offset` (un-index it),
+/// so a gap scan sees the offset as missing rather than present-with-None.
+pub fn del_path_hashes_by_offset<T: DbTxMut>(
+    tx: &T,
+    offset: PartitionChunkOffset,
+) -> eyre::Result<()> {
+    tx.delete::<ChunkPathHashesByOffset>(offset, None)?;
+    Ok(())
 }
 
 /// get DataRootInfos for the `data_root`
@@ -523,6 +542,54 @@ mod tests {
 
         let gap = db.view_eyre(|tx| first_missing_path_hash_offset_in_tx(tx, o(5), o(10)))?;
         assert_eq!(gap, Some(o(8)), "must not treat padded entries() as dense");
+
+        Ok(())
+    }
+
+    /// Deleting a path-hash entry must make the offset look missing to both
+    /// a direct lookup and the gap scan — not present-with-`None` fields.
+    #[test]
+    fn del_path_hashes_by_offset_makes_offset_a_gap() -> eyre::Result<()> {
+        use super::{
+            ChunkPathHashes, del_path_hashes_by_offset, first_missing_path_hash_offset_in_tx,
+            get_path_hashes_by_offset, set_path_hashes_by_offset,
+        };
+        use crate::submodule::tables::SubmoduleTables;
+        use crate::{IrysDatabaseArgs as _, open_or_create_db};
+        use irys_testing_utils::utils::TempDirBuilder;
+        use irys_types::H256;
+        use reth_db::Database as _;
+        use reth_db::mdbx::DatabaseArguments;
+
+        let temp_dir = TempDirBuilder::new()
+            .prefix("path_hash_delete")
+            .with_tracing()
+            .build();
+        let db = open_or_create_db(
+            temp_dir,
+            SubmoduleTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+
+        let path_hashes = ChunkPathHashes {
+            data_path_hash: Some(H256::random()),
+            tx_path_hash: Some(H256::random()),
+        };
+        {
+            let tx = db.tx_mut()?;
+            for off in 0_u32..10 {
+                set_path_hashes_by_offset(&tx, o(off), path_hashes.clone())?;
+            }
+            tx.commit()?;
+        }
+
+        db.update_eyre(|tx| del_path_hashes_by_offset(tx, o(3)))?;
+
+        let entry = db.view_eyre(|tx| get_path_hashes_by_offset(tx, o(3)))?;
+        assert_eq!(entry, None);
+
+        let gap = db.view_eyre(|tx| first_missing_path_hash_offset_in_tx(tx, o(0), o(10)))?;
+        assert_eq!(gap, Some(o(3)));
 
         Ok(())
     }

--- a/crates/domain/src/models/storage_module.rs
+++ b/crates/domain/src/models/storage_module.rs
@@ -44,7 +44,7 @@ use irys_database::{
     submodule::{
         add_data_path_hash_to_offset_index, add_data_root_info, add_full_data_path,
         add_full_tx_path, add_tx_leaf_binding, add_tx_path_hash_to_offset_index,
-        clear_submodule_database, create_or_open_submodule_db,
+        clear_submodule_database, create_or_open_submodule_db, del_path_hashes_by_offset,
         first_missing_path_hash_offset_in_tx, get_data_path_by_offset,
         get_data_root_infos_for_data_root, get_full_data_path, get_full_tx_path,
         get_path_hashes_by_offset, get_tx_leaf_binding, get_tx_path_by_offset,
@@ -1085,8 +1085,7 @@ impl StorageModule {
             submodule.db.update_eyre(|tx| {
                 for offset in cursor..=slice_end {
                     let part_offset = PartitionChunkOffset::from(offset);
-                    add_tx_path_hash_to_offset_index(tx, part_offset, None)?;
-                    add_data_path_hash_to_offset_index(tx, part_offset, None)?;
+                    del_path_hashes_by_offset(tx, part_offset)?;
                 }
                 Ok(())
             })?;
@@ -2552,6 +2551,74 @@ mod tests {
             "only the canonical placement whose extent lies entirely outside [3, 5] \
              survives; the placement starting at offset 2 but extending into the \
              range is dropped by extent overlap"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn clear_offset_index_in_range_leaves_the_range_as_a_gap() -> eyre::Result<()> {
+        use irys_database::submodule::{set_path_hashes_by_offset, tables::ChunkPathHashes};
+
+        let infos = [StorageModuleInfo {
+            id: 0,
+            partition_assignment: Some(PartitionAssignment::default()),
+            submodules: vec![(partition_chunk_offset_ii!(0, 9), "hdd0-test".into())],
+        }];
+        let tmp_dir = TempDirBuilder::new()
+            .prefix("clear_offset_index_test")
+            .build();
+        let node_config = NodeConfig {
+            consensus: irys_types::ConsensusOptions::Custom(ConsensusConfig {
+                chunk_size: 32,
+                num_chunks_in_partition: 10,
+                ..ConsensusConfig::testing()
+            }),
+            base_directory: tmp_dir.path().to_path_buf(),
+            ..NodeConfig::testing()
+        };
+        let config = Config::new_with_random_peer_id(node_config);
+        let storage_module = StorageModule::new(&infos[0], &config)?;
+
+        // Index a dense range [0, 9].
+        let path_hashes = ChunkPathHashes {
+            data_path_hash: Some(H256::random()),
+            tx_path_hash: Some(H256::random()),
+        };
+        let (_, submodule) =
+            storage_module.get_submodule_for_offset(PartitionChunkOffset::from(0))?;
+        submodule.db.update_eyre(|tx| {
+            for offset in 0..10_u32 {
+                set_path_hashes_by_offset(
+                    tx,
+                    PartitionChunkOffset::from(offset),
+                    path_hashes.clone(),
+                )?;
+            }
+            Ok(())
+        })?;
+
+        // Before clearing, the range is fully indexed.
+        assert_eq!(
+            storage_module.first_missing_path_hash_offset(
+                PartitionChunkOffset::from(0),
+                PartitionChunkOffset::from(10)
+            )?,
+            None
+        );
+
+        storage_module.clear_offset_index_in_range(
+            PartitionChunkOffset::from(3),
+            PartitionChunkOffset::from(5),
+        )?;
+
+        // The cleared range must be reported as missing, not present-with-None.
+        assert_eq!(
+            storage_module.first_missing_path_hash_offset(
+                PartitionChunkOffset::from(0),
+                PartitionChunkOffset::from(10)
+            )?,
+            Some(PartitionChunkOffset::from(3))
         );
 
         Ok(())


### PR DESCRIPTION
Follow-up hardening on top of #1531 (startup index heal + data-sync reconnect). Review-driven; node-local index-repair + data-sync liveness only — no consensus/validation/EVM path touched.

## What & why
- **Delete path-hash keys on clear** instead of writing `{None,None}` placeholders. A reorg-recovery clear used to leave empty-but-present entries, so the gap scan saw "no gap," heal never repaired the range, and data-sync retried→failed→re-blocked forever. Now cleared ranges are real gaps and get re-indexed.
- **Per-module, verified unblock.** Replaced the global all-or-nothing / trust-migrate-returned-OK gate with a per-SM post-migration re-verify against the plan-time range snapshot: only modules whose gap actually closed unblock. Fixes one broken module stalling all others, and false "success" when a reorg made the migration a no-op.
- **Steady backlog drain.** Re-arm blocked offsets on a ~1s cadence (decoupled from the 250ms dispatch loop, so fetch throughput is unaffected), and stop re-arming a module the instant a write shows its index regressed.
- **Fail safe / clean shutdown.** Startup heal soft-skips missing block/tx data (was a panic) + emits an unrepaired-index metric; startup and epoch backfill bail promptly on shutdown.
- Housekeeping: checked numeric conversions, deterministic unblock order, comment cleanup.

## Tests
delete-on-clear gap visibility, density fast-path, per-module unblock filtering, backlog-drains-across-ticks, reblock-clears-flag, and an end-to-end two-module test (healthy SM unblocks, gapped SM stays blocked). `nextest -p irys-actors -p irys-database -p irys-domain`: 817 passing.

## Deferred (follow-ups)
- Legacy `{None,None}` path-hash tombstone scrub for disks corrupted before this fix (key-presence scan can't see them; pre-dates this work).
- Softer re-arm-freeze policy (N re-blocks before freezing a module's drain).
- O(1) skip so the re-arm timer doesn't scan modules with nothing blocked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved storage index healing so only verified, gap-free storage modules are reactivated.
  - Prevented incomplete or stale path-hash entries from being treated as valid data.
  - Ensured missing data is re-queued deterministically and continues processing across multiple synchronization cycles.
  - Added safer handling for shutdowns and unavailable ledger boundaries during lengthy healing operations.

- **Monitoring**
  - Added metrics for index-healing issues and improved reporting of synchronization activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->