### PR TITLE
fix(chunk-ingress): recover chunks parked during TX/CDR race

### DIFF
--- a/crates/actors/src/chunk_ingress_service.rs
+++ b/crates/actors/src/chunk_ingress_service.rs
@@ -180,11 +180,9 @@ impl ChunkIngressServiceInner {
 
     /// Pop and re-ingress any chunks parked for `data_root`.
     ///
-    /// Called when a data TX header lands (`ProcessPendingChunks`) and also
-    /// from the pre-header park path after a post-park `CachedDataRoot`
-    /// re-check closes the race where this drain ran against an empty map
-    /// before the concurrent chunk finished parking.
-    pub(crate) async fn process_pending_chunks_for_root(&self, data_root: DataRoot) {
+    /// Invoked by the `ProcessPendingChunks` control-plane message (from TX
+    /// postprocess, and from post-park CDR re-check rescue).
+    async fn process_pending_chunks_for_root(&self, data_root: DataRoot) {
         let option_chunks_map = self.pending_chunks.write().await.pop(&data_root);
         if let Some(chunks_map) = option_chunks_map {
             let chunks: Vec<_> = chunks_map.into_iter().map(|(_, chunk)| chunk).collect();

--- a/crates/actors/src/chunk_ingress_service.rs
+++ b/crates/actors/src/chunk_ingress_service.rs
@@ -178,7 +178,13 @@ impl ChunkIngressServiceInner {
         }
     }
 
-    async fn process_pending_chunks_for_root(&self, data_root: DataRoot) {
+    /// Pop and re-ingress any chunks parked for `data_root`.
+    ///
+    /// Called when a data TX header lands (`ProcessPendingChunks`) and also
+    /// from the pre-header park path after a post-park `CachedDataRoot`
+    /// re-check closes the race where this drain ran against an empty map
+    /// before the concurrent chunk finished parking.
+    pub(crate) async fn process_pending_chunks_for_root(&self, data_root: DataRoot) {
         let option_chunks_map = self.pending_chunks.write().await.pop(&data_root);
         if let Some(chunks_map) = option_chunks_map {
             let chunks: Vec<_> = chunks_map.into_iter().map(|(_, chunk)| chunk).collect();

--- a/crates/actors/src/chunk_ingress_service/chunks.rs
+++ b/crates/actors/src/chunk_ingress_service/chunks.rs
@@ -133,11 +133,7 @@ impl ChunkIngressServiceInner {
     /// Direct re-entry into `process_pending_chunks_for_root` would recurse
     /// through this async ingress stack (`E0733`), so we always go via the
     /// control-plane channel.
-    async fn maybe_rescue_after_park(
-        &self,
-        data_root: DataRoot,
-        required_min_data_size: Option<u64>,
-    ) {
+    fn maybe_rescue_after_park(&self, data_root: DataRoot, required_min_data_size: Option<u64>) {
         let cdr_lookup = self
             .irys_db
             .view_eyre(|read_tx| irys_database::cached_data_root_by_data_root(read_tx, data_root))
@@ -359,7 +355,7 @@ impl ChunkIngressServiceInner {
 
                 // Close the TX/chunk gossip TOCTOU (see maybe_rescue_after_park).
                 // Any CDR is enough: the header that commits it owns this root.
-                self.maybe_rescue_after_park(data_root, None).await;
+                self.maybe_rescue_after_park(data_root, None);
                 return Ok(());
             }
         };
@@ -394,8 +390,7 @@ impl ChunkIngressServiceInner {
                     .put(Arc::unwrap_or_clone(chunk));
                 // Only re-drain if CDR grew enough to accept this claim;
                 // otherwise leave parked for the larger TX's ProcessPendingChunks.
-                self.maybe_rescue_after_park(data_root, Some(claimed_size))
-                    .await;
+                self.maybe_rescue_after_park(data_root, Some(claimed_size));
                 return Ok(());
             }
         }

--- a/crates/actors/src/chunk_ingress_service/chunks.rs
+++ b/crates/actors/src/chunk_ingress_service/chunks.rs
@@ -1,3 +1,4 @@
+use super::ChunkIngressMessage;
 use super::ChunkIngressServiceInner;
 use super::ingress_proofs::generate_and_store_ingress_proof;
 use super::metrics::{
@@ -259,23 +260,65 @@ impl ChunkIngressServiceInner {
                 // Acquire a single write lock so the count check and the insert are
                 // atomic with respect to concurrent ingress calls, eliminating the
                 // TOCTOU race that could allow the per-item cap to be exceeded.
-                let mut pending_chunks_guard = self.pending_chunks.write().await;
-                let current_chunk_count = pending_chunks_guard
-                    .get(&chunk.data_root)
-                    .map(lru::LruCache::len)
-                    .unwrap_or(0);
-                if current_chunk_count >= preheader_chunks_per_item {
-                    warn!(
-                        "Dropping pre-header chunk for {} at offset {}: cache full ({}/{})",
-                        &chunk.data_root,
-                        &chunk.tx_offset,
-                        current_chunk_count,
-                        preheader_chunks_per_item
-                    );
-                    return Err(AdvisoryChunkIngressError::PreHeaderOffsetExceedsCap.into());
+                let data_root = chunk.data_root;
+                let tx_offset = chunk.tx_offset;
+                {
+                    let mut pending_chunks_guard = self.pending_chunks.write().await;
+                    let current_chunk_count = pending_chunks_guard
+                        .get(&data_root)
+                        .map(lru::LruCache::len)
+                        .unwrap_or(0);
+                    if current_chunk_count >= preheader_chunks_per_item {
+                        warn!(
+                            "Dropping pre-header chunk for {} at offset {}: cache full ({}/{})",
+                            &data_root,
+                            &tx_offset,
+                            current_chunk_count,
+                            preheader_chunks_per_item
+                        );
+                        return Err(AdvisoryChunkIngressError::PreHeaderOffsetExceedsCap.into());
+                    }
+
+                    pending_chunks_guard.put(Arc::unwrap_or_clone(chunk));
                 }
 
-                pending_chunks_guard.put(Arc::unwrap_or_clone(chunk));
+                // Visible park signal: previous builds returned Ok silently,
+                // which made holder-side cache misses look like "gossip worked".
+                info!(
+                    chunk.data_root = %data_root,
+                    chunk.tx_offset = %tx_offset,
+                    "Parked chunk: no CachedDataRoot yet (awaiting tx header / CDR commit)"
+                );
+
+                // Close the TX/chunk gossip TOCTOU:
+                //   1. chunk looks up CachedDataRoot → miss
+                //   2. concurrent TX commits CDR + ProcessPendingChunks (pending empty)
+                //   3. chunk parks into pending → stranded forever, never CachedChunks
+                // Re-check CDR after the put. If the header committed in the window,
+                // schedule ProcessPendingChunks again (cannot call it directly —
+                // that recurses through this async fn and fails to compile).
+                let cdr_now = self
+                    .irys_db
+                    .view_eyre(|read_tx| {
+                        irys_database::cached_data_root_by_data_root(read_tx, data_root)
+                    })
+                    .map_err(|_| CriticalChunkIngressError::DatabaseError)?;
+                if cdr_now.is_some() {
+                    debug!(
+                        chunk.data_root = %data_root,
+                        "CachedDataRoot appeared after park; scheduling ProcessPendingChunks"
+                    );
+                    if let Err(e) = self.service_senders.chunk_ingress.send_traced(
+                        ChunkIngressMessage::ProcessPendingChunks(data_root),
+                    ) {
+                        warn!(
+                            chunk.data_root = %data_root,
+                            error = ?e,
+                            "Failed to schedule ProcessPendingChunks after post-park CDR recheck"
+                        );
+                    }
+                }
+
                 return Ok(());
             }
         };

--- a/crates/actors/src/chunk_ingress_service/chunks.rs
+++ b/crates/actors/src/chunk_ingress_service/chunks.rs
@@ -271,10 +271,7 @@ impl ChunkIngressServiceInner {
                     if current_chunk_count >= preheader_chunks_per_item {
                         warn!(
                             "Dropping pre-header chunk for {} at offset {}: cache full ({}/{})",
-                            &data_root,
-                            &tx_offset,
-                            current_chunk_count,
-                            preheader_chunks_per_item
+                            &data_root, &tx_offset, current_chunk_count, preheader_chunks_per_item
                         );
                         return Err(AdvisoryChunkIngressError::PreHeaderOffsetExceedsCap.into());
                     }
@@ -308,9 +305,11 @@ impl ChunkIngressServiceInner {
                         chunk.data_root = %data_root,
                         "CachedDataRoot appeared after park; scheduling ProcessPendingChunks"
                     );
-                    if let Err(e) = self.service_senders.chunk_ingress.send_traced(
-                        ChunkIngressMessage::ProcessPendingChunks(data_root),
-                    ) {
+                    if let Err(e) = self
+                        .service_senders
+                        .chunk_ingress
+                        .send_traced(ChunkIngressMessage::ProcessPendingChunks(data_root))
+                    {
                         warn!(
                             chunk.data_root = %data_root,
                             error = ?e,

--- a/crates/actors/src/chunk_ingress_service/chunks.rs
+++ b/crates/actors/src/chunk_ingress_service/chunks.rs
@@ -65,6 +65,30 @@ pub struct DataSizeInfo {
     pub is_from_publish_ledger: bool,
 }
 
+/// Pure post-park rescue decision for the TX/chunk gossip TOCTOU.
+///
+/// After a chunk is parked, we re-read `CachedDataRoot`. This function decides
+/// whether to schedule another `ProcessPendingChunks` drain:
+/// - `cdr_lookup = Err(_)` → leave parked (do **not** fail the already-accepted park)
+/// - `cdr_lookup = Ok(None)` → leave parked (still waiting for the header)
+/// - `cdr_lookup = Ok(Some(size))` → drain if `required_min_data_size` is `None`
+///   (any CDR is enough) or `size >= required_min_data_size` (oversized-claim park)
+///
+/// Extracted so deleting the rescue path without updating tests fails CI.
+#[must_use]
+pub(crate) fn should_schedule_pending_drain_after_park(
+    cdr_lookup: Result<Option<u64>, ()>,
+    required_min_data_size: Option<u64>,
+) -> bool {
+    match cdr_lookup {
+        Err(()) | Ok(None) => false,
+        Ok(Some(data_size)) => match required_min_data_size {
+            None => true,
+            Some(min) => data_size >= min,
+        },
+    }
+}
+
 /// Selects the authoritative data_size from multiple storage modules.
 #[must_use]
 pub fn select_data_size_from_storage_modules(
@@ -102,6 +126,52 @@ pub fn select_data_size_from_storage_modules(
 }
 
 impl ChunkIngressServiceInner {
+    /// After parking a chunk, re-check `CachedDataRoot` and schedule
+    /// `ProcessPendingChunks` if the concurrent TX committed in the park window.
+    ///
+    /// Never fails the already-accepted park: DB and channel errors warn only.
+    /// Direct re-entry into `process_pending_chunks_for_root` would recurse
+    /// through this async ingress stack (`E0733`), so we always go via the
+    /// control-plane channel.
+    async fn maybe_rescue_after_park(
+        &self,
+        data_root: DataRoot,
+        required_min_data_size: Option<u64>,
+    ) {
+        let cdr_lookup = self
+            .irys_db
+            .view_eyre(|read_tx| irys_database::cached_data_root_by_data_root(read_tx, data_root))
+            .map(|opt| opt.map(|cdr| cdr.data_size))
+            .map_err(|e| {
+                warn!(
+                    chunk.data_root = %data_root,
+                    error = ?e,
+                    "post-park CDR recheck failed; chunk remains parked"
+                );
+            });
+
+        if !should_schedule_pending_drain_after_park(cdr_lookup, required_min_data_size) {
+            return;
+        }
+
+        debug!(
+            chunk.data_root = %data_root,
+            ?required_min_data_size,
+            "CachedDataRoot usable after park; scheduling ProcessPendingChunks"
+        );
+        if let Err(e) = self
+            .service_senders
+            .chunk_ingress
+            .send_traced(ChunkIngressMessage::ProcessPendingChunks(data_root))
+        {
+            warn!(
+                chunk.data_root = %data_root,
+                error = ?e,
+                "Failed to schedule ProcessPendingChunks after post-park CDR recheck"
+            );
+        }
+    }
+
     #[instrument(level = "info", skip_all, err(Debug), fields(chunk.data_root = ?chunk.data_root, chunk.tx_offset = ?chunk.tx_offset))]
     pub(crate) async fn handle_chunk_ingress_message(
         &self,
@@ -287,37 +357,9 @@ impl ChunkIngressServiceInner {
                     "Parked chunk: no CachedDataRoot yet (awaiting tx header / CDR commit)"
                 );
 
-                // Close the TX/chunk gossip TOCTOU:
-                //   1. chunk looks up CachedDataRoot → miss
-                //   2. concurrent TX commits CDR + ProcessPendingChunks (pending empty)
-                //   3. chunk parks into pending → stranded forever, never CachedChunks
-                // Re-check CDR after the put. If the header committed in the window,
-                // schedule ProcessPendingChunks again (cannot call it directly —
-                // that recurses through this async fn and fails to compile).
-                let cdr_now = self
-                    .irys_db
-                    .view_eyre(|read_tx| {
-                        irys_database::cached_data_root_by_data_root(read_tx, data_root)
-                    })
-                    .map_err(|_| CriticalChunkIngressError::DatabaseError)?;
-                if cdr_now.is_some() {
-                    debug!(
-                        chunk.data_root = %data_root,
-                        "CachedDataRoot appeared after park; scheduling ProcessPendingChunks"
-                    );
-                    if let Err(e) = self
-                        .service_senders
-                        .chunk_ingress
-                        .send_traced(ChunkIngressMessage::ProcessPendingChunks(data_root))
-                    {
-                        warn!(
-                            chunk.data_root = %data_root,
-                            error = ?e,
-                            "Failed to schedule ProcessPendingChunks after post-park CDR recheck"
-                        );
-                    }
-                }
-
+                // Close the TX/chunk gossip TOCTOU (see maybe_rescue_after_park).
+                // Any CDR is enough: the header that commits it owns this root.
+                self.maybe_rescue_after_park(data_root, None).await;
                 return Ok(());
             }
         };
@@ -335,15 +377,25 @@ impl ChunkIngressServiceInner {
             } else {
                 // Unconfirmed: chunk claims larger size than cached.
                 // This may be legitimate (tx with larger size not yet processed).
-                // Park the chunk for the time being.
-                debug!(
-                    "Chunk claims larger data_size {} than unconfirmed cached {} for data_root {:?}. Parking chunk.",
-                    chunk.data_size, data_size, chunk.data_root
+                // Park the chunk for the time being — same TOCTOU as the
+                // pre-header path if ProcessPendingChunks runs before this put.
+                let data_root = chunk.data_root;
+                let claimed_size = chunk.data_size;
+                info!(
+                    chunk.data_root = %data_root,
+                    chunk.tx_offset = %chunk.tx_offset,
+                    claimed_data_size = claimed_size,
+                    cached_data_size = data_size,
+                    "Parked chunk: claims larger data_size than unconfirmed CachedDataRoot"
                 );
                 self.pending_chunks
                     .write()
                     .await
                     .put(Arc::unwrap_or_clone(chunk));
+                // Only re-drain if CDR grew enough to accept this claim;
+                // otherwise leave parked for the larger TX's ProcessPendingChunks.
+                self.maybe_rescue_after_park(data_root, Some(claimed_size))
+                    .await;
                 return Ok(());
             }
         }
@@ -972,6 +1024,42 @@ mod tests {
     fn ingress_gate_proceeds_when_size_confirmed_and_block_set_populated() {
         let cdr = cdr_gate_fixture(true, vec![H256::random()], vec![H256::random()], None);
         assert!(!should_skip_ingress_proof_generation(&cdr));
+    }
+
+    /// Pre-header park (no CDR at first look): any post-park CDR should drain.
+    #[test]
+    fn post_park_rescue_schedules_when_any_cdr_appears() {
+        assert!(should_schedule_pending_drain_after_park(Ok(Some(12)), None));
+        assert!(!should_schedule_pending_drain_after_park(Ok(None), None));
+    }
+
+    /// DB error after park must leave the chunk parked — not fail the ingest
+    /// and not skip rescue via `?` (which would reintroduce the strand).
+    #[test]
+    fn post_park_rescue_leaves_parked_on_db_error() {
+        assert!(!should_schedule_pending_drain_after_park(Err(()), None));
+        assert!(!should_schedule_pending_drain_after_park(Err(()), Some(12)));
+    }
+
+    /// Oversized-claim park: only drain once CDR has grown to the claim.
+    #[test]
+    fn post_park_rescue_oversized_requires_sufficient_cdr_size() {
+        assert!(!should_schedule_pending_drain_after_park(
+            Ok(Some(10)),
+            Some(12)
+        ));
+        assert!(should_schedule_pending_drain_after_park(
+            Ok(Some(12)),
+            Some(12)
+        ));
+        assert!(should_schedule_pending_drain_after_park(
+            Ok(Some(20)),
+            Some(12)
+        ));
+        assert!(!should_schedule_pending_drain_after_park(
+            Ok(None),
+            Some(12)
+        ));
     }
 
     /// Confirmed-but-not-block-set state: pending tx with chunks staged but

--- a/crates/actors/src/chunk_ingress_service/pending_chunks.rs
+++ b/crates/actors/src/chunk_ingress_service/pending_chunks.rs
@@ -209,7 +209,9 @@ mod tests {
         );
 
         // Post-park re-drain (what the fix schedules) recovers it.
-        let recovered = cache.pop(&root).expect("re-drain must recover parked chunk");
+        let recovered = cache
+            .pop(&root)
+            .expect("re-drain must recover parked chunk");
         assert_eq!(recovered.len(), 1);
         assert_eq!(cache.len(), 0);
     }

--- a/crates/actors/src/chunk_ingress_service/pending_chunks.rs
+++ b/crates/actors/src/chunk_ingress_service/pending_chunks.rs
@@ -177,4 +177,40 @@ mod tests {
         // Only 3 chunks should be kept (max_chunks_per_entry = 3)
         assert_eq!(cache.entries.get(&DataRoot::from(root)).unwrap().len(), 3);
     }
+
+    /// Regression fixture for the TX/chunk gossip TOCTOU that left holders
+    /// with no CachedChunks for a data_root (devnet H3xg / 3X98):
+    ///
+    /// 1. ProcessPendingChunks drains pending while empty (TX committed CDR)
+    /// 2. Concurrent chunk parks into pending after the drain
+    /// 3. Without a post-park re-drain, the chunk is stranded forever
+    ///
+    /// The product fix re-checks CachedDataRoot after park and schedules
+    /// another ProcessPendingChunks; this test pins the stranded state the
+    /// re-drain is required to clear.
+    #[test]
+    fn process_pending_before_park_strands_chunk_without_redrain() {
+        let mut cache = PriorityPendingChunks::new(10, 10);
+        let root_bytes = [0x3e_u8; 32];
+        let root = DataRoot::from(root_bytes);
+
+        // TX-side ProcessPendingChunks runs first — nothing parked yet.
+        assert!(
+            cache.pop(&root).is_none(),
+            "early ProcessPendingChunks sees an empty pending map"
+        );
+
+        // Chunk-side park completes after the drain.
+        cache.put(make_chunk(root_bytes, 0, 12));
+        assert_eq!(cache.len(), 1);
+        assert!(
+            cache.entries.contains_key(&root),
+            "parked chunk is stranded until a second drain"
+        );
+
+        // Post-park re-drain (what the fix schedules) recovers it.
+        let recovered = cache.pop(&root).expect("re-drain must recover parked chunk");
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(cache.len(), 0);
+    }
 }

--- a/crates/actors/src/chunk_ingress_service/pending_chunks.rs
+++ b/crates/actors/src/chunk_ingress_service/pending_chunks.rs
@@ -178,41 +178,21 @@ mod tests {
         assert_eq!(cache.entries.get(&DataRoot::from(root)).unwrap().len(), 3);
     }
 
-    /// Regression fixture for the TX/chunk gossip TOCTOU that left holders
-    /// with no CachedChunks for a data_root (devnet H3xg / 3X98):
-    ///
-    /// 1. ProcessPendingChunks drains pending while empty (TX committed CDR)
-    /// 2. Concurrent chunk parks into pending after the drain
-    /// 3. Without a post-park re-drain, the chunk is stranded forever
-    ///
-    /// The product fix re-checks CachedDataRoot after park and schedules
-    /// another ProcessPendingChunks; this test pins the stranded state the
-    /// re-drain is required to clear.
+    /// Map-level illustration of the TX/chunk TOCTOU order (drain-empty then
+    /// park). The product decision that *triggers* the second drain is covered
+    /// by `should_schedule_pending_drain_after_park` tests in `chunks.rs`.
     #[test]
-    fn process_pending_before_park_strands_chunk_without_redrain() {
+    fn early_drain_then_park_leaves_entry_until_second_pop() {
         let mut cache = PriorityPendingChunks::new(10, 10);
         let root_bytes = [0x3e_u8; 32];
         let root = DataRoot::from(root_bytes);
 
-        // TX-side ProcessPendingChunks runs first — nothing parked yet.
-        assert!(
-            cache.pop(&root).is_none(),
-            "early ProcessPendingChunks sees an empty pending map"
-        );
-
-        // Chunk-side park completes after the drain.
+        assert!(cache.pop(&root).is_none());
         cache.put(make_chunk(root_bytes, 0, 12));
-        assert_eq!(cache.len(), 1);
-        assert!(
-            cache.entries.contains_key(&root),
-            "parked chunk is stranded until a second drain"
-        );
-
-        // Post-park re-drain (what the fix schedules) recovers it.
+        assert!(cache.entries.contains_key(&root));
         let recovered = cache
             .pop(&root)
-            .expect("re-drain must recover parked chunk");
+            .expect("second drain recovers parked chunk");
         assert_eq!(recovered.len(), 1);
-        assert_eq!(cache.len(), 0);
     }
 }


### PR DESCRIPTION
## Summary

Closes a TOCTOU between concurrent **chunk gossip** and **data-TX ingress** that left holders with no `CachedChunks` write (devnet `H3xg` / `3X98`):

1. Chunk looks up Cached Data Root (CDR) → miss  
2. Concurrent TX commits CDR + sends `ProcessPendingChunks` (pending map still empty)  
3. Chunk parks into pending → stranded forever; migration at +6 silently skips the body  

### Fix

- After **both** park sites, re-check CDR and schedule another `ProcessPendingChunks` when usable:
  - **No-CDR park:** any CDR is enough (header landed)
  - **Oversized unconfirmed size park:** only if `CDR.data_size >= claimed_size` (avoids re-park loops)
- Never fail an already-accepted park on recheck DB/channel errors (warn + leave parked)
- Explicit park logs (was silent `Ok`)
- Pure `should_schedule_pending_drain_after_park` + unit tests so deleting the rescue decision fails CI
- Control-plane reschedule (not direct re-entry — avoids recursive async `E0733`)

### Happens-before (verified)

TX path commits CDR via `update_eyre` **before** sending `ProcessPendingChunks`, so the post-park recheck genuinely closes the concurrent miss.

### Out of scope (pre-existing / follow-ups)

- Block-confirmed CDR writer does not drain pending  
- `ProcessPendingChunks` still sent even if CDR write fails  
- Fire-and-forget control-plane loss on shutdown  
- Metrics counter for park/rescue (logs only for now)

## Test plan

- [x] `cargo test -p irys-actors --lib chunk_ingress_service` (28 passed)
  - `post_park_rescue_schedules_when_any_cdr_appears`
  - `post_park_rescue_leaves_parked_on_db_error`
  - `post_park_rescue_oversized_requires_sufficient_cdr_size`
  - `early_drain_then_park_leaves_entry_until_second_pop`
- [x] `cargo fmt`
- [x] `cargo clippy -p irys-actors --lib --tests -- -Dwarnings` (local; full workspace clippy needs CUDA on this machine)
- [ ] Optional: redeploy to devnet and re-upload; holders should log park + reprocess and show `Caching chunk` when TX races