### PR TITLE
fix(consensus): eliminate block-stream MDBX writer contention

### DIFF
--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -33,6 +33,18 @@ pub struct StreamReorgAppend {
     pub new_fork: Arc<Vec<Arc<SealedBlock>>>,
 }
 
+/// Stream-emission mode for [`BlockMigrationService::persist_metadata`].
+/// Single parameter so invalid pairings (e.g. disabled + reorg payload) are unrepresentable.
+#[derive(Debug, Clone, Copy)]
+pub enum StreamEmission<'a> {
+    /// Do not append durable stream frames.
+    Disabled,
+    /// Append one `observed` frame per confirmed block.
+    Observed,
+    /// Append one `reorged` frame; observed for the new fork is omitted.
+    Reorged(&'a StreamReorgAppend),
+}
+
 /// Block migration orchestration and DB persistence, called inline by `BlockTreeServiceInner`.
 #[derive(Debug)]
 pub struct BlockMigrationService {
@@ -285,16 +297,13 @@ impl BlockMigrationService {
     /// no-op for them. Re-canonical blocks on the new fork get their metadata
     /// (re)written when they migrate, not here — so this function never
     /// recreates a `{None, Some}` state.
-    /// When `emit_stream` is true, durable block-stream frames are appended in the same
-    /// consensus RW txn as the metadata writes and returned for live fan-out (Phase 4).
-    /// `stream_reorg` supplies the reorged frame when the clear/confirm batch is a reorg;
-    /// if set, observed frames for the new fork are omitted (covered by the reorged event).
+    /// Durable block-stream frames for `stream` are appended in the same consensus RW txn as
+    /// the metadata writes and returned for live fan-out (Phase 4).
     pub fn persist_metadata(
         &self,
         blocks_to_clear: &[Arc<SealedBlock>],
         blocks_to_confirm: &[Arc<SealedBlock>],
-        emit_stream: bool,
-        stream_reorg: Option<&StreamReorgAppend>,
+        stream: StreamEmission<'_>,
     ) -> eyre::Result<Vec<StreamFrame>> {
         // Phase 1 scrub and Phase 3 append both iterate
         // `block.transactions().get_ledger_txs(Submit)`.  The in-memory
@@ -347,6 +356,42 @@ impl BlockMigrationService {
                 }
             }
         }
+
+        // Serialize stream payloads before the consensus RW txn so a serde fault
+        // cannot abort metadata / index writes already staged in that transaction.
+        let prepared_stream: Vec<(StreamEvent, Vec<u8>)> = match stream {
+            StreamEmission::Disabled => Vec::new(),
+            StreamEmission::Observed => {
+                let mut out = Vec::with_capacity(blocks_to_confirm.len());
+                for block in blocks_to_confirm {
+                    let event =
+                        StreamEvent::Observed(BlockEvent::from_sealed(block, self.chunk_size));
+                    let payload = serde_json::to_vec(&event)?;
+                    out.push((event, payload));
+                }
+                out
+            }
+            StreamEmission::Reorged(reorg) => {
+                let event = StreamEvent::Reorged {
+                    fork_parent: BlockRef {
+                        height: reorg.fork_parent.height,
+                        block_hash: reorg.fork_parent.block_hash,
+                    },
+                    orphaned: reorg
+                        .old_fork
+                        .iter()
+                        .map(|b| BlockEvent::from_sealed(b, self.chunk_size))
+                        .collect(),
+                    new_fork: reorg
+                        .new_fork
+                        .iter()
+                        .map(|b| BlockEvent::from_sealed(b, self.chunk_size))
+                        .collect(),
+                };
+                let payload = serde_json::to_vec(&event)?;
+                vec![(event, payload)]
+            }
+        };
 
         let stream_frames = self.db.update_eyre_at("persist_metadata", |tx| {
             // Phase 1: Clear orphaned tx metadata, and scrub the orphaned
@@ -414,38 +459,11 @@ impl BlockMigrationService {
                 }
             }
 
-            // Phase 4: durable block-stream frames in this same RW txn.
-            let mut frames = Vec::new();
-            if emit_stream {
-                if let Some(reorg) = stream_reorg {
-                    let event = StreamEvent::Reorged {
-                        fork_parent: BlockRef {
-                            height: reorg.fork_parent.height,
-                            block_hash: reorg.fork_parent.block_hash,
-                        },
-                        orphaned: reorg
-                            .old_fork
-                            .iter()
-                            .map(|b| BlockEvent::from_sealed(b, self.chunk_size))
-                            .collect(),
-                        new_fork: reorg
-                            .new_fork
-                            .iter()
-                            .map(|b| BlockEvent::from_sealed(b, self.chunk_size))
-                            .collect(),
-                    };
-                    let payload = serde_json::to_vec(&event)?;
-                    let seq = append_block_stream_event(tx, payload)?;
-                    frames.push(StreamFrame { seq, event });
-                } else {
-                    for block in blocks_to_confirm {
-                        let event =
-                            StreamEvent::Observed(BlockEvent::from_sealed(block, self.chunk_size));
-                        let payload = serde_json::to_vec(&event)?;
-                        let seq = append_block_stream_event(tx, payload)?;
-                        frames.push(StreamFrame { seq, event });
-                    }
-                }
+            // Phase 4: append pre-serialized durable stream frames in this same RW txn.
+            let mut frames = Vec::with_capacity(prepared_stream.len());
+            for (event, payload) in prepared_stream {
+                let seq = append_block_stream_event(tx, payload)?;
+                frames.push(StreamFrame { seq, event });
             }
             Ok(frames)
         })?;
@@ -903,6 +921,16 @@ impl BlockMigrationService {
         let migrated_block = (**header).clone();
 
         let chunk_size = self.chunk_size;
+        // Serialize finalized stream payload before the consensus RW txn so a
+        // serde fault cannot abort index / header writes in that transaction.
+        let prepared_finalized: Option<(StreamEvent, Vec<u8>)> = if emit_stream {
+            let event = StreamEvent::Finalized(BlockEvent::from_sealed(sealed_block, chunk_size));
+            let payload = serde_json::to_vec(&event)?;
+            Some((event, payload))
+        } else {
+            None
+        };
+
         self.db.update_eyre_at("persist_block", |tx| {
             for commitment_tx in commitment_txs {
                 insert_commitment_tx(tx, commitment_tx)?;
@@ -938,10 +966,7 @@ impl BlockMigrationService {
 
             BlockIndex::push_block(tx, sealed_block, chunk_size)?;
 
-            if emit_stream {
-                let event =
-                    StreamEvent::Finalized(BlockEvent::from_sealed(sealed_block, chunk_size));
-                let payload = serde_json::to_vec(&event)?;
+            if let Some((event, payload)) = prepared_finalized {
                 let seq = append_block_stream_event(tx, payload)?;
                 Ok(Some(StreamFrame { seq, event }))
             } else {
@@ -988,7 +1013,7 @@ mod tests {
     //! satisfied with cheap placeholders.
     use super::*;
     use irys_database::{
-        IrysDatabaseArgs as _, cache_data_root, open_or_create_db,
+        IrysDatabaseArgs as _, cache_data_root, open_or_create_db, read_block_stream_from,
         tables::{CachedDataRoots, IrysTables},
     };
     use irys_domain::{BlockTree, StorageModuleInfo};
@@ -1184,7 +1209,11 @@ mod tests {
         let tip_hash = tip.block_hash;
         let tip_sealed = make_sealed_with_submit_txs(tip, &[(tx_id, data_root)]);
 
-        svc.persist_metadata(&[], std::slice::from_ref(&tip_sealed), false, None)?;
+        svc.persist_metadata(
+            &[],
+            std::slice::from_ref(&tip_sealed),
+            StreamEmission::Disabled,
+        )?;
 
         let cdr = read_cdr(&db, data_root).expect("CDR present");
         assert_eq!(
@@ -1214,7 +1243,11 @@ mod tests {
         let tip = make_block_header(1, H256::random(), 50, vec![tx_id]);
         let tip_sealed = make_sealed_with_submit_txs(tip, &[(tx_id, data_root)]);
 
-        svc.persist_metadata(&[], std::slice::from_ref(&tip_sealed), false, None)?;
+        svc.persist_metadata(
+            &[],
+            std::slice::from_ref(&tip_sealed),
+            StreamEmission::Disabled,
+        )?;
 
         assert!(
             read_cdr(&db, data_root).is_none(),
@@ -1249,7 +1282,11 @@ mod tests {
 
         let orphan_sealed = make_sealed_with_submit_txs(orphan_tip, &[(tx_id, data_root)]);
 
-        svc.persist_metadata(std::slice::from_ref(&orphan_sealed), &[], false, None)?;
+        svc.persist_metadata(
+            std::slice::from_ref(&orphan_sealed),
+            &[],
+            StreamEmission::Disabled,
+        )?;
 
         let cdr = read_cdr(&db, data_root).expect("CDR present");
         assert_eq!(
@@ -1450,7 +1487,11 @@ mod tests {
         );
         let epoch_sealed = make_sealed_commitment(epoch_block);
 
-        svc.persist_metadata(&[], std::slice::from_ref(&epoch_sealed), false, None)?;
+        svc.persist_metadata(
+            &[],
+            std::slice::from_ref(&epoch_sealed),
+            StreamEmission::Disabled,
+        )?;
 
         assert_eq!(
             read_commitment_tx_metadata(&db, &included_commitment)
@@ -1484,7 +1525,11 @@ mod tests {
         let epoch_sealed = make_sealed_commitment(epoch_block);
 
         // Orphan the epoch block.
-        svc.persist_metadata(std::slice::from_ref(&epoch_sealed), &[], false, None)?;
+        svc.persist_metadata(
+            std::slice::from_ref(&epoch_sealed),
+            &[],
+            StreamEmission::Disabled,
+        )?;
 
         assert_eq!(
             read_commitment_tx_metadata(&db, &included_commitment)
@@ -1511,7 +1556,7 @@ mod tests {
         let block = make_commitment_header(height, H256::random(), vec![commitment]);
         let sealed = make_sealed_commitment(block);
 
-        svc.persist_metadata(std::slice::from_ref(&sealed), &[], false, None)?;
+        svc.persist_metadata(std::slice::from_ref(&sealed), &[], StreamEmission::Disabled)?;
 
         assert!(
             read_commitment_tx_metadata(&db, &commitment).is_none(),
@@ -1537,7 +1582,11 @@ mod tests {
         // Migrated state: genesis wrote its commitment dedup row at migration.
         seed_commitment_included_height(&db, commitment, 0);
 
-        svc.persist_metadata(std::slice::from_ref(&genesis_sealed), &[], false, None)?;
+        svc.persist_metadata(
+            std::slice::from_ref(&genesis_sealed),
+            &[],
+            StreamEmission::Disabled,
+        )?;
         assert!(
             read_commitment_tx_metadata(&db, &commitment).is_none(),
             "genesis orphan clears the commitment dedup row (height 0 not epoch-skipped)",
@@ -1708,7 +1757,7 @@ mod tests {
         let commitment_sealed =
             make_sealed_commitment(make_commitment_header(2, H256::random(), vec![commitment]));
 
-        svc.persist_metadata(&[], &[sealed, commitment_sealed], false, None)?;
+        svc.persist_metadata(&[], &[sealed, commitment_sealed], StreamEmission::Disabled)?;
 
         // No canonical metadata written at confirmation.
         assert!(
@@ -1769,7 +1818,11 @@ mod tests {
         assert_eq!(meta.promoted_height, Some(publish_height));
 
         // Orphan the Publish block only
-        svc.persist_metadata(std::slice::from_ref(&publish_sealed), &[], false, None)?;
+        svc.persist_metadata(
+            std::slice::from_ref(&publish_sealed),
+            &[],
+            StreamEmission::Disabled,
+        )?;
 
         let meta = read_data_tx_metadata(&db, &tx_id)
             .expect("row must still exist: included_height is preserved");
@@ -1808,7 +1861,7 @@ mod tests {
         assert!(read_data_tx_metadata(&db, &tx_id).is_some());
 
         // Orphan it
-        svc.persist_metadata(std::slice::from_ref(&sealed), &[], false, None)?;
+        svc.persist_metadata(std::slice::from_ref(&sealed), &[], StreamEmission::Disabled)?;
 
         assert!(
             read_data_tx_metadata(&db, &tx_id).is_none(),
@@ -1842,7 +1895,7 @@ mod tests {
 
         assert!(read_data_tx_metadata(&db, &tx_id).is_some());
 
-        svc.persist_metadata(std::slice::from_ref(&sealed), &[], false, None)?;
+        svc.persist_metadata(std::slice::from_ref(&sealed), &[], StreamEmission::Disabled)?;
 
         assert!(
             read_data_tx_metadata(&db, &tx_id).is_none(),
@@ -1887,8 +1940,7 @@ mod tests {
         svc.persist_metadata(
             std::slice::from_ref(&orphan_sealed),
             std::slice::from_ref(&new_canonical_sealed),
-            false,
-            None,
+            StreamEmission::Disabled,
         )?;
 
         let cdr = read_cdr(&db, data_root).expect("CDR present");
@@ -1952,8 +2004,7 @@ mod tests {
         svc.persist_metadata(
             &[orphan1_sealed, orphan2_sealed],
             &[new1_sealed, new2_sealed],
-            false,
-            None,
+            StreamEmission::Disabled,
         )?;
 
         // Phase 1 cleared the orphaned rows. Confirmation no longer re-writes
@@ -2052,8 +2103,7 @@ mod tests {
         svc.persist_metadata(
             &[orphan1_sealed, orphan2_sealed],
             &[new1_sealed],
-            false,
-            None,
+            StreamEmission::Disabled,
         )?;
 
         // tx_a: cleared by Phase 1. Confirmation no longer re-writes metadata,
@@ -2101,6 +2151,130 @@ mod tests {
         Ok(())
     }
 
+    fn read_stream_frames(db: &DatabaseProvider) -> eyre::Result<Vec<StreamFrame>> {
+        db.view_eyre(|tx| {
+            let raw = read_block_stream_from(tx, 0)?;
+            raw.into_iter()
+                .map(|(seq, bytes)| {
+                    let event: StreamEvent = serde_json::from_slice(&bytes)?;
+                    Ok(StreamFrame { seq, event })
+                })
+                .collect()
+        })
+    }
+
+    /// Phase 4: `StreamEmission::Observed` appends one `observed` frame per confirm.
+    #[tokio::test]
+    async fn stream_emission_observed_appends_one_frame_per_confirm() -> eyre::Result<()> {
+        let (db, _db_tmp) = open_db()?;
+        let (svc, _svc_tmp) = make_service(db.clone());
+
+        let tx_id = H256::random();
+        let data_root = H256::random();
+        let tip = make_block_header(1, H256::zero(), 0, vec![tx_id]);
+        let tip_hash = tip.block_hash;
+        let sealed = make_sealed_with_submit_txs(tip, &[(tx_id, data_root)]);
+
+        let frames =
+            svc.persist_metadata(&[], std::slice::from_ref(&sealed), StreamEmission::Observed)?;
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0].seq, 0);
+        assert_eq!(frames[0].kind(), "observed");
+        assert_eq!(frames[0].block_hash(), Some(tip_hash));
+
+        let durable = read_stream_frames(&db)?;
+        assert_eq!(durable.len(), 1);
+        assert_eq!(durable[0].seq, 0);
+        assert_eq!(durable[0].kind(), "observed");
+        Ok(())
+    }
+
+    /// Phase 4: reorg emission is a single `reorged` frame (no per-block observed).
+    #[tokio::test]
+    async fn stream_emission_reorged_appends_one_reorged_frame() -> eyre::Result<()> {
+        let (db, _db_tmp) = open_db()?;
+        let (svc, _svc_tmp) = make_service(db.clone());
+
+        let orphan_tx = H256::random();
+        let orphan_root = H256::random();
+        let new_tx = H256::random();
+        let new_root = H256::random();
+        let orphan = make_block_header(1, H256::zero(), 0, vec![orphan_tx]);
+        let new_tip = make_block_header(1, H256::zero(), 0, vec![new_tx]);
+        let fork_parent = Arc::new(IrysBlockHeader::new_mock_header());
+        let orphan_sealed = make_sealed_with_submit_txs(orphan, &[(orphan_tx, orphan_root)]);
+        let new_sealed = make_sealed_with_submit_txs(new_tip, &[(new_tx, new_root)]);
+        let reorg = StreamReorgAppend {
+            fork_parent,
+            old_fork: Arc::new(vec![Arc::clone(&orphan_sealed)]),
+            new_fork: Arc::new(vec![Arc::clone(&new_sealed)]),
+        };
+
+        let frames = svc.persist_metadata(
+            std::slice::from_ref(&orphan_sealed),
+            std::slice::from_ref(&new_sealed),
+            StreamEmission::Reorged(&reorg),
+        )?;
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0].kind(), "reorged");
+
+        let durable = read_stream_frames(&db)?;
+        assert_eq!(durable.len(), 1);
+        assert_eq!(durable[0].kind(), "reorged");
+        match &durable[0].event {
+            StreamEvent::Reorged {
+                orphaned, new_fork, ..
+            } => {
+                assert_eq!(orphaned.len(), 1);
+                assert_eq!(new_fork.len(), 1);
+            }
+            other => panic!("expected reorged, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    /// Phase 4: `persist_block(..., true)` returns a durable finalized frame.
+    #[tokio::test]
+    async fn stream_emission_persist_block_appends_finalized() -> eyre::Result<()> {
+        let (db, _db_tmp) = open_db()?;
+        let (svc, _svc_tmp) = make_service_with_epoch(db.clone(), 1);
+
+        let commitment = H256::random();
+        let genesis = make_commitment_header(0, H256::zero(), vec![commitment]);
+        let genesis_hash = genesis.block_hash;
+        let genesis_sealed = make_sealed_commitment(genesis);
+
+        let frame = svc
+            .persist_block(genesis_sealed.as_ref(), true)?
+            .expect("finalized frame");
+        assert_eq!(frame.kind(), "finalized");
+        assert_eq!(frame.block_hash(), Some(genesis_hash));
+        assert_eq!(frame.seq, 0);
+
+        let durable = read_stream_frames(&db)?;
+        assert_eq!(durable.len(), 1);
+        assert_eq!(durable[0].kind(), "finalized");
+        Ok(())
+    }
+
+    /// Phase 4: disabled stream leaves the durable log empty.
+    #[tokio::test]
+    async fn stream_emission_disabled_leaves_log_empty() -> eyre::Result<()> {
+        let (db, _db_tmp) = open_db()?;
+        let (svc, _svc_tmp) = make_service(db.clone());
+
+        let tx_id = H256::random();
+        let data_root = H256::random();
+        let tip = make_block_header(1, H256::zero(), 0, vec![tx_id]);
+        let sealed = make_sealed_with_submit_txs(tip, &[(tx_id, data_root)]);
+
+        let frames =
+            svc.persist_metadata(&[], std::slice::from_ref(&sealed), StreamEmission::Disabled)?;
+        assert!(frames.is_empty());
+        assert!(read_stream_frames(&db)?.is_empty());
+        Ok(())
+    }
+
     /// Regression for the broadened `ensure_header_body_consistent` check:
     /// every data ledger (Submit / Publish / OneYear / ThirtyDay) must
     /// trigger the guard when its header advertises a tx_id its body lacks.
@@ -2133,7 +2307,11 @@ mod tests {
         ));
 
         let err = svc
-            .persist_metadata(&[], std::slice::from_ref(&stripped), false, None)
+            .persist_metadata(
+                &[],
+                std::slice::from_ref(&stripped),
+                StreamEmission::Disabled,
+            )
             .expect_err("stripped body must be rejected");
         let msg = err.to_string();
         assert!(

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -53,6 +53,10 @@ pub enum StreamEmission<'a> {
 /// absent from the restored tree and re-enter via gossip) must not append a
 /// second `observed` frame, and a re-migration must not append a second
 /// `finalized` unless a reorg rolled the block back in between.
+///
+/// Callers that check then append must hold this mutex across check, the
+/// appending RW txn, and post-commit recording so concurrent writers cannot
+/// both miss and both append.
 struct StreamDedup {
     emitted: LruCache<H256, ()>,
     finalized: LruCache<H256, ()>,
@@ -396,15 +400,24 @@ impl BlockMigrationService {
 
         // Serialize stream payloads before the consensus RW txn so a serde fault
         // cannot abort metadata / index writes already staged in that transaction.
+        // Observed de-dup must hold `stream_dedup` through check, append, and
+        // post-commit note so concurrent writers cannot both miss and both append.
+        let mut observed_dedup = match &stream {
+            StreamEmission::Observed => Some(
+                self.stream_dedup
+                    .lock()
+                    .unwrap_or_else(PoisonError::into_inner),
+            ),
+            _ => None,
+        };
         let prepared_stream: Vec<(StreamEvent, Vec<u8>)> = match stream {
             StreamEmission::Disabled => Vec::new(),
             StreamEmission::Observed => {
                 // Skip blocks already `observed` per the seeded restart de-dup:
                 // a block re-confirmed after a restart must not append twice.
-                let dedup = self
-                    .stream_dedup
-                    .lock()
-                    .unwrap_or_else(PoisonError::into_inner);
+                let dedup = observed_dedup
+                    .as_ref()
+                    .expect("Observed holds stream_dedup for the append critical section");
                 let mut out = Vec::with_capacity(blocks_to_confirm.len());
                 for block in blocks_to_confirm {
                     if dedup.emitted.contains(&block.header().block_hash) {
@@ -513,7 +526,13 @@ impl BlockMigrationService {
             }
             Ok(frames)
         })?;
-        self.note_stream_frames(&stream_frames);
+        // Note only after commit succeeds (update_eyre_at returned Ok). Observed
+        // reuses the lock held across check+append; other modes lock here.
+        if let Some(ref mut dedup) = observed_dedup {
+            Self::note_stream_frames_locked(dedup, &stream_frames);
+        } else {
+            self.note_stream_frames(&stream_frames);
+        }
 
         info!(
             cleared_blocks = blocks_to_clear.len(),
@@ -535,6 +554,10 @@ impl BlockMigrationService {
             .stream_dedup
             .lock()
             .unwrap_or_else(PoisonError::into_inner);
+        Self::note_stream_frames_locked(&mut dedup, frames);
+    }
+
+    fn note_stream_frames_locked(dedup: &mut StreamDedup, frames: &[StreamFrame]) {
         for frame in frames {
             match &frame.event {
                 StreamEvent::Observed(block) => {
@@ -1012,14 +1035,21 @@ impl BlockMigrationService {
         // serde fault cannot abort index / header writes in that transaction.
         // The seeded restart de-dup suppresses a second `finalized` for a block
         // whose frame is already in the log (crash after commit, before the
-        // producer restart).
-        let already_finalized = emit_stream
-            && self
-                .stream_dedup
-                .lock()
-                .unwrap_or_else(PoisonError::into_inner)
-                .finalized
-                .contains(&header.block_hash);
+        // producer restart). Hold `stream_dedup` across check, append, and
+        // post-commit note so concurrent migrators cannot both miss and both
+        // append.
+        let mut finalized_dedup = if emit_stream {
+            Some(
+                self.stream_dedup
+                    .lock()
+                    .unwrap_or_else(PoisonError::into_inner),
+            )
+        } else {
+            None
+        };
+        let already_finalized = finalized_dedup
+            .as_ref()
+            .is_some_and(|d| d.finalized.contains(&header.block_hash));
         let prepared_finalized: Option<(StreamEvent, Vec<u8>)> = if emit_stream
             && !already_finalized
         {
@@ -1073,7 +1103,10 @@ impl BlockMigrationService {
             }
         })?;
         if let Some(frame) = &frame {
-            self.note_stream_frames(std::slice::from_ref(frame));
+            // Commit succeeded; record under the same lock held for the check.
+            if let Some(ref mut dedup) = finalized_dedup {
+                Self::note_stream_frames_locked(dedup, std::slice::from_ref(frame));
+            }
         }
         Ok(frame)
     }

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -419,22 +419,24 @@ impl BlockMigrationService {
 
         // Serialize stream payloads before the consensus RW txn so a serde fault
         // cannot abort metadata / index writes already staged in that transaction.
-        // Observed de-dup must hold `stream_dedup` through check, append, and
+        // Every emitting mode must hold `stream_dedup` through check, append, and
         // post-commit note so concurrent writers cannot both miss and both append.
-        let mut observed_dedup = match &stream {
-            StreamEmission::Observed => Some(
+        // `Reorged` records its `new_fork` hashes as emitted, the same key space
+        // `Observed` checks, so it holds the guard for the same span.
+        let mut stream_dedup = match &stream {
+            StreamEmission::Disabled => None,
+            StreamEmission::Observed | StreamEmission::Reorged(_) => Some(
                 self.stream_dedup
                     .lock()
                     .unwrap_or_else(PoisonError::into_inner),
             ),
-            _ => None,
         };
         let prepared_stream: Vec<(StreamEvent, Vec<u8>)> = match stream {
             StreamEmission::Disabled => Vec::new(),
             StreamEmission::Observed => {
                 // Skip blocks already `observed` per the seeded restart de-dup:
                 // a block re-confirmed after a restart must not append twice.
-                let dedup = observed_dedup
+                let dedup = stream_dedup
                     .as_ref()
                     .expect("Observed holds stream_dedup for the append critical section");
                 let mut out = Vec::with_capacity(blocks_to_confirm.len());
@@ -550,12 +552,10 @@ impl BlockMigrationService {
             }
             Ok(frames)
         })?;
-        // Note only after commit succeeds (update_eyre_at returned Ok). Observed
-        // reuses the lock held across check+append; other modes lock here.
-        if let Some(ref mut dedup) = observed_dedup {
+        // Note only after commit succeeds (update_eyre_at returned Ok), reusing the
+        // guard held across check+append. `Disabled` produced no frames to note.
+        if let Some(ref mut dedup) = stream_dedup {
             Self::note_stream_frames_locked(dedup, &stream_frames);
-        } else {
-            self.note_stream_frames(&stream_frames);
         }
 
         info!(
@@ -570,17 +570,6 @@ impl BlockMigrationService {
 
     /// Records appended frames in the restart de-dup. Called only after the
     /// appending txn commits, so a failed commit cannot mark a frame emitted.
-    fn note_stream_frames(&self, frames: &[StreamFrame]) {
-        if frames.is_empty() {
-            return;
-        }
-        let mut dedup = self
-            .stream_dedup
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner);
-        Self::note_stream_frames_locked(&mut dedup, frames);
-    }
-
     fn note_stream_frames_locked(dedup: &mut StreamDedup, frames: &[StreamFrame]) {
         for frame in frames {
             match &frame.event {

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -473,90 +473,100 @@ impl BlockMigrationService {
             }
         };
 
-        let stream_frames = self.db.update_eyre_at("persist_metadata", |tx| {
-            // Phase 1: Clear orphaned tx metadata, and scrub the orphaned
-            // block_hash from any CachedDataRoot.block_set that retained it.
-            //
-            // Per-ledger semantics:
-            //   - Term-ledger (Submit, OneYear, ThirtyDay): delete the row.
-            //     The reorg invariant guarantees the matching Publish block is
-            //     also in `blocks_to_clear` (if the tx was promoted at all),
-            //     so either iteration order ends with the row deleted.
-            //   - Publish ledger: clear `promoted_height` only.  A Submit-confirmed
-            //     `included_height` on the same tx must not be disturbed
-            //     (Publish-only orphan: Submit stays canonical, row kept as
-            //     `{Some, None}`).
-            for block in blocks_to_clear {
-                let header = block.header();
-                let orphan_block_hash = header.block_hash;
+        let (stream_frames, prune_interval_reached) =
+            self.db.update_eyre_at("persist_metadata", |tx| {
+                // Phase 1: Clear orphaned tx metadata, and scrub the orphaned
+                // block_hash from any CachedDataRoot.block_set that retained it.
+                //
+                // Per-ledger semantics:
+                //   - Term-ledger (Submit, OneYear, ThirtyDay): delete the row.
+                //     The reorg invariant guarantees the matching Publish block is
+                //     also in `blocks_to_clear` (if the tx was promoted at all),
+                //     so either iteration order ends with the row deleted.
+                //   - Publish ledger: clear `promoted_height` only.  A Submit-confirmed
+                //     `included_height` on the same tx must not be disturbed
+                //     (Publish-only orphan: Submit stays canonical, row kept as
+                //     `{Some, None}`).
+                for block in blocks_to_clear {
+                    let header = block.header();
+                    let orphan_block_hash = header.block_hash;
 
-                for dl in &header.data_ledgers {
-                    let tx_ids = &dl.tx_ids.0;
-                    if tx_ids.is_empty() {
-                        continue;
+                    for dl in &header.data_ledgers {
+                        let tx_ids = &dl.tx_ids.0;
+                        if tx_ids.is_empty() {
+                            continue;
+                        }
+                        if dl.ledger_id == DataLedger::Publish as u32 {
+                            irys_database::batch_clear_data_tx_promoted_height(tx, tx_ids)?;
+                        } else {
+                            // Term ledger (Submit / OneYear / ThirtyDay)
+                            irys_database::batch_clear_data_tx_included_height(tx, tx_ids)?;
+                        }
                     }
-                    if dl.ledger_id == DataLedger::Publish as u32 {
-                        irys_database::batch_clear_data_tx_promoted_height(tx, tx_ids)?;
-                    } else {
-                        // Term ledger (Submit / OneYear / ThirtyDay)
-                        irys_database::batch_clear_data_tx_included_height(tx, tx_ids)?;
+                    self.clear_commitment_inclusions(tx, header)?;
+
+                    for submit_tx in block.transactions().get_ledger_txs(DataLedger::Submit) {
+                        irys_database::remove_data_root_block_set_entry(
+                            tx,
+                            submit_tx.data_root,
+                            orphan_block_hash,
+                        )?;
                     }
                 }
-                self.clear_commitment_inclusions(tx, header)?;
-
-                for submit_tx in block.transactions().get_ledger_txs(DataLedger::Submit) {
-                    irys_database::remove_data_root_block_set_entry(
-                        tx,
-                        submit_tx.data_root,
-                        orphan_block_hash,
-                    )?;
+                // Phase 3: Maintain the CachedDataRoot.block_set hint for the
+                //          canonical Submit-ledger txs we just confirmed (update-only,
+                //          does not create cache entries for data_roots the node
+                //          never tracked chunks for).
+                //
+                // Canonical tx metadata (`IrysDataTxMetadata` / `IrysCommitmentTxMetadata`)
+                // is deliberately NOT written here. It is written only at migration
+                // (`persist_block`), atomically with `MigratedBlockHashes` and the
+                // block header — so a metadata row can never exist without its MBH
+                // entry naming the same canonical block. Writing it here (at
+                // confirmation, depth 0) previously let an orphaned tip strand a
+                // metadata row that a later block migrating at the same height would
+                // read as canonical. Unmigrated blocks are served branch-correctly
+                // from the in-memory block tree (see `tx_inclusion` / the validator's
+                // by-hash walk), so the DB metadata is only ever consulted for
+                // migrated heights, where `MigratedBlockHashes` is branch-stable.
+                // `block_set` is only a non-consensus hint (never read by
+                // `find_canonical_ledger_range` / `canonical_*_height`), and the
+                // ingress-proof pipeline needs it populated at confirmation, so it
+                // stays here.
+                for block in blocks_to_confirm {
+                    let block_hash = block.header().block_hash;
+                    for submit_tx in block.transactions().get_ledger_txs(DataLedger::Submit) {
+                        irys_database::update_data_root_block_set(
+                            tx,
+                            submit_tx.data_root,
+                            block_hash,
+                        )?;
+                    }
                 }
-            }
-            // Phase 3: Maintain the CachedDataRoot.block_set hint for the
-            //          canonical Submit-ledger txs we just confirmed (update-only,
-            //          does not create cache entries for data_roots the node
-            //          never tracked chunks for).
-            //
-            // Canonical tx metadata (`IrysDataTxMetadata` / `IrysCommitmentTxMetadata`)
-            // is deliberately NOT written here. It is written only at migration
-            // (`persist_block`), atomically with `MigratedBlockHashes` and the
-            // block header — so a metadata row can never exist without its MBH
-            // entry naming the same canonical block. Writing it here (at
-            // confirmation, depth 0) previously let an orphaned tip strand a
-            // metadata row that a later block migrating at the same height would
-            // read as canonical. Unmigrated blocks are served branch-correctly
-            // from the in-memory block tree (see `tx_inclusion` / the validator's
-            // by-hash walk), so the DB metadata is only ever consulted for
-            // migrated heights, where `MigratedBlockHashes` is branch-stable.
-            // `block_set` is only a non-consensus hint (never read by
-            // `find_canonical_ledger_range` / `canonical_*_height`), and the
-            // ingress-proof pipeline needs it populated at confirmation, so it
-            // stays here.
-            for block in blocks_to_confirm {
-                let block_hash = block.header().block_hash;
-                for submit_tx in block.transactions().get_ledger_txs(DataLedger::Submit) {
-                    irys_database::update_data_root_block_set(tx, submit_tx.data_root, block_hash)?;
-                }
-            }
 
-            // Phase 4: append pre-serialized durable stream frames in this same RW txn.
-            let mut frames = Vec::with_capacity(prepared_stream.len());
-            for (event, payload) in prepared_stream {
-                let seq = append_block_stream_event(tx, payload)?;
-                frames.push(StreamFrame { seq, event });
-            }
-            // Writer-side retention: prune even if the producer has halted.
-            if let Some(last) = frames.last() {
-                let n = u64::try_from(frames.len()).unwrap_or(u64::MAX);
-                self.maybe_prune_stream_in_tx(tx, last.seq, n)?;
-            }
-            Ok(frames)
-        })?;
+                // Phase 4: append pre-serialized durable stream frames in this same RW txn.
+                let mut frames = Vec::with_capacity(prepared_stream.len());
+                for (event, payload) in prepared_stream {
+                    let seq = append_block_stream_event(tx, payload)?;
+                    frames.push(StreamFrame { seq, event });
+                }
+                // Writer-side retention: prune even if the producer has halted.
+                let mut prune_interval_reached = false;
+                if let Some(last) = frames.last() {
+                    let n = u64::try_from(frames.len()).unwrap_or(u64::MAX);
+                    prune_interval_reached = self.maybe_prune_stream_in_tx(tx, last.seq, n)?;
+                }
+                Ok((frames, prune_interval_reached))
+            })?;
         // Note only after commit succeeds (update_eyre_at returned Ok), reusing the
         // guard held across check+append. `Disabled` produced no frames to note.
         if let Some(ref mut dedup) = stream_dedup {
             Self::note_stream_frames_locked(dedup, &stream_frames);
         }
+        self.note_stream_appends(
+            u64::try_from(stream_frames.len()).unwrap_or(u64::MAX),
+            prune_interval_reached,
+        );
 
         info!(
             cleared_blocks = blocks_to_clear.len(),
@@ -1111,12 +1121,16 @@ impl BlockMigrationService {
             if let Some((event, payload)) = prepared_finalized {
                 let seq = append_block_stream_event(tx, payload)?;
                 // Writer-side retention: prune even if the producer has halted.
-                self.maybe_prune_stream_in_tx(tx, seq, 1)?;
-                Ok(Some(StreamFrame { seq, event }))
+                let prune_interval_reached = self.maybe_prune_stream_in_tx(tx, seq, 1)?;
+                Ok(Some((StreamFrame { seq, event }, prune_interval_reached)))
             } else {
                 Ok(None)
             }
         })?;
+        let frame = frame.map(|(frame, prune_interval_reached)| {
+            self.note_stream_appends(1, prune_interval_reached);
+            frame
+        });
         if let Some(frame) = &frame {
             // Commit succeeded; record under the same lock held for the check.
             if let Some(ref mut dedup) = finalized_dedup {
@@ -1130,33 +1144,58 @@ impl BlockMigrationService {
     /// halted producer cannot leave the log growing without bound. Batched
     /// every [`crate::block_stream_service::PRUNE_INTERVAL`] frames; deletes
     /// below `latest_seq + 1 - RETENTION_EVENTS` inside the same RW txn.
+    ///
+    /// Returns whether the batching interval was reached. The counter itself is
+    /// left untouched here and advanced by [`Self::note_stream_appends`] only
+    /// after the enclosing txn commits: a rolled-back txn must neither count
+    /// frames that never became durable nor reset the interval, since repeated
+    /// failures at the threshold would defer pruning while the log keeps
+    /// growing.
     fn maybe_prune_stream_in_tx<T: reth_db::transaction::DbTxMut>(
         &self,
         tx: &T,
         latest_seq: u64,
         frames_appended: u64,
-    ) -> eyre::Result<()> {
+    ) -> eyre::Result<bool> {
         if frames_appended == 0 {
-            return Ok(());
+            return Ok(false);
         }
         use crate::block_stream_service::{PRUNE_INTERVAL, RETENTION_EVENTS};
-        let prev = self
+        let pending = self
             .stream_appends_since_prune
-            .fetch_add(frames_appended, Ordering::Relaxed);
-        if prev.saturating_add(frames_appended) < PRUNE_INTERVAL {
-            return Ok(());
+            .load(Ordering::Relaxed)
+            .saturating_add(frames_appended);
+        if pending < PRUNE_INTERVAL {
+            return Ok(false);
         }
-        self.stream_appends_since_prune.store(0, Ordering::Relaxed);
+        // Interval reached: the counter resets on commit even when there is
+        // nothing below the retention floor yet, so the check runs once per
+        // interval rather than on every append.
         let Some(keep_from) = latest_seq
             .checked_add(1)
             .and_then(|len| len.checked_sub(RETENTION_EVENTS))
         else {
-            return Ok(());
+            return Ok(true);
         };
         if keep_from == 0 {
-            return Ok(());
+            return Ok(true);
         }
-        prune_block_stream_below(tx, keep_from)
+        prune_block_stream_below(tx, keep_from)?;
+        Ok(true)
+    }
+
+    /// Advances the retention counter after the appending txn commits.
+    /// See [`Self::maybe_prune_stream_in_tx`] for why this cannot run inside it.
+    fn note_stream_appends(&self, frames_appended: u64, prune_interval_reached: bool) {
+        if frames_appended == 0 {
+            return;
+        }
+        if prune_interval_reached {
+            self.stream_appends_since_prune.store(0, Ordering::Relaxed);
+        } else {
+            self.stream_appends_since_prune
+                .fetch_add(frames_appended, Ordering::Relaxed);
+        }
     }
 
     /// Notify ChunkMigrationService about the migrated block (fire-and-forget).

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -546,11 +546,17 @@ impl BlockMigrationService {
                 StreamEvent::Reorged {
                     orphaned, new_fork, ..
                 } => {
+                    // New-fork hashes are marked emitted so a later confirm does
+                    // not also append `observed` for them (reorg frame already
+                    // carries the switch). Orphaned hashes stay in `emitted`:
+                    // re-adoption is delivered via a later reorged `new_fork`
+                    // list, which re-marks them — popping would invite a
+                    // duplicate Observed if confirmation ran first.
                     for block in new_fork {
                         dedup.emitted.put(block.header.block_hash, ());
                     }
-                    // A rolled-back block must be free to emit `finalized`
-                    // again if its fork is re-adopted and it re-migrates.
+                    // Pop finalized for orphans so re-migration after re-adoption
+                    // can append a fresh `finalized` frame.
                     for block in orphaned {
                         dedup.finalized.pop(&block.header.block_hash);
                     }

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -17,15 +17,16 @@ use irys_types::{
     PartitionChunkOffset, PartitionChunkRange, SealedBlock, SendTraced as _, SystemLedger, Traced,
     U256, app_state::DatabaseProvider,
 };
+use lru::LruCache;
 use std::{
     collections::HashMap,
-    sync::{Arc, RwLock},
+    sync::{Arc, Mutex, PoisonError, RwLock},
 };
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{debug, info, warn};
 
 /// Optional reorg payload so `persist_metadata` can append a durable `reorged` stream frame
-/// inside the same consensus RW txn as confirmation metadata (Phase 4).
+/// inside the same consensus RW txn as confirmation metadata.
 #[derive(Debug)]
 pub struct StreamReorgAppend {
     pub fork_parent: Arc<IrysBlockHeader>,
@@ -45,10 +46,32 @@ pub enum StreamEmission<'a> {
     Reorged(&'a StreamReorgAppend),
 }
 
+/// Restart de-duplication for durable stream appends, seeded from the log tail
+/// at construction. The producer's in-memory caches cannot guard these appends
+/// — they happen upstream, inside consensus txns — so the writer holds its own:
+/// a block re-confirmed after a restart (confirmed-but-unmigrated blocks are
+/// absent from the restored tree and re-enter via gossip) must not append a
+/// second `observed` frame, and a re-migration must not append a second
+/// `finalized` unless a reorg rolled the block back in between.
+struct StreamDedup {
+    emitted: LruCache<H256, ()>,
+    finalized: LruCache<H256, ()>,
+}
+
+impl std::fmt::Debug for StreamDedup {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StreamDedup")
+            .field("emitted", &self.emitted.len())
+            .field("finalized", &self.finalized.len())
+            .finish()
+    }
+}
+
 /// Block migration orchestration and DB persistence, called inline by `BlockTreeServiceInner`.
 #[derive(Debug)]
 pub struct BlockMigrationService {
     db: DatabaseProvider,
+    stream_dedup: Mutex<StreamDedup>,
     block_index_guard: BlockIndexReadGuard,
     supply_state: Option<Arc<SupplyState>>,
     chunk_size: u64,
@@ -169,8 +192,22 @@ impl BlockMigrationService {
         chunk_migration_sender: UnboundedSender<Traced<ChunkMigrationServiceMessage>>,
         packing_sender: PackingSender,
     ) -> Self {
+        // Best-effort seed: an unreadable log tail degrades to an empty de-dup
+        // (worst case a duplicate frame, exactly the pre-seed behaviour) rather
+        // than failing construction.
+        let stream_dedup = match crate::block_stream_service::rebuild_state(&db) {
+            Ok((emitted, finalized)) => StreamDedup { emitted, finalized },
+            Err(e) => {
+                warn!(error = ?e, "failed to seed stream de-dup from the log tail; starting empty");
+                StreamDedup {
+                    emitted: LruCache::new(crate::block_stream_service::DEDUP_CAPACITY),
+                    finalized: LruCache::new(crate::block_stream_service::DEDUP_CAPACITY),
+                }
+            }
+        };
         Self {
             db,
+            stream_dedup: Mutex::new(stream_dedup),
             block_index_guard,
             supply_state,
             chunk_size,
@@ -298,7 +335,7 @@ impl BlockMigrationService {
     /// (re)written when they migrate, not here — so this function never
     /// recreates a `{None, Some}` state.
     /// Durable block-stream frames for `stream` are appended in the same consensus RW txn as
-    /// the metadata writes and returned for live fan-out (Phase 4).
+    /// the metadata writes and returned for live fan-out.
     pub fn persist_metadata(
         &self,
         blocks_to_clear: &[Arc<SealedBlock>],
@@ -362,8 +399,17 @@ impl BlockMigrationService {
         let prepared_stream: Vec<(StreamEvent, Vec<u8>)> = match stream {
             StreamEmission::Disabled => Vec::new(),
             StreamEmission::Observed => {
+                // Skip blocks already `observed` per the seeded restart de-dup:
+                // a block re-confirmed after a restart must not append twice.
+                let dedup = self
+                    .stream_dedup
+                    .lock()
+                    .unwrap_or_else(PoisonError::into_inner);
                 let mut out = Vec::with_capacity(blocks_to_confirm.len());
                 for block in blocks_to_confirm {
+                    if dedup.emitted.contains(&block.header().block_hash) {
+                        continue;
+                    }
                     let event =
                         StreamEvent::Observed(BlockEvent::from_sealed(block, self.chunk_size));
                     let payload = serde_json::to_vec(&event)?;
@@ -467,6 +513,7 @@ impl BlockMigrationService {
             }
             Ok(frames)
         })?;
+        self.note_stream_frames(&stream_frames);
 
         info!(
             cleared_blocks = blocks_to_clear.len(),
@@ -476,6 +523,40 @@ impl BlockMigrationService {
         );
 
         Ok(stream_frames)
+    }
+
+    /// Records appended frames in the restart de-dup. Called only after the
+    /// appending txn commits, so a failed commit cannot mark a frame emitted.
+    fn note_stream_frames(&self, frames: &[StreamFrame]) {
+        if frames.is_empty() {
+            return;
+        }
+        let mut dedup = self
+            .stream_dedup
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        for frame in frames {
+            match &frame.event {
+                StreamEvent::Observed(block) => {
+                    dedup.emitted.put(block.header.block_hash, ());
+                }
+                StreamEvent::Finalized(block) => {
+                    dedup.finalized.put(block.header.block_hash, ());
+                }
+                StreamEvent::Reorged {
+                    orphaned, new_fork, ..
+                } => {
+                    for block in new_fork {
+                        dedup.emitted.put(block.header.block_hash, ());
+                    }
+                    // A rolled-back block must be free to emit `finalized`
+                    // again if its fork is re-adopted and it re-migrates.
+                    for block in orphaned {
+                        dedup.finalized.pop(&block.header.block_hash);
+                    }
+                }
+            }
+        }
     }
 
     /// Rolls back blocks migrated on a minority fork during network partition recovery.
@@ -923,7 +1004,19 @@ impl BlockMigrationService {
         let chunk_size = self.chunk_size;
         // Serialize finalized stream payload before the consensus RW txn so a
         // serde fault cannot abort index / header writes in that transaction.
-        let prepared_finalized: Option<(StreamEvent, Vec<u8>)> = if emit_stream {
+        // The seeded restart de-dup suppresses a second `finalized` for a block
+        // whose frame is already in the log (crash after commit, before the
+        // producer restart).
+        let already_finalized = emit_stream
+            && self
+                .stream_dedup
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .finalized
+                .contains(&header.block_hash);
+        let prepared_finalized: Option<(StreamEvent, Vec<u8>)> = if emit_stream
+            && !already_finalized
+        {
             let event = StreamEvent::Finalized(BlockEvent::from_sealed(sealed_block, chunk_size));
             let payload = serde_json::to_vec(&event)?;
             Some((event, payload))
@@ -931,7 +1024,7 @@ impl BlockMigrationService {
             None
         };
 
-        self.db.update_eyre_at("persist_block", |tx| {
+        let frame = self.db.update_eyre_at("persist_block", |tx| {
             for commitment_tx in commitment_txs {
                 insert_commitment_tx(tx, commitment_tx)?;
             }
@@ -972,7 +1065,11 @@ impl BlockMigrationService {
             } else {
                 Ok(None)
             }
-        })
+        })?;
+        if let Some(frame) = &frame {
+            self.note_stream_frames(std::slice::from_ref(frame));
+        }
+        Ok(frame)
     }
 
     /// Notify ChunkMigrationService about the migrated block (fire-and-forget).
@@ -2163,7 +2260,7 @@ mod tests {
         })
     }
 
-    /// Phase 4: `StreamEmission::Observed` appends one `observed` frame per confirm.
+    /// `StreamEmission::Observed` appends one `observed` frame per confirm.
     #[tokio::test]
     async fn stream_emission_observed_appends_one_frame_per_confirm() -> eyre::Result<()> {
         let (db, _db_tmp) = open_db()?;
@@ -2189,7 +2286,7 @@ mod tests {
         Ok(())
     }
 
-    /// Phase 4: reorg emission is a single `reorged` frame (no per-block observed).
+    /// Reorg emission is a single `reorged` frame (no per-block observed).
     #[tokio::test]
     async fn stream_emission_reorged_appends_one_reorged_frame() -> eyre::Result<()> {
         let (db, _db_tmp) = open_db()?;
@@ -2233,7 +2330,7 @@ mod tests {
         Ok(())
     }
 
-    /// Phase 4: `persist_block(..., true)` returns a durable finalized frame.
+    /// `persist_block(..., true)` returns a durable finalized frame.
     #[tokio::test]
     async fn stream_emission_persist_block_appends_finalized() -> eyre::Result<()> {
         let (db, _db_tmp) = open_db()?;
@@ -2257,7 +2354,7 @@ mod tests {
         Ok(())
     }
 
-    /// Phase 4: disabled stream leaves the durable log empty.
+    /// A disabled stream leaves the durable log empty.
     #[tokio::test]
     async fn stream_emission_disabled_leaves_log_empty() -> eyre::Result<()> {
         let (db, _db_tmp) = open_db()?;
@@ -2272,6 +2369,98 @@ mod tests {
             svc.persist_metadata(&[], std::slice::from_ref(&sealed), StreamEmission::Disabled)?;
         assert!(frames.is_empty());
         assert!(read_stream_frames(&db)?.is_empty());
+        Ok(())
+    }
+
+    /// Restart de-dup (M2): a block whose `observed` frame is already durable must not append a
+    /// second one when it is re-confirmed by a fresh service (seeded from the log tail), while a
+    /// genuinely new block still appends.
+    #[tokio::test]
+    async fn observed_append_is_idempotent_across_restart() -> eyre::Result<()> {
+        let (db, _db_tmp) = open_db()?;
+        let tx_id = H256::random();
+        let data_root = H256::random();
+        let tip = make_block_header(1, H256::zero(), 0, vec![tx_id]);
+        let sealed = make_sealed_with_submit_txs(tip, &[(tx_id, data_root)]);
+
+        {
+            let (svc, _svc_tmp) = make_service(db.clone());
+            let frames =
+                svc.persist_metadata(&[], std::slice::from_ref(&sealed), StreamEmission::Observed)?;
+            assert_eq!(frames.len(), 1);
+        }
+
+        // Restart: confirmed-but-unmigrated blocks are absent from the restored tree and
+        // re-enter via gossip, so the same block is re-confirmed by a fresh service.
+        let (svc, _svc_tmp) = make_service(db.clone());
+        let frames =
+            svc.persist_metadata(&[], std::slice::from_ref(&sealed), StreamEmission::Observed)?;
+        assert!(
+            frames.is_empty(),
+            "re-confirmation after restart must not re-append observed"
+        );
+        assert_eq!(read_stream_frames(&db)?.len(), 1);
+
+        let tx2 = H256::random();
+        let root2 = H256::random();
+        let tip2 = make_block_header(2, sealed.header().block_hash, 0, vec![tx2]);
+        let sealed2 = make_sealed_with_submit_txs(tip2, &[(tx2, root2)]);
+        let frames = svc.persist_metadata(
+            &[],
+            std::slice::from_ref(&sealed2),
+            StreamEmission::Observed,
+        )?;
+        assert_eq!(frames.len(), 1, "a new block still appends");
+        Ok(())
+    }
+
+    /// Restart de-dup (M2), finalized side: a re-migration of an already-finalised block appends
+    /// nothing across a restart, but a reorg that orphans it reopens the emission — also across a
+    /// restart between the reorg and the re-migration.
+    #[tokio::test]
+    async fn finalized_dedup_survives_restart_and_reorg_reopens_it() -> eyre::Result<()> {
+        let (db, _db_tmp) = open_db()?;
+
+        let genesis = make_commitment_header(0, H256::zero(), vec![H256::random()]);
+        let genesis_hash = genesis.block_hash;
+        let genesis_sealed = make_sealed_commitment(genesis);
+        let block_1 = make_commitment_header(1, genesis_hash, vec![H256::random()]);
+        let block_1_sealed = make_sealed_commitment(block_1);
+
+        {
+            let (svc, _svc_tmp) = make_service_with_epoch(db.clone(), 10);
+            svc.persist_block(genesis_sealed.as_ref(), false)?;
+            assert!(svc.persist_block(block_1_sealed.as_ref(), true)?.is_some());
+        }
+
+        // Restart: re-migrating the same block must be suppressed by the seeded de-dup.
+        {
+            let (svc, _svc_tmp) = make_service_with_epoch(db.clone(), 10);
+            assert!(
+                svc.persist_block(block_1_sealed.as_ref(), true)?.is_none(),
+                "re-migration after restart must not re-append finalized"
+            );
+
+            // A reorg orphaning the block reopens its finalized emission.
+            let reorg = StreamReorgAppend {
+                fork_parent: Arc::new(IrysBlockHeader::new_mock_header()),
+                old_fork: Arc::new(vec![Arc::clone(&block_1_sealed)]),
+                new_fork: Arc::new(vec![]),
+            };
+            svc.persist_metadata(
+                std::slice::from_ref(&block_1_sealed),
+                &[],
+                StreamEmission::Reorged(&reorg),
+            )?;
+        }
+
+        // Restart between the reorg and the re-migration: the seeded de-dup mirrors the
+        // eviction, so the re-adopted block emits finalized again.
+        let (svc, _svc_tmp) = make_service_with_epoch(db, 10);
+        assert!(
+            svc.persist_block(block_1_sealed.as_ref(), true)?.is_some(),
+            "re-migrated orphan must re-emit finalized"
+        );
         Ok(())
     }
 

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -1157,8 +1157,7 @@ impl BlockMigrationService {
         if prev.saturating_add(frames_appended) < PRUNE_INTERVAL {
             return Ok(());
         }
-        self.stream_appends_since_prune
-            .store(0, Ordering::Relaxed);
+        self.stream_appends_since_prune.store(0, Ordering::Relaxed);
         let Some(keep_from) = latest_seq
             .checked_add(1)
             .and_then(|len| len.checked_sub(RETENTION_EVENTS))

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -2,8 +2,8 @@ use crate::chunk_migration_service::ChunkMigrationServiceMessage;
 use crate::packing_service::{PackingRequest, PackingSender};
 use eyre::{OptionExt as _, ensure};
 use irys_database::{
-    block_header_by_hash, db::IrysDatabaseExt as _, insert_commitment_tx, insert_tx_header,
-    tx_header_by_txid,
+    append_block_stream_event, block_header_by_hash, db::IrysDatabaseExt as _,
+    insert_commitment_tx, insert_tx_header, tx_header_by_txid,
 };
 use irys_domain::{
     BlockIndex, BlockTree, ChunkType, StorageModule, StorageModulesReadGuard, SupplyState,
@@ -11,6 +11,7 @@ use irys_domain::{
     get_overlapped_storage_modules,
 };
 use irys_storage::ii;
+use irys_types::block_stream::{BlockEvent, BlockRef, StreamEvent, StreamFrame};
 use irys_types::{
     DataLedger, DataTransactionHeader, H256, IrysBlockHeader, LedgerChunkOffset, LedgerChunkRange,
     PartitionChunkOffset, PartitionChunkRange, SealedBlock, SendTraced as _, SystemLedger, Traced,
@@ -22,6 +23,15 @@ use std::{
 };
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{debug, info, warn};
+
+/// Optional reorg payload so `persist_metadata` can append a durable `reorged` stream frame
+/// inside the same consensus RW txn as confirmation metadata (Phase 4).
+#[derive(Debug)]
+pub struct StreamReorgAppend {
+    pub fork_parent: Arc<IrysBlockHeader>,
+    pub old_fork: Arc<Vec<Arc<SealedBlock>>>,
+    pub new_fork: Arc<Vec<Arc<SealedBlock>>>,
+}
 
 /// Block migration orchestration and DB persistence, called inline by `BlockTreeServiceInner`.
 #[derive(Debug)]
@@ -275,11 +285,17 @@ impl BlockMigrationService {
     /// no-op for them. Re-canonical blocks on the new fork get their metadata
     /// (re)written when they migrate, not here — so this function never
     /// recreates a `{None, Some}` state.
+    /// When `emit_stream` is true, durable block-stream frames are appended in the same
+    /// consensus RW txn as the metadata writes and returned for live fan-out (Phase 4).
+    /// `stream_reorg` supplies the reorged frame when the clear/confirm batch is a reorg;
+    /// if set, observed frames for the new fork are omitted (covered by the reorged event).
     pub fn persist_metadata(
         &self,
         blocks_to_clear: &[Arc<SealedBlock>],
         blocks_to_confirm: &[Arc<SealedBlock>],
-    ) -> eyre::Result<()> {
+        emit_stream: bool,
+        stream_reorg: Option<&StreamReorgAppend>,
+    ) -> eyre::Result<Vec<StreamFrame>> {
         // Phase 1 scrub and Phase 3 append both iterate
         // `block.transactions().get_ledger_txs(Submit)`.  The in-memory
         // block-tree path always carries full transactions, but future code
@@ -332,7 +348,7 @@ impl BlockMigrationService {
             }
         }
 
-        self.db.update_eyre(|tx| {
+        let stream_frames = self.db.update_eyre_at("persist_metadata", |tx| {
             // Phase 1: Clear orphaned tx metadata, and scrub the orphaned
             // block_hash from any CachedDataRoot.block_set that retained it.
             //
@@ -397,16 +413,51 @@ impl BlockMigrationService {
                     irys_database::update_data_root_block_set(tx, submit_tx.data_root, block_hash)?;
                 }
             }
-            Ok(())
+
+            // Phase 4: durable block-stream frames in this same RW txn.
+            let mut frames = Vec::new();
+            if emit_stream {
+                if let Some(reorg) = stream_reorg {
+                    let event = StreamEvent::Reorged {
+                        fork_parent: BlockRef {
+                            height: reorg.fork_parent.height,
+                            block_hash: reorg.fork_parent.block_hash,
+                        },
+                        orphaned: reorg
+                            .old_fork
+                            .iter()
+                            .map(|b| BlockEvent::from_sealed(b, self.chunk_size))
+                            .collect(),
+                        new_fork: reorg
+                            .new_fork
+                            .iter()
+                            .map(|b| BlockEvent::from_sealed(b, self.chunk_size))
+                            .collect(),
+                    };
+                    let payload = serde_json::to_vec(&event)?;
+                    let seq = append_block_stream_event(tx, payload)?;
+                    frames.push(StreamFrame { seq, event });
+                } else {
+                    for block in blocks_to_confirm {
+                        let event =
+                            StreamEvent::Observed(BlockEvent::from_sealed(block, self.chunk_size));
+                        let payload = serde_json::to_vec(&event)?;
+                        let seq = append_block_stream_event(tx, payload)?;
+                        frames.push(StreamFrame { seq, event });
+                    }
+                }
+            }
+            Ok(frames)
         })?;
 
         info!(
             cleared_blocks = blocks_to_clear.len(),
             confirmed_blocks = blocks_to_confirm.len(),
+            stream_frames = stream_frames.len(),
             "Persisted metadata to DB"
         );
 
-        Ok(())
+        Ok(stream_frames)
     }
 
     /// Rolls back blocks migrated on a minority fork during network partition recovery.
@@ -701,7 +752,8 @@ impl BlockMigrationService {
     pub fn migrate_blocks(
         &self,
         migration_block: &Arc<IrysBlockHeader>,
-        mut on_migrated: impl FnMut(&Arc<SealedBlock>),
+        emit_stream: bool,
+        mut on_migrated: impl FnMut(&Arc<SealedBlock>, Option<StreamFrame>),
     ) -> eyre::Result<()> {
         debug!("migrating block via BlockMigrationService");
 
@@ -727,11 +779,11 @@ impl BlockMigrationService {
         debug!("prepared {} block(s) for migration", prepared.len());
 
         for sealed_block in &prepared {
-            self.persist_block(sealed_block)?;
-            // Signal this block as finalized the moment its DB/index commit lands: that commit is
-            // irreversible, so the later reward and chunk-migration steps may fail without stranding
-            // an already-migrated block in the index but absent from the follower stream.
-            on_migrated(sealed_block);
+            let stream_frame = self.persist_block(sealed_block, emit_stream)?;
+            // Fan-out happens after commit: the DB/index write is irreversible, so later reward
+            // and chunk-migration steps may fail without stranding a migrated block absent from
+            // the durable stream log (frame already committed with the index write).
+            on_migrated(sealed_block, stream_frame);
             if let Some(supply_state) = &self.supply_state {
                 let block = sealed_block.header();
                 supply_state.add_block_reward(block.height, block.reward_amount)?;
@@ -825,8 +877,13 @@ impl BlockMigrationService {
     }
 
     /// Persists block data and block index in a single atomic DB transaction.
+    /// When `emit_stream` is true, also appends a durable `finalized` stream frame in that txn.
     #[tracing::instrument(level = "trace", skip_all, fields(block.hash = %sealed_block.header().block_hash, block.height = sealed_block.header().height))]
-    fn persist_block(&self, sealed_block: &SealedBlock) -> eyre::Result<()> {
+    fn persist_block(
+        &self,
+        sealed_block: &SealedBlock,
+        emit_stream: bool,
+    ) -> eyre::Result<Option<StreamFrame>> {
         // Mirror of the `persist_metadata` guard: a stripped body would write
         // ledger metadata + block index from `header.data_ledgers` while
         // inserting zero tx-header rows from `transactions().get_ledger_txs`,
@@ -846,7 +903,7 @@ impl BlockMigrationService {
         let migrated_block = (**header).clone();
 
         let chunk_size = self.chunk_size;
-        self.db.update_eyre(|tx| {
+        self.db.update_eyre_at("persist_block", |tx| {
             for commitment_tx in commitment_txs {
                 insert_commitment_tx(tx, commitment_tx)?;
             }
@@ -881,10 +938,16 @@ impl BlockMigrationService {
 
             BlockIndex::push_block(tx, sealed_block, chunk_size)?;
 
-            Ok(())
-        })?;
-
-        Ok(())
+            if emit_stream {
+                let event =
+                    StreamEvent::Finalized(BlockEvent::from_sealed(sealed_block, chunk_size));
+                let payload = serde_json::to_vec(&event)?;
+                let seq = append_block_stream_event(tx, payload)?;
+                Ok(Some(StreamFrame { seq, event }))
+            } else {
+                Ok(None)
+            }
+        })
     }
 
     /// Notify ChunkMigrationService about the migrated block (fire-and-forget).
@@ -1121,7 +1184,7 @@ mod tests {
         let tip_hash = tip.block_hash;
         let tip_sealed = make_sealed_with_submit_txs(tip, &[(tx_id, data_root)]);
 
-        svc.persist_metadata(&[], std::slice::from_ref(&tip_sealed))?;
+        svc.persist_metadata(&[], std::slice::from_ref(&tip_sealed), false, None)?;
 
         let cdr = read_cdr(&db, data_root).expect("CDR present");
         assert_eq!(
@@ -1151,7 +1214,7 @@ mod tests {
         let tip = make_block_header(1, H256::random(), 50, vec![tx_id]);
         let tip_sealed = make_sealed_with_submit_txs(tip, &[(tx_id, data_root)]);
 
-        svc.persist_metadata(&[], std::slice::from_ref(&tip_sealed))?;
+        svc.persist_metadata(&[], std::slice::from_ref(&tip_sealed), false, None)?;
 
         assert!(
             read_cdr(&db, data_root).is_none(),
@@ -1186,7 +1249,7 @@ mod tests {
 
         let orphan_sealed = make_sealed_with_submit_txs(orphan_tip, &[(tx_id, data_root)]);
 
-        svc.persist_metadata(std::slice::from_ref(&orphan_sealed), &[])?;
+        svc.persist_metadata(std::slice::from_ref(&orphan_sealed), &[], false, None)?;
 
         let cdr = read_cdr(&db, data_root).expect("CDR present");
         assert_eq!(
@@ -1387,7 +1450,7 @@ mod tests {
         );
         let epoch_sealed = make_sealed_commitment(epoch_block);
 
-        svc.persist_metadata(&[], std::slice::from_ref(&epoch_sealed))?;
+        svc.persist_metadata(&[], std::slice::from_ref(&epoch_sealed), false, None)?;
 
         assert_eq!(
             read_commitment_tx_metadata(&db, &included_commitment)
@@ -1421,7 +1484,7 @@ mod tests {
         let epoch_sealed = make_sealed_commitment(epoch_block);
 
         // Orphan the epoch block.
-        svc.persist_metadata(std::slice::from_ref(&epoch_sealed), &[])?;
+        svc.persist_metadata(std::slice::from_ref(&epoch_sealed), &[], false, None)?;
 
         assert_eq!(
             read_commitment_tx_metadata(&db, &included_commitment)
@@ -1448,7 +1511,7 @@ mod tests {
         let block = make_commitment_header(height, H256::random(), vec![commitment]);
         let sealed = make_sealed_commitment(block);
 
-        svc.persist_metadata(std::slice::from_ref(&sealed), &[])?;
+        svc.persist_metadata(std::slice::from_ref(&sealed), &[], false, None)?;
 
         assert!(
             read_commitment_tx_metadata(&db, &commitment).is_none(),
@@ -1474,7 +1537,7 @@ mod tests {
         // Migrated state: genesis wrote its commitment dedup row at migration.
         seed_commitment_included_height(&db, commitment, 0);
 
-        svc.persist_metadata(std::slice::from_ref(&genesis_sealed), &[])?;
+        svc.persist_metadata(std::slice::from_ref(&genesis_sealed), &[], false, None)?;
         assert!(
             read_commitment_tx_metadata(&db, &commitment).is_none(),
             "genesis orphan clears the commitment dedup row (height 0 not epoch-skipped)",
@@ -1495,7 +1558,7 @@ mod tests {
         let genesis_commitment = H256::random();
         let genesis = make_commitment_header(0, H256::zero(), vec![genesis_commitment]);
         let genesis_sealed = make_sealed_commitment(genesis);
-        svc.persist_block(genesis_sealed.as_ref())?;
+        svc.persist_block(genesis_sealed.as_ref(), false)?;
         assert_eq!(
             read_commitment_tx_metadata(&db, &genesis_commitment).and_then(|m| m.included_height),
             Some(0),
@@ -1511,7 +1574,7 @@ mod tests {
             vec![epoch_commitment],
         );
         let epoch_sealed = make_sealed_commitment(epoch_block);
-        svc.persist_block(epoch_sealed.as_ref())?;
+        svc.persist_block(epoch_sealed.as_ref(), false)?;
         assert!(
             read_commitment_tx_metadata(&db, &epoch_commitment).is_none(),
             "migration of a non-genesis epoch block must not write commitment included_height",
@@ -1586,7 +1649,7 @@ mod tests {
         let header = make_block_header(0, H256::zero(), 50, vec![tx_id]);
         let sealed = make_sealed_same_block_submit_publish_promotion(header, tx_id, data_root);
 
-        svc.persist_block(sealed.as_ref())?;
+        svc.persist_block(sealed.as_ref(), false)?;
 
         let meta = read_data_tx_metadata(&db, &tx_id).expect("metadata must exist after migration");
         assert_eq!(meta.included_height, Some(0));
@@ -1645,7 +1708,7 @@ mod tests {
         let commitment_sealed =
             make_sealed_commitment(make_commitment_header(2, H256::random(), vec![commitment]));
 
-        svc.persist_metadata(&[], &[sealed, commitment_sealed])?;
+        svc.persist_metadata(&[], &[sealed, commitment_sealed], false, None)?;
 
         // No canonical metadata written at confirmation.
         assert!(
@@ -1706,7 +1769,7 @@ mod tests {
         assert_eq!(meta.promoted_height, Some(publish_height));
 
         // Orphan the Publish block only
-        svc.persist_metadata(std::slice::from_ref(&publish_sealed), &[])?;
+        svc.persist_metadata(std::slice::from_ref(&publish_sealed), &[], false, None)?;
 
         let meta = read_data_tx_metadata(&db, &tx_id)
             .expect("row must still exist: included_height is preserved");
@@ -1745,7 +1808,7 @@ mod tests {
         assert!(read_data_tx_metadata(&db, &tx_id).is_some());
 
         // Orphan it
-        svc.persist_metadata(std::slice::from_ref(&sealed), &[])?;
+        svc.persist_metadata(std::slice::from_ref(&sealed), &[], false, None)?;
 
         assert!(
             read_data_tx_metadata(&db, &tx_id).is_none(),
@@ -1779,7 +1842,7 @@ mod tests {
 
         assert!(read_data_tx_metadata(&db, &tx_id).is_some());
 
-        svc.persist_metadata(std::slice::from_ref(&sealed), &[])?;
+        svc.persist_metadata(std::slice::from_ref(&sealed), &[], false, None)?;
 
         assert!(
             read_data_tx_metadata(&db, &tx_id).is_none(),
@@ -1824,6 +1887,8 @@ mod tests {
         svc.persist_metadata(
             std::slice::from_ref(&orphan_sealed),
             std::slice::from_ref(&new_canonical_sealed),
+            false,
+            None,
         )?;
 
         let cdr = read_cdr(&db, data_root).expect("CDR present");
@@ -1887,6 +1952,8 @@ mod tests {
         svc.persist_metadata(
             &[orphan1_sealed, orphan2_sealed],
             &[new1_sealed, new2_sealed],
+            false,
+            None,
         )?;
 
         // Phase 1 cleared the orphaned rows. Confirmation no longer re-writes
@@ -1982,7 +2049,12 @@ mod tests {
         let orphan2_sealed = make_sealed_with_submit_txs(orphan2, &[(tx_id_b, data_root_b)]);
         let new1_sealed = make_sealed_with_submit_txs(new1, &[(tx_id_a, data_root_a)]);
 
-        svc.persist_metadata(&[orphan1_sealed, orphan2_sealed], &[new1_sealed])?;
+        svc.persist_metadata(
+            &[orphan1_sealed, orphan2_sealed],
+            &[new1_sealed],
+            false,
+            None,
+        )?;
 
         // tx_a: cleared by Phase 1. Confirmation no longer re-writes metadata,
         // so it's absent until the new fork migrates — the re-confirmation is
@@ -2061,7 +2133,7 @@ mod tests {
         ));
 
         let err = svc
-            .persist_metadata(&[], std::slice::from_ref(&stripped))
+            .persist_metadata(&[], std::slice::from_ref(&stripped), false, None)
             .expect_err("stripped body must be rejected");
         let msg = err.to_string();
         assert!(
@@ -2071,7 +2143,7 @@ mod tests {
 
         // And the same for `persist_block`, which mirrors the guard.
         let err = svc
-            .persist_block(&stripped)
+            .persist_block(&stripped, false)
             .expect_err("persist_block stripped body must be rejected");
         let msg = err.to_string();
         assert!(

--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -3,7 +3,7 @@ use crate::packing_service::{PackingRequest, PackingSender};
 use eyre::{OptionExt as _, ensure};
 use irys_database::{
     append_block_stream_event, block_header_by_hash, db::IrysDatabaseExt as _,
-    insert_commitment_tx, insert_tx_header, tx_header_by_txid,
+    insert_commitment_tx, insert_tx_header, prune_block_stream_below, tx_header_by_txid,
 };
 use irys_domain::{
     BlockIndex, BlockTree, ChunkType, StorageModule, StorageModulesReadGuard, SupplyState,
@@ -20,7 +20,10 @@ use irys_types::{
 use lru::LruCache;
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex, PoisonError, RwLock},
+    sync::{
+        Arc, Mutex, PoisonError, RwLock,
+        atomic::{AtomicU64, Ordering},
+    },
 };
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{debug, info, warn};
@@ -76,6 +79,10 @@ impl std::fmt::Debug for StreamDedup {
 pub struct BlockMigrationService {
     db: DatabaseProvider,
     stream_dedup: Mutex<StreamDedup>,
+    /// Counts durable stream frames appended by this service since the last
+    /// in-txn prune. Writers prune so a halted producer cannot leave the log
+    /// growing without bound (`RETENTION_EVENTS` still enforced).
+    stream_appends_since_prune: AtomicU64,
     block_index_guard: BlockIndexReadGuard,
     supply_state: Option<Arc<SupplyState>>,
     chunk_size: u64,
@@ -195,23 +202,35 @@ impl BlockMigrationService {
         cache: Arc<RwLock<BlockTree>>,
         chunk_migration_sender: UnboundedSender<Traced<ChunkMigrationServiceMessage>>,
         packing_sender: PackingSender,
+        // When false (`http.expose_internal_api` off), skip the 10k-entry log
+        // scan: no frames will be appended and de-dup is unused.
+        seed_stream_dedup: bool,
     ) -> Self {
         // Best-effort seed: an unreadable log tail degrades to an empty de-dup
         // (worst case a duplicate frame, exactly the pre-seed behaviour) rather
         // than failing construction.
-        let stream_dedup = match crate::block_stream_service::rebuild_state(&db) {
-            Ok((emitted, finalized)) => StreamDedup { emitted, finalized },
-            Err(e) => {
-                warn!(error = ?e, "failed to seed stream de-dup from the log tail; starting empty");
-                StreamDedup {
-                    emitted: LruCache::new(crate::block_stream_service::DEDUP_CAPACITY),
-                    finalized: LruCache::new(crate::block_stream_service::DEDUP_CAPACITY),
+        let empty_dedup = || StreamDedup {
+            emitted: LruCache::new(crate::block_stream_service::DEDUP_CAPACITY),
+            finalized: LruCache::new(crate::block_stream_service::DEDUP_CAPACITY),
+        };
+        let stream_dedup = if seed_stream_dedup {
+            match crate::block_stream_service::rebuild_state(&db) {
+                Ok((emitted, finalized)) => StreamDedup { emitted, finalized },
+                Err(e) => {
+                    warn!(
+                        error = ?e,
+                        "failed to seed stream de-dup from the log tail; starting empty"
+                    );
+                    empty_dedup()
                 }
             }
+        } else {
+            empty_dedup()
         };
         Self {
             db,
             stream_dedup: Mutex::new(stream_dedup),
+            stream_appends_since_prune: AtomicU64::new(0),
             block_index_guard,
             supply_state,
             chunk_size,
@@ -523,6 +542,11 @@ impl BlockMigrationService {
             for (event, payload) in prepared_stream {
                 let seq = append_block_stream_event(tx, payload)?;
                 frames.push(StreamFrame { seq, event });
+            }
+            // Writer-side retention: prune even if the producer has halted.
+            if let Some(last) = frames.last() {
+                let n = u64::try_from(frames.len()).unwrap_or(u64::MAX);
+                self.maybe_prune_stream_in_tx(tx, last.seq, n)?;
             }
             Ok(frames)
         })?;
@@ -1097,6 +1121,8 @@ impl BlockMigrationService {
 
             if let Some((event, payload)) = prepared_finalized {
                 let seq = append_block_stream_event(tx, payload)?;
+                // Writer-side retention: prune even if the producer has halted.
+                self.maybe_prune_stream_in_tx(tx, seq, 1)?;
                 Ok(Some(StreamFrame { seq, event }))
             } else {
                 Ok(None)
@@ -1109,6 +1135,40 @@ impl BlockMigrationService {
             }
         }
         Ok(frame)
+    }
+
+    /// Count-based stream log retention, driven from the append path so a
+    /// halted producer cannot leave the log growing without bound. Batched
+    /// every [`crate::block_stream_service::PRUNE_INTERVAL`] frames; deletes
+    /// below `latest_seq + 1 - RETENTION_EVENTS` inside the same RW txn.
+    fn maybe_prune_stream_in_tx<T: reth_db::transaction::DbTxMut>(
+        &self,
+        tx: &T,
+        latest_seq: u64,
+        frames_appended: u64,
+    ) -> eyre::Result<()> {
+        if frames_appended == 0 {
+            return Ok(());
+        }
+        use crate::block_stream_service::{PRUNE_INTERVAL, RETENTION_EVENTS};
+        let prev = self
+            .stream_appends_since_prune
+            .fetch_add(frames_appended, Ordering::Relaxed);
+        if prev.saturating_add(frames_appended) < PRUNE_INTERVAL {
+            return Ok(());
+        }
+        self.stream_appends_since_prune
+            .store(0, Ordering::Relaxed);
+        let Some(keep_from) = latest_seq
+            .checked_add(1)
+            .and_then(|len| len.checked_sub(RETENTION_EVENTS))
+        else {
+            return Ok(());
+        };
+        if keep_from == 0 {
+            return Ok(());
+        }
+        prune_block_stream_below(tx, keep_from)
     }
 
     /// Notify ChunkMigrationService about the migrated block (fire-and-forget).
@@ -1221,6 +1281,7 @@ mod tests {
             cache,
             chunk_migration_sender,
             packing_sender,
+            true, // unit tests that exercise stream emission need a seeded de-dup
         );
         (svc, tmp)
     }

--- a/crates/actors/src/block_stream_service.rs
+++ b/crates/actors/src/block_stream_service.rs
@@ -19,6 +19,10 @@
 //! [`BlockStreamHandle::subscribe`], which snapshots the durable replay suffix and registers a
 //! live receiver under one lock; frames whose `seq` predates a subscriber's snapshot are skipped
 //! at fan-out, so the replay→live handover has no gap or duplicate.
+//!
+//! Live channel order is not a durability contract: steady-state enqueue is seq-monotonic, but
+//! startup reconciliation can fan out ahead of still-queued writer frames. Consumers should treat
+//! `seq <= last_seen` as a no-op (or reconnect for durable replay).
 
 use eyre::OptionExt as _;
 use irys_database::db::IrysDatabaseExt as _;
@@ -33,10 +37,10 @@ use tracing::{Instrument as _, error, info, warn};
 
 /// Count-based retention: keep at most this many events; older ones are pruned. Sized to comfortably
 /// exceed the maximum expected follower downtime (the follower only ever resumes from a recent
-/// `seq`).
-const RETENTION_EVENTS: u64 = 100_000;
+/// `seq`). Shared with confirmation/migration writers so pruning continues if the producer halts.
+pub(crate) const RETENTION_EVENTS: u64 = 100_000;
 /// Prune at most once per this many appends, to batch the delete writes.
-const PRUNE_INTERVAL: u64 = 1_000;
+pub(crate) const PRUNE_INTERVAL: u64 = 1_000;
 /// De-dup window for emitted `observed` block hashes. Must comfortably exceed the reorg depth so a
 /// re-adopted block is still remembered.
 pub(crate) const DEDUP_CAPACITY: NonZeroUsize = match NonZeroUsize::new(10_000) {

--- a/crates/actors/src/block_stream_service.rs
+++ b/crates/actors/src/block_stream_service.rs
@@ -88,6 +88,19 @@ impl BlockStreamHandle {
         }
     }
 
+    /// Handle for nodes that do not run the durable block-stream producer
+    /// (`http.expose_internal_api = false`). Live subscribe registers no sender;
+    /// `/internal/*` routes that use this handle are unmounted when the flag is off.
+    pub fn disabled(db: DatabaseProvider) -> Self {
+        Self {
+            live: Mutex::new(LiveSubscribers {
+                senders: Vec::new(),
+                closed: true,
+            }),
+            db,
+        }
+    }
+
     /// Atomic replay→live handover: under one lock, snapshot the durable replay bounds `[start, end)` and
     /// register a live sender, so no append interleaves between the snapshot and the registration. The
     /// caller replays `[start, end)` via [`Self::replay_page`] (after the fan-out lock is released), then
@@ -182,7 +195,8 @@ impl BlockStreamHandle {
     }
 
     /// Producer-only. Append `event` to the durable log (assigning `seq`) and fan it out, holding
-    /// the same lock as [`Self::subscribe`].
+    /// the same lock as [`Self::subscribe`]. Used by unit tests and startup reconciliation; the
+    /// production hot path appends inside confirmation/migration txns and calls [`Self::fanout_only`].
     fn append_and_fanout(&self, event: StreamEvent) -> eyre::Result<u64> {
         let payload = serde_json::to_vec(&event)?;
         // The lock must cover the durable append, not just the fan-out: `subscribe` snapshots its
@@ -196,14 +210,30 @@ impl BlockStreamHandle {
             .db
             .update_eyre(|tx| irys_database::append_block_stream_event(tx, payload))?;
         let frame = Arc::new(StreamFrame { seq, event });
+        Self::fanout_locked(&mut live, &frame);
+        Ok(seq)
+    }
+
+    /// Fan out a frame that is already durable (Phase 4 production path). Does not open a RW txn.
+    /// Live SSE clients skip `seq < end` from their subscribe snapshot so a race with late
+    /// registration cannot duplicate frames on the wire.
+    fn fanout_only(&self, frame: &Arc<StreamFrame>) -> eyre::Result<()> {
+        let mut live = self
+            .live
+            .lock()
+            .map_err(|_| eyre::eyre!("block-stream fan-out lock poisoned"))?;
+        Self::fanout_locked(&mut live, frame);
+        Ok(())
+    }
+
+    fn fanout_locked(live: &mut LiveSubscribers, frame: &Arc<StreamFrame>) {
         // Drop subscribers whose receiver is closed or lagging past `SUBSCRIBER_BUFFER`; a dropped
         // follower reconnects and replays from the durable log via `subscribe(from_seq)`.
         live.senders.retain(|sender| {
             sender
-                .try_send(Arc::clone(&frame)) // clone: live subscribers share one immutable frame allocation
+                .try_send(Arc::clone(frame)) // clone: live subscribers share one immutable frame allocation
                 .is_ok()
         });
-        Ok(seq)
     }
 
     fn prune(&self, keep_from_seq: u64) -> eyre::Result<()> {
@@ -438,6 +468,11 @@ impl Producer {
 
     fn handle_signal(&mut self, signal: BlockStreamSignal) -> eyre::Result<()> {
         match signal {
+            BlockStreamSignal::Durable(frame) => {
+                self.note_event_for_dedup(&frame.event);
+                self.handle.fanout_only(&frame)?;
+                self.maybe_prune(frame.seq)?;
+            }
             BlockStreamSignal::Confirmed(block) => {
                 let hash = block.header().block_hash;
                 if self.emitted.contains(&hash) {
@@ -495,8 +530,33 @@ impl Producer {
         Ok(())
     }
 
+    fn note_event_for_dedup(&mut self, event: &StreamEvent) {
+        match event {
+            StreamEvent::Observed(block) => {
+                self.emitted.put(block.header.block_hash, ());
+            }
+            StreamEvent::Finalized(block) => {
+                self.finalized.put(block.header.block_hash, ());
+            }
+            StreamEvent::Reorged {
+                orphaned, new_fork, ..
+            } => {
+                for block in new_fork {
+                    self.emitted.put(block.header.block_hash, ());
+                }
+                for block in orphaned {
+                    self.finalized.pop(&block.header.block_hash);
+                }
+            }
+        }
+    }
+
     fn append(&mut self, event: StreamEvent) -> eyre::Result<()> {
         let seq = self.handle.append_and_fanout(event)?;
+        self.maybe_prune(seq)
+    }
+
+    fn maybe_prune(&mut self, seq: u64) -> eyre::Result<()> {
         self.appends_since_prune += 1;
         if self.appends_since_prune >= PRUNE_INTERVAL {
             self.appends_since_prune = 0;

--- a/crates/actors/src/block_stream_service.rs
+++ b/crates/actors/src/block_stream_service.rs
@@ -1,27 +1,28 @@
-//! The block-stream producer: the single, node-wide writer of the durable `seq` event log.
+//! The block-stream producer: live fan-out, retention, and startup reconciliation for the durable
+//! `seq` event log.
 //!
-//! The producer consumes an unbounded feed of [`BlockStreamSignal`]s emitted from the node's
-//! authoritative sites (the confirmation loop, the reorg site, and the per-block migration loop).
-//! For each signal it builds the wire [`StreamEvent`], appends it to the durable log (assigning
-//! the next `seq`), and fans it out to live SSE subscribers. Being the sole writer makes `seq`
-//! assignment monotonic and gap-free.
+//! The log has multiple writers, serialised by the consensus environment's single RW transaction:
+//! confirmation appends `observed`/`reorged` frames and migration appends `finalized` frames
+//! inside their own canonical transactions (`BlockMigrationService::persist_metadata` /
+//! `persist_block`), which makes each frame atomic with the state transition it reports. The
+//! producer receives each already-durable frame over an unbounded channel and only fans it out to
+//! live SSE subscribers — it opens no RW transaction on that path. The producer itself appends
+//! solely during [`Producer::reconcile_finalized_tail`], which repairs `finalized` frames a
+//! pre-atomic-append build lost to a crash between its migration commit and its producer append.
 //!
-//! The feed is lossless while the node runs — the channel is unbounded and an append failure halts
-//! the producer rather than skipping an event — but a signal is in-memory until its append
-//! commits, so a crash between a state transition and its append can lose that frame. For
-//! `finalized` the durable truth survives in the block index, and startup reconciliation
-//! ([`Producer::reconcile_finalized_tail`]) re-derives and appends the missing frames; `observed`
-//! and `reorged` frames lost this way are recovered by a follower through the canonical read
-//! endpoints, which serve current state rather than transition history.
+//! Because production frames commit with their transitions, a crash cannot lose an `observed`,
+//! `reorged`, or `finalized` frame for a transition that persisted; the residual loss window is
+//! confined to the reconciliation appends themselves. Restart re-emission is suppressed at the
+//! writer: `BlockMigrationService` seeds its de-dup from the log tail ([`rebuild_state`]).
 //!
-//! The HTTP handlers never touch `seq`: they hold an [`Arc<BlockStreamHandle>`] and call the atomic
-//! [`BlockStreamHandle::subscribe`], which snapshots the durable replay suffix and registers a live
-//! receiver under one lock so the replay→live handover has no gap or duplicate.
+//! The HTTP handlers never touch `seq`: they hold an [`Arc<BlockStreamHandle>`] and call
+//! [`BlockStreamHandle::subscribe`], which snapshots the durable replay suffix and registers a
+//! live receiver under one lock; frames whose `seq` predates a subscriber's snapshot are skipped
+//! at fan-out, so the replay→live handover has no gap or duplicate.
 
-use crate::block_tree_service::BlockStreamSignal;
 use eyre::OptionExt as _;
 use irys_database::db::IrysDatabaseExt as _;
-use irys_types::block_stream::{BlockEvent, BlockRef, EventsPage, StreamEvent, StreamFrame};
+use irys_types::block_stream::{BlockEvent, EventsPage, StreamEvent, StreamFrame};
 use irys_types::{DatabaseProvider, H256, TokioServiceHandle};
 use lru::LruCache;
 use reth::tasks::shutdown::Shutdown;
@@ -38,7 +39,7 @@ const RETENTION_EVENTS: u64 = 100_000;
 const PRUNE_INTERVAL: u64 = 1_000;
 /// De-dup window for emitted `observed` block hashes. Must comfortably exceed the reorg depth so a
 /// re-adopted block is still remembered.
-const DEDUP_CAPACITY: NonZeroUsize = match NonZeroUsize::new(10_000) {
+pub(crate) const DEDUP_CAPACITY: NonZeroUsize = match NonZeroUsize::new(10_000) {
     Some(capacity) => capacity,
     None => NonZeroUsize::MIN,
 };
@@ -60,16 +61,17 @@ const RECONCILE_SCAN_CAP: u64 = 1_000;
 /// into `ApiState` so every SSE handler shares the one producer.
 #[derive(Debug)]
 pub struct BlockStreamHandle {
-    /// Live SSE subscribers. The lock is shared with [`Self::append_and_fanout`] so a subscribe's
-    /// snapshot+register pair cannot interleave with an append. Bounded senders: a lagging
-    /// subscriber is dropped rather than buffered without limit.
+    /// Live SSE subscribers. The lock serialises registration against fan-out (and against
+    /// reconciliation's [`Self::append_and_fanout`]); production appends commit outside it and
+    /// rely on per-subscriber `replay_end` to suppress replay/live duplicates. Bounded senders: a
+    /// lagging subscriber is dropped rather than buffered without limit.
     live: Mutex<LiveSubscribers>,
     db: DatabaseProvider,
 }
 
 /// One live subscriber: bounded sender plus the durable-log `end` snapped at registration.
-/// Fan-out skips frames with `seq < replay_end` so Phase 4 durable-append-then-fanout cannot
-/// duplicate a frame already covered by that subscriber's replay range.
+/// Fan-out skips frames with `seq < replay_end` so a frame committed before the snapshot cannot
+/// be delivered both in the replay range and on the live channel.
 #[derive(Debug)]
 struct LiveSubscriber {
     sender: Sender<Arc<StreamFrame>>,
@@ -111,10 +113,12 @@ impl BlockStreamHandle {
         }
     }
 
-    /// Atomic replay→live handover: under one lock, snapshot the durable replay bounds `[start, end)` and
-    /// register a live sender, so no append interleaves between the snapshot and the registration. The
-    /// caller replays `[start, end)` via [`Self::replay_page`] (after the fan-out lock is released), then
-    /// tails the live receiver.
+    /// Replay→live handover: snapshot the durable replay bounds `[start, end)` and register a live
+    /// sender under one lock. The lock serialises registration against fan-out only — durable
+    /// appends commit outside it — so a frame committed around the snapshot can reach both the
+    /// replay range and the live channel; [`Self::fanout_locked`] suppresses the live copy for any
+    /// `seq < replay_end`. The caller replays `[start, end)` via [`Self::replay_page`] (after the
+    /// lock is released), then tails the live receiver.
     pub fn subscribe(&self, from_seq: u64) -> eyre::Result<(u64, u64, Receiver<Arc<StreamFrame>>)> {
         let mut live = self
             .live
@@ -207,9 +211,9 @@ impl BlockStreamHandle {
         Ok(Some((page.next_seq, page.frames)))
     }
 
-    /// Producer-only. Append `event` to the durable log (assigning `seq`) and fan it out, holding
-    /// the same lock as [`Self::subscribe`]. Used by unit tests and startup reconciliation; the
-    /// production hot path appends inside confirmation/migration txns and calls [`Self::fanout_only`].
+    /// Append `event` to the durable log (assigning `seq`) and fan it out, holding the same lock
+    /// as [`Self::subscribe`]. Startup reconciliation is the only production caller; the hot path
+    /// appends inside confirmation/migration txns and calls [`Self::fanout_only`].
     fn append_and_fanout(&self, event: StreamEvent) -> eyre::Result<u64> {
         let payload = serde_json::to_vec(&event)?;
         // The lock must cover the durable append, not just the fan-out: `subscribe` snapshots its
@@ -227,7 +231,7 @@ impl BlockStreamHandle {
         Ok(seq)
     }
 
-    /// Fan out a frame that is already durable (Phase 4 production path). Does not open a RW txn.
+    /// Fan out a frame that is already durable (the production path). Does not open a RW txn.
     /// Subscribers whose `replay_end` already covers `frame.seq` are skipped (no live/replay dup).
     fn fanout_only(&self, frame: &Arc<StreamFrame>) -> eyre::Result<()> {
         let mut live = self
@@ -242,7 +246,7 @@ impl BlockStreamHandle {
         // Drop subscribers whose receiver is closed or lagging past `SUBSCRIBER_BUFFER`; a dropped
         // follower reconnects and replays from the durable log via `subscribe(from_seq)`.
         // Skip delivery when `frame.seq < replay_end` — that seq is already in the subscriber's
-        // durable replay window (Phase 4 can fan out after a late subscribe snapped past it).
+        // durable replay window (fan-out can trail a late subscribe that snapped past it).
         live.senders.retain(|sub| {
             if frame.seq < sub.replay_end {
                 return true; // keep subscriber; do not deliver a replay-covered frame
@@ -283,7 +287,7 @@ pub struct BlockStreamService;
 
 impl BlockStreamService {
     pub fn spawn_service(
-        signal_rx: UnboundedReceiver<BlockStreamSignal>,
+        signal_rx: UnboundedReceiver<Arc<StreamFrame>>,
         db: DatabaseProvider,
         chunk_size: u64,
         runtime_handle: tokio::runtime::Handle,
@@ -295,18 +299,9 @@ impl BlockStreamService {
 
         let join = runtime_handle.spawn(
             async move {
-                // A failed de-dup rebuild halts the producer (duplicate re-emission would be the
-                // alternative); the node itself keeps running with a stale stream, and the halt is
-                // surfaced through the `irys.block_stream.halted` gauge.
-                let startup_handle = Arc::clone(&producer_handle);
-                match Producer::new(producer_handle, chunk_size, shutdown_rx, signal_rx) {
-                    Ok(mut producer) => producer.run().await,
-                    Err(e) => {
-                        error!(error = ?e, "block-stream producer failed to start: de-dup rebuild failed");
-                        crate::metrics::record_block_stream_halted();
-                        startup_handle.close_live_subscribers();
-                    }
-                }
+                Producer::new(producer_handle, chunk_size, shutdown_rx, signal_rx)
+                    .run()
+                    .await;
             }
             .in_current_span(),
         );
@@ -324,14 +319,8 @@ struct Producer {
     handle: Arc<BlockStreamHandle>,
     chunk_size: u64,
     shutdown: Shutdown,
-    signal_rx: UnboundedReceiver<BlockStreamSignal>,
-    /// `block_hash`es already emitted as `observed` (or carried in a reorg's `new_fork`), so a
-    /// re-confirmed block is not re-emitted.
-    emitted: LruCache<H256, ()>,
-    /// `block_hash`es already emitted as `finalized`, to guard against a double `finalized` for the
-    /// same block. Keyed by hash (not height) so a block re-migrated at a previously-finalised
-    /// height after deep-reorg recovery (`recover_from_network_partition`) still emits.
-    finalized: LruCache<H256, ()>,
+    /// Already-durable frames from the confirmation/migration writers, to fan out live.
+    signal_rx: UnboundedReceiver<Arc<StreamFrame>>,
     appends_since_prune: u64,
 }
 
@@ -340,22 +329,29 @@ impl Producer {
         handle: Arc<BlockStreamHandle>,
         chunk_size: u64,
         shutdown: Shutdown,
-        signal_rx: UnboundedReceiver<BlockStreamSignal>,
-    ) -> eyre::Result<Self> {
-        let (emitted, finalized) = rebuild_state(&handle.db)?;
-        Ok(Self {
+        signal_rx: UnboundedReceiver<Arc<StreamFrame>>,
+    ) -> Self {
+        Self {
             handle,
             chunk_size,
             shutdown,
             signal_rx,
-            emitted,
-            finalized,
             appends_since_prune: 0,
-        })
+        }
     }
 
     async fn run(&mut self) {
         info!("block-stream producer started");
+        // Fan out frames already queued before reconciling, so their (lower) seqs reach the wire
+        // before anything reconciliation appends. Frames committed after this drain are covered
+        // by reconciliation's single-txn snapshot (never re-appended); only their live fan-out
+        // can trail reconciliation's, and a follower's durable replay corrects that on reconnect.
+        if let Err(e) = self.drain_pending_frames() {
+            error!(error = ?e, "block-stream producer halting: pre-reconcile fan-out failed");
+            crate::metrics::record_block_stream_halted();
+            self.handle.close_live_subscribers();
+            return;
+        }
         if let Err(e) = self.reconcile_finalized_tail() {
             error!(error = ?e, "block-stream producer halting: finalized reconciliation failed");
             crate::metrics::record_block_stream_halted();
@@ -372,14 +368,14 @@ impl Producer {
                     }
                     break;
                 }
-                maybe_signal = self.signal_rx.recv() => {
-                    match maybe_signal {
-                        Some(signal) => {
-                            if let Err(e) = self.handle_signal(signal) {
-                                // A durable append failed: halt rather than silently skip the event
-                                // and keep assigning later `seq`s, which would break the lossless-log
-                                // contract. Followers reconnect and replay up to the last good `seq`.
-                                error!(error = ?e, "block-stream producer halting: durable append failed");
+                maybe_frame = self.signal_rx.recv() => {
+                    match maybe_frame {
+                        Some(frame) => {
+                            if let Err(e) = self.handle_frame(frame) {
+                                // Fan-out or prune failed (poisoned lock / DB fault). Halt and
+                                // disconnect subscribers; the log itself stays durable and
+                                // followers replay it on reconnect.
+                                error!(error = ?e, "block-stream producer halting: fan-out failed");
                                 crate::metrics::record_block_stream_halted();
                                 break;
                             }
@@ -398,33 +394,45 @@ impl Producer {
         self.handle.close_live_subscribers();
     }
 
+    /// Shutdown path: stop accepting new frames, then fan out whatever is queued.
     fn drain_queued_signals(&mut self) -> eyre::Result<()> {
         self.signal_rx.close();
+        self.drain_pending_frames()
+    }
+
+    /// Fans out every frame currently queued without closing the channel.
+    fn drain_pending_frames(&mut self) -> eyre::Result<()> {
         loop {
             match self.signal_rx.try_recv() {
-                Ok(signal) => self.handle_signal(signal)?,
+                Ok(frame) => self.handle_frame(frame)?,
                 Err(TryRecvError::Empty | TryRecvError::Disconnected) => return Ok(()),
             }
         }
     }
 
-    /// Re-derives `finalized` frames lost to a crash between a block's migration commit and the
-    /// producer's append (a signal is in-memory until appended). Walks the block index backward
-    /// from its tip until it meets a hash the log already finalised, then appends the gap in
-    /// ascending height order.
+    /// Re-derives `finalized` frames a pre-atomic-append build lost to a crash between a block's
+    /// migration commit and its producer append. Walks the block index backward from its tip
+    /// until it meets a hash the log already finalised, then appends the gap in ascending height
+    /// order. Migration now appends its frame inside the migration txn, so this repairs only logs
+    /// written by older builds (or the producer-append paths themselves).
     ///
-    /// Runs only when the rebuilt de-dup state holds at least one finalised hash: on a young or
-    /// freshly-reset log the index tail predates the log entirely, and "reconciling" it would
-    /// emit `finalized` for deep history a follower bootstraps from the canonical reads instead.
-    /// The same reasoning caps the backward scan — the crash window loses at most the migration
-    /// batch that was in flight, so a scan that runs [`RECONCILE_SCAN_CAP`] deep means the log and
-    /// index tails do not meet, and reconciliation aborts rather than replay history.
+    /// The log tail and the index are snapshotted in ONE read transaction: a migration committing
+    /// concurrently lands in both or neither, so an already-logged block can never look missing
+    /// (the duplicate-`finalized` race a stale pre-read de-dup cache would allow).
+    ///
+    /// Runs only when the log tail holds at least one finalised hash: on a young or freshly-reset
+    /// log the index tail predates the log entirely, and "reconciling" it would emit `finalized`
+    /// for deep history a follower bootstraps from the canonical reads instead. The same reasoning
+    /// caps the backward scan — a real gap is at most the migration batch that was in flight, so a
+    /// scan [`RECONCILE_SCAN_CAP`] deep means the log and index tails do not meet, and
+    /// reconciliation aborts rather than replay history.
     fn reconcile_finalized_tail(&mut self) -> eyre::Result<()> {
-        if self.finalized.is_empty() {
-            return Ok(());
-        }
         let missing = self.handle.db.view_eyre(|tx| {
             let mut missing: Vec<(u64, H256)> = Vec::new();
+            let (_, finalized) = rebuild_state_in(tx)?;
+            if finalized.is_empty() {
+                return Ok(missing);
+            }
             let Some(latest) = irys_database::block_index_latest_height(tx)? else {
                 return Ok(missing);
             };
@@ -432,7 +440,7 @@ impl Producer {
                 let Some(hash) = irys_database::block_index_hash_by_height(tx, height)? else {
                     break;
                 };
-                if self.finalized.contains(&hash) {
+                if finalized.contains(&hash) {
                     break;
                 }
                 missing.push((height, hash));
@@ -478,82 +486,14 @@ impl Producer {
                 "appending finalized frame reconciled from the block index"
             );
             self.append(StreamEvent::Finalized(event))?;
-            self.finalized.put(hash, ());
         }
         Ok(())
     }
 
-    fn handle_signal(&mut self, signal: BlockStreamSignal) -> eyre::Result<()> {
-        match signal {
-            BlockStreamSignal::Durable(frame) => {
-                self.note_event_for_dedup(&frame.event);
-                self.handle.fanout_only(&frame)?;
-                self.maybe_prune(frame.seq)?;
-            }
-            BlockStreamSignal::Confirmed(block) => {
-                let hash = block.header().block_hash;
-                if self.emitted.contains(&hash) {
-                    return Ok(());
-                }
-                let event = StreamEvent::Observed(BlockEvent::from_sealed(&block, self.chunk_size));
-                self.append(event.clone())?; // clone: note_event_for_dedup after successful append
-                self.note_event_for_dedup(&event);
-            }
-            BlockStreamSignal::Finalized(block) => {
-                let hash = block.header().block_hash;
-                if self.finalized.contains(&hash) {
-                    return Ok(());
-                }
-                let event =
-                    StreamEvent::Finalized(BlockEvent::from_sealed(&block, self.chunk_size));
-                self.append(event.clone())?; // clone: note_event_for_dedup after successful append
-                self.note_event_for_dedup(&event);
-            }
-            BlockStreamSignal::Reorged {
-                fork_parent,
-                old_fork,
-                new_fork,
-            } => {
-                let event = StreamEvent::Reorged {
-                    fork_parent: BlockRef {
-                        height: fork_parent.height,
-                        block_hash: fork_parent.block_hash,
-                    },
-                    orphaned: old_fork
-                        .iter()
-                        .map(|b| BlockEvent::from_sealed(b, self.chunk_size))
-                        .collect(),
-                    new_fork: new_fork
-                        .iter()
-                        .map(|b| BlockEvent::from_sealed(b, self.chunk_size))
-                        .collect(),
-                };
-                self.append(event.clone())?; // clone: note_event_for_dedup after successful append
-                self.note_event_for_dedup(&event);
-            }
-        }
-        Ok(())
-    }
-
-    fn note_event_for_dedup(&mut self, event: &StreamEvent) {
-        match event {
-            StreamEvent::Observed(block) => {
-                self.emitted.put(block.header.block_hash, ());
-            }
-            StreamEvent::Finalized(block) => {
-                self.finalized.put(block.header.block_hash, ());
-            }
-            StreamEvent::Reorged {
-                orphaned, new_fork, ..
-            } => {
-                for block in new_fork {
-                    self.emitted.put(block.header.block_hash, ());
-                }
-                for block in orphaned {
-                    self.finalized.pop(&block.header.block_hash);
-                }
-            }
-        }
+    /// Production path: the frame is already durable; fan it out and maybe prune.
+    fn handle_frame(&mut self, frame: Arc<StreamFrame>) -> eyre::Result<()> {
+        self.handle.fanout_only(&frame)?;
+        self.maybe_prune(frame.seq)
     }
 
     fn append(&mut self, event: StreamEvent) -> eyre::Result<()> {
@@ -577,25 +517,34 @@ impl Producer {
     }
 }
 
-/// Rebuilds the producer's in-memory de-dup state (`observed` and `finalized` hashes) from the
-/// durable log tail on startup, so a restart does not re-emit for blocks already in the log.
+/// Rebuilds the stream de-dup state (`observed` and `finalized` hashes) from the durable log
+/// tail, so a restart does not re-emit for blocks already in the log. Seeds
+/// `BlockMigrationService`'s writer-side de-dup at construction.
 ///
-/// A failed log read is an error — starting with empty de-dup state would re-emit duplicate
-/// frames for every recent block; the caller halts the producer instead. An individual entry that
-/// fails to decode is skipped with a warning: unlike the serving path (which must error rather
-/// than put a `seq` gap on the wire), the rebuild only mines hashes out of the tail.
-fn rebuild_state(db: &DatabaseProvider) -> eyre::Result<(LruCache<H256, ()>, LruCache<H256, ()>)> {
+/// An individual entry that fails to decode is skipped with a warning: unlike the serving path
+/// (which must error rather than put a `seq` gap on the wire), the rebuild only mines hashes out
+/// of the tail.
+pub(crate) fn rebuild_state(
+    db: &DatabaseProvider,
+) -> eyre::Result<(LruCache<H256, ()>, LruCache<H256, ()>)> {
+    db.view_eyre(rebuild_state_in)
+}
+
+/// [`rebuild_state`] against an already-open read transaction, so callers (reconciliation) can
+/// snapshot the log tail and other tables atomically.
+fn rebuild_state_in<T: reth_db::transaction::DbTx>(
+    tx: &T,
+) -> eyre::Result<(LruCache<H256, ()>, LruCache<H256, ()>)> {
     let mut emitted = LruCache::new(DEDUP_CAPACITY);
     let mut finalized = LruCache::new(DEDUP_CAPACITY);
 
-    // One read tx for both the latest seq and the tail it bounds — an atomic snapshot at startup.
-    let events = db.view_eyre(|tx| {
-        let Some(latest) = irys_database::block_stream_latest_seq(tx)? else {
-            return Ok(Vec::new());
-        };
-        let capacity = u64::try_from(DEDUP_CAPACITY.get()).unwrap_or(u64::MAX);
-        irys_database::read_block_stream_from(tx, latest.saturating_sub(capacity))
-    })?;
+    let events = match irys_database::block_stream_latest_seq(tx)? {
+        None => Vec::new(),
+        Some(latest) => {
+            let capacity = u64::try_from(DEDUP_CAPACITY.get()).unwrap_or(u64::MAX);
+            irys_database::read_block_stream_from(tx, latest.saturating_sub(capacity))?
+        }
+    };
 
     for (_seq, bytes) in &events {
         match serde_json::from_slice::<StreamEvent>(bytes) {
@@ -898,59 +847,79 @@ mod tests {
     }
 
     #[test]
-    fn shutdown_drain_persists_every_queued_signal() {
+    fn shutdown_drain_fans_out_every_queued_frame() {
         let (handle, _tmp) = handle_with_events(0);
         let handle = Arc::new(handle);
+        let (_start, _end, mut live) = handle.subscribe(0).unwrap(); // replay_end = 0
         let (_shutdown_tx, shutdown) = reth::tasks::shutdown::signal();
         let (signal_tx, signal_rx) = mpsc::unbounded_channel();
-        signal_tx
-            .send(BlockStreamSignal::Confirmed(sample_block(1)))
-            .expect("queue first signal");
-        signal_tx
-            .send(BlockStreamSignal::Confirmed(sample_block(2)))
-            .expect("queue second signal");
-        let mut producer =
-            Producer::new(Arc::clone(&handle), 1, shutdown, signal_rx).expect("producer");
 
-        producer.drain_queued_signals().expect("drain signals");
+        // Frames are durable before they reach the channel (the writer appends in its own txn).
+        for seq in 0..2_u64 {
+            let event = sample_stream_event();
+            handle
+                .db
+                .update_eyre(|tx| append_block_stream_event(tx, serde_json::to_vec(&event)?))
+                .unwrap();
+            signal_tx
+                .send(Arc::new(StreamFrame { seq, event }))
+                .expect("queue frame");
+        }
+        let mut producer = Producer::new(Arc::clone(&handle), 1, shutdown, signal_rx);
 
-        let (start, end, _live) = handle.subscribe(0).unwrap();
-        let frames = collect_replay(&handle, start, end);
+        producer.drain_queued_signals().expect("drain frames");
+
+        let mut delivered = Vec::new();
+        while let Ok(frame) = live.try_recv() {
+            delivered.push(frame.seq);
+        }
         assert_eq!(
-            frames.iter().map(|frame| frame.seq).collect::<Vec<_>>(),
-            vec![0, 1]
+            delivered,
+            vec![0, 1],
+            "drain must fan out every queued frame"
         );
     }
 
-    /// A producer whose signals these tests feed by direct `handle_signal` calls, so the returned
-    /// shutdown/sender halves are unused and may drop.
+    /// A producer these tests drive directly, so the returned shutdown/sender halves are unused
+    /// and may drop.
     fn producer_over(handle: &Arc<BlockStreamHandle>) -> Producer {
         let (_shutdown_tx, shutdown) = reth::tasks::shutdown::signal();
         let (_signal_tx, signal_rx) = mpsc::unbounded_channel();
-        Producer::new(Arc::clone(handle), 1, shutdown, signal_rx).expect("producer")
+        Producer::new(Arc::clone(handle), 1, shutdown, signal_rx)
     }
 
-    /// The CX-1 regression: a block finalised, then orphaned by a reorg, must emit `finalized`
-    /// again when its fork is re-adopted and it re-migrates — live and across a restart's rebuild.
+    fn finalized_event(block: &Arc<SealedBlock>) -> StreamEvent {
+        StreamEvent::Finalized(BlockEvent::from_sealed(block, 1))
+    }
+
+    fn reorged_event(orphaned: &Arc<SealedBlock>, new_fork: &Arc<SealedBlock>) -> StreamEvent {
+        let fork_parent = IrysBlockHeader::default();
+        StreamEvent::Reorged {
+            fork_parent: irys_types::block_stream::BlockRef {
+                height: fork_parent.height,
+                block_hash: fork_parent.block_hash,
+            },
+            orphaned: vec![BlockEvent::from_sealed(orphaned, 1)],
+            new_fork: vec![BlockEvent::from_sealed(new_fork, 1)],
+        }
+    }
+
+    /// The CX-1 regression, now at the rebuild layer that seeds the writer-side de-dup: a block
+    /// finalised, then orphaned by a reorg, must be free to emit `finalized` again after its fork
+    /// is re-adopted — so the rebuilt state must mirror the reorg eviction.
     #[test]
-    fn orphaned_block_refinalizes_after_readoption() {
+    fn rebuild_state_evicts_orphaned_finalized_for_readoption() {
         let (handle, _tmp) = handle_with_events(0);
         let handle = Arc::new(handle);
-        let mut producer = producer_over(&handle);
 
         let block_b = sample_block(1);
         let block_c = sample_block(2);
-        let fork_parent = Arc::new(IrysBlockHeader::default());
 
-        producer
-            .handle_signal(BlockStreamSignal::Finalized(Arc::clone(&block_b)))
+        handle
+            .append_and_fanout(finalized_event(&block_b))
             .expect("finalize B");
-        producer
-            .handle_signal(BlockStreamSignal::Reorged {
-                fork_parent: Arc::clone(&fork_parent),
-                old_fork: Arc::new(vec![Arc::clone(&block_b)]),
-                new_fork: Arc::new(vec![Arc::clone(&block_c)]),
-            })
+        handle
+            .append_and_fanout(reorged_event(&block_b, &block_c))
             .expect("reorg orphaning B");
 
         // Restart here — between the reorg and the re-migration: the rebuilt de-dup state must
@@ -962,8 +931,8 @@ mod tests {
         );
         assert!(emitted.contains(&block_c.header().block_hash));
 
-        producer
-            .handle_signal(BlockStreamSignal::Finalized(Arc::clone(&block_b)))
+        handle
+            .append_and_fanout(finalized_event(&block_b))
             .expect("re-finalize B after re-adoption");
 
         let (start, end, _live) = handle.subscribe(0).unwrap();
@@ -971,11 +940,7 @@ mod tests {
             .iter()
             .map(StreamFrame::kind)
             .collect();
-        assert_eq!(
-            kinds,
-            vec!["finalized", "reorged", "finalized"],
-            "the re-migrated orphan must re-emit finalized, not be de-dup-suppressed"
-        );
+        assert_eq!(kinds, vec!["finalized", "reorged", "finalized"]);
 
         // After the re-finalise is durable, a rebuild suppresses a further duplicate again.
         let (_, finalized) = rebuild_state(&handle.db).expect("rebuild after re-finalise");
@@ -992,14 +957,11 @@ mod tests {
         let handle = Arc::new(handle);
 
         // Block 1 migrated AND logged; blocks 2 and 3 migrated (index + headers committed) but
-        // their finalized signals died with the process before the producer appended them.
+        // their finalized frames were lost by a pre-atomic-append build's crash window.
         let blocks: Vec<Arc<SealedBlock>> = (1_u64..=3).map(sample_block).collect();
-        {
-            let mut producer = producer_over(&handle);
-            producer
-                .handle_signal(BlockStreamSignal::Finalized(Arc::clone(&blocks[0])))
-                .expect("finalize block 1");
-        }
+        handle
+            .append_and_fanout(finalized_event(&blocks[0]))
+            .expect("finalize block 1");
         handle
             .db
             .update_eyre(|tx| {
@@ -1049,5 +1011,64 @@ mod tests {
             .expect("second reconciliation");
         let (_, end_after, _live) = handle.subscribe(0).unwrap();
         assert_eq!(end, end_after, "reconciliation is idempotent");
+    }
+
+    /// The duplicate-`finalized` race: a migration that commits its index row and frame AFTER the
+    /// producer starts (but before reconciliation runs) must not be re-appended. Reconciliation
+    /// snapshots the log tail and the index in one read txn, so the committed frame is visible.
+    #[test]
+    fn reconcile_skips_frames_committed_after_producer_creation() {
+        use irys_types::BlockIndexItem;
+
+        let (handle, _tmp) = handle_with_events(0);
+        let handle = Arc::new(handle);
+
+        // Log tail non-empty at producer creation (block 1 finalised and logged).
+        let block_1 = sample_block(1);
+        handle
+            .append_and_fanout(finalized_event(&block_1))
+            .expect("finalize block 1");
+        let mut producer = producer_over(&handle);
+
+        // Migration of block 2 commits — index row AND finalized frame — after the producer
+        // exists but before reconciliation runs.
+        let block_2 = sample_block(2);
+        handle
+            .db
+            .update_eyre(|tx| {
+                for block in [&block_1, &block_2] {
+                    let header = block.header();
+                    irys_database::insert_block_header(tx, header)?;
+                    irys_database::insert_block_index_item(
+                        tx,
+                        header.height,
+                        &BlockIndexItem {
+                            block_hash: header.block_hash,
+                            ..Default::default()
+                        },
+                    )?;
+                }
+                Ok(())
+            })
+            .expect("seed index and headers");
+        handle
+            .append_and_fanout(finalized_event(&block_2))
+            .expect("finalize block 2 (writer path)");
+
+        producer
+            .reconcile_finalized_tail()
+            .expect("reconciliation succeeds");
+
+        let (start, end, _live) = handle.subscribe(0).unwrap();
+        let finalized_for_2 = collect_replay(&handle, start, end)
+            .iter()
+            .filter(|f| {
+                f.kind() == "finalized" && f.block_hash() == Some(block_2.header().block_hash)
+            })
+            .count();
+        assert_eq!(
+            finalized_for_2, 1,
+            "a frame committed after producer creation must not be re-appended by reconciliation"
+        );
     }
 }

--- a/crates/actors/src/block_stream_service.rs
+++ b/crates/actors/src/block_stream_service.rs
@@ -67,13 +67,23 @@ pub struct BlockStreamHandle {
     db: DatabaseProvider,
 }
 
+/// One live subscriber: bounded sender plus the durable-log `end` snapped at registration.
+/// Fan-out skips frames with `seq < replay_end` so Phase 4 durable-append-then-fanout cannot
+/// duplicate a frame already covered by that subscriber's replay range.
+#[derive(Debug)]
+struct LiveSubscriber {
+    sender: Sender<Arc<StreamFrame>>,
+    /// Exclusive upper bound of the durable replay snapshot (`[start, end)`).
+    replay_end: u64,
+}
+
 /// The live fan-out registry: subscriber senders plus a `closed` flag the producer sets when it
 /// stops appending for good. Once closed, [`BlockStreamHandle::subscribe`] registers no new sender,
 /// so a reconnecting follower's SSE ends cleanly after its replay instead of hanging on a live tail
 /// nothing will ever feed.
 #[derive(Debug)]
 struct LiveSubscribers {
-    senders: Vec<Sender<Arc<StreamFrame>>>,
+    senders: Vec<LiveSubscriber>,
     closed: bool,
 }
 
@@ -126,7 +136,10 @@ impl BlockStreamHandle {
         // closes `rx`, so the reconnecting follower's SSE ends cleanly after its replay rather than
         // hanging on a live tail nothing will ever feed.
         if !live.closed {
-            live.senders.push(tx);
+            live.senders.push(LiveSubscriber {
+                sender: tx,
+                replay_end: end,
+            });
         }
         Ok((start, end, rx))
     }
@@ -215,8 +228,7 @@ impl BlockStreamHandle {
     }
 
     /// Fan out a frame that is already durable (Phase 4 production path). Does not open a RW txn.
-    /// Live SSE clients skip `seq < end` from their subscribe snapshot so a race with late
-    /// registration cannot duplicate frames on the wire.
+    /// Subscribers whose `replay_end` already covers `frame.seq` are skipped (no live/replay dup).
     fn fanout_only(&self, frame: &Arc<StreamFrame>) -> eyre::Result<()> {
         let mut live = self
             .live
@@ -229,8 +241,13 @@ impl BlockStreamHandle {
     fn fanout_locked(live: &mut LiveSubscribers, frame: &Arc<StreamFrame>) {
         // Drop subscribers whose receiver is closed or lagging past `SUBSCRIBER_BUFFER`; a dropped
         // follower reconnects and replays from the durable log via `subscribe(from_seq)`.
-        live.senders.retain(|sender| {
-            sender
+        // Skip delivery when `frame.seq < replay_end` — that seq is already in the subscriber's
+        // durable replay window (Phase 4 can fan out after a late subscribe snapped past it).
+        live.senders.retain(|sub| {
+            if frame.seq < sub.replay_end {
+                return true; // keep subscriber; do not deliver a replay-covered frame
+            }
+            sub.sender
                 .try_send(Arc::clone(frame)) // clone: live subscribers share one immutable frame allocation
                 .is_ok()
         });
@@ -479,8 +496,8 @@ impl Producer {
                     return Ok(());
                 }
                 let event = StreamEvent::Observed(BlockEvent::from_sealed(&block, self.chunk_size));
-                self.append(event)?;
-                self.emitted.put(hash, ());
+                self.append(event.clone())?; // clone: note_event_for_dedup after successful append
+                self.note_event_for_dedup(&event);
             }
             BlockStreamSignal::Finalized(block) => {
                 let hash = block.header().block_hash;
@@ -489,8 +506,8 @@ impl Producer {
                 }
                 let event =
                     StreamEvent::Finalized(BlockEvent::from_sealed(&block, self.chunk_size));
-                self.append(event)?;
-                self.finalized.put(hash, ());
+                self.append(event.clone())?; // clone: note_event_for_dedup after successful append
+                self.note_event_for_dedup(&event);
             }
             BlockStreamSignal::Reorged {
                 fork_parent,
@@ -511,20 +528,8 @@ impl Producer {
                         .map(|b| BlockEvent::from_sealed(b, self.chunk_size))
                         .collect(),
                 };
-                self.append(event)?;
-                // Mark the new-fork hashes seen so the `Confirmed` signals that follow this tick do
-                // not also emit `observed` for them: `propagate_block` sends the `Reorged` signal
-                // before the per-block `Confirmed` signals, and the signal channel is FIFO.
-                for block in new_fork.iter() {
-                    self.emitted.put(block.header().block_hash, ());
-                }
-                // An orphaned block may have been migrated (and emitted `finalized`) before this
-                // reorg rolled it back. Evict it from the finalized de-dup so that if its fork is
-                // later re-adopted and it re-migrates, the fresh `finalized` is emitted rather than
-                // suppressed — a follower that demoted it on this frame is waiting for exactly that.
-                for block in old_fork.iter() {
-                    self.finalized.pop(&block.header().block_hash);
-                }
+                self.append(event.clone())?; // clone: note_event_for_dedup after successful append
+                self.note_event_for_dedup(&event);
             }
         }
         Ok(())

--- a/crates/actors/src/block_stream_service.rs
+++ b/crates/actors/src/block_stream_service.rs
@@ -880,6 +880,32 @@ mod tests {
         );
     }
 
+    /// Covers `fanout_locked`'s `seq < replay_end` skip: a late subscribe must not
+    /// receive live copies of frames already inside its durable replay window.
+    #[test]
+    fn fanout_skips_frames_covered_by_subscriber_replay() {
+        let (handle, _tmp) = handle_with_events(2); // durable seqs 0,1 → logical_len = 2
+        let (_start, end, mut live) = handle.subscribe(0).unwrap();
+        assert_eq!(end, 2);
+
+        let covered = Arc::new(StreamFrame {
+            seq: 1,
+            event: sample_stream_event(),
+        });
+        handle.fanout_only(&covered).unwrap();
+        assert!(
+            live.try_recv().is_err(),
+            "replay-covered frame must not be delivered live"
+        );
+
+        let fresh = Arc::new(StreamFrame {
+            seq: 2,
+            event: sample_stream_event(),
+        });
+        handle.fanout_only(&fresh).unwrap();
+        assert_eq!(live.try_recv().expect("live frame").seq, 2);
+    }
+
     /// A producer these tests drive directly, so the returned shutdown/sender halves are unused
     /// and may drop.
     fn producer_over(handle: &Arc<BlockStreamHandle>) -> Producer {

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -1260,8 +1260,7 @@ impl BlockTreeServiceInner {
         // Persist metadata atomically (same code path for both normal blocks and reorgs).
         // Phase 4: durable observed/reorged stream frames land in this same RW txn.
         let stream_frames = {
-            use crate::block_migration_service::StreamReorgAppend;
-            let emit_stream = self.block_stream_enabled();
+            use crate::block_migration_service::{StreamEmission, StreamReorgAppend};
             let old_fork: &[Arc<SealedBlock>] = reorg_event
                 .as_ref()
                 .map_or(&[] as &[_], |e| e.old_fork.as_ref());
@@ -1270,12 +1269,15 @@ impl BlockTreeServiceInner {
                 old_fork: Arc::clone(&e.old_fork),
                 new_fork: Arc::clone(&e.new_fork),
             });
-            self.block_migration_service.persist_metadata(
-                old_fork,
-                &blocks_to_confirm,
-                emit_stream,
-                stream_reorg.as_ref(),
-            )?
+            let stream = if !self.block_stream_enabled() {
+                StreamEmission::Disabled
+            } else if let Some(reorg) = stream_reorg.as_ref() {
+                StreamEmission::Reorged(reorg)
+            } else {
+                StreamEmission::Observed
+            };
+            self.block_migration_service
+                .persist_metadata(old_fork, &blocks_to_confirm, stream)?
         };
         self.fanout_durable_stream_frames(stream_frames);
 

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -2259,6 +2259,7 @@ mod tests {
                 cache.clone(),
                 chunk_migration_sender,
                 service_senders.packing_sender(),
+                false, // tests do not seed stream de-dup
             );
 
             // Real (not mocked) VDF state pinned at `live_step`; the gate only

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -169,19 +169,23 @@ pub struct ReorgEvent {
     pub db: Option<DatabaseProvider>,
 }
 
-/// A per-block signal fed to the block-stream producer over a dedicated unbounded channel.
+/// Signals fed to the block-stream producer over a dedicated unbounded channel.
 ///
-/// Emitted from the node's authoritative sites — the `blocks_to_confirm` loop (`observed`), the
-/// reorg construction (`reorged`), and the per-block migration loop (`finalized`) — each carrying
-/// the `Arc<SealedBlock>` already in hand. Unbounded so it cannot drop under backpressure; the
-/// producer turns these into durable, fanned-out `StreamFrame`s.
+/// Production (Phase 4): confirmation/migration/reorg write the durable log inside the same
+/// consensus MDBX transaction as metadata/index work, then emit [`Self::Durable`] so the producer
+/// only fans out to live SSE subscribers (no second RW txn).
+///
+/// [`Self::Confirmed`] / [`Self::Finalized`] / [`Self::Reorged`] still append+fanout for unit tests
+/// and any residual callers; startup reconciliation also appends via the producer.
 #[derive(Debug, Clone)]
 pub enum BlockStreamSignal {
-    /// A block reached canonical confirmation ⇒ `observed`.
+    /// Frame already committed to the durable log; producer fans out only.
+    Durable(Arc<irys_types::block_stream::StreamFrame>),
+    /// A block reached canonical confirmation ⇒ append `observed` then fan out.
     Confirmed(Arc<SealedBlock>),
-    /// A block migrated to the index ⇒ `finalized`.
+    /// A block migrated to the index ⇒ append `finalized` then fan out.
     Finalized(Arc<SealedBlock>),
-    /// A reorg occurred ⇒ one batched `reorged` frame.
+    /// A reorg occurred ⇒ append one batched `reorged` frame then fan out.
     Reorged {
         fork_parent: Arc<IrysBlockHeader>,
         old_fork: Arc<Vec<Arc<SealedBlock>>>,
@@ -568,19 +572,47 @@ impl BlockTreeServiceInner {
             .map_err(|e| eyre::eyre!("Failed waiting for Reth FCU ack: {e}"))
     }
 
+    /// Whether the durable block-stream producer is running (same gate as `/internal/*` routes).
+    fn block_stream_enabled(&self) -> bool {
+        self.config.node_config.http.expose_internal_api
+    }
+
     /// Migrates finalized blocks into the block index and DB via `BlockMigrationService`.
     fn migrate_block(&mut self, block: &Arc<IrysBlockHeader>) -> eyre::Result<()> {
+        let emit_stream = self.block_stream_enabled();
         let block_stream = self.service_senders.block_stream.clone();
-        self.block_migration_service
-            .migrate_blocks(block, |sealed| {
-                if block_stream
-                    .send(BlockStreamSignal::Finalized(Arc::clone(sealed)))
-                    .is_err()
+        self.block_migration_service.migrate_blocks(
+            block,
+            emit_stream,
+            |_sealed, stream_frame| {
+                if let Some(frame) = stream_frame
+                    && block_stream
+                        .send(BlockStreamSignal::Durable(Arc::new(frame)))
+                        .is_err()
                 {
-                    tracing::debug!("block-stream producer gone; dropping finalized signal");
+                    tracing::debug!(
+                        "block-stream producer gone; dropping durable finalized fanout"
+                    );
                 }
-            })?;
+            },
+        )?;
         Ok(())
+    }
+
+    fn fanout_durable_stream_frames(&self, frames: Vec<irys_types::block_stream::StreamFrame>) {
+        if frames.is_empty() {
+            return;
+        }
+        let block_stream = &self.service_senders.block_stream;
+        for frame in frames {
+            if block_stream
+                .send(BlockStreamSignal::Durable(Arc::new(frame)))
+                .is_err()
+            {
+                debug!("block-stream producer gone; dropping durable stream fanout");
+                break;
+            }
+        }
     }
 
     /// Handles pre-validated blocks received from the validation service.
@@ -1225,14 +1257,27 @@ impl BlockTreeServiceInner {
             self.send_epoch_events(&epoch_block)?;
         }
 
-        // Persist metadata atomically (same code path for both normal blocks and reorgs)
-        {
+        // Persist metadata atomically (same code path for both normal blocks and reorgs).
+        // Phase 4: durable observed/reorged stream frames land in this same RW txn.
+        let stream_frames = {
+            use crate::block_migration_service::StreamReorgAppend;
+            let emit_stream = self.block_stream_enabled();
             let old_fork: &[Arc<SealedBlock>] = reorg_event
                 .as_ref()
                 .map_or(&[] as &[_], |e| e.old_fork.as_ref());
-            self.block_migration_service
-                .persist_metadata(old_fork, &blocks_to_confirm)?;
-        }
+            let stream_reorg = reorg_event.as_ref().map(|e| StreamReorgAppend {
+                fork_parent: Arc::clone(&e.fork_parent),
+                old_fork: Arc::clone(&e.old_fork),
+                new_fork: Arc::clone(&e.new_fork),
+            });
+            self.block_migration_service.persist_metadata(
+                old_fork,
+                &blocks_to_confirm,
+                emit_stream,
+                stream_reorg.as_ref(),
+            )?
+        };
+        self.fanout_durable_stream_frames(stream_frames);
 
         // Broadcast reorg event if applicable
         let reorg_occurred = reorg_event.is_some();
@@ -1240,20 +1285,6 @@ impl BlockTreeServiceInner {
             // Deep reorg may poison VDF seeds; re-anchor before reorg fans out.
             self.maybe_reanchor_vdf_after_reorg(&arc_block, &reorg_event);
 
-            // Feed the block-stream producer one batched `reorged` signal (cheap Arc clones of the
-            // forks already in hand) before the broadcast send consumes the event.
-            if self
-                .service_senders
-                .block_stream
-                .send(BlockStreamSignal::Reorged {
-                    fork_parent: Arc::clone(&reorg_event.fork_parent),
-                    old_fork: Arc::clone(&reorg_event.old_fork),
-                    new_fork: Arc::clone(&reorg_event.new_fork),
-                })
-                .is_err()
-            {
-                debug!("block-stream producer gone; dropping reorged signal");
-            }
             if let Err(e) = self.service_senders.reorg_events.send(reorg_event) {
                 error!(
                     "Failed to broadcast reorg event - mempool state may be stale: {:?}",
@@ -1291,21 +1322,11 @@ impl BlockTreeServiceInner {
             // Emit consensus events
             self.emit_fcu(markers).await?;
 
-            // Emit block confirmations for all relevant blocks. The mempool may
-            // already be shutting down (its receiver dropped); log and continue
-            // — block confirmation itself is still valid, the mempool just
-            // won't be informed of this particular block.
+            // Mempool confirmations. The mempool may already be shutting down (its receiver
+            // dropped); log and continue — block confirmation itself is still valid.
+            // Stream `observed`/`reorged` frames were already durable-appended + fanout-queued
+            // inside `persist_metadata` (Phase 4); migration appends `finalized` the same way.
             for sealed_block in &blocks_to_confirm {
-                // Feed the block-stream producer one `observed` signal per confirmed block — the
-                // authoritative per-block confirmation set (includes ancestors on a fork switch).
-                if self
-                    .service_senders
-                    .block_stream
-                    .send(BlockStreamSignal::Confirmed(Arc::clone(sealed_block)))
-                    .is_err()
-                {
-                    debug!("block-stream producer gone; dropping confirmed signal");
-                }
                 if let Err(e) =
                     self.service_senders
                         .mempool
@@ -1321,7 +1342,6 @@ impl BlockTreeServiceInner {
                 }
             }
 
-            // Delegate migration to BlockMigrationService (validates continuity internally)
             if tip_changed {
                 self.migrate_block(&markers.migration_block)?;
             }

--- a/crates/actors/src/block_tree_service.rs
+++ b/crates/actors/src/block_tree_service.rs
@@ -169,30 +169,6 @@ pub struct ReorgEvent {
     pub db: Option<DatabaseProvider>,
 }
 
-/// Signals fed to the block-stream producer over a dedicated unbounded channel.
-///
-/// Production (Phase 4): confirmation/migration/reorg write the durable log inside the same
-/// consensus MDBX transaction as metadata/index work, then emit [`Self::Durable`] so the producer
-/// only fans out to live SSE subscribers (no second RW txn).
-///
-/// [`Self::Confirmed`] / [`Self::Finalized`] / [`Self::Reorged`] still append+fanout for unit tests
-/// and any residual callers; startup reconciliation also appends via the producer.
-#[derive(Debug, Clone)]
-pub enum BlockStreamSignal {
-    /// Frame already committed to the durable log; producer fans out only.
-    Durable(Arc<irys_types::block_stream::StreamFrame>),
-    /// A block reached canonical confirmation ⇒ append `observed` then fan out.
-    Confirmed(Arc<SealedBlock>),
-    /// A block migrated to the index ⇒ append `finalized` then fan out.
-    Finalized(Arc<SealedBlock>),
-    /// A reorg occurred ⇒ append one batched `reorged` frame then fan out.
-    Reorged {
-        fork_parent: Arc<IrysBlockHeader>,
-        old_fork: Arc<Vec<Arc<SealedBlock>>>,
-        new_fork: Arc<Vec<Arc<SealedBlock>>>,
-    },
-}
-
 /// Event broadcast when a block's state changes in the block tree.
 #[derive(Debug, Clone)]
 pub struct BlockStateUpdated {
@@ -586,9 +562,7 @@ impl BlockTreeServiceInner {
             emit_stream,
             |_sealed, stream_frame| {
                 if let Some(frame) = stream_frame
-                    && block_stream
-                        .send(BlockStreamSignal::Durable(Arc::new(frame)))
-                        .is_err()
+                    && block_stream.send(Arc::new(frame)).is_err()
                 {
                     tracing::debug!(
                         "block-stream producer gone; dropping durable finalized fanout"
@@ -605,10 +579,7 @@ impl BlockTreeServiceInner {
         }
         let block_stream = &self.service_senders.block_stream;
         for frame in frames {
-            if block_stream
-                .send(BlockStreamSignal::Durable(Arc::new(frame)))
-                .is_err()
-            {
+            if block_stream.send(Arc::new(frame)).is_err() {
                 debug!("block-stream producer gone; dropping durable stream fanout");
                 break;
             }
@@ -1257,8 +1228,8 @@ impl BlockTreeServiceInner {
             self.send_epoch_events(&epoch_block)?;
         }
 
-        // Persist metadata atomically (same code path for both normal blocks and reorgs).
-        // Phase 4: durable observed/reorged stream frames land in this same RW txn.
+        // Persist metadata atomically (same code path for both normal blocks and reorgs);
+        // durable observed/reorged stream frames land in this same RW txn.
         let stream_frames = {
             use crate::block_migration_service::{StreamEmission, StreamReorgAppend};
             let old_fork: &[Arc<SealedBlock>] = reorg_event
@@ -1279,7 +1250,6 @@ impl BlockTreeServiceInner {
             self.block_migration_service
                 .persist_metadata(old_fork, &blocks_to_confirm, stream)?
         };
-        self.fanout_durable_stream_frames(stream_frames);
 
         // Broadcast reorg event if applicable
         let reorg_occurred = reorg_event.is_some();
@@ -1324,10 +1294,15 @@ impl BlockTreeServiceInner {
             // Emit consensus events
             self.emit_fcu(markers).await?;
 
+            // Live stream fan-out only after FCU succeeds, so a follower reacting to `observed`
+            // never races the execution-layer head update (the pre-change ordering). The frames
+            // are already durable; on an FCU error the follower recovers them via replay.
+            self.fanout_durable_stream_frames(stream_frames);
+
             // Mempool confirmations. The mempool may already be shutting down (its receiver
             // dropped); log and continue — block confirmation itself is still valid.
-            // Stream `observed`/`reorged` frames were already durable-appended + fanout-queued
-            // inside `persist_metadata` (Phase 4); migration appends `finalized` the same way.
+            // Stream `observed`/`reorged` frames were durable-appended inside `persist_metadata`;
+            // migration appends `finalized` the same way.
             for sealed_block in &blocks_to_confirm {
                 if let Err(e) =
                     self.service_senders

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -388,31 +388,45 @@ impl InnerCacheTask {
         {
             let tx = self.db.tx()?;
             let mut cdr_cursor = tx.cursor_read::<CachedDataRoots>()?;
-            let mut cdr_walk = cdr_cursor.walk(None)?;
+            let seek_key: DataRoot = H256::random();
+            let mut cdr_walk = cdr_cursor.walk(Some(seek_key))?;
+            let mut wrapped = false;
 
             // Cap is on candidates collected (read-phase), not on roots that
-            // actually prune chunks in the write phase. A stable set of
-            // non-yielding candidates early in hash order can consume the
-            // budget and starve later prunable roots (hash-order scan, no
-            // wraparound). Count is work attempted, not work applied.
+            // actually prune chunks in the write phase: count is work
+            // attempted, not work applied. The scan therefore starts at a
+            // random key and wraps (same shape as `prune_data_root_cache`), so
+            // a stable set of non-yielding candidates early in hash order
+            // cannot consume the budget every run and starve later prunable
+            // roots. The wrap stops at `seek_key` so no root is visited twice.
             // TODO: try to deprioritise data_roots that almost have all their chunks.
-            while let Some((data_root, _cached)) = cdr_walk.next().transpose()? {
-                if candidates.len() >= MAX_EVICTIONS_PER_RUN {
-                    warn!(
-                        chunk.candidates = candidates.len(),
-                        "Hit max eviction limit collecting prune candidates, will continue next cycle"
-                    );
+            loop {
+                while let Some((data_root, _cached)) = cdr_walk.next().transpose()? {
+                    if wrapped && data_root >= seek_key {
+                        break;
+                    }
+                    if candidates.len() >= MAX_EVICTIONS_PER_RUN {
+                        warn!(
+                            chunk.candidates = candidates.len(),
+                            "Hit max eviction limit collecting prune candidates, will continue next cycle"
+                        );
+                        break;
+                    }
+
+                    if self.ingress_proof_generation_state.is_generating(data_root) {
+                        debug!(ingress_proof.data_root = ?data_root, "Skipping chunk prune due to active proof generation");
+                        continue;
+                    }
+
+                    if !Self::has_local_ingress_proof(&tx, data_root, local_address)? {
+                        candidates.push(data_root);
+                    }
+                }
+                if wrapped || candidates.len() >= MAX_EVICTIONS_PER_RUN {
                     break;
                 }
-
-                if self.ingress_proof_generation_state.is_generating(data_root) {
-                    debug!(ingress_proof.data_root = ?data_root, "Skipping chunk prune due to active proof generation");
-                    continue;
-                }
-
-                if !Self::has_local_ingress_proof(&tx, data_root, local_address)? {
-                    candidates.push(data_root);
-                }
+                wrapped = true;
+                cdr_walk = cdr_cursor.walk(None)?;
             }
             drop(cdr_walk);
             drop(cdr_cursor);

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -35,6 +35,13 @@ use tracing::{Instrument as _, debug, error, info, trace, warn};
 
 pub const REGENERATE_PROOFS: bool = true;
 
+/// Outcome of the CDR pruning-horizon policy for one `CachedDataRoots` entry.
+struct CdrEvictionState {
+    inclusion_max_height: Option<u64>,
+    horizon: Option<u64>,
+    evictable: bool,
+}
+
 /// Maximum evictions per invocation to prevent blocking the service.
 /// If this limit is reached, eviction will continue in the next cycle.
 const MAX_EVICTIONS_PER_RUN: usize = 10_000;
@@ -292,6 +299,71 @@ impl InnerCacheTask {
     /// expired/invalid proofs, any remaining proof entry is treated as active.
     /// Data roots currently undergoing proof generation are skipped to avoid races.
     #[tracing::instrument(level = "trace", skip_all)]
+    /// True when this node's own ingress proof for `data_root` is present.
+    /// Shared by the scan and write phases of both prune passes so the
+    /// local-proof exemption cannot diverge between collect-time and
+    /// delete-time (the RO scan and the gated write are separate txns).
+    fn has_local_ingress_proof<T: reth_db::transaction::DbTx>(
+        tx: &T,
+        data_root: DataRoot,
+        local_address: irys_types::IrysAddress,
+    ) -> eyre::Result<bool> {
+        let mut proofs_cursor = tx.cursor_read::<IngressProofs>()?;
+        let mut walker = proofs_cursor.walk(Some(data_root))?;
+        while let Some((key, compact)) = walker.next().transpose()? {
+            if key != data_root {
+                break;
+            }
+            if compact.0.address == local_address {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    /// Evaluates the CDR pruning-horizon policy for `cached`, reading tx
+    /// metadata through `tx`. Shared by `prune_data_root_cache`'s scan and
+    /// write phases so the delete-time re-check applies exactly the
+    /// collect-time policy.
+    fn cdr_eviction_state<T: reth_db::transaction::DbTx>(
+        tx: &T,
+        cached: &irys_database::db_cache::CachedDataRoot,
+        prune_height: u64,
+    ) -> eyre::Result<CdrEvictionState> {
+        let mut inclusion_max_height: Option<u64> = None;
+        let mut all_txs_confirmed = true;
+        for tx_id in cached.txid_set.iter() {
+            match get_data_tx_metadata(tx, tx_id)?.and_then(|m| m.included_height) {
+                Some(h) => {
+                    inclusion_max_height = Some(inclusion_max_height.map_or(h, |x| x.max(h)));
+                }
+                None => {
+                    all_txs_confirmed = false;
+                    break;
+                }
+            }
+        }
+        let horizon = if all_txs_confirmed {
+            match (inclusion_max_height, cached.expiry_height) {
+                (Some(h), _) => Some(h),
+                (None, Some(e)) => Some(e),
+                (None, None) => None,
+            }
+        } else {
+            cached.expiry_height
+        };
+        let evictable = match (horizon, all_txs_confirmed) {
+            (Some(max_height), _) => max_height < prune_height,
+            (None, true) => true,
+            (None, false) => false,
+        };
+        Ok(CdrEvictionState {
+            inclusion_max_height,
+            horizon,
+            evictable,
+        })
+    }
+
     fn prune_chunks_without_active_ingress_proofs(&self) -> eyre::Result<()> {
         let local_address = self.config.irys_signer().address();
         let min_chunk_age_in_blocks = self
@@ -334,20 +406,7 @@ impl InnerCacheTask {
                     continue;
                 }
 
-                let mut proofs_cursor = tx.cursor_read::<IngressProofs>()?;
-                let mut has_any_local_proof = false;
-                let mut walker = proofs_cursor.walk(Some(data_root))?;
-                while let Some((key, compact)) = walker.next().transpose()? {
-                    if key != data_root {
-                        break;
-                    }
-                    if compact.0.address == local_address {
-                        has_any_local_proof = true;
-                        break;
-                    }
-                }
-
-                if !has_any_local_proof {
+                if !Self::has_local_ingress_proof(&tx, data_root, local_address)? {
                     candidates.push(data_root);
                 }
             }
@@ -361,6 +420,14 @@ impl InnerCacheTask {
             self.db
                 .update_eyre_at("cache_service.prune_chunks_batch", |write_tx| {
                     for &root in batch {
+                        // Re-validate under the write txn: proof generation may have
+                        // started, or a local proof landed, between the RO scan and
+                        // this gated write.
+                        if self.ingress_proof_generation_state.is_generating(root)
+                            || Self::has_local_ingress_proof(write_tx, root, local_address)?
+                        {
+                            continue;
+                        }
                         trace!(
                             chunk.data_root = ?root,
                             "Pruning chunks for data root without active proofs"
@@ -392,7 +459,6 @@ impl InnerCacheTask {
         // emitted only after `commit()` succeeds — otherwise a failed commit
         // (or a mid-loop delete error that drops the tx) would report
         // evictions/chunks that never persisted.
-        #[derive(Clone)]
         struct EvictionRecord {
             data_root: H256,
             block_set: Vec<H256>,
@@ -425,56 +491,11 @@ impl InnerCacheTask {
                         break;
                     }
 
-                    let mut inclusion_max_height: Option<u64> = None;
-                    let mut all_txs_confirmed = true;
-                    for tx_id in cached.txid_set.iter() {
-                        match irys_database::get_data_tx_metadata(&tx, tx_id)?
-                            .and_then(|m| m.included_height)
-                        {
-                            Some(h) => {
-                                inclusion_max_height =
-                                    Some(inclusion_max_height.map_or(h, |x| x.max(h)));
-                            }
-                            None => {
-                                all_txs_confirmed = false;
-                                break;
-                            }
-                        }
-                    }
-
-                    let horizon = if all_txs_confirmed {
-                        match (inclusion_max_height, cached.expiry_height) {
-                            (Some(h), _) => Some(h),
-                            (None, Some(e)) => Some(e),
-                            (None, None) => None,
-                        }
-                    } else {
-                        cached.expiry_height
-                    };
-
-                    let is_eviction_candidate = match (horizon, all_txs_confirmed) {
-                        (Some(max_height), _) => max_height < prune_height,
-                        (None, true) => true,
-                        (None, false) => false,
-                    };
-
-                    if !is_eviction_candidate {
+                    let state = Self::cdr_eviction_state(&tx, &cached, prune_height)?;
+                    if !state.evictable {
                         continue;
                     }
-
-                    let mut proofs_cursor = tx.cursor_read::<IngressProofs>()?;
-                    let mut has_local_proof = false;
-                    let mut proof_walker = proofs_cursor.walk(Some(data_root))?;
-                    while let Some((key, compact)) = proof_walker.next().transpose()? {
-                        if key != data_root {
-                            break;
-                        }
-                        if compact.0.address == local_addr {
-                            has_local_proof = true;
-                            break;
-                        }
-                    }
-                    if has_local_proof {
+                    if Self::has_local_ingress_proof(&tx, data_root, local_addr)? {
                         continue;
                     }
 
@@ -482,9 +503,9 @@ impl InnerCacheTask {
                         data_root,
                         block_set: cached.block_set,
                         txid_set_size: cached.txid_set.len(),
-                        inclusion_max_height,
+                        inclusion_max_height: state.inclusion_max_height,
                         expiry_height: cached.expiry_height,
-                        horizon,
+                        horizon: state.horizon,
                     });
                 }
                 if wrapped || candidates.len() >= MAX_EVICTIONS_PER_RUN {
@@ -506,8 +527,16 @@ impl InnerCacheTask {
             self.db
                 .update_eyre_at("cache_service.prune_data_root_cache", |write_tx| {
                     for rec in batch {
-                        // Re-check presence: root may have been re-cached since the scan.
-                        if write_tx.get::<CachedDataRoots>(rec.data_root)?.is_none() {
+                        // Re-validate under the write txn: the root may have been
+                        // re-cached, gained a local proof, or left its eviction
+                        // horizon between the RO scan and this gated write.
+                        let Some(cached) = write_tx.get::<CachedDataRoots>(rec.data_root)? else {
+                            continue;
+                        };
+                        let state = Self::cdr_eviction_state(write_tx, &cached, prune_height)?;
+                        if !state.evictable
+                            || Self::has_local_ingress_proof(write_tx, rec.data_root, local_addr)?
+                        {
                             continue;
                         }
                         write_tx.delete::<IngressProofs>(rec.data_root, None)?;
@@ -515,7 +544,16 @@ impl InnerCacheTask {
                             delete_cached_chunks_by_data_root(write_tx, rec.data_root)?,
                         );
                         write_tx.delete::<CachedDataRoots>(rec.data_root, None)?;
-                        batch_applied.push(rec.clone()); // clone: log after commit outside txn
+                        // Fresh values from the write txn, not the scan snapshot,
+                        // so post-commit logging reflects what was actually deleted.
+                        batch_applied.push(EvictionRecord {
+                            data_root: rec.data_root,
+                            block_set: cached.block_set,
+                            txid_set_size: cached.txid_set.len(),
+                            inclusion_max_height: state.inclusion_max_height,
+                            expiry_height: cached.expiry_height,
+                            horizon: state.horizon,
+                        });
                     }
                     Ok(())
                 })?;
@@ -2990,6 +3028,77 @@ mod tests {
         Ok((temp_dir, db, config, data_root))
     }
 
+    /// TOCTOU pin for the prune write phases: the shared predicate helpers must veto a delete
+    /// when state changed between the RO scan and the gated write — a local proof landing, or
+    /// the horizon reopening — because both phases re-evaluate exactly these helpers.
+    #[tokio::test]
+    async fn prune_recheck_predicate_vetoes_stale_candidates() -> eyre::Result<()> {
+        let config = Config::new_with_random_peer_id(NodeConfig::testing());
+        let local_addr = config.irys_signer().address();
+        let temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db_env = open_or_create_db(
+            &temp_dir,
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        let db = DatabaseProvider(Arc::new(db_env));
+
+        let data_root = H256::random();
+        let cdr = CachedDataRoot {
+            data_size: 64,
+            data_size_confirmed: false,
+            txid_set: vec![],
+            block_set: vec![],
+            expiry_height: Some(1),
+            cached_at: irys_types::UnixTimestamp::now()?,
+        };
+        db.update(|wtx| -> eyre::Result<()> {
+            wtx.put::<CachedDataRoots>(data_root, cdr)?;
+            Ok(())
+        })??;
+
+        // Scan-time view: past its horizon, no local proof → evictable.
+        db.view_eyre(|tx| {
+            let cached = tx.get::<CachedDataRoots>(data_root)?.expect("cdr");
+            let state = InnerCacheTask::cdr_eviction_state(tx, &cached, 100)?;
+            assert!(state.evictable, "expired unprotected CDR is evictable");
+            assert!(!InnerCacheTask::has_local_ingress_proof(
+                tx, data_root, local_addr
+            )?);
+            Ok(())
+        })?;
+
+        // A local proof lands after the scan; the write-phase re-check must veto.
+        db.update(|wtx| -> eyre::Result<()> {
+            let mut proof = IngressProof::default();
+            proof.data_root = data_root;
+            irys_database::store_external_ingress_proof_checked(wtx, &proof, local_addr)?;
+            Ok(())
+        })??;
+        db.view_eyre(|tx| {
+            assert!(InnerCacheTask::has_local_ingress_proof(
+                tx, data_root, local_addr
+            )?);
+            Ok(())
+        })?;
+
+        // The horizon can also reopen (root re-cached with a future expiry): re-evaluated
+        // under the write txn, the predicate stops the delete.
+        db.update(|wtx| -> eyre::Result<()> {
+            let mut cached = wtx.get::<CachedDataRoots>(data_root)?.expect("cdr");
+            cached.expiry_height = Some(1_000);
+            wtx.put::<CachedDataRoots>(data_root, cached)?;
+            Ok(())
+        })??;
+        db.view_eyre(|tx| {
+            let cached = tx.get::<CachedDataRoots>(data_root)?.expect("cdr");
+            let state = InnerCacheTask::cdr_eviction_state(tx, &cached, 100)?;
+            assert!(!state.evictable, "revived expiry must veto eviction");
+            Ok(())
+        })?;
+        Ok(())
+    }
+
     // T1 (regression pin): a tx re-confirmed in a canonical-but-unmigrated
     // block (present in the tree's Submit ledger, NO metadata row) must NOT be
     // scrubbed from txid_set. Before the tree-snapshot recheck, the scrub only
@@ -3107,10 +3216,10 @@ mod tests {
                 .block_hash()
         };
 
-        // Hold the consensus writer gate + MDBX RW tx so the scrub parks inside
+        // Hold this env's writer gate + MDBX RW tx so the scrub parks inside
         // `update_eyre` (on the gate, then the env lock) before it can read the tree.
         // Locals drop in reverse order: MDBX first, then the gate.
-        let gate = irys_database::db::lock_consensus_writer_gate("test.spares_txid_blocker");
+        let gate = irys_database::db::lock_writer_gate(&db, "test.spares_txid_blocker");
         let blocker = db.tx_mut()?;
 
         // Queue tx_x for removal and run the scrub on another thread; with the

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -31,7 +31,7 @@ use tokio::sync::{
     mpsc::{UnboundedReceiver, UnboundedSender},
     oneshot,
 };
-use tracing::{Instrument as _, debug, error, info, info_span, trace, warn};
+use tracing::{Instrument as _, debug, error, info, trace, warn};
 
 pub const REGENERATE_PROOFS: bool = true;
 
@@ -359,54 +359,43 @@ impl InnerCacheTask {
 
             // Commit a small batch to avoid large transactions
             if pending_roots.len() >= 256 {
-                // Span attributes any libmdbx writer-lock stall warning fired
-                // during begin_rw_txn to libmdbx_rw_tx_lock_stalls_total
-                // {scope="irys-consensus"} (see crates/utils/utils/src/mdbx_metrics.rs).
-                let _span = info_span!(
-                    irys_utils::MDBX_RW_TX_SPAN,
-                    db_scope = irys_utils::DB_SCOPE_IRYS_CONSENSUS
-                )
-                .entered();
-                let write_tx = self.db.tx_mut()?;
-                for root in pending_roots.drain(..) {
-                    trace!(
-                        chunk.data_root = ?root,
-                        "Pruning chunks for data root without active proofs"
-                    );
-                    let pruned = delete_cached_chunks_by_data_root_older_than(
-                        &write_tx,
-                        root,
-                        delete_chunks_older_than,
-                    )?;
-                    if pruned > 0 {
-                        evictions_performed = evictions_performed.saturating_add(1);
-                        debug!(chunk.data_root = ?root, chunk.pruined_chunks = pruned, "Pruned chunks for data root without active proofs");
+                self.db.update_eyre_at("cache_service.prune_chunks_batch", |write_tx| {
+                    for root in pending_roots.drain(..) {
+                        trace!(
+                            chunk.data_root = ?root,
+                            "Pruning chunks for data root without active proofs"
+                        );
+                        let pruned = delete_cached_chunks_by_data_root_older_than(
+                            write_tx,
+                            root,
+                            delete_chunks_older_than,
+                        )?;
+                        if pruned > 0 {
+                            evictions_performed = evictions_performed.saturating_add(1);
+                            debug!(chunk.data_root = ?root, chunk.pruined_chunks = pruned, "Pruned chunks for data root without active proofs");
+                        }
                     }
-                }
-                write_tx.commit()?;
+                    Ok(())
+                })?;
             }
         }
 
         // Flush any remaining pending deletions
         if !pending_roots.is_empty() {
-            let _span = info_span!(
-                irys_utils::MDBX_RW_TX_SPAN,
-                db_scope = irys_utils::DB_SCOPE_IRYS_CONSENSUS
-            )
-            .entered();
-            let write_tx = self.db.tx_mut()?;
-            for root in pending_roots.drain(..) {
-                let pruned = delete_cached_chunks_by_data_root_older_than(
-                    &write_tx,
-                    root,
-                    delete_chunks_older_than,
-                )?;
-                if pruned > 0 {
-                    evictions_performed = evictions_performed.saturating_add(1);
-                    debug!(chunk.data_root = ?root, chunk.pruned_chunks = pruned, "Pruned chunks for data root without active proofs");
+            self.db.update_eyre_at("cache_service.prune_chunks_flush", |write_tx| {
+                for root in pending_roots.drain(..) {
+                    let pruned = delete_cached_chunks_by_data_root_older_than(
+                        write_tx,
+                        root,
+                        delete_chunks_older_than,
+                    )?;
+                    if pruned > 0 {
+                        evictions_performed = evictions_performed.saturating_add(1);
+                        debug!(chunk.data_root = ?root, chunk.pruned_chunks = pruned, "Pruned chunks for data root without active proofs");
+                    }
                 }
-            }
-            write_tx.commit()?;
+                Ok(())
+            })?;
         }
 
         info!(
@@ -436,181 +425,179 @@ impl InnerCacheTask {
         let mut chunks_pruned: u64 = 0;
         let mut eviction_count: usize = 0;
         let mut evictions: Vec<EvictionRecord> = Vec::new();
-        let _span = info_span!(
-            irys_utils::MDBX_RW_TX_SPAN,
-            db_scope = irys_utils::DB_SCOPE_IRYS_CONSENSUS
-        )
-        .entered();
-        let write_tx = self.db.tx_mut()?;
-        let mut cursor = write_tx.cursor_write::<CachedDataRoots>()?;
-        // Seed the cursor with a random data_root so MDBX seeks to the
-        // nearest key; without this, a stable backlog of CDRs protected by
-        // the pending-tx / local-proof exemptions re-scans from the front
-        // every cycle and starves later entries.  Mirrors the TODO at
-        // `prune_ingress_proofs` (~L696).  When the first walk runs out of
-        // entries without hitting `MAX_EVICTIONS_PER_RUN`, fall through to
-        // a second walk from the beginning so total coverage stays
-        // wrap-around-complete (otherwise tests + small tables with all
-        // keys above the random seek would silently scan zero entries).
-        let seek_key: DataRoot = H256::random();
-        let mut walker = cursor.walk(Some(seek_key))?;
-        let mut wrapped = false;
-        loop {
-            while let Some((data_root, cached)) = walker.next().transpose()? {
-                if eviction_count >= MAX_EVICTIONS_PER_RUN {
-                    warn!(
-                        evictions_performed = eviction_count,
-                        "Hit max eviction limit in prune_data_root_cache, will continue next cycle"
-                    );
-                    break;
-                }
-                // Pruning horizon priority: canonical tx inclusion > expiry height > evict-anomalous.
-                //
-                // CDR lifetime is bounded by either (a) `expiry_height` set at tx
-                // ingress (`cache_data_root_with_expiry`), or (b) the tx's
-                // `included_height`, written at migration by
-                // `BlockMigrationService::persist_block` (`write_data_ledger_metadata`).
-                // `expiry_height` is cleared earlier, at confirmation, by
-                // `persist_metadata` Phase 3 (`update_data_root_block_set`).  The
-                // local-proof exemption below extends (b) indefinitely while a
-                // local ingress proof is present.
-                //
-                // The `(None, None)` arm is reachable only when a CDR has lost
-                // both bounds: a reorg cleared `included_height` for every tx in
-                // `txid_set` after the confirmation already cleared
-                // `expiry_height`, and the mempool re-anchor path did not restore
-                // expiry (e.g. orphan resubmission failed).  Under the lifetime
-                // model such an entry should not exist, so treat it as a
-                // candidate for eviction — but keep the local-proof exemption so
-                // an entry that still carries a useful commitment survives.
-                let mut inclusion_max_height: Option<u64> = None;
-                let mut all_txs_confirmed = true;
-                for tx_id in cached.txid_set.iter() {
-                    match irys_database::get_data_tx_metadata(&write_tx, tx_id)?
-                        .and_then(|m| m.included_height)
-                    {
-                        Some(h) => {
-                            inclusion_max_height =
-                                Some(inclusion_max_height.map_or(h, |x| x.max(h)));
+        self.db
+            .update_eyre_at("cache_service.prune_data_root_cache", |write_tx| {
+                let mut cursor = write_tx.cursor_write::<CachedDataRoots>()?;
+                // Seed the cursor with a random data_root so MDBX seeks to the
+                // nearest key; without this, a stable backlog of CDRs protected by
+                // the pending-tx / local-proof exemptions re-scans from the front
+                // every cycle and starves later entries.  Mirrors the TODO at
+                // `prune_ingress_proofs` (~L696).  When the first walk runs out of
+                // entries without hitting `MAX_EVICTIONS_PER_RUN`, fall through to
+                // a second walk from the beginning so total coverage stays
+                // wrap-around-complete (otherwise tests + small tables with all
+                // keys above the random seek would silently scan zero entries).
+                let seek_key: DataRoot = H256::random();
+                let mut walker = cursor.walk(Some(seek_key))?;
+                let mut wrapped = false;
+                loop {
+                    while let Some((data_root, cached)) = walker.next().transpose()? {
+                        if eviction_count >= MAX_EVICTIONS_PER_RUN {
+                            warn!(
+                                evictions_performed = eviction_count,
+                                "Hit max eviction limit in prune_data_root_cache, will continue next cycle"
+                            );
+                            break;
                         }
-                        // No metadata row, or row exists with `included_height = None`:
-                        // this tx (sharing `data_root` with the rest of `txid_set`) is
-                        // still pending.  `inclusion_max_height` alone would prematurely
-                        // prune chunks the pending tx still needs — e.g. a Publish-
-                        // promotion sibling of an already-confirmed term-ledger tx that
-                        // shares the same `data_root`.
+                        // Pruning horizon priority: canonical tx inclusion > expiry height > evict-anomalous.
                         //
-                        // Once any tx is pending, the horizon below ignores
-                        // `inclusion_max_height` and defers to `expiry_height`, so
-                        // further metadata reads are wasted DB work inside the open
-                        // write tx.  Bail early.
-                        None => {
-                            all_txs_confirmed = false;
-                            break;
+                        // CDR lifetime is bounded by either (a) `expiry_height` set at tx
+                        // ingress (`cache_data_root_with_expiry`), or (b) the tx's
+                        // `included_height`, written at migration by
+                        // `BlockMigrationService::persist_block` (`write_data_ledger_metadata`).
+                        // `expiry_height` is cleared earlier, at confirmation, by
+                        // `persist_metadata` Phase 3 (`update_data_root_block_set`).  The
+                        // local-proof exemption below extends (b) indefinitely while a
+                        // local ingress proof is present.
+                        //
+                        // The `(None, None)` arm is reachable only when a CDR has lost
+                        // both bounds: a reorg cleared `included_height` for every tx in
+                        // `txid_set` after the confirmation already cleared
+                        // `expiry_height`, and the mempool re-anchor path did not restore
+                        // expiry (e.g. orphan resubmission failed).  Under the lifetime
+                        // model such an entry should not exist, so treat it as a
+                        // candidate for eviction — but keep the local-proof exemption so
+                        // an entry that still carries a useful commitment survives.
+                        let mut inclusion_max_height: Option<u64> = None;
+                        let mut all_txs_confirmed = true;
+                        for tx_id in cached.txid_set.iter() {
+                            match irys_database::get_data_tx_metadata(write_tx, tx_id)?
+                                .and_then(|m| m.included_height)
+                            {
+                                Some(h) => {
+                                    inclusion_max_height =
+                                        Some(inclusion_max_height.map_or(h, |x| x.max(h)));
+                                }
+                                // No metadata row, or row exists with `included_height = None`:
+                                // this tx (sharing `data_root` with the rest of `txid_set`) is
+                                // still pending.  `inclusion_max_height` alone would prematurely
+                                // prune chunks the pending tx still needs — e.g. a Publish-
+                                // promotion sibling of an already-confirmed term-ledger tx that
+                                // shares the same `data_root`.
+                                //
+                                // Once any tx is pending, the horizon below ignores
+                                // `inclusion_max_height` and defers to `expiry_height`, so
+                                // further metadata reads are wasted DB work inside the open
+                                // write tx.  Bail early.
+                                None => {
+                                    all_txs_confirmed = false;
+                                    break;
+                                }
+                            }
                         }
-                    }
-                }
 
-                // Horizon policy:
-                //  - All txs confirmed: use the latest `included_height` as the
-                //    boundary (falling back to `expiry_height`, then `(None, None)`
-                //    anomalous-eviction).
-                //  - Any tx still pending: defer to `expiry_height`.  An already-
-                //    confirmed sibling's `included_height` does NOT bind the
-                //    pending tx's chunk lifetime; using it as the horizon would
-                //    prematurely prune chunks the pending tx still needs.  If
-                //    expiry was already cleared by the sibling confirmation,
-                //    `horizon` is `None` and the eviction-candidate arm protects
-                //    the entry until the pending tx either confirms or is dropped
-                //    by mempool TTL.
-                let horizon = if all_txs_confirmed {
-                    match (inclusion_max_height, cached.expiry_height) {
-                        (Some(h), _) => Some(h),
-                        (None, Some(e)) => Some(e),
-                        (None, None) => None,
-                    }
-                } else {
-                    cached.expiry_height
-                };
+                        // Horizon policy:
+                        //  - All txs confirmed: use the latest `included_height` as the
+                        //    boundary (falling back to `expiry_height`, then `(None, None)`
+                        //    anomalous-eviction).
+                        //  - Any tx still pending: defer to `expiry_height`.  An already-
+                        //    confirmed sibling's `included_height` does NOT bind the
+                        //    pending tx's chunk lifetime; using it as the horizon would
+                        //    prematurely prune chunks the pending tx still needs.  If
+                        //    expiry was already cleared by the sibling confirmation,
+                        //    `horizon` is `None` and the eviction-candidate arm protects
+                        //    the entry until the pending tx either confirms or is dropped
+                        //    by mempool TTL.
+                        let horizon = if all_txs_confirmed {
+                            match (inclusion_max_height, cached.expiry_height) {
+                                (Some(h), _) => Some(h),
+                                (None, Some(e)) => Some(e),
+                                (None, None) => None,
+                            }
+                        } else {
+                            cached.expiry_height
+                        };
 
-                // Decide whether this entry is a candidate for eviction.
-                //  * horizon present: the historical "past the bound" check.
-                //  * horizon absent + all txs confirmed: truly anomalous state
-                //    (empty `txid_set`, or all txs confirmed-and-orphaned with
-                //    expiry already cleared) — evict unless the local-proof
-                //    exemption below applies.
-                //  * horizon absent + pending tx remains: protect (see horizon
-                //    policy above).
-                let is_eviction_candidate = match (horizon, all_txs_confirmed) {
-                    (Some(max_height), _) => max_height < prune_height,
-                    (None, true) => true,
-                    (None, false) => false,
-                };
+                        // Decide whether this entry is a candidate for eviction.
+                        //  * horizon present: the historical "past the bound" check.
+                        //  * horizon absent + all txs confirmed: truly anomalous state
+                        //    (empty `txid_set`, or all txs confirmed-and-orphaned with
+                        //    expiry already cleared) — evict unless the local-proof
+                        //    exemption below applies.
+                        //  * horizon absent + pending tx remains: protect (see horizon
+                        //    policy above).
+                        let is_eviction_candidate = match (horizon, all_txs_confirmed) {
+                            (Some(max_height), _) => max_height < prune_height,
+                            (None, true) => true,
+                            (None, false) => false,
+                        };
 
-                trace!(
-                    data_root.data_root = ?data_root,
-                    horizon = ?horizon,
-                    prune_height,
-                    is_eviction_candidate,
-                    "Processing data root for prune evaluation"
-                );
-
-                if is_eviction_candidate {
-                    // Check for locally generated ingress proof
-                    let mut proofs_cursor = write_tx.cursor_read::<IngressProofs>()?;
-                    let mut has_local_proof = false;
-                    let mut proof_walker = proofs_cursor.walk(Some(data_root))?;
-                    while let Some((key, compact)) = proof_walker.next().transpose()? {
-                        if key != data_root {
-                            break;
-                        }
-                        if compact.0.address == local_addr {
-                            has_local_proof = true;
-                            break;
-                        }
-                    }
-
-                    if has_local_proof {
                         trace!(
                             data_root.data_root = ?data_root,
                             horizon = ?horizon,
-                            "Skipping prune for data root with locally generated ingress proof"
+                            prune_height,
+                            is_eviction_candidate,
+                            "Processing data root for prune evaluation"
                         );
-                        continue;
+
+                        if is_eviction_candidate {
+                            // Check for locally generated ingress proof
+                            let mut proofs_cursor = write_tx.cursor_read::<IngressProofs>()?;
+                            let mut has_local_proof = false;
+                            let mut proof_walker = proofs_cursor.walk(Some(data_root))?;
+                            while let Some((key, compact)) = proof_walker.next().transpose()? {
+                                if key != data_root {
+                                    break;
+                                }
+                                if compact.0.address == local_addr {
+                                    has_local_proof = true;
+                                    break;
+                                }
+                            }
+
+                            if has_local_proof {
+                                trace!(
+                                    data_root.data_root = ?data_root,
+                                    horizon = ?horizon,
+                                    "Skipping prune for data root with locally generated ingress proof"
+                                );
+                                continue;
+                            }
+
+                            // Capture txid_set_size before `cached` is partially moved below.
+                            let txid_set_size = cached.txid_set.len();
+                            let expiry_height = cached.expiry_height;
+
+                            write_tx.delete::<IngressProofs>(data_root, None)?;
+                            chunks_pruned = chunks_pruned.saturating_add(
+                                delete_cached_chunks_by_data_root(write_tx, data_root)?,
+                            );
+                            write_tx.delete::<CachedDataRoots>(data_root, None)?;
+                            eviction_count += 1;
+
+                            evictions.push(EvictionRecord {
+                                data_root,
+                                block_set: cached.block_set,
+                                txid_set_size,
+                                inclusion_max_height,
+                                expiry_height,
+                                horizon,
+                            });
+                        }
                     }
-
-                    // Capture txid_set_size before `cached` is partially moved below.
-                    let txid_set_size = cached.txid_set.len();
-                    let expiry_height = cached.expiry_height;
-
-                    write_tx.delete::<IngressProofs>(data_root, None)?;
-                    chunks_pruned = chunks_pruned
-                        .saturating_add(delete_cached_chunks_by_data_root(&write_tx, data_root)?);
-                    write_tx.delete::<CachedDataRoots>(data_root, None)?;
-                    eviction_count += 1;
-
-                    evictions.push(EvictionRecord {
-                        data_root,
-                        block_set: cached.block_set,
-                        txid_set_size,
-                        inclusion_max_height,
-                        expiry_height,
-                        horizon,
-                    });
+                    if wrapped || eviction_count >= MAX_EVICTIONS_PER_RUN {
+                        break;
+                    }
+                    // First walk ran from `Some(seek_key)` to end without hitting the
+                    // eviction cap.  Wrap around and scan the prefix `[start,
+                    // seek_key)` so coverage is complete.  Without this fall-through
+                    // a small table whose keys all sort above `seek_key` would
+                    // silently scan zero entries this cycle.
+                    wrapped = true;
+                    walker = cursor.walk(None)?;
                 }
-            }
-            if wrapped || eviction_count >= MAX_EVICTIONS_PER_RUN {
-                break;
-            }
-            // First walk ran from `Some(seek_key)` to end without hitting the
-            // eviction cap.  Wrap around and scan the prefix `[start,
-            // seek_key)` so coverage is complete.  Without this fall-through
-            // a small table whose keys all sort above `seek_key` would
-            // silently scan zero entries this cycle.
-            wrapped = true;
-            walker = cursor.walk(None)?;
-        }
-        write_tx.commit()?;
+                Ok(())
+            })?;
 
         // Post-commit: only now is it safe to report what actually persisted.
         // `has_local_proof` is hardcoded false because the eviction branch
@@ -3198,12 +3185,14 @@ mod tests {
                 .block_hash()
         };
 
-        // Hold the global MDBX writer lock so the scrub blocks inside
-        // `update_eyre` before it can read the tree.
+        // Hold the consensus writer gate + MDBX RW tx so the scrub parks inside
+        // `update_eyre` (on the gate, then the env lock) before it can read the tree.
+        // Locals drop in reverse order: MDBX first, then the gate.
+        let gate = irys_database::db::lock_consensus_writer_gate("test.spares_txid_blocker");
         let blocker = db.tx_mut()?;
 
         // Queue tx_x for removal and run the scrub on another thread; with the
-        // fix it parks on the writer lock this thread holds, ahead of the tree read.
+        // fix it parks on the writer path this thread holds, ahead of the tree read.
         let task_thread = task.clone();
         let by: HashMap<H256, Vec<H256>> = HashMap::from([(data_root, vec![tx_x])]);
         let handle =
@@ -3243,9 +3232,10 @@ mod tests {
             .expect("add canonical child");
         }
 
-        // Release the writer lock; the scrub proceeds and reads the tree (now
+        // Release MDBX then the gate; the scrub proceeds and reads the tree (now
         // carrying tx_x) inside its own write txn.
         drop(blocker);
+        drop(gate);
 
         handle.join().expect("prune thread panicked")?;
 

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -501,6 +501,10 @@ impl InnerCacheTask {
             let mut wrapped = false;
             loop {
                 while let Some((data_root, cached)) = walker.next().transpose()? {
+                    // The wrap stops at the seek key so no root is visited twice.
+                    if wrapped && data_root >= seek_key {
+                        break;
+                    }
                     if candidates.len() >= MAX_EVICTIONS_PER_RUN {
                         warn!(
                             candidates = candidates.len(),

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -309,58 +309,58 @@ impl InnerCacheTask {
         let delete_chunks_older_than =
             UnixTimestamp::from_secs(now.saturating_sub(min_chunk_age_secs));
 
-        let tx = self.db.tx()?;
+        // Scan candidates under a short-lived read txn, then drop it before any
+        // gated write (same shape as `prune_ingress_proofs`): holding a RO txn
+        // across consensus-writer-gate waits pins MVCC free-page reclamation.
+        let mut candidates: Vec<DataRoot> = Vec::new();
+        {
+            let tx = self.db.tx()?;
+            let mut cdr_cursor = tx.cursor_read::<CachedDataRoots>()?;
+            let mut cdr_walk = cdr_cursor.walk(None)?;
 
-        // Collect candidate data roots from CachedDataRoots
-        let mut cdr_cursor = tx.cursor_read::<CachedDataRoots>()?;
-        let mut cdr_walk = cdr_cursor.walk(None)?;
+            // Cap candidates so the write phase cannot exceed MAX_EVICTIONS_PER_RUN.
+            // TODO: try to deprioritise data_roots that almost have all their chunks.
+            while let Some((data_root, _cached)) = cdr_walk.next().transpose()? {
+                if candidates.len() >= MAX_EVICTIONS_PER_RUN {
+                    warn!(
+                        chunk.candidates = candidates.len(),
+                        "Hit max eviction limit collecting prune candidates, will continue next cycle"
+                    );
+                    break;
+                }
 
-        // Limit total evictions to avoid long pauses
+                if self.ingress_proof_generation_state.is_generating(data_root) {
+                    debug!(ingress_proof.data_root = ?data_root, "Skipping chunk prune due to active proof generation");
+                    continue;
+                }
+
+                let mut proofs_cursor = tx.cursor_read::<IngressProofs>()?;
+                let mut has_any_local_proof = false;
+                let mut walker = proofs_cursor.walk(Some(data_root))?;
+                while let Some((key, compact)) = walker.next().transpose()? {
+                    if key != data_root {
+                        break;
+                    }
+                    if compact.0.address == local_address {
+                        has_any_local_proof = true;
+                        break;
+                    }
+                }
+
+                if !has_any_local_proof {
+                    candidates.push(data_root);
+                }
+            }
+            drop(cdr_walk);
+            drop(cdr_cursor);
+            drop(tx);
+        }
+
         let mut evictions_performed: usize = 0;
-
-        // We'll do deletions in a write tx per batch to keep lock times short
-        let mut pending_roots: Vec<DataRoot> = Vec::new();
-
-        // TODO: try to deprioritise data_roots that almost have all their chunks, as we want as many full data_roots as possible so we can provide proofs
-        while let Some((data_root, _cached)) = cdr_walk.next().transpose()? {
-            if evictions_performed >= MAX_EVICTIONS_PER_RUN {
-                warn!(
-                    chunk.evictions_performed = evictions_performed,
-                    "Hit max eviction limit in prune_chunks_without_active_ingress_proofs, will continue next cycle"
-                );
-                break;
-            }
-
-            // Skip if an ingress proof is actively being generated for this root
-            if self.ingress_proof_generation_state.is_generating(data_root) {
-                debug!(ingress_proof.data_root = ?data_root, "Skipping chunk prune due to active proof generation");
-                continue;
-            }
-
-            // Presence of at least one proof indicates the data root is active
-            let mut proofs_cursor = tx.cursor_read::<IngressProofs>()?;
-            let mut has_any_local_proof = false;
-            let mut walker = proofs_cursor.walk(Some(data_root))?;
-            while let Some((key, compact)) = walker.next().transpose()? {
-                // Walked all records for this data root
-                if key != data_root {
-                    break;
-                }
-                // Found at least one proof, mark as active
-                if compact.0.address == local_address {
-                    has_any_local_proof = true;
-                    break;
-                }
-            }
-
-            if !has_any_local_proof {
-                pending_roots.push(data_root);
-            }
-
-            // Commit a small batch to avoid large transactions
-            if pending_roots.len() >= 256 {
-                self.db.update_eyre_at("cache_service.prune_chunks_batch", |write_tx| {
-                    for root in pending_roots.drain(..) {
+        for batch in candidates.chunks(256) {
+            self.db
+                .update_eyre_at("cache_service.prune_chunks_batch", |write_tx| {
+                    for &root in batch {
                         trace!(
                             chunk.data_root = ?root,
                             "Pruning chunks for data root without active proofs"
@@ -372,30 +372,11 @@ impl InnerCacheTask {
                         )?;
                         if pruned > 0 {
                             evictions_performed = evictions_performed.saturating_add(1);
-                            debug!(chunk.data_root = ?root, chunk.pruined_chunks = pruned, "Pruned chunks for data root without active proofs");
+                            debug!(chunk.data_root = ?root, chunk.pruned_chunks = pruned, "Pruned chunks for data root without active proofs");
                         }
                     }
                     Ok(())
                 })?;
-            }
-        }
-
-        // Flush any remaining pending deletions
-        if !pending_roots.is_empty() {
-            self.db.update_eyre_at("cache_service.prune_chunks_flush", |write_tx| {
-                for root in pending_roots.drain(..) {
-                    let pruned = delete_cached_chunks_by_data_root_older_than(
-                        write_tx,
-                        root,
-                        delete_chunks_older_than,
-                    )?;
-                    if pruned > 0 {
-                        evictions_performed = evictions_performed.saturating_add(1);
-                        debug!(chunk.data_root = ?root, chunk.pruned_chunks = pruned, "Pruned chunks for data root without active proofs");
-                    }
-                }
-                Ok(())
-            })?;
         }
 
         info!(
@@ -411,6 +392,7 @@ impl InnerCacheTask {
         // emitted only after `commit()` succeeds — otherwise a failed commit
         // (or a mid-loop delete error that drops the tx) would report
         // evictions/chunks that never persisted.
+        #[derive(Clone)]
         struct EvictionRecord {
             data_root: H256,
             block_set: Vec<H256>,
@@ -422,187 +404,127 @@ impl InnerCacheTask {
 
         let signer = self.config.irys_signer();
         let local_addr = signer.address();
-        let mut chunks_pruned: u64 = 0;
-        let mut eviction_count: usize = 0;
-        let mut evictions: Vec<EvictionRecord> = Vec::new();
-        self.db
-            .update_eyre_at("cache_service.prune_data_root_cache", |write_tx| {
-                let mut cursor = write_tx.cursor_write::<CachedDataRoots>()?;
-                // Seed the cursor with a random data_root so MDBX seeks to the
-                // nearest key; without this, a stable backlog of CDRs protected by
-                // the pending-tx / local-proof exemptions re-scans from the front
-                // every cycle and starves later entries.  Mirrors the TODO at
-                // `prune_ingress_proofs` (~L696).  When the first walk runs out of
-                // entries without hitting `MAX_EVICTIONS_PER_RUN`, fall through to
-                // a second walk from the beginning so total coverage stays
-                // wrap-around-complete (otherwise tests + small tables with all
-                // keys above the random seek would silently scan zero entries).
-                let seek_key: DataRoot = H256::random();
-                let mut walker = cursor.walk(Some(seek_key))?;
-                let mut wrapped = false;
-                loop {
-                    while let Some((data_root, cached)) = walker.next().transpose()? {
-                        if eviction_count >= MAX_EVICTIONS_PER_RUN {
-                            warn!(
-                                evictions_performed = eviction_count,
-                                "Hit max eviction limit in prune_data_root_cache, will continue next cycle"
-                            );
-                            break;
-                        }
-                        // Pruning horizon priority: canonical tx inclusion > expiry height > evict-anomalous.
-                        //
-                        // CDR lifetime is bounded by either (a) `expiry_height` set at tx
-                        // ingress (`cache_data_root_with_expiry`), or (b) the tx's
-                        // `included_height`, written at migration by
-                        // `BlockMigrationService::persist_block` (`write_data_ledger_metadata`).
-                        // `expiry_height` is cleared earlier, at confirmation, by
-                        // `persist_metadata` Phase 3 (`update_data_root_block_set`).  The
-                        // local-proof exemption below extends (b) indefinitely while a
-                        // local ingress proof is present.
-                        //
-                        // The `(None, None)` arm is reachable only when a CDR has lost
-                        // both bounds: a reorg cleared `included_height` for every tx in
-                        // `txid_set` after the confirmation already cleared
-                        // `expiry_height`, and the mempool re-anchor path did not restore
-                        // expiry (e.g. orphan resubmission failed).  Under the lifetime
-                        // model such an entry should not exist, so treat it as a
-                        // candidate for eviction — but keep the local-proof exemption so
-                        // an entry that still carries a useful commitment survives.
-                        let mut inclusion_max_height: Option<u64> = None;
-                        let mut all_txs_confirmed = true;
-                        for tx_id in cached.txid_set.iter() {
-                            match irys_database::get_data_tx_metadata(write_tx, tx_id)?
-                                .and_then(|m| m.included_height)
-                            {
-                                Some(h) => {
-                                    inclusion_max_height =
-                                        Some(inclusion_max_height.map_or(h, |x| x.max(h)));
-                                }
-                                // No metadata row, or row exists with `included_height = None`:
-                                // this tx (sharing `data_root` with the rest of `txid_set`) is
-                                // still pending.  `inclusion_max_height` alone would prematurely
-                                // prune chunks the pending tx still needs — e.g. a Publish-
-                                // promotion sibling of an already-confirmed term-ledger tx that
-                                // shares the same `data_root`.
-                                //
-                                // Once any tx is pending, the horizon below ignores
-                                // `inclusion_max_height` and defers to `expiry_height`, so
-                                // further metadata reads are wasted DB work inside the open
-                                // write tx.  Bail early.
-                                None => {
-                                    all_txs_confirmed = false;
-                                    break;
-                                }
-                            }
-                        }
 
-                        // Horizon policy:
-                        //  - All txs confirmed: use the latest `included_height` as the
-                        //    boundary (falling back to `expiry_height`, then `(None, None)`
-                        //    anomalous-eviction).
-                        //  - Any tx still pending: defer to `expiry_height`.  An already-
-                        //    confirmed sibling's `included_height` does NOT bind the
-                        //    pending tx's chunk lifetime; using it as the horizon would
-                        //    prematurely prune chunks the pending tx still needs.  If
-                        //    expiry was already cleared by the sibling confirmation,
-                        //    `horizon` is `None` and the eviction-candidate arm protects
-                        //    the entry until the pending tx either confirms or is dropped
-                        //    by mempool TTL.
-                        let horizon = if all_txs_confirmed {
-                            match (inclusion_max_height, cached.expiry_height) {
-                                (Some(h), _) => Some(h),
-                                (None, Some(e)) => Some(e),
-                                (None, None) => None,
-                            }
-                        } else {
-                            cached.expiry_height
-                        };
-
-                        // Decide whether this entry is a candidate for eviction.
-                        //  * horizon present: the historical "past the bound" check.
-                        //  * horizon absent + all txs confirmed: truly anomalous state
-                        //    (empty `txid_set`, or all txs confirmed-and-orphaned with
-                        //    expiry already cleared) — evict unless the local-proof
-                        //    exemption below applies.
-                        //  * horizon absent + pending tx remains: protect (see horizon
-                        //    policy above).
-                        let is_eviction_candidate = match (horizon, all_txs_confirmed) {
-                            (Some(max_height), _) => max_height < prune_height,
-                            (None, true) => true,
-                            (None, false) => false,
-                        };
-
-                        trace!(
-                            data_root.data_root = ?data_root,
-                            horizon = ?horizon,
-                            prune_height,
-                            is_eviction_candidate,
-                            "Processing data root for prune evaluation"
+        // Collect eviction candidates under a short RO txn (random seek + wraparound),
+        // then apply deletes in gated write batches so the consensus writer gate is
+        // released between batches rather than held for the whole table scan.
+        let mut candidates: Vec<EvictionRecord> = Vec::new();
+        {
+            let tx = self.db.tx()?;
+            let mut cursor = tx.cursor_read::<CachedDataRoots>()?;
+            let seek_key: DataRoot = H256::random();
+            let mut walker = cursor.walk(Some(seek_key))?;
+            let mut wrapped = false;
+            loop {
+                while let Some((data_root, cached)) = walker.next().transpose()? {
+                    if candidates.len() >= MAX_EVICTIONS_PER_RUN {
+                        warn!(
+                            candidates = candidates.len(),
+                            "Hit max eviction limit collecting prune_data_root_cache candidates, will continue next cycle"
                         );
-
-                        if is_eviction_candidate {
-                            // Check for locally generated ingress proof
-                            let mut proofs_cursor = write_tx.cursor_read::<IngressProofs>()?;
-                            let mut has_local_proof = false;
-                            let mut proof_walker = proofs_cursor.walk(Some(data_root))?;
-                            while let Some((key, compact)) = proof_walker.next().transpose()? {
-                                if key != data_root {
-                                    break;
-                                }
-                                if compact.0.address == local_addr {
-                                    has_local_proof = true;
-                                    break;
-                                }
-                            }
-
-                            if has_local_proof {
-                                trace!(
-                                    data_root.data_root = ?data_root,
-                                    horizon = ?horizon,
-                                    "Skipping prune for data root with locally generated ingress proof"
-                                );
-                                continue;
-                            }
-
-                            // Capture txid_set_size before `cached` is partially moved below.
-                            let txid_set_size = cached.txid_set.len();
-                            let expiry_height = cached.expiry_height;
-
-                            write_tx.delete::<IngressProofs>(data_root, None)?;
-                            chunks_pruned = chunks_pruned.saturating_add(
-                                delete_cached_chunks_by_data_root(write_tx, data_root)?,
-                            );
-                            write_tx.delete::<CachedDataRoots>(data_root, None)?;
-                            eviction_count += 1;
-
-                            evictions.push(EvictionRecord {
-                                data_root,
-                                block_set: cached.block_set,
-                                txid_set_size,
-                                inclusion_max_height,
-                                expiry_height,
-                                horizon,
-                            });
-                        }
-                    }
-                    if wrapped || eviction_count >= MAX_EVICTIONS_PER_RUN {
                         break;
                     }
-                    // First walk ran from `Some(seek_key)` to end without hitting the
-                    // eviction cap.  Wrap around and scan the prefix `[start,
-                    // seek_key)` so coverage is complete.  Without this fall-through
-                    // a small table whose keys all sort above `seek_key` would
-                    // silently scan zero entries this cycle.
-                    wrapped = true;
-                    walker = cursor.walk(None)?;
-                }
-                Ok(())
-            })?;
 
-        // Post-commit: only now is it safe to report what actually persisted.
-        // `has_local_proof` is hardcoded false because the eviction branch
-        // `continue`s on `has_local_proof == true` before reaching this buffer.
-        for entry in &evictions {
+                    let mut inclusion_max_height: Option<u64> = None;
+                    let mut all_txs_confirmed = true;
+                    for tx_id in cached.txid_set.iter() {
+                        match irys_database::get_data_tx_metadata(&tx, tx_id)?
+                            .and_then(|m| m.included_height)
+                        {
+                            Some(h) => {
+                                inclusion_max_height =
+                                    Some(inclusion_max_height.map_or(h, |x| x.max(h)));
+                            }
+                            None => {
+                                all_txs_confirmed = false;
+                                break;
+                            }
+                        }
+                    }
+
+                    let horizon = if all_txs_confirmed {
+                        match (inclusion_max_height, cached.expiry_height) {
+                            (Some(h), _) => Some(h),
+                            (None, Some(e)) => Some(e),
+                            (None, None) => None,
+                        }
+                    } else {
+                        cached.expiry_height
+                    };
+
+                    let is_eviction_candidate = match (horizon, all_txs_confirmed) {
+                        (Some(max_height), _) => max_height < prune_height,
+                        (None, true) => true,
+                        (None, false) => false,
+                    };
+
+                    if !is_eviction_candidate {
+                        continue;
+                    }
+
+                    let mut proofs_cursor = tx.cursor_read::<IngressProofs>()?;
+                    let mut has_local_proof = false;
+                    let mut proof_walker = proofs_cursor.walk(Some(data_root))?;
+                    while let Some((key, compact)) = proof_walker.next().transpose()? {
+                        if key != data_root {
+                            break;
+                        }
+                        if compact.0.address == local_addr {
+                            has_local_proof = true;
+                            break;
+                        }
+                    }
+                    if has_local_proof {
+                        continue;
+                    }
+
+                    candidates.push(EvictionRecord {
+                        data_root,
+                        block_set: cached.block_set,
+                        txid_set_size: cached.txid_set.len(),
+                        inclusion_max_height,
+                        expiry_height: cached.expiry_height,
+                        horizon,
+                    });
+                }
+                if wrapped || candidates.len() >= MAX_EVICTIONS_PER_RUN {
+                    break;
+                }
+                wrapped = true;
+                walker = cursor.walk(None)?;
+            }
+            drop(walker);
+            drop(cursor);
+            drop(tx);
+        }
+
+        let mut chunks_pruned: u64 = 0;
+        let mut applied: Vec<EvictionRecord> = Vec::new();
+        for batch in candidates.chunks(256) {
+            let mut batch_applied: Vec<EvictionRecord> = Vec::new();
+            let mut batch_chunks: u64 = 0;
+            self.db
+                .update_eyre_at("cache_service.prune_data_root_cache", |write_tx| {
+                    for rec in batch {
+                        // Re-check presence: root may have been re-cached since the scan.
+                        if write_tx.get::<CachedDataRoots>(rec.data_root)?.is_none() {
+                            continue;
+                        }
+                        write_tx.delete::<IngressProofs>(rec.data_root, None)?;
+                        batch_chunks = batch_chunks.saturating_add(
+                            delete_cached_chunks_by_data_root(write_tx, rec.data_root)?,
+                        );
+                        write_tx.delete::<CachedDataRoots>(rec.data_root, None)?;
+                        batch_applied.push(rec.clone()); // clone: log after commit outside txn
+                    }
+                    Ok(())
+                })?;
+            chunks_pruned = chunks_pruned.saturating_add(batch_chunks);
+            applied.extend(batch_applied);
+        }
+
+        // Post-commit: only report what actually persisted in a committed write batch.
+        for entry in &applied {
             info!(
                 data_root = %entry.data_root,
                 block_set_size = entry.block_set.len(),

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -294,11 +294,6 @@ impl InnerCacheTask {
         Ok(())
     }
 
-    /// Prunes cached chunks for data roots that have no ingress proofs.
-    /// Since `prune_ingress_proofs()` runs immediately before this and removes
-    /// expired/invalid proofs, any remaining proof entry is treated as active.
-    /// Data roots currently undergoing proof generation are skipped to avoid races.
-    #[tracing::instrument(level = "trace", skip_all)]
     /// True when this node's own ingress proof for `data_root` is present.
     /// Shared by the scan and write phases of both prune passes so the
     /// local-proof exemption cannot diverge between collect-time and
@@ -364,6 +359,11 @@ impl InnerCacheTask {
         })
     }
 
+    /// Prunes cached chunks for data roots that have no ingress proofs.
+    /// Since `prune_ingress_proofs()` runs immediately before this and removes
+    /// expired/invalid proofs, any remaining proof entry is treated as active.
+    /// Data roots currently undergoing proof generation are skipped to avoid races.
+    #[tracing::instrument(level = "trace", skip_all)]
     fn prune_chunks_without_active_ingress_proofs(&self) -> eyre::Result<()> {
         let local_address = self.config.irys_signer().address();
         let min_chunk_age_in_blocks = self

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -390,7 +390,11 @@ impl InnerCacheTask {
             let mut cdr_cursor = tx.cursor_read::<CachedDataRoots>()?;
             let mut cdr_walk = cdr_cursor.walk(None)?;
 
-            // Cap candidates so the write phase cannot exceed MAX_EVICTIONS_PER_RUN.
+            // Cap is on candidates collected (read-phase), not on roots that
+            // actually prune chunks in the write phase. A stable set of
+            // non-yielding candidates early in hash order can consume the
+            // budget and starve later prunable roots (hash-order scan, no
+            // wraparound). Count is work attempted, not work applied.
             // TODO: try to deprioritise data_roots that almost have all their chunks.
             while let Some((data_root, _cached)) = cdr_walk.next().transpose()? {
                 if candidates.len() >= MAX_EVICTIONS_PER_RUN {

--- a/crates/actors/src/services.rs
+++ b/crates/actors/src/services.rs
@@ -4,9 +4,7 @@ use crate::{
     DataSyncServiceMessage, StorageModuleServiceMessage,
     block_discovery::BlockDiscoveryMessage,
     block_producer::BlockProducerCommand,
-    block_tree_service::{
-        BlockStateUpdated, BlockStreamSignal, BlockTreeServiceMessage, ReorgEvent,
-    },
+    block_tree_service::{BlockStateUpdated, BlockTreeServiceMessage, ReorgEvent},
     cache_service::CacheServiceAction,
     chunk_migration_service::ChunkMigrationServiceMessage,
     mempool_service::MempoolServiceMessage,
@@ -110,7 +108,7 @@ pub struct ServiceReceivers {
     pub peer_events: broadcast::Receiver<PeerEvent>,
     pub peer_network: UnboundedReceiver<PeerNetworkServiceMessage>,
     pub block_discovery: UnboundedReceiver<Traced<BlockDiscoveryMessage>>,
-    pub block_stream: UnboundedReceiver<BlockStreamSignal>,
+    pub block_stream: UnboundedReceiver<Arc<irys_types::block_stream::StreamFrame>>,
     pub packing: tokio::sync::mpsc::Receiver<PackingRequest>,
 }
 
@@ -140,7 +138,7 @@ pub struct ServiceSendersInner {
     pub peer_events: broadcast::Sender<PeerEvent>,
     pub peer_network: PeerNetworkSender,
     pub block_discovery: UnboundedSender<Traced<BlockDiscoveryMessage>>,
-    pub block_stream: UnboundedSender<BlockStreamSignal>,
+    pub block_stream: UnboundedSender<Arc<irys_types::block_stream::StreamFrame>>,
     pub mining_bus: MiningBus,
     pub packing_sender: PackingSender,
 }
@@ -177,7 +175,8 @@ impl ServiceSendersInner {
         let (peer_network_sender, peer_network_receiver) = tokio::sync::mpsc::unbounded_channel();
         let (block_discovery_sender, block_discovery_receiver) =
             unbounded_channel::<Traced<BlockDiscoveryMessage>>();
-        let (block_stream_sender, block_stream_receiver) = unbounded_channel::<BlockStreamSignal>();
+        let (block_stream_sender, block_stream_receiver) =
+            unbounded_channel::<Arc<irys_types::block_stream::StreamFrame>>();
         let (packing_sender, packing_receiver) = PackingService::channel(5_000);
 
         let mining_bus = MiningBus::new();

--- a/crates/api-server/src/routes/internal/mod.rs
+++ b/crates/api-server/src/routes/internal/mod.rs
@@ -6,10 +6,11 @@
 //! matched as a literal segment rather than captured as a height.
 //!
 //! SECURITY: these endpoints carry no application-layer authentication. They are mounted only when
-//! `http.expose_internal_api` is set (off by default); when enabled they ride the same HTTP listener
-//! as the public API. They expose internal block data and a long-lived SSE stream, so a deployment
-//! that enables them MUST restrict `/internal/*` at the network layer (firewall / reverse proxy /
-//! bind address) to the trusted gateway.
+//! `http.expose_internal_api` is set (off by default); that same flag also starts the durable
+//! block-stream producer that writes the seq log these routes read. When enabled they ride the
+//! same HTTP listener as the public API. They expose internal block data and a long-lived SSE
+//! stream, so a deployment that enables them MUST restrict `/internal/*` at the network layer
+//! (firewall / reverse proxy / bind address) to the trusted gateway.
 
 use crate::ApiState;
 use crate::error::ApiError;
@@ -71,9 +72,14 @@ async fn blocks_stream(
             // through to the live tail (that would push a seq gap onto the wire).
             return;
         }
-        // Live tail [end, ..). `recv` yields `None` when the producer halts and drops the sender, ending
-        // the SSE cleanly after replay.
+        // Live tail [end, ..). `recv` yields `None` when the producer halts and drops the sender,
+        // ending the SSE cleanly after replay. Skip `seq < end`: Phase 4 fans out frames that were
+        // already durable when `subscribe` snapped `end`, so a late registration can see them both
+        // in replay and on the live channel — drop the live duplicates.
         while let Some(frame) = live.recv().await {
+            if frame.seq < end {
+                continue;
+            }
             yield sse_bytes(&frame)?;
         }
     };

--- a/crates/api-server/src/routes/internal/mod.rs
+++ b/crates/api-server/src/routes/internal/mod.rs
@@ -73,13 +73,9 @@ async fn blocks_stream(
             return;
         }
         // Live tail [end, ..). `recv` yields `None` when the producer halts and drops the sender,
-        // ending the SSE cleanly after replay. Skip `seq < end`: Phase 4 fans out frames that were
-        // already durable when `subscribe` snapped `end`, so a late registration can see them both
-        // in replay and on the live channel — drop the live duplicates.
+        // ending the SSE cleanly after replay. The handle skips live delivery of frames with
+        // `seq < end` (already covered by the durable replay snapshot).
         while let Some(frame) = live.recv().await {
-            if frame.seq < end {
-                continue;
-            }
             yield sse_bytes(&frame)?;
         }
     };

--- a/crates/chain-tests/src/integration/block_stream.rs
+++ b/crates/chain-tests/src/integration/block_stream.rs
@@ -180,9 +180,9 @@ async fn finalized_emitted_on_migration() -> eyre::Result<()> {
     Ok(())
 }
 
-/// Phase 2 ordering pin: for a given block, `observed` (Confirmed) is assigned a lower durable
-/// `seq` than `finalized` (migration), even though migrate runs before Confirmed is sent on the
-/// tip-advance path (Confirmed is for the tip; Finalized is for the older migration-depth block).
+/// Durable-seq ordering pin: for a given block, the confirmation txn assigns `observed` a lower
+/// `seq` than the later migration txn assigns `finalized` — confirmation always precedes that
+/// block's migration by at least `block_migration_depth` blocks.
 #[test_log::test(tokio::test)]
 async fn observed_seq_precedes_finalized_for_same_block() -> eyre::Result<()> {
     let mut node = IrysNodeTest::default_async();

--- a/crates/chain-tests/src/integration/block_stream.rs
+++ b/crates/chain-tests/src/integration/block_stream.rs
@@ -180,6 +180,43 @@ async fn finalized_emitted_on_migration() -> eyre::Result<()> {
     Ok(())
 }
 
+/// Phase 2 ordering pin: for a given block, `observed` (Confirmed) is assigned a lower durable
+/// `seq` than `finalized` (migration), even though migrate runs before Confirmed is sent on the
+/// tip-advance path (Confirmed is for the tip; Finalized is for the older migration-depth block).
+#[test_log::test(tokio::test)]
+async fn observed_seq_precedes_finalized_for_same_block() -> eyre::Result<()> {
+    let mut node = IrysNodeTest::default_async();
+    node.cfg.consensus.get_mut().block_migration_depth = 2;
+    let node = node.start().await;
+    let handle = node.node_ctx.block_stream_handle.clone();
+    let (_, _, mut live) = handle.subscribe(0)?;
+
+    let blk = node.mine_block().await?;
+    node.wait_until_height(blk.height, 10).await?;
+
+    let observed = next_frame_for(&mut live, |f| {
+        f.kind() == "observed" && f.block_hash() == Some(blk.block_hash)
+    })
+    .await?;
+
+    node.mine_blocks(3).await?;
+    node.wait_until_block_index_height(blk.height, 30).await?;
+
+    let finalized = next_frame_for(&mut live, |f| {
+        f.kind() == "finalized" && f.block_hash() == Some(blk.block_hash)
+    })
+    .await?;
+
+    assert!(
+        observed.seq < finalized.seq,
+        "Confirmed/observed must precede Finalized for the same block: observed.seq={}, finalized.seq={}",
+        observed.seq,
+        finalized.seq
+    );
+
+    Ok(())
+}
+
 #[test_log::test(tokio::test)]
 async fn internal_reads_by_height_and_range() -> eyre::Result<()> {
     let mut node = IrysNodeTest::default_async();

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -1801,6 +1801,9 @@ impl IrysNode {
             Arc::clone(&block_tree_cache),
             service_senders.chunk_migration.clone(),
             service_senders.packing_sender(),
+            // Same gate as `/internal/*` and the durable producer: skip the
+            // 10k-entry de-dup seed when the stream is not written.
+            config.node_config.http.expose_internal_api,
         );
 
         // Create the VDF state before the block tree service: its re-anchor

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -33,7 +33,7 @@ use irys_actors::{
 use irys_api_server::{API_VERSION, ApiState, create_listener, run_server};
 use irys_config::submodules::StorageSubmodulesConfig;
 use irys_database::database;
-use irys_database::db::RethDbWrapper;
+use irys_database::db::{IrysDatabaseExt as _, RethDbWrapper};
 use irys_domain::chain_sync_state::ChainSyncState;
 use irys_domain::forkchoice_markers::ForkChoiceMarkers;
 use irys_domain::{
@@ -73,7 +73,7 @@ use reth::{
     chainspec::ChainSpec,
     tasks::{RuntimeBuilder, RuntimeConfig, TaskExecutor, TokioConfig},
 };
-use reth_db::{Database as _, transaction::DbTx as _};
+use reth_db::Database as _;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 use std::{
@@ -89,7 +89,7 @@ use tokio::{
     },
 };
 use tokio_util::sync::CancellationToken;
-use tracing::{Instrument as _, debug, error, info, info_span, instrument, warn};
+use tracing::{Instrument as _, debug, error, info, instrument, warn};
 
 #[derive(Debug, Clone)]
 pub struct IrysNodeCtx {
@@ -108,8 +108,8 @@ pub struct IrysNodeCtx {
     pub mempool_guard: MempoolReadGuard,
     pub vdf_steps_guard: VdfStateReadonly,
     pub service_senders: ServiceSenders,
-    /// Shared handle to the block-stream producer; cloned into [`ApiState`] so the `/internal`
-    /// SSE handlers can call `subscribe(from_seq)`.
+    /// Shared block-stream handle; live producer when `http.expose_internal_api`, else
+    /// [`BlockStreamHandle::disabled`]. Cloned into [`ApiState`] for `/internal` SSE handlers.
     pub block_stream_handle: Arc<irys_actors::block_stream_service::BlockStreamHandle>,
     pub partition_controllers: Vec<PartitionMiningController>,
     pub packing_waiter: irys_actors::packing_service::PackingIdleWaiter,
@@ -782,38 +782,25 @@ impl IrysNode {
             // Continue even if saving to disk fails - not critical
         }
 
-        // Open a database transaction. Span attributes any libmdbx writer-lock
-        // stall warning fired during begin_rw_txn to
-        // libmdbx_rw_tx_lock_stalls_total{scope="irys-consensus"}
-        // (see crates/utils/utils/src/mdbx_metrics.rs).
-        let _span = info_span!(
-            irys_utils::MDBX_RW_TX_SPAN,
-            db_scope = irys_utils::DB_SCOPE_IRYS_CONSENSUS
-        )
-        .entered();
-        let write_tx = irys_db.tx_mut()?;
+        // Single gated RW txn (consensus writer gate + irys-consensus scope).
+        irys_db.update_eyre_at("chain.persist_genesis", |write_tx| {
+            database::insert_block_header(write_tx, genesis_block)?;
 
-        // Insert the genesis block header
-        database::insert_block_header(&write_tx, genesis_block)?;
+            for commitment_tx in genesis_commitments {
+                debug!("Persisting genesis commitment: {}", commitment_tx.id());
+                database::insert_commitment_tx(write_tx, commitment_tx)?;
+            }
 
-        // Insert all commitment transactions
-        for commitment_tx in genesis_commitments {
-            debug!("Persisting genesis commitment: {}", commitment_tx.id());
-            database::insert_commitment_tx(&write_tx, commitment_tx)?;
-        }
-
-        // Insert the genesis block index entry.
-        // Use full sealing here so we verify genesis commitments match the header.
-        let genesis_body = BlockBody {
-            block_hash: genesis_block.block_hash,
-            data_transactions: vec![],
-            commitment_transactions: genesis_commitments.to_vec(),
-        };
-        let genesis_sealed = SealedBlock::new(genesis_block.clone(), genesis_body)?;
-        BlockIndex::push_block(&write_tx, &genesis_sealed, self.config.consensus.chunk_size)?;
-
-        // Commit the database transaction
-        write_tx.commit()?;
+            // Full sealing verifies genesis commitments match the header.
+            let genesis_body = BlockBody {
+                block_hash: genesis_block.block_hash,
+                data_transactions: vec![],
+                commitment_transactions: genesis_commitments.to_vec(),
+            };
+            let genesis_sealed = SealedBlock::new(genesis_block.clone(), genesis_body)?;
+            BlockIndex::push_block(write_tx, &genesis_sealed, self.config.consensus.chunk_size)?;
+            Ok(())
+        })?;
 
         info!("Genesis block and commitments successfully persisted");
         Ok(())
@@ -1850,15 +1837,34 @@ impl IrysNode {
             runtime_handle.clone(),
         );
 
-        // Start the block-stream producer: consumes the `block_stream` signal feed and exposes the
-        // shared handle the `/internal` SSE handlers call `subscribe(from_seq)` on.
-        let (block_stream_service_handle, block_stream_handle) =
-            irys_actors::block_stream_service::BlockStreamService::spawn_service(
-                receivers.block_stream,
-                irys_db.clone(),
-                config.consensus.chunk_size,
-                runtime_handle.clone(),
+        // Block-stream producer + durable log only when `/internal/*` is exposed. Default-off
+        // nodes (Observers, miners without a trusted gateway) must not pay consensus-MDBX
+        // writer tax for a stream nobody can read.
+        let (block_stream_service_handle, block_stream_handle) = if config
+            .node_config
+            .http
+            .expose_internal_api
+        {
+            let (service_handle, handle) =
+                irys_actors::block_stream_service::BlockStreamService::spawn_service(
+                    receivers.block_stream,
+                    irys_db.clone(),
+                    config.consensus.chunk_size,
+                    runtime_handle.clone(),
+                );
+            (Some(service_handle), handle)
+        } else {
+            drop(receivers.block_stream);
+            info!(
+                "block-stream producer disabled (http.expose_internal_api=false); no durable stream log will be written"
             );
+            (
+                None,
+                Arc::new(
+                    irys_actors::block_stream_service::BlockStreamHandle::disabled(irys_db.clone()),
+                ),
+            )
+        };
 
         let (oneshot_tx, oneshot_rx) = tokio::sync::oneshot::channel();
         let block_tree_sender = service_senders.block_tree.clone();
@@ -2277,7 +2283,9 @@ impl IrysNode {
 
             // 6. Chain management
             services.push(block_tree_handle);
-            services.push(block_stream_service_handle);
+            if let Some(block_stream_service_handle) = block_stream_service_handle {
+                services.push(block_stream_service_handle);
+            }
 
             // 7. State management
             services.push(mempool_handle);

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -1855,6 +1855,9 @@ impl IrysNode {
             (Some(service_handle), handle)
         } else {
             drop(receivers.block_stream);
+            // While disabled, no frames append and no stream prune runs; an existing log tail is
+            // left as-is. Re-enabling later can leave a semantic history gap for blocks migrated
+            // offline — see docs/90-services/06-rpc-api.md ("Flag toggle gap").
             info!(
                 "block-stream producer disabled (http.expose_internal_api=false); no durable stream log will be written"
             );

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -1314,12 +1314,11 @@ pub fn block_ledger_tx_headers<T: DbTx>(
 /// Appends a block-stream event to the durable log, assigning and returning the next monotonic
 /// `seq`.
 ///
-/// Callers must be the only concurrent writer of this table for the process (serialized by the
-/// consensus writer gate / single RW txn): confirmation and migration append inside their
-/// canonical txns; the producer still appends on startup reconciliation and unit-test signals.
-/// Reading the last key and incrementing within the same write transaction is race-free. `seq`
-/// keys sort numerically because reth encodes integer DB keys big-endian (the same property the
-/// block-index range scans rely on).
+/// Appends are serialized by the consensus environment's writer gate / single RW txn:
+/// confirmation and migration append inside their canonical txns; the producer appends only
+/// during startup reconciliation. Reading the last key and incrementing within the same write
+/// transaction is race-free. `seq` keys sort numerically because reth encodes integer DB keys
+/// big-endian (the same property the block-index range scans rely on).
 pub fn append_block_stream_event<T: DbTx + DbTxMut>(tx: &T, value: Vec<u8>) -> eyre::Result<u64> {
     let next_seq = {
         let mut cursor = tx.cursor_read::<IrysBlockStreamEvents>()?;

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -1314,9 +1314,12 @@ pub fn block_ledger_tx_headers<T: DbTx>(
 /// Appends a block-stream event to the durable log, assigning and returning the next monotonic
 /// `seq`.
 ///
-/// The block-stream producer is the sole writer, so reading the last key and incrementing within
-/// the same write transaction is race-free. `seq` keys sort numerically because reth encodes
-/// integer DB keys big-endian (the same property the block-index range scans rely on).
+/// Callers must be the only concurrent writer of this table for the process (serialized by the
+/// consensus writer gate / single RW txn): confirmation and migration append inside their
+/// canonical txns; the producer still appends on startup reconciliation and unit-test signals.
+/// Reading the last key and incrementing within the same write transaction is race-free. `seq`
+/// keys sort numerically because reth encodes integer DB keys big-endian (the same property the
+/// block-index range scans rely on).
 pub fn append_block_stream_event<T: DbTx + DbTxMut>(tx: &T, value: Vec<u8>) -> eyre::Result<u64> {
     let next_seq = {
         let mut cursor = tx.cursor_read::<IrysBlockStreamEvents>()?;

--- a/crates/database/src/db.rs
+++ b/crates/database/src/db.rs
@@ -55,6 +55,13 @@ pub type WriterGateGuard = MutexGuard<'static, ()>;
 ///
 /// Recovers from a poisoned mutex so one panicked writer does not permanently
 /// wedge writes to this environment.
+///
+/// # Reentrancy
+///
+/// The gate is not reentrant. While a thread holds this guard, it must not call
+/// [`IrysDatabaseExt::update_eyre`], [`IrysDatabaseExt::update_eyre_at`], or
+/// [`IrysDatabaseExt::update_scoped`] on the same environment; those methods take
+/// the same gate and the thread would deadlock.
 pub fn lock_writer_gate(env: &DatabaseEnv, call_site: &'static str) -> WriterGateGuard {
     let start = Instant::now();
     let guard = writer_gate_for(env)

--- a/crates/database/src/db.rs
+++ b/crates/database/src/db.rs
@@ -24,13 +24,17 @@ use irys_utils::{
 /// OS mutex) parks waiters until the previous writer commits, so residual Busy
 /// sleeps are rare when every production writer takes the gate before `tx_mut`.
 ///
-/// Gates are keyed by environment address so independent environments have
-/// independent queues: the consensus DB and each storage-submodule DB serialise
-/// their own writers without contending with one another. Gate values are
-/// leaked (`&'static`) so guards borrow no registry lock; the registry is
-/// append-only, bounded by the number of environments opened over the process
-/// lifetime. An address reused by a later environment shares the earlier gate,
-/// which merely merges two queues and stays correct.
+/// Gates are keyed by the Rust wrapper address (`ptr::from_ref(env)`), not the
+/// intrinsic MDBX env pointer. Independent wrappers therefore get independent
+/// queues (consensus vs each submodule). Two wrappers over **one** MDBX env
+/// would under-serialise and restore Busy sleeps — that happens once at
+/// startup when `ensure_db_version_compatible` runs on a stack-local env
+/// before it is moved into `Arc` (`init_irys_db`); that window is single-
+/// threaded and ends before concurrent writers start. An address reused by a
+/// later environment shares the earlier gate, which merely merges queues and
+/// stays correct. Gate values are leaked (`&'static`) so guards borrow no
+/// registry lock; the registry is append-only, bounded by environments opened
+/// over the process lifetime.
 static WRITER_GATES: LazyLock<Mutex<std::collections::HashMap<usize, &'static Mutex<()>>>> =
     LazyLock::new(Default::default);
 
@@ -64,9 +68,24 @@ pub type WriterGateGuard = MutexGuard<'static, ()>;
 /// the same gate and the thread would deadlock.
 pub fn lock_writer_gate(env: &DatabaseEnv, call_site: &'static str) -> WriterGateGuard {
     let start = Instant::now();
-    let guard = writer_gate_for(env)
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let mutex = writer_gate_for(env);
+    // try_lock first so a contended (or nested same-thread) wait is visible in
+    // debug builds; a nested lock on this non-reentrant mutex still deadlocks,
+    // but the log names the waiter `call_site` before the park.
+    let guard = match mutex.try_lock() {
+        Ok(g) => g,
+        Err(std::sync::TryLockError::WouldBlock) => {
+            #[cfg(debug_assertions)]
+            tracing::debug!(
+                call_site,
+                "writer gate contended; parking (nested same-thread acquire deadlocks)"
+            );
+            mutex
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+        }
+        Err(std::sync::TryLockError::Poisoned(p)) => p.into_inner(),
+    };
     metrics::histogram!(
         DB_WRITER_GATE_WAIT_SECONDS,
         "call_site" => call_site,
@@ -196,8 +215,12 @@ pub trait IrysDatabaseExt: reth_db::Database {
     where
         F: FnOnce(&Self::TXMut) -> eyre::Result<T>;
 
-    /// Like [`Self::update_eyre`] but records the consensus writer-gate wait under
-    /// `call_site` (histogram `db.consensus_writer_gate_wait_seconds`).
+    /// Like [`Self::update_eyre`] but labels the per-env writer-gate wait with
+    /// `call_site` (histogram `db.writer_gate_wait_seconds`) on [`DatabaseEnv`].
+    ///
+    /// On [`RethDbWrapper`] `call_site` is ignored: that impl takes no writer
+    /// gate (separate MDBX environment) and records only reth-EVM scope spans
+    /// and the reth `tx_mut` acquire histogram.
     fn update_eyre_at<T, F>(&self, call_site: &'static str, f: F) -> eyre::Result<T>
     where
         F: FnOnce(&Self::TXMut) -> eyre::Result<T>;
@@ -216,8 +239,9 @@ pub trait IrysDatabaseExt: reth_db::Database {
     /// Use this for every consensus-DB write that doesn't return an
     /// `eyre::Result` (those can use [`update_eyre`] instead).
     ///
-    /// On the consensus DB this also takes the process-wide writer gate so
+    /// On [`DatabaseEnv`] this also takes the per-environment writer gate so
     /// concurrent writers park on an app mutex instead of the 250 ms Busy poll.
+    /// On [`RethDbWrapper`] there is no gate (separate env).
     fn update_scoped<T, F>(&self, f: F) -> Result<T, DatabaseError>
     where
         F: FnOnce(&Self::TXMut) -> T;
@@ -426,7 +450,7 @@ mod tests {
     use std::sync::Barrier;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::thread;
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
 
     /// Two overlapping `update_eyre` writers must be mutually exclusive on the
     /// per-env gate, and neither may pay the 250 ms libmdbx Busy sleep.
@@ -463,7 +487,6 @@ mod tests {
             let max_occupancy = Arc::clone(&max_occupancy);
             joins.push(thread::spawn(move || {
                 if i == 0 {
-                    let started = Instant::now();
                     db.update_eyre_at("test.concurrent_writer", |_tx| {
                         enter(&occupancy, &max_occupancy);
                         first_writer_in_tx.wait();
@@ -472,37 +495,28 @@ mod tests {
                         Ok(())
                     })
                     .unwrap();
-                    started.elapsed()
                 } else {
                     first_writer_in_tx.wait();
-                    let started = Instant::now();
                     db.update_eyre_at("test.concurrent_writer", |_tx| {
                         enter(&occupancy, &max_occupancy);
                         occupancy.fetch_sub(1, Ordering::SeqCst);
                         Ok(())
                     })
                     .unwrap();
-                    started.elapsed()
                 }
             }));
         }
 
-        let mut durations = Vec::new();
         for j in joins {
-            durations.push(j.join().expect("writer thread panicked"));
+            j.join().expect("writer thread panicked");
         }
 
+        // Occupancy alone proves serialization; a wall-clock bound on gate wait
+        // is load-sensitive under CI and is not required.
         assert_eq!(
             max_occupancy.load(Ordering::SeqCst),
             1,
             "two writers were inside their write closures at once; gate failed to serialize"
-        );
-        // The second writer started while the first held the gate, so its wait
-        // proves it parked on the app mutex, not the 250 ms libmdbx Busy poll.
-        let max = durations.iter().max().unwrap();
-        assert!(
-            *max < Duration::from_millis(250),
-            "no writer may reach the 250ms Busy floor; max={max:?} times={durations:?}"
         );
     }
 }

--- a/crates/database/src/db.rs
+++ b/crates/database/src/db.rs
@@ -444,13 +444,21 @@ mod tests {
             durations.push(j.join().expect("writer thread panicked"));
         }
 
-        // Both writers finish well under the Busy sleep floor (250 ms).
-        // With gate: ~10 ms hold + ~10 ms wait ≈ 20–50 ms wall each in practice.
-        // Without gate: loser would pay ≥250 ms on Busy.
+        // Serialization: the slower writer waited at least one hold period.
+        // Busy avoidance: neither writer paid the 250 ms libmdbx Busy quantum.
         let max = durations.iter().map(|(_, d)| *d).max().unwrap();
+        let min = durations.iter().map(|(_, d)| *d).min().unwrap();
         assert!(
-            max < Duration::from_millis(150),
-            "gated concurrent writers must finish without 250ms Busy floor; max={max:?} times={durations:?}"
+            max >= hold,
+            "slower writer must wait at least one hold (proves gate serialization); max={max:?} hold={hold:?} times={durations:?}"
+        );
+        assert!(
+            max < Duration::from_millis(250),
+            "no writer may reach the 250ms Busy floor; max={max:?} times={durations:?}"
+        );
+        assert!(
+            min >= hold,
+            "each writer holds for at least `hold`; min={min:?} hold={hold:?} times={durations:?}"
         );
     }
 }

--- a/crates/database/src/db.rs
+++ b/crates/database/src/db.rs
@@ -13,26 +13,40 @@ use std::time::Instant;
 use tracing::{info, info_span};
 
 use irys_utils::{
-    DB_CONSENSUS_WRITER_GATE_WAIT_SECONDS, DB_SCOPE_IRYS_CONSENSUS, DB_SCOPE_RETH_EVM,
-    DB_TX_MUT_ACQUIRE_DURATION_SECONDS, MDBX_RW_TX_SPAN,
+    DB_SCOPE_IRYS_CONSENSUS, DB_SCOPE_RETH_EVM, DB_TX_MUT_ACQUIRE_DURATION_SECONDS,
+    DB_WRITER_GATE_WAIT_SECONDS, MDBX_RW_TX_SPAN,
 };
 
-/// Process-wide gate for the irys-consensus MDBX environment's single writer.
+/// Per-environment writer gates for `DatabaseEnv` MDBX environments.
 ///
 /// MDBX allows one RW transaction per env; concurrent `begin_rw_txn` callers hit
-/// `Error::Busy` and sleep 250 ms in reth-irys libmdbx. Waiting here (OS mutex)
-/// parks waiters until the previous writer commits, so residual Busy sleeps are
-/// rare when every production writer takes this gate before `tx_mut`.
+/// `Error::Busy` and sleep 250 ms in reth-irys libmdbx. Waiting on the gate (an
+/// OS mutex) parks waiters until the previous writer commits, so residual Busy
+/// sleeps are rare when every production writer takes the gate before `tx_mut`.
 ///
-/// Process-global (not per-env): all consensus `DatabaseEnv` instances in the
-/// process share one queue. That is correct for a node (one consensus DB) and
-/// only serializes writers across independent test DBs, which is safe.
-static CONSENSUS_WRITER_GATE: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+/// Gates are keyed by environment address so independent environments have
+/// independent queues: the consensus DB and each storage-submodule DB serialise
+/// their own writers without contending with one another. Gate values are
+/// leaked (`&'static`) so guards borrow no registry lock; the registry is
+/// append-only, bounded by the number of environments opened over the process
+/// lifetime. An address reused by a later environment shares the earlier gate,
+/// which merely merges two queues and stays correct.
+static WRITER_GATES: LazyLock<Mutex<std::collections::HashMap<usize, &'static Mutex<()>>>> =
+    LazyLock::new(Default::default);
 
-/// RAII guard for [`lock_consensus_writer_gate`]. Drop to release the gate.
-pub type ConsensusWriterGuard = MutexGuard<'static, ()>;
+fn writer_gate_for(env: &DatabaseEnv) -> &'static Mutex<()> {
+    let key = std::ptr::from_ref(env) as usize;
+    WRITER_GATES
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+        .entry(key)
+        .or_insert_with(|| Box::leak(Box::new(Mutex::new(()))))
+}
 
-/// Acquire the consensus writer gate. Prefer [`IrysDatabaseExt::update_eyre`] /
+/// RAII guard for [`lock_writer_gate`]. Drop to release the gate.
+pub type WriterGateGuard = MutexGuard<'static, ()>;
+
+/// Acquire `env`'s writer gate. Prefer [`IrysDatabaseExt::update_eyre`] /
 /// [`IrysDatabaseExt::update_scoped`] for normal writes. Use this only when a
 /// raw `tx_mut` must join the same serialization (long multi-statement writers,
 /// tests that hold the lock across other work).
@@ -40,16 +54,15 @@ pub type ConsensusWriterGuard = MutexGuard<'static, ()>;
 /// # Poisoning
 ///
 /// Recovers from a poisoned mutex so one panicked writer does not permanently
-/// wedge consensus writes.
-pub fn lock_consensus_writer_gate(call_site: &'static str) -> ConsensusWriterGuard {
+/// wedge writes to this environment.
+pub fn lock_writer_gate(env: &DatabaseEnv, call_site: &'static str) -> WriterGateGuard {
     let start = Instant::now();
-    let guard = CONSENSUS_WRITER_GATE
+    let guard = writer_gate_for(env)
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     metrics::histogram!(
-        DB_CONSENSUS_WRITER_GATE_WAIT_SECONDS,
+        DB_WRITER_GATE_WAIT_SECONDS,
         "call_site" => call_site,
-        "scope" => DB_SCOPE_IRYS_CONSENSUS,
     )
     .record(start.elapsed().as_secs_f64());
     guard
@@ -274,9 +287,9 @@ impl IrysDatabaseExt for DatabaseEnv {
         // stall warning fired during begin_rw_txn lands under
         // libmdbx_rw_tx_lock_stalls_total{scope="irys-consensus"}.
         let _span = info_span!(MDBX_RW_TX_SPAN, db_scope = DB_SCOPE_IRYS_CONSENSUS).entered();
-        // Take the app gate before begin_rw_txn so concurrent consensus writers
-        // park here instead of Busy-sleeping 250 ms in libmdbx.
-        let _gate = lock_consensus_writer_gate(call_site);
+        // Take this env's gate before begin_rw_txn so concurrent writers park
+        // here instead of Busy-sleeping 250 ms in libmdbx.
+        let _gate = lock_writer_gate(self, call_site);
 
         // Time tx_mut() acquisition (should be near-zero when all writers use the gate).
         let start = Instant::now();
@@ -307,7 +320,7 @@ impl IrysDatabaseExt for DatabaseEnv {
         F: FnOnce(&Self::TXMut) -> T,
     {
         let _span = info_span!(MDBX_RW_TX_SPAN, db_scope = DB_SCOPE_IRYS_CONSENSUS).entered();
-        let _gate = lock_consensus_writer_gate("update_scoped");
+        let _gate = lock_writer_gate(self, "update_scoped");
         let start = Instant::now();
         let tx_result = self.tx_mut();
         IRYS_CONSENSUS_TX_MUT_ACQUIRE_HISTOGRAM.record(start.elapsed().as_secs_f64());
@@ -403,15 +416,20 @@ mod tests {
     use crate::tables::IrysTables;
     use crate::{IrysDatabaseArgs as _, open_or_create_db};
     use reth_db::mdbx::DatabaseArguments;
-    use std::sync::{Arc, Barrier};
+    use std::sync::Barrier;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::thread;
     use std::time::{Duration, Instant};
 
-    /// Two concurrent `update_eyre` writers must serialize on the app gate so
-    /// neither pays the 250 ms libmdbx Busy sleep. Wall-clock for both holds
-    /// (~10 ms each) plus queue wait should stay well under one Busy quantum.
+    /// Two overlapping `update_eyre` writers must be mutually exclusive on the
+    /// per-env gate, and neither may pay the 250 ms libmdbx Busy sleep.
+    ///
+    /// Overlap is guaranteed: the first writer signals from *inside* its write
+    /// closure and the second writer starts only after that signal, so the gate
+    /// is provably contended. Exclusion is asserted structurally via an
+    /// occupancy counter rather than wall-clock arithmetic.
     #[test]
-    fn consensus_writer_gate_avoids_250ms_busy_floor() {
+    fn writer_gate_serializes_overlapping_writers_without_busy_floor() {
         let tmp = irys_testing_utils::utils::TempDirBuilder::new().build();
         let db = open_or_create_db(
             tmp.path(),
@@ -420,22 +438,45 @@ mod tests {
         )
         .unwrap();
         let db = Arc::new(db);
-        let barrier = Arc::new(Barrier::new(2));
+        let first_writer_in_tx = Arc::new(Barrier::new(2));
+        let occupancy = Arc::new(AtomicUsize::new(0));
+        let max_occupancy = Arc::new(AtomicUsize::new(0));
         let hold = Duration::from_millis(10);
+
+        let enter = |occupancy: &AtomicUsize, max_occupancy: &AtomicUsize| {
+            let now = occupancy.fetch_add(1, Ordering::SeqCst) + 1;
+            max_occupancy.fetch_max(now, Ordering::SeqCst);
+        };
 
         let mut joins = Vec::new();
         for i in 0..2 {
             let db = Arc::clone(&db);
-            let barrier = Arc::clone(&barrier);
+            let first_writer_in_tx = Arc::clone(&first_writer_in_tx);
+            let occupancy = Arc::clone(&occupancy);
+            let max_occupancy = Arc::clone(&max_occupancy);
             joins.push(thread::spawn(move || {
-                barrier.wait();
-                let started = Instant::now();
-                db.update_eyre_at("test.concurrent_writer", |_tx| {
-                    thread::sleep(hold);
-                    Ok(())
-                })
-                .unwrap();
-                (i, started.elapsed())
+                if i == 0 {
+                    let started = Instant::now();
+                    db.update_eyre_at("test.concurrent_writer", |_tx| {
+                        enter(&occupancy, &max_occupancy);
+                        first_writer_in_tx.wait();
+                        thread::sleep(hold);
+                        occupancy.fetch_sub(1, Ordering::SeqCst);
+                        Ok(())
+                    })
+                    .unwrap();
+                    started.elapsed()
+                } else {
+                    first_writer_in_tx.wait();
+                    let started = Instant::now();
+                    db.update_eyre_at("test.concurrent_writer", |_tx| {
+                        enter(&occupancy, &max_occupancy);
+                        occupancy.fetch_sub(1, Ordering::SeqCst);
+                        Ok(())
+                    })
+                    .unwrap();
+                    started.elapsed()
+                }
             }));
         }
 
@@ -444,21 +485,17 @@ mod tests {
             durations.push(j.join().expect("writer thread panicked"));
         }
 
-        // Serialization: the slower writer waited at least one hold period.
-        // Busy avoidance: neither writer paid the 250 ms libmdbx Busy quantum.
-        let max = durations.iter().map(|(_, d)| *d).max().unwrap();
-        let min = durations.iter().map(|(_, d)| *d).min().unwrap();
-        assert!(
-            max >= hold,
-            "slower writer must wait at least one hold (proves gate serialization); max={max:?} hold={hold:?} times={durations:?}"
+        assert_eq!(
+            max_occupancy.load(Ordering::SeqCst),
+            1,
+            "two writers were inside their write closures at once; gate failed to serialize"
         );
+        // The second writer started while the first held the gate, so its wait
+        // proves it parked on the app mutex, not the 250 ms libmdbx Busy poll.
+        let max = durations.iter().max().unwrap();
         assert!(
-            max < Duration::from_millis(250),
+            *max < Duration::from_millis(250),
             "no writer may reach the 250ms Busy floor; max={max:?} times={durations:?}"
-        );
-        assert!(
-            min >= hold,
-            "each writer holds for at least `hold`; min={min:?} hold={hold:?} times={durations:?}"
         );
     }
 }

--- a/crates/database/src/db.rs
+++ b/crates/database/src/db.rs
@@ -448,17 +448,21 @@ mod tests {
     use crate::{IrysDatabaseArgs as _, open_or_create_db};
     use reth_db::mdbx::DatabaseArguments;
     use std::sync::Barrier;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::thread;
     use std::time::Duration;
 
-    /// Two overlapping `update_eyre` writers must be mutually exclusive on the
-    /// per-env gate, and neither may pay the 250 ms libmdbx Busy sleep.
+    /// Two overlapping `update_eyre` writers must be mutually exclusive.
     ///
     /// Overlap is guaranteed: the first writer signals from *inside* its write
     /// closure and the second writer starts only after that signal, so the gate
     /// is provably contended. Exclusion is asserted structurally via an
     /// occupancy counter rather than wall-clock arithmetic.
+    ///
+    /// Exclusion alone does not attribute the serialization to the gate —
+    /// libmdbx enforces it too, after the loser pays the 250 ms Busy sleep.
+    /// `writer_gate_blocks_txn_start_so_libmdbx_never_sees_a_busy_writer`
+    /// covers that half.
     #[test]
     fn writer_gate_serializes_overlapping_writers_without_busy_floor() {
         let tmp = irys_testing_utils::utils::TempDirBuilder::new().build();
@@ -517,6 +521,59 @@ mod tests {
             max_occupancy.load(Ordering::SeqCst),
             1,
             "two writers were inside their write closures at once; gate failed to serialize"
+        );
+    }
+
+    /// A writer must park on the gate *before* `begin_rw_txn`, so libmdbx never
+    /// sees two concurrent writers and the 250 ms Busy retry is unreachable.
+    ///
+    /// Asserted as a negative under a held gate rather than as a duration
+    /// bound: the contended writer must not have entered its closure while the
+    /// gate is held. A slow or loaded machine only delays that thread further,
+    /// so load cannot turn a passing run into a failing one — only an actual
+    /// regression (a writer reaching libmdbx while another writer is open) can.
+    #[test]
+    fn writer_gate_blocks_txn_start_so_libmdbx_never_sees_a_busy_writer() {
+        let tmp = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db = open_or_create_db(
+            tmp.path(),
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing().unwrap(),
+        )
+        .unwrap();
+        let db = Arc::new(db);
+        let writer_spawned = Arc::new(Barrier::new(2));
+        let entered_closure = Arc::new(AtomicBool::new(false));
+
+        let gate = lock_writer_gate(&db, "test.hold_gate");
+
+        let writer = thread::spawn({
+            let db = Arc::clone(&db);
+            let writer_spawned = Arc::clone(&writer_spawned);
+            let entered_closure = Arc::clone(&entered_closure);
+            move || {
+                writer_spawned.wait();
+                db.update_eyre_at("test.gated_writer", |_tx| {
+                    entered_closure.store(true, Ordering::SeqCst);
+                    Ok(())
+                })
+                .unwrap();
+            }
+        });
+
+        // The writer is running and can only be inside `lock_writer_gate`.
+        writer_spawned.wait();
+        thread::sleep(Duration::from_millis(50));
+        assert!(
+            !entered_closure.load(Ordering::SeqCst),
+            "writer opened a txn while the gate was held; it would reach libmdbx contended and pay the Busy sleep"
+        );
+
+        drop(gate);
+        writer.join().expect("writer thread panicked");
+        assert!(
+            entered_closure.load(Ordering::SeqCst),
+            "writer never ran after the gate was released"
         );
     }
 }

--- a/crates/database/src/db.rs
+++ b/crates/database/src/db.rs
@@ -8,12 +8,52 @@ use reth_db::{Database, DatabaseEnv};
 use reth_db_api::database_metrics::DatabaseMetrics;
 use std::borrow::Cow;
 use std::path::PathBuf;
-use std::sync::{Arc, LazyLock, PoisonError, RwLock, RwLockReadGuard};
+use std::sync::{Arc, LazyLock, Mutex, MutexGuard, PoisonError, RwLock, RwLockReadGuard};
+use std::time::Instant;
 use tracing::{info, info_span};
 
 use irys_utils::{
-    DB_SCOPE_IRYS_CONSENSUS, DB_SCOPE_RETH_EVM, DB_TX_MUT_ACQUIRE_DURATION_SECONDS, MDBX_RW_TX_SPAN,
+    DB_CONSENSUS_WRITER_GATE_WAIT_SECONDS, DB_SCOPE_IRYS_CONSENSUS, DB_SCOPE_RETH_EVM,
+    DB_TX_MUT_ACQUIRE_DURATION_SECONDS, MDBX_RW_TX_SPAN,
 };
+
+/// Process-wide gate for the irys-consensus MDBX environment's single writer.
+///
+/// MDBX allows one RW transaction per env; concurrent `begin_rw_txn` callers hit
+/// `Error::Busy` and sleep 250 ms in reth-irys libmdbx. Waiting here (OS mutex)
+/// parks waiters until the previous writer commits, so residual Busy sleeps are
+/// rare when every production writer takes this gate before `tx_mut`.
+///
+/// Process-global (not per-env): all consensus `DatabaseEnv` instances in the
+/// process share one queue. That is correct for a node (one consensus DB) and
+/// only serializes writers across independent test DBs, which is safe.
+static CONSENSUS_WRITER_GATE: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+/// RAII guard for [`lock_consensus_writer_gate`]. Drop to release the gate.
+pub type ConsensusWriterGuard = MutexGuard<'static, ()>;
+
+/// Acquire the consensus writer gate. Prefer [`IrysDatabaseExt::update_eyre`] /
+/// [`IrysDatabaseExt::update_scoped`] for normal writes. Use this only when a
+/// raw `tx_mut` must join the same serialization (long multi-statement writers,
+/// tests that hold the lock across other work).
+///
+/// # Poisoning
+///
+/// Recovers from a poisoned mutex so one panicked writer does not permanently
+/// wedge consensus writes.
+pub fn lock_consensus_writer_gate(call_site: &'static str) -> ConsensusWriterGuard {
+    let start = Instant::now();
+    let guard = CONSENSUS_WRITER_GATE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    metrics::histogram!(
+        DB_CONSENSUS_WRITER_GATE_WAIT_SECONDS,
+        "call_site" => call_site,
+        "scope" => DB_SCOPE_IRYS_CONSENSUS,
+    )
+    .record(start.elapsed().as_secs_f64());
+    guard
+}
 
 // Cache the per-scope histogram handles so the hot rw-tx path doesn't re-resolve
 // the recorder + per-call Key allocation on every `update_eyre`. Handles bind to
@@ -136,6 +176,12 @@ pub trait IrysDatabaseExt: reth_db::Database {
     where
         F: FnOnce(&Self::TXMut) -> eyre::Result<T>;
 
+    /// Like [`Self::update_eyre`] but records the consensus writer-gate wait under
+    /// `call_site` (histogram `db.consensus_writer_gate_wait_seconds`).
+    fn update_eyre_at<T, F>(&self, call_site: &'static str, f: F) -> eyre::Result<T>
+    where
+        F: FnOnce(&Self::TXMut) -> eyre::Result<T>;
+
     /// Takes a function and passes a read-only transaction into it, making sure it's closed in the
     /// end of the execution. This functions allows for `eyre` results.
     fn view_eyre<T, F>(&self, f: F) -> eyre::Result<T>
@@ -149,6 +195,9 @@ pub trait IrysDatabaseExt: reth_db::Database {
     /// impl on `DatabaseEnv` lives upstream and cannot be intercepted directly.
     /// Use this for every consensus-DB write that doesn't return an
     /// `eyre::Result` (those can use [`update_eyre`] instead).
+    ///
+    /// On the consensus DB this also takes the process-wide writer gate so
+    /// concurrent writers park on an app mutex instead of the 250 ms Busy poll.
     fn update_scoped<T, F>(&self, f: F) -> Result<T, DatabaseError>
     where
         F: FnOnce(&Self::TXMut) -> T;
@@ -159,16 +208,23 @@ impl IrysDatabaseExt for RethDbWrapper {
     where
         F: FnOnce(&Self::TXMut) -> eyre::Result<T>,
     {
+        self.update_eyre_at("reth_evm.update_eyre", f)
+    }
+
+    fn update_eyre_at<T, F>(&self, _call_site: &'static str, f: F) -> eyre::Result<T>
+    where
+        F: FnOnce(&Self::TXMut) -> eyre::Result<T>,
+    {
         // Inline the body rather than delegating to DatabaseEnv::update_eyre so
         // libmdbx writer-lock stall warnings and the tx_mut acquire histogram
-        // are attributed to scope="reth-evm" instead of the consensus scope
-        // the inner helper hardcodes.
+        // are attributed to scope="reth-evm" instead of the consensus scope.
+        // No consensus writer gate: this is a separate MDBX environment.
         let _span = info_span!(MDBX_RW_TX_SPAN, db_scope = DB_SCOPE_RETH_EVM).entered();
 
         let guard = self.db.read().map_err(db_read_error)?;
         let db = guard.as_ref().ok_or_else(db_connection_closed_error)?;
 
-        let start = std::time::Instant::now();
+        let start = Instant::now();
         let tx_result = db.tx_mut();
         RETH_EVM_TX_MUT_ACQUIRE_HISTOGRAM.record(start.elapsed().as_secs_f64());
         let tx = tx_result?;
@@ -196,8 +252,8 @@ impl IrysDatabaseExt for RethDbWrapper {
         F: FnOnce(&Self::TXMut) -> T,
     {
         // RethDbWrapper's own Database::update impl already wraps the call in
-        // an `mdbx_rw_tx` span carrying `db_scope=reth-evm` (see line 104), so
-        // this trait method just delegates — no second span needed.
+        // an `mdbx_rw_tx` span carrying `db_scope=reth-evm`, so this trait
+        // method just delegates — no second span or consensus gate.
         <Self as Database>::update(self, f)
     }
 }
@@ -207,18 +263,23 @@ impl IrysDatabaseExt for DatabaseEnv {
     where
         F: FnOnce(&Self::TXMut) -> eyre::Result<T>,
     {
+        self.update_eyre_at("update_eyre", f)
+    }
+
+    fn update_eyre_at<T, F>(&self, call_site: &'static str, f: F) -> eyre::Result<T>
+    where
+        F: FnOnce(&Self::TXMut) -> eyre::Result<T>,
+    {
         // Active span carries the consensus scope so any libmdbx writer-lock
         // stall warning fired during begin_rw_txn lands under
-        // libmdbx_rw_tx_lock_stalls_total{scope="irys-consensus"}. Direct
-        // tx_mut() callers that bypass update_eyre fall back to scope=unknown.
+        // libmdbx_rw_tx_lock_stalls_total{scope="irys-consensus"}.
         let _span = info_span!(MDBX_RW_TX_SPAN, db_scope = DB_SCOPE_IRYS_CONSENSUS).entered();
+        // Take the app gate before begin_rw_txn so concurrent consensus writers
+        // park here instead of Busy-sleeping 250 ms in libmdbx.
+        let _gate = lock_consensus_writer_gate(call_site);
 
-        // Time tx_mut() acquisition. MDBX serializes all writers on a single
-        // global writer lock, so this histogram surfaces contention caused by
-        // any writer — including Database::update(...) callers we can't
-        // intercept directly. Both successful and failed acquires are recorded
-        // so genuinely-slow-then-failed waits are visible.
-        let start = std::time::Instant::now();
+        // Time tx_mut() acquisition (should be near-zero when all writers use the gate).
+        let start = Instant::now();
         let tx_result = self.tx_mut();
         IRYS_CONSENSUS_TX_MUT_ACQUIRE_HISTOGRAM.record(start.elapsed().as_secs_f64());
         let tx = tx_result?;
@@ -246,7 +307,14 @@ impl IrysDatabaseExt for DatabaseEnv {
         F: FnOnce(&Self::TXMut) -> T,
     {
         let _span = info_span!(MDBX_RW_TX_SPAN, db_scope = DB_SCOPE_IRYS_CONSENSUS).entered();
-        <Self as Database>::update(self, f)
+        let _gate = lock_consensus_writer_gate("update_scoped");
+        let start = Instant::now();
+        let tx_result = self.tx_mut();
+        IRYS_CONSENSUS_TX_MUT_ACQUIRE_HISTOGRAM.record(start.elapsed().as_secs_f64());
+        let tx = tx_result?;
+        let res = f(&tx);
+        tx.commit()?;
+        Ok(res)
     }
 }
 
@@ -326,5 +394,63 @@ impl<K: TransactionKind, T: DupSort> IrysDupCursorExt<T> for Cursor<K, T> {
                 None => None,
             },
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tables::IrysTables;
+    use crate::{IrysDatabaseArgs as _, open_or_create_db};
+    use reth_db::mdbx::DatabaseArguments;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    /// Two concurrent `update_eyre` writers must serialize on the app gate so
+    /// neither pays the 250 ms libmdbx Busy sleep. Wall-clock for both holds
+    /// (~10 ms each) plus queue wait should stay well under one Busy quantum.
+    #[test]
+    fn consensus_writer_gate_avoids_250ms_busy_floor() {
+        let tmp = irys_testing_utils::utils::TempDirBuilder::new().build();
+        let db = open_or_create_db(
+            tmp.path(),
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing().unwrap(),
+        )
+        .unwrap();
+        let db = Arc::new(db);
+        let barrier = Arc::new(Barrier::new(2));
+        let hold = Duration::from_millis(10);
+
+        let mut joins = Vec::new();
+        for i in 0..2 {
+            let db = Arc::clone(&db);
+            let barrier = Arc::clone(&barrier);
+            joins.push(thread::spawn(move || {
+                barrier.wait();
+                let started = Instant::now();
+                db.update_eyre_at("test.concurrent_writer", |_tx| {
+                    thread::sleep(hold);
+                    Ok(())
+                })
+                .unwrap();
+                (i, started.elapsed())
+            }));
+        }
+
+        let mut durations = Vec::new();
+        for j in joins {
+            durations.push(j.join().expect("writer thread panicked"));
+        }
+
+        // Both writers finish well under the Busy sleep floor (250 ms).
+        // With gate: ~10 ms hold + ~10 ms wait ≈ 20–50 ms wall each in practice.
+        // Without gate: loser would pay ≥250 ms on Busy.
+        let max = durations.iter().map(|(_, d)| *d).max().unwrap();
+        assert!(
+            max < Duration::from_millis(150),
+            "gated concurrent writers must finish without 250ms Busy floor; max={max:?} times={durations:?}"
+        );
     }
 }

--- a/crates/types/src/block_stream.rs
+++ b/crates/types/src/block_stream.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::borrow::Cow;
 
 /// One stream frame: a monotonic `seq` flattened beside a `kind`-tagged event.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Serialize)]
 pub struct StreamFrame {
     pub seq: u64,
     #[serde(flatten)]

--- a/crates/types/src/block_stream.rs
+++ b/crates/types/src/block_stream.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::borrow::Cow;
 
 /// One stream frame: a monotonic `seq` flattened beside a `kind`-tagged event.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct StreamFrame {
     pub seq: u64,
     #[serde(flatten)]

--- a/crates/types/src/config/node.rs
+++ b/crates/types/src/config/node.rs
@@ -731,10 +731,13 @@ pub struct HttpConfig {
     /// Actix worker count. Defaults to half the available system threads.
     #[serde(default = "default_actix_workers")]
     pub actix_workers: usize,
-    /// Whether to mount the node-internal `/internal/*` endpoints (block-stream SSE, canonical
-    /// block reads, unpacked chunk-range reads) on this HTTP listener. Off by default: these routes
-    /// carry no application-layer authentication, so enable them only on a node whose HTTP bind is
-    /// restricted to a trusted gateway at the network layer (firewall / reverse proxy / bind address).
+    /// Whether to expose the node-internal block-follower stack: mount `/internal/*` HTTP routes
+    /// (block-stream SSE, canonical block reads, unpacked chunk-range reads) **and** run the durable
+    /// block-stream producer that appends `observed` / `finalized` / `reorged` frames to the
+    /// consensus MDBX log. Off by default: routes carry no application-layer authentication, and
+    /// the producer is unnecessary write load when nothing can subscribe. Enable only on a node
+    /// whose HTTP bind is restricted to a trusted gateway at the network layer (firewall / reverse
+    /// proxy / bind address).
     #[serde(default)]
     pub expose_internal_api: bool,
 }

--- a/crates/utils/utils/src/lib.rs
+++ b/crates/utils/utils/src/lib.rs
@@ -7,9 +7,9 @@ pub mod shutdown;
 pub mod signal;
 
 pub use mdbx_metrics::{
-    DB_SCOPE_FIELD, DB_SCOPE_IRYS_CONSENSUS, DB_SCOPE_RETH_EVM, DB_SCOPE_UNKNOWN,
-    DB_TX_MUT_ACQUIRE_DURATION_SECONDS, MDBX_RW_TX_LOCK_STALLS_TOTAL, MDBX_RW_TX_SPAN,
-    mdbx_lock_metrics_layer,
+    DB_CONSENSUS_WRITER_GATE_WAIT_SECONDS, DB_SCOPE_FIELD, DB_SCOPE_IRYS_CONSENSUS,
+    DB_SCOPE_RETH_EVM, DB_SCOPE_UNKNOWN, DB_TX_MUT_ACQUIRE_DURATION_SECONDS,
+    MDBX_RW_TX_LOCK_STALLS_TOTAL, MDBX_RW_TX_SPAN, mdbx_lock_metrics_layer,
 };
 
 /// Installs Reth's prometheus recorder as the global `metrics` recorder.

--- a/crates/utils/utils/src/lib.rs
+++ b/crates/utils/utils/src/lib.rs
@@ -7,9 +7,9 @@ pub mod shutdown;
 pub mod signal;
 
 pub use mdbx_metrics::{
-    DB_CONSENSUS_WRITER_GATE_WAIT_SECONDS, DB_SCOPE_FIELD, DB_SCOPE_IRYS_CONSENSUS,
-    DB_SCOPE_RETH_EVM, DB_SCOPE_UNKNOWN, DB_TX_MUT_ACQUIRE_DURATION_SECONDS,
-    MDBX_RW_TX_LOCK_STALLS_TOTAL, MDBX_RW_TX_SPAN, mdbx_lock_metrics_layer,
+    DB_SCOPE_FIELD, DB_SCOPE_IRYS_CONSENSUS, DB_SCOPE_RETH_EVM, DB_SCOPE_UNKNOWN,
+    DB_TX_MUT_ACQUIRE_DURATION_SECONDS, DB_WRITER_GATE_WAIT_SECONDS, MDBX_RW_TX_LOCK_STALLS_TOTAL,
+    MDBX_RW_TX_SPAN, mdbx_lock_metrics_layer,
 };
 
 /// Installs Reth's prometheus recorder as the global `metrics` recorder.

--- a/crates/utils/utils/src/mdbx_metrics.rs
+++ b/crates/utils/utils/src/mdbx_metrics.rs
@@ -18,11 +18,13 @@ pub const MDBX_RW_TX_LOCK_STALLS_TOTAL: &str = "libmdbx.rw_tx_lock_stalls_total"
 /// not via the [`metrics::describe_histogram!`] macro.
 pub const DB_TX_MUT_ACQUIRE_DURATION_SECONDS: &str = "db.tx_mut_acquire_duration_seconds";
 
-/// Histogram name for time spent waiting on the process-wide consensus writer
-/// gate (seconds), labelled by `call_site` and `scope`. Recorded before
-/// `begin_rw_txn` so residual MDBX Busy sleeps (250 ms) are not conflated with
-/// app-level queueing.
-pub const DB_CONSENSUS_WRITER_GATE_WAIT_SECONDS: &str = "db.consensus_writer_gate_wait_seconds";
+/// Histogram name for time spent waiting on a per-environment MDBX writer
+/// gate (seconds), labelled by `call_site`. Recorded before `begin_rw_txn` so
+/// residual MDBX Busy sleeps (250 ms) are not conflated with app-level
+/// queueing. Environments are not distinguished by label; `call_site` is the
+/// operator's handle on who queued (submodule writers use the plain
+/// `update_eyre` site).
+pub const DB_WRITER_GATE_WAIT_SECONDS: &str = "db.writer_gate_wait_seconds";
 
 /// Span field name read by [`MdbxLockMetricsLayer`] to attribute a stall to a
 /// particular database. Callers should set this field on a parent span using
@@ -78,9 +80,9 @@ pub(crate) fn describe_mdbx_metrics() {
         "Time spent acquiring a libmdbx writer transaction via begin_rw_txn, attributed by scope. Both successful and failed acquires are recorded so genuinely-slow-then-failed waits are visible."
     );
     metrics::describe_histogram!(
-        DB_CONSENSUS_WRITER_GATE_WAIT_SECONDS,
+        DB_WRITER_GATE_WAIT_SECONDS,
         metrics::Unit::Seconds,
-        "Time spent waiting on the process-wide irys-consensus writer gate before begin_rw_txn, attributed by call_site and scope."
+        "Time spent waiting on a per-environment MDBX writer gate before begin_rw_txn, attributed by call_site."
     );
 }
 

--- a/crates/utils/utils/src/mdbx_metrics.rs
+++ b/crates/utils/utils/src/mdbx_metrics.rs
@@ -18,6 +18,12 @@ pub const MDBX_RW_TX_LOCK_STALLS_TOTAL: &str = "libmdbx.rw_tx_lock_stalls_total"
 /// not via the [`metrics::describe_histogram!`] macro.
 pub const DB_TX_MUT_ACQUIRE_DURATION_SECONDS: &str = "db.tx_mut_acquire_duration_seconds";
 
+/// Histogram name for time spent waiting on the process-wide consensus writer
+/// gate (seconds), labelled by `call_site` and `scope`. Recorded before
+/// `begin_rw_txn` so residual MDBX Busy sleeps (250 ms) are not conflated with
+/// app-level queueing.
+pub const DB_CONSENSUS_WRITER_GATE_WAIT_SECONDS: &str = "db.consensus_writer_gate_wait_seconds";
+
 /// Span field name read by [`MdbxLockMetricsLayer`] to attribute a stall to a
 /// particular database. Callers should set this field on a parent span using
 /// one of the `DB_SCOPE_*` constants below.
@@ -70,6 +76,11 @@ pub(crate) fn describe_mdbx_metrics() {
         DB_TX_MUT_ACQUIRE_DURATION_SECONDS,
         metrics::Unit::Seconds,
         "Time spent acquiring a libmdbx writer transaction via begin_rw_txn, attributed by scope. Both successful and failed acquires are recorded so genuinely-slow-then-failed waits are visible."
+    );
+    metrics::describe_histogram!(
+        DB_CONSENSUS_WRITER_GATE_WAIT_SECONDS,
+        metrics::Unit::Seconds,
+        "Time spent waiting on the process-wide irys-consensus writer gate before begin_rw_txn, attributed by call_site and scope."
     );
 }
 

--- a/docs/90-services/06-rpc-api.md
+++ b/docs/90-services/06-rpc-api.md
@@ -5,10 +5,12 @@ exposes the node's durable block-event log two ways — a push stream and an equ
 canonical block reads and an unpacked chunk-range read. Both transports carry the **same** `StreamFrame`s
 from the **same** seq-keyed log, so a follower may use either and reach identical state.
 
-> **Security.** These routes carry no application-layer authentication. They are mounted only when the
-> node sets `http.expose_internal_api` (off by default); when enabled they ride the same HTTP listener as
-> the public API. A deployment that enables them **must** restrict `/internal/*` at the network layer
-> (firewall / reverse proxy / bind address) to the trusted gateway.
+> **Security / runtime.** These routes carry no application-layer authentication. They are mounted only
+> when the node sets `http.expose_internal_api` (off by default). That same flag starts the durable
+> block-stream producer that appends `observed` / `finalized` / `reorged` frames; when the flag is off
+> the producer is not started and no stream log is written. When enabled they ride the same HTTP
+> listener as the public API. A deployment that enables them **must** restrict `/internal/*` at the
+> network layer (firewall / reverse proxy / bind address) to the trusted gateway.
 
 ## The event log and its cursor
 
@@ -124,12 +126,13 @@ size requests within `MAX_CHUNK_SPAN`, or a conforming node would answer with a 
   request that is malformed (bad `ledger`, unparsable or inverted `offset`) or wider than `MAX_CHUNK_SPAN`.
 - `5xx` only on a genuine log-read fault.
 - **`404` means the endpoint is not available.** The `/internal` routes are mounted only when the node
-  sets `http.expose_internal_api` (off by default); a node with it disabled, or an older build that lacks
-  the route entirely, serves a normal not-found. The gateway's transport selector treats `404` /
-  connection-refused as "this transport is unsupported" and falls back accordingly. When the routes are
-  mounted they never return `404` for an empty, short, or out-of-range log. The one exception is
-  `GET /internal/blocks/{height}`, whose `404` also means "no canonical block at that height" — a
-  transport prober must key on the stream/events routes, never on the by-height read.
+  sets `http.expose_internal_api` (off by default); with the flag off the durable producer is also not
+  started. A node with it disabled, or an older build that lacks the route entirely, serves a normal
+  not-found. The gateway's transport selector treats `404` / connection-refused as "this transport is
+  unsupported" and falls back accordingly. When the routes are mounted they never return `404` for an
+  empty, short, or out-of-range log. The one exception is `GET /internal/blocks/{height}`, whose `404`
+  also means "no canonical block at that height" — a transport prober must key on the stream/events
+  routes, never on the by-height read.
 
 ## Limitation: the crash window
 

--- a/docs/90-services/06-rpc-api.md
+++ b/docs/90-services/06-rpc-api.md
@@ -11,6 +11,14 @@ from the **same** seq-keyed log, so a follower may use either and reach identica
 > the producer is not started and no stream log is written. When enabled they ride the same HTTP
 > listener as the public API. A deployment that enables them **must** restrict `/internal/*` at the
 > network layer (firewall / reverse proxy / bind address) to the trusted gateway.
+>
+> **Flag toggle gap.** If the flag was on (log written), then off across restarts (no appends, no
+> prune), then on again, `seq` stays contiguous but the event history has a hole for every block that
+> migrated while the producer was disabled. Startup reconciliation only backfills missing `finalized`
+> frames within `RECONCILE_SCAN_CAP` of the index tail; after a long disabled window it may abort and
+> log a warning. Followers that resume from an old cursor will not receive a `truncated` signal for
+> that semantic hole — they must re-bootstrap from canonical block reads. A stronger guarantee would
+> require recording the disable period (e.g. a reset-marker frame).
 
 ## The event log and its cursor
 

--- a/docs/90-services/06-rpc-api.md
+++ b/docs/90-services/06-rpc-api.md
@@ -29,8 +29,11 @@ or repeats a `seq` — that is the follower's resume cursor (never height, which
 The **live SSE channel** is best-effort delivery of already-durable frames. In steady state the single
 block-tree task enqueues in commit order so live order matches `seq`. At startup, reconciliation can
 append frames that fan out before earlier writer frames still queued on the channel, so a connected
-subscriber may briefly see `N+1` before `N`. Consumers should ignore a live frame with
-`seq <= last_seen` (or re-sync via poll/replay). Poll pages always read the log in ascending `seq`.
+subscriber may briefly see `N+1` before `N`. Consumers should therefore track the highest *contiguous*
+`seq` they have processed, not the highest `seq` they have seen, and ignore only frames at or below that
+watermark. A frame that arrives above the watermark leaves a gap: buffer it until the missing frames
+arrive, or re-sync from the first missing `seq` via poll/replay. Discarding on `seq <= highest seen`
+instead loses `N` whenever `N+1` overtakes it. Poll pages always read the log in ascending `seq`.
 
 The log is pruned: once it exceeds `RETENTION_EVENTS` (100,000) the oldest events are deleted (batched, so
 the retained count is ~100k with up to `PRUNE_INTERVAL` overshoot). Two quantities therefore matter:

--- a/docs/90-services/06-rpc-api.md
+++ b/docs/90-services/06-rpc-api.md
@@ -161,9 +161,12 @@ not. The producer's remaining append path is startup reconciliation, which repai
 frames that a pre-atomic-append build lost between a migration commit and its separate producer
 append, walking the block index tail and appending the gap in height order. Live SSE delivery is
 best-effort on top of this durable log: a committed frame whose fan-out is missed (say, a halted
-producer) is recovered through replay on reconnect for as long as it remains retained. Only a cursor
-that has fallen below `lowest_retained_seq` is unrecoverable by replay — that is the `truncated`
-case, which returns no frames and requires a re-bootstrap from canonical block reads.
+producer) is recovered through replay on reconnect for as long as it remains retained. Within one log
+lifetime the only cursor replay cannot recover is one that has fallen below `lowest_retained_seq` —
+the `truncated` case, which returns no frames and requires a re-bootstrap from canonical block reads.
+Log recreation is a separate failure, not a deeper truncation: `seq` restarts at `0`, so a cursor
+above the new floor replays *different* frames rather than none. See "Limitation: log recreation
+(reset)" below — it needs an operator-coordinated re-bootstrap, which replay cannot signal.
 
 **FCU timing.** An `observed` (or `reorged`) frame becomes durable when confirmation's consensus
 txn commits, which is **before** the execution-layer fork-choice update (FCU) for that tip.

--- a/docs/90-services/06-rpc-api.md
+++ b/docs/90-services/06-rpc-api.md
@@ -160,8 +160,10 @@ transition that persisted — the two are atomic — and a frame cannot exist fo
 not. The producer's remaining append path is startup reconciliation, which repairs `finalized`
 frames that a pre-atomic-append build lost between a migration commit and its separate producer
 append, walking the block index tail and appending the gap in height order. Live SSE delivery is
-best-effort on top of this durable log: a frame whose fan-out is missed (say, a halted producer) is
-recovered through replay on reconnect, exactly as after a `truncated` poll.
+best-effort on top of this durable log: a committed frame whose fan-out is missed (say, a halted
+producer) is recovered through replay on reconnect for as long as it remains retained. Only a cursor
+that has fallen below `lowest_retained_seq` is unrecoverable by replay — that is the `truncated`
+case, which returns no frames and requires a re-bootstrap from canonical block reads.
 
 **FCU timing.** An `observed` (or `reorged`) frame becomes durable when confirmation's consensus
 txn commits, which is **before** the execution-layer fork-choice update (FCU) for that tip.

--- a/docs/90-services/06-rpc-api.md
+++ b/docs/90-services/06-rpc-api.md
@@ -23,8 +23,14 @@ from the **same** seq-keyed log, so a follower may use either and reach identica
 ## The event log and its cursor
 
 The node appends `observed` / `finalized` / `reorged` events to a durable, append-only log keyed by a
-monotonic `seq` (the 0-based append index). `seq` never rewinds or repeats within one log lifetime, so it
-is the follower's resume cursor — never height, which repeats across forks.
+monotonic `seq` (the 0-based append index). Within one log lifetime the **durable log** never rewinds
+or repeats a `seq` — that is the follower's resume cursor (never height, which repeats across forks).
+
+The **live SSE channel** is best-effort delivery of already-durable frames. In steady state the single
+block-tree task enqueues in commit order so live order matches `seq`. At startup, reconciliation can
+append frames that fan out before earlier writer frames still queued on the channel, so a connected
+subscriber may briefly see `N+1` before `N`. Consumers should ignore a live frame with
+`seq <= last_seen` (or re-sync via poll/replay). Poll pages always read the log in ascending `seq`.
 
 The log is pruned: once it exceeds `RETENTION_EVENTS` (100,000) the oldest events are deleted (batched, so
 the retained count is ~100k with up to `PRUNE_INTERVAL` overshoot). Two quantities therefore matter:
@@ -153,6 +159,14 @@ frames that a pre-atomic-append build lost between a migration commit and its se
 append, walking the block index tail and appending the gap in height order. Live SSE delivery is
 best-effort on top of this durable log: a frame whose fan-out is missed (say, a halted producer) is
 recovered through replay on reconnect, exactly as after a `truncated` poll.
+
+**FCU timing.** An `observed` (or `reorged`) frame becomes durable when confirmation's consensus
+txn commits, which is **before** the execution-layer fork-choice update (FCU) for that tip.
+Live SSE defers fan-out until after a successful FCU ack; the poll transport reads the log with no
+FCU gate, so a poll can return `observed` for a block whose EL head has not advanced yet (window:
+one FCU round-trip). Presence in the log does not imply the EL head has moved. Gateways that
+cross-read `eth_*` at `latest` on `observed` must tolerate that lag or wait for EL confirmation
+separately.
 
 ## Limitation: log recreation (reset)
 

--- a/docs/90-services/06-rpc-api.md
+++ b/docs/90-services/06-rpc-api.md
@@ -142,14 +142,17 @@ size requests within `MAX_CHUNK_SPAN`, or a conforming node would answer with a 
   also means "no canonical block at that height" — a transport prober must key on the stream/events
   routes, never on the by-height read.
 
-## Limitation: the crash window
+## Durability: frames commit with their transitions
 
-A signal is in-memory between its authoritative site and the producer's durable append, so the log
-is lossless only while the node runs: a crash inside that window loses the frame. For `finalized`
-the durable truth survives in the block index, and the producer reconciles the index tail against
-the log at startup, appending any missing `finalized` frames in height order. A lost `observed` or
-`reorged` frame is not replayed; a follower recovers the resulting state through the canonical
-reads, exactly as it does after a `truncated` poll.
+Production frames are appended inside the same consensus database transaction as the state
+transition they report: confirmation writes `observed`/`reorged` frames with its metadata, and
+migration writes `finalized` with its block-index push. A crash therefore cannot lose a frame for a
+transition that persisted — the two are atomic — and a frame cannot exist for a transition that did
+not. The producer's remaining append path is startup reconciliation, which repairs `finalized`
+frames that a pre-atomic-append build lost between a migration commit and its separate producer
+append, walking the block index tail and appending the gap in height order. Live SSE delivery is
+best-effort on top of this durable log: a frame whose fan-out is missed (say, a halted producer) is
+recovered through replay on reconnect, exactly as after a `truncated` poll.
 
 ## Limitation: log recreation (reset)
 


### PR DESCRIPTION
**Describe the changes**
**Before**: Block-stream always wrote separate consensus RW txns and raced migration; Busy → 250 ms sleep per collision during catch-up.

**After**: Default-off gate on producer; stream frames fold into confirm/migrate txns; residual writers use app mutex gate.

**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Block-stream events are durably recorded and delivered in sequence.
  - Restart recovery prevents duplicate replayed or live events.
  - Reorganizations remove orphaned finalized blocks and emit updated events.
  - Stream production can be enabled or disabled through the internal API setting.
  - Startup recovery reconciles recent events after interruptions.

- **Bug Fixes**
  - Improved consistency across block, metadata, and stream updates.
  - Strengthened cache cleanup and concurrent database write handling.
  - Rejected inconsistent block header and body data.

- **Documentation**
  - Clarified replay behavior, event-history gaps, recovery, and live-stream limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->