### PR TITLE
fix(consensus): bind registered, header, and EVM coinbase reward addresses

### DIFF
--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -612,6 +612,21 @@ pub trait BlockProdStrategy {
 
         let block_reward = self.block_reward(&prev_block_header)?;
 
+        // Registered payout for this miner on the parent epoch snapshot must be
+        // what we declare on the Irys header and pay via EVM coinbase.
+        let reward_address = {
+            let tree = self.inner().block_tree_guard.read();
+            let epoch_snapshot = tree
+                .get_epoch_snapshot(&prev_block_header.block_hash)
+                .ok_or_else(|| {
+                    eyre!(
+                        "parent epoch snapshot missing for {}",
+                        prev_block_header.block_hash
+                    )
+                })?;
+            epoch_snapshot.resolve_reward_address(solution.mining_address)
+        };
+
         let (eth_built_payload, final_treasury) = self
             .create_evm_block(
                 &prev_block_header,
@@ -620,6 +635,7 @@ pub trait BlockProdStrategy {
                 block_reward,
                 current_timestamp,
                 solution.solution_hash,
+                reward_address,
             )
             .await?;
         let evm_block = eth_built_payload.block();
@@ -634,6 +650,7 @@ pub trait BlockProdStrategy {
                 evm_block,
                 &prev_block_ema_snapshot,
                 final_treasury,
+                reward_address,
             )
             .await?;
 
@@ -924,6 +941,8 @@ pub trait BlockProdStrategy {
         reward_amount: Amount<irys_types::storage_pricing::phantoms::Irys>,
         timestamp_ms: UnixTimestampMs,
         solution_hash: H256,
+        // Registered / declared payout (must match stake entry and EVM coinbase).
+        reward_address: IrysAddress,
     ) -> Result<(EthBuiltPayload, U256), BlockProductionError> {
         let block_height = prev_block_header.height + 1;
         let local_signer = LocalSigner::from(self.inner().config.irys_signer().signer);
@@ -934,7 +953,7 @@ pub trait BlockProdStrategy {
         // Generate expected shadow transactions using shared logic
         let mut shadow_tx_generator = ShadowTxGenerator::new(
             &block_height,
-            &self.inner().config.node_config.reward_address,
+            &reward_address,
             &reward_amount.amount,
             prev_block_header,
             &solution_hash,
@@ -981,6 +1000,7 @@ pub trait BlockProdStrategy {
                 timestamp_ms,
                 shadow_txs,
                 perv_evm_block.header.mix_hash,
+                reward_address,
             )
             .await?;
 
@@ -998,6 +1018,7 @@ pub trait BlockProdStrategy {
         timestamp_ms: UnixTimestampMs,
         shadow_txs: Vec<EthPooledTransaction>,
         parent_mix_hash: B256,
+        reward_address: IrysAddress,
     ) -> Result<EthBuiltPayload, BlockProductionError> {
         debug!("Building Reth payload attributes");
 
@@ -1006,7 +1027,8 @@ pub trait BlockProdStrategy {
             inner: PayloadAttributes {
                 timestamp: timestamp_ms.to_secs().as_secs(), // **THIS HAS TO BE SECONDS**
                 prev_randao: parent_mix_hash,
-                suggested_fee_recipient: self.inner().config.node_config.reward_address.into(),
+                // Coinbase must match registered + Irys header reward_address.
+                suggested_fee_recipient: reward_address.into(),
                 withdrawals: None, // these should ALWAYS be none
                 parent_beacon_block_root: Some(prev_block_header.block_hash.into()),
             },
@@ -1105,6 +1127,7 @@ pub trait BlockProdStrategy {
         eth_built_payload: &SealedBlock<reth_ethereum_primitives::Block>,
         perv_block_ema_snapshot: &EmaSnapshot,
         final_treasury: U256,
+        reward_address: IrysAddress,
     ) -> eyre::Result<Option<(Arc<IrysSealedBlock>, Option<AdjustmentStats>)>> {
         let prev_block_hash = prev_block_header.block_hash;
         let block_height = prev_block_header.height + 1;
@@ -1229,7 +1252,7 @@ pub trait BlockProdStrategy {
             previous_block_hash: prev_block_hash,
             previous_cumulative_diff: prev_block_header.cumulative_diff,
             poa,
-            reward_address: self.inner().config.node_config.reward_address,
+            reward_address,
             reward_amount: block_reward.amount,
             miner_address: solution.mining_address,
             signature: Signature::test_signature().into(), // temp value until block is signed with the mining singer

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -224,6 +224,16 @@ pub enum PreValidationError {
     RewardCurveError(String),
     #[error("Reward mismatch: got {got}, expected {expected}")]
     RewardMismatch { got: U256, expected: U256 },
+    /// Header `reward_address` must equal the registered payout for `miner_address`
+    /// (stake entry via parent epoch snapshot, else the miner address itself).
+    #[error(
+        "Reward address mismatch: header {got} does not match registered payout {expected} for miner {miner}"
+    )]
+    RewardAddressMismatch {
+        got: IrysAddress,
+        expected: IrysAddress,
+        miner: IrysAddress,
+    },
     #[error("Invalid solution_hash - expected difficulty >={expected} got {got}")]
     SolutionHashBelowDifficulty { expected: U256, got: U256 },
     #[error("Invalid solution_hash link - expected {expected} got {got}")]
@@ -629,6 +639,7 @@ impl PreValidationError {
             | Self::PublishTxMissingPriorSubmit { .. }
             | Self::PublishTxProofLengthMismatch
             | Self::RewardMismatch { .. }
+            | Self::RewardAddressMismatch { .. }
             | Self::SolutionHashBelowDifficulty { .. }
             | Self::SolutionHashLinkInvalid { .. }
             | Self::SubmitTxAlreadyIncluded { .. }
@@ -708,6 +719,7 @@ impl PreValidationError {
             Self::PreviousSolutionHashMismatch { .. } => "prev_solution_hash_mismatch",
             Self::RewardCurveError(_) => "reward_curve_error",
             Self::RewardMismatch { .. } => "reward_mismatch",
+            Self::RewardAddressMismatch { .. } => "reward_address_mismatch",
             Self::SolutionHashBelowDifficulty { .. } => "solution_hash_below_difficulty",
             Self::SolutionHashLinkInvalid { .. } => "solution_hash_link_invalid",
             Self::SystemTimeError(_) => "system_time_error",
@@ -1844,6 +1856,17 @@ pub async fn prevalidate_block(
         return Err(PreValidationError::RewardMismatch {
             got: block.reward_amount,
             expected: reward.amount,
+        });
+    }
+
+    // Declared payout (header) must match the registered payout for the miner
+    // (stake entry reward_address on the parent epoch snapshot, or miner if unstaked).
+    let registered_reward = parent_epoch_snapshot.resolve_reward_address(block.miner_address);
+    if block.reward_address != registered_reward {
+        return Err(PreValidationError::RewardAddressMismatch {
+            got: block.reward_address,
+            expected: registered_reward,
+            miner: block.miner_address,
         });
     }
 
@@ -4817,6 +4840,18 @@ pub async fn shadow_transactions_are_valid(
     let evm_block: Block = payload_v3
         .try_into_block()
         .map_err(|e| reject(format!("payload conversion failed: {e}")))?;
+
+    // Paid payout (EVM coinbase / beneficiary) must match the declared header
+    // reward_address. Prevalidation already requires header == registered
+    // stake payout, so this completes the three-way bind:
+    // registered == header.reward_address == evm.beneficiary.
+    let coinbase = IrysAddress::from(evm_block.header.beneficiary);
+    if coinbase != block.reward_address {
+        return Err(reject(format!(
+            "EVM coinbase {coinbase} does not match block reward_address {}",
+            block.reward_address
+        )));
+    }
 
     // Reject presence of EIP-7685 requests via header-level requests_hash as we disable requests.
     if evm_block.header.requests_hash.is_some() {

--- a/crates/actors/src/shadow_tx_generator.rs
+++ b/crates/actors/src/shadow_tx_generator.rs
@@ -1170,6 +1170,78 @@ mod tests {
             });
     }
 
+    /// H2 (partial): BlockReward packet is amount-only. The generator stores
+    /// `reward_address` but never binds it into the reward packet — EL pays the
+    /// EVM beneficiary (coinbase) instead. Changing the address must not change
+    /// the emitted header shadow tx.
+    ///
+    /// Paired with chain-tests validation test that shows CL accepts a header
+    /// whose `reward_address` differs from the payload coinbase.
+    #[test]
+    fn block_reward_packet_ignores_reward_address() {
+        let config = ConsensusConfig::testing();
+        let parent_block = IrysBlockHeader::new_mock_header();
+        let block_height = 101_u64;
+        let reward_amount = U256::from(5000);
+        let initial_treasury = U256::from(2_000_000);
+        let publish_ledger = PublishLedgerWithTxs {
+            txs: vec![],
+            proofs: None,
+        };
+        let solution_hash = H256::zero();
+        let empty_fees = LedgerExpiryBalanceDelta {
+            reward_balance_increment: BTreeMap::new(),
+            user_perm_fee_refunds: Vec::new(),
+        };
+        let epoch_snapshot = test_epoch_snapshot();
+
+        let addr_a = IrysAddress::from([0xAA; 20]);
+        let addr_b = IrysAddress::from([0xBB; 20]);
+        assert_ne!(addr_a, addr_b);
+
+        let first_shadow = |reward_address: &IrysAddress| {
+            ShadowTxGenerator::new(
+                &block_height,
+                reward_address,
+                &reward_amount,
+                &parent_block,
+                &solution_hash,
+                &config,
+                &[],
+                &[],
+                &[],
+                &[],
+                &publish_ledger,
+                initial_treasury,
+                &empty_fees,
+                &[],
+                &[],
+                &epoch_snapshot,
+            )
+            .expect("generator")
+            .next()
+            .expect("header phase")
+            .expect("ok")
+        };
+
+        let a = first_shadow(&addr_a);
+        let b = first_shadow(&addr_b);
+        assert_eq!(
+            a, b,
+            "BlockReward shadow must be identical for different reward_address values"
+        );
+        let expected = ShadowMetadata {
+            shadow_tx: ShadowTransaction::new_v1(
+                TransactionPacket::BlockReward(BlockRewardIncrement {
+                    amount: reward_amount.into(),
+                }),
+                solution_hash.into(),
+            ),
+            transaction_fee: 0,
+        };
+        assert_eq!(a, expected);
+    }
+
     #[test]
     fn test_three_commitments() {
         let config = ConsensusConfig::testing();

--- a/crates/actors/src/shadow_tx_generator.rs
+++ b/crates/actors/src/shadow_tx_generator.rs
@@ -1175,8 +1175,8 @@ mod tests {
     /// EVM beneficiary (coinbase) instead. Changing the address must not change
     /// the emitted header shadow tx.
     ///
-    /// Paired with chain-tests validation test that shows CL accepts a header
-    /// whose `reward_address` differs from the payload coinbase.
+    /// Paired with chain-tests validation test that rejects a header whose
+    /// `reward_address` differs from the payload coinbase.
     #[test]
     fn block_reward_packet_ignores_reward_address() {
         let config = ConsensusConfig::testing();

--- a/crates/chain-tests/src/block_production/block_production.rs
+++ b/crates/chain-tests/src/block_production/block_production.rs
@@ -1072,6 +1072,7 @@ async fn block_prod_will_not_build_on_invalid_blocks() -> eyre::Result<()> {
             reward_amount: Amount<irys_types::storage_pricing::phantoms::Irys>,
             timestamp_ms: UnixTimestampMs,
             solution_hash: H256,
+            reward_address: irys_types::IrysAddress,
         ) -> Result<
             (EthBuiltPayload, irys_types::U256),
             irys_actors::block_producer::BlockProductionError,
@@ -1090,6 +1091,7 @@ async fn block_prod_will_not_build_on_invalid_blocks() -> eyre::Result<()> {
                     reward_amount,
                     timestamp_ms,
                     solution_hash,
+                    reward_address,
                 )
                 .await
         }
@@ -1496,6 +1498,7 @@ async fn test_invalid_solution_hash_rejected() -> eyre::Result<()> {
             reward_amount: Amount<irys_types::storage_pricing::phantoms::Irys>,
             timestamp_ms: UnixTimestampMs,
             _solution_hash: H256,
+            reward_address: irys_types::IrysAddress,
         ) -> Result<
             (EthBuiltPayload, irys_types::U256),
             irys_actors::block_producer::BlockProductionError,
@@ -1511,6 +1514,7 @@ async fn test_invalid_solution_hash_rejected() -> eyre::Result<()> {
                     reward_amount,
                     timestamp_ms,
                     invalid_solution_hash,
+                    reward_address,
                 )
                 .await
         }

--- a/crates/chain-tests/src/block_production/block_validation.rs
+++ b/crates/chain-tests/src/block_production/block_validation.rs
@@ -159,6 +159,7 @@ async fn test_future_block_rejection() -> Result<()> {
             reward_amount: Amount<irys_types::storage_pricing::phantoms::Irys>,
             _timestamp_ms: UnixTimestampMs,
             solution_hash: H256,
+            reward_address: irys_types::IrysAddress,
         ) -> Result<(EthBuiltPayload, U256), irys_actors::block_producer::BlockProductionError>
         {
             self.prod
@@ -169,6 +170,7 @@ async fn test_future_block_rejection() -> Result<()> {
                     reward_amount,
                     self.invalid_timestamp,
                     solution_hash,
+                    reward_address,
                 )
                 .await
         }
@@ -183,6 +185,7 @@ async fn test_future_block_rejection() -> Result<()> {
             eth_built_payload: &RethSealedBlock<reth_ethereum_primitives::Block>,
             prev_block_ema_snapshot: &EmaSnapshot,
             treasury: U256,
+            reward_address: irys_types::IrysAddress,
         ) -> eyre::Result<Option<(Arc<SealedBlock>, Option<AdjustmentStats>)>> {
             self.prod
                 .produce_block_without_broadcasting(
@@ -194,6 +197,7 @@ async fn test_future_block_rejection() -> Result<()> {
                     eth_built_payload,
                     prev_block_ema_snapshot,
                     treasury,
+                    reward_address,
                 )
                 .await
         }

--- a/crates/chain-tests/src/multi_node/validation.rs
+++ b/crates/chain-tests/src/multi_node/validation.rs
@@ -58,6 +58,7 @@ async fn heavy_block_invalid_evm_block_reward_gets_rejected() -> eyre::Result<()
             reward_amount: Amount<irys_types::storage_pricing::phantoms::Irys>,
             timestamp_ms: UnixTimestampMs,
             solution_hash: H256,
+            reward_address: irys_types::IrysAddress,
         ) -> Result<(EthBuiltPayload, U256), irys_actors::block_producer::BlockProductionError>
         {
             let invalid_reward_amount = Amount::new(reward_amount.amount.pow(2_u64.into()));
@@ -70,6 +71,7 @@ async fn heavy_block_invalid_evm_block_reward_gets_rejected() -> eyre::Result<()
                     invalid_reward_amount,
                     timestamp_ms,
                     solution_hash,
+                    reward_address,
                 )
                 .await
         }
@@ -234,6 +236,7 @@ async fn heavy_block_shadow_txs_misalignment_block_rejected() -> eyre::Result<()
             reward_amount: Amount<irys_types::storage_pricing::phantoms::Irys>,
             timestamp_ms: UnixTimestampMs,
             solution_hash: H256,
+            reward_address: irys_types::IrysAddress,
         ) -> Result<(EthBuiltPayload, U256), irys_actors::block_producer::BlockProductionError>
         {
             let mut tampered_mempool = mempool.clone();
@@ -246,6 +249,7 @@ async fn heavy_block_shadow_txs_misalignment_block_rejected() -> eyre::Result<()
                     reward_amount,
                     timestamp_ms,
                     solution_hash,
+                    reward_address,
                 )
                 .await
         }
@@ -338,6 +342,7 @@ async fn heavy_block_shadow_txs_different_order_of_txs() -> eyre::Result<()> {
             reward_amount: Amount<irys_types::storage_pricing::phantoms::Irys>,
             timestamp_ms: UnixTimestampMs,
             solution_hash: H256,
+            reward_address: irys_types::IrysAddress,
         ) -> Result<(EthBuiltPayload, U256), irys_actors::block_producer::BlockProductionError>
         {
             // NOTE: We reverse the order of txs, this means
@@ -354,6 +359,7 @@ async fn heavy_block_shadow_txs_different_order_of_txs() -> eyre::Result<()> {
                     reward_amount,
                     timestamp_ms,
                     solution_hash,
+                    reward_address,
                 )
                 .await
         }

--- a/crates/chain-tests/src/validation/mod.rs
+++ b/crates/chain-tests/src/validation/mod.rs
@@ -19,6 +19,7 @@ mod promote_after_activation_straddle;
 mod promote_after_submit_expiry;
 mod publish_after_submit_expiry_filtered;
 mod reorg_submit_expiry;
+mod reward_address_coinbase;
 mod same_block_promotion;
 mod slow_path_submit_expiry;
 mod unpledge_partition;

--- a/crates/chain-tests/src/validation/reward_address_coinbase.rs
+++ b/crates/chain-tests/src/validation/reward_address_coinbase.rs
@@ -1,0 +1,98 @@
+//! Three-way reward-address bind: registered stake payout, Irys header
+//! `reward_address`, and EVM coinbase must all match.
+//!
+//! Regression for H2: a block that declares a spoofed header `reward_address`
+//! while keeping the original EVM coinbase (and registered stake payout) must
+//! be rejected.
+
+use std::sync::Arc;
+
+use super::send_block_and_read_state;
+use crate::utils::{IrysNodeTest, assert_validation_error, solution_context};
+use irys_actors::block_validation::ValidationError;
+use irys_actors::{BlockProdStrategy as _, ProductionStrategy};
+use irys_types::{IrysAddress, NodeConfig, SealedBlock as IrysSealedBlock};
+
+/// Spoof header `reward_address` after production (coinbase unchanged).
+/// Full validation must reject on coinbase ≠ header.reward_address.
+///
+/// Note: this harness injects via `BlockPreValidated`, so prevalidation
+/// (registered ↔ header) is not re-run here; that check is covered on the
+/// gossip/discovery path. This test locks the paid ↔ declared bind.
+#[test_log::test(tokio::test)]
+async fn heavy_test_reward_address_not_bound_to_evm_coinbase() -> eyre::Result<()> {
+    let num_blocks_in_epoch = 4;
+    let seconds_to_wait = 20;
+    let mut genesis_config = NodeConfig::testing_with_epochs(num_blocks_in_epoch);
+    genesis_config.consensus.get_mut().chunk_size = 32;
+
+    let signer = genesis_config.signer().clone();
+    let configured_reward = genesis_config.reward_address;
+    let spoofed_reward = IrysAddress::random();
+    eyre::ensure!(
+        configured_reward != spoofed_reward,
+        "test requires distinct spoofed reward address"
+    );
+
+    let genesis_node = IrysNodeTest::new_genesis(genesis_config)
+        .start_and_wait_for_packing("GENESIS", seconds_to_wait)
+        .await;
+    genesis_node.mine_block().await?;
+
+    let block_prod_strategy = ProductionStrategy {
+        inner: genesis_node.node_ctx.block_producer_inner.clone(),
+    };
+    let (sealed, _stats, eth_payload) = block_prod_strategy
+        .fully_produce_new_block_without_gossip(&solution_context(&genesis_node.node_ctx).await?)
+        .await?
+        .ok_or_else(|| eyre::eyre!("no block produced"))?;
+
+    let coinbase = eth_payload.block().header().beneficiary;
+    assert_eq!(
+        IrysAddress::from(coinbase),
+        sealed.header().reward_address,
+        "honest production binds coinbase to header reward_address"
+    );
+    assert_eq!(
+        sealed.header().reward_address,
+        configured_reward,
+        "produced header should use registered/config reward_address"
+    );
+
+    let mut header = sealed.header().as_ref().clone();
+    header.reward_address = spoofed_reward;
+    signer.sign_block_header(&mut header)?;
+
+    assert_ne!(
+        IrysAddress::from(coinbase),
+        header.reward_address,
+        "test setup: header reward_address must diverge from EVM coinbase"
+    );
+
+    let mut body = sealed.to_block_body();
+    body.block_hash = header.block_hash;
+    let mismatched = Arc::new(IrysSealedBlock::new(header, body)?);
+
+    genesis_node
+        .node_ctx
+        .block_pool
+        .add_execution_payload_to_cache(eth_payload.block().clone())
+        .await;
+
+    let outcome =
+        send_block_and_read_state(&genesis_node.node_ctx, Arc::clone(&mismatched), true).await?;
+
+    assert_validation_error(
+        outcome,
+        |e| match e {
+            ValidationError::ShadowTransactionInvalid(msg) => {
+                msg.contains("EVM coinbase") && msg.contains("reward_address")
+            }
+            _ => false,
+        },
+        "spoofed header reward_address must be rejected (coinbase != declared)",
+    );
+
+    genesis_node.stop().await;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Enforce a three-way bind for block reward payout: parent-epoch `resolve_reward_address(miner)` must match Irys header `reward_address`, and EVM coinbase (`beneficiary`) must match the header.
- Producers resolve the registered payout for both the header field and `suggested_fee_recipient`, so honest mining stays valid after `UpdateRewardAddress`.
- Add a regression test that rejects a spoofed header with a mismatched coinbase.

## Test plan

- [x] `cargo xtask local-checks --fix`
- [x] `cargo nextest run -p irys-actors block_reward_packet_ignores_reward_address`
- [x] `cargo nextest run -p irys-chain-tests heavy_test_reward_address_not_bound_to_evm_coinbase`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Miner payout/coinbase addresses are now resolved dynamically per produced block.
  * Block headers and the EVM coinbase are kept consistent with the resolved payout address.

* **Bug Fixes**
  * Validation now rejects blocks where the declared payout address doesn’t match the EVM coinbase beneficiary.

* **Tests**
  * Added regression and integration coverage to ensure payout-address/coinbase consistency, including spoofing that must fail validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->