### PR TITLE
feat(storage): resolve data_root + tx_offset for residual Entropy holes

### DIFF
--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -1972,8 +1972,9 @@ impl IrysNode {
             shutdown_token.clone(),
         );
 
-        // set up chunk provider
-        let chunk_provider = Self::init_chunk_provider(&config, storage_modules_guard.clone());
+        // set up chunk provider (main irys_db powers cache-backed data_root GETs)
+        let chunk_provider =
+            Self::init_chunk_provider(&config, storage_modules_guard.clone(), irys_db.clone());
 
         // set up sync service
         let (sync_service_facade, sync_service_handle) = Self::init_sync_service(
@@ -2187,8 +2188,9 @@ impl IrysNode {
     fn init_chunk_provider(
         config: &Config,
         storage_modules_guard: StorageModulesReadGuard,
+        irys_db: DatabaseProvider,
     ) -> Arc<ChunkProvider> {
-        let chunk_provider = ChunkProvider::new(config.clone(), storage_modules_guard);
+        let chunk_provider = ChunkProvider::new(config.clone(), storage_modules_guard, irys_db);
 
         Arc::new(chunk_provider)
     }

--- a/crates/domain/src/models/chunk_provider.rs
+++ b/crates/domain/src/models/chunk_provider.rs
@@ -1,7 +1,9 @@
 use eyre::OptionExt as _;
+use irys_database::db::IrysDatabaseExt as _;
+use irys_database::{cached_chunk_by_chunk_offset, cached_data_root_by_data_root};
 use irys_types::{
     ChunkFormat, Config, DataLedger, DataRoot, LedgerChunkOffset, PackedChunk, TxChunkOffset,
-    UnpackedChunk,
+    UnpackedChunk, app_state::DatabaseProvider,
 };
 use tracing::debug;
 
@@ -12,14 +14,23 @@ use crate::{StorageModulesReadGuard, checked_add_i32_u64, get_storage_module_at_
 pub struct ChunkProvider {
     /// Collection of storage modules for distributing chunk data
     pub storage_modules_guard: StorageModulesReadGuard,
+    /// Main node DB — used for cache-backed data_root fetches when no local SM
+    /// has the body (upload/API / proof-generator nodes often lack a ledger
+    /// assignment but still hold `CachedChunks` long enough to serve peers).
+    pub db: DatabaseProvider,
     pub config: Config,
 }
 
 impl ChunkProvider {
-    pub fn new(config: Config, storage_modules_guard: StorageModulesReadGuard) -> Self {
+    pub fn new(
+        config: Config,
+        storage_modules_guard: StorageModulesReadGuard,
+        db: DatabaseProvider,
+    ) -> Self {
         Self {
             config,
             storage_modules_guard,
+            db,
         }
     }
 
@@ -56,15 +67,25 @@ impl ChunkProvider {
         )))
     }
 
-    /// Retrieves a chunk by [`DataRoot`]
+    /// Retrieves a chunk by [`DataRoot`] + tx-relative offset.
+    ///
+    /// Lookup order:
+    /// 1. Local storage modules assigned to `ledger` (returns packed when present).
+    /// 2. Node chunk cache (`CachedChunks`) — allows non-assignees (upload targets /
+    ///    ingress-proof generators) to serve bodies that never landed in an SM.
+    ///
+    /// Cache hits are returned as [`ChunkFormat::Unpacked`]. Callers that need
+    /// packed form (or that accept either) should handle both variants — e.g.
+    /// block validation already does.
+    ///
+    /// Note: ingress-proof gossip is not chunk replication. Cache-backed serve is
+    /// best-effort; pruned cache entries yield `Ok(None)` the same as a missing SM.
     pub fn get_chunk_by_data_root(
         &self,
         ledger: DataLedger,
         data_root: DataRoot,
         data_tx_offset: TxChunkOffset,
     ) -> eyre::Result<Option<ChunkFormat>> {
-        // TODO: read from the cache
-
         debug!(
             "getting ledger: {:?}, data_root: {}, offset: {}",
             &ledger, &data_root, &data_tx_offset
@@ -100,8 +121,50 @@ impl ChunkProvider {
                 }
             }
         }
+        drop(binding);
 
-        Ok(None)
+        // Fall back to the node chunk cache. Non-assignees often never have an SM
+        // for this ledger/slot, but may still hold the body after POST /chunk
+        // (long enough to generate an ingress proof and to serve residual holes).
+        self.get_chunk_from_cache(data_root, data_tx_offset)
+    }
+
+    /// Reads an unpacked chunk body from `CachedChunks` / `CachedDataRoots`.
+    ///
+    /// Returns `Ok(None)` when the data_root metadata is missing, the offset is
+    /// not indexed, or the body was pruned (`chunk: None`).
+    fn get_chunk_from_cache(
+        &self,
+        data_root: DataRoot,
+        data_tx_offset: TxChunkOffset,
+    ) -> eyre::Result<Option<ChunkFormat>> {
+        self.db.view_eyre(|tx| {
+            let Some(cdr) = cached_data_root_by_data_root(tx, data_root)? else {
+                return Ok(None);
+            };
+            let Some((_meta, cached)) =
+                cached_chunk_by_chunk_offset(tx, data_root, data_tx_offset)?
+            else {
+                return Ok(None);
+            };
+            // Index-only rows (body pruned / stored only in a partition) cannot be served.
+            let Some(bytes) = cached.chunk else {
+                debug!(
+                    data_root = %data_root,
+                    tx_offset = %data_tx_offset,
+                    "cache index hit but chunk body missing; cannot serve data_root fetch"
+                );
+                return Ok(None);
+            };
+
+            Ok(Some(ChunkFormat::Unpacked(UnpackedChunk {
+                data_root,
+                data_size: cdr.data_size,
+                data_path: cached.data_path,
+                bytes,
+                tx_offset: data_tx_offset,
+            })))
+        })
     }
 
     pub fn get_ledger_offsets_for_data_root(
@@ -154,6 +217,7 @@ mod tests {
     use crate::{StorageModule, StorageModuleInfo};
 
     use super::*;
+    use irys_database::{cache_chunk, cache_data_root};
     use irys_packing::unpack_with_entropy;
     use irys_testing_utils::utils::TempDirBuilder;
     use irys_types::{
@@ -249,7 +313,10 @@ mod tests {
         let storage_modules_guard =
             StorageModulesReadGuard::new(Arc::new(RwLock::new(vec![Arc::new(storage_module)])));
 
-        let chunk_provider = ChunkProvider::new(config.clone(), storage_modules_guard);
+        // Empty main DB is fine: SM path still serves packed chunks.
+        let db_path = tmp_dir.path().join("irys_db");
+        let db = create_test_db(&db_path);
+        let chunk_provider = ChunkProvider::new(config.clone(), storage_modules_guard, db);
 
         for original_chunk in unpacked_chunks {
             let chunk = chunk_provider
@@ -273,5 +340,108 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    /// Non-assignee / no-SM case: body only in the node chunk cache must still
+    /// be served via data_root + tx_offset (enables residual-hole heal from
+    /// ingress-proof generators that never held a ledger assignment).
+    #[test]
+    fn get_by_data_root_serves_from_chunk_cache_without_sm() -> eyre::Result<()> {
+        let tmp_dir = TempDirBuilder::new()
+            .prefix("get_by_data_root_cache_test")
+            .with_tracing()
+            .build();
+        let node_config = NodeConfig {
+            consensus: irys_types::ConsensusOptions::Custom(ConsensusConfig {
+                chunk_size: 32,
+                num_chunks_in_partition: 100,
+                ..ConsensusConfig::testing()
+            }),
+            base_directory: tmp_dir.path().to_path_buf(),
+            ..NodeConfig::testing()
+        };
+        let config = Config::new_with_random_peer_id(node_config);
+
+        let data_size = (config.consensus.chunk_size as f64 * 2.5).round() as usize;
+        let mut data_bytes = vec![0_u8; data_size];
+        rand::thread_rng().fill(&mut data_bytes[..]);
+
+        let irys = IrysSigner::random_signer(&config.consensus);
+        let tx = irys
+            .create_transaction(data_bytes.clone(), H256::zero())
+            .unwrap();
+        let tx = irys.sign_transaction(tx).unwrap();
+        let data_root = tx.header.data_root;
+
+        let db = create_test_db(&tmp_dir.path().join("irys_db"));
+        db.update_eyre(|wtx| {
+            cache_data_root(wtx, &tx.header, None)?;
+            for (tx_chunk_offset, chunk_node) in tx.chunks.iter().enumerate() {
+                let min = chunk_node.min_byte_range;
+                let max = chunk_node.max_byte_range;
+                let chunk = UnpackedChunk {
+                    data_root,
+                    data_size: data_size as u64,
+                    data_path: Base64(tx.proofs[tx_chunk_offset].proof.clone()),
+                    bytes: Base64(data_bytes[min..max].to_vec()),
+                    tx_offset: TxChunkOffset::from(
+                        TryInto::<u32>::try_into(tx_chunk_offset).expect("Value exceeds u32::MAX"),
+                    ),
+                };
+                cache_chunk(wtx, &chunk)?;
+            }
+            Ok(())
+        })?;
+
+        // No storage modules: simulates an upload/API node that is not assigned
+        // to the Submit slot but still holds cache after POST /chunk.
+        let storage_modules_guard = StorageModulesReadGuard::new(Arc::new(RwLock::new(Vec::new())));
+        let chunk_provider = ChunkProvider::new(config, storage_modules_guard, db);
+
+        for (tx_chunk_offset, chunk_node) in tx.chunks.iter().enumerate() {
+            let offset = TxChunkOffset::from(
+                TryInto::<u32>::try_into(tx_chunk_offset).expect("Value exceeds u32::MAX"),
+            );
+            let min = chunk_node.min_byte_range;
+            let max = chunk_node.max_byte_range;
+            let expected = UnpackedChunk {
+                data_root,
+                data_size: data_size as u64,
+                data_path: Base64(tx.proofs[tx_chunk_offset].proof.clone()),
+                bytes: Base64(data_bytes[min..max].to_vec()),
+                tx_offset: offset,
+            };
+
+            let served = chunk_provider
+                .get_chunk_by_data_root(DataLedger::Submit, data_root, offset)?
+                .expect("cache-backed data_root fetch should find body");
+            let unpacked = served
+                .as_unpacked()
+                .expect("cache path returns ChunkFormat::Unpacked");
+            assert_eq!(unpacked, expected);
+        }
+
+        // Missing offset → None (not an error)
+        let missing = TxChunkOffset::from(99_u32);
+        assert!(
+            chunk_provider
+                .get_chunk_by_data_root(DataLedger::Submit, data_root, missing)?
+                .is_none()
+        );
+
+        Ok(())
+    }
+
+    fn create_test_db(path: &std::path::Path) -> DatabaseProvider {
+        use irys_database::{IrysDatabaseArgs as _, open_or_create_db, tables::IrysTables};
+        use reth_db::mdbx::DatabaseArguments;
+
+        let db = open_or_create_db(
+            path,
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing().unwrap(),
+        )
+        .unwrap();
+        DatabaseProvider(Arc::new(db))
     }
 }

--- a/crates/domain/src/models/storage_module.rs
+++ b/crates/domain/src/models/storage_module.rs
@@ -1569,6 +1569,74 @@ impl StorageModule {
         })
     }
 
+    /// Resolves `(data_root, tx_offset)` for a partition offset from the SM index alone.
+    ///
+    /// Unlike [`Self::get_chunk_metadata`] / [`Self::generate_full_chunk`], this does **not**
+    /// require a written chunk body (`data_path_hash` may be missing). That is the residual
+    /// Entropy-hole case after tx migration: `tx_path` + `DataRootInfos` present, body never
+    /// written. data_sync uses this to address proof-signer peers with
+    /// `GET /chunk/data-root/{ledger}/{data_root}/{tx_offset}` instead of ledger-offset.
+    ///
+    /// `tx_offset` is derived as `partition_offset - DataRootInfo.start_offset` for the
+    /// placement that covers this offset (validated against `data_size`).
+    ///
+    /// Returns `Ok(None)` when no tx_path is indexed, no covering `DataRootInfo` exists, or
+    /// the offset falls outside the funded extent.
+    pub fn data_root_and_tx_offset_at(
+        &self,
+        partition_offset: PartitionChunkOffset,
+    ) -> eyre::Result<Option<(DataRoot, TxChunkOffset)>> {
+        let chunk_size = self.config.consensus.chunk_size;
+        self.query_submodule_db_by_offset(partition_offset, |tx| {
+            // data_path_hash may be None — that is the residual-hole case we support.
+            let Some((data_root, _data_path_hash)) =
+                recover_tx_path_data_root(tx, partition_offset)?
+            else {
+                return Ok(None);
+            };
+
+            let Some(mut data_root_infos) = get_data_root_infos_for_data_root(tx, data_root)?
+            else {
+                return Ok(None);
+            };
+            if data_root_infos.0.is_empty() {
+                return Ok(None);
+            }
+
+            // Same placement selection as generate_full_chunk: last start_offset that is
+            // still ≤ partition_offset (handles multi-placement of the same data_root).
+            data_root_infos.0.sort_unstable();
+            let partition_rel = RelativeChunkOffset::from(partition_offset);
+            let index = data_root_infos
+                .0
+                .partition_point(|info| info.start_offset <= partition_rel)
+                .saturating_sub(1);
+            if index >= data_root_infos.0.len() {
+                return Ok(None);
+            }
+            let info = &data_root_infos.0[index];
+            if info.start_offset > partition_rel {
+                return Ok(None);
+            }
+
+            // partition_offset = start_offset + tx_offset (write path); invert it.
+            // start_offset can be negative when a multi-partition tx straddles modules.
+            let tx_offset_i32 = *partition_rel - *info.start_offset;
+            if tx_offset_i32 < 0 {
+                return Ok(None);
+            }
+            let tx_offset_u32 = tx_offset_i32 as u32;
+
+            // Funded extent: last valid byte is data_size - 1; reject offsets past it.
+            let chunk_byte_offset = u64::from(tx_offset_u32).saturating_mul(chunk_size);
+            if chunk_byte_offset >= info.data_size {
+                return Ok(None);
+            }
+
+            Ok(Some((data_root, TxChunkOffset::from(tx_offset_u32))))
+        })
+    }
+
     /// Gets the tx_path and data_path for a chunk using its ledger relative offset
     pub fn read_tx_data_path(
         &self,
@@ -2553,6 +2621,114 @@ mod tests {
             "only the canonical placement whose extent lies entirely outside [3, 5] \
              survives; the placement starting at offset 2 but extending into the \
              range is dropped by extent overlap"
+        );
+
+        Ok(())
+    }
+
+    /// Residual Entropy hole: tx migration wrote `tx_path` + `DataRootInfos` but
+    /// no chunk body / `data_path_hash`. `data_root_and_tx_offset_at` must still
+    /// resolve addressing for data_root-based fetch (proof-signer path).
+    #[test]
+    fn data_root_and_tx_offset_at_works_without_chunk_body() -> eyre::Result<()> {
+        let tmp_dir = TempDirBuilder::new()
+            .prefix("data_root_tx_offset_residual")
+            .with_tracing()
+            .build();
+        let chunk_size = 32_u64;
+        let node_config = NodeConfig {
+            consensus: irys_types::ConsensusOptions::Custom(ConsensusConfig {
+                chunk_size,
+                num_chunks_in_partition: 100,
+                ..ConsensusConfig::testing()
+            }),
+            base_directory: tmp_dir.path().to_path_buf(),
+            ..NodeConfig::testing()
+        };
+        let config = Config::new_with_random_peer_id(node_config);
+        let sm = StorageModule::new(
+            &StorageModuleInfo {
+                id: 0,
+                partition_assignment: Some(PartitionAssignment::default()),
+                submodules: vec![(partition_chunk_offset_ii!(0, 99), "hdd0".into())],
+            },
+            &config,
+        )?;
+        sm.pack_with_zeros();
+
+        // 3 chunks (2.5 * chunk_size rounded up)
+        let data_size = (chunk_size as f64 * 2.5).round() as usize;
+        let mut data_bytes = vec![0_u8; data_size];
+        for (i, b) in data_bytes.iter_mut().enumerate() {
+            *b = (i % 251) as u8;
+        }
+        let irys = IrysSigner::random_signer(&config.consensus);
+        let tx = irys
+            .create_transaction(data_bytes.clone(), H256::zero())
+            .unwrap();
+        let tx = irys.sign_transaction(tx).unwrap();
+        let data_root = tx.header.data_root;
+
+        // Place the tx at partition-relative start 10 → offsets 10, 11, 12.
+        let start = 10_u32;
+        let num_chunks = data_size.div_ceil(chunk_size as usize) as u32;
+        assert_eq!(num_chunks, 3);
+        let end = start + num_chunks - 1;
+        let (_tx_root, proofs) =
+            DataTransactionLedger::merklize_tx_root(std::slice::from_ref(&tx.header));
+        sm.index_transaction_data(
+            &tx.header,
+            &proofs[0].proof,
+            LedgerChunkRange(ledger_chunk_offset_ii!(start, end)),
+        )?;
+
+        // No write_data_chunk: every offset is a residual hole (Entropy, no data_path).
+        for tx_off in 0..num_chunks {
+            let part_off = PartitionChunkOffset::from(start + tx_off);
+            assert_eq!(
+                sm.get_chunk_type(&part_off),
+                Some(ChunkType::Entropy),
+                "offset {part_off} should still be Entropy (no body written)"
+            );
+            // get_chunk_metadata requires data_path — residual holes must return None.
+            assert!(
+                sm.get_chunk_metadata(part_off)?.is_none(),
+                "get_chunk_metadata needs data_path_hash; residual holes have none"
+            );
+
+            let resolved = sm
+                .data_root_and_tx_offset_at(part_off)?
+                .expect("residual hole must still resolve data_root + tx_offset");
+            assert_eq!(resolved.0, data_root);
+            assert_eq!(*resolved.1, tx_off);
+        }
+
+        // Write only the middle chunk body; outer residual holes still resolve.
+        let mid = 1_u32;
+        let min = tx.chunks[mid as usize].min_byte_range;
+        let max = tx.chunks[mid as usize].max_byte_range;
+        sm.write_data_chunk(&UnpackedChunk {
+            data_root,
+            data_size: data_size as u64,
+            data_path: Base64(tx.proofs[mid as usize].proof.clone()),
+            bytes: Base64(data_bytes[min..max].to_vec()),
+            tx_offset: TxChunkOffset::from(mid),
+        })?;
+        sm.sync_pending_chunks()?;
+
+        for tx_off in 0..num_chunks {
+            let part_off = PartitionChunkOffset::from(start + tx_off);
+            let resolved = sm
+                .data_root_and_tx_offset_at(part_off)?
+                .expect("resolution works with or without body");
+            assert_eq!(resolved.0, data_root);
+            assert_eq!(*resolved.1, tx_off);
+        }
+
+        // Unindexed offset → None
+        assert!(
+            sm.data_root_and_tx_offset_at(PartitionChunkOffset::from(50))?
+                .is_none()
         );
 
         Ok(())


### PR DESCRIPTION
## Summary

- Adds `StorageModule::data_root_and_tx_offset_at(partition_offset) → Option<(DataRoot, TxChunkOffset)>`
- Works when **only** tx migration is present (`tx_path` + `DataRootInfos`) and the chunk body / `data_path_hash` is still missing — the residual Entropy-hole case
- Derives `tx_offset = partition_offset - DataRootInfo.start_offset` for the covering placement (same placement selection as `generate_full_chunk`), validated against funded `data_size`
- Unlike `get_chunk_metadata` / `generate_full_chunk`, does **not** require a written body

This is **PR2** of residual-hole heal. Stacks on #1537 (cache-backed data_root GET).

## Why

data_sync will need to request residual holes from ingress-proof signers via:

```
GET /v1/chunk/data-root/{ledger}/{data_root}/{tx_offset}
```

Assignees know the partition offset of the hole but previously had no public API to recover `(data_root, tx_offset)` without a body. This helper closes that gap.

## Test plan

- [x] `cargo test -p irys-domain data_root_and_tx_offset_at` — residual holes (no body), partial body write, unindexed offset → None
- [x] `cargo clippy -p irys-domain --tests --all-targets -- -D warnings`
- [ ] PR3 will wire this into data_sync peer selection + dual fetch

## Stack

1. #1537 — cache-backed `GET /chunk/data-root` (base)
2. **this PR** — SM offset → `(data_root, tx_offset)`
3. PR3 — data_sync expands peers with proof signers + dual fetch