### PR TITLE
fix(chunk-ingress): report a failed writer flush instead of answering success

### DIFF
--- a/crates/actors/src/chunk_ingress_service/chunks.rs
+++ b/crates/actors/src/chunk_ingress_service/chunks.rs
@@ -611,6 +611,12 @@ impl ChunkIngressServiceInner {
                 e
             );
             record_flush_failure();
+            // Forget the chunk before reporting, so a re-send is processed rather than skipped.
+            // This chunk was recorded as recently valid before the flush, and the duplicate check
+            // at the top of this function returns early on that record without reaching the
+            // ingress proof check — so leaving it in place would make every retry a silent
+            // no-op and the failure permanent after all.
+            self.recent_valid_chunks.write().await.pop(&chunk_path_hash);
             // Report the failure rather than returning success. The chunk is not durably stored,
             // and the ingress proof check below is skipped, so a caller told this succeeded has no
             // way to learn that the transaction can never be promoted: nothing revisits the proof

--- a/crates/actors/src/chunk_ingress_service/chunks.rs
+++ b/crates/actors/src/chunk_ingress_service/chunks.rs
@@ -611,7 +611,13 @@ impl ChunkIngressServiceInner {
                 e
             );
             record_flush_failure();
-            return Ok(());
+            // Report the failure rather than returning success. The chunk is not durably stored,
+            // and the ingress proof check below is skipped, so a caller told this succeeded has no
+            // way to learn that the transaction can never be promoted: nothing revisits the proof
+            // for a data_root once its last chunk has been acknowledged. Failing here surfaces the
+            // storage error and leaves the caller free to re-send, which is how every other write
+            // failure on this path already behaves.
+            return Err(CriticalChunkIngressError::DatabaseError.into());
         }
 
         self.try_generate_ingress_proof_for_root(root_hash.into(), chunk_size)


### PR DESCRIPTION
Fixes #1556.

When the chunk-data writer's flush fails, `handle_chunk_ingress_message` logged the error and returned `Ok(())`. Two things followed, neither visible to the client:

- `post_chunk` maps that `Ok(())` to **200 OK**, so the node acknowledged a chunk whose write did not commit.
- The early return skipped `try_generate_ingress_proof_for_root`, and nothing revisits the proof for a `data_root` afterwards — generation is only attempted on a chunk arrival or on `TryGenerateProofsForConfirmedRoots` at block confirmation. Once the last chunk has been acknowledged, neither happens again, so the transaction can never be promoted.

A client was therefore told every chunk succeeded while the transaction sat un-promoted indefinitely, with nothing to act on.

This looks like an oversight rather than a decision: the write-behind *enqueue* failure a few lines above already returns `CriticalChunkIngressError::Other`, and `post_chunk` already maps `DatabaseError` to 500. The queue path and the flush path simply disagreed about whether a storage failure is reportable.

## The change

Return `CriticalChunkIngressError::DatabaseError` instead of `Ok(())`. That maps to 500, matching the enqueue path, and lets the caller re-send — and a re-sent chunk re-triggers the proof check, so the transaction recovers once the underlying write problem clears.

## How it was found

Posting a ~4.8 GB transaction (19,073 chunks at the 256 KiB chunk size) to a single node from the Irys gateway's whole-stack test harness. The consensus database hit its map limit partway through ingress:

```
ERROR ...chunk_data_writer: Failed to cache chunk ... in table CachedChunks:
  environment map size limit reached (-30792)
ERROR ...chunk_data_writer: ChunkDataWriter MDBX transaction error:
  Commit(DatabaseErrorInfo { message: "botched transaction", code: -96001 })
ERROR ...chunks: Failed to flush chunk data writer before ingress proof check: WriteFailed
```

The last repeated 8,182 times, once per subsequent chunk. All 19,074 offsets were POSTed and answered 200; the transaction then sat un-promoted for the hour until the client gave up.

The map limit itself was a test-configuration artifact (`TEST_DB_GEOMETRY_MAX_SIZE`) and is not what this fixes — it was simply a reliable way to make a write fail. Any transient write failure reaches the same early return, and on the last chunk of a transaction it is unrecoverable.

## Worth considering separately

Proof generation depends on a chunk arrival or a block confirmation to be attempted at all, so any missed trigger is permanent rather than delayed. A periodic sweep over data_roots that have all their chunks but no local proof would make this whole class of failure self-healing. Not attempted here — it is a design call rather than a bug fix.

## Verification

`cargo check -p irys-actors` clean. The change is one returned value; I have not added a test, since reproducing it needs a write failure mid-ingress and the natural place for that is a fault-injection hook the crate does not currently have. Happy to add one if you would like it covered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Chunk ingestion now reports a critical database error when data cannot be flushed successfully.
  - Recently valid cache entries are removed after flush failures, enabling safe retries.
  - Failed ingestion is no longer reported as successful when proof generation is skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->