### PR TITLE
fix(data-sync): look up storage modules by id, drop redundant request fields

### DIFF
--- a/crates/actors/src/data_sync_service.rs
+++ b/crates/actors/src/data_sync_service.rs
@@ -92,6 +92,20 @@ pub struct DataSyncService {
 
 type StorageModuleId = usize;
 
+/// Resolve a storage module by its stable `id` field.
+///
+/// The `storage_modules` vec is **not** ordered by id — modules are inserted in
+/// ledger-assignment processing order (Publish → Submit → OneYear → ThirtyDay →
+/// Capacity). Using `vec.get(id)` therefore returns the wrong module whenever
+/// `id != vec_index` (common for term-ledger SMs whose directory indices are
+/// higher than their insertion rank). Always look up by `StorageModule::id`.
+fn storage_module_by_id(
+    storage_modules: &[Arc<StorageModule>],
+    id: StorageModuleId,
+) -> Option<Arc<StorageModule>> {
+    storage_modules.iter().find(|sm| sm.id == id).cloned()
+}
+
 pub struct DataSyncServiceInner {
     pub block_tree: BlockTreeReadGuard,
     pub storage_modules: Arc<RwLock<Vec<Arc<StorageModule>>>>,
@@ -361,13 +375,8 @@ impl DataSyncServiceInner {
             consensus.chain_id,
         );
 
-        let sm = self
-            .storage_modules
-            .read()
-            .unwrap()
-            .get(storage_module_id)
-            .ok_or_else(|| eyre::eyre!("storage_module_id {storage_module_id} not found"))?
-            .clone();
+        let sm = storage_module_by_id(&self.storage_modules.read().unwrap(), storage_module_id)
+            .ok_or_else(|| eyre::eyre!("storage_module_id {storage_module_id} not found"))?;
 
         let pa = sm.partition_assignment();
         let ledger_id = pa.and_then(|p| p.ledger_id);
@@ -633,8 +642,7 @@ impl DataSyncServiceInner {
 
         // Drop orchestrators for modules that no longer hold a data ledger assignment
         self.chunk_orchestrators.retain(|sm_id, _| {
-            storage_modules
-                .get(*sm_id)
+            storage_module_by_id(&storage_modules, *sm_id)
                 .and_then(|sm| sm.partition_assignment())
                 .and_then(|pa| pa.ledger_id)
                 .is_some()
@@ -686,11 +694,47 @@ impl DataSyncServiceInner {
         let mut peer_updates: Vec<(StorageModuleId, Vec<IrysAddress>)> = Vec::new();
 
         for sm_id in sm_ids {
-            let Some(storage_module) = storage_modules.get(sm_id) else {
+            let Some(storage_module) = storage_module_by_id(&storage_modules, sm_id) else {
                 continue;
             };
 
-            let best_peers = self.get_best_available_peers(storage_module, 4);
+            let best_peers = self.get_best_available_peers(&storage_module, 4);
+
+            // data_sync_probe: a data-assigned SM with entropy still to sync but
+            // zero selectable peers. `matching_assignments` distinguishes "no
+            // peer advertises this ledger/slot" (=0, peer-side gap) from "peers
+            // advertise it but selection failed" (>0, local lookup/selection bug).
+            if best_peers.is_empty()
+                && let Some(pa) = storage_module.partition_assignment()
+                && let Some(ledger_id) = pa.ledger_id
+                && let Some((max_offset, _)) = self
+                    .chunk_orchestrators
+                    .get(&sm_id)
+                    .and_then(ChunkOrchestrator::get_max_chunk_offset)
+                && storage_module
+                    .get_intervals(ChunkType::Entropy)
+                    .iter()
+                    .any(|iv| *iv.start() <= *max_offset)
+            {
+                let managers = self.active_peer_bandwidth_managers.read().unwrap();
+                let matching = managers
+                    .values()
+                    .filter(|m| {
+                        m.partition_assignments.iter().any(|a| {
+                            a.ledger_id == Some(ledger_id) && a.slot_index == pa.slot_index
+                        })
+                    })
+                    .count();
+                debug!(
+                    "data_sync_probe empty_peers sm_id={} ledger={:?} slot={:?} managers={} matching_assignments={}",
+                    sm_id,
+                    pa.ledger_id,
+                    pa.slot_index,
+                    managers.len(),
+                    matching
+                );
+            }
+
             peer_updates.push((sm_id, best_peers));
         }
 
@@ -887,6 +931,79 @@ impl DataSyncService {
 
         tracing::info!("shutting down DataSync Service gracefully");
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod storage_module_lookup_tests {
+    use super::storage_module_by_id;
+    use irys_domain::{StorageModule, StorageModuleInfo};
+    use irys_testing_utils::TempDirBuilder;
+    use irys_types::{
+        Config, ConsensusConfig, DataLedger, H256, IrysAddress, NodeConfig, PartitionChunkOffset,
+        partition::PartitionAssignment, partition_chunk_offset_ie,
+    };
+    use std::sync::Arc;
+
+    fn test_sm(id: usize, ledger: Option<u32>, base: &std::path::Path) -> Arc<StorageModule> {
+        let node_config = NodeConfig {
+            consensus: irys_types::ConsensusOptions::Custom(ConsensusConfig {
+                chunk_size: 32,
+                num_chunks_in_partition: 4,
+                num_chunks_in_recall_range: 2,
+                num_partitions_per_slot: 1,
+                entropy_packing_iterations: 1,
+                chain_id: 1,
+                ..ConsensusConfig::testing()
+            }),
+            base_directory: base.join(format!("sm-{id}")),
+            ..NodeConfig::testing()
+        };
+        let config = Config::new_with_random_peer_id(node_config);
+        let pa = ledger.map(|ledger_id| PartitionAssignment {
+            ledger_id: Some(ledger_id),
+            slot_index: Some(0),
+            miner_address: IrysAddress::from([1_u8; 20]),
+            partition_hash: H256::random(),
+        });
+        let info = StorageModuleInfo {
+            id,
+            partition_assignment: pa,
+            submodules: vec![(partition_chunk_offset_ie!(0, 4), "chunks".into())],
+        };
+        Arc::new(StorageModule::new(&info, &config).expect("storage module"))
+    }
+
+    /// Regression: module vec is ledger-order, not id-order. Lookup must use
+    /// `StorageModule::id`, not the vec index — otherwise term-ledger SMs
+    /// (high directory ids, mid insertion rank) get empty data-sync peers.
+    #[test]
+    fn storage_module_by_id_ignores_vec_index() {
+        let tmp = TempDirBuilder::new().with_tracing().build();
+        // Mimic map_storage_modules_to_partition_assignments order:
+        // Publish(id=0), Submit(id=1), OneYear(id=7), ThirtyDay(id=6).
+        let modules = vec![
+            test_sm(0, Some(DataLedger::Publish.into()), tmp.path()),
+            test_sm(1, Some(DataLedger::Submit.into()), tmp.path()),
+            test_sm(7, Some(DataLedger::OneYear.into()), tmp.path()),
+            test_sm(6, Some(DataLedger::ThirtyDay.into()), tmp.path()),
+        ];
+
+        assert_eq!(storage_module_by_id(&modules, 0).unwrap().id, 0);
+        assert_eq!(storage_module_by_id(&modules, 1).unwrap().id, 1);
+        assert_eq!(storage_module_by_id(&modules, 7).unwrap().id, 7);
+        assert_eq!(storage_module_by_id(&modules, 6).unwrap().id, 6);
+        // Vec-index 2 is OneYear (id=7) — must NOT be returned for id=2.
+        assert!(storage_module_by_id(&modules, 2).is_none());
+        // Old bug: modules.get(7) would be None (len=4); by-id finds id=7 at index 2.
+        assert_eq!(
+            storage_module_by_id(&modules, 7)
+                .unwrap()
+                .partition_assignment()
+                .unwrap()
+                .ledger_id,
+            Some(DataLedger::OneYear.into())
+        );
     }
 }
 

--- a/crates/actors/src/data_sync_service/chunk_orchestrator/mod.rs
+++ b/crates/actors/src/data_sync_service/chunk_orchestrator/mod.rs
@@ -16,6 +16,12 @@ use std::{
 };
 use tracing::{Instrument as _, debug, warn};
 
+/// `data_sync_probe` diagnostics only fire for chunk offsets below this
+/// threshold. Residual sync stalls manifest as low-offset Entropy holes left
+/// behind while the packing tail (high offsets) is still legitimately Entropy —
+/// gating on low offsets keeps the probes quiet on healthy modules.
+const LOW_OFFSET_PROBE_THRESHOLD: u32 = 20_000;
+
 /// Why a chunk offset is blocked from the hot re-fetch loop.
 ///
 /// These are local progress blockers (not peer-delivery failures). Peers may
@@ -59,10 +65,11 @@ pub enum ChunkRequestState {
 }
 
 type ExcludedPeerAddresses = HashSet<IrysAddress>;
+/// Per-offset sync request. Ledger context lives on the parent
+/// [`ChunkOrchestrator`] (`self.ledger_id`); one orchestrator is one SM
+/// assignment, so it is not duplicated per request.
 #[derive(Debug)]
 pub struct ChunkRequest {
-    pub ledger_id: usize,
-    pub slot_index: usize,
     pub chunk_offset: PartitionChunkOffset,
     pub excluded: Option<ExcludedPeerAddresses>,
     pub request_state: ChunkRequestState,
@@ -85,7 +92,6 @@ pub struct ChunkOrchestrator {
     // Shared reference to peer bandwidth managers maintained by DataSyncService
     active_sync_peers: Arc<RwLock<HashMap<IrysAddress, PeerBandwidthManager>>>,
     service_senders: ServiceSenders,
-    slot_index: usize,
     ledger_id: u32,
     chunk_fetcher: Arc<dyn ChunkFetcher>,
     config: NodeConfig,
@@ -101,17 +107,11 @@ impl ChunkOrchestrator {
         config: NodeConfig,
         runtime_handle: tokio::runtime::Handle,
     ) -> Self {
-        let slot_index = storage_module
-            .partition_assignment()
-            .expect("storage_module should have a partition assignment")
-            .slot_index
-            .expect("storage_module should be assigned to a ledger slot");
-
         let ledger_id = storage_module
             .partition_assignment()
-            .unwrap()
+            .expect("storage_module should have a partition assignment")
             .ledger_id
-            .unwrap();
+            .expect("storage_module should be assigned to a data ledger");
 
         Self {
             storage_module,
@@ -122,7 +122,6 @@ impl ChunkOrchestrator {
             active_sync_peers: sync_peers,
             service_senders: service_senders.clone(),
             ledger_id,
-            slot_index,
             chunk_fetcher, // Store the chunk fetcher
             config,
             runtime_handle,
@@ -191,11 +190,41 @@ impl ChunkOrchestrator {
         let max_requests = self.config.data_sync.max_pending_chunk_requests as usize;
         let mut requests_to_add = max_requests.saturating_sub(pending_count);
 
+        let entropy_intervals = self.storage_module.get_intervals(ChunkType::Entropy);
+
+        // data_sync_probe: make empty-peer / residual-hole stalls diagnosable
+        // from DEBUG logs. Only fires when there is low-offset entropy (a hole
+        // below the packing tail) or pending/in-flight work, so healthy modules
+        // whose entropy is all packing tail stay silent on the 250ms tick.
+        let requested = self
+            .chunk_requests
+            .values()
+            .filter(|r| matches!(r.request_state, ChunkRequestState::Requested(..)))
+            .count();
+        let low_entropy: Vec<String> = entropy_intervals
+            .iter()
+            .filter(|iv| *iv.start() < LOW_OFFSET_PROBE_THRESHOLD)
+            .take(4)
+            .map(|iv| format!("{}-{}", *iv.start(), *iv.end()))
+            .collect();
+        if !low_entropy.is_empty() || pending_count > 0 || requested > 0 {
+            debug!(
+                "data_sync_probe ledger={:?} slot={:?} max={} pending={} requested={} peers={} to_add={} low_entropy={:?} map_size={}",
+                pa.ledger_id,
+                pa.slot_index,
+                *max_chunk_offset,
+                pending_count,
+                requested,
+                self.current_peers.len(),
+                requests_to_add,
+                low_entropy,
+                self.chunk_requests.len()
+            );
+        }
+
         if requests_to_add == 0 {
             return;
         }
-
-        let entropy_intervals = self.storage_module.get_intervals(ChunkType::Entropy);
 
         for interval in entropy_intervals {
             for interval_step in *interval.start()..=*interval.end() {
@@ -209,12 +238,17 @@ impl ChunkOrchestrator {
                 if let hash_map::Entry::Vacant(entry) = self.chunk_requests.entry(chunk_offset) {
                     // Only executes when the entry in the hashmap is vacant
                     entry.insert(ChunkRequest {
-                        ledger_id: self.storage_module.id,
-                        slot_index: self.slot_index,
                         chunk_offset,
                         excluded: None, // First time chunk requests don't have past failed peer addresses
                         request_state: ChunkRequestState::Pending,
                     });
+
+                    if *chunk_offset < LOW_OFFSET_PROBE_THRESHOLD {
+                        debug!(
+                            "data_sync_probe enqueued offset={} ledger={:?} slot={:?}",
+                            *chunk_offset, pa.ledger_id, pa.slot_index
+                        );
+                    }
 
                     requests_to_add -= 1;
                     if requests_to_add == 0 {
@@ -256,6 +290,14 @@ impl ChunkOrchestrator {
             };
             let Some(peer_address) = self.find_best_peer(chunk_request.excluded.as_ref()) else {
                 // No available peers to request from? skip this offset (can happen)
+                if *chunk_offset < LOW_OFFSET_PROBE_THRESHOLD {
+                    debug!(
+                        "data_sync_probe no_peer offset={} peers={} excluded={:?}",
+                        *chunk_offset,
+                        self.current_peers.len(),
+                        chunk_request.excluded.as_ref().map(HashSet::len)
+                    );
+                }
                 continue;
             };
 

--- a/crates/actors/src/data_sync_service/chunk_orchestrator/tests.rs
+++ b/crates/actors/src/data_sync_service/chunk_orchestrator/tests.rs
@@ -66,8 +66,6 @@ fn insert_requested(orch: &mut ChunkOrchestrator, offset: PartitionChunkOffset, 
     orch.chunk_requests.insert(
         offset,
         ChunkRequest {
-            ledger_id: 0,
-            slot_index: 0,
             chunk_offset: offset,
             excluded: None,
             request_state: ChunkRequestState::Requested(peer, Instant::now()),
@@ -97,8 +95,6 @@ async fn mark_helpers_require_requested_state() {
     orch.chunk_requests.insert(
         offset,
         ChunkRequest {
-            ledger_id: 0,
-            slot_index: 0,
             chunk_offset: offset,
             excluded: None,
             request_state: ChunkRequestState::Pending,
@@ -237,8 +233,6 @@ async fn blocked_excluded_from_pending_budget_and_dispatch_selection() {
     orch.chunk_requests.insert(
         offset3,
         ChunkRequest {
-            ledger_id: 0,
-            slot_index: 0,
             chunk_offset: offset3,
             excluded: None,
             request_state: ChunkRequestState::Pending,
@@ -278,8 +272,6 @@ async fn unblock_missing_data_root_index_requeues_only_that_reason() {
     orch.chunk_requests.insert(
         pending,
         ChunkRequest {
-            ledger_id: 0,
-            slot_index: 0,
             chunk_offset: pending,
             excluded: None,
             request_state: ChunkRequestState::Pending,


### PR DESCRIPTION
## Summary

Fixes data-sync bugs/traps where **storage-module directory id** (`sm-N`) was confused with **vec index** or **ledger id**. That coincidence holds for Publish/Submit (`0`/`1`) and breaks for term ledgers (OneYear=10, ThirtyDay=20) and high sm directory indices.

### 1. Look up storage modules by `StorageModule::id` (bugfix)

`storage_modules` is ordered by ledger-assignment processing (Publish → Submit → OneYear → ThirtyDay → Capacity), **not** by directory id. Call sites used `vec.get(storage_module_id)` as if the id were a vec index.

That mis-resolved term-ledger SMs (wrong module, empty peer selection, wrong write target).

**Change:** `storage_module_by_id()` finds by `sm.id` for chunk completion, orchestrator retain, and peer refresh.

**Test:** `storage_module_by_id_ignores_vec_index` — vec order `[id=0,1,7,6]` must not treat index 2 as id 2.

### 2. Remove redundant `ChunkRequest` ledger/slot fields

`ChunkRequest` carried `ledger_id` / `slot_index` that:

- were **never read** for control flow (handlers use `chunk_offset` + the orchestrator’s own fields)
- were historically filled from **`storage_module.id`** into a field named `ledger_id` (wrong ID space; same Publish/Submit coincidence)
- only added lying `Debug` output for term-ledger SMs

**Change:** drop both fields from `ChunkRequest`. Ledger context stays on `ChunkOrchestrator::ledger_id` only. Also drop unused orchestrator `slot_index` (never read after removing the per-request copies).

### 3. `data_sync_probe` DEBUG diagnostics

Optional DEBUG logs for residual stalls (gated so healthy packing-tail entropy stays quiet):

- low-offset entropy / pending / requested snapshot each tick when relevant
- enqueue of low offsets
- no peer available for a low offset
- data-assigned SM with entropy to sync but zero selectable peers, plus `matching_assignments` count (0 = peers don’t advertise ledger/slot; &gt;0 = selection bug)

## Test plan

- [x] `storage_module_by_id_ignores_vec_index`
- [x] chunk_orchestrator unit tests
- [x] `cargo clippy -p irys-actors --tests --all-targets -- -D warnings`
- [ ] CI