### PR TITLE
fix(pricing): reject zero oracle and token prices

### DIFF
--- a/crates/chain-tests/src/validation/mod.rs
+++ b/crates/chain-tests/src/validation/mod.rs
@@ -24,6 +24,7 @@ mod same_block_promotion;
 mod slow_path_submit_expiry;
 mod unpledge_partition;
 mod unstake_edge_cases;
+mod zero_oracle_price;
 
 use std::sync::Arc;
 

--- a/crates/chain-tests/src/validation/zero_oracle_price.rs
+++ b/crates/chain-tests/src/validation/zero_oracle_price.rs
@@ -1,0 +1,77 @@
+//! Zero `oracle_irys_price` must be rejected in prevalidation.
+//!
+//! A non-positive oracle price is never valid: fee math divides by the token
+//! price, and accepting zero makes the relative safe-range band collapse so
+//! the chain cannot recover via normal oracle updates.
+
+use std::sync::Arc;
+
+use crate::utils::{IrysNodeTest, solution_context};
+use irys_actors::{
+    BlockProdStrategy as _, ProductionStrategy,
+    block_discovery::{BlockDiscoveryError, BlockDiscoveryFacade as _, BlockDiscoveryFacadeImpl},
+    block_validation::PreValidationError,
+};
+use irys_types::{NodeConfig, SealedBlock, storage_pricing::Amount};
+use rust_decimal_macros::dec;
+
+/// Produce a valid block, rewrite `oracle_irys_price` to zero, re-sign, and
+/// assert BlockDiscovery rejects with `OraclePriceInvalid`.
+#[test_log::test(tokio::test)]
+async fn heavy_zero_oracle_price_block_rejected() -> eyre::Result<()> {
+    let mut genesis_config = NodeConfig::testing().with_consensus(|c| {
+        c.chunk_size = 32;
+    });
+
+    let test_signer = genesis_config.new_random_signer();
+    genesis_config.fund_genesis_accounts(vec![&test_signer]);
+
+    let genesis_node = IrysNodeTest::new_genesis(genesis_config.clone())
+        .start_and_wait_for_packing("GENESIS", 20)
+        .await;
+    genesis_node.mine_block().await?;
+
+    let block_prod_strategy = ProductionStrategy {
+        inner: genesis_node.node_ctx.block_producer_inner.clone(),
+    };
+
+    let (block, _stats, _payload) = block_prod_strategy
+        .fully_produce_new_block_without_gossip(&solution_context(&genesis_node.node_ctx).await?)
+        .await?
+        .expect("block production should succeed");
+
+    assert!(
+        !block.header().oracle_irys_price.amount.is_zero(),
+        "honest production must include a positive oracle price"
+    );
+
+    let mut header = (**block.header()).clone();
+    header.oracle_irys_price = Amount::token(dec!(0.0)).expect("zero token amount");
+    genesis_config.signer().sign_block_header(&mut header)?;
+
+    let mut tampered_body = block.to_block_body();
+    tampered_body.block_hash = header.block_hash;
+    let tampered_block = Arc::new(SealedBlock::new(header, tampered_body)?);
+
+    let block_discovery = BlockDiscoveryFacadeImpl::new(
+        genesis_node
+            .node_ctx
+            .service_senders
+            .block_discovery
+            .clone(),
+    );
+    let result = block_discovery.handle_block(tampered_block, false).await;
+
+    assert!(
+        matches!(
+            result,
+            Err(BlockDiscoveryError::BlockValidationError(
+                PreValidationError::OraclePriceInvalid
+            ))
+        ),
+        "block with oracle_irys_price = 0 must be rejected, got: {result:?}"
+    );
+
+    genesis_node.stop().await;
+    Ok(())
+}

--- a/crates/domain/src/snapshots/ema_snapshot.rs
+++ b/crates/domain/src/snapshots/ema_snapshot.rs
@@ -246,15 +246,22 @@ impl EmaSnapshot {
         }
     }
 
-    /// Validate that an oracle price is within the safe range.
+    /// Validate that an oracle price is positive and within the safe range.
     ///
-    /// This prevents sudden price spikes or drops that could be used for manipulation.
-    /// The safe range is typically ±n% from the previous oracle price, where n is configurable.
+    /// Zero (or non-positive) prices are always rejected: fee math divides by the
+    /// token price, and a zero parent makes the relative safe-range band collapse
+    /// to `{0}` so the chain cannot recover via normal oracle updates.
+    ///
+    /// The safe range then limits sudden spikes or drops vs the previous oracle
+    /// price (typically ±n%, configurable).
     pub fn oracle_price_is_valid(
         oracle_price: IrysTokenPrice,
         previous_oracle_price: IrysTokenPrice,
         safe_range: Amount<Percentage>,
     ) -> bool {
+        if oracle_price.amount.is_zero() {
+            return false;
+        }
         let capped = bound_in_min_max_range(oracle_price, safe_range, previous_oracle_price);
         oracle_price == capped
     }
@@ -868,6 +875,42 @@ mod test {
                     prop_assert_eq!(result, desired_price, "in-range value should pass through unchanged");
                 }
             }
+        }
+    }
+
+    mod oracle_price_is_valid_tests {
+        use super::*;
+        use rust_decimal_macros::dec;
+
+        #[test]
+        fn zero_oracle_price_is_always_invalid() {
+            let parent = IrysTokenPrice::token(dec!(1.0)).unwrap();
+            // Full ±100% range would otherwise treat 0 as the min bound of parent.
+            let full_range = Amount::percentage(dec!(1.0)).unwrap();
+            let zero = IrysTokenPrice::token(dec!(0.0)).unwrap();
+
+            assert!(
+                !EmaSnapshot::oracle_price_is_valid(zero, parent, full_range),
+                "zero oracle price must be rejected even when the relative safe range includes 0"
+            );
+        }
+
+        #[test]
+        fn positive_price_within_range_is_valid() {
+            let parent = IrysTokenPrice::token(dec!(1.0)).unwrap();
+            let range = Amount::percentage(dec!(0.1)).unwrap();
+            let price = IrysTokenPrice::token(dec!(1.05)).unwrap();
+
+            assert!(EmaSnapshot::oracle_price_is_valid(price, parent, range));
+        }
+
+        #[test]
+        fn positive_price_outside_range_is_invalid() {
+            let parent = IrysTokenPrice::token(dec!(1.0)).unwrap();
+            let range = Amount::percentage(dec!(0.1)).unwrap();
+            let price = IrysTokenPrice::token(dec!(1.20)).unwrap();
+
+            assert!(!EmaSnapshot::oracle_price_is_valid(price, parent, range));
         }
     }
 }

--- a/crates/types/src/storage_pricing.rs
+++ b/crates/types/src/storage_pricing.rs
@@ -335,13 +335,19 @@ impl Amount<(CostPerChunkDurationAdjusted, Usd)> {
     ///
     /// # Errors
     ///
-    /// Whenever any of the math operations fail due to bounds checks.
+    /// - Token price is zero (non-positive prices are not valid fee denominators)
+    /// - Whenever any of the math operations fail due to bounds checks.
     pub fn base_network_fee(
         self,
         bytes_to_store: U256,
         chunk_size: u64,
         irys_token_price: Amount<(IrysPrice, Usd)>,
     ) -> Result<Amount<(NetworkFee, Irys)>> {
+        ensure!(
+            !irys_token_price.amount.is_zero(),
+            "token price must be positive"
+        );
+
         // Calculate number of chunks (rounded up)
         let chunk_size_u256 = U256::from(chunk_size);
         let num_chunks = safe_div(
@@ -987,6 +993,30 @@ mod tests {
     mod user_fee {
         use super::*;
         use rust_decimal_macros::dec;
+
+        #[test]
+        fn test_zero_token_price_is_rejected() {
+            let cost_per_chunk_adjusted = Amount::token(dec!(0.001)).unwrap();
+            let zero_price = Amount::token(dec!(0.0)).unwrap();
+            let bytes_to_store = 256_u64 * 1024_u64;
+            let chunk_size = 256_u64 * 1024_u64;
+
+            let result = cost_per_chunk_adjusted.base_network_fee(
+                U256::from(bytes_to_store),
+                chunk_size,
+                zero_price,
+            );
+
+            assert!(
+                result.is_err(),
+                "base_network_fee must fail closed on non-positive token price"
+            );
+            let err = result.unwrap_err().to_string();
+            assert!(
+                err.contains("token price must be positive"),
+                "expected explicit price-floor error, got: {err}"
+            );
+        }
 
         #[test]
         fn test_normal_case() -> Result<()> {


### PR DESCRIPTION
## Summary

- Reject `oracle_irys_price == 0` in `oracle_price_is_valid` (prevalidation → `OraclePriceInvalid`). Zero is never a valid oracle sample: fee math divides by price, and a zero parent collapses the relative safe-range band so the chain cannot recover via normal oracle updates.
- Fail closed in `base_network_fee` when the token price is zero (explicit error; no free storage / no silent div-by-zero).
- Leave `token_price_safe_range` alone — oracle may track the market; EMA remains the smoothing path for fee pricing.

## Test plan

- [x] Unit: `oracle_price_is_valid` rejects zero even under ±100% safe range
- [x] Unit: `base_network_fee` rejects zero token price with explicit error
- [x] Integration: `heavy_zero_oracle_price_block_rejected` (tampered block → `OraclePriceInvalid`)
- [x] `cargo xtask local-checks`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Zero oracle prices are now rejected during block validation.
  * Network fee calculations now reject invalid zero token prices.
  * Oracle price validation consistently requires a positive, in-range value.

* **Tests**
  * Added coverage for zero, valid, and out-of-range oracle prices.
  * Added integration checks confirming blocks with zero oracle prices are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->