### PR TITLE
feat(consensus): Delta hardfork — seed slots for ledgers activated mid-chain

### DIFF
--- a/crates/actors/src/block_producer.rs
+++ b/crates/actors/src/block_producer.rs
@@ -1213,13 +1213,13 @@ pub trait BlockProdStrategy {
             .total_chunks
             .saturating_add(submit_chunks_added);
 
-        let cascade_active = self
+        let cascade_for_epoch = self
             .inner()
             .config
             .consensus
             .hardforks
-            .is_cascade_active_for_epoch(&epoch_snapshot);
-        let cascade = if cascade_active {
+            .cascade_for_epoch(&epoch_snapshot);
+        let cascade = if cascade_for_epoch.is_active() {
             self.inner().config.consensus.hardforks.cascade.as_ref()
         } else {
             None
@@ -1870,20 +1870,20 @@ pub trait BlockProdStrategy {
         // Cascade status of THIS block (its own timestamp — the value
         // `perform_epoch_tasks` reads to gate the `touch_active_ledger_slots` that
         // rescues slots written this epoch). Gates the write-window exclusion, and
-        // must NOT be the parent-snapshot helper `is_cascade_active_for_epoch`
+        // must NOT be the parent-snapshot helper `cascade_for_epoch`
         // below, which lags by an epoch at the activation boundary.
-        let cascade_active_for_block = self
+        let cascade_for_block = self
             .inner()
             .config
             .consensus
             .hardforks
-            .is_cascade_active_at(block_timestamp.to_secs());
-        let cascade_active_for_epoch = self
+            .cascade_for_block(block_timestamp.to_secs());
+        let cascade_for_epoch = self
             .inner()
             .config
             .consensus
             .hardforks
-            .is_cascade_active_for_epoch(parent_epoch_snapshot);
+            .cascade_for_epoch(parent_epoch_snapshot);
 
         // The producer's per-ledger `total_chunks` at this block = parent total +
         // chunks added by this block's selected txs. This is the exact value that
@@ -1898,8 +1898,8 @@ pub trait BlockProdStrategy {
             &self.inner().block_tree_guard,
             &self.inner().mempool_guard,
             &self.inner().db,
-            cascade_active_for_block,
-            cascade_active_for_epoch,
+            cascade_for_block,
+            cascade_for_epoch,
             |ledger| {
                 let txs: &[DataTransactionHeader] = match ledger {
                     DataLedger::Submit => &mempool_txs.submit_tx,

--- a/crates/actors/src/block_producer/ledger_expiry.rs
+++ b/crates/actors/src/block_producer/ledger_expiry.rs
@@ -70,7 +70,10 @@ use irys_domain::{BlockIndex, BlockTreeReadGuard, EpochSnapshot};
 use irys_types::{
     BlockHeight, BlockIndexItem, Config, DataLedger, DataTransactionHeader, H256, IrysAddress,
     IrysBlockHeader, IrysTransactionId, LedgerChunkOffset, LedgerChunkRange, U256,
-    app_state::DatabaseProvider, fee_distribution::TermFeeCharges, ledger_chunk_offset_ii,
+    app_state::DatabaseProvider,
+    fee_distribution::TermFeeCharges,
+    hardfork_config::{Cascade, ForBlock, ForEpoch},
+    ledger_chunk_offset_ii,
 };
 use nodit::{InclusiveInterval as _, interval::ii};
 use std::collections::{BTreeMap, BTreeSet};
@@ -110,7 +113,7 @@ pub async fn calculate_expired_ledger_fees(
     // slot-keyed minerless-slot refund (empty-`partitions` expired slots) is
     // unconditional, so for such a slot the settled set differs from pre-Cascade
     // master.
-    cascade_active: bool,
+    cascade_for_block: ForBlock<Cascade>,
 ) -> eyre::Result<LedgerExpiryBalanceDelta> {
     // Fee distribution is only implemented for Submit ledger. Publish expiry
     // simply resets partitions without fee redistribution.
@@ -126,7 +129,7 @@ pub async fn calculate_expired_ledger_fees(
         block_height,
         ledger_type,
         new_total_chunks,
-        cascade_active,
+        cascade_for_block,
     )?;
 
     tracing::info!(
@@ -250,9 +253,9 @@ pub async fn calculate_expired_ledger_fees(
 ///
 /// This is the single home for the three-call pattern so producer↔validator parity
 /// is **mechanical, not hand-maintained**: both sides pass the same
-/// `cascade_active_for_block` (the block's OWN timestamp — gates the write-window
-/// exclusion to match `touch_active_ledger_slots`, and must NOT be the
-/// epoch-lagging `is_cascade_active_for_epoch`) and `cascade_active_for_epoch`
+/// `cascade_for_block` (the block's OWN timestamp — gates the write-window
+/// exclusion to match `touch_active_ledger_slots`; a distinct type from the
+/// epoch-lagging state, so the two cannot be swapped) and `cascade_for_epoch`
 /// (gates whether the term ledgers settle at all). The ONLY legitimate difference —
 /// each ledger's cumulative `total_chunks` at this block — is supplied by
 /// `new_total_chunks`: the producer computes `parent + chunks_added`; the validator
@@ -267,8 +270,8 @@ pub async fn calculate_all_expired_ledger_fees(
     block_tree_guard: &BlockTreeReadGuard,
     mempool_guard: &MempoolReadGuard,
     db: &DatabaseProvider,
-    cascade_active_for_block: bool,
-    cascade_active_for_epoch: bool,
+    cascade_for_block: ForBlock<Cascade>,
+    cascade_for_epoch: ForEpoch<Cascade>,
     new_total_chunks: impl Fn(DataLedger) -> u64,
 ) -> eyre::Result<LedgerExpiryBalanceDelta> {
     let mut result = calculate_expired_ledger_fees(
@@ -283,12 +286,12 @@ pub async fn calculate_all_expired_ledger_fees(
         db,
         true, // Submit: expect promotion — refund the perm fee for unpromoted txs
         new_total_chunks(DataLedger::Submit),
-        cascade_active_for_block,
+        cascade_for_block,
     )
     .await?;
 
     // Term ledgers (no promotion) only settle once Cascade is active for the epoch.
-    if cascade_active_for_epoch {
+    if cascade_for_epoch.is_active() {
         for ledger in [DataLedger::OneYear, DataLedger::ThirtyDay] {
             let delta = calculate_expired_ledger_fees(
                 parent_epoch_snapshot,
@@ -302,7 +305,7 @@ pub async fn calculate_all_expired_ledger_fees(
                 db,
                 false, // term ledgers: no promotion expected
                 new_total_chunks(ledger),
-                cascade_active_for_block,
+                cascade_for_block,
             )
             .await?;
             result.merge(delta);
@@ -453,7 +456,7 @@ pub async fn expired_submit_tx_ids(
     // to `expired_submit_range`, so this differential-test oracle stays faithful
     // at the activation epoch boundary (NC-0042) — previously this derived it from
     // `parent_epoch_snapshot.epoch_block.timestamp_secs()`, which lags the block.
-    cascade_active: bool,
+    cascade_for_block: ForBlock<Cascade>,
     block_index: BlockIndex,
     block_tree_guard: &BlockTreeReadGuard,
     mempool_guard: &MempoolReadGuard,
@@ -462,7 +465,7 @@ pub async fn expired_submit_tx_ids(
     let slot_indexes = parent_epoch_snapshot.get_all_expired_term_slot_indexes(
         DataLedger::Submit,
         block_height,
-        cascade_active,
+        cascade_for_block,
         parent_block_header.ledger_total_chunks(DataLedger::Submit),
     );
     if slot_indexes.is_empty() {
@@ -523,7 +526,7 @@ pub async fn is_submit_storage_expired(
     parent_block_header: &IrysBlockHeader,
     config: &Config,
     // The block-under-test's own Cascade status — see `expired_submit_tx_ids`.
-    cascade_active: bool,
+    cascade_for_block: ForBlock<Cascade>,
     block_index: &BlockIndex,
     block_tree_guard: &BlockTreeReadGuard,
     mempool_guard: &MempoolReadGuard,
@@ -534,7 +537,7 @@ pub async fn is_submit_storage_expired(
         parent_epoch_snapshot,
         parent_block_header,
         config,
-        cascade_active,
+        cascade_for_block,
     )?
     else {
         return Ok(false);
@@ -576,7 +579,7 @@ pub struct ExpiredSubmitRange {
 /// a pure function of the block's own parent, identical on every node regardless
 /// of that node's migration-lagged block-index tip (NC-0042 F2). The branch-
 /// correct mapping from a candidate's inclusion to a chunk offset happens later,
-/// per candidate, in [`submit_tx_expired`]. `cascade_active` MUST be the
+/// per candidate, in [`submit_tx_expired`]. `cascade_for_block` MUST be the
 /// Cascade status of the block being produced/validated; pre-Cascade replay
 /// keeps the old allocation-anchored unwritten-slot expiry behavior.
 pub fn expired_submit_range(
@@ -584,13 +587,13 @@ pub fn expired_submit_range(
     parent_epoch_snapshot: &EpochSnapshot,
     parent_block_header: &IrysBlockHeader,
     config: &Config,
-    cascade_active: bool,
+    cascade_for_block: ForBlock<Cascade>,
 ) -> eyre::Result<Option<ExpiredSubmitRange>> {
     let parent_total = parent_block_header.ledger_total_chunks(DataLedger::Submit);
     let slot_indexes = parent_epoch_snapshot.get_all_expired_term_slot_indexes(
         DataLedger::Submit,
         block_height,
-        cascade_active,
+        cascade_for_block,
         parent_total,
     );
     let Some(&max_expired_slot) = slot_indexes.iter().max() else {
@@ -1189,13 +1192,13 @@ fn collect_expired_partitions(
     block_height: u64,
     target_ledger_type: DataLedger,
     new_total_chunks: u64,
-    cascade_active: bool,
+    cascade_for_block: ForBlock<Cascade>,
 ) -> eyre::Result<BTreeMap<SlotIndex, Vec<IrysAddress>>> {
     let partition_assignments = &parent_epoch_snapshot.partition_assignments;
     // Window-excluded (Cascade only): settle exactly the slots that actually
     // recycle, so a slot written in its expiry epoch (rescued by the last_height
     // touch) is not paid here and then again when it later recycles. Pre-Cascade
-    // the touch is gated off, so `cascade_active=false` disables the exclusion
+    // the touch is gated off, so an inactive block state disables the exclusion
     // and settlement matches the original master set.
     //
     // Slot-keyed, NOT partition-keyed: a slot whose replicas were all unpledged
@@ -1208,7 +1211,7 @@ fn collect_expired_partitions(
         block_height,
         target_ledger_type,
         new_total_chunks,
-        cascade_active,
+        cascade_for_block,
     );
     let mut expired_ledger_slot_indexes = BTreeMap::new();
 
@@ -1836,7 +1839,7 @@ mod tests {
     /// Shared fixture: an otherwise-empty `EpochSnapshot` seeded from `config`.
     fn empty_epoch_snapshot(config: &Config) -> EpochSnapshot {
         EpochSnapshot {
-            ledgers: irys_database::Ledgers::new(&config.consensus, false),
+            ledgers: irys_database::Ledgers::new(&config.consensus, ForBlock::inactive()),
             partition_assignments: PartitionAssignments::new(),
             all_active_partitions: Vec::new(),
             unassigned_partitions: Vec::new(),
@@ -3552,7 +3555,12 @@ mod tests {
         }
 
         assert_eq!(
-            epoch.get_all_expired_term_slot_indexes(DataLedger::Submit, probe_height, true, 19),
+            epoch.get_all_expired_term_slot_indexes(
+                DataLedger::Submit,
+                probe_height,
+                ForBlock::active(),
+                19
+            ),
             vec![0],
             "canonical epoch processing must skip unwritten preallocated Submit slots"
         );
@@ -3633,8 +3641,14 @@ mod tests {
         let tree = BlockTree::new(&inclusion_genesis, ConsensusConfig::testing());
         let guard = BlockTreeReadGuard::new(Arc::new(RwLock::new(tree)));
 
-        let range = expired_submit_range(probe_height, &epoch, &prev_epoch, &config, true)?
-            .expect("expired Submit slots must produce a range");
+        let range = expired_submit_range(
+            probe_height,
+            &epoch,
+            &prev_epoch,
+            &config,
+            ForBlock::active(),
+        )?
+        .expect("expired Submit slots must produce a range");
         assert!(
             submit_tx_expired(
                 tx_slot_0.id,
@@ -3662,7 +3676,7 @@ mod tests {
             "slot-1 tx must stay live even though later empty slots also expired"
         );
 
-        // Walk-oracle parity + the new `cascade_active` parameter: the (now
+        // Walk-oracle parity + the block-scoped Cascade state: the (now
         // parameterized) `expired_submit_tx_ids` walk must return EXACTLY the
         // per-candidate–expired set — only the slot-0 tx — when passed the block's
         // own Cascade status. Previously the oracle derived Cascade from the parent
@@ -3674,7 +3688,7 @@ mod tests {
             &prev_epoch,
             probe_height,
             &config,
-            true, // the block-under-test's own Cascade status (activation at genesis here)
+            ForBlock::active(), // the block-under-test's own Cascade status (activation at genesis here)
             block_index.clone(),
             &guard,
             &MempoolReadGuard::stub(),
@@ -3775,7 +3789,7 @@ mod tests {
         epoch.ledgers[DataLedger::Submit].allocate_slots(4, 1);
 
         // Touch slots 0 and 2 only (chunks [0,10) and [20,30)); slot 1 stays
-        // unwritten. With cascade_active=true, unwritten slots are excluded from
+        // unwritten. With Cascade active for the block, unwritten slots are excluded from
         // expiry, so slot 1 is never returned as expired.
         let chunks_per_slot = config.consensus.num_chunks_in_partition;
         epoch.ledgers.touch_filled_slots(
@@ -3784,7 +3798,7 @@ mod tests {
             chunks_per_slot,
             chunks_per_slot,
             1,
-            true,
+            ForBlock::active(),
         );
         epoch.ledgers.touch_filled_slots(
             DataLedger::Submit,
@@ -3792,7 +3806,7 @@ mod tests {
             3 * chunks_per_slot,
             chunks_per_slot,
             1,
-            true,
+            ForBlock::active(),
         );
 
         // block_height = min_blocks + 50 → expiry_height = 50. Slots 0 and 2 have
@@ -3807,7 +3821,7 @@ mod tests {
             epoch.get_all_expired_term_slot_indexes(
                 DataLedger::Submit,
                 block_height,
-                true,
+                ForBlock::active(),
                 3 * chunks_per_slot
             ),
             vec![0, 2],
@@ -3818,7 +3832,7 @@ mod tests {
         let mut parent = IrysBlockHeader::new_mock_header();
         parent.data_ledgers[DataLedger::Submit].total_chunks = 3 * chunks_per_slot;
 
-        let err = expired_submit_range(block_height, &epoch, &parent, &config, true)
+        let err = expired_submit_range(block_height, &epoch, &parent, &config, ForBlock::active())
             .expect_err("a non-prefix expired set must fail loud, not over-approximate");
         assert!(
             err.to_string().contains("not a contiguous prefix"),
@@ -3870,7 +3884,12 @@ mod tests {
         // expire; the frontier slot 1 must stay live.
         let probe_height = blocks_per_cycle + num_blocks_in_epoch + 1;
         assert_eq!(
-            epoch.get_all_expired_term_slot_indexes(DataLedger::Submit, probe_height, true, 18),
+            epoch.get_all_expired_term_slot_indexes(
+                DataLedger::Submit,
+                probe_height,
+                ForBlock::active(),
+                18
+            ),
             vec![0],
             "the write frontier's slot must not expire during an ingress stall"
         );
@@ -3882,8 +3901,9 @@ mod tests {
         // append (offset 18) lies outside it and stays promotable/settleable.
         let mut parent = IrysBlockHeader::new_mock_header();
         parent.data_ledgers[DataLedger::Submit].total_chunks = 18;
-        let range = expired_submit_range(probe_height, &epoch, &parent, &config, true)?
-            .expect("slot 0 expired, so a range must exist");
+        let range =
+            expired_submit_range(probe_height, &epoch, &parent, &config, ForBlock::active())?
+                .expect("slot 0 expired, so a range must exist");
         assert_eq!(
             range.range_end, 10,
             "expired range must end at the last full slot's boundary, not the frontier"
@@ -3904,7 +3924,7 @@ mod tests {
             epoch.get_all_expired_term_slot_indexes(
                 DataLedger::Submit,
                 resume_height + 1,
-                true,
+                ForBlock::active(),
                 25
             ),
             vec![0],
@@ -3995,7 +4015,7 @@ mod tests {
             epoch.get_all_expired_term_slot_indexes(
                 DataLedger::Submit,
                 expiry_height,
-                true,
+                ForBlock::active(),
                 submit_total
             ),
             vec![0],
@@ -4005,7 +4025,12 @@ mod tests {
         // not be derived from partition infos.
         assert!(
             epoch
-                .get_expiring_partition_info(expiry_height, DataLedger::Submit, submit_total, true)
+                .get_expiring_partition_info(
+                    expiry_height,
+                    DataLedger::Submit,
+                    submit_total,
+                    ForBlock::active()
+                )
                 .is_empty(),
             "partition-keyed expiring set has no entry for a partition-less slot"
         );
@@ -4120,7 +4145,7 @@ mod tests {
             &db,
             true, // Submit: refund the perm fee for unpromoted txs
             submit_total,
-            true,
+            ForBlock::active(),
         )
         .await?;
 
@@ -4173,7 +4198,7 @@ mod tests {
         // no partitions there are no expiring-partition infos to report.
         let infos = epoch.ledgers.expire_partitions(
             expiry_epoch,
-            false,
+            ForBlock::inactive(),
             |_| 0,
             config.consensus.num_chunks_in_partition,
         );
@@ -4187,7 +4212,12 @@ mod tests {
         );
         // The inclusive (non-promotability) set still contains the slot...
         assert_eq!(
-            epoch.get_all_expired_term_slot_indexes(DataLedger::Submit, expiry_epoch + 1, false, 0),
+            epoch.get_all_expired_term_slot_indexes(
+                DataLedger::Submit,
+                expiry_epoch + 1,
+                ForBlock::inactive(),
+                0
+            ),
             vec![0],
             "the recycled slot stays in the inclusive set"
         );
@@ -4196,7 +4226,13 @@ mod tests {
         // chunk range at all.
         let mut parent = IrysBlockHeader::new_mock_header();
         parent.data_ledgers[DataLedger::Submit].total_chunks = 0;
-        let range = expired_submit_range(expiry_epoch + 1, &epoch, &parent, &config, false)?;
+        let range = expired_submit_range(
+            expiry_epoch + 1,
+            &epoch,
+            &parent,
+            &config,
+            ForBlock::inactive(),
+        )?;
         assert!(
             range.is_none(),
             "an expired-but-never-written slot yields no expired chunk range"

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -7574,6 +7574,7 @@ mod tests {
                 aurora: None,
                 borealis: None,
                 cascade: None,
+                delta: None,
             };
 
             let parent_n = hardforks.number_of_ingress_proofs_total_at(parent_ts);
@@ -9235,6 +9236,7 @@ mod commitment_version_tests {
                 }),
                 borealis: None,
                 cascade: None,
+                delta: None,
             },
             ..ConsensusConfig::testing()
         }
@@ -9251,6 +9253,7 @@ mod commitment_version_tests {
                 aurora: None,
                 borealis: None,
                 cascade: None,
+                delta: None,
             },
             ..ConsensusConfig::testing()
         }

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -6276,7 +6276,7 @@ pub async fn data_txs_are_valid(
 
     // Cascade activation is derived from the parent epoch snapshot the
     // caller fetched — single source of truth. The previous bare-bool
-    // bool parameter computed it from a separate snapshot read, which gave
+    // parameter computed it from a separate snapshot read, which gave
     // two reads where only one was authoritative; the reads always agreed
     // (same parent hash, immutable `Arc<EpochSnapshot>`) but the bool was a
     // footgun for any future caller computing it from a stale snapshot.

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -34,7 +34,9 @@ use irys_types::{
     DataTransactionLedger, DifficultyAdjustmentConfig, H256, IrysAddress, IrysBlockHeader, PoaData,
     SealedBlock, SendTraced as _, SystemLedger, U256, UnixTimestamp,
     app_state::DatabaseProvider,
-    calculate_difficulty, next_cumulative_diff,
+    calculate_difficulty,
+    hardfork_config::{Cascade, ForEpoch},
+    next_cumulative_diff,
     transaction::fee_distribution::{PublishFeeCharges, TermFeeCharges},
     validate_path,
 };
@@ -1887,19 +1889,19 @@ pub async fn prevalidate_block(
     // Data Ledger Validation
     // ========================================
     // Ensure only active data ledgers are present in the block
-    let cascade_active = config
+    let cascade_for_epoch = config
         .consensus
         .hardforks
-        .is_cascade_active_for_epoch(&parent_epoch_snapshot);
+        .cascade_for_epoch(&parent_epoch_snapshot);
 
     // Validate 'expires' field on term ledgers
-    validate_term_ledger_expiry(block, &config.consensus, cascade_active)?;
+    validate_term_ledger_expiry(block, &config.consensus, cascade_for_epoch)?;
     for ledger in &block.data_ledgers {
         match DataLedger::try_from(ledger.ledger_id) {
             Ok(DataLedger::Publish | DataLedger::Submit) => {
                 // Always valid
             }
-            Ok(DataLedger::OneYear | DataLedger::ThirtyDay) if cascade_active => {
+            Ok(DataLedger::OneYear | DataLedger::ThirtyDay) if cascade_for_epoch.is_active() => {
                 // Valid when Cascade hardfork is active
             }
             _ => {
@@ -5226,12 +5228,12 @@ async fn generate_expected_shadow_transactions(
 
     // Use pre-fetched publish ledger transactions with proofs from block header.
     // `extract_data_ledgers` validates peer-supplied structure → consensus.
-    let cascade_active = config
+    let cascade_for_epoch = config
         .consensus
         .hardforks
-        .is_cascade_active_for_epoch(&parent_epoch_snapshot);
+        .cascade_for_epoch(&parent_epoch_snapshot);
     let (publish_ledger, _submit_ledger) =
-        extract_data_ledgers(block, cascade_active).map_err(consensus)?;
+        extract_data_ledgers(block, cascade_for_epoch).map_err(consensus)?;
     let publish_ledger_with_txs = PublishLedgerWithTxs {
         txs: transactions.get_ledger_txs(DataLedger::Publish).to_vec(),
         proofs: publish_ledger.proofs.clone(),
@@ -5277,16 +5279,16 @@ async fn generate_expected_shadow_transactions(
         // the same value `perform_epoch_tasks` reads to gate the
         // `touch_active_ledger_slots` that rescues these slots. Must match the
         // producer (which uses the produced block's timestamp), and must NOT be
-        // the parent-snapshot helper (`is_cascade_active_for_epoch`), which lags
+        // the parent-snapshot helper (`cascade_for_epoch`), which lags
         // by an epoch at the activation boundary.
-        let cascade_active_for_block = config
+        let cascade_for_block = config
             .consensus
             .hardforks
-            .is_cascade_active_at(block.timestamp_secs());
-        let cascade_active_for_epoch = config
+            .cascade_for_block(block.timestamp_secs());
+        let cascade_for_epoch = config
             .consensus
             .hardforks
-            .is_cascade_active_for_epoch(&parent_epoch_snapshot);
+            .cascade_for_epoch(&parent_epoch_snapshot);
         // Each ledger's cumulative `total_chunks` is read from the prevalidated
         // header so producer and validator settle the identical expiring set.
         ledger_expiry::calculate_all_expired_ledger_fees(
@@ -5298,8 +5300,8 @@ async fn generate_expected_shadow_transactions(
             block_tree_guard,
             mempool_guard,
             db,
-            cascade_active_for_block,
-            cascade_active_for_epoch,
+            cascade_for_block,
+            cascade_for_epoch,
             |ledger| block.ledger_total_chunks(ledger),
         )
         .in_current_span()
@@ -5384,13 +5386,13 @@ async fn generate_expected_shadow_transactions(
     // (the write-window exclusion in `get_expiring_partition_info`) is. So a node
     // replaying history from genesis applies these rules to PRE-Cascade blocks too
     // (`expired_submit_range` still returns allocation-anchored expired slots when
-    // `cascade_active=false`). We accept this because no persistent (mainnet /
+    // Cascade is inactive for the block). We accept this because no persistent (mainnet /
     // non-resettable-testnet) pre-softfork data-tx history exists that could trip it
     // — the only blocks it would newly reject are exactly the buggy
     // already-expired-promotion blocks this fix exists to forbid, which must not
     // exist on any chain we replay. If that assumption is ever falsified, gate this
     // block and the refund-algorithm changes behind
-    // `is_cascade_active_at(block.timestamp_secs())` so pre-activation replay
+    // `cascade_for_block(block.timestamp_secs())` so pre-activation replay
     // reproduces old behavior bit-for-bit. Pinned by the mixed-mode test
     // `slow_heavy_cascade_midchain_submit_expiry_refunds_across_activation`.
     {
@@ -5398,16 +5400,16 @@ async fn generate_expected_shadow_transactions(
         // so resolve it once and reuse it per-candidate. Locally derived (parent
         // epoch snapshot, our block_index/mempool/DB); a failure here is a hard
         // node-local fault, not a peer statement. `None` → nothing expired.
-        let cascade_active_for_block = config
+        let cascade_for_block = config
             .consensus
             .hardforks
-            .is_cascade_active_at(block.timestamp_secs());
+            .cascade_for_block(block.timestamp_secs());
         let expired_range = ledger_expiry::expired_submit_range(
             block.height,
             &parent_epoch_snapshot,
             &prev_block,
             config,
-            cascade_active_for_block,
+            cascade_for_block,
         )
         .map_err(|e| node_fault(format!("NC-0042 expiry check: {e}")))?;
         if let Some(range) = &expired_range {
@@ -6160,7 +6162,7 @@ fn validate_term_only_price(
 fn validate_term_ledger_expiry(
     block: &IrysBlockHeader,
     consensus: &ConsensusConfig,
-    cascade_active: bool,
+    cascade_for_epoch: ForEpoch<Cascade>,
 ) -> Result<(), PreValidationError> {
     let cascade = consensus.hardforks.cascade.as_ref();
 
@@ -6180,8 +6182,10 @@ fn validate_term_ledger_expiry(
         let expected_expires = match ledger {
             DataLedger::Publish => None,
             DataLedger::Submit => Some(consensus.epoch.submit_ledger_epoch_length),
-            DataLedger::OneYear if cascade_active => Some(cascade_config()?.one_year_epoch_length),
-            DataLedger::ThirtyDay if cascade_active => {
+            DataLedger::OneYear if cascade_for_epoch.is_active() => {
+                Some(cascade_config()?.one_year_epoch_length)
+            }
+            DataLedger::ThirtyDay if cascade_for_epoch.is_active() => {
                 Some(cascade_config()?.thirty_day_epoch_length)
             }
             _ => continue, // non-active cascade ledgers handled by presence check
@@ -6275,18 +6279,18 @@ pub async fn data_txs_are_valid(
     }
 
     // Cascade activation is derived from the parent epoch snapshot the
-    // caller fetched — single source of truth. The previous `cascade_active`
+    // caller fetched — single source of truth. The previous bare-bool
     // bool parameter computed it from a separate snapshot read, which gave
     // two reads where only one was authoritative; the reads always agreed
     // (same parent hash, immutable `Arc<EpochSnapshot>`) but the bool was a
     // footgun for any future caller computing it from a stale snapshot.
-    let cascade_active = config
+    let cascade_for_epoch = config
         .consensus
         .hardforks
-        .is_cascade_active_for_epoch(&parent_epoch_snapshot);
+        .cascade_for_epoch(&parent_epoch_snapshot);
 
     // Extract publish ledger for ingress proofs validation
-    let (publish_ledger, _submit_ledger) = extract_data_ledgers(block, cascade_active)
+    let (publish_ledger, _submit_ledger) = extract_data_ledgers(block, cascade_for_epoch)
         .map_err(|e| PreValidationError::DataLedgerExtractionFailed(e.to_string()))?;
 
     // Step 1: Identify same-block promotions (txs appearing in both ledgers of current block)
@@ -6906,12 +6910,12 @@ pub async fn data_txs_are_valid(
 
 fn extract_data_ledgers(
     block: &IrysBlockHeader,
-    cascade_active: bool,
+    cascade_for_epoch: ForEpoch<Cascade>,
 ) -> eyre::Result<(&DataTransactionLedger, &DataTransactionLedger)> {
     let (publish_ledger, submit_ledger) = match &block.data_ledgers[..] {
         [publish_ledger, submit_ledger] => {
             ensure!(
-                !cascade_active,
+                !cascade_for_epoch.is_active(),
                 "Post-Cascade blocks must have 4 data ledgers, got 2"
             );
             ensure!(
@@ -6931,7 +6935,7 @@ fn extract_data_ledgers(
             thirty_day_ledger,
         ] => {
             ensure!(
-                cascade_active,
+                cascade_for_epoch.is_active(),
                 "Pre-Cascade blocks must have 2 data ledgers, got 4"
             );
             ensure!(
@@ -6971,7 +6975,7 @@ fn extract_data_ledgers(
         }
         [..] => eyre::bail!(
             "Expected {} data ledgers on the block, got {}",
-            if cascade_active { 4 } else { 2 },
+            if cascade_for_epoch.is_active() { 4 } else { 2 },
             block.data_ledgers.len()
         ),
     };

--- a/crates/actors/src/block_validation.rs
+++ b/crates/actors/src/block_validation.rs
@@ -5285,10 +5285,6 @@ async fn generate_expected_shadow_transactions(
             .consensus
             .hardforks
             .cascade_for_block(block.timestamp_secs());
-        let cascade_for_epoch = config
-            .consensus
-            .hardforks
-            .cascade_for_epoch(&parent_epoch_snapshot);
         // Each ledger's cumulative `total_chunks` is read from the prevalidated
         // header so producer and validator settle the identical expiring set.
         ledger_expiry::calculate_all_expired_ledger_fees(

--- a/crates/actors/src/mempool_service/data_txs.rs
+++ b/crates/actors/src/mempool_service/data_txs.rs
@@ -77,7 +77,8 @@ impl Inner {
                     .node_config
                     .consensus_config()
                     .hardforks
-                    .is_cascade_active_for_epoch(&epoch_snapshot)
+                    .cascade_for_epoch(&epoch_snapshot)
+                    .is_active()
             };
             if !cascade_active {
                 return Err(TxIngressError::InvalidLedger(tx.ledger_id));

--- a/crates/actors/src/tx_selector/mod.rs
+++ b/crates/actors/src/tx_selector/mod.rs
@@ -659,7 +659,8 @@ pub async fn select_best_txs(
                 let consensus = ctx.config.node_config.consensus_config();
                 if !consensus
                     .hardforks
-                    .is_cascade_active_for_epoch(&parent_epoch_snapshot)
+                    .cascade_for_epoch(&parent_epoch_snapshot)
+                    .is_active()
                 {
                     debug!(
                         tx.id = ?tx.id,
@@ -1006,17 +1007,17 @@ async fn get_publish_txs_and_proofs(
         // so compute it once here and reuse it per-candidate via `submit_tx_expired`
         // (which then costs at most one canonical Submit-height read each). `None`
         // means nothing has expired as of this block → no candidate is filtered.
-        let cascade_active_for_block = ctx
+        let cascade_for_block = ctx
             .config
             .consensus
             .hardforks
-            .is_cascade_active_at(current_timestamp);
+            .cascade_for_block(current_timestamp);
         let expired_submit_range = crate::block_producer::ledger_expiry::expired_submit_range(
             next_block_height,
             epoch_snapshot,
             parent_block_header,
             ctx.config,
-            cascade_active_for_block,
+            cascade_for_block,
         )?;
 
         // Branch-correct "already promoted?" set. `DataTransactionHeader::

--- a/crates/actors/tests/epoch_snapshot_tests.rs
+++ b/crates/actors/tests/epoch_snapshot_tests.rs
@@ -397,13 +397,15 @@ async fn unique_addresses_per_slot_test() {
 /// about the new ledgers from the header. Delta seeds them directly; before
 /// Delta the ledgers stay slotless (and therefore unassigned) for a full epoch.
 #[rstest::rstest]
-#[case::delta_active(true, 1)]
-#[case::pre_delta(false, 0)]
+#[case::delta_active(true, 1, 1)]
+#[case::pre_delta(false, 0, 2)]
 #[tokio::test]
 async fn new_ledger_activation_slots_test(
     #[case] delta_active: bool,
-    #[case] expected_slots: usize,
+    #[case] activation_epoch_slots: usize,
+    #[case] next_epoch_slots: usize,
 ) {
+    use irys_types::DataTransactionLedger;
     use irys_types::UnixTimestamp;
     use irys_types::hardfork_config::{Cascade, Delta};
 
@@ -498,7 +500,7 @@ async fn new_ledger_activation_slots_test(
         let slots = epoch_snapshot.ledgers.get_slots(ledger);
         assert_eq!(
             slots.len(),
-            expected_slots,
+            activation_epoch_slots,
             "{:?} slot count at the activation epoch (delta_active={})",
             ledger,
             delta_active
@@ -519,11 +521,42 @@ async fn new_ledger_activation_slots_test(
         }
     }
 
-    // Seeding happens once: the ledgers are still absent from later epoch
-    // headers, but their slots already exist so no further slots are added.
+    // The NEXT epoch block does carry the term ledgers: its producer reads the
+    // now-cascade-active parent snapshot, and `extract_data_ledgers` rejects a
+    // 2-ledger block from here on. So this is where the un-seeded ledger meets
+    // `calculate_additional_slots` for the first time, and the two cases diverge:
+    //
+    //   delta_active: 1 seeded slot already exists, and with no term data written
+    //     the capacity threshold is not met -> stays at 1. Seeding happens once.
+    //   pre_delta: `num_slots == 0` collapses the threshold to 0, which any
+    //     ledger size meets -> 2 slots, a full epoch after the ledger went live.
+    //
+    // That one-epoch slotless window is what Delta exists to close.
     let mut later_epoch_block = IrysBlockHeader::new_mock_header();
     later_epoch_block.height = config.consensus.epoch.num_blocks_in_epoch * 2;
-    later_epoch_block.timestamp = UnixTimestampMs::from_millis(EPOCH_BLOCK_SECS as u128 * 2000);
+    later_epoch_block.timestamp = UnixTimestampMs::from_millis(EPOCH_BLOCK_SECS as u128 * 2 * 1000);
+    let cascade = config
+        .consensus
+        .hardforks
+        .cascade
+        .as_ref()
+        .expect("cascade is configured above");
+    for (ledger, expires) in [
+        (DataLedger::OneYear, cascade.one_year_epoch_length),
+        (DataLedger::ThirtyDay, cascade.thirty_day_epoch_length),
+    ] {
+        later_epoch_block.data_ledgers.push(DataTransactionLedger {
+            ledger_id: ledger as u32,
+            tx_root: H256::zero(),
+            tx_ids: H256List::default(),
+            // No term data was written during the activation epoch, so the
+            // seeded slot is nowhere near full.
+            total_chunks: 0,
+            expires: Some(expires),
+            proofs: None,
+            required_proof_count: None,
+        });
+    }
 
     epoch_snapshot
         .perform_epoch_tasks(
@@ -536,8 +569,8 @@ async fn new_ledger_activation_slots_test(
     for ledger in [DataLedger::OneYear, DataLedger::ThirtyDay] {
         assert_eq!(
             epoch_snapshot.ledgers.get_slots(ledger).len(),
-            expected_slots,
-            "{:?} must not gain slots at epochs after activation (delta_active={})",
+            next_epoch_slots,
+            "{:?} slot count at the epoch after activation (delta_active={})",
             ledger,
             delta_active
         );

--- a/crates/actors/tests/epoch_snapshot_tests.rs
+++ b/crates/actors/tests/epoch_snapshot_tests.rs
@@ -518,6 +518,30 @@ async fn new_ledger_activation_slots_test(
             );
         }
     }
+
+    // Seeding happens once: the ledgers are still absent from later epoch
+    // headers, but their slots already exist so no further slots are added.
+    let mut later_epoch_block = IrysBlockHeader::new_mock_header();
+    later_epoch_block.height = config.consensus.epoch.num_blocks_in_epoch * 2;
+    later_epoch_block.timestamp = UnixTimestampMs::from_millis(EPOCH_BLOCK_SECS as u128 * 2000);
+
+    epoch_snapshot
+        .perform_epoch_tasks(
+            &Some(new_epoch_block.clone()),
+            &later_epoch_block,
+            Vec::new(),
+        )
+        .unwrap();
+
+    for ledger in [DataLedger::OneYear, DataLedger::ThirtyDay] {
+        assert_eq!(
+            epoch_snapshot.ledgers.get_slots(ledger).len(),
+            expected_slots,
+            "{:?} must not gain slots at epochs after activation (delta_active={})",
+            ledger,
+            delta_active
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/actors/tests/epoch_snapshot_tests.rs
+++ b/crates/actors/tests/epoch_snapshot_tests.rs
@@ -12,6 +12,7 @@ use irys_database::{
 use irys_domain::{BlockIndex, EpochBlockData, EpochSnapshot, StorageModule, StorageModuleVec};
 use irys_testing_utils::utils::TempDirBuilder;
 use irys_types::PartitionChunkRange;
+use irys_types::UnixTimestampMs;
 use irys_types::irys::IrysSigner;
 use irys_types::{
     BlockTransactions, DataLedger, DbSyncMode, H256, IrysBlockHeader, SealedBlock,
@@ -385,6 +386,138 @@ async fn unique_addresses_per_slot_test() {
     assert!(submit_addresses_set.contains(&genesis_signer.address()));
     assert!(submit_addresses_set.contains(&signer1.address()));
     assert!(submit_addresses_set.contains(&signer2.address()));
+}
+
+/// A ledger that a hardfork activates mid-chain must get its first slots in the
+/// epoch that activates it.
+///
+/// The activation epoch block's header carries only the pre-activation ledger
+/// set — the producer derives the header ledger set from the parent epoch
+/// snapshot, which still predates activation — so slot allocation cannot learn
+/// about the new ledgers from the header. Delta seeds them directly; before
+/// Delta the ledgers stay slotless (and therefore unassigned) for a full epoch.
+#[rstest::rstest]
+#[case::delta_active(true, 1)]
+#[case::pre_delta(false, 0)]
+#[tokio::test]
+async fn new_ledger_activation_slots_test(
+    #[case] delta_active: bool,
+    #[case] expected_slots: usize,
+) {
+    use irys_types::UnixTimestamp;
+    use irys_types::hardfork_config::{Cascade, Delta};
+
+    const GENESIS_SECS: u64 = 1_000;
+    const CASCADE_ACTIVATION_SECS: u64 = 2_000;
+    const EPOCH_BLOCK_SECS: u64 = 3_000;
+
+    let tmp_dir = TempDirBuilder::new()
+        .prefix("new_ledger_activation_slots_test")
+        .with_tracing()
+        .build();
+    let consensus_config = ConsensusConfig {
+        chunk_size: 32,
+        num_chunks_in_partition: 10,
+        num_chunks_in_recall_range: 2,
+        num_partitions_per_slot: 1,
+        block_migration_depth: 1,
+        chain_id: 333,
+        epoch: EpochConfig {
+            capacity_scalar: 100,
+            num_blocks_in_epoch: 100,
+            num_capacity_partitions: Some(123),
+            submit_ledger_epoch_length: 5,
+            publish_ledger_epoch_length: None,
+        },
+        hardforks: irys_types::hardfork_config::IrysHardforkConfig {
+            // Cascade activates between genesis and the first epoch block, so
+            // its term ledgers are activated by `perform_epoch_tasks` below.
+            cascade: Some(Cascade {
+                activation_timestamp: UnixTimestamp::from_secs(CASCADE_ACTIVATION_SECS),
+                one_year_epoch_length: 365,
+                thirty_day_epoch_length: 30,
+                annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
+            }),
+            delta: delta_active.then(|| Delta {
+                activation_timestamp: UnixTimestamp::from_secs(0),
+                initial_slots_per_new_ledger: Delta::default_initial_slots_per_new_ledger(),
+            }),
+            ..ConsensusConfig::testing().hardforks
+        },
+        ..ConsensusConfig::testing()
+    };
+    let mut testing_config = NodeConfig::testing();
+    testing_config.base_directory = tmp_dir.path().to_path_buf();
+    testing_config.consensus = ConsensusOptions::Custom(consensus_config);
+    let config = Config::new_with_random_peer_id(testing_config);
+
+    let mut genesis_block = IrysBlockHeader::new_mock_header();
+    genesis_block.height = 0;
+    genesis_block.timestamp = UnixTimestampMs::from_millis(GENESIS_SECS as u128 * 1000);
+    // Enough pledged capacity partitions to fill the genesis ledger slots and
+    // both newly activated ledgers.
+    let (commitments, initial_treasury) = add_test_commitments(&mut genesis_block, 5, &config)
+        .await
+        .unwrap();
+    genesis_block.treasury = initial_treasury;
+
+    let storage_submodules_config = StorageSubmodulesConfig::load(
+        config.node_config.base_directory.clone(),
+        config.node_config.node_mode,
+    )
+    .unwrap();
+
+    let mut epoch_snapshot = EpochSnapshot::new(
+        &storage_submodules_config,
+        genesis_block.clone(),
+        commitments,
+        &config,
+    );
+
+    // Pre-activation the term ledgers do not exist at all.
+    assert_eq!(epoch_snapshot.ledgers.active_ledgers().len(), 2);
+
+    // The activation epoch block: cascade-active by timestamp, but its header
+    // lists only Publish and Submit (what a producer on the parent snapshot emits).
+    let mut new_epoch_block = IrysBlockHeader::new_mock_header();
+    new_epoch_block.height = config.consensus.epoch.num_blocks_in_epoch;
+    new_epoch_block.timestamp = UnixTimestampMs::from_millis(EPOCH_BLOCK_SECS as u128 * 1000);
+    assert_eq!(new_epoch_block.data_ledgers.len(), 2);
+
+    epoch_snapshot
+        .perform_epoch_tasks(&Some(genesis_block), &new_epoch_block, Vec::new())
+        .unwrap();
+
+    assert_eq!(
+        epoch_snapshot.ledgers.active_ledgers().len(),
+        4,
+        "cascade must activate the term ledgers at this epoch boundary"
+    );
+
+    for ledger in [DataLedger::OneYear, DataLedger::ThirtyDay] {
+        let slots = epoch_snapshot.ledgers.get_slots(ledger);
+        assert_eq!(
+            slots.len(),
+            expected_slots,
+            "{:?} slot count at the activation epoch (delta_active={})",
+            ledger,
+            delta_active
+        );
+        for (slot_index, slot) in slots.iter().enumerate() {
+            assert_eq!(
+                slot.partitions.len() as u64,
+                config.consensus.num_partitions_per_slot,
+                "{:?} slot {} must have its partitions assigned in the same epoch",
+                ledger,
+                slot_index
+            );
+            assert_eq!(
+                slot.last_height, new_epoch_block.height,
+                "{:?} slot {} must be aged from the activation epoch",
+                ledger, slot_index
+            );
+        }
+    }
 }
 
 #[tokio::test]

--- a/crates/api-server/src/routes/ledger.rs
+++ b/crates/api-server/src/routes/ledger.rs
@@ -935,6 +935,7 @@ mod tests {
     use irys_database::Ledgers;
     use irys_domain::PartitionAssignments;
     use irys_types::ConsensusConfig;
+    use irys_types::hardfork_config::ForBlock;
     use rstest::rstest;
 
     fn make_test_ledgers(publish_epoch_length: Option<u64>) -> Ledgers {
@@ -942,7 +943,7 @@ mod tests {
         config.epoch.num_blocks_in_epoch = 10;
         config.epoch.submit_ledger_epoch_length = 5;
         config.epoch.publish_ledger_epoch_length = publish_epoch_length;
-        Ledgers::new(&config, false)
+        Ledgers::new(&config, ForBlock::inactive())
     }
 
     #[test]
@@ -1701,7 +1702,7 @@ mod tests {
 
         // Real protocol expiry math: at epoch_height=60, expiry_height=60-50=10;
         // slot 0 (last_height=1<=10, not last slot) expires.
-        ledgers.expire_partitions(60, false, |_| 0, 1);
+        ledgers.expire_partitions(60, ForBlock::inactive(), |_| 0, 1);
 
         let response =
             build_epoch_ledger_summary_response(&ledgers, DataLedger::Submit, 123, 25, 10).unwrap();

--- a/crates/api-server/src/routes/price.rs
+++ b/crates/api-server/src/routes/price.rs
@@ -170,7 +170,8 @@ pub async fn get_price(
                 .config
                 .consensus
                 .hardforks
-                .is_cascade_active_for_epoch(&epoch_snapshot);
+                .cascade_for_epoch(&epoch_snapshot)
+                .is_active();
             if !cascade_active {
                 return Err((
                     format!(

--- a/crates/chain-tests/src/api/hardfork_tests.rs
+++ b/crates/chain-tests/src/api/hardfork_tests.rs
@@ -109,6 +109,7 @@ fn create_test_config(aurora: Option<Aurora>) -> NodeConfig {
         aurora,
         borealis: None,
         cascade: None,
+        delta: None,
     };
     config
 }
@@ -603,6 +604,7 @@ mod epoch_block_filtering {
             aurora,
             borealis: None,
             cascade: None,
+            delta: None,
         };
         config
     }
@@ -713,6 +715,7 @@ mod epoch_block_filtering {
             }),
             borealis: None,
             cascade: None,
+            delta: None,
         };
         let [signer1, signer2] = create_funded_signers(&mut config);
         let node = IrysNodeTest::new_genesis(config)
@@ -787,6 +790,7 @@ mod borealis_hardfork {
             aurora,
             borealis,
             cascade: None,
+            delta: None,
         };
         config
     }
@@ -883,6 +887,7 @@ mod borealis_hardfork {
                 activation_timestamp: UnixTimestamp::from_secs(borealis_activation),
             }),
             cascade: None,
+            delta: None,
         };
 
         let signer = create_funded_signer(&mut config);
@@ -1004,6 +1009,7 @@ mod peer_sync_recovery {
             next_name_tbd: None,
             borealis: None,
             cascade: None,
+            delta: None,
         };
 
         // Fund signers: 9 for V1 (3 epochs * 3 blocks), 9 for V2 (3 epochs * 3 blocks), 1 for peer

--- a/crates/chain-tests/src/api/pricing_endpoint.rs
+++ b/crates/chain-tests/src/api/pricing_endpoint.rs
@@ -414,6 +414,7 @@ async fn heavy_pricing_endpoint_hardfork_changes_ingress_proofs() -> eyre::Resul
         aurora: None,
         borealis: None,
         cascade: None,
+        delta: None,
     };
 
     let ctx = crate::utils::IrysNodeTest::new_genesis(config)

--- a/crates/chain-tests/src/validation/cascade_ledger_shape.rs
+++ b/crates/chain-tests/src/validation/cascade_ledger_shape.rs
@@ -96,7 +96,7 @@ async fn heavy_cascade_block_header_ledger_shape_at_activation_epoch() -> eyre::
 
 /// Mid-chain Cascade activation must leave the term ledgers with slots and
 /// partition assignments in the epoch that activates them, and term data posted
-/// in the following epoch must reach disk.
+/// in that same epoch must reach disk.
 ///
 /// The activation epoch block's own header carries only Publish + Submit: the
 /// producer derives the header ledger set from the parent epoch snapshot, which
@@ -243,7 +243,7 @@ async fn heavy_cascade_midchain_activation_seeds_term_ledger_slots() -> eyre::Re
             .get_data_ledger_tx_ids()
             .get(&DataLedger::OneYear)
             .is_some_and(|ids| ids.contains(&tx.header.id)),
-        "the term tx must be included in the block right after the activation epoch"
+        "the term tx must be included in the block right after the activation epoch block"
     );
 
     for i in 0..chunks.len() {

--- a/crates/chain-tests/src/validation/cascade_ledger_shape.rs
+++ b/crates/chain-tests/src/validation/cascade_ledger_shape.rs
@@ -94,6 +94,123 @@ async fn heavy_cascade_block_header_ledger_shape_at_activation_epoch() -> eyre::
     Ok(())
 }
 
+/// Mid-chain Cascade activation must leave the term ledgers with slots and
+/// partition assignments in the epoch that activates them.
+///
+/// The activation epoch block's own header carries only Publish + Submit: the
+/// producer derives the header ledger set from the parent epoch snapshot, which
+/// still predates the activation. Slot allocation skips ledgers absent from the
+/// header, so before Delta the term ledgers stayed slotless — no partitions, no
+/// miner storing them — for a full epoch, while blocks in that epoch already
+/// accepted term data.
+///
+/// Activation is performed via stop -> set `cascade.activation_timestamp` from
+/// the chain tip -> restart, so replayed history stays pre-activation and only
+/// newly mined epoch blocks are cascade-active (no wall-clock race).
+#[test_log::test(tokio::test)]
+async fn heavy_cascade_midchain_activation_seeds_term_ledger_slots() -> eyre::Result<()> {
+    use irys_config::submodules::StorageSubmodulesConfig;
+    use irys_types::hardfork_config::{Cascade, Delta};
+
+    let num_blocks_in_epoch = 2_u64;
+    let config = NodeConfig::testing().with_consensus(|c| {
+        c.epoch.num_blocks_in_epoch = num_blocks_in_epoch;
+        // Delta is active for the whole chain; it only has an effect in an epoch
+        // that activates a ledger.
+        c.hardforks.delta = Some(Delta {
+            activation_timestamp: UnixTimestamp::from_secs(1),
+            initial_slots_per_new_ledger: Delta::default_initial_slots_per_new_ledger(),
+        });
+        // Cascade intentionally NOT configured yet — activated mid-chain below.
+    });
+
+    // 5 submodules: 2 partitions for the genesis ledgers, the rest available for
+    // the term ledger slots seeded at activation.
+    let test = IrysNodeTest::new_genesis(config);
+    StorageSubmodulesConfig::load_for_test(test.cfg.base_directory.clone(), 5)?;
+    let node = test.start_and_wait_for_packing("GENESIS", 20).await;
+
+    // Mine to an epoch boundary while pre-Cascade.
+    while node.get_canonical_chain_height().await < num_blocks_in_epoch {
+        node.mine_block().await?;
+    }
+    let tip_height = node.get_canonical_chain_height().await;
+    let activation_timestamp = node
+        .get_block_by_height(tip_height)
+        .await?
+        .timestamp_secs()
+        .as_secs()
+        + 1;
+
+    let mut stopped = node.stop().await;
+    stopped.cfg.consensus.get_mut().hardforks.cascade = Some(Cascade {
+        activation_timestamp: UnixTimestamp::from_secs(activation_timestamp),
+        one_year_epoch_length: 365,
+        thirty_day_epoch_length: 30,
+        annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
+    });
+    let node = stopped.start().await;
+
+    // Advance epoch by epoch until one lands at or after the activation
+    // timestamp: that is the activation epoch block, and we assert on it before
+    // any later epoch can paper over the gap. Driven by the mined block's own
+    // timestamp rather than an assumed height, so a restart that finishes inside
+    // the same wall-clock second cannot mis-identify the boundary.
+    let activation_epoch = loop {
+        let boundary = super::next_epoch_boundary(
+            node.get_canonical_chain_height().await + 1,
+            num_blocks_in_epoch,
+        );
+        while node.get_canonical_chain_height().await < boundary {
+            node.mine_block().await?;
+        }
+        if node
+            .get_block_by_height(boundary)
+            .await?
+            .timestamp_secs()
+            .as_secs()
+            >= activation_timestamp
+        {
+            break boundary;
+        }
+    };
+
+    let epoch_block = node.get_block_by_height(activation_epoch).await?;
+    assert_eq!(
+        epoch_block.data_ledgers.len(),
+        2,
+        "the activation epoch block's header carries only the pre-activation \
+         ledger set — this is the condition Delta compensates for"
+    );
+
+    let snapshot = {
+        let tree = node.node_ctx.block_tree_guard.read();
+        tree.get_epoch_snapshot(&epoch_block.block_hash)
+            .expect("epoch snapshot should exist for the activation epoch block")
+    };
+    assert_eq!(
+        snapshot.ledgers.active_ledgers().len(),
+        4,
+        "cascade must activate the term ledgers at this epoch boundary"
+    );
+    for ledger in [DataLedger::OneYear, DataLedger::ThirtyDay] {
+        let slots = snapshot.ledgers.get_slots(ledger);
+        assert_eq!(
+            slots.len(),
+            1,
+            "{ledger:?} must be seeded with a slot in its activation epoch"
+        );
+        assert_eq!(
+            slots[0].partitions.len() as u64,
+            node.node_ctx.config.consensus.num_partitions_per_slot,
+            "{ledger:?} slot 0 must have its partitions assigned in the same epoch"
+        );
+    }
+
+    node.stop().await;
+    Ok(())
+}
+
 /// Regression test for the 2026-06-11 devnet incident: a positive Cascade
 /// activation timestamp at or before the genesis timestamp must yield a
 /// genesis header with all four data ledgers, and a node hosting term-ledger

--- a/crates/chain-tests/src/validation/cascade_ledger_shape.rs
+++ b/crates/chain-tests/src/validation/cascade_ledger_shape.rs
@@ -95,7 +95,8 @@ async fn heavy_cascade_block_header_ledger_shape_at_activation_epoch() -> eyre::
 }
 
 /// Mid-chain Cascade activation must leave the term ledgers with slots and
-/// partition assignments in the epoch that activates them.
+/// partition assignments in the epoch that activates them, and term data posted
+/// in the following epoch must reach disk.
 ///
 /// The activation epoch block's own header carries only Publish + Submit: the
 /// producer derives the header ledger set from the parent epoch snapshot, which
@@ -111,10 +112,16 @@ async fn heavy_cascade_block_header_ledger_shape_at_activation_epoch() -> eyre::
 async fn heavy_cascade_midchain_activation_seeds_term_ledger_slots() -> eyre::Result<()> {
     use irys_config::submodules::StorageSubmodulesConfig;
     use irys_types::hardfork_config::{Cascade, Delta};
+    use irys_types::{BoundedFee, LedgerChunkOffset};
 
-    let num_blocks_in_epoch = 2_u64;
-    let config = NodeConfig::testing().with_consensus(|c| {
+    // 4-block epochs leave room to include a term tx and migrate its block to
+    // disk without crossing the next epoch boundary — the boundary that would
+    // allocate the term slots from the header ledger set even without Delta.
+    let num_blocks_in_epoch = 4_u64;
+    let mut config = NodeConfig::testing().with_consensus(|c| {
         c.epoch.num_blocks_in_epoch = num_blocks_in_epoch;
+        c.chunk_size = 32;
+        c.block_migration_depth = 1;
         // Delta is active for the whole chain; it only has an effect in an epoch
         // that activates a ledger.
         c.hardforks.delta = Some(Delta {
@@ -123,6 +130,8 @@ async fn heavy_cascade_midchain_activation_seeds_term_ledger_slots() -> eyre::Re
         });
         // Cascade intentionally NOT configured yet — activated mid-chain below.
     });
+    let signer = config.new_random_signer();
+    config.fund_genesis_accounts(vec![&signer]);
 
     // 5 submodules: 2 partitions for the genesis ledgers, the rest available for
     // the term ledger slots seeded at activation.
@@ -205,6 +214,61 @@ async fn heavy_cascade_midchain_activation_seeds_term_ledger_slots() -> eyre::Re
             node.node_ctx.config.consensus.num_partitions_per_slot,
             "{ledger:?} slot 0 must have its partitions assigned in the same epoch"
         );
+    }
+
+    // The window Delta exists for: from here until the next epoch block, term
+    // txs are accepted (the canonical epoch snapshot is now cascade-active) but
+    // only the seeded slots can store them. Data posted in this window must
+    // reach disk, not wait an epoch for slots.
+    node.wait_for_packing(30).await;
+
+    let chunks = vec![[10_u8; 32], [20_u8; 32], [30_u8; 32]];
+    let data: Vec<u8> = chunks.concat();
+    let data_size = data.len() as u64;
+    let price = node.get_data_price(DataLedger::OneYear, data_size).await?;
+    let tx = signer.create_transaction_with_fees(
+        data,
+        node.get_anchor().await?,
+        DataLedger::OneYear,
+        BoundedFee::new(price.term_fee),
+        None,
+    )?;
+    let tx = signer.sign_transaction(tx)?;
+    node.ingest_data_tx(tx.header.clone()).await?;
+    node.wait_for_mempool(tx.header.id, 30).await?;
+
+    let inclusion_block = node.mine_block().await?;
+    assert!(
+        inclusion_block
+            .get_data_ledger_tx_ids()
+            .get(&DataLedger::OneYear)
+            .is_some_and(|ids| ids.contains(&tx.header.id)),
+        "the term tx must be included in the block right after the activation epoch"
+    );
+
+    for i in 0..chunks.len() {
+        node.post_chunk_32b(&tx, i, &chunks).await;
+    }
+
+    // One more block migrates the inclusion block (block_migration_depth = 1),
+    // writing its chunks into the storage module behind the seeded slot. The
+    // ledger-offset read below only consults storage modules, never the chunk
+    // cache, so a hit means the bytes are on disk.
+    node.mine_block().await?;
+    assert!(
+        node.get_canonical_chain_height().await < activation_epoch + num_blocks_in_epoch,
+        "the on-disk check must land before the next epoch boundary, or a later \
+         epoch block could have allocated the slots instead of Delta"
+    );
+
+    for (i, chunk) in chunks.iter().enumerate() {
+        node.verify_migrated_chunk_32b(
+            DataLedger::OneYear,
+            LedgerChunkOffset::from(i as u64),
+            chunk,
+            data_size,
+        )
+        .await;
     }
 
     node.stop().await;

--- a/crates/chain-tests/src/validation/cascade_submit_expiry_promotion.rs
+++ b/crates/chain-tests/src/validation/cascade_submit_expiry_promotion.rs
@@ -216,7 +216,7 @@ async fn heavy_cascade_block_promoting_already_expired_submit_tx_gets_rejected()
         .config
         .consensus
         .hardforks
-        .is_cascade_active_at(expiry_block.timestamp_secs());
+        .cascade_for_block(expiry_block.timestamp_secs());
     let expired_set = irys_actors::block_producer::ledger_expiry::expired_submit_tx_ids(
         &expiry_parent_snapshot,
         &expiry_parent_block,
@@ -359,7 +359,7 @@ async fn heavy_cascade_block_promoting_already_expired_submit_tx_gets_rejected()
         .config
         .consensus
         .hardforks
-        .is_cascade_active_at(evil_parent_block.timestamp_secs());
+        .cascade_for_block(evil_parent_block.timestamp_secs());
     let mut target: Option<&irys_types::DataTransaction> = None;
     for tx in &txs {
         let per_candidate = irys_actors::block_producer::ledger_expiry::is_submit_storage_expired(

--- a/crates/chain-tests/src/validation/cascade_term_expiry.rs
+++ b/crates/chain-tests/src/validation/cascade_term_expiry.rs
@@ -4,6 +4,7 @@ use irys_config::submodules::StorageSubmodulesConfig;
 use irys_reth_node_bridge::irys_reth::shadow_tx::{ShadowTransaction, TransactionPacket};
 use irys_types::{
     BoundedFee, DataLedger, H256, NodeConfig, U256, UnixTimestamp, hardfork_config::Cascade,
+    hardfork_config::ForBlock,
 };
 use reth::rpc::types::TransactionTrait as _;
 
@@ -829,7 +830,7 @@ async fn heavy_cascade_expiry_fee_model_matches_actual_recycle() -> eyre::Result
         // cascade_active=true: this scenario runs post-activation (cascade
         // activated at timestamp 0), matching the producer/validator gate.
         parent_snap
-            .get_expiring_partition_info(e, DataLedger::ThirtyDay, e_total, true)
+            .get_expiring_partition_info(e, DataLedger::ThirtyDay, e_total, ForBlock::active())
             .into_iter()
             .map(|p| p.slot_index)
             .collect::<Vec<_>>()
@@ -874,7 +875,12 @@ async fn heavy_cascade_expiry_fee_model_matches_actual_recycle() -> eyre::Result
     // contract rather than the post-touch epoch-block total.
     let parent_total = parent_block.ledger_total_chunks(DataLedger::ThirtyDay);
     let blocked: std::collections::BTreeSet<usize> = parent_snap
-        .get_all_expired_term_slot_indexes(DataLedger::ThirtyDay, e, true, parent_total)
+        .get_all_expired_term_slot_indexes(
+            DataLedger::ThirtyDay,
+            e,
+            ForBlock::active(),
+            parent_total,
+        )
         .into_iter()
         .collect();
     let recycled: std::collections::BTreeSet<usize> = actual_set.iter().copied().collect();
@@ -1022,7 +1028,12 @@ async fn heavy_cascade_expiry_blocked_set_surplus_is_previously_expired() -> eyr
     // heavy_cascade_expiry_fee_model_matches_actual_recycle fixture.
     let parent_total = parent_block.ledger_total_chunks(DataLedger::ThirtyDay);
     let blocked: std::collections::BTreeSet<usize> = parent_snap
-        .get_all_expired_term_slot_indexes(DataLedger::ThirtyDay, e2, true, parent_total)
+        .get_all_expired_term_slot_indexes(
+            DataLedger::ThirtyDay,
+            e2,
+            ForBlock::active(),
+            parent_total,
+        )
         .into_iter()
         .collect();
 
@@ -1433,7 +1444,7 @@ async fn heavy_pre_cascade_submit_expiry_fee_model_matches_actual_recycle() -> e
         let snap = tree
             .get_epoch_snapshot(&parent_block.block_hash)
             .expect("parent epoch snapshot");
-        snap.get_expiring_partition_info(e, DataLedger::Submit, e_total, false)
+        snap.get_expiring_partition_info(e, DataLedger::Submit, e_total, ForBlock::inactive())
             .into_iter()
             .map(|p| p.slot_index)
             .collect::<Vec<_>>()
@@ -1456,7 +1467,7 @@ async fn heavy_pre_cascade_submit_expiry_fee_model_matches_actual_recycle() -> e
         let snap = tree
             .get_epoch_snapshot(&parent_block.block_hash)
             .expect("parent epoch snapshot");
-        snap.get_expiring_partition_info(e, DataLedger::Submit, e_total, true)
+        snap.get_expiring_partition_info(e, DataLedger::Submit, e_total, ForBlock::active())
             .into_iter()
             .map(|p| p.slot_index)
             .collect::<Vec<_>>()

--- a/crates/chain-tests/src/validation/mid_epoch_promotability.rs
+++ b/crates/chain-tests/src/validation/mid_epoch_promotability.rs
@@ -288,7 +288,7 @@ async fn heavy_mid_epoch_boundary_crossing_defers_then_rescues() -> eyre::Result
         .config
         .consensus
         .hardforks
-        .is_cascade_active_at(append_block.timestamp_secs());
+        .cascade_for_block(append_block.timestamp_secs());
 
     // Oracle (anti-vacuity): T really is inside the boundary-crossed-but-unrescued
     // window as of the block we are about to produce.

--- a/crates/chain-tests/src/validation/promote_after_activation_straddle.rs
+++ b/crates/chain-tests/src/validation/promote_after_activation_straddle.rs
@@ -182,9 +182,9 @@ async fn slow_heavy_promote_after_activation_straddle_rejected() -> eyre::Result
         .config
         .consensus
         .hardforks
-        .is_cascade_active_at(evil_parent_block.timestamp_secs());
+        .cascade_for_block(evil_parent_block.timestamp_secs());
     assert!(
-        cascade_active,
+        cascade_active.is_active(),
         "evil block's parent tip must be cascade-active post-activation \
          (activation anchored at the pre-restart tip + 1s)"
     );

--- a/crates/chain-tests/src/validation/promote_after_submit_expiry.rs
+++ b/crates/chain-tests/src/validation/promote_after_submit_expiry.rs
@@ -75,7 +75,7 @@ async fn heavy_block_promoting_already_expired_submit_tx_gets_rejected() -> eyre
         .config
         .consensus
         .hardforks
-        .is_cascade_active_at(evil_parent_block.timestamp_secs());
+        .cascade_for_block(evil_parent_block.timestamp_secs());
     let expired_set = irys_actors::block_producer::ledger_expiry::expired_submit_tx_ids(
         &tip_snapshot,
         &evil_parent_block,

--- a/crates/chain-tests/src/validation/publish_after_submit_expiry_filtered.rs
+++ b/crates/chain-tests/src/validation/publish_after_submit_expiry_filtered.rs
@@ -222,7 +222,7 @@ async fn heavy_producer_drops_publish_candidate_whose_submit_storage_expired() -
         .config
         .consensus
         .hardforks
-        .is_cascade_active_at(expiry_parent_block.timestamp_secs());
+        .cascade_for_block(expiry_parent_block.timestamp_secs());
     let expired_set = irys_actors::block_producer::ledger_expiry::expired_submit_tx_ids(
         &expiry_parent_snapshot,
         &expiry_parent_block,

--- a/crates/chain-tests/src/validation/reorg_submit_expiry.rs
+++ b/crates/chain-tests/src/validation/reorg_submit_expiry.rs
@@ -224,7 +224,7 @@ async fn heavy_reorg_across_submit_expiry_epoch_settles_on_winning_branch() -> e
         .config
         .consensus
         .hardforks
-        .is_cascade_active_at(expiry_block.timestamp_secs());
+        .cascade_for_block(expiry_block.timestamp_secs());
     let pipeline_b = calculate_expired_ledger_fees(
         &expiry_parent_snapshot,
         &expiry_parent_block,

--- a/crates/chain-tests/src/validation/slow_path_submit_expiry.rs
+++ b/crates/chain-tests/src/validation/slow_path_submit_expiry.rs
@@ -69,7 +69,7 @@ async fn heavy_submit_expiry_resolves_unmigrated_inclusion_via_slow_path() -> ey
         .config
         .consensus
         .hardforks
-        .is_cascade_active_at(evil_parent_block.timestamp_secs());
+        .cascade_for_block(evil_parent_block.timestamp_secs());
     let expired_set = irys_actors::block_producer::ledger_expiry::expired_submit_tx_ids(
         &tip_snapshot,
         &evil_parent_block,

--- a/crates/config/templates/testnet_config.toml
+++ b/crates/config/templates/testnet_config.toml
@@ -183,6 +183,12 @@ number_of_ingress_proofs_from_assignees = 0
 # thirty_day_epoch_length = 30      # epochs per ThirtyDay term (default: 30)
 # annual_cost_per_gb = 0.028        # USD/GB/year override (default: 0.028)
 
+# To enable Delta (a ledger a hardfork activates mid-chain gets its first slots
+# in the activating epoch instead of the one after), uncomment:
+# [consensus.Custom.hardforks.delta]
+# activation_timestamp = "2026-09-01T00:00:00+00:00"
+# initial_slots_per_new_ledger = 1   # slots seeded per newly activated ledger (default: 1)
+
 # Reth Prometheus endpoint (port 9001). The default 127.0.0.1 restricts the
 # listener to the host loopback; deployments expose it externally only via
 # an mTLS-terminating reverse proxy. See the ansible repo's

--- a/crates/database/src/data_ledger.rs
+++ b/crates/database/src/data_ledger.rs
@@ -1,4 +1,8 @@
-use irys_types::{ConsensusConfig, DataLedger, H256, partition::PartitionHash};
+use irys_types::{
+    ConsensusConfig, DataLedger, H256,
+    hardfork_config::{Cascade, ForBlock},
+    partition::PartitionHash,
+};
 use serde::Serialize;
 use std::ops::{Index, IndexMut};
 /// Manages the global ledger state within the epoch service, tracking:
@@ -60,12 +64,12 @@ fn fully_written_slot_count(total_chunks: u64, chunks_per_slot: u64) -> u64 {
 /// invariant `num_blocks_in_epoch > block_tree_depth` (see `Config::validate`)
 /// keeps at most one epoch transition unfinalized at a time.
 fn cascade_expiry_gate(
-    cascade_active: bool,
+    cascade: ForBlock<Cascade>,
     slot: &LedgerSlot,
     slot_index: usize,
     fully_written_slots: u64,
 ) -> bool {
-    !cascade_active || (slot.has_been_written && (slot_index as u64) < fully_written_slots)
+    !cascade.is_active() || (slot.has_been_written && (slot_index as u64) < fully_written_slots)
 }
 
 #[derive(Debug, Clone, Copy, Hash)]
@@ -130,7 +134,7 @@ impl TermLedger {
     pub fn get_expired_slot_indexes(
         &self,
         epoch_height: u64,
-        cascade_active: bool,
+        cascade: ForBlock<Cascade>,
         total_chunks: u64,
         chunks_per_slot: u64,
     ) -> Vec<usize> {
@@ -180,7 +184,7 @@ impl TermLedger {
                 tracing::warn!("Skipping slot {} (last slot)", slot_index);
                 continue;
             }
-            if cascade_expiry_gate(cascade_active, slot, slot_index, fully_written_slots)
+            if cascade_expiry_gate(cascade, slot, slot_index, fully_written_slots)
                 && slot.last_height <= expiry_height
                 && !slot.is_expired
             {
@@ -212,7 +216,7 @@ impl TermLedger {
     pub fn get_all_expired_slot_indexes(
         &self,
         epoch_height: u64,
-        cascade_active: bool,
+        cascade: ForBlock<Cascade>,
         total_chunks: u64,
         chunks_per_slot: u64,
     ) -> Vec<usize> {
@@ -249,7 +253,7 @@ impl TermLedger {
                 }
                 // Never expire the last slot in a ledger (matches get_expired_slot_indexes).
                 *slot_index != last_slot_index
-                    && cascade_expiry_gate(cascade_active, slot, *slot_index, fully_written_slots)
+                    && cascade_expiry_gate(cascade, slot, *slot_index, fully_written_slots)
                     && slot.last_height <= expiry_height
             })
             .map(|(slot_index, _)| slot_index)
@@ -260,16 +264,12 @@ impl TermLedger {
     pub fn expire_old_slots(
         &mut self,
         epoch_height: u64,
-        cascade_active: bool,
+        cascade: ForBlock<Cascade>,
         total_chunks: u64,
         chunks_per_slot: u64,
     ) -> Vec<usize> {
-        let expired_slot_indexes = self.get_expired_slot_indexes(
-            epoch_height,
-            cascade_active,
-            total_chunks,
-            chunks_per_slot,
-        );
+        let expired_slot_indexes =
+            self.get_expired_slot_indexes(epoch_height, cascade, total_chunks, chunks_per_slot);
 
         // Mark collected slots as expired
         for &idx in &expired_slot_indexes {
@@ -423,14 +423,15 @@ pub struct LedgerMeta {
 
 impl Ledgers {
     /// Instantiate a Ledgers struct with the correct Ledgers.
-    /// When `cascade_active` is true, includes OneYear and ThirtyDay term ledgers.
-    pub fn new(config: &ConsensusConfig, cascade_active: bool) -> Self {
+    /// When Cascade is active for the block, includes OneYear and ThirtyDay term ledgers.
+    pub fn new(config: &ConsensusConfig, cascade: ForBlock<Cascade>) -> Self {
         let mut term = vec![TermLedger::new(
             DataLedger::Submit,
             config,
             config.epoch.submit_ledger_epoch_length,
         )];
-        if let Some(cascade) = cascade_active
+        if let Some(cascade) = cascade
+            .is_active()
             .then_some(config.hardforks.cascade.as_ref())
             .flatten()
         {
@@ -511,7 +512,7 @@ impl Ledgers {
     pub fn expire_partitions(
         &mut self,
         epoch_height: u64,
-        cascade_active: bool,
+        cascade: ForBlock<Cascade>,
         total_chunks: impl Fn(DataLedger) -> u64,
         chunks_per_slot: u64,
     ) -> Vec<ExpiringPartitionInfo> {
@@ -520,7 +521,7 @@ impl Ledgers {
         // Expire perm ledger slots using shared helper
         for (slot_index, partition_hashes, ledger_id) in self.get_perm_expiring_slots(
             epoch_height,
-            cascade_active,
+            cascade,
             total_chunks(DataLedger::Publish),
             chunks_per_slot,
         ) {
@@ -540,7 +541,7 @@ impl Ledgers {
                 .expect("term ledger_id is always constructed from a valid DataLedger variant");
             for expired_index in term_ledger.expire_old_slots(
                 epoch_height,
-                cascade_active,
+                cascade,
                 total_chunks(ledger_id),
                 chunks_per_slot,
             ) {
@@ -569,7 +570,7 @@ impl Ledgers {
     pub fn get_expiring_slots(
         &self,
         epoch_height: u64,
-        cascade_active: bool,
+        cascade: ForBlock<Cascade>,
         total_chunks: impl Fn(DataLedger) -> u64,
         chunks_per_slot: u64,
     ) -> Vec<(DataLedger, usize, Vec<PartitionHash>)> {
@@ -578,7 +579,7 @@ impl Ledgers {
         // Check perm ledger slots using shared helper
         for (slot_index, partition_hashes, ledger_id) in self.get_perm_expiring_slots(
             epoch_height,
-            cascade_active,
+            cascade,
             total_chunks(DataLedger::Publish),
             chunks_per_slot,
         ) {
@@ -591,7 +592,7 @@ impl Ledgers {
                 .expect("term ledger_id is always constructed from a valid DataLedger variant");
             for expiring_slot_index in term_ledger.get_expired_slot_indexes(
                 epoch_height,
-                cascade_active,
+                cascade,
                 total_chunks(ledger_id),
                 chunks_per_slot,
             ) {
@@ -615,13 +616,13 @@ impl Ledgers {
         &self,
         ledger: DataLedger,
         epoch_height: u64,
-        cascade_active: bool,
+        cascade: ForBlock<Cascade>,
         total_chunks: u64,
         chunks_per_slot: u64,
     ) -> Vec<usize> {
         self.get_term_ledger(ledger).get_all_expired_slot_indexes(
             epoch_height,
-            cascade_active,
+            cascade,
             total_chunks,
             chunks_per_slot,
         )
@@ -647,7 +648,7 @@ impl Ledgers {
     fn get_perm_expiring_slots(
         &self,
         epoch_height: u64,
-        cascade_active: bool,
+        cascade: ForBlock<Cascade>,
         total_chunks: u64,
         chunks_per_slot: u64,
     ) -> Vec<(usize, Vec<PartitionHash>, DataLedger)> {
@@ -683,7 +684,7 @@ impl Ledgers {
             // safe for the perm ledger too. Publish offsets are cumulative like
             // the term ledgers', so the fully-written frontier rule applies the
             // same way (see `fully_written_slot_count`).
-            if cascade_expiry_gate(cascade_active, slot, slot_index, fully_written_slots)
+            if cascade_expiry_gate(cascade, slot, slot_index, fully_written_slots)
                 && slot.last_height <= expiry_height
                 && !slot.is_expired
             {
@@ -793,7 +794,7 @@ impl Ledgers {
     }
 
     /// Mark every slot that received new canonical data during this epoch as
-    /// written. When `refresh_last_height` is true, also refresh `last_height`
+    /// written. When `refresh_last_height` is Cascade-active, also refresh `last_height`
     /// so the slot's expiry clock counts from the last time data was written
     /// into it rather than from when the slot was allocated.
     ///
@@ -815,7 +816,7 @@ impl Ledgers {
         new_total_chunks: u64,
         chunks_per_slot: u64,
         height: u64,
-        refresh_last_height: bool,
+        refresh_last_height: ForBlock<Cascade>,
     ) {
         // No data added this epoch (or misconfigured slot size) -> nothing to do.
         if new_total_chunks <= prev_total_chunks || chunks_per_slot == 0 {
@@ -847,7 +848,7 @@ impl Ledgers {
             slot.has_been_written = true;
 
             // Don't resurrect an already-expired slot.
-            if refresh_last_height && !slot.is_expired {
+            if refresh_last_height.is_active() && !slot.is_expired {
                 slot.last_height = height;
             }
         }
@@ -916,7 +917,7 @@ mod tests {
     #[test]
     fn test_ledgers_new_without_cascade() {
         let config = ConsensusConfig::testing();
-        let ledgers = Ledgers::new(&config, false);
+        let ledgers = Ledgers::new(&config, ForBlock::inactive());
         assert_eq!(ledgers.len(), 2);
         assert_eq!(
             ledgers.active_ledgers(),
@@ -927,7 +928,7 @@ mod tests {
     #[test]
     fn test_ledgers_new_with_cascade_active() {
         let config = config_with_cascade();
-        let ledgers = Ledgers::new(&config, true);
+        let ledgers = Ledgers::new(&config, ForBlock::active());
         assert_eq!(ledgers.len(), 4);
         let active = ledgers.active_ledgers();
         assert!(active.contains(&DataLedger::Publish));
@@ -940,14 +941,14 @@ mod tests {
     fn test_ledgers_new_cascade_active_but_no_config() {
         // cascade_active=true but cascade config is None: only 2 ledgers
         let config = ConsensusConfig::testing(); // cascade is None
-        let ledgers = Ledgers::new(&config, true);
+        let ledgers = Ledgers::new(&config, ForBlock::active());
         assert_eq!(ledgers.len(), 2);
     }
 
     #[test]
     fn test_ledgers_activate_cascade() {
         let config = config_with_cascade();
-        let mut ledgers = Ledgers::new(&config, false);
+        let mut ledgers = Ledgers::new(&config, ForBlock::inactive());
         assert_eq!(ledgers.len(), 2);
 
         ledgers.activate_cascade(&config);
@@ -960,7 +961,7 @@ mod tests {
     #[test]
     fn test_ledgers_activate_cascade_idempotent() {
         let config = config_with_cascade();
-        let mut ledgers = Ledgers::new(&config, false);
+        let mut ledgers = Ledgers::new(&config, ForBlock::inactive());
 
         ledgers.activate_cascade(&config);
         assert_eq!(ledgers.len(), 4);
@@ -973,7 +974,7 @@ mod tests {
     #[test]
     fn test_ledgers_activate_cascade_no_config() {
         let config = ConsensusConfig::testing(); // cascade is None
-        let mut ledgers = Ledgers::new(&config, false);
+        let mut ledgers = Ledgers::new(&config, ForBlock::inactive());
         assert_eq!(ledgers.len(), 2);
 
         ledgers.activate_cascade(&config);
@@ -983,19 +984,19 @@ mod tests {
     #[test]
     fn test_perm_expiry_disabled() {
         let config = make_test_config(None);
-        let mut ledgers = Ledgers::new(&config, false);
+        let mut ledgers = Ledgers::new(&config, ForBlock::inactive());
         // Add a perm slot at height 1
         ledgers.perm.allocate_slots(1, 1);
         ledgers.perm.slots[0].partitions.push(H256::random());
         // At height 1000, nothing should expire
-        let expired = ledgers.expire_partitions(1000, true, |_| 10, 10);
+        let expired = ledgers.expire_partitions(1000, ForBlock::active(), |_| 10, 10);
         assert!(expired.iter().all(|e| e.ledger_id != DataLedger::Publish));
     }
 
     #[test]
     fn test_perm_expiry_enabled() {
         let config = make_test_config(Some(2)); // 2 epochs
-        let mut ledgers = Ledgers::new(&config, false);
+        let mut ledgers = Ledgers::new(&config, ForBlock::inactive());
         // num_blocks_in_epoch = 10, epoch_length = 2
         // expiry_height = epoch_height - (2 * 10) = epoch_height - 20
 
@@ -1010,7 +1011,7 @@ mod tests {
         // At epoch_height = 30: expiry_height = 30 - 20 = 10
         // Slot 0 (last_height=1) <= 10: EXPIRED
         // Slot 1 (last_height=25) > 10: NOT expired (also last slot)
-        let expired = ledgers.expire_partitions(30, true, |_| 20, 10);
+        let expired = ledgers.expire_partitions(30, ForBlock::active(), |_| 20, 10);
         let perm_expired: Vec<_> = expired
             .iter()
             .filter(|e| e.ledger_id == DataLedger::Publish)
@@ -1023,14 +1024,14 @@ mod tests {
     #[test]
     fn test_perm_expiry_never_expires_last_slot() {
         let config = make_test_config(Some(1)); // 1 epoch
-        let mut ledgers = Ledgers::new(&config, false);
+        let mut ledgers = Ledgers::new(&config, ForBlock::inactive());
         // Add only one perm slot
         ledgers.perm.allocate_slots(1, 1);
         ledgers.perm.slots[0].partitions.push(H256::random());
         ledgers.perm.slots[0].has_been_written = true;
 
         // At epoch_height = 100: should NOT expire (it's the last slot)
-        let expired = ledgers.expire_partitions(100, true, |_| 10, 10);
+        let expired = ledgers.expire_partitions(100, ForBlock::active(), |_| 10, 10);
         let perm_expired: Vec<_> = expired
             .iter()
             .filter(|e| e.ledger_id == DataLedger::Publish)
@@ -1042,7 +1043,7 @@ mod tests {
     #[test]
     fn test_perm_expiry_not_enough_blocks() {
         let config = make_test_config(Some(2)); // 2 epochs * 10 blocks = 20 min
-        let mut ledgers = Ledgers::new(&config, false);
+        let mut ledgers = Ledgers::new(&config, ForBlock::inactive());
         ledgers.perm.allocate_slots(2, 1);
         ledgers.perm.slots[0].partitions.push(H256::random());
         ledgers.perm.slots[1].partitions.push(H256::random());
@@ -1050,7 +1051,7 @@ mod tests {
         ledgers.perm.slots[1].has_been_written = true;
 
         // At epoch_height = 15 (< 20 minimum): nothing expires
-        let expired = ledgers.expire_partitions(15, true, |_| 20, 10);
+        let expired = ledgers.expire_partitions(15, ForBlock::active(), |_| 20, 10);
         let perm_expired: Vec<_> = expired
             .iter()
             .filter(|e| e.ledger_id == DataLedger::Publish)
@@ -1067,7 +1068,7 @@ mod tests {
         // because it is not fully written. This is the perm-ledger analogue of the
         // Submit frontier protection.
         let config = make_test_config(Some(2)); // publish expiry enabled; min_blocks = 2*10 = 20
-        let mut ledgers = Ledgers::new(&config, false);
+        let mut ledgers = Ledgers::new(&config, ForBlock::inactive());
         ledgers.perm.allocate_slots(3, 1); // slots 0,1,2 all allocated at height 1
         for i in 0..2 {
             ledgers.perm.slots[i].partitions.push(H256::random());
@@ -1081,7 +1082,7 @@ mod tests {
         // ledger-swap bug that read the wrong total would make the gate permissive.
         let expired = ledgers.expire_partitions(
             100,
-            true,
+            ForBlock::active(),
             |l| if l == DataLedger::Publish { 15 } else { 100 },
             10,
         );
@@ -1109,7 +1110,7 @@ mod tests {
         // fully_written_slots=2). Slot 1 (index 1 < 2) is now fully written and aged,
         // and slot 2 is the protected last slot, so slot 1 becomes eligible.
         let config = make_test_config(Some(2));
-        let mut ledgers = Ledgers::new(&config, false);
+        let mut ledgers = Ledgers::new(&config, ForBlock::inactive());
         ledgers.perm.allocate_slots(3, 1);
         for i in 0..2 {
             ledgers.perm.slots[i].partitions.push(H256::random());
@@ -1118,7 +1119,7 @@ mod tests {
         }
         let expired = ledgers.expire_partitions(
             100,
-            true,
+            ForBlock::active(),
             |l| if l == DataLedger::Publish { 20 } else { 100 },
             10,
         );
@@ -1142,7 +1143,7 @@ mod tests {
         // the allocation-anchored behavior. Locks that Task-2's post-Cascade change did
         // not alter pre-Cascade expiry.
         let config = make_test_config(Some(2));
-        let mut ledgers = Ledgers::new(&config, false);
+        let mut ledgers = Ledgers::new(&config, ForBlock::inactive());
         ledgers.perm.allocate_slots(3, 1);
         for i in 0..2 {
             ledgers.perm.slots[i].partitions.push(H256::random());
@@ -1151,7 +1152,7 @@ mod tests {
         }
         let expired = ledgers.expire_partitions(
             100,
-            false, // pre-Cascade
+            ForBlock::inactive(), // pre-Cascade
             |l| if l == DataLedger::Publish { 15 } else { 100 },
             10,
         );
@@ -1171,7 +1172,7 @@ mod tests {
     #[test]
     fn test_get_expiring_partitions_includes_perm() {
         let config = make_test_config(Some(2));
-        let mut ledgers = Ledgers::new(&config, false);
+        let mut ledgers = Ledgers::new(&config, ForBlock::inactive());
         ledgers.perm.allocate_slots(2, 1);
         ledgers.perm.slots[0].partitions.push(H256::random());
         ledgers.perm.slots[1].partitions.push(H256::random());
@@ -1179,7 +1180,7 @@ mod tests {
         ledgers.perm.slots[1].has_been_written = true;
 
         // Read-only: should report slot 0 as expiring without marking it
-        let expiring = ledgers.get_expiring_slots(30, true, |_| 20, 10);
+        let expiring = ledgers.get_expiring_slots(30, ForBlock::active(), |_| 20, 10);
         let perm_expiring: Vec<_> = expiring
             .iter()
             .filter(|(ledger_id, _, _)| *ledger_id == DataLedger::Publish)
@@ -1211,11 +1212,11 @@ mod tests {
     #[test]
     fn test_get_expiring_partitions_disabled_perm() {
         let config = make_test_config(None);
-        let mut ledgers = Ledgers::new(&config, false);
+        let mut ledgers = Ledgers::new(&config, ForBlock::inactive());
         ledgers.perm.allocate_slots(1, 1);
         ledgers.perm.slots[0].partitions.push(H256::random());
 
-        let expiring = ledgers.get_expiring_slots(1000, true, |_| 10, 10);
+        let expiring = ledgers.get_expiring_slots(1000, ForBlock::active(), |_| 10, 10);
         assert!(
             expiring
                 .iter()
@@ -1226,7 +1227,7 @@ mod tests {
     /// Allocate `count` Submit slots, all stamped with `last_height = alloc_height`.
     fn ledgers_with_submit_slots(count: u64, alloc_height: u64) -> Ledgers {
         let config = ConsensusConfig::testing();
-        let mut ledgers = Ledgers::new(&config, false);
+        let mut ledgers = Ledgers::new(&config, ForBlock::inactive());
         ledgers[DataLedger::Submit].allocate_slots(count, alloc_height);
         ledgers
     }
@@ -1251,7 +1252,7 @@ mod tests {
     fn test_touch_filled_slots_marks_all_written_slots() {
         // 3 slots of 10 chunks each; new chunks [0, 25) span slots 0,1,2.
         let mut ledgers = ledgers_with_submit_slots(3, 1);
-        ledgers.touch_filled_slots(DataLedger::Submit, 0, 25, 10, 100, true);
+        ledgers.touch_filled_slots(DataLedger::Submit, 0, 25, 10, 100, ForBlock::active());
         assert_eq!(submit_last_heights(&ledgers), vec![100, 100, 100]);
         assert_eq!(submit_written_flags(&ledgers), vec![true, true, true]);
     }
@@ -1260,7 +1261,7 @@ mod tests {
     fn test_touch_filled_slots_partial_window_touches_only_overlap() {
         // New chunks [12, 18) fall entirely within slot 1 (covers [10, 20)).
         let mut ledgers = ledgers_with_submit_slots(3, 1);
-        ledgers.touch_filled_slots(DataLedger::Submit, 12, 18, 10, 100, true);
+        ledgers.touch_filled_slots(DataLedger::Submit, 12, 18, 10, 100, ForBlock::active());
         assert_eq!(submit_last_heights(&ledgers), vec![1, 100, 1]);
         assert_eq!(submit_written_flags(&ledgers), vec![false, true, false]);
     }
@@ -1270,7 +1271,7 @@ mod tests {
         // prev exactly on a slot boundary: [10, 11) is the first chunk of slot 1,
         // so slot 0 must NOT be touched.
         let mut ledgers = ledgers_with_submit_slots(3, 1);
-        ledgers.touch_filled_slots(DataLedger::Submit, 10, 11, 10, 100, true);
+        ledgers.touch_filled_slots(DataLedger::Submit, 10, 11, 10, 100, ForBlock::active());
         assert_eq!(submit_last_heights(&ledgers), vec![1, 100, 1]);
         assert_eq!(submit_written_flags(&ledgers), vec![false, true, false]);
     }
@@ -1279,8 +1280,8 @@ mod tests {
     fn test_touch_filled_slots_noop_when_no_data() {
         // new <= prev means no chunks were added this epoch.
         let mut ledgers = ledgers_with_submit_slots(2, 1);
-        ledgers.touch_filled_slots(DataLedger::Submit, 15, 15, 10, 100, true);
-        ledgers.touch_filled_slots(DataLedger::Submit, 20, 10, 10, 100, true);
+        ledgers.touch_filled_slots(DataLedger::Submit, 15, 15, 10, 100, ForBlock::active());
+        ledgers.touch_filled_slots(DataLedger::Submit, 20, 10, 10, 100, ForBlock::active());
         assert_eq!(submit_last_heights(&ledgers), vec![1, 1]);
         assert_eq!(submit_written_flags(&ledgers), vec![false, false]);
     }
@@ -1289,7 +1290,7 @@ mod tests {
     fn test_touch_filled_slots_noop_when_zero_slot_size() {
         // chunks_per_slot == 0 must be a guarded no-op (no divide-by-zero panic).
         let mut ledgers = ledgers_with_submit_slots(2, 1);
-        ledgers.touch_filled_slots(DataLedger::Submit, 0, 100, 0, 100, true);
+        ledgers.touch_filled_slots(DataLedger::Submit, 0, 100, 0, 100, ForBlock::active());
         assert_eq!(submit_last_heights(&ledgers), vec![1, 1]);
         assert_eq!(submit_written_flags(&ledgers), vec![false, false]);
     }
@@ -1299,7 +1300,7 @@ mod tests {
         // An already-expired slot must not be resurrected, even if data lands in it.
         let mut ledgers = ledgers_with_submit_slots(3, 1);
         ledgers.slots_mut(DataLedger::Submit)[1].is_expired = true;
-        ledgers.touch_filled_slots(DataLedger::Submit, 0, 25, 10, 100, true);
+        ledgers.touch_filled_slots(DataLedger::Submit, 0, 25, 10, 100, ForBlock::active());
 
         let slots = ledgers.get_slots(DataLedger::Submit);
         assert_eq!(slots[0].last_height, 100);
@@ -1320,7 +1321,7 @@ mod tests {
         // Window implies slots up to index 4 but only 2 slots exist: no panic,
         // existing slots still updated.
         let mut ledgers = ledgers_with_submit_slots(2, 1);
-        ledgers.touch_filled_slots(DataLedger::Submit, 0, 50, 10, 100, true);
+        ledgers.touch_filled_slots(DataLedger::Submit, 0, 50, 10, 100, ForBlock::active());
         assert_eq!(submit_last_heights(&ledgers), vec![100, 100]);
         assert_eq!(submit_written_flags(&ledgers), vec![true, true]);
     }
@@ -1332,7 +1333,7 @@ mod tests {
         // the touch must be a no-op — no panic, no slot marked written or
         // refreshed.
         let mut ledgers = ledgers_with_submit_slots(2, 1);
-        ledgers.touch_filled_slots(DataLedger::Submit, 30, 35, 10, 100, true);
+        ledgers.touch_filled_slots(DataLedger::Submit, 30, 35, 10, 100, ForBlock::active());
         assert_eq!(submit_last_heights(&ledgers), vec![1, 1]);
         assert_eq!(submit_written_flags(&ledgers), vec![false, false]);
     }
@@ -1345,10 +1346,10 @@ mod tests {
         // exactly as for term ledgers — otherwise perm expiry would still count
         // from allocation instead of the last write.
         let config = ConsensusConfig::testing();
-        let mut ledgers = Ledgers::new(&config, false);
+        let mut ledgers = Ledgers::new(&config, ForBlock::inactive());
         ledgers[DataLedger::Publish].allocate_slots(3, 1);
         // New chunks [0, 25) span perm slots 0,1,2 (10 chunks each).
-        ledgers.touch_filled_slots(DataLedger::Publish, 0, 25, 10, 100, true);
+        ledgers.touch_filled_slots(DataLedger::Publish, 0, 25, 10, 100, ForBlock::active());
         let heights: Vec<u64> = ledgers
             .get_slots(DataLedger::Publish)
             .iter()
@@ -1375,7 +1376,7 @@ mod tests {
 
         let mut ledger = TermLedger::new(DataLedger::Submit, &config, epoch_length);
         ledger.allocate_slots(1, 0); // single slot allocated at genesis
-        // Mark the slot written so the `!cascade_active || has_been_written`
+        // Mark the slot written so the `!cascade.is_active() || has_been_written`
         // write-window shortcut passes (cascade_active=true below) and the slot is
         // excluded ONLY by the last-slot rule under test — not vacuously skipped as
         // an unwritten slot.
@@ -1385,12 +1386,12 @@ mod tests {
         // never expires — exactly where the cycle-math approximation diverged.
         assert!(
             ledger
-                .get_all_expired_slot_indexes(blocks_per_cycle, true, 10, 10)
+                .get_all_expired_slot_indexes(blocks_per_cycle, ForBlock::active(), 10, 10)
                 .is_empty()
         );
         assert!(
             ledger
-                .get_all_expired_slot_indexes(blocks_per_cycle * 10, true, 10, 10)
+                .get_all_expired_slot_indexes(blocks_per_cycle * 10, ForBlock::active(), 10, 10)
                 .is_empty()
         );
     }
@@ -1418,32 +1419,32 @@ mod tests {
         // One epoch before: nothing expired yet.
         assert!(
             ledger
-                .get_all_expired_slot_indexes(expiry - num_blocks, true, 20, 10)
+                .get_all_expired_slot_indexes(expiry - num_blocks, ForBlock::active(), 20, 10)
                 .is_empty()
         );
 
         // At expiry, slot 0 is in both sets.
         assert_eq!(
-            ledger.get_all_expired_slot_indexes(expiry, true, 20, 10),
+            ledger.get_all_expired_slot_indexes(expiry, ForBlock::active(), 20, 10),
             vec![0]
         );
         assert_eq!(
-            ledger.get_expired_slot_indexes(expiry, true, 20, 10),
+            ledger.get_expired_slot_indexes(expiry, ForBlock::active(), 20, 10),
             vec![0]
         );
 
         // After it is marked expired, the inclusive set still returns it
         // (a tx in slot 0 stays non-promotable at every later block) while the
         // newly-expiring set drops it (it must only be refunded once).
-        ledger.expire_old_slots(expiry, true, 20, 10);
+        ledger.expire_old_slots(expiry, ForBlock::active(), 20, 10);
         assert_eq!(
-            ledger.get_all_expired_slot_indexes(expiry + 1, true, 20, 10),
+            ledger.get_all_expired_slot_indexes(expiry + 1, ForBlock::active(), 20, 10),
             vec![0],
             "an already-expired slot must remain in the inclusive set (cross-block guard)"
         );
         assert!(
             ledger
-                .get_expired_slot_indexes(expiry + 1, true, 20, 10)
+                .get_expired_slot_indexes(expiry + 1, ForBlock::active(), 20, 10)
                 .is_empty(),
             "get_expired_slot_indexes returns only newly-expiring slots"
         );
@@ -1460,8 +1461,8 @@ mod tests {
         // 4 slots allocated at height 1. Canonical data first fills slots 0 and 1,
         // then a later epoch touches only slot 1. Slots 2 and 3 remain unwritten.
         let mut ledgers = ledgers_with_submit_slots(4, 1);
-        ledgers.touch_filled_slots(DataLedger::Submit, 0, 18, 10, 50, true);
-        ledgers.touch_filled_slots(DataLedger::Submit, 18, 19, 10, 100, true);
+        ledgers.touch_filled_slots(DataLedger::Submit, 0, 18, 10, 50, ForBlock::active());
+        ledgers.touch_filled_slots(DataLedger::Submit, 18, 19, 10, 100, ForBlock::active());
         assert_eq!(submit_last_heights(&ledgers), vec![50, 100, 1, 1]);
         assert_eq!(
             submit_written_flags(&ledgers),
@@ -1474,7 +1475,7 @@ mod tests {
             ledgers.get_all_expired_term_slot_indexes(
                 DataLedger::Submit,
                 min_blocks + 75,
-                true,
+                ForBlock::active(),
                 19,
                 10
             ),
@@ -1491,14 +1492,14 @@ mod tests {
         let min_blocks = config.epoch.submit_ledger_epoch_length * config.epoch.num_blocks_in_epoch;
 
         let mut ledgers = ledgers_with_submit_slots(4, 1);
-        ledgers.touch_filled_slots(DataLedger::Submit, 0, 18, 10, 50, true);
-        ledgers.touch_filled_slots(DataLedger::Submit, 18, 19, 10, 100, true);
+        ledgers.touch_filled_slots(DataLedger::Submit, 0, 18, 10, 50, ForBlock::active());
+        ledgers.touch_filled_slots(DataLedger::Submit, 18, 19, 10, 100, ForBlock::active());
 
         assert_eq!(
             ledgers.get_all_expired_term_slot_indexes(
                 DataLedger::Submit,
                 min_blocks + 75,
-                false,
+                ForBlock::inactive(),
                 19,
                 10
             ),
@@ -1522,20 +1523,26 @@ mod tests {
         // 3 slots of 10 chunks. Data [0, 15) at height 50: slot 0 full, slot 1
         // holds the write frontier (5/10 chunks), slot 2 is unwritten headroom.
         let mut ledgers = ledgers_with_submit_slots(3, 1);
-        ledgers.touch_filled_slots(DataLedger::Submit, 0, 15, 10, 50, true);
+        ledgers.touch_filled_slots(DataLedger::Submit, 0, 15, 10, 50, ForBlock::active());
 
         // Far past both written slots' expiry heights: only the FULL slot 0 may
         // expire; the frontier slot 1 must stay live in both sets.
         let height = min_blocks + 100;
         assert_eq!(
-            ledgers.get_all_expired_term_slot_indexes(DataLedger::Submit, height, true, 15, 10),
+            ledgers.get_all_expired_term_slot_indexes(
+                DataLedger::Submit,
+                height,
+                ForBlock::active(),
+                15,
+                10
+            ),
             vec![0],
             "the slot holding the write frontier must never enter the non-promotability set"
         );
         assert_eq!(
             ledgers
                 .get_term_ledger(DataLedger::Submit)
-                .get_expired_slot_indexes(height, true, 15, 10),
+                .get_expired_slot_indexes(height, ForBlock::active(), 15, 10),
             vec![0],
             "the slot holding the write frontier must not be settled/recycled"
         );
@@ -1551,18 +1558,24 @@ mod tests {
         let min_blocks = config.epoch.submit_ledger_epoch_length * config.epoch.num_blocks_in_epoch;
 
         let mut ledgers = ledgers_with_submit_slots(3, 1);
-        ledgers.touch_filled_slots(DataLedger::Submit, 0, 15, 10, 50, true);
+        ledgers.touch_filled_slots(DataLedger::Submit, 0, 15, 10, 50, ForBlock::active());
 
         // Ingress stalls for well over a full term: slot 1 must survive.
         let resume = 50 + min_blocks + 200;
         assert_eq!(
-            ledgers.get_all_expired_term_slot_indexes(DataLedger::Submit, resume, true, 15, 10),
+            ledgers.get_all_expired_term_slot_indexes(
+                DataLedger::Submit,
+                resume,
+                ForBlock::active(),
+                15,
+                10
+            ),
             vec![0]
         );
 
         // Ingress resumes and fills slot 1. Because the slot never expired, the
         // touch refreshes its expiry clock (an expired slot would stay frozen).
-        ledgers.touch_filled_slots(DataLedger::Submit, 15, 20, 10, resume, true);
+        ledgers.touch_filled_slots(DataLedger::Submit, 15, 20, 10, resume, ForBlock::active());
         assert_eq!(
             ledgers.get_slots(DataLedger::Submit)[1].last_height,
             resume,
@@ -1574,7 +1587,7 @@ mod tests {
             ledgers.get_all_expired_term_slot_indexes(
                 DataLedger::Submit,
                 resume + min_blocks - 1,
-                true,
+                ForBlock::active(),
                 20,
                 10
             ),
@@ -1585,7 +1598,7 @@ mod tests {
             ledgers.get_all_expired_term_slot_indexes(
                 DataLedger::Submit,
                 resume + min_blocks,
-                true,
+                ForBlock::active(),
                 20,
                 10
             ),
@@ -1602,13 +1615,19 @@ mod tests {
         let min_blocks = config.epoch.submit_ledger_epoch_length * config.epoch.num_blocks_in_epoch;
 
         let mut ledgers = ledgers_with_submit_slots(3, 1);
-        ledgers.touch_filled_slots(DataLedger::Submit, 0, 15, 10, 50, true);
+        ledgers.touch_filled_slots(DataLedger::Submit, 0, 15, 10, 50, ForBlock::active());
 
         // Pre-Cascade the fully-written rule must not apply (slot 1 expires by
         // age; slot 2 is the last slot and is excluded by the last-slot rule).
         let height = min_blocks + 100;
         assert_eq!(
-            ledgers.get_all_expired_term_slot_indexes(DataLedger::Submit, height, false, 15, 10),
+            ledgers.get_all_expired_term_slot_indexes(
+                DataLedger::Submit,
+                height,
+                ForBlock::inactive(),
+                15,
+                10
+            ),
             vec![0, 1],
             "pre-Cascade replay must keep the allocation-anchored expiry for partial slots"
         );
@@ -1629,7 +1648,7 @@ mod tests {
 
         // Data [0, 15): slot 0 full, slot 1 holds the write frontier (5/10).
         let mut ledgers = ledgers_with_submit_slots(3, 1);
-        ledgers.touch_filled_slots(DataLedger::Submit, 0, 15, 10, 50, true);
+        ledgers.touch_filled_slots(DataLedger::Submit, 0, 15, 10, 50, ForBlock::active());
         // The pre-Cascade epoch recycled the partially-written slot 1.
         ledgers.slots_mut(DataLedger::Submit)[1].is_expired = true;
 
@@ -1637,7 +1656,13 @@ mod tests {
         // slot 1 — but `is_expired` keeps the already-recycled slot in the set.
         let height = min_blocks + 100;
         assert_eq!(
-            ledgers.get_all_expired_term_slot_indexes(DataLedger::Submit, height, true, 15, 10),
+            ledgers.get_all_expired_term_slot_indexes(
+                DataLedger::Submit,
+                height,
+                ForBlock::active(),
+                15,
+                10
+            ),
             vec![0, 1],
             "a slot recycled while partially written must remain non-promotable post-Cascade"
         );
@@ -1650,7 +1675,7 @@ mod tests {
     #[test]
     fn zero_chunks_per_slot_expires_nothing_post_cascade() {
         let mut ledgers = ledgers_with_submit_slots(3, 1);
-        ledgers.touch_filled_slots(DataLedger::Submit, 0, 15, 10, 50, true);
+        ledgers.touch_filled_slots(DataLedger::Submit, 0, 15, 10, 50, ForBlock::active());
 
         let config = ConsensusConfig::testing();
         let min_blocks = config.epoch.submit_ledger_epoch_length * config.epoch.num_blocks_in_epoch;
@@ -1659,7 +1684,7 @@ mod tests {
                 .get_all_expired_term_slot_indexes(
                     DataLedger::Submit,
                     min_blocks + 100,
-                    true,
+                    ForBlock::active(),
                     15,
                     0
                 )
@@ -1670,7 +1695,7 @@ mod tests {
     #[test]
     fn test_ledger_meta_for_perm_epoch_length_none() {
         let config = make_test_config(None);
-        let ledgers = Ledgers::new(&config, false);
+        let ledgers = Ledgers::new(&config, ForBlock::inactive());
         let meta = ledgers.ledger_meta_for(DataLedger::Publish).unwrap();
         assert_eq!(meta.ledger_id, DataLedger::Publish as u32);
         assert_eq!(meta.epoch_length, None);
@@ -1680,7 +1705,7 @@ mod tests {
     #[test]
     fn test_ledger_meta_for_perm_epoch_length_some() {
         let config = make_test_config(Some(2));
-        let ledgers = Ledgers::new(&config, false);
+        let ledgers = Ledgers::new(&config, ForBlock::inactive());
         let meta = ledgers.ledger_meta_for(DataLedger::Publish).unwrap();
         assert_eq!(meta.epoch_length, Some(2));
     }
@@ -1688,7 +1713,7 @@ mod tests {
     #[test]
     fn test_ledger_meta_for_term_ledger_epoch_length_always_some() {
         let config = make_test_config(None);
-        let ledgers = Ledgers::new(&config, false);
+        let ledgers = Ledgers::new(&config, ForBlock::inactive());
         let meta = ledgers.ledger_meta_for(DataLedger::Submit).unwrap();
         assert_eq!(
             meta.epoch_length,
@@ -1699,14 +1724,14 @@ mod tests {
     #[test]
     fn test_ledger_meta_for_inactive_cascade_ledger_returns_none() {
         let config = make_test_config(None); // cascade not activated
-        let ledgers = Ledgers::new(&config, false);
+        let ledgers = Ledgers::new(&config, ForBlock::inactive());
         assert!(ledgers.ledger_meta_for(DataLedger::OneYear).is_none());
     }
 
     #[test]
     fn test_ledger_meta_lists_all_active_ledgers_in_order() {
         let config = config_with_cascade();
-        let ledgers = Ledgers::new(&config, true);
+        let ledgers = Ledgers::new(&config, ForBlock::active());
         let ids: Vec<u32> = ledgers.ledger_meta().iter().map(|m| m.ledger_id).collect();
         assert_eq!(
             ids,
@@ -1722,7 +1747,7 @@ mod tests {
     #[test]
     fn test_num_blocks_in_epoch_accessor() {
         let config = make_test_config(None); // make_test_config sets num_blocks_in_epoch = 10
-        let ledgers = Ledgers::new(&config, false);
+        let ledgers = Ledgers::new(&config, ForBlock::inactive());
         assert_eq!(ledgers.num_blocks_in_epoch(), 10);
     }
 
@@ -1742,7 +1767,7 @@ mod tests {
     #[test]
     fn expiry_frontier_for_zero_when_no_slots_allocated() {
         let config = ConsensusConfig::testing();
-        let ledgers = Ledgers::new(&config, false); // Submit ledger active but empty
+        let ledgers = Ledgers::new(&config, ForBlock::inactive()); // Submit ledger active but empty
         assert_eq!(ledgers.expiry_frontier_for(DataLedger::Submit), 0);
     }
 
@@ -1813,8 +1838,8 @@ mod tests {
                 slot.is_expired = i < exp && i < frontier && i != num_slots - 1;
             }
 
-            let newly = ledger.get_expired_slot_indexes(epoch_height, true, total_chunks, CPS);
-            let inclusive = ledger.get_all_expired_slot_indexes(epoch_height, true, total_chunks, CPS);
+            let newly = ledger.get_expired_slot_indexes(epoch_height, ForBlock::active(), total_chunks, CPS);
+            let inclusive = ledger.get_all_expired_slot_indexes(epoch_height, ForBlock::active(), total_chunks, CPS);
 
             // (a) both sets are strictly ascending & contiguous. The inclusive set
             // starts at 0 (already-expired slots always pass). The newly-expiring set

--- a/crates/database/src/data_ledger.rs
+++ b/crates/database/src/data_ledger.rs
@@ -794,9 +794,9 @@ impl Ledgers {
     }
 
     /// Mark every slot that received new canonical data during this epoch as
-    /// written. When `refresh_last_height` is Cascade-active, also refresh `last_height`
-    /// so the slot's expiry clock counts from the last time data was written
-    /// into it rather than from when the slot was allocated.
+    /// written. When Cascade is active for the epoch block, also refresh
+    /// `last_height` so the slot's expiry clock counts from the last time data
+    /// was written into it rather than from when the slot was allocated.
     ///
     /// `prev_total_chunks` / `new_total_chunks` are the ledger's cumulative
     /// chunk counts at the previous and current epoch blocks (read from the

--- a/crates/domain/src/hardfork_ext.rs
+++ b/crates/domain/src/hardfork_ext.rs
@@ -1,15 +1,19 @@
 use crate::EpochSnapshot;
-use irys_types::hardfork_config::IrysHardforkConfig;
+use irys_types::hardfork_config::{Cascade, ForEpoch, IrysHardforkConfig};
 
 /// Extension trait for hardfork checks that require EpochSnapshot context.
 pub trait HardforkConfigExt {
     /// Check if UpdateRewardAddress commitments are allowed for the given epoch.
     fn is_update_reward_address_allowed_for_epoch(&self, epoch_snapshot: &EpochSnapshot) -> bool;
 
-    /// Check if the Cascade hardfork is active for the given epoch.
-    /// Activation is epoch-aligned: enabled for all blocks in an epoch if the epoch block's
-    /// timestamp >= activation_timestamp.
-    fn is_cascade_active_for_epoch(&self, epoch_snapshot: &EpochSnapshot) -> bool;
+    /// Cascade's activation state for the given epoch (epoch-aligned): active for
+    /// all blocks in an epoch if the epoch block's timestamp >= activation_timestamp.
+    ///
+    /// Distinct from `cascade_for_block`: throughout the epoch in which Cascade
+    /// activates, this still reads inactive while blocks' own timestamps read
+    /// active. Anything that must agree with epoch processing needs the block
+    /// state, not this one.
+    fn cascade_for_epoch(&self, epoch_snapshot: &EpochSnapshot) -> ForEpoch<Cascade>;
 }
 
 impl HardforkConfigExt for IrysHardforkConfig {
@@ -17,7 +21,7 @@ impl HardforkConfigExt for IrysHardforkConfig {
         self.is_borealis_active_at(epoch_snapshot.epoch_block.timestamp_secs())
     }
 
-    fn is_cascade_active_for_epoch(&self, epoch_snapshot: &EpochSnapshot) -> bool {
-        self.is_cascade_active_at(epoch_snapshot.epoch_block.timestamp_secs())
+    fn cascade_for_epoch(&self, epoch_snapshot: &EpochSnapshot) -> ForEpoch<Cascade> {
+        ForEpoch::new(self.is_cascade_active_at(epoch_snapshot.epoch_block.timestamp_secs()))
     }
 }

--- a/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
+++ b/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
@@ -331,7 +331,7 @@ impl EpochSnapshot {
             .config
             .consensus
             .hardforks
-            .delta_at(new_epoch_block.timestamp_secs());
+            .delta_for_block(new_epoch_block.timestamp_secs());
 
         self.allocate_additional_ledger_slots(previous_epoch_block, new_epoch_block, delta);
 

--- a/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
+++ b/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
@@ -570,12 +570,20 @@ impl EpochSnapshot {
                 // A ledger activated by THIS epoch block cannot appear in its
                 // own header: the producer derives the header ledger set from
                 // the parent epoch snapshot, which still predates the
-                // activation. Seed the ledger's first slots here (as genesis
-                // init does for the ledgers active at genesis) so it has
-                // partitions from the epoch it becomes active — blocks in that
-                // epoch already accept data for it, and the header only catches
-                // up an epoch later. `slot_count() == 0` never recurs once
-                // seeded: slots are marked expired, never removed.
+                // activation. Seed the ledger's first slots here so the epoch
+                // that activates it can also serve it — blocks in that epoch
+                // already accept data for it, and the header only catches up an
+                // epoch later.
+                //
+                // Slots only. The partitions come from
+                // `backfill_missing_partitions`, which draws from the
+                // already-pledged capacity pool and leaves a slot empty if that
+                // pool is exhausted — capacity minting runs after it. Unlike
+                // genesis init, which mints capacity and assigns pledges before
+                // the shared backfill, this path has no such guarantee.
+                //
+                // `slot_count() == 0` never recurs once seeded: slots are
+                // marked expired, never removed.
                 if let Activation::Active(delta) = delta
                     && self.ledgers[ledger].slot_count() == 0
                 {

--- a/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
+++ b/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
@@ -10,6 +10,7 @@ use irys_types::{
 };
 use irys_types::{
     CommitmentTransaction, ConsensusConfig, IrysAddress, PartitionChunkOffset,
+    hardfork_config::{Activation, Delta},
     partition_chunk_offset_ie,
 };
 use openssl::sha;
@@ -324,7 +325,15 @@ impl EpochSnapshot {
 
         self.try_genesis_init(new_epoch_block);
 
-        self.allocate_additional_ledger_slots(previous_epoch_block, new_epoch_block);
+        // Epoch-aligned, like the Cascade gate above: the epoch block's own
+        // timestamp decides Delta for every block in this epoch.
+        let delta = self
+            .config
+            .consensus
+            .hardforks
+            .delta_at(new_epoch_block.timestamp_secs());
+
+        self.allocate_additional_ledger_slots(previous_epoch_block, new_epoch_block, delta);
 
         // Update the canonical write window AFTER allocation (so this epoch's
         // new slots exist) and BEFORE expiry (so freshly-written slots aren't
@@ -545,6 +554,7 @@ impl EpochSnapshot {
         &mut self,
         previous_epoch_block: &Option<IrysBlockHeader>,
         new_epoch_block: &IrysBlockHeader,
+        delta: Activation<Delta>,
     ) {
         for ledger in self.ledgers.active_ledgers() {
             // Skip ledgers not present in the block (e.g. pre-hardfork blocks)
@@ -553,6 +563,25 @@ impl EpochSnapshot {
                 .iter()
                 .any(|l| l.ledger_id == ledger as u32)
             {
+                // A ledger activated by THIS epoch block cannot appear in its
+                // own header: the producer derives the header ledger set from
+                // the parent epoch snapshot, which still predates the
+                // activation. Seed the ledger's first slots here (as genesis
+                // init does for the ledgers active at genesis) so it has
+                // partitions from the epoch it becomes active — blocks in that
+                // epoch already accept data for it, and the header only catches
+                // up an epoch later. `slot_count() == 0` never recurs once
+                // seeded: slots are marked expired, never removed.
+                if let Activation::Active(delta) = delta
+                    && self.ledgers[ledger].slot_count() == 0
+                {
+                    let slots = delta.initial_slots_per_new_ledger.get();
+                    debug!(
+                        "Seeding {} slots for newly activated ledger {:?}",
+                        slots, ledger
+                    );
+                    self.ledgers[ledger].allocate_slots(slots, new_epoch_block.height);
+                }
                 continue;
             }
             let part_slots =

--- a/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
+++ b/crates/domain/src/snapshots/epoch_snapshot/epoch_snapshot.rs
@@ -10,7 +10,7 @@ use irys_types::{
 };
 use irys_types::{
     CommitmentTransaction, ConsensusConfig, IrysAddress, PartitionChunkOffset,
-    hardfork_config::{Activation, Delta},
+    hardfork_config::{Activation, Cascade, Delta, ForBlock},
     partition_chunk_offset_ie,
 };
 use openssl::sha;
@@ -50,7 +50,7 @@ impl Default for EpochSnapshot {
         let node_config = NodeConfig::testing();
         let config = Config::new_with_random_peer_id(node_config);
         Self {
-            ledgers: Ledgers::new(&config.consensus, false),
+            ledgers: Ledgers::new(&config.consensus, ForBlock::inactive()),
             partition_assignments: PartitionAssignments::new(),
             all_active_partitions: Vec::new(),
             unassigned_partitions: Vec::new(),
@@ -119,12 +119,12 @@ impl EpochSnapshot {
         commitments: Vec<CommitmentTransaction>,
         config: &Config,
     ) -> Self {
-        let cascade_active = config
+        let cascade = config
             .consensus
             .hardforks
-            .is_cascade_active_at(genesis_block.timestamp_secs());
+            .cascade_for_block(genesis_block.timestamp_secs());
         let mut new_self = Self {
-            ledgers: Ledgers::new(&config.consensus, cascade_active),
+            ledgers: Ledgers::new(&config.consensus, cascade),
             partition_assignments: PartitionAssignments::new(),
             all_active_partitions: Vec::new(),
             unassigned_partitions: Vec::new(),
@@ -310,14 +310,14 @@ impl EpochSnapshot {
         // "this slot has canonical data" marker is updated unconditionally so
         // post-Cascade expiry can distinguish written slots from empty preallocations
         // (pre-Cascade, allocation-aged unwritten slots still expire).
-        let cascade_active = self
+        let cascade = self
             .config
             .consensus
             .hardforks
-            .is_cascade_active_at(new_epoch_block.timestamp_secs());
+            .cascade_for_block(new_epoch_block.timestamp_secs());
 
         // Activate Cascade hardfork ledgers at the activation epoch boundary
-        if cascade_active {
+        if cascade.is_active() {
             self.ledgers.activate_cascade(&self.config.consensus);
         }
 
@@ -345,13 +345,13 @@ impl EpochSnapshot {
         // which `block_producer::ledger_expiry` derives by calling
         // `get_expiring_partition_info` on the PARENT snapshot with the same
         // window exclusion. The last-height refresh above and that exclusion are
-        // gated on this same `cascade_active` (the new epoch block's Cascade
+        // gated on this same `cascade` state (the new epoch block's Cascade
         // status); if one is gated and the other isn't they diverge — a slot
         // would recycle here yet still be settled, or vice versa. Keep the two
         // gates aligned.
-        self.touch_active_ledger_slots(previous_epoch_block, new_epoch_block, cascade_active);
+        self.touch_active_ledger_slots(previous_epoch_block, new_epoch_block, cascade);
 
-        self.expire_ledger_slots(new_epoch_block, cascade_active);
+        self.expire_ledger_slots(new_epoch_block, cascade);
 
         self.apply_unpledges(&new_epoch_commitments)?;
 
@@ -517,13 +517,17 @@ impl EpochSnapshot {
     /// Loops through all ledgers and looks for slots that are older
     /// than their configured epoch length. Marks them expired and stores
     /// the expired partition hashes in the epoch snapshot.
-    fn expire_ledger_slots(&mut self, new_epoch_block: &IrysBlockHeader, cascade_active: bool) {
+    fn expire_ledger_slots(
+        &mut self,
+        new_epoch_block: &IrysBlockHeader,
+        cascade: ForBlock<Cascade>,
+    ) {
         let epoch_height = new_epoch_block.height;
         // Same write-frontier inputs as `touch_active_ledger_slots`: the new
         // epoch block's cumulative per-ledger totals.
         let expired_partitions: Vec<ExpiringPartitionInfo> = self.ledgers.expire_partitions(
             epoch_height,
-            cascade_active,
+            cascade,
             |ledger| new_epoch_block.ledger_total_chunks(ledger),
             self.config.consensus.num_chunks_in_partition,
         );
@@ -602,7 +606,7 @@ impl EpochSnapshot {
         &mut self,
         previous_epoch_block: &Option<IrysBlockHeader>,
         new_epoch_block: &IrysBlockHeader,
-        refresh_last_height: bool,
+        refresh_last_height: ForBlock<Cascade>,
     ) {
         let chunks_per_slot = self.config.consensus.num_chunks_in_partition;
         for ledger in self.ledgers.active_ledgers() {
@@ -1362,8 +1366,8 @@ impl EpochSnapshot {
     /// epoch block; `prev` is read from this (parent) snapshot's epoch block,
     /// matching `touch_active_ledger_slots`.
     ///
-    /// `cascade_active` MUST be the Cascade status of the epoch block being
-    /// produced/validated (`is_cascade_active_at(new_epoch_block.timestamp)`),
+    /// `cascade` MUST be the Cascade status of the epoch block being
+    /// produced/validated (`cascade_for_block(new_epoch_block.timestamp)`),
     /// NOT of this parent snapshot — it has to mirror the
     /// `touch_active_ledger_slots` gate in `perform_epoch_tasks`, which keys off
     /// the new epoch block. When false, the window exclusion is skipped and the
@@ -1377,11 +1381,11 @@ impl EpochSnapshot {
         epoch_height: u64,
         ledger: DataLedger,
         new_total_chunks: u64,
-        cascade_active: bool,
+        cascade: ForBlock<Cascade>,
     ) -> Vec<ExpiringPartitionInfo> {
         // Flattened per-partition view of the slot-keyed set, so the two can
         // never diverge. A slot with no partitions contributes nothing here.
-        self.get_expiring_slot_partitions(epoch_height, ledger, new_total_chunks, cascade_active)
+        self.get_expiring_slot_partitions(epoch_height, ledger, new_total_chunks, cascade)
             .into_iter()
             .flat_map(|(slot_index, partition_hashes)| {
                 partition_hashes
@@ -1407,7 +1411,7 @@ impl EpochSnapshot {
         epoch_height: u64,
         ledger: DataLedger,
         new_total_chunks: u64,
-        cascade_active: bool,
+        cascade: ForBlock<Cascade>,
     ) -> Vec<(usize, Vec<PartitionHash>)> {
         let chunks_per_slot = self.config.consensus.num_chunks_in_partition;
         let prev_total_chunks = self.epoch_block.ledger_total_chunks(ledger);
@@ -1418,7 +1422,8 @@ impl EpochSnapshot {
         // when Cascade is inactive so the expiring set matches the original
         // master behavior (no window exclusion) for bit-identical replay.
         let written_this_epoch = |slot_index: usize| -> bool {
-            if !cascade_active || new_total_chunks <= prev_total_chunks || chunks_per_slot == 0 {
+            if !cascade.is_active() || new_total_chunks <= prev_total_chunks || chunks_per_slot == 0
+            {
                 return false;
             }
             let first = prev_total_chunks / chunks_per_slot;
@@ -1435,7 +1440,7 @@ impl EpochSnapshot {
         self.ledgers
             .get_expiring_slots(
                 epoch_height,
-                cascade_active,
+                cascade,
                 // LOCKSTEP with `expire_ledger_slots`: the target ledger uses the
                 // new epoch block's total. Other ledgers fall back to this
                 // (parent) snapshot's totals — their entries are discarded by the
@@ -1471,13 +1476,13 @@ impl EpochSnapshot {
         &self,
         ledger: DataLedger,
         epoch_height: u64,
-        cascade_active: bool,
+        cascade: ForBlock<Cascade>,
         total_chunks: u64,
     ) -> Vec<usize> {
         self.ledgers.get_all_expired_term_slot_indexes(
             ledger,
             epoch_height,
-            cascade_active,
+            cascade,
             total_chunks,
             self.config.consensus.num_chunks_in_partition,
         )
@@ -1667,7 +1672,7 @@ mod tests {
         });
         let config = Config::new_with_random_peer_id(node_config);
         let mut snapshot = EpochSnapshot {
-            ledgers: Ledgers::new(&config.consensus, false),
+            ledgers: Ledgers::new(&config.consensus, ForBlock::inactive()),
             partition_assignments: PartitionAssignments::new(),
             all_active_partitions: Vec::new(),
             unassigned_partitions: Vec::new(),

--- a/crates/types/src/config/consensus.rs
+++ b/crates/types/src/config/consensus.rs
@@ -842,6 +842,8 @@ impl ConsensusConfig {
                     thirty_day_epoch_length: 30,
                     annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
                 }),
+                // Delta hardfork - not scheduled yet
+                delta: None,
             },
         }
     }
@@ -978,6 +980,9 @@ impl ConsensusConfig {
                 // Cascade hardfork - not active by default in testing;
                 // tests that need it should override via with_consensus()
                 cascade: None,
+                // Delta hardfork - not active by default in testing;
+                // tests that need it should override via with_consensus()
+                delta: None,
             },
         }
     }
@@ -1113,6 +1118,8 @@ impl ConsensusConfig {
                     thirty_day_epoch_length: 10, // 10 hrs
                     annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
                 }),
+                // Delta hardfork - not scheduled yet
+                delta: None,
             },
         }
     }

--- a/crates/types/src/config/consensus.rs
+++ b/crates/types/src/config/consensus.rs
@@ -1295,9 +1295,18 @@ mod tests {
                 .hardforks
                 .is_cascade_active_at(UnixTimestamp::from_secs(1785758400 + 1))
         );
+
+        // Delta — unscheduled. Scheduling it is a protocol change that also moves
+        // the canonical config hash pinned by
+        // `test_mainnet_genesis_constants_are_frozen`.
+        assert!(
+            config.hardforks.delta.is_none(),
+            "mainnet Delta is unscheduled"
+        );
     }
 
-    /// Pins the testnet Borealis activation time (controlled rollout).
+    /// Pins the testnet hardfork schedule: the Borealis activation time
+    /// (controlled rollout) and the forks that must stay unscheduled.
     #[test]
     fn test_testnet_borealis_activation_time() {
         let config = ConsensusConfig::testnet();
@@ -1311,6 +1320,13 @@ mod tests {
                 .expect("testnet Borealis must be configured")
                 .activation_timestamp,
             UnixTimestamp::from_secs(1779436800)
+        );
+
+        // Delta — unscheduled. Scheduling it also moves the canonical config hash
+        // pinned by `test_testnet_genesis_constants_are_frozen`.
+        assert!(
+            config.hardforks.delta.is_none(),
+            "testnet Delta is unscheduled"
         );
     }
 

--- a/crates/types/src/hardfork_config.rs
+++ b/crates/types/src/hardfork_config.rs
@@ -180,22 +180,6 @@ pub enum Activation<T> {
     Inactive,
 }
 
-impl<T> Activation<T> {
-    #[must_use]
-    pub const fn is_active(&self) -> bool {
-        matches!(self, Self::Active(_))
-    }
-
-    /// The fork's parameters, or `None` while it is inactive.
-    #[must_use]
-    pub fn params(self) -> Option<T> {
-        match self {
-            Self::Active(params) => Some(params),
-            Self::Inactive => None,
-        }
-    }
-}
-
 impl<T> From<Option<T>> for Activation<T> {
     fn from(params: Option<T>) -> Self {
         match params {
@@ -355,11 +339,15 @@ impl IrysHardforkConfig {
         ForBlock::new(self.is_cascade_active_at(timestamp))
     }
 
-    /// Resolve the Delta hardfork's activation state at the given timestamp
-    /// (in seconds). Raw timestamp check — epoch alignment is the caller's
-    /// concern (pass an epoch block's timestamp for epoch-aligned semantics).
+    /// Delta's activation state at a block's OWN timestamp (in seconds), with
+    /// its parameters while active.
+    ///
+    /// Named like [`Self::cascade_for_block`] because the scope is the same — the
+    /// epoch block's own timestamp decides the epoch it opens. It carries the
+    /// fork's parameters rather than a [`ForBlock`] tag because its single
+    /// consumer needs them.
     #[must_use]
-    pub fn delta_at(&self, timestamp: UnixTimestamp) -> Activation<Delta> {
+    pub fn delta_for_block(&self, timestamp: UnixTimestamp) -> Activation<Delta> {
         self.delta
             .filter(|f| timestamp >= f.activation_timestamp)
             .into()
@@ -727,7 +715,7 @@ mod tests {
     }
 
     #[test]
-    fn test_delta_at_activation_boundary() {
+    fn test_delta_for_block_activation_boundary() {
         let config = IrysHardforkConfig {
             frontier: FrontierParams {
                 number_of_ingress_proofs_total: 5,
@@ -744,14 +732,18 @@ mod tests {
         };
 
         assert_eq!(
-            config.delta_at(UnixTimestamp::from_secs(1499)),
+            config.delta_for_block(UnixTimestamp::from_secs(1499)),
             Activation::Inactive
         );
-        let Activation::Active(delta) = config.delta_at(UnixTimestamp::from_secs(1500)) else {
+        let Activation::Active(delta) = config.delta_for_block(UnixTimestamp::from_secs(1500))
+        else {
             panic!("delta must be active at its activation timestamp");
         };
         assert_eq!(delta.initial_slots_per_new_ledger.get(), 2);
-        assert!(config.delta_at(UnixTimestamp::from_secs(1501)).is_active());
+        assert!(matches!(
+            config.delta_for_block(UnixTimestamp::from_secs(1501)),
+            Activation::Active(_)
+        ));
 
         // Unconfigured means never active.
         let no_delta = IrysHardforkConfig {
@@ -759,7 +751,7 @@ mod tests {
             ..config
         };
         assert_eq!(
-            no_delta.delta_at(UnixTimestamp::from_secs(u64::MAX)),
+            no_delta.delta_for_block(UnixTimestamp::from_secs(u64::MAX)),
             Activation::Inactive
         );
     }

--- a/crates/types/src/hardfork_config.rs
+++ b/crates/types/src/hardfork_config.rs
@@ -40,8 +40,8 @@ pub struct IrysHardforkConfig {
     pub cascade: Option<Cascade>,
 
     /// Delta hardfork - seeds slots for a data ledger in the epoch it activates.
-    /// Activation is epoch-aligned: enabled for all blocks in an epoch if the epoch block's
-    /// timestamp >= activation_timestamp. None means disabled.
+    /// Resolved at the epoch block's own timestamp; no per-block effect, since it
+    /// only acts during epoch processing. None means disabled.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub delta: Option<Delta>,
 }
@@ -143,8 +143,10 @@ impl Cascade {
 /// without this fork the ledger stays slotless — and therefore unassigned and
 /// unstorable — until the following epoch.
 ///
-/// Activation is epoch-aligned: enabled for all blocks in an epoch if the epoch
-/// block's timestamp >= activation_timestamp. None means disabled.
+/// Resolved at the epoch block's own timestamp — the first epoch block whose
+/// timestamp meets `activation_timestamp` is the one that seeds. There is no
+/// per-block effect: this fork only acts during epoch processing. None means
+/// disabled.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Delta {
     /// Timestamp (seconds since epoch) at which this hardfork activates.
@@ -191,12 +193,16 @@ impl<T> From<Option<T>> for Activation<T> {
 
 /// Fork `T`'s activation state resolved at **one block's own timestamp**.
 ///
-/// For an epoch-aligned fork this is the value that governs the epoch a block
+/// On an epoch block this is also the value that governs the epoch that block
 /// opens, so it is what epoch processing (slot touch, expiry) and anything that
-/// must agree with epoch processing takes. It is NOT interchangeable with
-/// [`ForEpoch`]: for the whole epoch in which such a fork activates, a block's
-/// own status is already active while its governing epoch block's is not.
-/// Distinct types so the two cannot be swapped at a call site.
+/// must agree with epoch processing takes. On an ordinary block it is just that
+/// block's own status — which is what the expiry-policy gates read, and which
+/// can flip mid-epoch, before epoch processing has applied the new rules.
+///
+/// It is NOT interchangeable with [`ForEpoch`]: for the whole epoch in which an
+/// epoch-aligned fork activates, a block's own status is already active while
+/// its governing epoch block's is not. Distinct types so the two cannot be
+/// swapped at a call site.
 #[derive(Debug, PartialEq, Eq)]
 pub struct ForBlock<T> {
     active: bool,
@@ -366,7 +372,7 @@ impl IrysHardforkConfig {
     /// Only the Cascade term ledgers (OneYear/ThirtyDay) qualify, and only before
     /// Cascade activates. This uses the block's own `timestamp` as a proxy,
     /// whereas the authoritative ledger-set check (`extract_data_ledgers`) is
-    /// epoch-aligned (`is_cascade_active_for_epoch`). In the window between
+    /// epoch-aligned (`cascade_for_epoch`). In the window between
     /// Cascade's activation timestamp and the next epoch boundary the two can
     /// disagree, so callers treat an "unexpected" absence as a warning — the
     /// block's shape is already validated upstream — and degrade gracefully

--- a/crates/types/src/hardfork_config.rs
+++ b/crates/types/src/hardfork_config.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 use rust_decimal_macros::dec;
 use serde::{Deserialize, Serialize};
+use std::marker::PhantomData;
 use std::num::NonZeroU64;
 
 /// Configurable hardfork schedule - part of ConsensusConfig.
@@ -204,6 +205,71 @@ impl<T> From<Option<T>> for Activation<T> {
     }
 }
 
+/// Fork `T`'s activation state resolved at **one block's own timestamp**.
+///
+/// For an epoch-aligned fork this is the value that governs the epoch a block
+/// opens, so it is what epoch processing (slot touch, expiry) and anything that
+/// must agree with epoch processing takes. It is NOT interchangeable with
+/// [`ForEpoch`]: for the whole epoch in which such a fork activates, a block's
+/// own status is already active while its governing epoch block's is not.
+/// Distinct types so the two cannot be swapped at a call site.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ForBlock<T> {
+    active: bool,
+    _fork: PhantomData<T>,
+}
+
+/// Fork `T`'s activation state resolved at the **epoch block governing a
+/// block's epoch** — the epoch-aligned status, which lags a block's own status
+/// throughout the activation epoch. See [`ForBlock`].
+#[derive(Debug, PartialEq, Eq)]
+pub struct ForEpoch<T> {
+    active: bool,
+    _fork: PhantomData<T>,
+}
+
+macro_rules! impl_fork_scope {
+    ($scope:ident) => {
+        // Hand-written so the scope stays `Copy` regardless of whether the fork's
+        // parameter type is: the scope holds only activeness plus a phantom.
+        impl<T> Clone for $scope<T> {
+            fn clone(&self) -> Self {
+                *self
+            }
+        }
+
+        impl<T> Copy for $scope<T> {}
+
+        impl<T> $scope<T> {
+            #[must_use]
+            pub const fn new(active: bool) -> Self {
+                Self {
+                    active,
+                    _fork: PhantomData,
+                }
+            }
+
+            #[must_use]
+            pub const fn active() -> Self {
+                Self::new(true)
+            }
+
+            #[must_use]
+            pub const fn inactive() -> Self {
+                Self::new(false)
+            }
+
+            #[must_use]
+            pub const fn is_active(self) -> bool {
+                self.active
+            }
+        }
+    };
+}
+
+impl_fork_scope!(ForBlock);
+impl_fork_scope!(ForEpoch);
+
 /// Result of looking up a data ledger in a block header via
 /// [`IrysHardforkConfig::classify_data_ledger`].
 ///
@@ -276,6 +342,17 @@ impl IrysHardforkConfig {
     #[must_use]
     pub fn is_cascade_active_at(&self, timestamp: UnixTimestamp) -> bool {
         self.cascade_at(timestamp).is_some()
+    }
+
+    /// Cascade's activation state at a block's OWN timestamp (in seconds).
+    ///
+    /// This is the value epoch processing uses (the epoch block's own timestamp
+    /// decides the epoch it opens), and therefore the value everything that must
+    /// stay in lockstep with epoch processing must use — never the epoch-aligned
+    /// [`ForEpoch`] state, which lags for the whole activation epoch.
+    #[must_use]
+    pub fn cascade_for_block(&self, timestamp: UnixTimestamp) -> ForBlock<Cascade> {
+        ForBlock::new(self.is_cascade_active_at(timestamp))
     }
 
     /// Resolve the Delta hardfork's activation state at the given timestamp

--- a/crates/types/src/hardfork_config.rs
+++ b/crates/types/src/hardfork_config.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 use rust_decimal_macros::dec;
 use serde::{Deserialize, Serialize};
+use std::num::NonZeroU64;
 
 /// Configurable hardfork schedule - part of ConsensusConfig.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -36,6 +37,12 @@ pub struct IrysHardforkConfig {
     /// timestamp >= activation_timestamp. None means disabled.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cascade: Option<Cascade>,
+
+    /// Delta hardfork - seeds slots for a data ledger in the epoch it activates.
+    /// Activation is epoch-aligned: enabled for all blocks in an epoch if the epoch block's
+    /// timestamp >= activation_timestamp. None means disabled.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delta: Option<Delta>,
 }
 
 /// Parameters for Frontier hardfork (genesis defaults).
@@ -125,6 +132,78 @@ impl Cascade {
     }
 }
 
+/// Delta hardfork - a data ledger that becomes active mid-chain gets its first
+/// slots in the epoch that activates it.
+///
+/// A hardfork that adds a data ledger activates it inside `perform_epoch_tasks`,
+/// but the epoch block's own header cannot list it: the producer derives the
+/// header ledger set from the parent epoch snapshot, which still predates the
+/// activation. Slot allocation skips any ledger absent from the header, so
+/// without this fork the ledger stays slotless — and therefore unassigned and
+/// unstorable — until the following epoch.
+///
+/// Activation is epoch-aligned: enabled for all blocks in an epoch if the epoch
+/// block's timestamp >= activation_timestamp. None means disabled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Delta {
+    /// Timestamp (seconds since epoch) at which this hardfork activates.
+    /// The actual activation happens at the first epoch boundary where the
+    /// epoch block's timestamp meets or exceeds this value.
+    #[serde(with = "unix_timestamp_string_serde")]
+    pub activation_timestamp: UnixTimestamp,
+    /// Slots allocated to a data ledger in the epoch it becomes active
+    /// (default: 1, matching the per-ledger allocation at genesis init).
+    /// Non-zero: seeding zero slots is what this fork exists to prevent.
+    #[serde(default = "Delta::default_initial_slots_per_new_ledger")]
+    pub initial_slots_per_new_ledger: NonZeroU64,
+}
+
+impl Delta {
+    pub const fn default_initial_slots_per_new_ledger() -> NonZeroU64 {
+        NonZeroU64::MIN
+    }
+}
+
+/// The resolved activation state of a hardfork, carrying that fork's parameters
+/// while it is active.
+///
+/// Consensus code takes this instead of a bare `bool`. Which timestamp a fork is
+/// resolved against decides the activation boundary — a block's own timestamp
+/// and its epoch block's timestamp disagree for a whole epoch after an
+/// epoch-aligned fork activates — so the resolution happens once, where the
+/// state is built, and the state travels to its call sites as a named type that
+/// cannot be confused with an unrelated flag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Activation<T> {
+    Active(T),
+    Inactive,
+}
+
+impl<T> Activation<T> {
+    #[must_use]
+    pub const fn is_active(&self) -> bool {
+        matches!(self, Self::Active(_))
+    }
+
+    /// The fork's parameters, or `None` while it is inactive.
+    #[must_use]
+    pub fn params(self) -> Option<T> {
+        match self {
+            Self::Active(params) => Some(params),
+            Self::Inactive => None,
+        }
+    }
+}
+
+impl<T> From<Option<T>> for Activation<T> {
+    fn from(params: Option<T>) -> Self {
+        match params {
+            Some(params) => Self::Active(params),
+            None => Self::Inactive,
+        }
+    }
+}
+
 /// Result of looking up a data ledger in a block header via
 /// [`IrysHardforkConfig::classify_data_ledger`].
 ///
@@ -197,6 +276,16 @@ impl IrysHardforkConfig {
     #[must_use]
     pub fn is_cascade_active_at(&self, timestamp: UnixTimestamp) -> bool {
         self.cascade_at(timestamp).is_some()
+    }
+
+    /// Resolve the Delta hardfork's activation state at the given timestamp
+    /// (in seconds). Raw timestamp check — epoch alignment is the caller's
+    /// concern (pass an epoch block's timestamp for epoch-aligned semantics).
+    #[must_use]
+    pub fn delta_at(&self, timestamp: UnixTimestamp) -> Activation<Delta> {
+        self.delta
+            .filter(|f| timestamp >= f.activation_timestamp)
+            .into()
     }
 
     /// Check if the Borealis hardfork is active at the given timestamp (in seconds).
@@ -295,6 +384,7 @@ mod tests {
             aurora: None,
             borealis: None,
             cascade: None,
+            delta: None,
         };
 
         assert_eq!(
@@ -327,6 +417,7 @@ mod tests {
             }),
             borealis: None,
             cascade: None,
+            delta: None,
         };
 
         // Before activation timestamp
@@ -358,6 +449,7 @@ mod tests {
                 thirty_day_epoch_length: 30,
                 annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
             }),
+            delta: None,
         };
 
         // Before activation timestamp
@@ -381,6 +473,7 @@ mod tests {
         // No cascade configured
         let no_cascade = IrysHardforkConfig {
             cascade: None,
+            delta: None,
             ..config
         };
         assert!(
@@ -407,6 +500,7 @@ mod tests {
                 thirty_day_epoch_length: 30,
                 annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
             }),
+            delta: None,
         };
 
         let before = UnixTimestamp::from_secs(1499);
@@ -426,6 +520,7 @@ mod tests {
         // absence is always expected (never an invariant violation).
         let no_cascade = IrysHardforkConfig {
             cascade: None,
+            delta: None,
             ..config
         };
         assert!(no_cascade.ledger_absence_expected(DataLedger::OneYear as u32, at));
@@ -452,6 +547,7 @@ mod tests {
                 thirty_day_epoch_length: 30,
                 annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
             }),
+            delta: None,
         };
 
         // Cascade active at the block's timestamp.
@@ -488,6 +584,7 @@ mod tests {
                 activation_timestamp: UnixTimestamp::from_secs(1500),
             }),
             cascade: None,
+            delta: None,
         };
 
         assert!(!config.is_borealis_active_at(UnixTimestamp::from_secs(1499)));
@@ -516,6 +613,7 @@ mod tests {
             aurora: None,
             borealis: None,
             cascade: None,
+            delta: None,
         };
 
         // Before activation timestamp
@@ -552,6 +650,59 @@ mod tests {
     }
 
     #[test]
+    fn test_delta_at_activation_boundary() {
+        let config = IrysHardforkConfig {
+            frontier: FrontierParams {
+                number_of_ingress_proofs_total: 5,
+                number_of_ingress_proofs_from_assignees: 0,
+            },
+            next_name_tbd: None,
+            aurora: None,
+            borealis: None,
+            cascade: None,
+            delta: Some(Delta {
+                activation_timestamp: UnixTimestamp::from_secs(1500),
+                initial_slots_per_new_ledger: NonZeroU64::new(2).expect("non-zero"),
+            }),
+        };
+
+        assert_eq!(
+            config.delta_at(UnixTimestamp::from_secs(1499)),
+            Activation::Inactive
+        );
+        let Activation::Active(delta) = config.delta_at(UnixTimestamp::from_secs(1500)) else {
+            panic!("delta must be active at its activation timestamp");
+        };
+        assert_eq!(delta.initial_slots_per_new_ledger.get(), 2);
+        assert!(config.delta_at(UnixTimestamp::from_secs(1501)).is_active());
+
+        // Unconfigured means never active.
+        let no_delta = IrysHardforkConfig {
+            delta: None,
+            ..config
+        };
+        assert_eq!(
+            no_delta.delta_at(UnixTimestamp::from_secs(u64::MAX)),
+            Activation::Inactive
+        );
+    }
+
+    #[test]
+    fn test_delta_toml_defaults_initial_slots() {
+        let toml_str = "
+            [frontier]
+            number_of_ingress_proofs_total = 5
+            number_of_ingress_proofs_from_assignees = 0
+
+            [delta]
+            activation_timestamp = \"2026-09-01T00:00:00+00:00\"
+        ";
+        let config: IrysHardforkConfig = toml::from_str(toml_str).unwrap();
+        let delta = config.delta.expect("delta must parse");
+        assert_eq!(delta.initial_slots_per_new_ledger.get(), 1);
+    }
+
+    #[test]
     fn test_toml_serialization() {
         let config = IrysHardforkConfig {
             frontier: FrontierParams {
@@ -566,6 +717,7 @@ mod tests {
             aurora: None,
             borealis: None,
             cascade: None,
+            delta: None,
         };
 
         let toml_str = toml::to_string_pretty(&config).unwrap();
@@ -612,6 +764,7 @@ mod tests {
                 }),
                 borealis: None,
                 cascade: None,
+                delta: None,
             };
 
             prop_assert!(config.aurora_at(UnixTimestamp::from_secs(query_ts)).is_none());
@@ -638,6 +791,7 @@ mod tests {
                 }),
                 borealis: None,
                 cascade: None,
+                delta: None,
             };
 
             let result = config.aurora_at(UnixTimestamp::from_secs(query_ts));
@@ -657,6 +811,7 @@ mod tests {
                 aurora: None,
                 borealis: None,
                 cascade: None,
+                delta: None,
             };
 
             prop_assert!(config.aurora_at(UnixTimestamp::from_secs(query_ts)).is_none());
@@ -689,6 +844,7 @@ mod tests {
                 }),
                 borealis: None,
                 cascade: None,
+                delta: None,
             };
 
             let aurora = config.aurora_at(UnixTimestamp::from_secs(query_ts));
@@ -721,6 +877,7 @@ mod tests {
                 }),
                 borealis: None,
                 cascade: None,
+                delta: None,
             }
         }
 
@@ -734,6 +891,7 @@ mod tests {
                 aurora: None,
                 borealis: None,
                 cascade: None,
+                delta: None,
             }
         }
 
@@ -825,6 +983,7 @@ mod tests {
                 aurora: None,
                 borealis: None,
                 cascade: None,
+                delta: None,
             }
         }
 
@@ -837,6 +996,7 @@ mod tests {
                     thirty_day_epoch_length: 30,
                     annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
                 }),
+                delta: None,
                 ..base_config()
             };
             let toml_str = toml::to_string_pretty(&config).unwrap();


### PR DESCRIPTION
## Problem

Cascade activated on mainnet at the epoch block for height 2,066,400. The OneYear and ThirtyDay ledgers appeared in the epoch snapshot but with **zero slots**, so no partitions were assigned and no miner was storing them — while blocks in that epoch already accepted term data.

Sequence at the activating epoch block:

1. `perform_epoch_tasks` sees Cascade active at that block's own timestamp and calls `activate_cascade`, appending both term ledgers with `slots: Vec::new()`.
2. `allocate_additional_ledger_slots` skips any ledger absent from the epoch block's header.
3. That header lists only Publish + Submit, because the producer derives the header ledger set from the **parent** epoch snapshot, which still predates activation (`is_cascade_active_for_epoch` lags by an epoch at the boundary).

So the epoch that creates the ledgers is exactly the epoch that cannot seed them. Observed on mainnet: epoch block 2,066,400 header carries 2 ledgers, the tip carries 4, and `/v1/epoch/latest/ledger/10` and `/20` report `numSlots: 0`. It self-heals one epoch later, which on mainnet is a full day of ingress with no storage behind it.

## Change

**Delta hardfork** (`activation_timestamp`, `initial_slots_per_new_ledger: NonZeroU64`, default 1). When active, a ledger that is active in the snapshot, absent from the epoch block's header, and has `slot_count() == 0` is seeded with its first slots at that epoch — so `backfill_missing_partitions` assigns partitions in the same epoch, mirroring what genesis init does for the ledgers active at genesis.

The gate is epoch-aligned on the epoch block's own timestamp, like Cascade's. `delta: None` on mainnet, testnet and testing, so existing chains replay bit-identically; the fix applies to the next fork that adds a ledger.

Not folded into `next_name_tbd`: that placeholder is the vehicle for the pending ingress-proof count change, so scheduling it would drag that along.

## Scope-tagged activation state

Cascade has two resolutions with different boundaries — at a block's own timestamp, and at the epoch block governing that block's epoch — that disagree for the whole activation epoch. Both were bare `bool`s threaded through expiry, fee settlement and prevalidation, kept apart only by parameter names and the LOCKSTEP comments. They are now distinct types, `ForBlock<Cascade>` and `ForEpoch<Cascade>`, built by `cascade_for_block` / `cascade_for_epoch`; passing the epoch-aligned state where epoch processing needs the block state no longer compiles.

Note the two scopes are not separable at the `data_ledger` boundary: those helpers want one value — the status at the driving epoch block's own timestamp — which both callers derive from a block timestamp, so they take `ForBlock`. No behavioral change: every converted call site keeps the value it had, and call-site conversion was driven off rustc's reported spans rather than by hand.

## Verification

- `new_ledger_activation_slots_test` — rstest over the gate: Delta active → 1 slot with partitions assigned at the activation epoch; pre-Delta → 0 slots, pinning the current behavior.
- `heavy_cascade_midchain_activation_seeds_term_ledger_slots` — a real node activates Cascade mid-chain (stop → set activation from the tip → restart) and asserts on the activation epoch block itself: its header carries 2 ledgers, its snapshot carries 4 with 1 slot each and partitions assigned. With the domain change reverted this test fails `left: 0, right: 1` — the mainnet symptom.
- Config tests for the activation boundary and the serde default.
- Clippy clean workspace-wide; 1754 unit tests and the 3 `cascade_ledger_shape` chain tests pass.

## Not included

Mainnet needs no action — its missing slots are created at the next epoch boundary (height 2,073,600). Changing epoch state at an activation boundary a chain has already passed would be retroactively divergent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Delta hardfork support, allowing newly activated ledgers to receive initial slots during the activation epoch.
  * Added clearer block- and epoch-based hardfork activation handling.

* **Bug Fixes**
  * Improved ledger expiry, promotion, refunds, and fee calculations across branches and reorgs.
  * Corrected transaction-to-miner attribution and minerless expired-slot handling.
  * Added validation for invalid ledger sizing and slot attribution.

* **Tests**
  * Expanded coverage for activation boundaries, reorgs, expiry, and ledger initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->