### PR TITLE
fix(storage): decouple ingress proofs from chunk cache

### DIFF
--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -421,10 +421,12 @@ impl InnerCacheTask {
             }
         }
 
-        let mut evictions_performed: usize = 0;
+        let mut pruned_chunks = 0_u64;
         for batch in durable_by_root.chunks(256) {
-            self.db
+            let batch_pruned = self
+                .db
                 .update_eyre_at("cache_service.prune_chunks_batch", |write_tx| {
+                    let mut batch_pruned = 0_u64;
                     for (root, durable_tx_offsets) in batch {
                         trace!(
                             chunk.data_root = ?root,
@@ -438,16 +440,18 @@ impl InnerCacheTask {
                             delete_chunks_older_than,
                         )?;
                         if pruned > 0 {
-                            evictions_performed = evictions_performed.saturating_add(1);
+                            batch_pruned = batch_pruned.saturating_add(pruned);
                             debug!(chunk.data_root = ?root, chunk.pruned_chunks = pruned, "Pruned durably stored cached chunk bodies");
                         }
                     }
-                    Ok(())
+                    Ok(batch_pruned)
                 })?;
+            // Count only deletes whose enclosing MDBX transaction committed.
+            pruned_chunks = pruned_chunks.saturating_add(batch_pruned);
         }
 
         info!(
-            chunk.eviction_batches = evictions_performed,
+            chunk.pruned_chunks = pruned_chunks,
             "Completed chunk pruning pass"
         );
         Ok(())

--- a/crates/actors/src/cache_service.rs
+++ b/crates/actors/src/cache_service.rs
@@ -1,32 +1,37 @@
 use crate::chunk_ingress_service::ChunkIngressServiceInner;
 use crate::chunk_ingress_service::ingress_proofs::{
-    RegenAction, generate_and_store_ingress_proof, reanchor_and_store_ingress_proof,
+    IngressProofGenerationState, RegenAction, generate_and_store_ingress_proof,
+    reanchor_and_store_ingress_proof,
 };
 use crate::metrics;
 use irys_database::{
-    cached_data_root_by_data_root, delete_cached_chunks_by_data_root_older_than,
-    delete_ingress_proof_if_unchanged, get_data_tx_metadata, tx_header_by_txid,
+    cached_data_root_by_data_root, delete_ingress_proof_if_unchanged,
+    delete_reclaimable_cached_chunks_older_than, get_data_tx_metadata, tx_header_by_txid,
 };
 use irys_database::{
     db::IrysDatabaseExt as _,
     delete_cached_chunks_by_data_root, get_cache_size,
-    tables::{CachedChunks, CachedDataRoots, CompactCachedIngressProof, IngressProofs},
+    tables::{
+        CachedChunks, CachedChunksIndex, CachedDataRoots, CompactCachedIngressProof, IngressProofs,
+    },
 };
-use irys_domain::{BlockBoundsError, BlockIndexReadGuard, BlockTreeReadGuard, EpochSnapshot};
+use irys_domain::{
+    BlockBoundsError, BlockIndexReadGuard, BlockTreeReadGuard, EpochSnapshot,
+    StorageModulesReadGuard,
+};
 use irys_types::ingress::CachedIngressProof;
 use irys_types::v2::GossipBroadcastMessageV2;
 use irys_types::{
     Config, DataLedger, DataRoot, DatabaseProvider, GIGABYTE, H256, IngressProof,
-    LedgerChunkOffset, SendTraced as _, TokioServiceHandle, Traced, UnixTimestamp,
+    LedgerChunkOffset, SendTraced as _, TokioServiceHandle, Traced, TxChunkOffset, UnixTimestamp,
 };
 use reth::tasks::shutdown::Shutdown;
 use reth_db::cursor::DbCursorRO as _;
 use reth_db::transaction::DbTx as _;
 use reth_db::transaction::DbTxMut as _;
 use reth_db::*;
-use std::collections::{HashMap, HashSet, VecDeque};
-use std::sync::mpsc::Sender;
-use std::sync::{Arc, RwLock};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
+use std::sync::Arc;
 use tokio::sync::{
     mpsc::{UnboundedReceiver, UnboundedSender},
     oneshot,
@@ -61,17 +66,6 @@ pub enum CacheServiceAction {
     EpochProcessingCompleted(eyre::Result<()>),
     /// Internal signal: txid pruning task completed
     PruneTxidsCompleted(eyre::Result<()>),
-    /// Marks the start of ingress proof generation for the specified data root. Chunks that are
-    /// related to this data root should not be pruned if the ingress proof is still being generated.
-    NotifyProofGenerationStarted(DataRoot),
-    /// Send this when ingress proof generation is completed and the proof has been persisted to the
-    /// db. Chunks related to this data root can now be pruned if needed.
-    NotifyProofGenerationCompleted(DataRoot),
-    /// Requests whether ingress proof generation is currently ongoing for the specified data root.
-    RequestIngressProofGenerationState {
-        data_root: DataRoot,
-        response_sender: Sender<bool>,
-    },
     /// Remove specific txids from `CachedDataRoot.txid_set` entries.
     /// Sent by the mempool when txs are pruned (anchor expired) to prevent stale
     /// txid references from blocking publish candidate selection.
@@ -99,48 +93,6 @@ pub enum CacheServiceAction {
     },
 }
 
-/// Tracks data roots for which ingress proofs are currently being generated
-/// to prevent race conditions with chunk pruning
-#[derive(Clone, Debug)]
-pub struct IngressProofGenerationState {
-    inner: Arc<RwLock<HashSet<DataRoot>>>,
-}
-
-impl Default for IngressProofGenerationState {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl IngressProofGenerationState {
-    pub fn new() -> Self {
-        Self {
-            inner: Arc::new(RwLock::new(HashSet::new())),
-        }
-    }
-
-    pub fn mark_generating(&self, data_root: DataRoot) -> bool {
-        self.inner
-            .write()
-            .expect("expected to acquire a lock for an ingress proof generation state")
-            .insert(data_root)
-    }
-
-    pub fn unmark_generating(&self, data_root: DataRoot) {
-        self.inner
-            .write()
-            .expect("expected to acquire a lock for an ingress proof generation state")
-            .remove(&data_root);
-    }
-
-    pub fn is_generating(&self, data_root: DataRoot) -> bool {
-        self.inner
-            .read()
-            .expect("expected to acquire a lock for an ingress proof generation state")
-            .contains(&data_root)
-    }
-}
-
 /// Context for cache pruning tasks. You can safely clone this struct to spawn pruning tasks on
 /// separate runtimes/threads.
 #[derive(Debug, Clone)]
@@ -152,6 +104,9 @@ pub struct InnerCacheTask {
     pub gossip_broadcast: UnboundedSender<Traced<GossipBroadcastMessageV2>>,
     pub ingress_proof_generation_state: IngressProofGenerationState,
     pub cache_sender: CacheServiceSender,
+    /// Read access to local storage modules, used to answer "is this chunk
+    /// body durably stored?" at prune time.
+    pub storage_modules_guard: StorageModulesReadGuard,
 }
 
 /// Outcome of one [`InnerCacheTask::try_prune_txids_once`] attempt.
@@ -281,12 +236,15 @@ impl InnerCacheTask {
             debug!("Cache above target capacity, proceeding with pruning");
             if chunk_cache_size > max_cache_size_bytes {
                 warn!(
-                    "Cache above max capacity! size: {} max: {}",
+                    "Cache above configured soft maximum; unmigrated bodies remain protected: size: {} max: {}",
                     &chunk_cache_size, &max_cache_size_bytes
                 )
             }
-            // Then, prune chunks that no longer have active ingress proofs
-            self.prune_chunks_without_active_ingress_proofs()?;
+            // This is a correctness-constrained soft target: bodies that have
+            // not completed the durable write/leaf handoff may temporarily
+            // keep the cache above its configured maximum. Normal terminal
+            // lifecycle pruning still removes expired or abandoned roots.
+            self.prune_durably_migrated_chunk_bodies()?;
         } else {
             debug!("Cache under target capacity, skipping chunk pruning");
         }
@@ -359,12 +317,17 @@ impl InnerCacheTask {
         })
     }
 
-    /// Prunes cached chunks for data roots that have no ingress proofs.
-    /// Since `prune_ingress_proofs()` runs immediately before this and removes
-    /// expired/invalid proofs, any remaining proof entry is treated as active.
-    /// Data roots currently undergoing proof generation are skipped to avoid races.
+    /// Capacity-prunes cached bodies that are durably stored in a local
+    /// storage module.
+    ///
+    /// Durability is read straight from the storage modules' interval state —
+    /// the same state restart recovery reloads — so the pruner can never
+    /// disagree with what the node will see after a crash. The database delete
+    /// additionally requires the current signer's compact ingress hash. A body
+    /// missing either independent prerequisite is never reclaimed, whatever
+    /// its root's ingress-proof state.
     #[tracing::instrument(level = "trace", skip_all)]
-    fn prune_chunks_without_active_ingress_proofs(&self) -> eyre::Result<()> {
+    fn prune_durably_migrated_chunk_bodies(&self) -> eyre::Result<()> {
         let local_address = self.config.irys_signer().address();
         let min_chunk_age_in_blocks = self
             .config
@@ -384,28 +347,32 @@ impl InnerCacheTask {
         // Scan candidates under a short-lived read txn, then drop it before any
         // gated write (same shape as `prune_ingress_proofs`): holding a RO txn
         // across consensus-writer-gate waits pins MVCC free-page reclamation.
-        let mut candidates: Vec<DataRoot> = Vec::new();
+        let mut candidates: BTreeMap<DataRoot, BTreeSet<TxChunkOffset>> = BTreeMap::new();
         {
             let tx = self.db.tx()?;
-            let mut cdr_cursor = tx.cursor_read::<CachedDataRoots>()?;
+            let mut chunk_cursor = tx.cursor_dup_read::<CachedChunksIndex>()?;
             let seek_key: DataRoot = H256::random();
-            let mut cdr_walk = cdr_cursor.walk(Some(seek_key))?;
+            let mut chunk_walk = chunk_cursor.walk(Some(seek_key))?;
             let mut wrapped = false;
 
-            // Cap is on candidates collected (read-phase), not on roots that
-            // actually prune chunks in the write phase: count is work
-            // attempted, not work applied. The scan therefore starts at a
+            // Cap is on roots with old cached bodies collected in the read
+            // phase, not on roots that ultimately yield a durable deletion.
+            // The scan therefore starts at a
             // random key and wraps (same shape as `prune_data_root_cache`), so
             // a stable set of non-yielding candidates early in hash order
             // cannot consume the budget every run and starve later prunable
             // roots. The wrap stops at `seek_key` so no root is visited twice.
-            // TODO: try to deprioritise data_roots that almost have all their chunks.
             loop {
-                while let Some((data_root, _cached)) = cdr_walk.next().transpose()? {
+                while let Some((data_root, entry)) = chunk_walk.next().transpose()? {
                     if wrapped && data_root >= seek_key {
                         break;
                     }
-                    if candidates.len() >= MAX_EVICTIONS_PER_RUN {
+                    if entry.meta.updated_at >= delete_chunks_older_than {
+                        continue;
+                    }
+                    if candidates.len() >= MAX_EVICTIONS_PER_RUN
+                        && !candidates.contains_key(&data_root)
+                    {
                         warn!(
                             chunk.candidates = candidates.len(),
                             "Hit max eviction limit collecting prune candidates, will continue next cycle"
@@ -413,51 +380,66 @@ impl InnerCacheTask {
                         break;
                     }
 
-                    if self.ingress_proof_generation_state.is_generating(data_root) {
-                        debug!(ingress_proof.data_root = ?data_root, "Skipping chunk prune due to active proof generation");
-                        continue;
-                    }
-
-                    if !Self::has_local_ingress_proof(&tx, data_root, local_address)? {
-                        candidates.push(data_root);
-                    }
+                    candidates.entry(data_root).or_default().insert(entry.index);
                 }
                 if wrapped || candidates.len() >= MAX_EVICTIONS_PER_RUN {
                     break;
                 }
                 wrapped = true;
-                cdr_walk = cdr_cursor.walk(None)?;
+                chunk_walk = chunk_cursor.walk(None)?;
             }
-            drop(cdr_walk);
-            drop(cdr_cursor);
+            drop(chunk_walk);
+            drop(chunk_cursor);
             drop(tx);
         }
 
+        // Resolve durability outside the write txn: each root costs one
+        // submodule index read per storage module, and roots with nothing
+        // durable are dropped before the gated write.
+        let storage_modules = self.storage_modules_guard.read().clone();
+        let mut durable_by_root: Vec<(DataRoot, BTreeSet<TxChunkOffset>)> =
+            Vec::with_capacity(candidates.len());
+        for (root, cached_offsets) in candidates {
+            let mut durable = BTreeSet::new();
+            for storage_module in &storage_modules {
+                match storage_module.durable_tx_offsets_for_data_root(root, &cached_offsets) {
+                    Ok(offsets) => durable.extend(offsets),
+                    Err(error) => {
+                        // Unreadable placement metadata is not evidence of
+                        // durability; leave the bodies for a later pass.
+                        warn!(
+                            chunk.data_root = ?root,
+                            storage_module = %storage_module.id,
+                            ?error,
+                            "Skipping chunk prune candidate with unreadable storage metadata"
+                        );
+                    }
+                }
+            }
+            if !durable.is_empty() {
+                durable_by_root.push((root, durable));
+            }
+        }
+
         let mut evictions_performed: usize = 0;
-        for batch in candidates.chunks(256) {
+        for batch in durable_by_root.chunks(256) {
             self.db
                 .update_eyre_at("cache_service.prune_chunks_batch", |write_tx| {
-                    for &root in batch {
-                        // Re-validate under the write txn: proof generation may have
-                        // started, or a local proof landed, between the RO scan and
-                        // this gated write.
-                        if self.ingress_proof_generation_state.is_generating(root)
-                            || Self::has_local_ingress_proof(write_tx, root, local_address)?
-                        {
-                            continue;
-                        }
+                    for (root, durable_tx_offsets) in batch {
                         trace!(
                             chunk.data_root = ?root,
-                            "Pruning chunks for data root without active proofs"
+                            "Pruning durably stored cached chunk bodies"
                         );
-                        let pruned = delete_cached_chunks_by_data_root_older_than(
+                        let pruned = delete_reclaimable_cached_chunks_older_than(
                             write_tx,
-                            root,
+                            *root,
+                            local_address,
+                            durable_tx_offsets,
                             delete_chunks_older_than,
                         )?;
                         if pruned > 0 {
                             evictions_performed = evictions_performed.saturating_add(1);
-                            debug!(chunk.data_root = ?root, chunk.pruned_chunks = pruned, "Pruned chunks for data root without active proofs");
+                            debug!(chunk.data_root = ?root, chunk.pruned_chunks = pruned, "Pruned durably stored cached chunk bodies");
                         }
                     }
                     Ok(())
@@ -565,6 +547,7 @@ impl InnerCacheTask {
                         batch_chunks = batch_chunks.saturating_add(
                             delete_cached_chunks_by_data_root(write_tx, rec.data_root)?,
                         );
+                        irys_database::delete_ingress_leaves_by_data_root(write_tx, rec.data_root)?;
                         write_tx.delete::<CachedDataRoots>(rec.data_root, None)?;
                         // Fresh values from the write txn, not the scan snapshot,
                         // so post-commit logging reflects what was actually deleted.
@@ -971,7 +954,7 @@ impl InnerCacheTask {
                     &signer,
                     proof,
                     &self.gossip_broadcast,
-                    &self.cache_sender,
+                    &self.ingress_proof_generation_state,
                 ) {
                     if error.is_benign() {
                         debug!(ingress_proof.data_root = ?proof, "Skipped ingress proof reanchoring: {error}");
@@ -1008,7 +991,7 @@ impl InnerCacheTask {
                     proof.data_root,
                     None,
                     &self.gossip_broadcast,
-                    &self.cache_sender,
+                    &self.ingress_proof_generation_state,
                 ) {
                     if error.is_benign() {
                         debug!(ingress_proof.data_root = ?proof.data_root, "Skipped ingress proof regeneration: {error}");
@@ -1188,6 +1171,8 @@ impl ChunkCacheService {
         config: Config,
         gossip_broadcast: UnboundedSender<Traced<GossipBroadcastMessageV2>>,
         cache_sender: CacheServiceSender,
+        storage_modules_guard: StorageModulesReadGuard,
+        ingress_proof_generation_state: IngressProofGenerationState,
         runtime_handle: tokio::runtime::Handle,
     ) -> TokioServiceHandle {
         info!("Spawning chunk cache service");
@@ -1204,8 +1189,9 @@ impl ChunkCacheService {
                     block_index_guard,
                     config,
                     gossip_broadcast,
-                    ingress_proof_generation_state: IngressProofGenerationState::new(),
+                    ingress_proof_generation_state,
                     cache_sender,
+                    storage_modules_guard,
                 },
                 pruning_running: false,
                 pruning_queue: VecDeque::new(),
@@ -1315,28 +1301,6 @@ impl ChunkCacheService {
                     self.cache_task.spawn_epoch_processing(e, s);
                 }
             }
-            CacheServiceAction::NotifyProofGenerationStarted(data_root) => {
-                self.cache_task
-                    .ingress_proof_generation_state
-                    .mark_generating(data_root);
-            }
-            CacheServiceAction::NotifyProofGenerationCompleted(data_root) => {
-                self.cache_task
-                    .ingress_proof_generation_state
-                    .unmark_generating(data_root);
-            }
-            CacheServiceAction::RequestIngressProofGenerationState {
-                data_root,
-                response_sender,
-            } => {
-                let is_generating = self
-                    .cache_task
-                    .ingress_proof_generation_state
-                    .is_generating(data_root);
-                if let Err(e) = response_sender.send(is_generating) {
-                    warn!(custom.error = ?e, "Failed to respond to RequestIngressProofGenerationState");
-                }
-            }
             CacheServiceAction::PruneTxidsFromCachedDataRoots(by_data_root) => {
                 // Enqueue txid pruning; start if idle
                 self.txid_prune_queue.push_back(by_data_root);
@@ -1382,6 +1346,88 @@ impl ChunkCacheService {
 
 #[cfg(test)]
 mod tests {
+    /// Cache tests exercise pruning policy, not storage placement; an empty
+    /// module set means "nothing is durably stored locally".
+    fn test_storage_modules_guard() -> StorageModulesReadGuard {
+        StorageModulesReadGuard::new(Arc::new(RwLock::new(Vec::new())))
+    }
+
+    /// A guard holding one storage module that genuinely reports `offsets` of
+    /// `data_root` as fsynced `Data` — indexed, written, and flushed the way the
+    /// real write path does. Needed because reclamation is gated on the storage
+    /// module's own interval state, so an empty guard can never evict.
+    fn storage_modules_guard_with_durable(
+        base_directory: std::path::PathBuf,
+        data_root: DataRoot,
+        data_size: u64,
+        offsets: &[u32],
+    ) -> eyre::Result<StorageModulesReadGuard> {
+        use irys_database::submodule::{add_data_root_info, tables::DataRootInfo};
+        use irys_domain::{ChunkType, StorageModule, StorageModuleInfo};
+        use irys_types::{
+            ConsensusConfig, PartitionChunkOffset, RelativeChunkOffset,
+            partition::PartitionAssignment, partition_chunk_offset_ie,
+        };
+
+        let num_chunks = 10_u64;
+        let node_config = NodeConfig {
+            consensus: irys_types::ConsensusOptions::Custom(ConsensusConfig {
+                chunk_size: 32,
+                num_chunks_in_partition: num_chunks,
+                num_chunks_in_recall_range: 2,
+                num_partitions_per_slot: 1,
+                entropy_packing_iterations: 1,
+                chain_id: 1,
+                ..ConsensusConfig::testing()
+            }),
+            base_directory,
+            ..NodeConfig::testing()
+        };
+        let sm_config = Config::new_with_random_peer_id(node_config);
+        let info = StorageModuleInfo {
+            id: 0,
+            partition_assignment: Some(PartitionAssignment {
+                ledger_id: Some(DataLedger::Submit.into()),
+                slot_index: Some(0),
+                miner_address: IrysAddress::random(),
+                partition_hash: H256::random(),
+            }),
+            submodules: vec![(
+                partition_chunk_offset_ie!(0, num_chunks as u32),
+                "chunks".into(),
+            )],
+        };
+        let sm = Arc::new(StorageModule::new(&info, &sm_config)?);
+        let (_, submodule) = sm.get_submodule_for_offset(PartitionChunkOffset::from(0_u32))?;
+        submodule.db.update_eyre(|tx| {
+            add_data_root_info(
+                tx,
+                data_root,
+                &DataRootInfo {
+                    start_offset: RelativeChunkOffset::from(0_i32),
+                    data_size,
+                },
+            )
+        })?;
+        for offset in offsets {
+            sm.write_chunk(
+                PartitionChunkOffset::from(*offset),
+                vec![9_u8; 32],
+                ChunkType::Data,
+            );
+        }
+        sm.force_sync_pending_chunks()?;
+        for offset in offsets {
+            eyre::ensure!(
+                sm.is_data_chunk_durable_at(PartitionChunkOffset::from(*offset)),
+                "test fixture failed to make offset {offset} durable"
+            );
+        }
+        Ok(StorageModulesReadGuard::new(Arc::new(RwLock::new(vec![
+            sm,
+        ]))))
+    }
+
     use super::*;
     use irys_database::{
         IrysDatabaseArgs as _, database,
@@ -1487,6 +1533,7 @@ mod tests {
                 gossip_broadcast: tokio::sync::mpsc::unbounded_channel().0,
                 ingress_proof_generation_state: IngressProofGenerationState::new(),
                 cache_sender: tx,
+                storage_modules_guard: test_storage_modules_guard(),
             },
             pruning_running: false,
             pruning_queue: VecDeque::new(),
@@ -1573,6 +1620,7 @@ mod tests {
                 gossip_broadcast: tokio::sync::mpsc::unbounded_channel().0,
                 ingress_proof_generation_state: IngressProofGenerationState::new(),
                 cache_sender: tx,
+                storage_modules_guard: test_storage_modules_guard(),
             },
             pruning_running: false,
             pruning_queue: VecDeque::new(),
@@ -1595,106 +1643,9 @@ mod tests {
         Ok(())
     }
 
-    // Chunks should remain when there is an active ingress proof present for the data_root.
+    // A missing proof is not evidence that an individual body was durably migrated.
     #[tokio::test]
-    async fn does_not_prune_chunks_with_active_proof() -> eyre::Result<()> {
-        let node_config = NodeConfig::testing();
-        let config = Config::new_with_random_peer_id(node_config);
-        let _temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
-        let db_env = open_or_create_db(
-            &_temp_dir,
-            IrysTables::ALL,
-            DatabaseArguments::irys_testing()?,
-        )?;
-        let db = DatabaseProvider(Arc::new(db_env));
-
-        // Create tx header + data root + chunk
-        let tx_header = DataTransactionHeader::V1(DataTransactionHeaderV1WithMetadata {
-            tx: DataTransactionHeaderV1 {
-                data_size: 64,
-                ..Default::default()
-            },
-            metadata: DataTransactionMetadata::new(),
-        });
-        db.update(|wtx| {
-            database::cache_data_root(wtx, &tx_header, None)?;
-            eyre::Ok(())
-        })??;
-        let chunk = UnpackedChunk {
-            data_root: tx_header.data_root,
-            data_size: tx_header.data_size,
-            data_path: Base64(vec![]),
-            bytes: Base64(vec![1_u8; 8]),
-            tx_offset: TxChunkOffset::from(0_u32),
-        };
-        db.update(|wtx| {
-            database::cache_chunk(wtx, &chunk)?;
-            eyre::Ok(())
-        })??;
-
-        // Insert a (non-expired) ingress proof entry for the data root so pruning treats it as active
-        db.update(|wtx| {
-            let mut ingress_proof = IngressProof::default();
-            ingress_proof.data_root = tx_header.data_root;
-            irys_database::store_external_ingress_proof_checked(
-                wtx,
-                &ingress_proof,
-                irys_types::IrysAddress::random(),
-            )?;
-            eyre::Ok(())
-        })??;
-
-        // Setup minimal service context
-        let genesis_block = new_mock_signed_header();
-        let block_tree = BlockTree::new(&genesis_block, config.consensus.clone());
-        let block_tree_guard =
-            irys_domain::BlockTreeReadGuard::new(Arc::new(RwLock::new(block_tree)));
-        let block_index = BlockIndex::new_for_testing(db.clone());
-        let block_index_guard =
-            irys_domain::block_index_guard::BlockIndexReadGuard::new(block_index);
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-        let service_task = InnerCacheTask {
-            db: db.clone(),
-            block_tree_guard,
-            block_index_guard,
-            config,
-            gossip_broadcast: tokio::sync::mpsc::unbounded_channel().0,
-            ingress_proof_generation_state: IngressProofGenerationState::new(),
-            cache_sender: tx,
-        };
-
-        // Execute chunk-only pruning (proofs present so should skip deletion)
-        service_task.prune_chunks_without_active_ingress_proofs()?;
-
-        // Verify chunk still exists
-        db.view(|rtx| -> eyre::Result<()> {
-            let mut dup_cursor = rtx.cursor_dup_read::<CachedChunksIndex>()?;
-            let mut walk = dup_cursor.walk(Some(tx_header.data_root))?;
-            let has_index = walk.next().transpose()?.is_some();
-            eyre::ensure!(
-                has_index,
-                "CachedChunksIndex entry missing after prune but proof was active"
-            );
-            // Attempt to resolve chunk from index metadata
-            if let Some((_, idx_entry)) = rtx
-                .cursor_dup_read::<CachedChunksIndex>()?
-                .seek_exact(tx_header.data_root)?
-            {
-                let meta: irys_database::db_cache::CachedChunkIndexMetadata = idx_entry.into();
-                let chunk_entry = rtx.get::<CachedChunks>(meta.chunk_path_hash)?;
-                eyre::ensure!(
-                    chunk_entry.is_some(),
-                    "CachedChunks value missing after prune but proof was active"
-                );
-            }
-            Ok(())
-        })??;
-        Ok(())
-    }
-
-    // Chunks should be pruned when there is no ingress proof for the data_root.
-    #[tokio::test]
-    async fn prunes_chunks_without_any_proof() -> eyre::Result<()> {
+    async fn does_not_capacity_prune_unmigrated_chunks_without_a_proof() -> eyre::Result<()> {
         let node_config = NodeConfig::testing();
         let config = Config::new_with_random_peer_id(node_config);
         let _temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
@@ -1753,19 +1704,20 @@ mod tests {
             gossip_broadcast: tokio::sync::mpsc::unbounded_channel().0,
             ingress_proof_generation_state: IngressProofGenerationState::new(),
             cache_sender: tx,
+            storage_modules_guard: test_storage_modules_guard(),
         };
 
-        // Execute chunk pruning (no proofs -> should delete)
-        service_task.prune_chunks_without_active_ingress_proofs()?;
+        // Execute capacity pruning. No durable storage offset exists, so the body stays.
+        service_task.prune_durably_migrated_chunk_bodies()?;
 
-        // Verify chunk removed
+        // Verify the unmigrated body remains recoverable.
         db.view(|rtx| -> eyre::Result<()> {
             let mut dup_cursor = rtx.cursor_dup_read::<CachedChunksIndex>()?;
             let mut walk = dup_cursor.walk(Some(tx_header.data_root))?;
             let index_entry = walk.next().transpose()?;
             eyre::ensure!(
-                index_entry.is_none(),
-                "CachedChunksIndex entry still present but should have been pruned"
+                index_entry.is_some(),
+                "unmigrated chunk was pruned merely because its root lacks a proof"
             );
             Ok(())
         })??;
@@ -1774,7 +1726,7 @@ mod tests {
 
     // Chunks older than threshold should be deleted while newer ones should remain.
     #[tokio::test]
-    async fn prunes_only_chunks_older_than_threshold() -> eyre::Result<()> {
+    async fn prunes_only_migrated_chunks_older_than_threshold() -> eyre::Result<()> {
         let _temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
         let db_env = open_or_create_db(
             &_temp_dir,
@@ -1800,6 +1752,7 @@ mod tests {
             },
             metadata: DataTransactionMetadata::new(),
         });
+        let address = IrysAddress::random();
         db.update(|wtx| {
             database::cache_data_root(wtx, &tx_header_old, None)?;
             database::cache_data_root(wtx, &tx_header_new, None)?;
@@ -1830,7 +1783,13 @@ mod tests {
                 hash_old,
                 irys_database::db_cache::CachedChunk::from(&chunk_old),
             )?;
-
+            irys_database::store_ingress_data_hash(
+                wtx,
+                tx_header_old.data_root,
+                address,
+                chunk_old.tx_offset,
+                irys_types::generate_ingress_data_hash(&chunk_old.bytes.0, address),
+            )?;
             let chunk_new = mk_chunk(tx_header_new.data_root, 0, 11);
             let hash_new = chunk_new.chunk_path_hash();
             let idx_new = irys_database::db_cache::CachedChunkIndexEntry {
@@ -1869,9 +1828,11 @@ mod tests {
         })??;
 
         db.update(|wtx| {
-            let pruned = delete_cached_chunks_by_data_root_older_than(
+            let pruned = delete_reclaimable_cached_chunks_older_than(
                 wtx,
                 tx_header_old.data_root,
+                address,
+                &BTreeSet::from([TxChunkOffset::from(0)]),
                 UnixTimestamp::from_secs(5),
             )?;
             eyre::ensure!(pruned >= 1, "Expected old root chunk to be pruned");
@@ -1915,6 +1876,7 @@ mod tests {
         // First run: below 80% (set to 96B; 64B cache < 76.8B threshold)
         node_config.cache.max_cache_size_bytes = 96;
         let config_below = Config::new_with_random_peer_id(node_config.clone());
+        let ingress_address = config_below.irys_signer().address();
 
         let _temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
         let db_env = open_or_create_db(
@@ -1951,6 +1913,20 @@ mod tests {
             };
             database::cache_chunk(wtx, &c0)?;
             database::cache_chunk(wtx, &c1)?;
+            database::store_ingress_data_hash(
+                wtx,
+                tx_header.data_root,
+                ingress_address,
+                c0.tx_offset,
+                irys_types::generate_ingress_data_hash(&c0.bytes.0, ingress_address),
+            )?;
+            database::store_ingress_data_hash(
+                wtx,
+                tx_header.data_root,
+                ingress_address,
+                c1.tx_offset,
+                irys_types::generate_ingress_data_hash(&c1.bytes.0, ingress_address),
+            )?;
 
             // Mark both chunks as very old
             let mut cur = wtx.cursor_dup_write::<CachedChunksIndex>()?;
@@ -1983,6 +1959,7 @@ mod tests {
             gossip_broadcast: tokio::sync::mpsc::unbounded_channel().0,
             ingress_proof_generation_state: IngressProofGenerationState::new(),
             cache_sender: tx.clone(),
+            storage_modules_guard: test_storage_modules_guard(),
         };
         task_below.prune_cache(0)?;
 
@@ -2005,7 +1982,9 @@ mod tests {
             Ok(())
         })??;
 
-        // Above-capacity prune: set max to 64B so 64B cache > 51.2B threshold
+        // Above-capacity prune: set max to 64B so 64B cache > 51.2B threshold.
+        // Both offsets are durably stored, so the pass may reclaim them.
+        let sm_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
         let mut node_config2 = node_config;
         node_config2.cache.max_cache_size_bytes = 64;
         let config_above = Config::new_with_random_peer_id(node_config2);
@@ -2017,11 +1996,16 @@ mod tests {
             gossip_broadcast: tokio::sync::mpsc::unbounded_channel().0,
             ingress_proof_generation_state: IngressProofGenerationState::new(),
             cache_sender: tx,
+            storage_modules_guard: storage_modules_guard_with_durable(
+                sm_dir.path().to_path_buf(),
+                tx_header.data_root,
+                tx_header.data_size,
+                &[0, 1],
+            )?,
         };
         task_above.prune_cache(0)?;
 
         db.view(|rtx| -> eyre::Result<()> {
-            // Expect indices pruned now that we're above capacity
             let mut cur = rtx.cursor_dup_read::<CachedChunksIndex>()?;
             let mut walk = cur.walk(Some(tx_header.data_root))?;
             eyre::ensure!(
@@ -2031,76 +2015,6 @@ mod tests {
             Ok(())
         })??;
 
-        Ok(())
-    }
-
-    // Chunks should not be pruned when proof generation state marks the data_root active, even with no ingress proof yet.
-    #[tokio::test]
-    async fn skips_pruning_during_active_generation_state() -> eyre::Result<()> {
-        let node_config = NodeConfig::testing();
-        let config = Config::new_with_random_peer_id(node_config);
-        let _temp_dir = irys_testing_utils::utils::TempDirBuilder::new().build();
-        let db_env = open_or_create_db(
-            &_temp_dir,
-            IrysTables::ALL,
-            DatabaseArguments::irys_testing()?,
-        )?;
-        let db = DatabaseProvider(Arc::new(db_env));
-        let tx_header = DataTransactionHeader::V1(DataTransactionHeaderV1WithMetadata {
-            tx: DataTransactionHeaderV1 {
-                data_size: 64,
-                ..Default::default()
-            },
-            metadata: DataTransactionMetadata::new(),
-        });
-        db.update(|wtx| {
-            database::cache_data_root(wtx, &tx_header, None)?;
-            eyre::Ok(())
-        })??;
-        let chunk = UnpackedChunk {
-            data_root: tx_header.data_root,
-            data_size: tx_header.data_size,
-            data_path: Base64(vec![]),
-            bytes: Base64(vec![3_u8; 8]),
-            tx_offset: TxChunkOffset::from(0_u32),
-        };
-        db.update(|wtx| {
-            database::cache_chunk(wtx, &chunk)?;
-            eyre::Ok(())
-        })??;
-
-        let genesis_block = new_mock_signed_header();
-        let block_tree = BlockTree::new(&genesis_block, config.consensus.clone());
-        let block_tree_guard =
-            irys_domain::BlockTreeReadGuard::new(Arc::new(RwLock::new(block_tree)));
-        let block_index = BlockIndex::new_for_testing(db.clone());
-        let block_index_guard =
-            irys_domain::block_index_guard::BlockIndexReadGuard::new(block_index);
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-        let generation_state = IngressProofGenerationState::new();
-        generation_state.mark_generating(tx_header.data_root);
-        let service_task = InnerCacheTask {
-            db: db.clone(),
-            block_tree_guard,
-            block_index_guard,
-            config,
-            gossip_broadcast: tokio::sync::mpsc::unbounded_channel().0,
-            ingress_proof_generation_state: generation_state,
-            cache_sender: tx,
-        };
-
-        service_task.prune_chunks_without_active_ingress_proofs()?;
-
-        db.view(|rtx| -> eyre::Result<()> {
-            let mut dup_cursor = rtx.cursor_dup_read::<CachedChunksIndex>()?;
-            let mut walk = dup_cursor.walk(Some(tx_header.data_root))?;
-            let still_present = walk.next().transpose()?.is_some();
-            eyre::ensure!(
-                still_present,
-                "CachedChunksIndex entry wrongly pruned during active generation state"
-            );
-            Ok(())
-        })??;
         Ok(())
     }
 
@@ -2171,6 +2085,7 @@ mod tests {
             gossip_broadcast: tokio::sync::mpsc::unbounded_channel().0,
             ingress_proof_generation_state: IngressProofGenerationState::new(),
             cache_sender: tx,
+            storage_modules_guard: test_storage_modules_guard(),
         };
 
         // Prune with prune_height greater than expiry (6 > 5).
@@ -2247,6 +2162,7 @@ mod tests {
             gossip_broadcast: tokio::sync::mpsc::unbounded_channel().0,
             ingress_proof_generation_state: IngressProofGenerationState::new(),
             cache_sender: tx,
+            storage_modules_guard: test_storage_modules_guard(),
         };
 
         service_task.prune_data_root_cache(1)?;
@@ -2335,6 +2251,7 @@ mod tests {
             gossip_broadcast: tokio::sync::mpsc::unbounded_channel().0,
             ingress_proof_generation_state: IngressProofGenerationState::new(),
             cache_sender: tx,
+            storage_modules_guard: test_storage_modules_guard(),
         };
 
         // Without the local-proof exemption the (None, None) state would be
@@ -2418,6 +2335,7 @@ mod tests {
             gossip_broadcast: tokio::sync::mpsc::unbounded_channel().0,
             ingress_proof_generation_state: IngressProofGenerationState::new(),
             cache_sender: tx,
+            storage_modules_guard: test_storage_modules_guard(),
         };
 
         // `prune_height = 100` is well past the confirmed tx's `included_height`
@@ -2497,6 +2415,7 @@ mod tests {
             gossip_broadcast: tokio::sync::mpsc::unbounded_channel().0,
             ingress_proof_generation_state: IngressProofGenerationState::new(),
             cache_sender: tx,
+            storage_modules_guard: test_storage_modules_guard(),
         };
 
         // Spawn the prune task and wait for the background thread to finish.
@@ -2634,6 +2553,7 @@ mod tests {
             gossip_broadcast: tokio::sync::mpsc::unbounded_channel().0,
             ingress_proof_generation_state: IngressProofGenerationState::new(),
             cache_sender: tx,
+            storage_modules_guard: test_storage_modules_guard(),
         };
 
         service_task.prune_ingress_proofs()?;
@@ -2762,6 +2682,7 @@ mod tests {
             gossip_broadcast: tokio::sync::mpsc::unbounded_channel().0,
             ingress_proof_generation_state: IngressProofGenerationState::new(),
             cache_sender: tx,
+            storage_modules_guard: test_storage_modules_guard(),
         };
 
         service_task.prune_ingress_proofs()?;
@@ -2903,6 +2824,7 @@ mod tests {
             gossip_broadcast: tokio::sync::mpsc::unbounded_channel().0,
             ingress_proof_generation_state: IngressProofGenerationState::new(),
             cache_sender: tx,
+            storage_modules_guard: test_storage_modules_guard(),
         };
 
         service_task.prune_ingress_proofs()?;
@@ -3010,6 +2932,7 @@ mod tests {
             gossip_broadcast: tokio::sync::mpsc::unbounded_channel().0,
             ingress_proof_generation_state: IngressProofGenerationState::new(),
             cache_sender: tx,
+            storage_modules_guard: test_storage_modules_guard(),
         }
     }
 

--- a/crates/actors/src/chunk_ingress_service.rs
+++ b/crates/actors/src/chunk_ingress_service.rs
@@ -325,17 +325,25 @@ impl ChunkIngressService {
                         ingress_proof_generation_state,
                     }),
                 };
-                for data_root in retry_roots {
-                    if let Err(error) = service.inner.try_generate_ingress_proof_for_root(
-                        data_root,
-                        service.inner.config.consensus.chunk_size,
-                    ) {
-                        warn!(
-                            %data_root,
-                            ?error,
-                            "Failed startup ingress-proof retry after compact-hash backfill"
-                        );
-                    }
+                let retry_inner = Arc::clone(&service.inner);
+                if let Err(error) = handle_for_inner
+                    .spawn_blocking(move || {
+                        let chunk_size = retry_inner.config.consensus.chunk_size;
+                        for data_root in retry_roots {
+                            if let Err(error) = retry_inner
+                                .try_generate_ingress_proof_for_root(data_root, chunk_size)
+                            {
+                                warn!(
+                                    %data_root,
+                                    ?error,
+                                    "Failed startup ingress-proof retry after compact-hash backfill"
+                                );
+                            }
+                        }
+                    })
+                    .await
+                {
+                    warn!(?error, "Startup ingress-proof retry task failed");
                 }
                 service
                     .start(handle_for_inner)

--- a/crates/actors/src/chunk_ingress_service.rs
+++ b/crates/actors/src/chunk_ingress_service.rs
@@ -6,7 +6,9 @@ pub(crate) mod metrics;
 pub mod pending_chunks;
 
 pub use chunks::{AdvisoryChunkIngressError, ChunkIngressError, CriticalChunkIngressError};
-pub use ingress_proofs::{IngressProofError, IngressProofGenerationError};
+pub use ingress_proofs::{
+    IngressProofError, IngressProofGenerationError, IngressProofGenerationState,
+};
 pub use pending_chunks::PriorityPendingChunks;
 
 use std::num::NonZeroUsize;
@@ -107,6 +109,7 @@ pub(crate) struct ChunkIngressServiceInner {
     pub(crate) recent_valid_chunks: tokio::sync::RwLock<LruCache<ChunkPathHash, ()>>,
     pub(crate) pending_chunks: Arc<RwLock<PriorityPendingChunks>>,
     pub(crate) chunk_data_writer: chunk_data_writer::ChunkDataWriter,
+    pub(crate) ingress_proof_generation_state: IngressProofGenerationState,
 }
 
 impl ChunkIngressServiceInner {
@@ -157,13 +160,6 @@ impl ChunkIngressServiceInner {
                 self.process_pending_chunks_for_root(data_root).await;
             }
             ChunkIngressMessage::TryGenerateProofsForConfirmedRoots(data_roots) => {
-                // Flush to ensure any buffered chunk writes are visible before reading.
-                if let Err(e) = self.chunk_data_writer.flush().await {
-                    error!(
-                        "Failed to flush chunk data writer before post-confirmation proof check: {:?}",
-                        e
-                    );
-                }
                 let chunk_size = self.config.consensus.chunk_size;
                 for data_root in data_roots {
                     if let Err(e) = self.try_generate_ingress_proof_for_root(data_root, chunk_size)
@@ -208,6 +204,7 @@ impl ChunkIngressService {
         rx: UnboundedReceiver<Traced<ChunkIngressMessage>>,
         config: &Config,
         service_senders: &ServiceSenders,
+        ingress_proof_generation_state: IngressProofGenerationState,
         runtime_handle: tokio::runtime::Handle,
         task_executor: TaskExecutor,
     ) -> (TokioServiceHandle, ChunkIngressState) {
@@ -276,8 +273,32 @@ impl ChunkIngressService {
                 let recent_valid_chunks = tokio::sync::RwLock::new(LruCache::new(
                     NonZeroUsize::new(max_valid_chunks).unwrap(),
                 ));
+                let ingress_address = config.irys_signer().address();
+                let ingress_chunk_size = config.consensus.chunk_size;
+                let backfill_db = irys_db.clone();
+                let retry_roots = match handle_for_inner
+                    .spawn_blocking(move || {
+                        irys_database::backfill_cached_ingress_data_hashes(
+                            &backfill_db,
+                            ingress_address,
+                            ingress_chunk_size,
+                        )
+                    })
+                    .await
+                {
+                    Ok(Ok(roots)) => roots,
+                    Ok(Err(error)) => {
+                        warn!(?error, "Failed to backfill cached ingress hashes");
+                        Default::default()
+                    }
+                    Err(error) => {
+                        warn!(?error, "Cached ingress-hash backfill task failed");
+                        Default::default()
+                    }
+                };
                 let chunk_data_writer = chunk_data_writer::ChunkDataWriter::spawn(
                     irys_db.clone(),
+                    ingress_address,
                     chunk_writer_buffer_size,
                     &handle_for_inner,
                 );
@@ -301,8 +322,21 @@ impl ChunkIngressService {
                         recent_valid_chunks,
                         pending_chunks,
                         chunk_data_writer,
+                        ingress_proof_generation_state,
                     }),
                 };
+                for data_root in retry_roots {
+                    if let Err(error) = service.inner.try_generate_ingress_proof_for_root(
+                        data_root,
+                        service.inner.config.consensus.chunk_size,
+                    ) {
+                        warn!(
+                            %data_root,
+                            ?error,
+                            "Failed startup ingress-proof retry after compact-hash backfill"
+                        );
+                    }
+                }
                 service
                     .start(handle_for_inner)
                     .await
@@ -457,68 +491,46 @@ impl ChunkIngressService {
             }
         }
 
-        // Phase 2: drain BOTH lanes before flushing. `process_pending_chunks_for_root`
-        // runs on the control-plane lane and queues writes through `chunk_data_writer`,
-        // so an early flush before control-plane quiescence would race those writers
-        // and lose chunks on exit. Use `acquire_many_owned` so permits are not
-        // lifetime-tied to the semaphore arcs.
+        // Phase 2: drain both lanes. Every ingress writer awaits the exact MDBX
+        // batch containing its own chunk, so handler quiescence also guarantees
+        // there are no unacknowledged chunk-cache writes. Use
+        // `acquire_many_owned` so permits are not lifetime-tied to the semaphore
+        // arcs.
         let drain_deadline = tokio::time::Instant::now() + Duration::from_secs(30);
         let chunk_acquire = self
             .inner
             .message_handler_semaphore
             .clone()
             .acquire_many_owned(self.inner.max_concurrent_tasks);
-        let chunk_quiesced = match tokio::time::timeout_at(drain_deadline, chunk_acquire).await {
+        match tokio::time::timeout_at(drain_deadline, chunk_acquire).await {
             Ok(Ok(permits)) => {
                 tracing::debug!("All chunk ingress handlers completed");
                 let _permits = permits;
-                true
             }
             Ok(Err(_)) => {
                 error!("Chunk-lane semaphore closed during chunk ingress shutdown drain");
-                false
             }
             Err(_) => {
                 warn!("Timed out waiting for in-flight chunk ingress handlers");
-                false
             }
-        };
+        }
 
         let control_acquire = self
             .inner
             .control_plane_semaphore
             .clone()
             .acquire_many_owned(self.inner.max_control_plane_tasks);
-        let control_quiesced = match tokio::time::timeout_at(drain_deadline, control_acquire).await
-        {
+        match tokio::time::timeout_at(drain_deadline, control_acquire).await {
             Ok(Ok(permits)) => {
                 tracing::debug!("All control-plane handlers completed");
                 let _permits = permits;
-                true
             }
             Ok(Err(_)) => {
                 error!("Control-plane semaphore closed during chunk ingress shutdown drain");
-                false
             }
             Err(_) => {
                 warn!("Timed out waiting for in-flight control-plane handlers");
-                false
             }
-        };
-
-        // Flush only when both lanes are quiesced, otherwise an in-flight
-        // control-plane writer could queue chunk writes after the flush
-        // returns — losing those chunks on exit.
-        if chunk_quiesced && control_quiesced {
-            if let Err(e) = self.inner.chunk_data_writer.flush().await {
-                warn!("Failed to flush chunk writer on shutdown: {:?}", e);
-            }
-        } else {
-            warn!(
-                chunk_quiesced,
-                control_quiesced,
-                "Skipping chunk-writer flush; not all lanes quiesced before timeout"
-            );
         }
 
         info!("ChunkIngressService shut down");

--- a/crates/actors/src/chunk_ingress_service/chunk_data_writer.rs
+++ b/crates/actors/src/chunk_ingress_service/chunk_data_writer.rs
@@ -1,16 +1,18 @@
 use dashmap::DashSet;
-use irys_database::cache_chunk_verified;
 use irys_database::db::IrysDatabaseExt as _;
-use irys_types::{ChunkPathHash, DatabaseProvider, UnpackedChunk};
+use irys_database::{cache_chunk_verified, store_ingress_data_hash};
+use irys_types::{
+    ChunkPathHash, DatabaseProvider, H256, IrysAddress, UnpackedChunk, generate_ingress_data_hash,
+};
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, error, warn};
 
 const MAX_BATCH_SIZE: usize = 64;
 
-enum WriterCommand {
-    WriteChunk(Arc<UnpackedChunk>),
-    Flush(oneshot::Sender<Result<(), QueueError>>),
+struct PendingChunkWrite {
+    chunk: Arc<UnpackedChunk>,
+    done: oneshot::Sender<Result<(), QueueError>>,
 }
 
 /// Async write-behind buffer for chunk MDBX writes.
@@ -21,14 +23,30 @@ enum WriterCommand {
 /// in-flight duplicates without hitting the database.
 #[derive(Debug)]
 pub(crate) struct ChunkDataWriter {
-    tx: mpsc::Sender<WriterCommand>,
+    tx: mpsc::Sender<PendingChunkWrite>,
     pending_hashes: Arc<DashSet<ChunkPathHash>>,
+}
+
+pub(crate) struct QueuedChunkWrite {
+    is_duplicate: bool,
+    done: oneshot::Receiver<Result<(), QueueError>>,
+}
+
+impl QueuedChunkWrite {
+    pub(crate) const fn is_duplicate(&self) -> bool {
+        self.is_duplicate
+    }
+
+    pub(crate) async fn committed(self) -> Result<(), QueueError> {
+        self.done.await.map_err(|_| QueueError::ChannelClosed)?
+    }
 }
 
 impl ChunkDataWriter {
     /// Spawn the background writer task and return the writer handle.
     pub(crate) fn spawn(
         db: DatabaseProvider,
+        address: IrysAddress,
         buffer_size: usize,
         runtime_handle: &tokio::runtime::Handle,
     ) -> Self {
@@ -38,6 +56,7 @@ impl ChunkDataWriter {
         let writer = BackgroundWriter {
             rx,
             db,
+            address,
             pending_hashes: Arc::clone(&pending_hashes),
         };
         runtime_handle.spawn(writer.run());
@@ -45,43 +64,39 @@ impl ChunkDataWriter {
         Self { tx, pending_hashes }
     }
 
-    /// Queue a chunk for asynchronous write to the cache DB.
+    /// Queue a chunk and return its exact batch-commit acknowledgement.
     ///
-    /// Returns `true` if the chunk hash is already pending (duplicate).
-    pub(crate) async fn queue_write(&self, chunk: Arc<UnpackedChunk>) -> Result<bool, QueueError> {
+    /// Concurrent writes are still committed in shared MDBX batches, but each
+    /// caller receives an acknowledgement for the batch containing its own
+    /// chunk. The returned handle also records whether the chunk hash was
+    /// already pending (duplicate).
+    pub(crate) async fn queue_write(
+        &self,
+        chunk: Arc<UnpackedChunk>,
+    ) -> Result<QueuedChunkWrite, QueueError> {
         let hash = chunk.chunk_path_hash();
-        if !self.pending_hashes.insert(hash) {
-            return Ok(true);
-        }
+        let is_duplicate = !self.pending_hashes.insert(hash);
+        let (done_tx, done_rx) = oneshot::channel();
         if self
             .tx
-            .send(WriterCommand::WriteChunk(chunk))
+            .send(PendingChunkWrite {
+                chunk,
+                done: done_tx,
+            })
             .await
             .is_err()
         {
             self.pending_hashes.remove(&hash);
             return Err(QueueError::ChannelClosed);
         }
-        Ok(false)
-    }
-
-    /// Drain all pending writes before returning.
-    ///
-    /// Sends a flush sentinel through the channel and waits for the
-    /// background writer to acknowledge it. Because the channel is FIFO,
-    /// all chunks queued before the flush are guaranteed to be committed
-    /// to MDBX by the time this returns.
-    pub(crate) async fn flush(&self) -> Result<(), QueueError> {
-        let (done_tx, done_rx) = oneshot::channel();
-        self.tx
-            .send(WriterCommand::Flush(done_tx))
-            .await
-            .map_err(|_| QueueError::ChannelClosed)?;
-        done_rx.await.map_err(|_| QueueError::ChannelClosed)?
+        Ok(QueuedChunkWrite {
+            is_duplicate,
+            done: done_rx,
+        })
     }
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
 pub(crate) enum QueueError {
     #[error("writer channel closed")]
     ChannelClosed,
@@ -90,106 +105,115 @@ pub(crate) enum QueueError {
 }
 
 struct BackgroundWriter {
-    rx: mpsc::Receiver<WriterCommand>,
+    rx: mpsc::Receiver<PendingChunkWrite>,
     db: DatabaseProvider,
+    address: IrysAddress,
     pending_hashes: Arc<DashSet<ChunkPathHash>>,
 }
 
 impl BackgroundWriter {
     async fn run(mut self) {
-        let mut batch: Vec<Arc<UnpackedChunk>> = Vec::with_capacity(MAX_BATCH_SIZE);
+        let mut batch: Vec<PendingChunkWrite> = Vec::with_capacity(MAX_BATCH_SIZE);
 
         loop {
-            let cmd = match self.rx.recv().await {
-                Some(cmd) => cmd,
+            let write = match self.rx.recv().await {
+                Some(write) => write,
                 None => {
-                    debug!("ChunkDataWriter channel closed, flushing remaining");
+                    debug!("ChunkDataWriter channel closed, committing remaining writes");
                     break;
                 }
             };
 
-            match cmd {
-                WriterCommand::WriteChunk(chunk) => batch.push(chunk),
-                WriterCommand::Flush(done) => {
-                    let result = if !batch.is_empty() {
-                        let r = self.write_batch(&batch);
-                        batch.clear();
-                        r
-                    } else {
-                        Ok(())
-                    };
-                    let _ = done.send(result);
-                    continue;
-                }
-            }
+            batch.push(write);
 
             while batch.len() < MAX_BATCH_SIZE {
                 match self.rx.try_recv() {
-                    Ok(WriterCommand::WriteChunk(chunk)) => batch.push(chunk),
-                    Ok(WriterCommand::Flush(done)) => {
-                        let result = self.write_batch(&batch);
-                        batch.clear();
-                        let _ = done.send(result);
-                        break;
-                    }
+                    Ok(write) => batch.push(write),
                     Err(_) => break,
                 }
             }
 
-            if !batch.is_empty() {
-                if let Err(e) = self.write_batch(&batch) {
-                    error!("ChunkDataWriter auto-drain write failed: {:?}", e);
-                }
-                batch.clear();
+            if !batch.is_empty()
+                && let Err(e) = self.commit_batch(&mut batch)
+            {
+                error!("ChunkDataWriter auto-drain write failed: {:?}", e);
             }
         }
 
-        if !batch.is_empty()
-            && let Err(e) = self.write_batch(&batch)
-        {
+        if let Err(e) = self.commit_batch(&mut batch) {
             error!("ChunkDataWriter shutdown-drain write failed: {:?}", e);
         }
     }
 
+    /// Commits one batch and reports the same transaction outcome to every
+    /// write it contained, so an auto-drain failure reaches each exact caller.
+    fn commit_batch(&self, batch: &mut Vec<PendingChunkWrite>) -> Result<(), QueueError> {
+        if batch.is_empty() {
+            return Ok(());
+        }
+        let result = self.write_batch(batch);
+        for pending in batch.drain(..) {
+            let _ = pending.done.send(result);
+        }
+        result
+    }
+
     #[tracing::instrument(level = "trace", skip_all, fields(batch_size = batch.len()))]
-    fn write_batch(&self, batch: &[Arc<UnpackedChunk>]) -> Result<(), QueueError> {
+    fn write_batch(&self, batch: &[PendingChunkWrite]) -> Result<(), QueueError> {
         if batch.is_empty() {
             return Ok(());
         }
 
-        let hashes: Vec<ChunkPathHash> = batch.iter().map(|c| c.chunk_path_hash()).collect();
+        let hashes: Vec<(ChunkPathHash, H256)> = batch
+            .iter()
+            .map(|pending| {
+                (
+                    pending.chunk.chunk_path_hash(),
+                    generate_ingress_data_hash(&pending.chunk.bytes.0, self.address),
+                )
+            })
+            .collect();
 
-        let result = self.db.update_scoped(|tx| {
+        let result = self.db.update_eyre(|tx| {
             let mut written = 0_usize;
-            for (chunk, hash) in batch.iter().zip(hashes.iter()) {
-                match cache_chunk_verified(tx, chunk) {
+            for (pending, (chunk_path_hash, ingress_data_hash)) in batch.iter().zip(&hashes) {
+                match cache_chunk_verified(tx, &pending.chunk) {
                     Ok(is_duplicate) => {
                         if is_duplicate {
                             warn!(
                                 "Duplicate chunk {} of {} in write-behind batch",
-                                hash, chunk.data_root
+                                chunk_path_hash, pending.chunk.data_root
                             );
                         } else {
                             written += 1;
                         }
+                        store_ingress_data_hash(
+                            tx,
+                            pending.chunk.data_root,
+                            self.address,
+                            pending.chunk.tx_offset,
+                            *ingress_data_hash,
+                        )
+                        .map_err(eyre::Report::from)?;
                     }
                     Err(e) => {
                         error!(
                             "Failed to cache chunk {} of {}: {:?}",
-                            hash, chunk.data_root, e
+                            chunk_path_hash, pending.chunk.data_root, e
                         );
+                        return Err(e);
                     }
                 }
             }
-            Ok::<usize, eyre::Report>(written)
+            Ok(written)
         });
 
-        for hash in &hashes {
-            self.pending_hashes.remove(hash);
+        for (chunk_path_hash, _) in &hashes {
+            self.pending_hashes.remove(chunk_path_hash);
         }
 
         match result {
-            Ok(Ok(written)) => {
+            Ok(written) => {
                 debug!(
                     "ChunkDataWriter committed batch of {} ({} written)",
                     batch.len(),
@@ -197,14 +221,146 @@ impl BackgroundWriter {
                 );
                 Ok(())
             }
-            Ok(Err(e)) => {
-                error!("ChunkDataWriter batch inner error: {:?}", e);
-                Err(QueueError::WriteFailed)
-            }
             Err(e) => {
-                error!("ChunkDataWriter MDBX transaction error: {:?}", e);
+                error!("ChunkDataWriter batch transaction failed: {:?}", e);
                 Err(QueueError::WriteFailed)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use irys_database::{
+        cached_chunk_by_chunk_offset, cached_ingress_leaf, complete_ingress_leaves,
+        database::{IrysDatabaseArgs as _, open_or_create_db},
+        db_cache::CachedDataRoot,
+        tables::{CachedDataRoots, IrysTables},
+    };
+    use irys_testing_utils::TempDirBuilder;
+    use irys_types::{Base64, H256, TxChunkOffset};
+    use reth_db::{mdbx::DatabaseArguments, transaction::DbTxMut as _};
+
+    #[test_log::test(tokio::test)]
+    async fn validated_leaf_is_persisted_without_a_storage_assignment() -> eyre::Result<()> {
+        let dir = TempDirBuilder::new().with_tracing().build();
+        let env = open_or_create_db(
+            dir.path(),
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        let db = DatabaseProvider(Arc::new(env));
+        let data_root = H256::random();
+        let address = IrysAddress::random();
+        let tx_offset = TxChunkOffset::from(0_u32);
+        let chunk = Arc::new(UnpackedChunk {
+            data_root,
+            data_size: 8,
+            data_path: Base64::default(),
+            bytes: Base64(vec![7_u8; 8]),
+            tx_offset,
+        });
+        let ingress_data_hash = generate_ingress_data_hash(&chunk.bytes.0, address);
+        let leaf = irys_types::generate_ingress_leaf_from_data_hash(ingress_data_hash, 8)?;
+        db.update_eyre(|tx| {
+            tx.put::<CachedDataRoots>(
+                data_root,
+                CachedDataRoot {
+                    data_size: 8,
+                    data_size_confirmed: true,
+                    block_set: vec![H256::random()],
+                    ..Default::default()
+                },
+            )?;
+            Ok(())
+        })?;
+
+        let writer =
+            ChunkDataWriter::spawn(db.clone(), address, 8, &tokio::runtime::Handle::current());
+        let queued = writer.queue_write(chunk).await?;
+        assert!(!queued.is_duplicate());
+        queued.committed().await?;
+
+        db.view_eyre(|tx| {
+            assert!(cached_chunk_by_chunk_offset(tx, data_root, tx_offset)?.is_some());
+            let cached_leaf = cached_ingress_leaf(tx, data_root, address, tx_offset)?
+                .expect("validated leaf must be stored without any storage assignment");
+            assert_eq!(cached_leaf.ingress_data_hash, ingress_data_hash);
+            assert_eq!(
+                complete_ingress_leaves(tx, data_root, address, 8, 8)?.unwrap(),
+                vec![leaf],
+                "a non-assignee's validated leaves must satisfy proof readiness"
+            );
+            Ok(())
+        })
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn every_write_in_a_failed_auto_drain_batch_receives_the_error() -> eyre::Result<()> {
+        let dir = TempDirBuilder::new().with_tracing().build();
+        let env = open_or_create_db(
+            dir.path(),
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        let db = DatabaseProvider(Arc::new(env));
+        let data_root = H256::random();
+        let address = IrysAddress::random();
+        let tx_offset = TxChunkOffset::from(0_u32);
+        let chunk = Arc::new(UnpackedChunk {
+            data_root,
+            data_size: 8,
+            data_path: Base64::default(),
+            bytes: Base64(vec![7_u8; 8]),
+            tx_offset,
+        });
+        db.update_eyre(|tx| {
+            tx.put::<CachedDataRoots>(
+                data_root,
+                CachedDataRoot {
+                    data_size: 8,
+                    data_size_confirmed: true,
+                    block_set: vec![H256::random()],
+                    ..Default::default()
+                },
+            )?;
+            store_ingress_data_hash(tx, data_root, address, tx_offset, H256::repeat_byte(9))?;
+            Ok(())
+        })?;
+
+        let (command_tx, command_rx) = mpsc::channel(4);
+        let pending_hashes = Arc::new(DashSet::new());
+        let background = BackgroundWriter {
+            rx: command_rx,
+            db: db.clone(),
+            address,
+            pending_hashes,
+        };
+        let (first_done_tx, first_done_rx) = oneshot::channel();
+        let (second_done_tx, second_done_rx) = oneshot::channel();
+        for done in [first_done_tx, second_done_tx] {
+            command_tx
+                .send(PendingChunkWrite {
+                    chunk: Arc::clone(&chunk),
+                    done,
+                })
+                .await?;
+        }
+        drop(command_tx);
+
+        background.run().await;
+        assert_eq!(first_done_rx.await?, Err(QueueError::WriteFailed));
+        assert_eq!(second_done_rx.await?, Err(QueueError::WriteFailed));
+        db.view_eyre(|tx| {
+            assert!(cached_chunk_by_chunk_offset(tx, data_root, tx_offset)?.is_none());
+            assert_eq!(
+                cached_ingress_leaf(tx, data_root, address, tx_offset)?
+                    .expect("pre-existing leaf remains after rollback")
+                    .ingress_data_hash,
+                H256::repeat_byte(9)
+            );
+            Ok(())
+        })
     }
 }

--- a/crates/actors/src/chunk_ingress_service/chunk_data_writer.rs
+++ b/crates/actors/src/chunk_ingress_service/chunk_data_writer.rs
@@ -254,6 +254,8 @@ mod tests {
         let data_root = H256::random();
         let address = IrysAddress::random();
         let tx_offset = TxChunkOffset::from(0_u32);
+        // The stored repeat-byte hash intentionally conflicts with the hash
+        // generated from these bytes, forcing the whole auto-drained batch to fail.
         let chunk = Arc::new(UnpackedChunk {
             data_root,
             data_size: 8,

--- a/crates/actors/src/chunk_ingress_service/chunks.rs
+++ b/crates/actors/src/chunk_ingress_service/chunks.rs
@@ -456,9 +456,21 @@ impl ChunkIngressServiceInner {
         validate_path_byte_range(
             &path_result,
             (expected_min_byte_range, expected_max_byte_range),
-            is_last_chunk,
         )
         .map_err(|error| CriticalChunkIngressError::InvalidOffset(error.to_string()))?;
+
+        // Once the layout is confirmed, Merkle rightmost status must agree
+        // with the transaction position. Before confirmation, a full prefix
+        // chunk may validly belong to a larger root than an incorrect header
+        // claims; accepting it preserves overlapping-data-root recovery while
+        // the genuinely rightmost path remains the only size authority.
+        if data_size_confirmed && path_result.is_rightmost_chunk != is_last_chunk {
+            return Err(CriticalChunkIngressError::InvalidOffset(
+                "data path rightmost status does not match the confirmed chunk position"
+                    .to_string(),
+            )
+            .into());
+        }
 
         // Check that the leaf hash on the data_path matches the chunk_hash
         let hash_256 = hash_sha256(&chunk.bytes.0);

--- a/crates/actors/src/chunk_ingress_service/chunks.rs
+++ b/crates/actors/src/chunk_ingress_service/chunks.rs
@@ -1,32 +1,26 @@
 use super::ChunkIngressMessage;
 use super::ChunkIngressServiceInner;
-use super::ingress_proofs::generate_and_store_ingress_proof;
+use super::ingress_proofs::generate_and_store_ingress_proof_from_leaves;
 use super::metrics::{
     record_chunk_duplicate, record_chunk_ingested, record_enqueue_duration, record_flush_failure,
     record_validation_duration,
 };
-use eyre::eyre;
+
 use irys_database::{
-    confirm_data_size_for_data_root,
-    db::{IrysDatabaseExt as _, IrysDupCursorExt as _},
-    db_cache::data_size_to_chunk_count,
-    tables::{CachedChunks, CachedChunksIndex},
+    complete_ingress_leaves, confirm_data_size_for_data_root, db::IrysDatabaseExt as _,
 };
 use irys_types::gossip::v2::GossipBroadcastMessageV2;
 use irys_types::{
-    DataLedger, DataRoot, DatabaseProvider, H256, IngressProof, SendTraced as _,
-    chunk::{UnpackedChunk, max_chunk_offset},
-    hash_sha256,
-    irys::IrysSigner,
-    validate_path,
+    DataLedger, DataRoot, DatabaseProvider, H256, IngressMerkleLeaf, IngressProof, SendTraced as _,
+    chunk::UnpackedChunk, expected_chunk_byte_range, hash_sha256, irys::IrysSigner, validate_path,
+    validate_path_byte_range,
 };
 use irys_utils::ElapsedMs as _;
 use rayon::prelude::*;
 use reth::revm::primitives::alloy_primitives::ChainId;
-use reth_db::{cursor::DbDupCursorRO as _, transaction::DbTx as _};
+use std::fmt::Display;
 use std::sync::Arc;
 use std::time::Instant;
-use std::{collections::HashSet, fmt::Display};
 use tracing::{Instrument as _, debug, error, info, info_span, instrument, warn};
 
 /// CDR-only ingress-proof eligibility gate, factored out so the contract is
@@ -399,44 +393,29 @@ impl ChunkIngressServiceInner {
         // data_root->chunk_hash
         let _proof_span = info_span!("chunk.validate_proof").entered();
 
-        let Some(max_valid_offset) = max_chunk_offset(data_size, chunk_size) else {
+        // Before confirmation, CachedDataRoot holds the largest size claimed by
+        // any header sharing this root. Validate against this chunk's claim so
+        // a rightmost data path can authoritatively correct that provisional
+        // maximum downward. Once confirmed, only the cached size is accepted.
+        let layout_data_size = if data_size_confirmed {
+            data_size
+        } else {
+            chunk.data_size
+        };
+        if layout_data_size == 0 {
             error!(
                 "Error: {:?}. Invalid data_size for data_root: {:?}. got 0 bytes",
                 CriticalChunkIngressError::InvalidDataSize,
                 chunk.data_root,
             );
             return Err(CriticalChunkIngressError::InvalidDataSize.into());
-        };
-
-        let offset_u64 = u64::from(*chunk.tx_offset);
-
-        if offset_u64 > max_valid_offset {
-            let num_chunks = data_size.div_ceil(chunk_size);
-            error!(
-                "Invalid tx_offset: {} exceeds max valid offset {} for data_size {} (num_chunks: {})",
-                offset_u64, max_valid_offset, data_size, num_chunks
-            );
-            return Err(CriticalChunkIngressError::InvalidOffset(format!(
-                "tx_offset {} exceeds max valid offset {} for data_size {}",
-                offset_u64, max_valid_offset, data_size
-            ))
-            .into());
         }
 
+        let (expected_min_byte_range, expected_max_byte_range) =
+            expected_chunk_byte_range(chunk.tx_offset, layout_data_size, chunk_size)
+                .map_err(|error| CriticalChunkIngressError::InvalidOffset(error.to_string()))?;
+        let target_offset = u128::from(expected_max_byte_range - 1);
         let root_hash = chunk.data_root.0;
-        let target_offset = match chunk.end_byte_offset_checked(chunk_size) {
-            Some(offset) => u128::from(offset),
-            None => {
-                error!(
-                    "Byte offset calculation failed for tx_offset {} with data_size {}",
-                    *chunk.tx_offset, chunk.data_size
-                );
-                return Err(CriticalChunkIngressError::InvalidOffset(
-                    "Byte offset calculation overflow or invalid offset".to_string(),
-                )
-                .into());
-            }
-        };
         let path_buff = &chunk.data_path;
 
         info!(
@@ -455,27 +434,6 @@ impl ChunkIngressServiceInner {
             Ok(v) => v,
         };
 
-        // Check and see if this is the rightmost chunk
-        if path_result.is_rightmost_chunk {
-            // If this is the rightmost chunk in the data_root we can use it to
-            // validate the data_size and mark it as "confirmed" in the cache.
-            //
-            // In this case the data path stores offsets so we need to add one
-            // to get the size in bytes.
-            let confirmed_data_size: u64 = path_result
-                .max_byte_range
-                .try_into()
-                .expect("to convert U128 path_result.max_byte_range to data_size to u64");
-
-            self.irys_db
-                .update_eyre(|db_tx| {
-                    confirm_data_size_for_data_root(db_tx, &chunk.data_root, confirmed_data_size)
-                })
-                .expect("confirm_data_size database operation to succeed");
-        }
-
-        // Use data_size to identify and validate that only the last chunk
-        // can be less than chunk_size
         let chunk_len = u64::try_from(chunk.bytes.len())
             .map_err(|_| CriticalChunkIngressError::InvalidChunkSize)?;
 
@@ -485,29 +443,22 @@ impl ChunkIngressServiceInner {
         // consensus size, then the data_root is actually invalid and no future
         // chunks from that data_root should be ingressed.
 
-        // Note: num_chunks, chunk_size, offset_u64, and max_valid_offset already
-        // computed in offset validation above
-        let is_last_chunk = offset_u64 == max_valid_offset;
-
-        if is_last_chunk {
-            // Last chunk can be <= chunk_size
-            if chunk_len > chunk_size {
-                error!(
-                    "Last chunk exceeds max size: tx_offset {} chunk_len {} max {}",
-                    chunk.tx_offset, chunk_len, chunk_size
-                );
-                return Ok(());
-            }
-        } else {
-            // Non-last chunk must be exactly chunk_size
-            if chunk_len != chunk_size {
-                error!(
-                    "Non-last chunk has wrong size: tx_offset {} chunk_len {} expected {}",
-                    chunk.tx_offset, chunk_len, chunk_size
-                );
-                return Ok(());
-            }
+        let expected_chunk_len = expected_max_byte_range - expected_min_byte_range;
+        if chunk_len != expected_chunk_len {
+            error!(
+                "Chunk has wrong size: tx_offset {} chunk_len {} expected {}",
+                chunk.tx_offset, chunk_len, expected_chunk_len
+            );
+            return Ok(());
         }
+
+        let is_last_chunk = expected_max_byte_range == layout_data_size;
+        validate_path_byte_range(
+            &path_result,
+            (expected_min_byte_range, expected_max_byte_range),
+            is_last_chunk,
+        )
+        .map_err(|error| CriticalChunkIngressError::InvalidOffset(error.to_string()))?;
 
         // Check that the leaf hash on the data_path matches the chunk_hash
         let hash_256 = hash_sha256(&chunk.bytes.0);
@@ -519,34 +470,62 @@ impl ChunkIngressServiceInner {
             return Err(CriticalChunkIngressError::InvalidDataHash.into());
         }
 
+        // A rightmost path attests the declared data size only after its exact
+        // range and body have both been validated.
+        if path_result.is_rightmost_chunk {
+            self.irys_db
+                .update_eyre(|db_tx| {
+                    confirm_data_size_for_data_root(
+                        db_tx,
+                        &chunk.data_root,
+                        expected_max_byte_range,
+                    )
+                })
+                .expect("confirm_data_size database operation to succeed");
+        }
+
         record_validation_duration(validation_start.elapsed_ms());
 
         drop(_proof_span);
 
-        // Write-behind: defers MDBX write for throughput
+        // The background writer batches concurrent MDBX writes, but returns
+        // only after the exact batch containing this chunk commits.
         let storage_start = Instant::now();
-        match self
+        let queued_write = match self
             .chunk_data_writer
             .queue_write(Arc::clone(&chunk))
             .instrument(info_span!("chunk.cache_write"))
             .await
         {
-            Ok(true) => {
-                record_chunk_duplicate();
-            }
-            Ok(false) => {}
+            Ok(queued) => queued,
             Err(e) => {
                 error!(
-                    "Write-behind queue error for chunk data_root {:?} tx_offset {}: {:?}",
+                    "Failed to queue chunk cache write for data_root {:?} tx_offset {}: {:?}",
                     chunk.data_root, chunk.tx_offset, e
                 );
-                return Err(CriticalChunkIngressError::Other(format!(
-                    "Write-behind channel closed: {e:?}"
-                ))
-                .into());
+                return Err(CriticalChunkIngressError::DatabaseError.into());
             }
+        };
+        if queued_write.is_duplicate() {
+            record_chunk_duplicate();
         }
         record_enqueue_duration(storage_start.elapsed_ms());
+
+        // Commit the validated body and assignment-independent leaf before
+        // making the chunk eligible for storage-module durability. Otherwise a
+        // fast SM fsync could delete the cache row before this batch commits,
+        // and a delayed writer could reinsert the body. The acknowledgement is
+        // tied to this exact write, so another batch cannot mask its failure.
+        if let Err(error) = queued_write.committed().await {
+            error!(
+                %error,
+                data_root = %chunk.data_root,
+                tx_offset = %chunk.tx_offset,
+                "Chunk cache batch failed"
+            );
+            record_flush_failure();
+            return Err(CriticalChunkIngressError::DatabaseError.into());
+        }
 
         // Add to recent valid chunks cache to prevent re-processing
         self.recent_valid_chunks
@@ -604,36 +583,21 @@ impl ChunkIngressServiceInner {
             );
         }
 
-        // Flush to ensure chunks are committed before ingress proof check.
-        if let Err(e) = self.chunk_data_writer.flush().await {
-            error!(
-                "Failed to flush chunk data writer before ingress proof check: {:?}",
-                e
-            );
-            record_flush_failure();
-            // Forget the chunk before reporting, so a re-send is processed rather than skipped.
-            // This chunk was recorded as recently valid before the flush, and the duplicate check
-            // at the top of this function returns early on that record without reaching the
-            // ingress proof check — so leaving it in place would make every retry a silent
-            // no-op and the failure permanent after all.
-            self.recent_valid_chunks.write().await.pop(&chunk_path_hash);
-            // Report the failure rather than returning success. The chunk is not durably stored,
-            // and the ingress proof check below is skipped, so a caller told this succeeded has no
-            // way to learn that the transaction can never be promoted: nothing revisits the proof
-            // for a data_root once its last chunk has been acknowledged. Failing here surfaces the
-            // storage error and leaves the caller free to re-send, which is how every other write
-            // failure on this path already behaves.
-            return Err(CriticalChunkIngressError::DatabaseError.into());
-        }
+        // Leaf persistence is assignment-independent: any staked node that
+        // validates every chunk can produce the same proof it could before the
+        // compact-leaf refactor. Storage-module durability separately authorizes
+        // body reclamation; leaf presence alone is never an eviction fence.
+        self.try_generate_ingress_proof_for_root(chunk_data_root, chunk_size)?;
 
-        self.try_generate_ingress_proof_for_root(root_hash.into(), chunk_size)
+        // Storage-module writes retain their normal batching/striping policy.
+        Ok(())
     }
 
     /// Checks whether an ingress proof should be generated for the given `data_root`
     /// and spawns proof generation if all prerequisites are met:
     /// - the CDR-only prerequisites in [`should_skip_ingress_proof_generation`]
     /// - no local proof already exists
-    /// - all expected chunks are present
+    /// - every expected validated compact leaf is present with no gaps
     pub(crate) fn try_generate_ingress_proof_for_root(
         &self,
         data_root: H256,
@@ -656,30 +620,15 @@ impl ChunkIngressServiceInner {
         // Be explicit that data_size used from here on is the confirmed data size
         let data_size = cdr.data_size;
 
-        // check if we have generated an ingress proof for this tx already
-        // if we have, update it's expiry height
-
-        // Determine existing proof state and chunk count
         let local_address = self.config.irys_signer().address();
-        let (chunk_count, existing_local_proof) = self
+        let existing_local_proof = self
             .irys_db
             .view_eyre(|tx| {
-                let existing_local_proof = irys_database::ingress_proof_by_data_root_address(
-                    tx,
-                    data_root,
-                    local_address,
-                )?;
-
-                // Count chunks (needed for generation & potential regeneration)
-                let mut cursor = tx.cursor_dup_read::<CachedChunksIndex>()?;
-                let count = cursor
-                    .dup_count(data_root)?
-                    .ok_or_else(|| eyre::eyre!("No chunks found for data root"))?;
-                Ok((count, existing_local_proof))
+                irys_database::ingress_proof_by_data_root_address(tx, data_root, local_address)
             })
             .map_err(|e| {
                 error!(
-                    "Database error checking ingress proof/chunk count for data_root {:?}: {:?}",
+                    "Database error checking ingress proof for data_root {:?}: {:?}",
                     data_root, e
                 );
                 CriticalChunkIngressError::DatabaseError
@@ -694,33 +643,46 @@ impl ChunkIngressServiceInner {
             return Ok(());
         }
 
-        // Compute expected number of chunks from data_size using ceil(data_size / chunk_size)
-        // This equals the last chunk index + 1 (since tx offsets are 0-indexed)
-        let Ok(expected_chunk_count) = data_size_to_chunk_count(data_size, chunk_size) else {
-            error!(
-                "Error: {:?}. Invalid data_size for data_root: {:?}",
-                CriticalChunkIngressError::InvalidDataSize,
-                data_root,
-            );
-            return Err(CriticalChunkIngressError::InvalidDataSize.into());
-        };
+        // `complete_ingress_leaves` uses a dup-count only as a cheap prefilter,
+        // then verifies every exact offset and byte boundary before returning.
+        let leaves = self
+            .irys_db
+            .view_eyre(|tx| {
+                complete_ingress_leaves(tx, data_root, local_address, data_size, chunk_size)
+            })
+            .map_err(|error| {
+                error!(
+                    ?data_root,
+                    ?error,
+                    "Database error loading compact ingress leaves"
+                );
+                CriticalChunkIngressError::DatabaseError
+            })?;
 
-        if chunk_count == expected_chunk_count {
-            // we *should* have all the chunks
+        if let Some(leaves) = leaves {
+            // Acquire only after this snapshot is complete. If an incomplete
+            // scan held the lease while the final writer committed, the final
+            // handler could lose its only proof-generation wake-up to
+            // contention. Every lease holder is therefore ready to make
+            // progress, and competing complete scans can safely coalesce.
+            let Some(generation_lease) = self.ingress_proof_generation_state.try_acquire(data_root)
+            else {
+                return Ok(());
+            };
             let db = self.irys_db.clone();
             let block_tree_read_guard = self.block_tree_read_guard.clone();
             let config = self.config.clone();
             let gossip_sender = self.service_senders.gossip_broadcast.clone();
-            let cache_sender = self.service_senders.chunk_cache.clone();
             let _fut = self.exec.clone().spawn_blocking(move || {
-                if let Err(error) = generate_and_store_ingress_proof(
+                if let Err(error) = generate_and_store_ingress_proof_from_leaves(
                     &block_tree_read_guard,
                     &db,
                     &config,
                     data_root,
                     None,
+                    leaves,
                     &gossip_sender,
-                    &cache_sender,
+                    generation_lease,
                 ) {
                     if error.is_benign() {
                         debug!(proof.data_root = ?data_root, "Skipped ingress proof generation: {error}");
@@ -911,91 +873,25 @@ impl AdvisoryChunkIngressError {
     }
 }
 
-/// Generates an ingress proof for a specific `data_root`
-/// pulls required data from all sources
+/// Generates an ingress proof for a specific `data_root` from its ordered,
+/// persisted compact leaves. Cached chunk bodies are not read on this path.
 #[must_use = "the generated ingress proof should be used or stored"]
 pub fn generate_ingress_proof(
     db: DatabaseProvider,
     data_root: DataRoot,
-    size: u64,
-    chunk_size: u64,
+    leaves: Vec<IngressMerkleLeaf>,
     signer: IrysSigner,
     chain_id: ChainId,
     anchor: H256,
 ) -> eyre::Result<IngressProof> {
-    // load the chunks from the DB
-    // TODO: for now we assume the chunks all all in the DB chunk cache
-    // in future, we'll need access to whatever unified storage provider API we have to get chunks
-    // regardless of actual location
-
-    let expected_chunk_count = data_size_to_chunk_count(size, chunk_size)?;
-
-    let (proof, actual_data_size, actual_chunk_count) = db.view_eyre(|tx| {
-        let mut dup_cursor = tx.cursor_dup_read::<CachedChunksIndex>()?;
-
-        // start from first duplicate entry for this root_hash
-        let dup_walker = dup_cursor.walk_dup(Some(data_root), None)?;
-
-        // we need to validate that the index is valid
-        // we do this by constructing a set over the chunk hashes, checking if we've seen this hash before
-        // if we have, we *must* error
-        let mut set = HashSet::<H256>::new();
-
-        let mut chunk_count: u32 = 0;
-        let mut total_data_size: u64 = 0;
-
-        let iter = dup_walker.into_iter().map(|entry| {
-            let (root_hash2, index_entry) = entry?;
-            // make sure we haven't traversed into the wrong key
-            assert_eq!(data_root, root_hash2);
-
-            let chunk_path_hash = index_entry.meta.chunk_path_hash;
-            if set.contains(&chunk_path_hash) {
-                return Err(eyre!(
-                    "Chunk with hash {} has been found twice for index entry {} of data_root {}",
-                    &chunk_path_hash,
-                    &index_entry.index,
-                    &data_root
-                ));
-            }
-            set.insert(chunk_path_hash);
-
-            // TODO: add code to read from ChunkProvider once it can read through CachedChunks & we have a nice system for unpacking chunks on-demand
-            let chunk = tx
-                .get::<CachedChunks>(index_entry.meta.chunk_path_hash)?
-                .ok_or(eyre!(
-                    "unable to get chunk {chunk_path_hash} for data root {data_root} from DB"
-                ))?;
-
-            let chunk_bin = chunk
-                .chunk
-                .ok_or(eyre!(
-                    "Missing required chunk ({chunk_path_hash}) body for data root {data_root} from DB"
-                ))?
-                .0;
-            let chunk_len =
-                u64::try_from(chunk_bin.len()).map_err(|_| eyre!("chunk length exceeds u64"))?;
-            total_data_size += chunk_len;
-            chunk_count += 1;
-
-            Ok(chunk_bin)
-        });
-
-        // generate the ingress proof hash
-        let proof = irys_types::ingress::generate_ingress_proof(
-            &signer, data_root, iter, chain_id, anchor,
-        )?;
-
-        Ok((proof, total_data_size, chunk_count))
-    })?;
+    let proof = irys_types::ingress::generate_ingress_proof_from_leaves(
+        &signer, data_root, leaves, chain_id, anchor,
+    )?;
 
     info!(
         "generated ingress proof {} for data root {}",
         &proof.proof, &data_root
     );
-    assert_eq!(actual_data_size, size);
-    assert_eq!(actual_chunk_count, expected_chunk_count);
-
     db.update_scoped(|rw_tx| irys_database::store_ingress_proof_checked(rw_tx, &proof, &signer))??;
 
     Ok(proof)

--- a/crates/actors/src/chunk_ingress_service/chunks.rs
+++ b/crates/actors/src/chunk_ingress_service/chunks.rs
@@ -493,7 +493,14 @@ impl ChunkIngressServiceInner {
                         expected_max_byte_range,
                     )
                 })
-                .expect("confirm_data_size database operation to succeed");
+                .map_err(|error| {
+                    error!(
+                        %error,
+                        data_root = %chunk.data_root,
+                        "Failed to confirm data-root size"
+                    );
+                    CriticalChunkIngressError::DatabaseError
+                })?;
         }
 
         record_validation_duration(validation_start.elapsed_ms());
@@ -648,6 +655,7 @@ impl ChunkIngressServiceInner {
 
         // Early return if we have a valid existing local proof
         if existing_local_proof.is_some() {
+            self.ingress_proof_generation_state.clear_retries(data_root);
             info!(
                 "Local ingress proof already exists and is valid for data root {}",
                 &data_root
@@ -685,8 +693,11 @@ impl ChunkIngressServiceInner {
             let block_tree_read_guard = self.block_tree_read_guard.clone();
             let config = self.config.clone();
             let gossip_sender = self.service_senders.gossip_broadcast.clone();
+            let retry_sender = self.service_senders.chunk_ingress.clone();
+            let generation_state = self.ingress_proof_generation_state.clone();
+            let runtime_handle = tokio::runtime::Handle::current();
             let _fut = self.exec.clone().spawn_blocking(move || {
-                if let Err(error) = generate_and_store_ingress_proof_from_leaves(
+                match generate_and_store_ingress_proof_from_leaves(
                     &block_tree_read_guard,
                     &db,
                     &config,
@@ -696,10 +707,31 @@ impl ChunkIngressServiceInner {
                     &gossip_sender,
                     generation_lease,
                 ) {
-                    if error.is_benign() {
+                    Ok(_) => generation_state.clear_retries(data_root),
+                    Err(error) if error.is_benign() => {
                         debug!(proof.data_root = ?data_root, "Skipped ingress proof generation: {error}");
-                    } else {
+                    }
+                    Err(error) => {
                         warn!(proof.data_root = ?data_root, "Failed to generate ingress proof: {error}");
+                        if let Some(delay) = generation_state.reserve_retry(data_root) {
+                            let retry_state = generation_state.clone();
+                            runtime_handle.spawn(async move {
+                                tokio::time::sleep(delay).await;
+                                retry_state.mark_retry_dispatched(data_root);
+                                if let Err(send_error) = retry_sender.send_traced(
+                                    ChunkIngressMessage::TryGenerateProofsForConfirmedRoots(vec![
+                                        data_root,
+                                    ]),
+                                ) {
+                                    retry_state.clear_retries(data_root);
+                                    warn!(
+                                        proof.data_root = ?data_root,
+                                        ?send_error,
+                                        "Failed to schedule ingress-proof retry"
+                                    );
+                                }
+                            });
+                        }
                     }
                 }
             }).in_current_span();

--- a/crates/actors/src/chunk_ingress_service/ingress_proofs.rs
+++ b/crates/actors/src/chunk_ingress_service/ingress_proofs.rs
@@ -1,5 +1,6 @@
 use super::ChunkIngressServiceInner;
 use irys_database::db::IrysDatabaseExt as _;
+use irys_database::db_cache::data_size_to_chunk_count;
 use irys_database::store_ingress_proof;
 use irys_database::{cached_data_root_by_data_root, complete_ingress_leaves};
 use irys_domain::BlockTreeReadGuard;
@@ -10,8 +11,9 @@ use irys_types::{
     SendTraced as _, Traced,
 };
 use reth_db::DatabaseError;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
+use std::time::Duration;
 use tracing::{debug, error, warn};
 
 /// Shared, process-local exclusion for proof generation by data root.
@@ -21,7 +23,14 @@ use tracing::{debug, error, warn};
 /// check-then-notify race through the cache-service channel.
 #[derive(Clone, Debug, Default)]
 pub struct IngressProofGenerationState {
-    inner: Arc<RwLock<HashSet<DataRoot>>>,
+    inner: Arc<RwLock<IngressProofGenerationStateInner>>,
+}
+
+#[derive(Debug, Default)]
+struct IngressProofGenerationStateInner {
+    active: HashSet<DataRoot>,
+    retry_attempts: HashMap<DataRoot, u8>,
+    retry_scheduled: HashSet<DataRoot>,
 }
 
 impl IngressProofGenerationState {
@@ -34,6 +43,7 @@ impl IngressProofGenerationState {
             .inner
             .write()
             .expect("proof generation state lock poisoned")
+            .active
             .insert(data_root);
         inserted.then(|| IngressProofGenerationLease {
             state: self.clone(),
@@ -46,7 +56,46 @@ impl IngressProofGenerationState {
         self.inner
             .read()
             .expect("proof generation state lock poisoned")
+            .active
             .contains(&data_root)
+    }
+
+    /// Reserves one bounded, monotonic retry for a failed generation attempt.
+    /// Concurrent failures coalesce, and persistent failures stop after the
+    /// capped sequence instead of creating an unbounded retry loop.
+    pub(crate) fn reserve_retry(&self, data_root: DataRoot) -> Option<Duration> {
+        const MAX_RETRIES: u8 = 6;
+        let mut inner = self
+            .inner
+            .write()
+            .expect("proof generation state lock poisoned");
+        if inner.retry_scheduled.contains(&data_root) {
+            return None;
+        }
+        let attempt = *inner.retry_attempts.get(&data_root).unwrap_or(&0);
+        if attempt >= MAX_RETRIES {
+            return None;
+        }
+        inner.retry_attempts.insert(data_root, attempt + 1);
+        inner.retry_scheduled.insert(data_root);
+        Some(Duration::from_secs(1_u64 << attempt))
+    }
+
+    pub(crate) fn mark_retry_dispatched(&self, data_root: DataRoot) {
+        self.inner
+            .write()
+            .expect("proof generation state lock poisoned")
+            .retry_scheduled
+            .remove(&data_root);
+    }
+
+    pub(crate) fn clear_retries(&self, data_root: DataRoot) {
+        let mut inner = self
+            .inner
+            .write()
+            .expect("proof generation state lock poisoned");
+        inner.retry_attempts.remove(&data_root);
+        inner.retry_scheduled.remove(&data_root);
     }
 }
 
@@ -61,6 +110,7 @@ impl Drop for IngressProofGenerationLease {
             .inner
             .write()
             .expect("proof generation state lock poisoned")
+            .active
             .remove(&self.data_root);
     }
 }
@@ -102,6 +152,12 @@ pub enum IngressProofGenerationError {
     /// Invalid data size for the transaction.
     #[error("Invalid data size: {0}")]
     InvalidDataSize(String),
+    /// The data root was removed before proof generation could begin.
+    #[error("Cached data root is no longer available")]
+    DataRootUnavailable,
+    /// Validated compact leaves have not arrived for every expected position.
+    #[error("Compact ingress leaves are incomplete")]
+    IncompleteLeaves,
     /// Failed to generate the proof.
     #[error("Proof generation failed: {0}")]
     GenerationFailed(String),
@@ -110,7 +166,13 @@ pub enum IngressProofGenerationError {
 impl IngressProofGenerationError {
     /// Returns true if this error is benign (e.g., node not staked) and should be logged at debug level.
     pub fn is_benign(&self) -> bool {
-        matches!(self, Self::NodeNotStaked | Self::AlreadyGenerating)
+        matches!(
+            self,
+            Self::NodeNotStaked
+                | Self::AlreadyGenerating
+                | Self::DataRootUnavailable
+                | Self::IncompleteLeaves
+        )
     }
 }
 
@@ -378,7 +440,7 @@ pub fn generate_and_store_ingress_proof(
     let generation_lease = generation_state
         .try_acquire(data_root)
         .ok_or(IngressProofGenerationError::AlreadyGenerating)?;
-    generate_and_store_ingress_proof_inner(
+    generate_and_store_ingress_proof_from_leaves(
         block_tree_guard,
         db,
         config,
@@ -403,28 +465,7 @@ pub(crate) fn generate_and_store_ingress_proof_from_leaves(
     gossip_sender: &tokio::sync::mpsc::UnboundedSender<Traced<GossipBroadcastMessageV2>>,
     generation_lease: IngressProofGenerationLease,
 ) -> Result<IngressProof, IngressProofGenerationError> {
-    generate_and_store_ingress_proof_inner(
-        block_tree_guard,
-        db,
-        config,
-        data_root,
-        anchor_hint,
-        leaves,
-        gossip_sender,
-        generation_lease,
-    )
-}
-
-fn generate_and_store_ingress_proof_inner(
-    block_tree_guard: &BlockTreeReadGuard,
-    db: &DatabaseProvider,
-    config: &Config,
-    data_root: DataRoot,
-    anchor_hint: Option<H256>,
-    leaves: Vec<IngressMerkleLeaf>,
-    gossip_sender: &tokio::sync::mpsc::UnboundedSender<Traced<GossipBroadcastMessageV2>>,
-    _generation_lease: IngressProofGenerationLease,
-) -> Result<IngressProof, IngressProofGenerationError> {
+    let _generation_lease = generation_lease;
     let signer: IrysSigner = config.irys_signer();
 
     // Only staked nodes should generate ingress proofs
@@ -536,21 +577,17 @@ pub fn load_complete_ingress_leaves(
     address: irys_types::IrysAddress,
     chunk_size: u64,
 ) -> Result<Vec<IngressMerkleLeaf>, IngressProofGenerationError> {
-    let err = |msg: String| IngressProofGenerationError::InvalidDataSize(msg);
+    let cdr = db
+        .view_eyre(|tx| cached_data_root_by_data_root(tx, data_root))
+        .map_err(|error| IngressProofGenerationError::GenerationFailed(error.to_string()))?
+        .ok_or(IngressProofGenerationError::DataRootUnavailable)?;
 
-    // Load data_size & confirm we have metadata for this root
-    db.view_eyre(|tx| {
-        let data_size = cached_data_root_by_data_root(tx, data_root)
-            .map_err(|e| eyre::eyre!("Failed to load cached_data_root: {e}"))?
-            .ok_or_else(|| eyre::eyre!("Missing cached_data_root for {data_root:?}"))?
-            .data_size;
-        let leaves = complete_ingress_leaves(tx, data_root, address, data_size, chunk_size)?
-            .ok_or_else(|| {
-                eyre::eyre!("compact ingress leaves are incomplete for data_root {data_root:?}")
-            })?;
-        Ok(leaves)
-    })
-    .map_err(|e| err(e.to_string()))
+    data_size_to_chunk_count(cdr.data_size, chunk_size)
+        .map_err(|error| IngressProofGenerationError::InvalidDataSize(error.to_string()))?;
+
+    db.view_eyre(|tx| complete_ingress_leaves(tx, data_root, address, cdr.data_size, chunk_size))
+        .map_err(|error| IngressProofGenerationError::GenerationFailed(error.to_string()))?
+        .ok_or(IngressProofGenerationError::IncompleteLeaves)
 }
 
 #[cfg(test)]
@@ -569,5 +606,27 @@ mod generation_state_tests {
         drop(lease);
         assert!(!state.is_generating(data_root));
         assert!(state.try_acquire(data_root).is_some());
+    }
+
+    #[test]
+    fn generation_retries_are_bounded_and_coalesced() {
+        let state = IngressProofGenerationState::new();
+        let data_root = H256::random();
+
+        assert_eq!(state.reserve_retry(data_root), Some(Duration::from_secs(1)));
+        assert_eq!(state.reserve_retry(data_root), None, "one retry at a time");
+
+        for expected_secs in [2, 4, 8, 16, 32] {
+            state.mark_retry_dispatched(data_root);
+            assert_eq!(
+                state.reserve_retry(data_root),
+                Some(Duration::from_secs(expected_secs))
+            );
+        }
+        state.mark_retry_dispatched(data_root);
+        assert_eq!(state.reserve_retry(data_root), None, "retry cap");
+
+        state.clear_retries(data_root);
+        assert_eq!(state.reserve_retry(data_root), Some(Duration::from_secs(1)));
     }
 }

--- a/crates/actors/src/chunk_ingress_service/ingress_proofs.rs
+++ b/crates/actors/src/chunk_ingress_service/ingress_proofs.rs
@@ -1,19 +1,69 @@
 use super::ChunkIngressServiceInner;
-use crate::cache_service::{CacheServiceAction, CacheServiceSender};
-use irys_database::db::{IrysDatabaseExt as _, IrysDupCursorExt as _};
-use irys_database::reth_db::transaction::DbTx as _;
+use irys_database::db::IrysDatabaseExt as _;
 use irys_database::store_ingress_proof;
-use irys_database::{
-    cached_data_root_by_data_root, db_cache::data_size_to_chunk_count, tables::CachedChunksIndex,
-};
+use irys_database::{cached_data_root_by_data_root, complete_ingress_leaves};
 use irys_domain::BlockTreeReadGuard;
 use irys_types::irys::IrysSigner;
 use irys_types::v2::GossipBroadcastMessageV2;
 use irys_types::{
-    BlockHash, Config, DataRoot, DatabaseProvider, H256, IngressProof, SendTraced as _, Traced,
+    BlockHash, Config, DataRoot, DatabaseProvider, H256, IngressMerkleLeaf, IngressProof,
+    SendTraced as _, Traced,
 };
 use reth_db::DatabaseError;
+use std::collections::HashSet;
+use std::sync::{Arc, RwLock};
 use tracing::{debug, error, warn};
+
+/// Shared, process-local exclusion for proof generation by data root.
+///
+/// Cache eviction no longer depends on this state. It belongs to proof
+/// generation itself and is acquired atomically, avoiding the former
+/// check-then-notify race through the cache-service channel.
+#[derive(Clone, Debug, Default)]
+pub struct IngressProofGenerationState {
+    inner: Arc<RwLock<HashSet<DataRoot>>>,
+}
+
+impl IngressProofGenerationState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn try_acquire(&self, data_root: DataRoot) -> Option<IngressProofGenerationLease> {
+        let inserted = self
+            .inner
+            .write()
+            .expect("proof generation state lock poisoned")
+            .insert(data_root);
+        inserted.then(|| IngressProofGenerationLease {
+            state: self.clone(),
+            data_root,
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_generating(&self, data_root: DataRoot) -> bool {
+        self.inner
+            .read()
+            .expect("proof generation state lock poisoned")
+            .contains(&data_root)
+    }
+}
+
+pub struct IngressProofGenerationLease {
+    state: IngressProofGenerationState,
+    data_root: DataRoot,
+}
+
+impl Drop for IngressProofGenerationLease {
+    fn drop(&mut self) {
+        self.state
+            .inner
+            .write()
+            .expect("proof generation state lock poisoned")
+            .remove(&self.data_root);
+    }
+}
 
 /// Errors that can occur when ingesting an external ingress proof.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -49,9 +99,6 @@ pub enum IngressProofGenerationError {
     /// Proof generation is already in progress for this data root.
     #[error("Proof generation already in progress")]
     AlreadyGenerating,
-    /// Failed to communicate with cache service.
-    #[error("Cache service error: {0}")]
-    CacheServiceError(String),
     /// Invalid data size for the transaction.
     #[error("Invalid data size: {0}")]
     InvalidDataSize(String),
@@ -306,7 +353,8 @@ impl ProofCheckResult {
     }
 }
 
-/// Generates (and stores) an ingress proof for the provided `data_root` if all chunks are present.
+/// Generates and stores an ingress proof once every expected validated compact
+/// leaf is present for the local signer.
 /// Validates the generated proof's anchor against the canonical chain and gossips it if valid.
 /// Returns the generated proof on success.
 pub fn generate_and_store_ingress_proof(
@@ -316,7 +364,66 @@ pub fn generate_and_store_ingress_proof(
     data_root: DataRoot,
     anchor_hint: Option<H256>,
     gossip_sender: &tokio::sync::mpsc::UnboundedSender<Traced<GossipBroadcastMessageV2>>,
-    cache_sender: &CacheServiceSender,
+    generation_state: &IngressProofGenerationState,
+) -> Result<IngressProof, IngressProofGenerationError> {
+    // Resolve readiness before taking the exclusion lease. A caller holding
+    // the lease with an incomplete snapshot could otherwise race the final
+    // leaf writer, causing that writer to drop its only generation wake-up.
+    let leaves = load_complete_ingress_leaves(
+        db,
+        data_root,
+        config.irys_signer().address(),
+        config.consensus.chunk_size,
+    )?;
+    let generation_lease = generation_state
+        .try_acquire(data_root)
+        .ok_or(IngressProofGenerationError::AlreadyGenerating)?;
+    generate_and_store_ingress_proof_inner(
+        block_tree_guard,
+        db,
+        config,
+        data_root,
+        anchor_hint,
+        leaves,
+        gossip_sender,
+        generation_lease,
+    )
+}
+
+/// Generates a proof from a leaf sequence already verified by the readiness
+/// check while holding the root's generation lease. This keeps the hot ingress
+/// path to one ordered leaf walk.
+pub(crate) fn generate_and_store_ingress_proof_from_leaves(
+    block_tree_guard: &BlockTreeReadGuard,
+    db: &DatabaseProvider,
+    config: &Config,
+    data_root: DataRoot,
+    anchor_hint: Option<H256>,
+    leaves: Vec<IngressMerkleLeaf>,
+    gossip_sender: &tokio::sync::mpsc::UnboundedSender<Traced<GossipBroadcastMessageV2>>,
+    generation_lease: IngressProofGenerationLease,
+) -> Result<IngressProof, IngressProofGenerationError> {
+    generate_and_store_ingress_proof_inner(
+        block_tree_guard,
+        db,
+        config,
+        data_root,
+        anchor_hint,
+        leaves,
+        gossip_sender,
+        generation_lease,
+    )
+}
+
+fn generate_and_store_ingress_proof_inner(
+    block_tree_guard: &BlockTreeReadGuard,
+    db: &DatabaseProvider,
+    config: &Config,
+    data_root: DataRoot,
+    anchor_hint: Option<H256>,
+    leaves: Vec<IngressMerkleLeaf>,
+    gossip_sender: &tokio::sync::mpsc::UnboundedSender<Traced<GossipBroadcastMessageV2>>,
+    _generation_lease: IngressProofGenerationLease,
 ) -> Result<IngressProof, IngressProofGenerationError> {
     let signer: IrysSigner = config.irys_signer();
 
@@ -327,9 +434,6 @@ pub fn generate_and_store_ingress_proof(
     }
 
     let chain_id = config.consensus.chain_id;
-    let chunk_size = config.consensus.chunk_size;
-
-    let data_size = calculate_and_validate_data_size(db, data_root, chunk_size)?;
 
     // Pick anchor: hint or latest canonical block
     let latest_anchor = block_tree_guard
@@ -338,75 +442,17 @@ pub fn generate_and_store_ingress_proof(
         .block_hash();
     let anchor = anchor_hint.unwrap_or(latest_anchor);
 
-    let is_already_generating = {
-        let (response_sender, response_receiver) = std::sync::mpsc::channel();
-        if let Err(err) =
-            cache_sender.send_traced(CacheServiceAction::RequestIngressProofGenerationState {
-                data_root,
-                response_sender,
-            })
-        {
-            return Err(IngressProofGenerationError::CacheServiceError(format!(
-                "Failed to request ingress proof generation state: {err}"
-            )));
-        }
-
-        response_receiver.recv().map_err(|err| {
-            IngressProofGenerationError::CacheServiceError(format!(
-                "Failed to receive ingress proof generation state response: {err}"
-            ))
-        })?
-    };
-
-    if is_already_generating {
-        return Err(IngressProofGenerationError::AlreadyGenerating);
-    }
-
-    // Notify start of proof generation
-    if let Err(e) =
-        cache_sender.send_traced(CacheServiceAction::NotifyProofGenerationStarted(data_root))
-    {
-        warn!(
-            ?data_root,
-            "Failed to notify cache of proof generation start: {e}"
-        );
-    }
-
-    let proof_res = super::chunks::generate_ingress_proof(
+    let proof = super::chunks::generate_ingress_proof(
         db.clone(),
         data_root,
-        data_size,
-        chunk_size,
+        leaves,
         signer,
         chain_id,
         anchor,
-    );
-
-    let proof = match proof_res {
-        Ok(p) => p,
-        Err(e) => {
-            if let Err(e) = cache_sender.send_traced(
-                CacheServiceAction::NotifyProofGenerationCompleted(data_root),
-            ) {
-                warn!(
-                    ?data_root,
-                    "Failed to notify cache of proof generation completion: {e}"
-                );
-            }
-            return Err(IngressProofGenerationError::GenerationFailed(e.to_string()));
-        }
-    };
+    )
+    .map_err(|error| IngressProofGenerationError::GenerationFailed(error.to_string()))?;
 
     gossip_ingress_proof(gossip_sender, &proof, block_tree_guard, db, config);
-
-    if let Err(e) = cache_sender.send_traced(CacheServiceAction::NotifyProofGenerationCompleted(
-        data_root,
-    )) {
-        warn!(
-            ?data_root,
-            "Failed to notify cache of proof generation completion: {e}"
-        );
-    }
     Ok(proof)
 }
 
@@ -417,7 +463,7 @@ pub fn reanchor_and_store_ingress_proof(
     signer: &IrysSigner,
     proof: &IngressProof,
     gossip_sender: &tokio::sync::mpsc::UnboundedSender<Traced<GossipBroadcastMessageV2>>,
-    cache_sender: &CacheServiceSender,
+    generation_state: &IngressProofGenerationState,
 ) -> Result<IngressProof, IngressProofGenerationError> {
     // Only staked nodes should reanchor ingress proofs
     let epoch_snapshot = block_tree_guard.read().canonical_epoch_snapshot();
@@ -425,46 +471,16 @@ pub fn reanchor_and_store_ingress_proof(
         return Err(IngressProofGenerationError::NodeNotStaked);
     }
 
-    let is_already_generating = {
-        let (response_sender, response_receiver) = std::sync::mpsc::channel();
-        if let Err(err) =
-            cache_sender.send_traced(CacheServiceAction::RequestIngressProofGenerationState {
-                data_root: proof.data_root,
-                response_sender,
-            })
-        {
-            return Err(IngressProofGenerationError::CacheServiceError(format!(
-                "Failed to request ingress proof generation state: {err}"
-            )));
-        }
-
-        response_receiver.recv().map_err(|err| {
-            IngressProofGenerationError::CacheServiceError(format!(
-                "Failed to receive ingress proof generation state response: {err}"
-            ))
-        })?
-    };
-
-    if is_already_generating {
-        return Err(IngressProofGenerationError::AlreadyGenerating);
-    }
-
-    if let Err(e) = cache_sender.send_traced(CacheServiceAction::NotifyProofGenerationStarted(
+    load_complete_ingress_leaves(
+        db,
         proof.data_root,
-    )) {
-        warn!(data_root = ?proof.data_root, "Failed to notify cache of proof generation start: {e}");
-    }
+        signer.address(),
+        config.consensus.chunk_size,
+    )?;
 
-    if let Err(e) =
-        calculate_and_validate_data_size(db, proof.data_root, config.consensus.chunk_size)
-    {
-        if let Err(e) = cache_sender.send_traced(
-            CacheServiceAction::NotifyProofGenerationCompleted(proof.data_root),
-        ) {
-            warn!(data_root = ?proof.data_root, "Failed to notify cache of proof generation completion: {e}");
-        }
-        return Err(e);
-    }
+    let _generation_lease = generation_state
+        .try_acquire(proof.data_root)
+        .ok_or(IngressProofGenerationError::AlreadyGenerating)?;
 
     let latest_anchor = block_tree_guard
         .read()
@@ -474,31 +490,14 @@ pub fn reanchor_and_store_ingress_proof(
     let mut proof = proof.clone();
     // Re-anchor and re-sign
     proof.anchor = latest_anchor;
-    if let Err(e) = signer.sign_ingress_proof(&mut proof) {
-        if let Err(e) = cache_sender.send_traced(
-            CacheServiceAction::NotifyProofGenerationCompleted(proof.data_root),
-        ) {
-            warn!(data_root = ?proof.data_root, "Failed to notify cache of proof generation completion: {e}");
-        }
-        return Err(IngressProofGenerationError::GenerationFailed(e.to_string()));
-    }
+    signer
+        .sign_ingress_proof(&mut proof)
+        .map_err(|error| IngressProofGenerationError::GenerationFailed(error.to_string()))?;
 
-    if let Err(e) = store_ingress_proof(db, &proof, signer) {
-        if let Err(e) = cache_sender.send_traced(
-            CacheServiceAction::NotifyProofGenerationCompleted(proof.data_root),
-        ) {
-            warn!(data_root = ?proof.data_root, "Failed to notify cache of proof generation completion: {e}");
-        }
-        return Err(IngressProofGenerationError::GenerationFailed(e.to_string()));
-    }
+    store_ingress_proof(db, &proof, signer)
+        .map_err(|error| IngressProofGenerationError::GenerationFailed(error.to_string()))?;
 
     gossip_ingress_proof(gossip_sender, &proof, block_tree_guard, db, config);
-
-    if let Err(e) = cache_sender.send_traced(CacheServiceAction::NotifyProofGenerationCompleted(
-        proof.data_root,
-    )) {
-        warn!(data_root = ?proof.data_root, "Failed to notify cache of proof generation completion: {e}");
-    }
     Ok(proof)
 }
 
@@ -529,35 +528,46 @@ pub fn gossip_ingress_proof(
     }
 }
 
-pub fn calculate_and_validate_data_size(
+/// Loads the exact gap-free compact leaf sequence for a confirmed data root.
+/// This is the sole database scan used by proof generation.
+pub fn load_complete_ingress_leaves(
     db: &DatabaseProvider,
     data_root: DataRoot,
+    address: irys_types::IrysAddress,
     chunk_size: u64,
-) -> Result<u64, IngressProofGenerationError> {
+) -> Result<Vec<IngressMerkleLeaf>, IngressProofGenerationError> {
     let err = |msg: String| IngressProofGenerationError::InvalidDataSize(msg);
 
     // Load data_size & confirm we have metadata for this root
-    let (data_size, chunk_count) = db
-        .view_eyre(|tx| {
-            let data_size = cached_data_root_by_data_root(tx, data_root)
-                .map_err(|e| eyre::eyre!("Failed to load cached_data_root: {e}"))?
-                .ok_or_else(|| eyre::eyre!("Missing cached_data_root for {data_root:?}"))?
-                .data_size;
-            let mut cursor = tx.cursor_dup_read::<CachedChunksIndex>()?;
-            let count = cursor
-                .dup_count(data_root)?
-                .ok_or_else(|| eyre::eyre!("No chunks found for data_root {data_root:?}"))?;
-            Ok((data_size, count))
-        })
-        .map_err(|e| err(e.to_string()))?;
+    db.view_eyre(|tx| {
+        let data_size = cached_data_root_by_data_root(tx, data_root)
+            .map_err(|e| eyre::eyre!("Failed to load cached_data_root: {e}"))?
+            .ok_or_else(|| eyre::eyre!("Missing cached_data_root for {data_root:?}"))?
+            .data_size;
+        let leaves = complete_ingress_leaves(tx, data_root, address, data_size, chunk_size)?
+            .ok_or_else(|| {
+                eyre::eyre!("compact ingress leaves are incomplete for data_root {data_root:?}")
+            })?;
+        Ok(leaves)
+    })
+    .map_err(|e| err(e.to_string()))
+}
 
-    let expected =
-        data_size_to_chunk_count(data_size, chunk_size).map_err(|e| err(e.to_string()))?;
-    if chunk_count != expected {
-        return Err(err(format!(
-            "have {chunk_count} chunks, expected {expected}"
-        )));
+#[cfg(test)]
+mod generation_state_tests {
+    use super::*;
+
+    #[test]
+    fn generation_lease_is_atomic_and_released_on_drop() {
+        let state = IngressProofGenerationState::new();
+        let data_root = H256::random();
+
+        let lease = state.try_acquire(data_root).expect("first acquisition");
+        assert!(state.is_generating(data_root));
+        assert!(state.try_acquire(data_root).is_none());
+
+        drop(lease);
+        assert!(!state.is_generating(data_root));
+        assert!(state.try_acquire(data_root).is_some());
     }
-
-    Ok(data_size)
 }

--- a/crates/actors/src/chunk_migration_service.rs
+++ b/crates/actors/src/chunk_migration_service.rs
@@ -8,11 +8,13 @@ use irys_database::{
 use irys_domain::{
     BlockIndex, StorageModule, StorageModulesReadGuard, get_overlapped_storage_modules,
 };
+use irys_packing::unpack;
 use irys_storage::{InclusiveInterval as _, ie, ii};
 use irys_types::{
     Base64, BlockHash, Config, DataLedger, DataRoot, DataTransactionHeader, DataTransactionLedger,
     H256, IrysBlockHeader, LedgerChunkOffset, LedgerChunkRange, Proof, SendTraced as _,
     TokioServiceHandle, Traced, TxChunkOffset, UnpackedChunk, app_state::DatabaseProvider,
+    hash_sha256, validate_path,
 };
 use reth::tasks::shutdown::Shutdown;
 use std::{collections::HashMap, sync::Arc};
@@ -173,7 +175,7 @@ impl ChunkMigrationServiceInner {
         // Collect working variables to move into the closure
         let block = block_header;
         let block_index = self.block_index.clone();
-        let chunk_size = self.config.consensus.chunk_size as usize;
+        let config = self.config.clone();
         let storage_modules = Arc::new(self.storage_modules_guard.clone());
         let db = Arc::new(self.db.clone());
         let service_senders = self.service_senders.clone();
@@ -222,7 +224,7 @@ impl ChunkMigrationServiceInner {
                 ledger,
                 txs,
                 &block_index,
-                chunk_size,
+                &config,
                 &storage_modules,
                 &db,
             )?;
@@ -250,10 +252,11 @@ pub fn process_ledger_transactions(
     ledger: DataLedger,
     txs: &[DataTransactionHeader],
     block_index: &BlockIndex,
-    chunk_size: usize,
+    config: &Config,
     storage_modules_guard: &StorageModulesReadGuard,
     db: &Arc<DatabaseProvider>,
 ) -> Result<(), MigrationError> {
+    let chunk_size = config.consensus.chunk_size as usize;
     let path_pairs = get_tx_path_pairs(block, ledger, txs).map_err(|e| {
         MigrationError::Other(format!("tx path merklization failed for {ledger:?}: {e}"))
     })?;
@@ -292,6 +295,7 @@ pub fn process_ledger_transactions(
             ledger,
             storage_modules_guard,
             db,
+            config,
         )?;
 
         for module in storage_modules_guard.read().iter() {
@@ -313,26 +317,142 @@ fn process_transaction_chunks(
     ledger: DataLedger,
     storage_modules_guard: &StorageModulesReadGuard,
     db: &DatabaseProvider,
+    config: &Config,
 ) -> Result<(), MigrationError> {
     for tx_chunk_offset in 0..num_chunks_in_tx {
         let tx_chunk_offset = TxChunkOffset::from(tx_chunk_offset);
-        // Attempt to retrieve the cached chunk from the mempool
-        let chunk_info = match get_cached_chunk(db, tx.data_root, tx_chunk_offset) {
-            Ok(Some(info)) => info,
-            _ => continue,
-        };
-
         // Find which storage module intersects this chunk
         let ledger_offset = tx_chunk_range.start() + *tx_chunk_offset;
-        let storage_module =
-            find_storage_module(storage_modules_guard, ledger, ledger_offset.into());
+        let Some(storage_module) =
+            find_storage_module(storage_modules_guard, ledger, ledger_offset.into())
+        else {
+            continue;
+        };
 
-        // Write the chunk data to the Storage Module
-        if let Some(module) = storage_module {
-            write_chunk_to_module(&module, chunk_info, tx, tx_chunk_offset)?;
+        // Idempotent replay: an already-durable target needs no source body, so
+        // a re-migrated block does not have to re-read or rewrite the chunk.
+        if let Some(target_offsets) = storage_module
+            .partition_offsets_for_data_root_chunk(tx.data_root, tx_chunk_offset)
+            .map_err(|error| {
+                MigrationError::Other(format!("resolving migration target: {error}"))
+            })?
+            && !target_offsets.is_empty()
+            && target_offsets
+                .iter()
+                .all(|offset| storage_module.is_data_chunk_durable_at(*offset))
+        {
+            continue;
         }
+
+        let Some(chunk) = load_chunk_for_migration(
+            storage_modules_guard,
+            db,
+            ledger,
+            tx,
+            tx_chunk_offset,
+            config,
+        )?
+        else {
+            tracing::warn!(
+                target_ledger = ?ledger,
+                data_root = %tx.data_root,
+                %tx_chunk_offset,
+                "Chunk body unavailable during migration; leaving the target offset for data sync"
+            );
+            continue;
+        };
+
+        write_chunk_to_module(&storage_module, &chunk)?;
     }
     Ok(())
+}
+
+fn load_chunk_for_migration(
+    storage_modules_guard: &StorageModulesReadGuard,
+    db: &DatabaseProvider,
+    target_ledger: DataLedger,
+    tx: &DataTransactionHeader,
+    tx_offset: TxChunkOffset,
+    config: &Config,
+) -> Result<Option<UnpackedChunk>, MigrationError> {
+    let chunk_size = config.consensus.chunk_size as usize;
+    match get_cached_chunk(db, tx.data_root, tx_offset) {
+        Ok(Some((_metadata, cached))) if cached.chunk.is_some() => {
+            return validate_chunk_for_migration(cached, tx, tx_offset, chunk_size).map(Some);
+        }
+        Ok(_) => {}
+        Err(error) => {
+            tracing::warn!(
+                data_root = %tx.data_root,
+                %tx_offset,
+                ?error,
+                "Failed to read cached chunk during migration; checking durable fallback"
+            );
+        }
+    }
+
+    // Submit is the only ledger whose transaction is later copied into a
+    // second ledger. Its cached body may be reclaimed after the Submit fsync,
+    // so Publish migration sources that normal cache-miss path from the durable
+    // Submit replica. Term-ledger transactions are written only once and do not
+    // need a cross-ledger fallback. If the Submit replica was reassigned or
+    // reset, the caller leaves a visible hole for data sync instead.
+    if target_ledger != DataLedger::Publish {
+        return Ok(None);
+    }
+
+    let storage_modules = storage_modules_guard.read().clone();
+    for module in &storage_modules {
+        let is_submit = module
+            .partition_assignment()
+            .and_then(|assignment| assignment.ledger_id)
+            == Some(DataLedger::Submit as u32);
+        if !is_submit {
+            continue;
+        }
+        let Some(partition_offsets) = module
+            .partition_offsets_for_data_root_chunk(tx.data_root, tx_offset)
+            .map_err(|error| {
+                MigrationError::Other(format!("resolving Submit fallback: {error}"))
+            })?
+        else {
+            continue;
+        };
+        for partition_offset in partition_offsets {
+            if !module.is_data_chunk_durable_at(partition_offset) {
+                continue;
+            }
+            let Some(packed) = module
+                .generate_full_chunk(partition_offset)
+                .map_err(|error| {
+                    MigrationError::Other(format!("reading durable Submit fallback: {error}"))
+                })?
+            else {
+                continue;
+            };
+            let unpacked = unpack(
+                &packed,
+                config.consensus.entropy_packing_iterations,
+                chunk_size,
+                config.consensus.chain_id,
+            );
+            if unpacked.data_root != tx.data_root || unpacked.tx_offset != tx_offset {
+                return Err(MigrationError::Other(format!(
+                    "durable Submit chunk identity mismatch for {} offset {}",
+                    tx.data_root, tx_offset
+                )));
+            }
+            return validate_chunk_parts_for_migration(
+                unpacked.data_path,
+                unpacked.bytes,
+                tx,
+                tx_offset,
+                chunk_size,
+            )
+            .map(Some);
+        }
+    }
+    Ok(None)
 }
 
 /// Computes the range of chunks added to a ledger by the transactions in a block,
@@ -479,30 +599,89 @@ fn find_storage_module(
 #[tracing::instrument(level = "trace", skip_all, err)]
 fn write_chunk_to_module(
     storage_module: &Arc<StorageModule>,
-    chunk_info: (CachedChunkIndexMetadata, CachedChunk),
+    chunk: &UnpackedChunk,
+) -> Result<(), MigrationError> {
+    storage_module.write_data_chunk(chunk).map_err(|e| {
+        error!(
+            "Failed to write chunk for data_root {:?} chunk_offset {} data_size {}: {:?}",
+            chunk.data_root, chunk.tx_offset, chunk.data_size, e
+        );
+        MigrationError::ChunkDataWrite
+    })
+}
+
+fn validate_chunk_for_migration(
+    cached: CachedChunk,
     tx: &DataTransactionHeader,
     chunk_offset: TxChunkOffset,
-) -> Result<(), MigrationError> {
-    let data_path = Base64::from(chunk_info.1.data_path.0.clone());
+    chunk_size: usize,
+) -> Result<UnpackedChunk, MigrationError> {
+    let bytes = cached.chunk.ok_or_else(|| {
+        MigrationError::Other(format!(
+            "cached chunk body missing for {} offset {}",
+            tx.data_root, chunk_offset
+        ))
+    })?;
+    validate_chunk_parts_for_migration(cached.data_path, bytes, tx, chunk_offset, chunk_size)
+}
 
-    if let Some(bytes) = chunk_info.1.chunk {
-        let chunk = UnpackedChunk {
-            data_root: tx.data_root,
-            data_size: tx.data_size,
-            data_path,
-            bytes,
-            tx_offset: chunk_offset,
-        };
-
-        storage_module.write_data_chunk(&chunk).map_err(|e| {
-            error!(
-                "Failed to write chunk for data_root {:?} chunk_offset {} data_size {}: {:?}",
-                tx.data_root, chunk_offset, tx.data_size, e
-            );
-            MigrationError::ChunkIndexWrite
+fn validate_chunk_parts_for_migration(
+    data_path: Base64,
+    bytes: Base64,
+    tx: &DataTransactionHeader,
+    chunk_offset: TxChunkOffset,
+    chunk_size: usize,
+) -> Result<UnpackedChunk, MigrationError> {
+    let chunk_size_u64 = u64::try_from(chunk_size)
+        .map_err(|_| MigrationError::Other("configured chunk size exceeds u64".to_string()))?;
+    let min_byte_range = u64::from(*chunk_offset)
+        .checked_mul(chunk_size_u64)
+        .ok_or_else(|| MigrationError::Other("chunk byte range overflow".to_string()))?;
+    let max_byte_range = min_byte_range
+        .checked_add(chunk_size_u64)
+        .map_or(tx.data_size, |end| end.min(tx.data_size));
+    let target_byte_position = max_byte_range.checked_sub(1).ok_or_else(|| {
+        MigrationError::Other(format!(
+            "chunk has an empty byte range for {} offset {}",
+            tx.data_root, chunk_offset
+        ))
+    })?;
+    let validation = validate_path(tx.data_root.0, &data_path, u128::from(target_byte_position))
+        .map_err(|error| {
+            MigrationError::Other(format!(
+                "data path failed revalidation for {} offset {}: {error}",
+                tx.data_root, chunk_offset
+            ))
         })?;
+    if validation.min_byte_range != u128::from(min_byte_range)
+        || validation.max_byte_range != u128::from(max_byte_range)
+    {
+        return Err(MigrationError::Other(format!(
+            "chunk byte range mismatch for {} offset {}: expected {}..{}, got {}..{}",
+            tx.data_root,
+            chunk_offset,
+            min_byte_range,
+            max_byte_range,
+            validation.min_byte_range,
+            validation.max_byte_range
+        )));
     }
-    Ok(())
+    let expected_len = max_byte_range.saturating_sub(min_byte_range);
+    if u64::try_from(bytes.len()).ok() != Some(expected_len)
+        || validation.leaf_hash != hash_sha256(bytes.as_slice())
+    {
+        return Err(MigrationError::Other(format!(
+            "chunk body failed revalidation for {} offset {}",
+            tx.data_root, chunk_offset
+        )));
+    }
+    Ok(UnpackedChunk {
+        data_root: tx.data_root,
+        data_size: tx.data_size,
+        data_path,
+        bytes,
+        tx_offset: chunk_offset,
+    })
 }
 
 impl ChunkMigrationService {

--- a/crates/actors/src/chunk_migration_service.rs
+++ b/crates/actors/src/chunk_migration_service.rs
@@ -256,7 +256,6 @@ pub fn process_ledger_transactions(
     storage_modules_guard: &StorageModulesReadGuard,
     db: &Arc<DatabaseProvider>,
 ) -> Result<(), MigrationError> {
-    let chunk_size = config.consensus.chunk_size as usize;
     let path_pairs = get_tx_path_pairs(block, ledger, txs).map_err(|e| {
         MigrationError::Other(format!("tx path merklization failed for {ledger:?}: {e}"))
     })?;
@@ -266,7 +265,7 @@ pub fn process_ledger_transactions(
     for ((_txid, tx_path), tx) in path_pairs {
         let num_chunks_in_tx: u32 = tx
             .data_size
-            .div_ceil(chunk_size as u64)
+            .div_ceil(config.consensus.chunk_size)
             .try_into()
             .map_err(|_| {
                 MigrationError::Other(format!(
@@ -375,10 +374,25 @@ fn load_chunk_for_migration(
     tx_offset: TxChunkOffset,
     config: &Config,
 ) -> Result<Option<UnpackedChunk>, MigrationError> {
-    let chunk_size = config.consensus.chunk_size as usize;
+    let chunk_size = usize::try_from(config.consensus.chunk_size).map_err(|_| {
+        MigrationError::Other(format!(
+            "configured chunk size {} does not fit usize",
+            config.consensus.chunk_size
+        ))
+    })?;
     match get_cached_chunk(db, tx.data_root, tx_offset) {
         Ok(Some((_metadata, cached))) if cached.chunk.is_some() => {
-            return validate_chunk_for_migration(cached, tx, tx_offset, chunk_size).map(Some);
+            match validate_chunk_for_migration(cached, tx, tx_offset, chunk_size) {
+                Ok(chunk) => return Ok(Some(chunk)),
+                Err(error) => {
+                    tracing::warn!(
+                        data_root = %tx.data_root,
+                        %tx_offset,
+                        ?error,
+                        "Cached chunk failed migration validation; checking durable fallback"
+                    );
+                }
+            }
         }
         Ok(_) => {}
         Err(error) => {
@@ -437,19 +451,34 @@ fn load_chunk_for_migration(
                 config.consensus.chain_id,
             );
             if unpacked.data_root != tx.data_root || unpacked.tx_offset != tx_offset {
-                return Err(MigrationError::Other(format!(
-                    "durable Submit chunk identity mismatch for {} offset {}",
-                    tx.data_root, tx_offset
-                )));
+                tracing::warn!(
+                    data_root = %tx.data_root,
+                    %tx_offset,
+                    storage_module.id = module.id,
+                    partition.offset = %partition_offset,
+                    "Durable Submit chunk identity mismatch; checking another replica"
+                );
+                continue;
             }
-            return validate_chunk_parts_for_migration(
+            match validate_chunk_parts_for_migration(
                 unpacked.data_path,
                 unpacked.bytes,
                 tx,
                 tx_offset,
                 chunk_size,
-            )
-            .map(Some);
+            ) {
+                Ok(chunk) => return Ok(Some(chunk)),
+                Err(error) => {
+                    tracing::warn!(
+                        data_root = %tx.data_root,
+                        %tx_offset,
+                        storage_module.id = module.id,
+                        partition.offset = %partition_offset,
+                        ?error,
+                        "Durable Submit chunk failed migration validation; checking another replica"
+                    );
+                }
+            }
         }
     }
     Ok(None)

--- a/crates/actors/src/data_sync_service.rs
+++ b/crates/actors/src/data_sync_service.rs
@@ -3,15 +3,20 @@ pub mod chunk_orchestrator;
 pub mod peer_bandwidth_manager;
 pub mod peer_stats;
 
-use crate::{chunk_fetcher::ChunkFetcherFactory, metrics, services::ServiceSenders};
+use crate::{
+    chunk_fetcher::ChunkFetcherFactory,
+    chunk_ingress_service::{ChunkIngressError, facade::ChunkIngressFacadeImpl},
+    metrics,
+    services::ServiceSenders,
+};
 use chunk_orchestrator::{ChunkBlockReason, ChunkOrchestrator, ChunkRequestState};
 use irys_database::db::IrysDatabaseExt as _;
 use irys_database::ingress_proofs_by_data_root;
 use irys_domain::{BlockTreeReadGuard, ChunkType, PeerList, StorageModule, WriteDataChunkError};
 use irys_packing::unpack;
 use irys_types::{
-    ChunkFormat, Config, DataRoot, IrysAddress, PartitionChunkOffset, SendTraced as _,
-    TokioServiceHandle, Traced, UnpackedChunk, app_state::DatabaseProvider,
+    ChunkFormat, Config, DataRoot, IrysAddress, PartitionChunkOffset, TokioServiceHandle, Traced,
+    UnpackedChunk, app_state::DatabaseProvider,
 };
 use peer_bandwidth_manager::PeerBandwidthManager;
 use reth::tasks::shutdown::Shutdown;
@@ -76,16 +81,13 @@ fn attempt_data_sync_write(
     }
 }
 
-fn forward_chunk_to_ingress(service_senders: &ServiceSenders, unpacked: UnpackedChunk) {
-    if let Err(e) = service_senders
-        .chunk_ingress
-        .send_traced(crate::chunk_ingress_service::ChunkIngressMessage::IngestChunk(unpacked, None))
-    {
-        warn!(
-            error = %e,
-            "Failed to forward data-sync chunk to chunk ingress validation"
-        );
-    }
+async fn forward_chunk_to_ingress(
+    service_senders: &ServiceSenders,
+    unpacked: UnpackedChunk,
+) -> Result<(), ChunkIngressError> {
+    ChunkIngressFacadeImpl::from(service_senders)
+        .handle_chunk_ingress(unpacked)
+        .await
 }
 
 pub struct DataSyncService {
@@ -211,7 +213,7 @@ impl DataSyncServiceInner {
     }
 
     #[tracing::instrument(level = "trace", skip_all, err)]
-    pub fn handle_message(&mut self, msg: DataSyncServiceMessage) -> eyre::Result<()> {
+    pub async fn handle_message(&mut self, msg: DataSyncServiceMessage) -> eyre::Result<()> {
         match msg {
             DataSyncServiceMessage::SyncPartitions => {
                 // New membership / post-heal: probe again promptly.
@@ -226,8 +228,9 @@ impl DataSyncServiceInner {
             } => {
                 // Fetch succeeded — record that separately from durable store.
                 metrics::record_data_sync_chunk_fetched();
-                if let Err(e) =
-                    self.on_chunk_completed(storage_module_id, chunk_offset, peer_addr, chunk)
+                if let Err(e) = self
+                    .on_chunk_completed(storage_module_id, chunk_offset, peer_addr, chunk)
+                    .await
                 {
                     error!(
                         storage_module.id = storage_module_id,
@@ -451,7 +454,7 @@ impl DataSyncServiceInner {
         chunk.offset = %chunk_offset,
         peer.address = %peer_addr,
     ))]
-    fn on_chunk_completed(
+    async fn on_chunk_completed(
         &mut self,
         storage_module_id: usize,
         chunk_offset: PartitionChunkOffset,
@@ -473,6 +476,21 @@ impl DataSyncServiceInner {
                 consensus.chain_id,
             ),
         };
+
+        // The ingress acknowledgement is the durable compact-leaf fence. Do
+        // not let the storage module make this fetch permanently complete
+        // until validation has committed the cached body and signer-specific
+        // ingress hash. This also makes a closed ingress channel retryable.
+        if let Err(error) =
+            forward_chunk_to_ingress(&self.service_senders, unpacked_chunk.clone()).await
+        {
+            if let Some(orchestrator) = self.chunk_orchestrators.get_mut(&storage_module_id) {
+                orchestrator.requeue_after_local_write_failure(chunk_offset)?;
+            }
+            return Err(eyre::eyre!(
+                "chunk ingress rejected data-sync body before durable write: {error}"
+            ));
+        }
 
         let sm = storage_module_by_id(&self.storage_modules.read().unwrap(), storage_module_id)
             .ok_or_else(|| eyre::eyre!("storage_module_id {storage_module_id} not found"))?;
@@ -576,13 +594,6 @@ impl DataSyncServiceInner {
                 }
             }
         }
-
-        // Storage placement and ingress-proof credit have different trust
-        // boundaries. Route every fetched body through the existing ingress
-        // validator so data sync can rebuild compact leaves without duplicating
-        // Merkle validation here. The ingress path also persists body + hash
-        // atomically; storage durability remains independently tracked above.
-        forward_chunk_to_ingress(&self.service_senders, unpacked_chunk);
 
         Ok(())
     }
@@ -1109,8 +1120,8 @@ impl DataSyncService {
                 msg = self.msg_rx.recv() => {
                     match msg {
                         Some(traced) => {
-                            let (msg, _entered) = traced.into_inner();
-                            self.inner.handle_message(msg)?;
+                            let (msg, span) = traced.into_parts();
+                            self.inner.handle_message(msg).instrument(span).await?;
                         }
                         None => {
                             tracing::warn!("Message channel closed unexpectedly");
@@ -1160,12 +1171,32 @@ impl DataSyncService {
 
         // Process remaining messages before shutdown
         while let Ok(traced) = self.msg_rx.try_recv() {
-            let (msg, _entered) = traced.into_inner();
-            self.inner.handle_message(msg)?;
+            let (msg, span) = traced.into_parts();
+            self.inner.handle_message(msg).instrument(span).await?;
         }
 
         tracing::info!("shutting down DataSync Service gracefully");
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod ingress_handoff_tests {
+    use super::forward_chunk_to_ingress;
+    use crate::services::ServiceSenders;
+    use irys_types::UnpackedChunk;
+
+    #[tokio::test]
+    async fn closed_ingress_channel_fails_the_handoff() {
+        let (senders, receivers) = ServiceSenders::new();
+        drop(receivers.chunk_ingress);
+
+        assert!(
+            forward_chunk_to_ingress(&senders, UnpackedChunk::default())
+                .await
+                .is_err(),
+            "data sync must not credit a body that ingress cannot durably acknowledge"
+        );
     }
 }
 

--- a/crates/actors/src/data_sync_service.rs
+++ b/crates/actors/src/data_sync_service.rs
@@ -32,8 +32,10 @@ const MAX_RESIDUAL_OFFSETS_FOR_PROOF_SCAN: usize = 16;
 /// Local write outcome after a successful peer fetch.
 #[derive(Debug, PartialEq, Eq)]
 enum DataSyncWriteOutcome {
-    /// Offset is durably [`ChunkType::Data`] after pending flush + fsync.
-    Stored,
+    /// Another writer already made the requested offset durably `Data`.
+    AlreadyDurable,
+    /// Offset is buffered as [`ChunkType::Data`] and awaits a completed fsync.
+    AwaitingDurability,
     /// SM has no `DataRootInfos` entry for this data_root — needs index rebuild.
     MissingDataRootIndex,
     /// data_root is indexed but no Entropy target at the expected offsets.
@@ -52,20 +54,14 @@ fn attempt_data_sync_write(
         Err(e) => DataSyncWriteOutcome::Other(e.to_string()),
         Ok(()) => {
             // write_data_chunk only enqueues into pending_writes; get_chunk_type
-            // can report Data before persistence. Do not mark Stored (or
-            // Completed in the orchestrator) until force_sync flushes + fsyncs.
-            // On flush failure we return Other → requeue; the request stays
-            // Requested until this function returns an outcome that advances it.
+            // can report Data before persistence. Keep the request in an
+            // explicit awaiting-durability state until the normal batched sync
+            // becomes durably visible after a completed fsync.
             if matches!(sm.get_chunk_type(&expected_offset), Some(ChunkType::Data)) {
-                if let Err(e) = sm.force_sync_pending_chunks() {
-                    return DataSyncWriteOutcome::Other(e.to_string());
-                }
-                if matches!(sm.get_chunk_type(&expected_offset), Some(ChunkType::Data)) {
-                    DataSyncWriteOutcome::Stored
+                if sm.is_data_chunk_durable_at(expected_offset) {
+                    DataSyncWriteOutcome::AlreadyDurable
                 } else {
-                    DataSyncWriteOutcome::Other(
-                        "chunk not Data after force_sync_pending_chunks".into(),
-                    )
+                    DataSyncWriteOutcome::AwaitingDurability
                 }
             } else if matches!(
                 sm.collect_data_root_infos(unpacked.data_root),
@@ -80,14 +76,14 @@ fn attempt_data_sync_write(
     }
 }
 
-fn try_send_chunk_to_ingress(service_senders: &ServiceSenders, unpacked: UnpackedChunk) {
+fn forward_chunk_to_ingress(service_senders: &ServiceSenders, unpacked: UnpackedChunk) {
     if let Err(e) = service_senders
         .chunk_ingress
         .send_traced(crate::chunk_ingress_service::ChunkIngressMessage::IngestChunk(unpacked, None))
     {
         warn!(
             error = %e,
-            "Failed to send ChunkIngressMessage to chunk ingress channel after data_sync write failure"
+            "Failed to forward data-sync chunk to chunk ingress validation"
         );
     }
 }
@@ -489,10 +485,10 @@ impl DataSyncServiceInner {
         let write_outcome = attempt_data_sync_write(&sm, &unpacked_chunk, chunk_offset);
 
         match write_outcome {
-            DataSyncWriteOutcome::Stored => {
+            DataSyncWriteOutcome::AlreadyDurable => {
                 metrics::record_data_sync_chunk_stored();
                 if let Some(orchestrator) = self.chunk_orchestrators.get_mut(&storage_module_id) {
-                    orchestrator.mark_chunk_stored(chunk_offset)?;
+                    orchestrator.mark_chunk_already_durable(chunk_offset)?;
                 }
                 debug!(
                     storage_module.id = storage_module_id,
@@ -502,7 +498,22 @@ impl DataSyncServiceInner {
                     ?slot_index,
                     ?partition_hash,
                     peer.address = %peer_addr,
-                    "data_sync chunk stored"
+                    "data_sync chunk was already durably stored"
+                );
+            }
+            DataSyncWriteOutcome::AwaitingDurability => {
+                if let Some(orchestrator) = self.chunk_orchestrators.get_mut(&storage_module_id) {
+                    orchestrator.mark_chunk_awaiting_durability(chunk_offset)?;
+                }
+                debug!(
+                    storage_module.id = storage_module_id,
+                    chunk.offset = %chunk_offset,
+                    chunk.data_root = %unpacked_chunk.data_root,
+                    ?ledger_id,
+                    ?slot_index,
+                    ?partition_hash,
+                    peer.address = %peer_addr,
+                    "data_sync chunk buffered awaiting durable batch"
                 );
             }
             DataSyncWriteOutcome::MissingDataRootIndex => {
@@ -526,9 +537,6 @@ impl DataSyncServiceInner {
                     orchestrator
                         .mark_chunk_blocked(chunk_offset, ChunkBlockReason::MissingDataRootIndex)?;
                 }
-                // Best-effort: mempool/ingress may still place the chunk if another
-                // path holds indexes; do not treat handoff as durable success.
-                try_send_chunk_to_ingress(&self.service_senders, unpacked_chunk);
             }
             DataSyncWriteOutcome::NoWriteableOffset => {
                 metrics::record_data_sync_chunk_write_failed("no_writeable_offset");
@@ -547,7 +555,6 @@ impl DataSyncServiceInner {
                 if let Some(orchestrator) = self.chunk_orchestrators.get_mut(&storage_module_id) {
                     orchestrator.requeue_after_local_write_failure(chunk_offset)?;
                 }
-                try_send_chunk_to_ingress(&self.service_senders, unpacked_chunk);
             }
             DataSyncWriteOutcome::Other(err) => {
                 metrics::record_data_sync_chunk_write_failed("other");
@@ -567,9 +574,15 @@ impl DataSyncServiceInner {
                 if let Some(orchestrator) = self.chunk_orchestrators.get_mut(&storage_module_id) {
                     orchestrator.requeue_after_local_write_failure(chunk_offset)?;
                 }
-                try_send_chunk_to_ingress(&self.service_senders, unpacked_chunk);
             }
         }
+
+        // Storage placement and ingress-proof credit have different trust
+        // boundaries. Route every fetched body through the existing ingress
+        // validator so data sync can rebuild compact leaves without duplicating
+        // Merkle validation here. The ingress path also persists body + hash
+        // atomically; storage durability remains independently tracked above.
+        forward_chunk_to_ingress(&self.service_senders, unpacked_chunk);
 
         Ok(())
     }
@@ -1450,11 +1463,16 @@ mod ingress_proof_peer_tests {
 #[cfg(test)]
 mod write_outcome_tests {
     use super::{DataSyncWriteOutcome, attempt_data_sync_write};
+    use irys_database::{
+        db::IrysDatabaseExt as _,
+        submodule::{add_data_root_info, tables::DataRootInfo},
+    };
     use irys_domain::{StorageModule, StorageModuleInfo, WriteDataChunkError};
     use irys_testing_utils::TempDirBuilder;
     use irys_types::{
         Config, ConsensusConfig, DataLedger, H256, IrysAddress, NodeConfig, PartitionChunkOffset,
-        TxChunkOffset, UnpackedChunk, partition::PartitionAssignment, partition_chunk_offset_ie,
+        RelativeChunkOffset, StorageSyncConfig, TxChunkOffset, UnpackedChunk,
+        partition::PartitionAssignment, partition_chunk_offset_ie,
     };
     use std::sync::Arc;
 
@@ -1515,5 +1533,84 @@ mod write_outcome_tests {
 
         let outcome = attempt_data_sync_write(&sm, &chunk, PartitionChunkOffset::from(0_u32));
         assert_eq!(outcome, DataSyncWriteOutcome::MissingDataRootIndex);
+    }
+
+    #[test]
+    fn successful_data_sync_write_stays_buffered_below_sync_threshold() {
+        let tmp = TempDirBuilder::new().with_tracing().build();
+        let num_chunks = 10_u64;
+        let chunk_size = 32_u64;
+        let node_config = NodeConfig {
+            consensus: irys_types::ConsensusOptions::Custom(ConsensusConfig {
+                chunk_size,
+                num_chunks_in_partition: num_chunks,
+                num_chunks_in_recall_range: 2,
+                num_partitions_per_slot: 1,
+                entropy_packing_iterations: 1,
+                chain_id: 1,
+                ..ConsensusConfig::testing()
+            }),
+            storage: StorageSyncConfig {
+                num_writes_before_sync: num_chunks,
+            },
+            base_directory: tmp.path().to_path_buf(),
+            ..NodeConfig::testing()
+        };
+        let config = Config::new_with_random_peer_id(node_config);
+        let info = StorageModuleInfo {
+            id: 0,
+            partition_assignment: Some(PartitionAssignment {
+                ledger_id: Some(DataLedger::Publish.into()),
+                slot_index: Some(0),
+                miner_address: IrysAddress::from([7_u8; 20]),
+                partition_hash: H256::random(),
+            }),
+            submodules: vec![(
+                partition_chunk_offset_ie!(0, num_chunks as u32),
+                "chunks".into(),
+            )],
+        };
+        let sm = Arc::new(StorageModule::new(&info, &config).expect("storage module"));
+        sm.pack_with_zeros();
+
+        let data_root = H256::random();
+        let offset = PartitionChunkOffset::from(0_u32);
+        let (_, submodule) = sm
+            .get_submodule_for_offset(offset)
+            .expect("submodule for offset");
+        submodule
+            .db
+            .update_eyre(|tx| {
+                add_data_root_info(
+                    tx,
+                    data_root,
+                    &DataRootInfo {
+                        start_offset: RelativeChunkOffset::from(0_i32),
+                        data_size: chunk_size,
+                    },
+                )
+            })
+            .expect("index data root");
+
+        let chunk = UnpackedChunk {
+            data_root,
+            data_size: chunk_size,
+            data_path: vec![1, 2, 3, 4].into(),
+            bytes: vec![0xcd; chunk_size as usize].into(),
+            tx_offset: TxChunkOffset::from(0_u32),
+        };
+
+        assert_eq!(
+            attempt_data_sync_write(&sm, &chunk, offset),
+            DataSyncWriteOutcome::AwaitingDurability
+        );
+        assert!(
+            sm.has_pending_writes(),
+            "the per-chunk data-sync path must not force a below-threshold fsync"
+        );
+        assert!(
+            !sm.is_data_chunk_durable_at(offset),
+            "buffered Data must not be reported as durable"
+        );
     }
 }

--- a/crates/actors/src/data_sync_service/chunk_orchestrator/mod.rs
+++ b/crates/actors/src/data_sync_service/chunk_orchestrator/mod.rs
@@ -13,7 +13,7 @@ use irys_types::{
 use std::{
     collections::{HashMap, HashSet, hash_map},
     sync::{Arc, RwLock},
-    time::Instant,
+    time::{Duration, Instant},
 };
 use tracing::{Instrument as _, debug, warn};
 
@@ -22,6 +22,11 @@ use tracing::{Instrument as _, debug, warn};
 /// behind while the packing tail (high offsets) is still legitimately Entropy —
 /// gating on low offsets keeps the probes quiet on healthy modules.
 pub(crate) const LOW_OFFSET_PROBE_THRESHOLD: u32 = 20_000;
+
+/// Durability normally follows the five-second idle-tail flush. A much larger
+/// monotonic deadline prevents a stalled write from parking sync forever
+/// without turning ordinary buffered writes into duplicate network requests.
+const DURABILITY_WAIT_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// How to request a missing body from a selected peer.
 ///
@@ -64,10 +69,16 @@ pub enum ChunkRequestState {
     /// Used for tracking timeouts and preventing duplicate requests.
     Requested(IrysAddress, Instant),
 
+    /// Peer delivery was accepted into the storage module's pending-write
+    /// buffer. Advanced to `Completed` once the storage module reports the body
+    /// as fsynced, polled every tick by `reconcile_awaiting_durability`.
+    AwaitingDurability(Instant),
+
     /// Chunk was successfully fetched **and** durably written as [`ChunkType::Data`].
     ///
     /// Fetch alone is not enough — see [`Self::on_chunk_fetched`] then
-    /// [`Self::mark_chunk_stored`].
+    /// [`Self::mark_chunk_awaiting_durability`], then the durability poll in
+    /// `reconcile_awaiting_durability`.
     Completed,
 
     /// Locally blocked from hot re-fetch (index gap, etc.). Still retained while
@@ -157,15 +168,51 @@ impl ChunkOrchestrator {
         Ok(())
     }
 
+    /// Promotes buffered writes the storage module now reports as fsynced, and
+    /// returns a wait that has outlived `timeout` to the fetch queue.
+    ///
+    /// This polls the storage module's interval state rather than consuming a
+    /// notification, so nothing can strand a request and the answer is always
+    /// the one restart recovery would reload.
+    fn reconcile_awaiting_durability(&mut self, now: Instant, timeout: Duration) {
+        for (offset, request) in &mut self.chunk_requests {
+            let ChunkRequestState::AwaitingDurability(started) = request.request_state else {
+                continue;
+            };
+
+            if self.storage_module.is_data_chunk_durable_at(*offset) {
+                request.request_state = ChunkRequestState::Completed;
+                debug!(
+                    chunk.offset = %offset,
+                    "data_sync chunk durably stored"
+                );
+            } else if now.saturating_duration_since(started) >= timeout {
+                request.request_state = ChunkRequestState::Pending;
+                request.excluded = None;
+                warn!(
+                    chunk.offset = %offset,
+                    timeout_secs = timeout.as_secs(),
+                    "Data-sync write did not become durable in time; returning chunk to pending"
+                );
+            }
+        }
+    }
+
     #[tracing::instrument(level = "trace", skip_all)]
     fn populate_request_queue(&mut self) {
+        self.reconcile_awaiting_durability(Instant::now(), DURABILITY_WAIT_TIMEOUT);
+
         // Retain in-flight requests (for telemetry tracking) and pending entropy requests.
         // Remove completed requests and pending requests for chunks that changed type
         // (satisfied via gossip/upload or invalidated by storage fault/expiry).
 
         self.chunk_requests.retain(|offset, cr| {
-            // Always retain in-flight requests
-            if matches!(cr.request_state, ChunkRequestState::Requested(..)) {
+            // Retain network requests and locally buffered writes until their
+            // respective completion event arrives.
+            if matches!(
+                cr.request_state,
+                ChunkRequestState::Requested(..) | ChunkRequestState::AwaitingDurability(..)
+            ) {
                 return true;
             }
 
@@ -616,7 +663,7 @@ impl ChunkOrchestrator {
 
     /// Peer delivered the chunk body. Credits peer bandwidth stats but leaves
     /// the request in [`ChunkRequestState::Requested`] until
-    /// [`Self::mark_chunk_stored`] / [`Self::mark_chunk_blocked`] /
+    /// [`Self::mark_chunk_awaiting_durability`] / [`Self::mark_chunk_blocked`] /
     /// [`Self::requeue_after_local_write_failure`] decides the local outcome.
     ///
     /// Peer delivery success must not be conflated with durable local storage.
@@ -635,6 +682,7 @@ impl ChunkOrchestrator {
         let (expected_peer, start_instant) = match request.request_state {
             ChunkRequestState::Requested(addr, started) => (addr, started),
             ref invalid_state @ (ChunkRequestState::Pending
+            | ChunkRequestState::AwaitingDurability(..)
             | ChunkRequestState::Completed
             | ChunkRequestState::Blocked(_)) => {
                 return Err(eyre::eyre!(
@@ -671,14 +719,44 @@ impl ChunkOrchestrator {
         Ok(completion_record)
     }
 
-    /// Durable local store succeeded — offset is (or will be observed as) Data.
-    pub fn mark_chunk_stored(&mut self, chunk_offset: PartitionChunkOffset) -> eyre::Result<()> {
+    /// Local write entered the pending buffer. Durability is confirmed
+    /// separately by the per-tick `reconcile_awaiting_durability` poll.
+    pub fn mark_chunk_awaiting_durability(
+        &mut self,
+        chunk_offset: PartitionChunkOffset,
+    ) -> eyre::Result<()> {
         let request = self.chunk_requests.get_mut(&chunk_offset).ok_or_else(|| {
-            eyre::eyre!("mark_chunk_stored for unknown offset: {:?}", chunk_offset)
+            eyre::eyre!(
+                "mark_chunk_awaiting_durability for unknown offset: {:?}",
+                chunk_offset
+            )
         })?;
         if !matches!(request.request_state, ChunkRequestState::Requested(..)) {
             return Err(eyre::eyre!(
-                "mark_chunk_stored expected Requested state at {:?}, got {:?}",
+                "mark_chunk_awaiting_durability expected Requested state at {:?}, got {:?}",
+                chunk_offset,
+                request.request_state
+            ));
+        }
+        request.request_state = ChunkRequestState::AwaitingDurability(Instant::now());
+        Ok(())
+    }
+
+    /// A concurrent local writer already completed this offset before the
+    /// fetched body reached the pending buffer.
+    pub fn mark_chunk_already_durable(
+        &mut self,
+        chunk_offset: PartitionChunkOffset,
+    ) -> eyre::Result<()> {
+        let request = self.chunk_requests.get_mut(&chunk_offset).ok_or_else(|| {
+            eyre::eyre!(
+                "mark_chunk_already_durable for unknown offset: {:?}",
+                chunk_offset
+            )
+        })?;
+        if !matches!(request.request_state, ChunkRequestState::Requested(..)) {
+            return Err(eyre::eyre!(
+                "mark_chunk_already_durable expected Requested state at {:?}, got {:?}",
                 chunk_offset,
                 request.request_state
             ));
@@ -807,6 +885,7 @@ impl ChunkOrchestrator {
         let expected_peer = match request.request_state {
             ChunkRequestState::Requested(addr, _) => addr,
             ChunkRequestState::Pending
+            | ChunkRequestState::AwaitingDurability(..)
             | ChunkRequestState::Completed
             | ChunkRequestState::Blocked(_) => {
                 return Err(eyre::eyre!(
@@ -865,17 +944,18 @@ impl ChunkOrchestrator {
     }
 
     pub fn get_metrics(&self) -> OrchestrationMetrics {
-        let (pending, active, completed, blocked) =
-            self.chunk_requests
-                .values()
-                .fold((0, 0, 0, 0), |(p, a, c, b), request| {
-                    match request.request_state {
-                        ChunkRequestState::Pending => (p + 1, a, c, b),
-                        ChunkRequestState::Requested(_, _) => (p, a + 1, c, b),
-                        ChunkRequestState::Completed => (p, a, c + 1, b),
-                        ChunkRequestState::Blocked(_) => (p, a, c, b + 1),
-                    }
-                });
+        let (pending, active, awaiting_durability, completed, blocked) = self
+            .chunk_requests
+            .values()
+            .fold((0, 0, 0, 0, 0), |(p, a, d, c, b), request| {
+                match request.request_state {
+                    ChunkRequestState::Pending => (p + 1, a, d, c, b),
+                    ChunkRequestState::Requested(_, _) => (p, a + 1, d, c, b),
+                    ChunkRequestState::AwaitingDurability(..) => (p, a, d + 1, c, b),
+                    ChunkRequestState::Completed => (p, a, d, c + 1, b),
+                    ChunkRequestState::Blocked(_) => (p, a, d, c, b + 1),
+                }
+            });
 
         let total_throughput_bps = if let Ok(peers) = self.active_sync_peers.read() {
             self.current_peers
@@ -891,6 +971,7 @@ impl ChunkOrchestrator {
             total_peers: self.current_peers.len(),
             pending_requests: pending,
             active_requests: active,
+            awaiting_durability_requests: awaiting_durability,
             completed_requests: completed,
             blocked_requests: blocked,
             total_throughput_bps,
@@ -903,6 +984,7 @@ pub struct OrchestrationMetrics {
     pub total_peers: usize,
     pub pending_requests: usize,
     pub active_requests: usize,
+    pub awaiting_durability_requests: usize,
     pub completed_requests: usize,
     pub blocked_requests: usize,
     pub total_throughput_bps: u64,

--- a/crates/actors/src/data_sync_service/chunk_orchestrator/mod.rs
+++ b/crates/actors/src/data_sync_service/chunk_orchestrator/mod.rs
@@ -182,6 +182,7 @@ impl ChunkOrchestrator {
 
             if self.storage_module.is_data_chunk_durable_at(*offset) {
                 request.request_state = ChunkRequestState::Completed;
+                metrics::record_data_sync_chunk_stored();
                 debug!(
                     chunk.offset = %offset,
                     "data_sync chunk durably stored"
@@ -189,6 +190,7 @@ impl ChunkOrchestrator {
             } else if now.saturating_duration_since(started) >= timeout {
                 request.request_state = ChunkRequestState::Pending;
                 request.excluded = None;
+                metrics::record_data_sync_durability_stalled();
                 warn!(
                     chunk.offset = %offset,
                     timeout_secs = timeout.as_secs(),

--- a/crates/actors/src/data_sync_service/chunk_orchestrator/tests.rs
+++ b/crates/actors/src/data_sync_service/chunk_orchestrator/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::{chunk_fetcher::MockChunkFetcher, test_helpers::build_test_service_senders};
+use irys_domain::ChunkType;
 use irys_domain::{BlockTree, StorageModuleInfo};
 use irys_testing_utils::TempDirBuilder;
 use irys_types::{
@@ -62,6 +63,25 @@ fn make_orchestrator(sm: Arc<StorageModule>, config: &Config) -> ChunkOrchestrat
     )
 }
 
+/// Makes `offset` durably `Data` the way the write path does: buffer, then
+/// flush + fsync. `is_data_chunk_durable_at` only becomes true after the fsync.
+fn store_durable_data(sm: &StorageModule, offset: PartitionChunkOffset, chunk_size: usize) {
+    assert!(
+        !sm.is_data_chunk_durable_at(offset),
+        "offset must start non-durable"
+    );
+    sm.write_chunk(offset, vec![9_u8; chunk_size], ChunkType::Data);
+    assert!(
+        !sm.is_data_chunk_durable_at(offset),
+        "a buffered write must not be reported as durable"
+    );
+    sm.force_sync_pending_chunks().expect("flush");
+    assert!(
+        sm.is_data_chunk_durable_at(offset),
+        "an fsynced write must be reported as durable"
+    );
+}
+
 fn insert_requested(orch: &mut ChunkOrchestrator, offset: PartitionChunkOffset, peer: IrysAddress) {
     orch.chunk_requests.insert(
         offset,
@@ -74,7 +94,7 @@ fn insert_requested(orch: &mut ChunkOrchestrator, offset: PartitionChunkOffset, 
 }
 
 #[test_log::test(tokio::test)]
-async fn mark_helpers_require_requested_state() {
+async fn mark_helpers_require_valid_source_state() {
     let tmp = TempDirBuilder::new().with_tracing().build();
     let num_chunks = 4;
     let config = test_config(tmp.path().to_path_buf(), num_chunks);
@@ -84,7 +104,8 @@ async fn mark_helpers_require_requested_state() {
     let offset = PartitionChunkOffset::from(0_u32);
 
     // Unknown offset
-    assert!(orch.mark_chunk_stored(offset).is_err());
+    assert!(orch.mark_chunk_awaiting_durability(offset).is_err());
+    assert!(orch.mark_chunk_already_durable(offset).is_err());
     assert!(
         orch.mark_chunk_blocked(offset, ChunkBlockReason::MissingDataRootIndex)
             .is_err()
@@ -100,16 +121,26 @@ async fn mark_helpers_require_requested_state() {
             request_state: ChunkRequestState::Pending,
         },
     );
-    assert!(orch.mark_chunk_stored(offset).is_err());
+    assert!(orch.mark_chunk_awaiting_durability(offset).is_err());
+    assert!(orch.mark_chunk_already_durable(offset).is_err());
     assert!(
         orch.mark_chunk_blocked(offset, ChunkBlockReason::MissingDataRootIndex)
             .is_err()
     );
     assert!(orch.requeue_after_local_write_failure(offset).is_err());
 
-    // Requested accepts each transition
+    // Requested accepts each initial local outcome.
     insert_requested(&mut orch, offset, peer);
-    orch.mark_chunk_stored(offset).expect("store");
+    orch.mark_chunk_awaiting_durability(offset).expect("buffer");
+    assert!(
+        matches!(
+            orch.chunk_requests[&offset].request_state,
+            ChunkRequestState::AwaitingDurability(..)
+        ),
+        "buffered write must wait for durability"
+    );
+    store_durable_data(&orch.storage_module, offset, 32);
+    orch.reconcile_awaiting_durability(Instant::now(), DURABILITY_WAIT_TIMEOUT);
     assert_eq!(
         orch.chunk_requests[&offset].request_state,
         ChunkRequestState::Completed
@@ -132,6 +163,134 @@ async fn mark_helpers_require_requested_state() {
     );
     // Requeue must not blame the delivering peer.
     assert!(orch.chunk_requests[&offset].excluded.is_none());
+}
+
+#[test_log::test(tokio::test)]
+async fn durability_poll_promotes_only_fsynced_offsets() {
+    let tmp = TempDirBuilder::new().with_tracing().build();
+    let num_chunks = 4;
+    let config = test_config(tmp.path().to_path_buf(), num_chunks);
+    let sm = packed_sm(&config, num_chunks);
+    let mut orch = make_orchestrator(Arc::clone(&sm), &config);
+    let peer = IrysAddress::from([8_u8; 20]);
+    let waiting = PartitionChunkOffset::from(1_u32);
+    let other = PartitionChunkOffset::from(2_u32);
+
+    insert_requested(&mut orch, waiting, peer);
+    orch.mark_chunk_awaiting_durability(waiting).unwrap();
+
+    // Another offset becoming durable must not promote this one.
+    store_durable_data(&sm, other, 32);
+    orch.reconcile_awaiting_durability(Instant::now(), DURABILITY_WAIT_TIMEOUT);
+    assert!(
+        matches!(
+            orch.chunk_requests[&waiting].request_state,
+            ChunkRequestState::AwaitingDurability(..)
+        ),
+        "durability credit must not leak across offsets"
+    );
+
+    store_durable_data(&sm, waiting, 32);
+    orch.reconcile_awaiting_durability(Instant::now(), DURABILITY_WAIT_TIMEOUT);
+    assert_eq!(
+        orch.chunk_requests[&waiting].request_state,
+        ChunkRequestState::Completed
+    );
+
+    // Polling again is a no-op: a completed request stays completed.
+    orch.reconcile_awaiting_durability(Instant::now(), DURABILITY_WAIT_TIMEOUT);
+    assert_eq!(
+        orch.chunk_requests[&waiting].request_state,
+        ChunkRequestState::Completed
+    );
+}
+
+#[test_log::test(tokio::test)]
+async fn durability_poll_returns_a_stalled_wait_to_pending() {
+    let tmp = TempDirBuilder::new().with_tracing().build();
+    let num_chunks = 4;
+    let config = test_config(tmp.path().to_path_buf(), num_chunks);
+    let sm = packed_sm(&config, num_chunks);
+    let mut orch = make_orchestrator(sm, &config);
+    let peer = IrysAddress::from([8_u8; 20]);
+    let waiting = PartitionChunkOffset::from(1_u32);
+
+    insert_requested(&mut orch, waiting, peer);
+    orch.mark_chunk_awaiting_durability(waiting).unwrap();
+
+    let started = Instant::now();
+    orch.reconcile_awaiting_durability(started, DURABILITY_WAIT_TIMEOUT);
+    assert!(matches!(
+        orch.chunk_requests[&waiting].request_state,
+        ChunkRequestState::AwaitingDurability(..)
+    ));
+
+    orch.reconcile_awaiting_durability(
+        started + DURABILITY_WAIT_TIMEOUT + Duration::from_secs(1),
+        DURABILITY_WAIT_TIMEOUT,
+    );
+    assert_eq!(
+        orch.chunk_requests[&waiting].request_state,
+        ChunkRequestState::Pending,
+        "a write that never became durable must be re-fetchable"
+    );
+    assert!(
+        orch.chunk_requests[&waiting].excluded.is_none(),
+        "a stalled local write must not blame the delivering peer"
+    );
+}
+
+#[test_log::test(tokio::test)]
+async fn awaiting_durability_is_observable_and_times_out_to_pending() {
+    let tmp = TempDirBuilder::new().with_tracing().build();
+    let num_chunks = 4;
+    let config = test_config(tmp.path().to_path_buf(), num_chunks);
+    let sm = packed_sm(&config, num_chunks);
+    let mut orch = make_orchestrator(sm, &config);
+    let peer = IrysAddress::from([9_u8; 20]);
+    let offset = PartitionChunkOffset::from(1_u32);
+
+    insert_requested(&mut orch, offset, peer);
+    orch.mark_chunk_awaiting_durability(offset).unwrap();
+    let metrics = orch.get_metrics();
+    assert_eq!(metrics.awaiting_durability_requests, 1);
+    assert_eq!(metrics.active_requests, 0);
+
+    orch.reconcile_awaiting_durability(Instant::now(), Duration::ZERO);
+    assert_eq!(
+        orch.chunk_requests[&offset].request_state,
+        ChunkRequestState::Pending,
+        "a stalled durability wait must not park data sync forever"
+    );
+    assert_eq!(orch.get_metrics().awaiting_durability_requests, 0);
+}
+
+#[test_log::test(tokio::test)]
+async fn awaiting_durability_rechecks_storage_before_refetching() {
+    let tmp = TempDirBuilder::new().with_tracing().build();
+    let num_chunks = 4;
+    let config = test_config(tmp.path().to_path_buf(), num_chunks);
+    let sm = packed_sm(&config, num_chunks);
+    let mut orch = make_orchestrator(Arc::clone(&sm), &config);
+    let peer = IrysAddress::from([10_u8; 20]);
+    let offset = PartitionChunkOffset::from(1_u32);
+
+    insert_requested(&mut orch, offset, peer);
+    orch.mark_chunk_awaiting_durability(offset).unwrap();
+    sm.write_chunk(
+        offset,
+        vec![0xab; config.consensus.chunk_size as usize],
+        ChunkType::Data,
+    );
+    sm.sync_pending_chunks().unwrap();
+    assert!(sm.is_data_chunk_durable_at(offset));
+
+    orch.reconcile_awaiting_durability(Instant::now(), Duration::ZERO);
+    assert_eq!(
+        orch.chunk_requests[&offset].request_state,
+        ChunkRequestState::Completed,
+        "durable storage must win over a stale wait state"
+    );
 }
 
 #[test_log::test(tokio::test)]
@@ -279,7 +438,9 @@ async fn unblock_missing_data_root_index_requeues_only_that_reason() {
     );
 
     insert_requested(&mut orch, completed, peer);
-    orch.mark_chunk_stored(completed).unwrap();
+    orch.mark_chunk_awaiting_durability(completed).unwrap();
+    store_durable_data(&orch.storage_module, completed, 32);
+    orch.reconcile_awaiting_durability(Instant::now(), DURABILITY_WAIT_TIMEOUT);
 
     insert_requested(&mut orch, requested, peer);
 

--- a/crates/actors/src/metrics.rs
+++ b/crates/actors/src/metrics.rs
@@ -30,6 +30,7 @@ irys_utils::define_metrics! {
     counter DATA_SYNC_CHUNK_WRITE_FAILED("irys.data_sync.chunk_write_failed_total", "Data sync local write failures after a successful fetch (labelled by reason)");
     counter DATA_SYNC_CHUNK_BLOCKED("irys.data_sync.chunk_blocked_total", "Data sync offsets blocked from hot re-fetch (labelled by reason)");
     counter DATA_SYNC_CHUNK_UNBLOCKED("irys.data_sync.chunk_unblocked_total", "Data sync Blocked offsets re-queued after local index-ready probe (MissingDataRootIndex → Pending)");
+    counter DATA_SYNC_DURABILITY_STALLED("irys.data_sync.durability_stalled_total", "Data sync writes that did not become durable before the monotonic durability deadline");
     counter DATA_INDEX_HEAL_UNREPAIRED("irys.storage.index_heal_unrepaired_total", "Ledger SMs still gapped/uncertain after a heal pass (labelled by reason)");
     counter DATA_SYNC_FETCH_BY_SOURCE("irys.data_sync.fetch_by_source_total", "Data sync peer fetches by peer source and outcome (source=assigned|ingress_proof, outcome=success|fail)");
     gauge DATA_SYNC_ACTIVE_PEERS("irys.data_sync.active_peers", "Number of active data sync peers");
@@ -271,6 +272,10 @@ pub(crate) fn record_data_sync_chunk_fetched() {
 pub(crate) fn record_data_sync_chunk_stored() {
     DATA_SYNC_CHUNKS_STORED.add(1, &[]);
     DATA_SYNC_CHUNKS_COMPLETED.add(1, &[]);
+}
+
+pub(crate) fn record_data_sync_durability_stalled() {
+    DATA_SYNC_DURABILITY_STALLED.add(1, &[]);
 }
 
 pub(crate) fn record_data_sync_chunk_failure() {

--- a/crates/actors/src/storage_module_service/mod.rs
+++ b/crates/actors/src/storage_module_service/mod.rs
@@ -138,13 +138,26 @@ impl StorageModuleServiceInner {
         };
 
         for sm in storage_modules.iter() {
-            if sm.last_pending_write().elapsed() > Duration::from_secs(5)
-                && let Err(e) = sm.force_sync_pending_chunks()
-            {
-                error!(
-                    "Couldn't flush pending chunks for storage_module {}: {}",
-                    sm.id, e
-                );
+            if sm.has_pending_writes() {
+                // Check the configured per-submodule batch threshold once per
+                // service tick, not once per ingested chunk.
+                if let Err(e) = sm.sync_pending_chunks() {
+                    error!(
+                        "Couldn't sync buffered chunks for storage_module {}: {}",
+                        sm.id, e
+                    );
+                }
+                // `last_pending_write` is monotonic. Force only an idle tail;
+                // active ingress continues to benefit from striped batches.
+                if sm.has_pending_writes()
+                    && sm.last_pending_write().elapsed() > Duration::from_secs(5)
+                    && let Err(e) = sm.force_sync_pending_chunks()
+                {
+                    error!(
+                        "Couldn't flush idle pending chunks for storage_module {}: {}",
+                        sm.id, e
+                    );
+                }
             }
         }
     }

--- a/crates/actors/tests/data_sync_test.rs
+++ b/crates/actors/tests/data_sync_test.rs
@@ -1,6 +1,7 @@
 use irys_actors::{
     DataSyncServiceInner, DataSyncServiceMessage,
     chunk_fetcher::{ChunkFetchError, ChunkFetcher, ChunkFetcherFactory, MockChunkFetcher},
+    chunk_ingress_service::ChunkIngressMessage,
     chunk_orchestrator::ChunkOrchestrator,
     peer_bandwidth_manager::PeerBandwidthManager,
     services::{ServiceReceivers, ServiceSenders},
@@ -52,6 +53,14 @@ async fn slow_heavy_test_data_sync_with_different_peer_performance() {
     let storage_module_ref = setup.storage_module.clone();
 
     debug!("Setting up test harness");
+    let mut chunk_ingress_rx = setup.service_receivers.chunk_ingress;
+    tokio::spawn(async move {
+        while let Some(traced) = chunk_ingress_rx.recv().await {
+            if let ChunkIngressMessage::IngestChunk(_, Some(reply)) = traced.inner {
+                let _ = reply.send(Ok(()));
+            }
+        }
+    });
     // Create the test harness instead of spawning the full service
     let mut harness = DataSyncServiceTestHarness::new(
         setup.block_tree,
@@ -64,7 +73,7 @@ async fn slow_heavy_test_data_sync_with_different_peer_performance() {
     );
 
     debug!("Starting sync process...");
-    harness.start_sync().expect("Failed to start sync");
+    harness.start_sync().await.expect("Failed to start sync");
 
     debug!("Running controlled sync with message processing...");
 
@@ -92,6 +101,7 @@ async fn slow_heavy_test_data_sync_with_different_peer_performance() {
     // Process any final pending messages
     harness
         .process_pending_messages()
+        .await
         .expect("Failed to process final messages");
 
     // Take final performance snapshot
@@ -103,6 +113,7 @@ async fn slow_heavy_test_data_sync_with_different_peer_performance() {
             &mock_fetchers,
             &storage_module_ref,
         )
+        .await
         .expect("Failed to take final snapshot");
 
     let _data_intervals = storage_module_ref.get_intervals(ChunkType::Data);
@@ -191,10 +202,10 @@ impl DataSyncServiceTestHarness {
     }
 
     /// Process all pending messages in the queue
-    fn process_pending_messages(&mut self) -> eyre::Result<usize> {
+    async fn process_pending_messages(&mut self) -> eyre::Result<usize> {
         let mut count = 0;
         while let Ok(traced) = self.msg_rx.try_recv() {
-            self.inner.handle_message(traced.inner)?;
+            self.inner.handle_message(traced.inner).await?;
             self.inner.storage_modules.read().unwrap()[0]
                 .sync_pending_chunks()
                 .expect("sync pending chunks to disk");
@@ -220,7 +231,7 @@ impl DataSyncServiceTestHarness {
             .await
             {
                 Ok(Some(traced)) => {
-                    self.inner.handle_message(traced.inner)?;
+                    self.inner.handle_message(traced.inner).await?;
                     self.inner.storage_modules.read().unwrap()[0]
                         .sync_pending_chunks()
                         .expect("sync pending chunks to disk");
@@ -260,27 +271,29 @@ impl DataSyncServiceTestHarness {
     }
 
     /// Handle a message directly
-    fn handle_message(&mut self, message: DataSyncServiceMessage) -> eyre::Result<()> {
-        self.inner.handle_message(message)
+    async fn handle_message(&mut self, message: DataSyncServiceMessage) -> eyre::Result<()> {
+        self.inner.handle_message(message).await
     }
 
     /// Convenience method to start syncing
-    fn start_sync(&mut self) -> eyre::Result<()> {
+    async fn start_sync(&mut self) -> eyre::Result<()> {
         self.handle_message(DataSyncServiceMessage::SyncPartitions)
+            .await
     }
 
     /// Get peers list
-    fn get_active_peers(
+    async fn get_active_peers(
         &mut self,
     ) -> eyre::Result<Arc<RwLock<HashMap<IrysAddress, PeerBandwidthManager>>>> {
         let (tx, mut rx) = oneshot::channel();
-        self.handle_message(DataSyncServiceMessage::GetActivePeersList(tx))?;
+        self.handle_message(DataSyncServiceMessage::GetActivePeersList(tx))
+            .await?;
         rx.try_recv()
             .map_err(|e| eyre::eyre!("Failed to receive peers: {}", e))
     }
 
     /// Take a performance snapshot and print results
-    fn take_performance_snapshot(
+    async fn take_performance_snapshot(
         &mut self,
         label: &str,
         peer_addresses: &(IrysAddress, IrysAddress, IrysAddress),
@@ -289,7 +302,7 @@ impl DataSyncServiceTestHarness {
     ) -> eyre::Result<()> {
         println!("\n=== {} Performance Snapshot ===", label);
 
-        let active_peers = self.get_active_peers()?;
+        let active_peers = self.get_active_peers().await?;
         let mut total_requests = 0;
         let active_peers = active_peers.read().unwrap();
 
@@ -350,7 +363,7 @@ impl DataSyncServiceTestHarness {
             debug!("=== Tick {}/{} ===", current_tick, num_ticks);
 
             // Process any pending messages first
-            self.process_pending_messages()?;
+            self.process_pending_messages().await?;
 
             // Run the tick
             debug!("Running tick...");
@@ -363,7 +376,8 @@ impl DataSyncServiceTestHarness {
                     peer_addresses,
                     mock_fetchers,
                     storage_module,
-                )?;
+                )
+                .await?;
             }
 
             if i < num_ticks - 1 {

--- a/crates/chain-tests/src/promotion/oversized_tx_cache_eviction.rs
+++ b/crates/chain-tests/src/promotion/oversized_tx_cache_eviction.rs
@@ -8,33 +8,15 @@ use irys_types::{DataLedger, NodeConfig, irys::IrysSigner};
 use reth_db::transaction::DbTx as _;
 use std::time::Duration;
 
-/// Exposes a flaw in the current promotion mechanism: a submit tx whose data is larger
-/// than the bounded chunk cache can never be promoted, no matter how it is uploaded.
+/// Regression: a Submit transaction larger than the bounded chunk cache can
+/// generate its ingress proof from persisted compact leaves and promote, even
+/// though its chunk bodies never coexist in the cache.
 ///
-/// THIS TEST ASSERTS THE BUGGY BEHAVIOR ON PURPOSE. The assertions below encode what the
-/// system does *today*, not what it should do. It is a characterization test guarding a
-/// known defect so the behavior is visible and cannot change silently.
-///
-/// The flaw: ingress-proof generation
-/// (`chunk_ingress_service::chunks::generate_ingress_proof`) reads *every* chunk of a
-/// data_root out of the `CachedChunks` DB cache and requires the complete set to be
-/// resident simultaneously (it asserts `actual_chunk_count == expected_chunk_count`).
-/// That cache is size-bounded (`cache.max_cache_size_bytes`) and pruned on block
-/// migration. So a tx whose data exceeds the cache can never have all its chunks resident
-/// at once — early chunks are evicted before the last one arrives — no ingress proof is
-/// ever produced, and the tx can never be promoted to the Publish ledger.
-///
-/// Scaled down here: chunk_size=32, a 3-chunk tx, and a cache sized below the tx. Two
-/// chunks are uploaded, aged past `min_chunk_age`, and evicted by the migration-driven
-/// prune before the third is uploaded, so the full set is never simultaneously present.
-///
-/// WHEN THE FLAW IS FIXED (e.g. ingress-proof generation streams chunks incrementally, or
-/// promotion no longer requires the whole data_root cached at once), this test SHOULD
-/// START FAILING. That failure is the signal the fix works. At that point invert it: the
-/// oversized tx should now produce an ingress proof and promote, so flip the two
-/// assertions at the end to expect `proof.is_ok()` and `get_is_promoted(..) == true`.
+/// Also pins the two invariants that make that safe: capacity pruning reclaims
+/// only bodies a storage module reports as fsynced, and Publish migration falls
+/// back to the durable Submit replica once a body has been reclaimed.
 #[test_log::test(tokio::test)]
-async fn heavy_test_oversized_tx_cache_eviction_blocks_promotion() -> eyre::Result<()> {
+async fn heavy_test_oversized_tx_cache_eviction_allows_promotion() -> eyre::Result<()> {
     initialize_tracing();
 
     let mut config = NodeConfig::testing();
@@ -48,7 +30,9 @@ async fn heavy_test_oversized_tx_cache_eviction_blocks_promotion() -> eyre::Resu
         // Single node self-promotes with a single proof.
         c.hardforks.frontier.number_of_ingress_proofs_total = 1;
     }
-    config.storage.num_writes_before_sync = 1;
+    // Keep batching enabled: chunks stripe together and the tail is flushed by
+    // the storage module's idle drain, so nothing on the write path force-syncs.
+    config.storage.num_writes_before_sync = 2;
     // Cache far below the 3-chunk (96 B) tx, and prune eagerly.
     config.cache.max_cache_size_bytes = 32;
     config.cache.cache_clean_lag = 0;
@@ -69,6 +53,7 @@ async fn heavy_test_oversized_tx_cache_eviction_blocks_promotion() -> eyre::Resu
             * consensus.difficulty_adjustment.block_time;
 
     let node = IrysNodeTest::new_genesis(config.clone()).start().await;
+    let ingress_address = node.node_ctx.config.irys_signer().address();
     node.node_ctx
         .packing_waiter
         .wait_for_idle(Some(Duration::from_secs(10)))
@@ -95,57 +80,126 @@ async fn heavy_test_oversized_tx_cache_eviction_blocks_promotion() -> eyre::Resu
     node.wait_for_mempool(tx.header.id, 20).await?;
     node.mine_blocks(2).await?;
 
-    // Upload only the first two chunks.
-    node.post_chunk_32b(&tx, 0, &data_chunks).await;
-    node.post_chunk_32b(&tx, 1, &data_chunks).await;
-
-    // Age them past min_chunk_age, then mine to drive the migration-triggered prune
-    // until the bounded cache has evicted the staged chunks.
-    tokio::time::sleep(Duration::from_secs(min_chunk_age_secs + 2)).await;
-
     let cached_count = |root| -> eyre::Result<u32> {
         node.node_ctx.db.view_eyre(|tx| {
             let mut cursor = tx.cursor_dup_read::<CachedChunksIndex>()?;
             Ok(cursor.dup_count(root)?.unwrap_or(0))
         })
     };
+    let leaf_count = |root| -> eyre::Result<usize> {
+        node.node_ctx.db.view_eyre(|db_tx| {
+            (0..3_u32).try_fold(0_usize, |count, offset| {
+                Ok(count
+                    + usize::from(
+                        irys_database::cached_ingress_leaf(
+                            db_tx,
+                            root,
+                            ingress_address,
+                            offset.into(),
+                        )?
+                        .is_some(),
+                    ))
+            })
+        })
+    };
 
-    let mut evicted = false;
+    // Each validated chunk records its leaf immediately, independent of any
+    // storage assignment, and keeps its cached body until the body is durable.
+    node.post_chunk_32b(&tx, 0, &data_chunks).await;
+    assert_eq!(cached_count(data_root)?, 1);
+    assert_eq!(leaf_count(data_root)?, 1);
+
+    node.post_chunk_32b(&tx, 1, &data_chunks).await;
+    assert_eq!(cached_count(data_root)?, 2);
+    assert_eq!(leaf_count(data_root)?, 2);
+
+    // Age the bodies past min_chunk_age and mine to drive the capacity-pruning
+    // pass. The cache is configured far below the tx size, so the pass runs;
+    // it may reclaim only what a storage module reports as fsynced.
+    tokio::time::sleep(Duration::from_secs(min_chunk_age_secs + 2)).await;
+    let mut early_chunks_reclaimed = false;
     for _ in 0..10 {
         node.mine_block().await?;
         if cached_count(data_root)? == 0 {
-            evicted = true;
+            early_chunks_reclaimed = true;
             break;
         }
-        tokio::time::sleep(Duration::from_secs(1)).await;
+        tokio::time::sleep(Duration::from_millis(500)).await;
     }
     assert!(
-        evicted,
-        "precondition unmet: bounded cache never evicted the staged chunks"
+        early_chunks_reclaimed,
+        "durable early chunk bodies were never capacity-reclaimed"
+    );
+    assert_eq!(
+        leaf_count(data_root)?,
+        2,
+        "reclaiming a body must not discard the leaf derived from it"
     );
 
-    // Upload the final chunk. The complete 3-chunk set is never simultaneously
-    // resident, so ingress-proof generation can never fire.
+    // Leaves live in the main DB, so a restart keeps proof readiness without
+    // any cached body present.
+    let node = node.stop().await.start().await;
+    node.node_ctx
+        .packing_waiter
+        .wait_for_idle(Some(Duration::from_secs(10)))
+        .await?;
+    let leaves_after_restart = node.node_ctx.db.view_eyre(|db_tx| {
+        (0..3_u32).try_fold(0_usize, |count, offset| {
+            Ok(count
+                + usize::from(
+                    irys_database::cached_ingress_leaf(
+                        db_tx,
+                        data_root,
+                        ingress_address,
+                        offset.into(),
+                    )?
+                    .is_some(),
+                ))
+        })
+    })?;
+    assert_eq!(
+        leaves_after_restart, 2,
+        "compact leaves must survive a restart"
+    );
+    let cached_after_restart = node.node_ctx.db.view_eyre(|tx| {
+        let mut cursor = tx.cursor_dup_read::<CachedChunksIndex>()?;
+        Ok(cursor.dup_count(data_root)?.unwrap_or(0))
+    })?;
+    assert_eq!(
+        cached_after_restart, 0,
+        "proof readiness must not depend on cached chunk bodies"
+    );
+
+    // Upload the final chunk. The complete 3-chunk body set never needs to be
+    // resident: proof generation uses the three persisted compact leaves.
     node.post_chunk_32b(&tx, 2, &data_chunks).await;
 
-    // BUG BEING CHARACTERIZED: no ingress proof is ever produced for this data_root,
-    // because the full chunk set is never simultaneously cached. When the flaw is fixed
-    // this assertion should flip to `proof.is_ok()`.
     let proof = node
         .wait_for_ingress_proofs_no_mining(vec![tx.header.id], 10)
         .await;
     assert!(
-        proof.is_err(),
-        "expected no ingress proof for the oversized tx (current flawed behavior), got: {proof:?}"
+        proof.is_ok(),
+        "expected an ingress proof built from persisted compact leaves, got: {proof:?}"
     );
 
-    // BUG BEING CHARACTERIZED: consequently the tx is never promoted, even after further
-    // mining. When the flaw is fixed this assertion should flip to expect promotion.
     node.mine_blocks(3).await?;
     assert!(
-        !node.get_is_promoted(&tx.header.id).await?,
-        "oversized submit tx does not promote today (current flawed behavior)"
+        node.get_is_promoted(&tx.header.id).await?,
+        "oversized submit tx should promote after compact ingress proof generation"
     );
+
+    // Cached Submit bodies were reclaimed before promotion. Publish migration
+    // must therefore read the validated durable Submit copy, not silently
+    // leave holes when CachedChunks no longer contains the body.
+    let app = node.start_public_api().await;
+    for publish_offset in 0..3 {
+        node.future_or_mine_on_timeout(
+            node.wait_for_chunk(&app, DataLedger::Publish, publish_offset, 60),
+            Duration::from_secs(5),
+        )
+        .await??;
+    }
+    drop(app);
 
     node.stop().await;
     Ok(())

--- a/crates/chain-tests/src/promotion/oversized_tx_cache_eviction.rs
+++ b/crates/chain-tests/src/promotion/oversized_tx_cache_eviction.rs
@@ -4,9 +4,35 @@ use alloy_genesis::GenesisAccount;
 use irys_database::db::{IrysDatabaseExt as _, IrysDupCursorExt as _};
 use irys_database::tables::CachedChunksIndex;
 use irys_testing_utils::initialize_tracing;
-use irys_types::{DataLedger, NodeConfig, irys::IrysSigner};
+use irys_types::{
+    DataLedger, DataRoot, DatabaseProvider, IrysAddress, NodeConfig, irys::IrysSigner,
+};
 use reth_db::transaction::DbTx as _;
 use std::time::Duration;
+
+fn cached_chunk_count(db: &DatabaseProvider, data_root: DataRoot) -> eyre::Result<u32> {
+    db.view_eyre(|tx| {
+        let mut cursor = tx.cursor_dup_read::<CachedChunksIndex>()?;
+        Ok(cursor.dup_count(data_root)?.unwrap_or(0))
+    })
+}
+
+fn ingress_leaf_count(
+    db: &DatabaseProvider,
+    data_root: DataRoot,
+    address: IrysAddress,
+    expected_chunks: u32,
+) -> eyre::Result<usize> {
+    db.view_eyre(|tx| {
+        (0..expected_chunks).try_fold(0_usize, |count, offset| {
+            Ok(count
+                + usize::from(
+                    irys_database::cached_ingress_leaf(tx, data_root, address, offset.into())?
+                        .is_some(),
+                ))
+        })
+    })
+}
 
 /// Regression: a Submit transaction larger than the bounded chunk cache can
 /// generate its ingress proof from persisted compact leaves and promote, even
@@ -80,38 +106,21 @@ async fn heavy_test_oversized_tx_cache_eviction_allows_promotion() -> eyre::Resu
     node.wait_for_mempool(tx.header.id, 20).await?;
     node.mine_blocks(2).await?;
 
-    let cached_count = |root| -> eyre::Result<u32> {
-        node.node_ctx.db.view_eyre(|tx| {
-            let mut cursor = tx.cursor_dup_read::<CachedChunksIndex>()?;
-            Ok(cursor.dup_count(root)?.unwrap_or(0))
-        })
-    };
-    let leaf_count = |root| -> eyre::Result<usize> {
-        node.node_ctx.db.view_eyre(|db_tx| {
-            (0..3_u32).try_fold(0_usize, |count, offset| {
-                Ok(count
-                    + usize::from(
-                        irys_database::cached_ingress_leaf(
-                            db_tx,
-                            root,
-                            ingress_address,
-                            offset.into(),
-                        )?
-                        .is_some(),
-                    ))
-            })
-        })
-    };
-
     // Each validated chunk records its leaf immediately, independent of any
     // storage assignment, and keeps its cached body until the body is durable.
     node.post_chunk_32b(&tx, 0, &data_chunks).await;
-    assert_eq!(cached_count(data_root)?, 1);
-    assert_eq!(leaf_count(data_root)?, 1);
+    assert_eq!(cached_chunk_count(&node.node_ctx.db, data_root)?, 1);
+    assert_eq!(
+        ingress_leaf_count(&node.node_ctx.db, data_root, ingress_address, 3)?,
+        1
+    );
 
     node.post_chunk_32b(&tx, 1, &data_chunks).await;
-    assert_eq!(cached_count(data_root)?, 2);
-    assert_eq!(leaf_count(data_root)?, 2);
+    assert_eq!(cached_chunk_count(&node.node_ctx.db, data_root)?, 2);
+    assert_eq!(
+        ingress_leaf_count(&node.node_ctx.db, data_root, ingress_address, 3)?,
+        2
+    );
 
     // Age the bodies past min_chunk_age and mine to drive the capacity-pruning
     // pass. The cache is configured far below the tx size, so the pass runs;
@@ -120,7 +129,7 @@ async fn heavy_test_oversized_tx_cache_eviction_allows_promotion() -> eyre::Resu
     let mut early_chunks_reclaimed = false;
     for _ in 0..10 {
         node.mine_block().await?;
-        if cached_count(data_root)? == 0 {
+        if cached_chunk_count(&node.node_ctx.db, data_root)? == 0 {
             early_chunks_reclaimed = true;
             break;
         }
@@ -131,7 +140,7 @@ async fn heavy_test_oversized_tx_cache_eviction_allows_promotion() -> eyre::Resu
         "durable early chunk bodies were never capacity-reclaimed"
     );
     assert_eq!(
-        leaf_count(data_root)?,
+        ingress_leaf_count(&node.node_ctx.db, data_root, ingress_address, 3)?,
         2,
         "reclaiming a body must not discard the leaf derived from it"
     );
@@ -143,28 +152,13 @@ async fn heavy_test_oversized_tx_cache_eviction_allows_promotion() -> eyre::Resu
         .packing_waiter
         .wait_for_idle(Some(Duration::from_secs(10)))
         .await?;
-    let leaves_after_restart = node.node_ctx.db.view_eyre(|db_tx| {
-        (0..3_u32).try_fold(0_usize, |count, offset| {
-            Ok(count
-                + usize::from(
-                    irys_database::cached_ingress_leaf(
-                        db_tx,
-                        data_root,
-                        ingress_address,
-                        offset.into(),
-                    )?
-                    .is_some(),
-                ))
-        })
-    })?;
+    let leaves_after_restart =
+        ingress_leaf_count(&node.node_ctx.db, data_root, ingress_address, 3)?;
     assert_eq!(
         leaves_after_restart, 2,
         "compact leaves must survive a restart"
     );
-    let cached_after_restart = node.node_ctx.db.view_eyre(|tx| {
-        let mut cursor = tx.cursor_dup_read::<CachedChunksIndex>()?;
-        Ok(cursor.dup_count(data_root)?.unwrap_or(0))
-    })?;
+    let cached_after_restart = cached_chunk_count(&node.node_ctx.db, data_root)?;
     assert_eq!(
         cached_after_restart, 0,
         "proof readiness must not depend on cached chunk bodies"

--- a/crates/chain-tests/src/promotion/promotion_with_multiple_proofs.rs
+++ b/crates/chain-tests/src/promotion/promotion_with_multiple_proofs.rs
@@ -5,7 +5,7 @@ use irys_testing_utils::initialize_tracing;
 use irys_types::{CommitmentTransaction, NodeConfig, irys::IrysSigner};
 
 #[tokio::test]
-async fn spiky_slow_heavy4_promotion_with_multiple_proofs_test() -> eyre::Result<()> {
+async fn slow_heavy4_promotion_with_multiple_proofs_test() -> eyre::Result<()> {
     // SAFETY: test code; env var set before other threads spawn.
     unsafe {
         std::env::set_var(

--- a/crates/chain/src/chain.rs
+++ b/crates/chain/src/chain.rs
@@ -1889,6 +1889,16 @@ impl IrysNode {
             .await
             .expect("to receive BlockTreeReadGuard response from GetBlockTreeReadGuard Message");
 
+        let epoch_snapshot = block_tree_guard.read().canonical_epoch_snapshot();
+        let storage_module_infos = epoch_snapshot.map_storage_modules_to_partition_assignments();
+
+        let storage_modules = Self::init_storage_modules(&config, storage_module_infos)?;
+        let storage_modules_guard = StorageModulesReadGuard::new(storage_modules.clone());
+        let ingress_proof_generation_state =
+            irys_actors::chunk_ingress_service::IngressProofGenerationState::default();
+
+        // Spawned after the storage modules: capacity pruning asks them which
+        // cached bodies are already fsynced before reclaiming any.
         let chunk_cache_handle = ChunkCacheService::spawn_service(
             block_index_guard.clone(),
             block_tree_guard.clone(),
@@ -1897,15 +1907,11 @@ impl IrysNode {
             config.clone(),
             service_senders.gossip_broadcast.clone(),
             service_senders.chunk_cache.clone(),
+            storage_modules_guard.clone(),
+            ingress_proof_generation_state.clone(),
             runtime_handle.clone(),
         );
         debug!("Chunk cache initialized");
-
-        let epoch_snapshot = block_tree_guard.read().canonical_epoch_snapshot();
-        let storage_module_infos = epoch_snapshot.map_storage_modules_to_partition_assignments();
-
-        let storage_modules = Self::init_storage_modules(&config, storage_module_infos)?;
-        let storage_modules_guard = StorageModulesReadGuard::new(storage_modules.clone());
 
         // Provide storage modules guard to block migration service for partition recovery
         service_senders
@@ -1945,6 +1951,7 @@ impl IrysNode {
                 receivers.chunk_ingress,
                 &config,
                 &service_senders,
+                ingress_proof_generation_state,
                 runtime_handle.clone(),
                 task_exec.clone(),
             );

--- a/crates/cli/src/cli_args.rs
+++ b/crates/cli/src/cli_args.rs
@@ -157,7 +157,8 @@ pub(crate) enum SnapshotMode {
         output: PathBuf,
 
         /// Include cache tables (CachedDataRoots, CachedChunksIndex, CachedChunks,
-        /// IngressProofs). Off by default — caches are rebuildable from canonical data.
+        /// CachedIngressLeaves, IngressProofs). Off by default — caches are rebuildable
+        /// from canonical data.
         #[arg(long)]
         include_caches: bool,
 

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -134,6 +134,58 @@ mod compact_ingress_leaf_tests {
     }
 
     #[test]
+    fn deleting_ingress_leaves_is_scoped_to_one_data_root() -> eyre::Result<()> {
+        let (_dir, db) = open_test_db()?;
+        let target_root = H256::random();
+        let other_root = H256::random();
+        let first_signer = IrysAddress::random();
+        let second_signer = IrysAddress::random();
+
+        db.update_eyre(|tx| {
+            store_ingress_data_hash(
+                tx,
+                target_root,
+                first_signer,
+                TxChunkOffset::from(0),
+                H256::random(),
+            )?;
+            store_ingress_data_hash(
+                tx,
+                target_root,
+                second_signer,
+                TxChunkOffset::from(1),
+                H256::random(),
+            )?;
+            store_ingress_data_hash(
+                tx,
+                other_root,
+                first_signer,
+                TxChunkOffset::from(0),
+                H256::random(),
+            )?;
+            assert_eq!(delete_ingress_leaves_by_data_root(tx, target_root)?, 2);
+            Ok(())
+        })?;
+
+        db.view_eyre(|tx| {
+            assert!(
+                cached_ingress_leaf(tx, target_root, first_signer, TxChunkOffset::from(0))?
+                    .is_none()
+            );
+            assert!(
+                cached_ingress_leaf(tx, target_root, second_signer, TxChunkOffset::from(1))?
+                    .is_none()
+            );
+            assert!(
+                cached_ingress_leaf(tx, other_root, first_signer, TxChunkOffset::from(0))?
+                    .is_some(),
+                "deleting one root must preserve another root's leaves"
+            );
+            Ok(())
+        })
+    }
+
+    #[test]
     fn startup_backfill_recovers_legacy_cached_bodies_idempotently() -> eyre::Result<()> {
         let (_dir, db) = open_test_db()?;
         let address = IrysAddress::random();

--- a/crates/database/src/database.rs
+++ b/crates/database/src/database.rs
@@ -5,15 +5,16 @@ use irys_types::DbSyncMode;
 
 use crate::db_cache::{
     CachedChunk, CachedChunkIndexEntry, CachedChunkIndexMetadata, CachedDataRoot,
+    CachedIngressLeaf, CachedIngressLeafKey,
 };
 use crate::tables::{
-    CachedChunks, CachedChunksIndex, CachedDataRoots, CompactCachedIngressProof,
-    CompactLedgerIndexItem, IngressProofs, IrysBlockHeaders, IrysBlockIndexItems,
-    IrysBlockStreamEvents, IrysCommitments, IrysDataTxHeaders, IrysPoAChunks, Metadata,
-    MigratedBlockHashes, PeerListItems,
+    CachedChunks, CachedChunksIndex, CachedDataRoots, CachedIngressLeaves,
+    CompactCachedIngressProof, CompactLedgerIndexItem, IngressProofs, IrysBlockHeaders,
+    IrysBlockIndexItems, IrysBlockStreamEvents, IrysCommitments, IrysDataTxHeaders, IrysPoAChunks,
+    Metadata, MigratedBlockHashes, PeerListItems,
 };
 
-use crate::db::IrysDatabaseExt as _;
+use crate::db::{IrysDatabaseExt as _, IrysDupCursorExt};
 use crate::metadata::MetadataKey;
 use crate::reth_ext::IrysRethDatabaseEnvMetricsExt as _;
 use irys_types::ingress::CachedIngressProof;
@@ -21,8 +22,10 @@ use irys_types::irys::IrysSigner;
 use irys_types::{
     BlockHash, BlockHeight, BlockIndexItem, ChunkPathHash, CommitmentTransaction, DataLedger,
     DataRoot, DataTransactionHeader, DataTransactionMetadata, DatabaseProvider, DatabaseVersion,
-    H256, IngressProof, IrysAddress, IrysBlockHeader, IrysPeerId, IrysTransactionId,
-    LedgerIndexItem, MEGABYTE, PeerListItem, TxChunkOffset, UnixTimestamp, UnpackedChunk,
+    H256, IngressMerkleLeaf, IngressProof, IrysAddress, IrysBlockHeader, IrysPeerId,
+    IrysTransactionId, LedgerIndexItem, MEGABYTE, PeerListItem, TxChunkOffset, UnixTimestamp,
+    UnpackedChunk, expected_chunk_byte_range, generate_ingress_data_hash,
+    generate_ingress_leaf_from_data_hash, hash_sha256, validate_path,
 };
 use reth_db::TableSet;
 use reth_db::cursor::DbDupCursorRO as _;
@@ -35,6 +38,7 @@ use reth_db::{
     cursor::*,
     mdbx::{DatabaseArguments, MaxReadTransactionDuration},
 };
+use std::collections::BTreeSet;
 use tracing::{debug, warn};
 
 /// Extension trait adding Irys preset constructors to [`DatabaseArguments`].
@@ -49,6 +53,300 @@ pub trait IrysDatabaseArgs {
 
     /// Cache-tuned args: larger growth/shrink thresholds (50 MB / 100 MB).
     fn irys_cache(sync_mode: DbSyncMode) -> eyre::Result<DatabaseArguments>;
+}
+
+#[cfg(test)]
+mod compact_ingress_leaf_tests {
+    use super::*;
+    use crate::{db_cache::CachedDataRoot, tables::IrysTables};
+    use irys_testing_utils::utils::TempDirBuilder;
+    use irys_types::{Base64, generate_data_root, generate_leaves, resolve_proofs};
+    use reth_db::mdbx::DatabaseArguments;
+    use std::sync::Arc;
+
+    fn open_test_db() -> eyre::Result<(tempfile::TempDir, DatabaseProvider)> {
+        let dir = TempDirBuilder::new().build();
+        let env = open_or_create_db(
+            dir.path(),
+            IrysTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )?;
+        Ok((dir, DatabaseProvider(Arc::new(env))))
+    }
+
+    #[test]
+    fn complete_leaves_require_every_position_and_signer() -> eyre::Result<()> {
+        let (_dir, db) = open_test_db()?;
+        let data_root = H256::random();
+        let address = IrysAddress::random();
+        let other_address = IrysAddress::random();
+        let hashes = [H256::random(), H256::random(), H256::random()];
+        let leaves = [
+            generate_ingress_leaf_from_data_hash(hashes[0], 32)?,
+            generate_ingress_leaf_from_data_hash(hashes[1], 64)?,
+            generate_ingress_leaf_from_data_hash(hashes[2], 71)?,
+        ];
+
+        // Persist out of order and repeat an offset: exact keys make the
+        // duplicate idempotent, but the missing middle position stays incomplete.
+        db.update_eyre(|tx| {
+            store_ingress_data_hash(tx, data_root, address, TxChunkOffset::from(2), hashes[2])?;
+            store_ingress_data_hash(tx, data_root, address, TxChunkOffset::from(0), hashes[0])?;
+            store_ingress_data_hash(tx, data_root, address, TxChunkOffset::from(0), hashes[0])?;
+            Ok(())
+        })?;
+        db.view_eyre(|tx| {
+            assert!(complete_ingress_leaves(tx, data_root, address, 71, 32)?.is_none());
+            assert!(
+                complete_ingress_leaves(tx, data_root, other_address, 71, 32)?.is_none(),
+                "leaves from another signer must not receive completion credit"
+            );
+            Ok(())
+        })?;
+
+        db.update_eyre(|tx| {
+            store_ingress_data_hash(tx, data_root, address, TxChunkOffset::from(1), hashes[1])?;
+            Ok(())
+        })?;
+        db.view_eyre(|tx| {
+            assert_eq!(
+                complete_ingress_leaves(tx, data_root, address, 71, 32)?.unwrap(),
+                leaves
+            );
+            Ok(())
+        })?;
+
+        let conflict = db.update_eyre(|tx| {
+            store_ingress_data_hash(
+                tx,
+                data_root,
+                address,
+                TxChunkOffset::from(1),
+                H256::random(),
+            )
+            .map_err(eyre::Report::from)
+        });
+        assert!(
+            conflict.is_err(),
+            "a duplicate offset cannot change its hash"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn startup_backfill_recovers_legacy_cached_bodies_idempotently() -> eyre::Result<()> {
+        let (_dir, db) = open_test_db()?;
+        let address = IrysAddress::random();
+        let tx_offset = TxChunkOffset::from(0);
+        let chunk_size = 32;
+        let bytes = vec![7_u8; 8];
+        let root = generate_data_root(generate_leaves(
+            std::iter::once(Ok(bytes.clone())),
+            chunk_size as usize,
+        )?)?;
+        let data_root = H256(root.id);
+        let data_path = Base64(resolve_proofs(root, None)?.remove(0).proof);
+        let chunk = UnpackedChunk {
+            data_root,
+            data_size: 8,
+            data_path,
+            bytes: Base64(bytes),
+            tx_offset,
+        };
+        db.update_eyre(|tx| {
+            tx.put::<CachedDataRoots>(
+                data_root,
+                CachedDataRoot {
+                    data_size: 8,
+                    data_size_confirmed: true,
+                    block_set: vec![H256::random()],
+                    ..Default::default()
+                },
+            )?;
+            cache_chunk(tx, &chunk)?;
+            Ok(())
+        })?;
+
+        assert_eq!(
+            backfill_cached_ingress_data_hashes(&db, address, chunk_size)?,
+            BTreeSet::from([data_root])
+        );
+        let expected = generate_ingress_data_hash(&chunk.bytes.0, address);
+        db.view_eyre(|tx| {
+            assert_eq!(
+                cached_ingress_leaf(tx, data_root, address, tx_offset)?
+                    .expect("legacy cached body must be backfilled")
+                    .ingress_data_hash,
+                expected
+            );
+            Ok(())
+        })?;
+
+        // A second startup sees the existing record and leaves it unchanged.
+        assert_eq!(
+            backfill_cached_ingress_data_hashes(&db, address, chunk_size)?,
+            BTreeSet::from([data_root])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn startup_backfill_rejects_cached_body_that_does_not_match_path() -> eyre::Result<()> {
+        let (_dir, db) = open_test_db()?;
+        let address = IrysAddress::random();
+        let chunk_size = 32;
+        let valid_bytes = vec![7_u8; 8];
+        let root = generate_data_root(generate_leaves(
+            std::iter::once(Ok(valid_bytes)),
+            chunk_size as usize,
+        )?)?;
+        let data_root = H256(root.id);
+        let chunk = UnpackedChunk {
+            data_root,
+            data_size: 8,
+            data_path: Base64(resolve_proofs(root, None)?.remove(0).proof),
+            bytes: Base64(vec![8_u8; 8]),
+            tx_offset: TxChunkOffset::from(0),
+        };
+        db.update_eyre(|tx| {
+            tx.put::<CachedDataRoots>(
+                data_root,
+                CachedDataRoot {
+                    data_size: 8,
+                    data_size_confirmed: true,
+                    block_set: vec![H256::random()],
+                    ..Default::default()
+                },
+            )?;
+            cache_chunk(tx, &chunk)?;
+            Ok(())
+        })?;
+
+        assert!(backfill_cached_ingress_data_hashes(&db, address, chunk_size)?.is_empty());
+        db.view_eyre(|tx| {
+            assert!(
+                cached_ingress_leaf(tx, data_root, address, chunk.tx_offset)?.is_none(),
+                "an invalid cached body must not become ingress-proof input"
+            );
+            Ok(())
+        })?;
+        Ok(())
+    }
+
+    #[test]
+    fn capacity_eviction_requires_a_durable_storage_offset() -> eyre::Result<()> {
+        let (_dir, db) = open_test_db()?;
+        let data_root = H256::random();
+        let address = IrysAddress::random();
+        let tx_offset = TxChunkOffset::from(0);
+        let chunk = UnpackedChunk {
+            data_root,
+            data_size: 8,
+            data_path: Base64::default(),
+            bytes: Base64(vec![7_u8; 8]),
+            tx_offset,
+        };
+        db.update_eyre(|tx| {
+            tx.put::<CachedDataRoots>(
+                data_root,
+                CachedDataRoot {
+                    data_size: 8,
+                    ..Default::default()
+                },
+            )?;
+            cache_chunk(tx, &chunk)?;
+            let meta = cached_chunk_meta_by_offset(tx, data_root, tx_offset)?.unwrap();
+            tx.delete::<CachedChunksIndex>(data_root, None)?;
+            tx.put::<CachedChunksIndex>(
+                data_root,
+                CachedChunkIndexEntry {
+                    index: tx_offset,
+                    meta: CachedChunkIndexMetadata {
+                        updated_at: UnixTimestamp::from_secs(0),
+                        ..meta
+                    },
+                },
+            )?;
+            Ok(())
+        })?;
+
+        db.update_eyre(|tx| {
+            // Durability without a compact hash is not reclaimable. This is
+            // possible during rolling upgrade before startup backfill reaches
+            // a legacy cached body.
+            assert_eq!(
+                delete_reclaimable_cached_chunks_older_than(
+                    tx,
+                    data_root,
+                    address,
+                    &BTreeSet::from([tx_offset]),
+                    UnixTimestamp::from_secs(1),
+                )?,
+                0,
+                "a durable body without a compact ingress hash must be retained"
+            );
+
+            // A validated hash is not a durability signal either: recording
+            // one must never authorize dropping the body by itself.
+            store_ingress_data_hash(tx, data_root, address, tx_offset, H256::random())?;
+            assert_eq!(
+                delete_reclaimable_cached_chunks_older_than(
+                    tx,
+                    data_root,
+                    address,
+                    &BTreeSet::new(),
+                    UnixTimestamp::from_secs(1),
+                )?,
+                0,
+                "a body no storage module reports as durable must be retained"
+            );
+
+            // A different offset being durable says nothing about this one.
+            assert_eq!(
+                delete_reclaimable_cached_chunks_older_than(
+                    tx,
+                    data_root,
+                    address,
+                    &BTreeSet::from([TxChunkOffset::from(1)]),
+                    UnixTimestamp::from_secs(1),
+                )?,
+                0,
+                "durability credit must not leak across chunk offsets"
+            );
+
+            // Durable, but not yet older than the age threshold.
+            assert_eq!(
+                delete_reclaimable_cached_chunks_older_than(
+                    tx,
+                    data_root,
+                    address,
+                    &BTreeSet::from([tx_offset]),
+                    UnixTimestamp::from_secs(0),
+                )?,
+                0,
+                "a durable body newer than the age threshold must be retained"
+            );
+
+            assert_eq!(
+                delete_reclaimable_cached_chunks_older_than(
+                    tx,
+                    data_root,
+                    address,
+                    &BTreeSet::from([tx_offset]),
+                    UnixTimestamp::from_secs(1),
+                )?,
+                1
+            );
+            assert!(cached_chunk_by_chunk_offset(tx, data_root, tx_offset)?.is_none());
+            assert!(
+                cached_ingress_leaf(tx, data_root, address, tx_offset)?.is_some(),
+                "the leaf must outlive the body it was derived from, so proof \
+                 generation still works after reclamation"
+            );
+            Ok(())
+        })?;
+        Ok(())
+    }
 }
 
 impl IrysDatabaseArgs for DatabaseArguments {
@@ -842,6 +1140,255 @@ pub fn cached_chunk_by_chunk_path_hash<T: DbTx>(
     tx.get::<CachedChunks>(*key)
 }
 
+/// Retrieves one validated compact ingress leaf for an exact signer and tx offset.
+pub fn cached_ingress_leaf<T: DbTx>(
+    tx: &T,
+    data_root: DataRoot,
+    address: IrysAddress,
+    tx_offset: TxChunkOffset,
+) -> Result<Option<CachedIngressLeaf>, DatabaseError> {
+    let key = CachedIngressLeafKey { data_root, address };
+    let mut cursor = tx.cursor_dup_read::<CachedIngressLeaves>()?;
+    Ok(cursor
+        .seek_by_key_subkey(key, *tx_offset)?
+        .filter(|leaf| leaf.tx_offset == tx_offset))
+}
+
+/// Loads a complete, gap-free compact ingress-leaf sequence.
+///
+/// `None` means at least one expected validated position has not been recorded.
+/// Boundaries and leaf ids are reconstructed from the stored miner-specific
+/// hashes and authoritative transaction metadata only after every exact offset
+/// is present.
+pub fn complete_ingress_leaves<T>(
+    tx: &T,
+    data_root: DataRoot,
+    address: IrysAddress,
+    data_size: u64,
+    chunk_size: u64,
+) -> eyre::Result<Option<Vec<IngressMerkleLeaf>>>
+where
+    T: DbTx,
+    T::DupCursor<CachedIngressLeaves>: IrysDupCursorExt<CachedIngressLeaves>,
+{
+    let expected_count = crate::db_cache::data_size_to_chunk_count(data_size, chunk_size)?;
+    let key = CachedIngressLeafKey { data_root, address };
+    let mut cursor = tx.cursor_dup_read::<CachedIngressLeaves>()?;
+    if cursor.dup_count(key)?.unwrap_or(0) != expected_count {
+        return Ok(None);
+    }
+
+    let mut leaves = Vec::with_capacity(expected_count as usize);
+    let mut walker = cursor.walk_dup(Some(key), None)?;
+    for raw_offset in 0..expected_count {
+        let Some((walked_key, leaf)) = walker.next().transpose()? else {
+            return Ok(None);
+        };
+        if walked_key != key || leaf.tx_offset != TxChunkOffset::from(raw_offset) {
+            return Ok(None);
+        }
+        let (_, expected_boundary) =
+            expected_chunk_byte_range(TxChunkOffset::from(raw_offset), data_size, chunk_size)?;
+        leaves.push(generate_ingress_leaf_from_data_hash(
+            leaf.ingress_data_hash,
+            expected_boundary,
+        )?);
+    }
+    Ok(Some(leaves))
+}
+
+/// Persists one validated miner-specific data hash idempotently. The key
+/// includes the signer address, so a key change cannot silently reuse hashes
+/// derived for another miner. Recording a hash never authorizes cached-body eviction; see
+/// [`delete_reclaimable_cached_chunks_older_than`].
+pub fn store_ingress_data_hash<T: DbTx + DbTxMut>(
+    tx: &T,
+    data_root: DataRoot,
+    address: IrysAddress,
+    tx_offset: TxChunkOffset,
+    ingress_data_hash: H256,
+) -> Result<(), DatabaseError> {
+    let key = CachedIngressLeafKey { data_root, address };
+    let mut cursor = tx.cursor_dup_read::<CachedIngressLeaves>()?;
+    // A duplicate gossip delivery must not change an already-validated leaf.
+    if let Some(existing) = cursor
+        .seek_by_key_subkey(key, *tx_offset)?
+        .filter(|existing| existing.tx_offset == tx_offset)
+    {
+        if existing.ingress_data_hash != ingress_data_hash {
+            return Err(DatabaseError::Other(format!(
+                "conflicting ingress leaf for data root {data_root}, address {address}, offset {tx_offset}"
+            )));
+        }
+        return Ok(());
+    }
+    drop(cursor);
+    tx.put::<CachedIngressLeaves>(
+        key,
+        CachedIngressLeaf {
+            tx_offset,
+            ingress_data_hash,
+        },
+    )
+}
+
+/// Backfills compact ingress hashes for validated chunk bodies cached by a
+/// pre-compact-leaf binary and returns roots that should retry proof generation.
+///
+/// Existing records are scanned first, so ordinary restarts only perform
+/// metadata reads. Chunk bodies are hashed only when the current signer lacks
+/// the exact `(data_root, tx_offset)` record. The write phase rechecks that the
+/// root and body still exist, preventing terminal cache cleanup from racing a
+/// stale backfill snapshot and resurrecting orphan leaf state.
+pub fn backfill_cached_ingress_data_hashes(
+    db: &DatabaseProvider,
+    address: IrysAddress,
+    chunk_size: u64,
+) -> eyre::Result<BTreeSet<DataRoot>> {
+    let (mut retry_roots, missing) = db.view_eyre(|tx| {
+        let mut existing = BTreeSet::new();
+        let mut retry_roots = BTreeSet::new();
+        let mut leaf_roots = BTreeSet::new();
+        let mut leaf_cursor = tx.cursor_read::<CachedIngressLeaves>()?;
+        let mut leaf_walker = leaf_cursor.walk(None)?;
+        while let Some((key, leaf)) = leaf_walker.next().transpose()? {
+            if key.address != address {
+                continue;
+            }
+            existing.insert((key.data_root, leaf.tx_offset));
+            leaf_roots.insert(key.data_root);
+        }
+        drop(leaf_walker);
+        drop(leaf_cursor);
+
+        for data_root in leaf_roots {
+            if let Some(cdr) = tx.get::<CachedDataRoots>(data_root)?
+                && cdr.data_size_confirmed
+                && !cdr.block_set.is_empty()
+                && ingress_proof_by_data_root_address(tx, data_root, address)?.is_none()
+            {
+                retry_roots.insert(data_root);
+            }
+        }
+
+        let mut missing = Vec::new();
+        let mut chunk_cursor = tx.cursor_dup_read::<CachedChunksIndex>()?;
+        let mut chunk_walker = chunk_cursor.walk(None)?;
+        while let Some((data_root, entry)) = chunk_walker.next().transpose()? {
+            if existing.contains(&(data_root, entry.index)) {
+                continue;
+            }
+            let Some(cached) = tx.get::<CachedChunks>(entry.meta.chunk_path_hash)? else {
+                warn!(
+                    %data_root,
+                    tx_offset = %entry.index,
+                    "Skipping ingress-hash backfill for an index entry without a cached body"
+                );
+                continue;
+            };
+            let Some(bytes) = cached.chunk else {
+                continue;
+            };
+            let chunk_len = u64::try_from(bytes.len())?;
+            let validation = (|| {
+                eyre::ensure!(chunk_size > 0, "chunk size must be non-zero");
+                eyre::ensure!(
+                    chunk_len > 0 && chunk_len <= chunk_size,
+                    "cached chunk length {chunk_len} is outside 1..={chunk_size}"
+                );
+                let min_byte_range = u64::from(*entry.index)
+                    .checked_mul(chunk_size)
+                    .ok_or_else(|| eyre::eyre!("cached chunk byte range overflow"))?;
+                let max_byte_range = min_byte_range
+                    .checked_add(chunk_len)
+                    .ok_or_else(|| eyre::eyre!("cached chunk byte range overflow"))?;
+                let path = validate_path(
+                    data_root.0,
+                    &cached.data_path,
+                    u128::from(max_byte_range - 1),
+                )?;
+                eyre::ensure!(
+                    path.min_byte_range == u128::from(min_byte_range)
+                        && path.max_byte_range == u128::from(max_byte_range),
+                    "cached data path range does not match its transaction offset and body length"
+                );
+                eyre::ensure!(
+                    path.is_rightmost_chunk || chunk_len == chunk_size,
+                    "non-rightmost cached chunk is not full-sized"
+                );
+                eyre::ensure!(
+                    path.leaf_hash == hash_sha256(&bytes.0),
+                    "cached body does not match its data path"
+                );
+                eyre::Ok(generate_ingress_data_hash(&bytes.0, address))
+            })();
+            let ingress_data_hash = match validation {
+                Ok(hash) => hash,
+                Err(error) => {
+                    warn!(
+                        %data_root,
+                        tx_offset = %entry.index,
+                        %error,
+                        "Skipping invalid cached chunk during ingress-hash backfill"
+                    );
+                    continue;
+                }
+            };
+            missing.push((
+                data_root,
+                entry.index,
+                entry.meta.chunk_path_hash,
+                ingress_data_hash,
+            ));
+        }
+        Ok((retry_roots, missing))
+    })?;
+
+    let inserted_roots = db.update_eyre(|tx| {
+        let mut inserted_roots = BTreeSet::new();
+        for (data_root, tx_offset, chunk_path_hash, ingress_data_hash) in &missing {
+            if tx.get::<CachedDataRoots>(*data_root)?.is_none()
+                || tx.get::<CachedChunks>(*chunk_path_hash)?.is_none()
+            {
+                continue;
+            }
+            store_ingress_data_hash(tx, *data_root, address, *tx_offset, *ingress_data_hash)?;
+            inserted_roots.insert(*data_root);
+        }
+        Ok(inserted_roots)
+    })?;
+    retry_roots.extend(inserted_roots);
+    Ok(retry_roots)
+}
+
+/// Deletes every compact leaf associated with a data root, across signer keys.
+pub fn delete_ingress_leaves_by_data_root<T: DbTx + DbTxMut>(
+    tx: &T,
+    data_root: DataRoot,
+) -> eyre::Result<u64> {
+    let start = CachedIngressLeafKey {
+        data_root,
+        address: IrysAddress::default(),
+    };
+    let mut cursor = tx.cursor_read::<CachedIngressLeaves>()?;
+    let mut walker = cursor.walk(Some(start))?;
+    let mut keys = BTreeSet::new();
+    let mut deleted = 0_u64;
+    while let Some((key, _)) = walker.next().transpose()? {
+        if key.data_root != data_root {
+            break;
+        }
+        keys.insert(key);
+        deleted = deleted.saturating_add(1);
+    }
+    drop(walker);
+    drop(cursor);
+    for key in &keys {
+        tx.delete::<CachedIngressLeaves>(*key, None)?;
+    }
+    Ok(deleted)
+}
+
 /// Deletes [`CachedChunk`]s from [`CachedChunks`] by looking up the [`ChunkPathHash`] in [`CachedChunksIndex`]
 /// It also removes the index values
 pub fn delete_cached_chunks_by_data_root<T: DbTxMut>(
@@ -862,33 +1409,38 @@ pub fn delete_cached_chunks_by_data_root<T: DbTxMut>(
     Ok(chunks_pruned)
 }
 
-/// Deletes [`CachedChunk`]s from [`CachedChunks`] by looking up the [`ChunkPathHash`] in [`CachedChunksIndex`]
-/// It also removes the index values
-pub fn delete_cached_chunks_by_data_root_older_than<T: DbTxMut>(
+/// Capacity-prunes only bodies old enough to evict, present in
+/// `durable_tx_offsets`, and backed by the current signer's compact ingress
+/// hash. The independent gates preserve the reclamation invariant during
+/// rolling upgrade as well as normal writes.
+pub fn delete_reclaimable_cached_chunks_older_than<T: DbTx + DbTxMut>(
     tx: &T,
     data_root: DataRoot,
+    address: IrysAddress,
+    durable_tx_offsets: &BTreeSet<TxChunkOffset>,
     older_than: UnixTimestamp,
 ) -> eyre::Result<u64> {
     let mut chunks_pruned = 0;
-    // get all chunks specified by the `CachedChunksIndex`
+    let leaf_key = CachedIngressLeafKey { data_root, address };
+    let mut leaf_cursor = tx.cursor_dup_read::<CachedIngressLeaves>()?;
     let mut cursor = tx.cursor_dup_write::<CachedChunksIndex>()?;
-    let mut walker = cursor.walk_dup(Some(data_root), None)?; // iterate a specific key's subkeys
-    while let Some((_k, c)) = walker.next().transpose()? {
-        if c.meta.updated_at >= older_than {
+    let mut walker = cursor.walk_dup(Some(data_root), None)?;
+    while let Some((_key, entry)) = walker.next().transpose()? {
+        let has_ingress_hash = leaf_cursor
+            .seek_by_key_subkey(leaf_key, *entry.index)?
+            .is_some_and(|leaf| leaf.tx_offset == entry.index);
+        if entry.meta.updated_at >= older_than
+            || !durable_tx_offsets.contains(&entry.index)
+            || !has_ingress_hash
+        {
             continue;
         }
-        // delete them
-        tx.delete::<CachedChunks>(c.meta.chunk_path_hash, None)?;
-        // delete the specific index entry instead of nuking the whole key
-        tx.delete::<CachedChunksIndex>(data_root, Some(c))?;
+        tx.delete::<CachedChunks>(entry.meta.chunk_path_hash, None)?;
+        tx.delete::<CachedChunksIndex>(data_root, Some(entry))?;
         chunks_pruned += 1;
     }
-    // If we removed all subkeys, remove the empty key bucket
-    let mut check_cursor = tx.cursor_dup_write::<CachedChunksIndex>()?;
-    let mut remaining = check_cursor.walk_dup(Some(data_root), None)?;
-    if remaining.next().transpose()?.is_none() {
-        tx.delete::<CachedChunksIndex>(data_root, None)?;
-    }
+    // MDBX removes the dupsort key with its final value, preserving the
+    // `dup_count(root) == None` empty-bucket invariant used by cache callers.
     Ok(chunks_pruned)
 }
 

--- a/crates/database/src/db_cache.rs
+++ b/crates/database/src/db_cache.rs
@@ -2,7 +2,7 @@ use alloy_primitives::aliases::U232;
 use arbitrary::Arbitrary;
 use bytes::Buf as _;
 use irys_types::{
-    Base64, ChunkPathHash, Compact, H256, TxChunkOffset, UnixTimestamp, UnpackedChunk,
+    Base64, ChunkPathHash, Compact, H256, IrysAddress, TxChunkOffset, UnixTimestamp, UnpackedChunk,
     partition::PartitionHash,
 };
 use reth_db::DatabaseError;
@@ -191,6 +191,85 @@ pub struct CachedChunkIndexMetadata {
     pub chunk_path_hash: ChunkPathHash,
     /// Last time this index entry was updated
     pub updated_at: UnixTimestamp,
+}
+
+/// Key for one persisted miner-specific ingress-leaf sequence.
+///
+/// A dupsort value begins with the big-endian transaction offset, preserving
+/// exact `(data_root, address, tx_offset)` ordering while allowing an O(1)
+/// count prefilter before the required gap-free verification walk.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Arbitrary)]
+pub struct CachedIngressLeafKey {
+    pub data_root: H256,
+    pub address: IrysAddress,
+}
+
+const CACHED_INGRESS_LEAF_KEY_BYTES: usize = 32 + 20;
+
+impl Encode for CachedIngressLeafKey {
+    type Encoded = [u8; CACHED_INGRESS_LEAF_KEY_BYTES];
+
+    fn encode(self) -> Self::Encoded {
+        let mut encoded = [0_u8; CACHED_INGRESS_LEAF_KEY_BYTES];
+        encoded[..32].copy_from_slice(&self.data_root.0);
+        encoded[32..].copy_from_slice(self.address.as_slice());
+        encoded
+    }
+}
+
+impl Decode for CachedIngressLeafKey {
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
+        if value.len() != CACHED_INGRESS_LEAF_KEY_BYTES {
+            return Err(DatabaseError::Decode);
+        }
+        Ok(Self {
+            data_root: H256::from_slice(&value[..32]),
+            address: IrysAddress::from_slice(&value[32..]),
+        })
+    }
+}
+
+/// Durable compact state sufficient to reconstruct one ingress Merkle leaf.
+///
+/// The byte boundary is deliberately not stored: it is derived from the
+/// transaction offset, confirmed data size, and consensus chunk size. Only the
+/// miner-specific data hash is unavailable after the cached body is reclaimed.
+/// Availability of this record says nothing about whether the chunk body is
+/// durably stored; reclamation is gated separately on storage-module state.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Arbitrary)]
+pub struct CachedIngressLeaf {
+    pub tx_offset: TxChunkOffset,
+    pub ingress_data_hash: H256,
+}
+
+const CACHED_INGRESS_LEAF_OFFSET_BYTES: usize = std::mem::size_of::<TxChunkOffset>();
+const CACHED_INGRESS_DATA_HASH_BYTES: usize = 32;
+
+// The uncompressed big-endian tx offset must lead the dupsort value so MDBX
+// subkey seeks and ordered walks follow transaction-relative chunk order.
+impl Compact for CachedIngressLeaf {
+    fn to_compact<B>(&self, buf: &mut B) -> usize
+    where
+        B: bytes::BufMut + AsMut<[u8]>,
+    {
+        buf.put_slice(&self.tx_offset.to_be_bytes());
+        buf.put_slice(&self.ingress_data_hash.0);
+        CACHED_INGRESS_LEAF_OFFSET_BYTES + CACHED_INGRESS_DATA_HASH_BYTES
+    }
+
+    fn from_compact(buf: &[u8], _len: usize) -> (Self, &[u8]) {
+        let offset_end = CACHED_INGRESS_LEAF_OFFSET_BYTES;
+        let hash_end = offset_end + CACHED_INGRESS_DATA_HASH_BYTES;
+        let tx_offset = TxChunkOffset::from_be_bytes(buf[..offset_end].try_into().unwrap());
+        let ingress_data_hash = H256::from_slice(&buf[offset_end..hash_end]);
+        (
+            Self {
+                tx_offset,
+                ingress_data_hash,
+            },
+            &buf[hash_end..],
+        )
+    }
 }
 
 impl From<CachedChunkIndexEntry> for CachedChunkIndexMetadata {

--- a/crates/database/src/snapshot.rs
+++ b/crates/database/src/snapshot.rs
@@ -12,8 +12,8 @@ use std::ffi::CString;
 use std::path::Path;
 
 use crate::tables::{
-    CachedChunks, CachedChunksIndex, CachedDataRoots, IngressProofs, IrysBlockStreamEvents,
-    PeerListItems,
+    CachedChunks, CachedChunksIndex, CachedDataRoots, CachedIngressLeaves, IngressProofs,
+    IrysBlockStreamEvents, PeerListItems,
 };
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -143,6 +143,8 @@ pub fn strip_node_local(env: &DatabaseEnv, include_caches: bool) -> eyre::Result
             .context("clearing CachedChunksIndex")?;
         tx.clear::<CachedChunks>()
             .context("clearing CachedChunks")?;
+        tx.clear::<CachedIngressLeaves>()
+            .context("clearing CachedIngressLeaves")?;
         tx.clear::<IngressProofs>()
             .context("clearing IngressProofs")?;
     }

--- a/crates/database/src/tables.rs
+++ b/crates/database/src/tables.rs
@@ -2,7 +2,9 @@ use crate::db_cache::{GlobalChunkOffset, PartitionHashes};
 use crate::metadata::MetadataKey;
 use crate::submodule::tables::{DataRootInfos, TxLeafBinding};
 use crate::{
-    db_cache::{CachedChunk, CachedChunkIndexEntry, CachedDataRoot},
+    db_cache::{
+        CachedChunk, CachedChunkIndexEntry, CachedDataRoot, CachedIngressLeaf, CachedIngressLeafKey,
+    },
     submodule::tables::ChunkPathHashes,
 };
 use irys_types::ingress::CachedIngressProof;
@@ -96,6 +98,7 @@ impl_compression_for_compact!(
     CachedDataRoot,
     CachedChunkIndexEntry,
     CachedChunk,
+    CachedIngressLeaf,
     ChunkPathHashes,
     PartitionHashes,
     DataRootInfos,
@@ -125,6 +128,14 @@ impl ValueWithSubKey for CachedChunkIndexEntry {
 
     fn get_subkey(&self) -> Self::SubKey {
         self.index.0
+    }
+}
+
+impl ValueWithSubKey for CachedIngressLeaf {
+    type SubKey = u32;
+
+    fn get_subkey(&self) -> Self::SubKey {
+        self.tx_offset.0
     }
 }
 
@@ -210,6 +221,15 @@ table CachedChunksIndex {
 table CachedChunks {
     type Key = ChunkPathHash;
     type Value = CachedChunk;
+}
+
+/// Stores one compact, miner-specific ingress leaf per transaction-relative
+/// chunk offset, recorded when the chunk is validated. Cached-body reclamation
+/// is gated on storage-module durability, not on the presence of a leaf.
+table CachedIngressLeaves {
+    type Key = CachedIngressLeafKey;
+    type Value = CachedIngressLeaf;
+    type SubKey = u32;
 }
 
 /// Indexes ingress proofs by DataRoot and Address

--- a/crates/domain/src/models/storage_module.rs
+++ b/crates/domain/src/models/storage_module.rs
@@ -68,7 +68,7 @@ use reth_db::Database as _;
 use reth_db::transaction::DbTx;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     fs::{self, File, OpenOptions},
     io::{Read as _, Seek as _, SeekFrom, Write as _},
     path::{Path, PathBuf},
@@ -141,6 +141,13 @@ type SubmoduleMap =
 /// Tracks storage state of chunk ranges across all submodules
 type StorageIntervals = NoditMap<PartitionChunkOffset, Interval<PartitionChunkOffset>, ChunkType>;
 
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SyncFailurePoint {
+    BeforeDataFsync,
+    BeforeIntervalCommit,
+}
+
 #[derive(Debug, Clone)]
 pub struct ChunkTimeRecord {
     pub chunk_offset: PartitionChunkOffset,
@@ -169,8 +176,15 @@ pub struct StorageModule {
     /// The (Optional) info about a partition assigned to this storage module
     pub partition_assignment: RwLock<Option<PartitionAssignment>>,
     /// In-memory chunk buffer awaiting disk write
-    pending_writes: Arc<RwLock<ChunkMap>>,
-    /// Tracks the wall clock time of the last pending write
+    pending_writes: RwLock<ChunkMap>,
+    /// Serializes flushes so two callers cannot claim and write the same
+    /// pending batch concurrently. Pending entries remain present until the
+    /// data fsync and interval commit both succeed, and therefore serve as the
+    /// durability fence themselves.
+    sync_in_progress: Mutex<()>,
+    #[cfg(test)]
+    sync_failure: Mutex<Option<SyncFailurePoint>>,
+    /// Monotonic instant of the last pending write, used only for idle flushing.
     last_pending_write: RwLock<Instant>,
     /// Tracks the storage state of each chunk across all submodules
     intervals: Arc<RwLock<StorageIntervals>>,
@@ -482,7 +496,10 @@ impl StorageModule {
         Ok(Self {
             id: storage_module_info.id,
             partition_assignment: RwLock::new(storage_module_info.partition_assignment),
-            pending_writes: Arc::new(RwLock::new(ChunkMap::new())),
+            pending_writes: RwLock::new(ChunkMap::new()),
+            sync_in_progress: Mutex::new(()),
+            #[cfg(test)]
+            sync_failure: Mutex::new(None),
             last_pending_write: RwLock::new(Instant::now()),
             intervals: Arc::new(RwLock::new(loaded_intervals)),
             submodules: submodule_map,
@@ -549,6 +566,130 @@ impl StorageModule {
         *self.last_pending_write.read().unwrap()
     }
 
+    pub fn has_pending_writes(&self) -> bool {
+        !self.pending_writes.read().unwrap().is_empty()
+    }
+
+    #[cfg(test)]
+    fn fail_next_sync_at(&self, point: SyncFailurePoint) {
+        *self.sync_failure.lock().unwrap() = Some(point);
+    }
+
+    #[cfg(test)]
+    fn inject_sync_failure(&self, point: SyncFailurePoint) -> eyre::Result<()> {
+        let mut failure = self.sync_failure.lock().unwrap();
+        if *failure == Some(point) {
+            *failure = None;
+            eyre::bail!("injected storage-module sync failure at {point:?}");
+        }
+        Ok(())
+    }
+
+    /// Resolves every local partition placement funded for one transaction
+    /// chunk. This is the canonical forward mapping used by ingress writes,
+    /// migration, and durability queries.
+    ///
+    /// `None` means this storage module has no index entry for `data_root`.
+    /// `Some([])` means the root is indexed, but this transaction-relative
+    /// offset is not funded inside this partition.
+    pub fn partition_offsets_for_data_root_chunk(
+        &self,
+        data_root: DataRoot,
+        tx_offset: TxChunkOffset,
+    ) -> eyre::Result<Option<Vec<PartitionChunkOffset>>> {
+        let infos = self.collect_data_root_infos(data_root)?;
+        if infos.0.is_empty() {
+            return Ok(None);
+        }
+
+        let raw_tx_offset = u32::from(tx_offset);
+        let chunk_byte_offset = u64::from(raw_tx_offset)
+            .checked_mul(self.config.consensus.chunk_size)
+            .ok_or_else(|| eyre::eyre!("chunk byte offset overflow"))?;
+        let num_chunks_in_partition = self.config.consensus.num_chunks_in_partition;
+        let mut offsets = Vec::new();
+        for info in infos.0 {
+            if chunk_byte_offset >= info.data_size {
+                warn!(
+                    %data_root,
+                    %tx_offset,
+                    start_offset = %info.start_offset,
+                    data_size = info.data_size,
+                    "Skipping storage-module placement past the data root's declared size"
+                );
+                continue;
+            }
+            let relative_offset = i64::from(info.start_offset.0) + i64::from(raw_tx_offset);
+            if relative_offset < 0 || relative_offset as u64 >= num_chunks_in_partition {
+                continue;
+            }
+            offsets.push(PartitionChunkOffset::from(relative_offset as u32));
+        }
+        offsets.sort_unstable();
+        offsets.dedup();
+        Ok(Some(offsets))
+    }
+
+    /// Returns true only when the offset is on disk as transaction data and no
+    /// buffered write currently supersedes it.
+    pub fn is_data_chunk_durable_at(&self, offset: PartitionChunkOffset) -> bool {
+        if self.pending_writes.read().unwrap().contains_key(&offset) {
+            return false;
+        }
+        self.intervals
+            .read()
+            .unwrap()
+            .get_at_point(offset)
+            .is_some_and(|chunk_type| *chunk_type == ChunkType::Data)
+    }
+
+    /// Candidate transaction-relative offsets of `data_root` whose bodies are
+    /// fsynced in this module as `ChunkType::Data`.
+    ///
+    /// This is the durability signal cached-body reclamation is gated on. It is
+    /// derived from the same interval state the node reloads after a restart, so
+    /// it cannot disagree with what recovery will see. Resolves the submodule
+    /// index once per root and checks only bodies the cache can actually
+    /// reclaim, rather than walking the transaction's entire funded range.
+    pub fn durable_tx_offsets_for_data_root(
+        &self,
+        data_root: DataRoot,
+        candidates: &BTreeSet<TxChunkOffset>,
+    ) -> eyre::Result<BTreeSet<TxChunkOffset>> {
+        let infos = self.collect_data_root_infos(data_root)?;
+        let mut durable = BTreeSet::new();
+        if infos.0.is_empty() {
+            return Ok(durable);
+        }
+
+        let chunk_size = self.config.consensus.chunk_size;
+        let num_chunks_in_partition = self.config.consensus.num_chunks_in_partition;
+        for tx_offset in candidates {
+            let raw_offset = u32::from(*tx_offset);
+            let chunk_byte_offset = u64::from(raw_offset)
+                .checked_mul(chunk_size)
+                .ok_or_else(|| eyre::eyre!("chunk byte offset overflow"))?;
+            for info in &infos.0 {
+                if chunk_byte_offset >= info.data_size {
+                    continue;
+                }
+                let relative_offset = i64::from(info.start_offset.0) + i64::from(raw_offset);
+                if relative_offset < 0 || relative_offset as u64 >= num_chunks_in_partition {
+                    continue;
+                }
+                // One short lock acquisition per offset rather than holding
+                // pending/intervals across the whole loop: this runs on the
+                // background prune path and must not stall chunk writes.
+                if self.is_data_chunk_durable_at(PartitionChunkOffset::from(relative_offset as u32))
+                {
+                    durable.insert(*tx_offset);
+                    break;
+                }
+            }
+        }
+        Ok(durable)
+    }
+
     /// Reinit intervals setting them as Uninitialized, and erase db
     pub fn reset(&self) -> eyre::Result<Interval<PartitionChunkOffset>> {
         let storage_interval = {
@@ -609,7 +750,14 @@ impl StorageModule {
         self.sync_pending_chunks_inner(false)
     }
 
-    /// Force syncs (writes) all pending writes for this SM
+    /// Force syncs (writes) all pending writes for this storage module.
+    ///
+    /// Use only for outlier tail-drain situations such as orderly shutdown,
+    /// recovery, or a module that has become idle. Calling this on a normal
+    /// ingestion or migration hot path defeats the pending-chunk buffer: it
+    /// prevents efficient disk striping and increases on-disk fragmentation.
+    /// Normal writers must use [`Self::sync_pending_chunks`], which preserves
+    /// the configured batching threshold.
     ///
     /// Process:
     /// 1. Collects pending writes for each submodule
@@ -627,6 +775,14 @@ impl StorageModule {
         // doing this removes having to locate the correct submodule again in `write_chunk_internal`,
         // and lets us increase throughput - we can spawn blocking tasks in parallel for each submodule (as each is it's own IO domain/drive)
 
+        // Multiple services may request a flush concurrently. Serializing the
+        // operation avoids duplicate writes and lets `pending_writes` remain
+        // the single durability fence until the whole batch commits.
+        let _sync_guard = self
+            .sync_in_progress
+            .lock()
+            .map_err(|error| eyre::eyre!("storage-module sync lock poisoned: {error}"))?;
+
         let then = Instant::now();
         let threshold = if force {
             0
@@ -634,11 +790,9 @@ impl StorageModule {
             self.config.node_config.storage.num_writes_before_sync
         };
 
-        let arc = self.pending_writes.clone();
-
         // First use read lock to check if we have work to do
         let write_batch = {
-            let pending = arc.read().unwrap();
+            let pending = self.pending_writes.read().unwrap();
 
             let pending_writes = self
                 .submodules
@@ -689,29 +843,17 @@ impl StorageModule {
 
         let len = write_batch.len();
 
-        let mut pending = arc.write().unwrap();
-        for (chunk_offset, (bytes, chunk_type)) in write_batch {
-            // self.intervals are updated by write_chunk_internal()
-            match self.write_chunk_internal(chunk_offset, bytes, chunk_type) {
-                Ok(_) => {}
-                Err(e) => {
-                    // persist state
-
-                    // make sure fsync succeeds
-                    for (_, submodule) in self.submodules.iter() {
-                        let file = submodule.file.lock().unwrap();
-                        file.sync_all()
-                            .map_err(|e| eyre::eyre!("Failed to sync data to disk: {}", e))?;
-                    }
-
-                    // we don't remove the failed write from pending - we can retry it
-                    self.write_intervals_to_submodules()?;
-                    return Err(e);
-                }
-            }
-            pending.remove(&chunk_offset); // Clean up written chunks
+        // Keep every snapshot entry in `pending_writes` while writing. A data
+        // interval is updated optimistically by `write_chunk_internal`, but the
+        // pending entry keeps durability queries false until both persistence
+        // steps below have succeeded. On any error the batch remains queued and
+        // the next service tick can retry it without a restart.
+        for (chunk_offset, (bytes, chunk_type)) in &write_batch {
+            self.write_chunk_internal(*chunk_offset, bytes.clone(), *chunk_type)?;
         }
-        drop(pending);
+
+        #[cfg(test)]
+        self.inject_sync_failure(SyncFailurePoint::BeforeDataFsync)?;
 
         // fsync this write batch BEFORE committing the interval state
         // as fsync can error on us if the underlying storage has issues
@@ -722,10 +864,23 @@ impl StorageModule {
                 .map_err(|e| eyre::eyre!("Failed to sync data to disk: {}", e))?;
         }
 
+        #[cfg(test)]
+        self.inject_sync_failure(SyncFailurePoint::BeforeIntervalCommit)?;
+
         // persist the state from all the write calls
         // save the updated intervals
         self.write_intervals_to_submodules()
             .wrap_err("Could not update submodule interval files, if this is a component test with storage_module that drops after the test, this error is benign")?;
+
+        // Remove only the exact values written by this snapshot. A concurrent
+        // producer may have replaced an entry while the disk I/O was running;
+        // that newer value must remain queued for the next batch.
+        let mut pending = self.pending_writes.write().unwrap();
+        for (chunk_offset, state) in &write_batch {
+            if pending.get(chunk_offset) == Some(state) {
+                pending.remove(chunk_offset);
+            }
+        }
 
         debug!(
             "sync_pending_chunks took {:.3}s for {} chunks",
@@ -880,14 +1035,15 @@ impl StorageModule {
     ) -> eyre::Result<ChunkMap> {
         let mut chunk_map = ChunkMap::new();
 
-        // Query overlapping intervals from storage map
-        let intervals = self.intervals.read().unwrap();
-        let intervals2 = intervals.clone();
-        // this is here to prevent a deadlock with the later `pending_writes.read()` rwlock acquisition
-        // this locking order (intervals -> pending_writes) is reversed in sync_pending_chunks (pending_writes -> intervals), which is the cause of the deadlock.
-        drop(intervals);
-        // TODO: figure out how to only clone the overlap instead of the entire interval map (low prio as the intervals should be small generally speaking)
-        let overlapping = intervals2.overlapping(chunk_range);
+        // Snapshot only the relevant interval metadata. Physical reads and
+        // pending-write lookups must not hold the global interval lock.
+        let overlapping = self
+            .intervals
+            .read()
+            .unwrap()
+            .overlapping(chunk_range)
+            .map(|(interval, chunk_type)| (*interval, *chunk_type))
+            .collect::<Vec<_>>();
 
         // Process each overlapping interval
         for (interval, interval_chunk_type) in overlapping {
@@ -919,7 +1075,7 @@ impl StorageModule {
                     // Case 3: No pending chunk, Data or Entropy interval_chunk_type - read from storage
                     (None, _) => {
                         let bytes = self.read_chunk_internal(partition_chunk_offset)?;
-                        chunk_map.insert(partition_chunk_offset, (bytes, *interval_chunk_type));
+                        chunk_map.insert(partition_chunk_offset, (bytes, interval_chunk_type));
                     }
                 }
             }
@@ -1249,58 +1405,21 @@ impl StorageModule {
         &self,
         chunk: &UnpackedChunk,
     ) -> eyre::Result<Vec<PartitionChunkOffset>> {
-        let data_root_infos = self.collect_data_root_infos(chunk.data_root)?;
-
-        if data_root_infos.0.is_empty() {
+        let Some(offsets) =
+            self.partition_offsets_for_data_root_chunk(chunk.data_root, chunk.tx_offset)?
+        else {
             debug!("Chunks data_root not found in storage module");
             return Ok(Vec::new());
-        }
+        };
 
         let intervals = self.intervals.read().unwrap();
-        let chunk_size = self.config.consensus.chunk_size;
-        let num_chunks_in_partition = self.config.consensus.num_chunks_in_partition;
-
-        // The data_root_infos contain all the start_offsets and data_sizes for this chunks data_root
-        // what we need to do is find all the ones where the chunks tx_offset fits within the data_size
-        // for the data_root at that offset.
-        Ok(data_root_infos
-            .0
+        Ok(offsets
             .iter()
-            .filter_map(|info| {
-                // Check if the chunk's tx_offset + start offset exceeds the data_size for the data root
-                let tx_offset: u32 = chunk.tx_offset.into();
-                let chunk_byte_offset: u64 = tx_offset as u64 * chunk_size;
-
-                if chunk_byte_offset >= info.data_size {
-                    // Skip any chunks that go past the data_size (don't error, just filter out)
-                    warn!("Skipping chunk with tx_offset {:?} for data_root {:?} with start_offset {:?} because the tx_offset is larger than the data_size {:?}",tx_offset, chunk.data_root, info.start_offset, info.data_size );
-                    None
-                } else {
-                    // Calculate the relative partition offset, this can sometimes be negative if the
-                    // data_root overlaps two partitions
-                    let relative_offset = info.start_offset + tx_offset as i32;
-
-                    // Only include a writeable offset for a partition if it has a >= 0
-                    // partition relative offset
-                    if relative_offset.0 >= 0
-                        && (relative_offset.0 as u64) < num_chunks_in_partition
-                    {
-                        // Convert the partition relative offset to a proper PartitionChunkOffset
-                        let partition_offset = PartitionChunkOffset::from(relative_offset.0 as u32);
-
-                        // Check if this offset is in an Entropy interval
-                        if intervals
-                            .get_at_point(partition_offset)
-                            .is_some_and(|s| *s == ChunkType::Entropy)
-                        {
-                            Some(partition_offset)
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
-                    }
-                }
+            .copied()
+            .filter(|partition_offset| {
+                intervals
+                    .get_at_point(*partition_offset)
+                    .is_some_and(|s| *s == ChunkType::Entropy)
             })
             .collect())
     }
@@ -1310,43 +1429,18 @@ impl StorageModule {
         let data_path = &chunk.data_path.0;
         let data_path_hash = UnpackedChunk::hash_data_path(data_path);
 
-        // Get all the places this chunks data_root starts in the partition
-        let data_root_infos = self.collect_data_root_infos(chunk.data_root)?;
-
-        if data_root_infos.0.is_empty() {
+        let Some(partition_offsets) =
+            self.partition_offsets_for_data_root_chunk(chunk.data_root, chunk.tx_offset)?
+        else {
             return Err(WriteDataChunkError::DataRootNotFound);
-        }
+        };
 
         // Lists for both types of offsets to process
         let mut writeable_offsets = vec![];
         let mut pending_offsets = vec![];
 
-        // Scan all potential locations and categorize them
-        for info in data_root_infos.0 {
-            let partition_offset =
-                PartitionChunkOffset::from(info.start_offset + (*chunk.tx_offset as i32));
-
-            // Calculate the number of chunks the data tx paid for
-            let data_size_in_chunks =
-                (info.data_size.div_ceil(self.config.consensus.chunk_size)) as i32;
-
-            // Calculate the last valid chunk offset for this data transaction.
-            // Convert data_size (bytes) to chunk count, then add to start_offset to get the
-            // exclusive end boundary. Subtract 1 to convert from count to the inclusive
-            // last offset.
-            // Example: 3-chunk tx starting at offset 5 reserves offsets [5,6,7]
-            //   → start=5, chunks=3, end_boundary=8, last_offset=7
-            let last_chunk_offset = (info.start_offset.0 + data_size_in_chunks)
-                .saturating_sub(1)
-                .into();
-
-            // Check to see if the offset being written is past the end of what was paid for
-            if partition_offset > last_chunk_offset {
-                // Skips writing to any partition chunk offsets that exceed the data_size
-                // amount of chunks paid for by the data transaction
-                continue;
-            }
-
+        // Scan all funded local placements and categorize them.
+        for partition_offset in partition_offsets {
             // Check if there's an entropy chunk in the intervals map at this location and collect if present
             let intervals = self.intervals.read().unwrap();
             if intervals
@@ -2869,6 +2963,12 @@ mod tests {
 
         // Sync the chunks
         storage_module.sync_pending_chunks()?;
+        assert!(
+            (0..10_u32)
+                .map(PartitionChunkOffset::from)
+                .all(|offset| !storage_module.is_data_chunk_durable_at(offset)),
+            "entropy writes must never be reported as durable transaction data"
+        );
 
         // Write 9 more entropy chunks
         for chunk_offset in 10..19_u32 {
@@ -2878,6 +2978,13 @@ mod tests {
                 ChunkType::Entropy,
             );
         }
+
+        // A normal sync below the configured threshold must preserve the buffer.
+        storage_module.sync_pending_chunks()?;
+        assert!(
+            storage_module.has_pending_writes(),
+            "a normal sync below the configured threshold must preserve the write buffer"
+        );
 
         let entropy = storage_module.get_intervals(ChunkType::Entropy);
         let uninitialized = storage_module.get_intervals(ChunkType::Uninitialized);
@@ -2989,6 +3096,13 @@ mod tests {
 
         // Test that they are stable and expected values after disk sync
         storage_module.sync_pending_chunks()?;
+
+        for offset in [2_u32, 11, 19].map(PartitionChunkOffset::from) {
+            assert!(
+                storage_module.is_data_chunk_durable_at(offset),
+                "fsynced data must be reported as durable at {offset}"
+            );
+        }
 
         {
             // Ensure all pending writes were written to disk
@@ -3441,6 +3555,54 @@ mod tests {
             )
             .join("db");
         info!("DB PATH {:?}", &db_path.canonicalize()?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn failed_sync_keeps_batch_pending_for_retry() -> eyre::Result<()> {
+        let tmp_dir = TempDirBuilder::new()
+            .prefix("sync_retry_test")
+            .with_tracing()
+            .build();
+        let node_config = NodeConfig {
+            consensus: irys_types::ConsensusOptions::Custom(ConsensusConfig {
+                chunk_size: 32,
+                num_chunks_in_partition: 4,
+                ..ConsensusConfig::testing()
+            }),
+            storage: StorageSyncConfig {
+                num_writes_before_sync: 1,
+            },
+            base_directory: tmp_dir.path().to_path_buf(),
+            ..NodeConfig::testing()
+        };
+        let config = Config::new_with_random_peer_id(node_config);
+        let storage_module = StorageModule::new(
+            &StorageModuleInfo {
+                id: 0,
+                partition_assignment: Some(PartitionAssignment::default()),
+                submodules: vec![(partition_chunk_offset_ii!(0, 3), "chunks".into())],
+            },
+            &config,
+        )?;
+
+        for (raw_offset, failure_point) in [
+            (0_u32, SyncFailurePoint::BeforeDataFsync),
+            (1_u32, SyncFailurePoint::BeforeIntervalCommit),
+        ] {
+            let offset = PartitionChunkOffset::from(raw_offset);
+            storage_module.write_chunk(offset, vec![raw_offset as u8; 32], ChunkType::Data);
+            storage_module.fail_next_sync_at(failure_point);
+
+            assert!(storage_module.force_sync_pending_chunks().is_err());
+            assert!(storage_module.has_pending_writes());
+            assert!(!storage_module.is_data_chunk_durable_at(offset));
+
+            storage_module.force_sync_pending_chunks()?;
+            assert!(storage_module.is_data_chunk_durable_at(offset));
+            assert!(!storage_module.has_pending_writes());
+        }
 
         Ok(())
     }

--- a/crates/domain/src/models/storage_module.rs
+++ b/crates/domain/src/models/storage_module.rs
@@ -623,7 +623,9 @@ impl StorageModule {
             if relative_offset < 0 || relative_offset as u64 >= num_chunks_in_partition {
                 continue;
             }
-            offsets.push(PartitionChunkOffset::from(relative_offset as u32));
+            let relative_offset = u32::try_from(relative_offset)
+                .map_err(|_| eyre::eyre!("partition-relative chunk offset exceeds u32"))?;
+            offsets.push(PartitionChunkOffset::from(relative_offset));
         }
         offsets.sort_unstable();
         offsets.dedup();
@@ -677,11 +679,12 @@ impl StorageModule {
                 if relative_offset < 0 || relative_offset as u64 >= num_chunks_in_partition {
                     continue;
                 }
+                let relative_offset = u32::try_from(relative_offset)
+                    .map_err(|_| eyre::eyre!("partition-relative chunk offset exceeds u32"))?;
                 // One short lock acquisition per offset rather than holding
                 // pending/intervals across the whole loop: this runs on the
                 // background prune path and must not stall chunk writes.
-                if self.is_data_chunk_durable_at(PartitionChunkOffset::from(relative_offset as u32))
-                {
+                if self.is_data_chunk_durable_at(PartitionChunkOffset::from(relative_offset)) {
                     durable.insert(*tx_offset);
                     break;
                 }

--- a/crates/types/src/chunk.rs
+++ b/crates/types/src/chunk.rs
@@ -134,22 +134,9 @@ impl UnpackedChunk {
         if self.data_size == 0 {
             return Some(0);
         }
-
-        let max_offset = self.max_valid_offset(chunk_size)?;
-        let offset_u64 = u64::from(self.tx_offset.0);
-
-        if offset_u64 > max_offset {
-            return None;
-        }
-
-        if offset_u64 == max_offset {
-            Some(self.data_size.saturating_sub(1))
-        } else {
-            offset_u64
-                .checked_add(1)?
-                .checked_mul(chunk_size)?
-                .checked_sub(1)
-        }
+        crate::expected_chunk_byte_range(self.tx_offset, self.data_size, chunk_size)
+            .ok()
+            .map(|(_, max)| max - 1)
     }
 }
 

--- a/crates/types/src/ingress.rs
+++ b/crates/types/src/ingress.rs
@@ -1,7 +1,8 @@
 use crate::irys::IrysSigner;
 use crate::{
-    DataRoot, H256, IrysAddress, IrysSignature, Node, Signable, VersionDiscriminant, Versioned,
-    decode_rlp_version, encode_rlp_version, generate_data_root, generate_ingress_leaves,
+    DataRoot, H256, IngressMerkleLeaf, IrysAddress, IrysSignature, Node, Signable,
+    VersionDiscriminant, Versioned, decode_rlp_version, encode_rlp_version, generate_data_root,
+    generate_ingress_leaves, generate_ingress_root_from_leaves,
 };
 use alloy_primitives::{ChainId, keccak256};
 use alloy_rlp::Encodable as _;
@@ -180,18 +181,41 @@ pub fn generate_ingress_proof<C: AsRef<[u8]>>(
     anchor: H256,
 ) -> eyre::Result<IngressProof> {
     let (root, _) = generate_ingress_proof_tree(chunks, signer.address(), false)?;
-    let proof = H256(root.id);
+    generate_ingress_proof_from_root(signer, data_root, H256(root.id), chain_id, anchor)
+}
 
+/// Signs the existing ingress-proof payload for a precomputed ingress root.
+/// This is deliberately the same payload and signer path used by full-body
+/// generation; only the storage lifecycle that produced `ingress_root` differs.
+pub fn generate_ingress_proof_from_root(
+    signer: &IrysSigner,
+    data_root: DataRoot,
+    ingress_root: H256,
+    chain_id: u64,
+    anchor: H256,
+) -> eyre::Result<IngressProof> {
     let mut proof = IngressProof::V1(IngressProofV1 {
         signature: Default::default(),
         data_root,
-        proof,
+        proof: ingress_root,
         chain_id,
         anchor,
     });
 
     signer.sign_ingress_proof(&mut proof)?;
     Ok(proof)
+}
+
+/// Builds and signs an ingress proof from ordered compact leaves.
+pub fn generate_ingress_proof_from_leaves(
+    signer: &IrysSigner,
+    data_root: DataRoot,
+    leaves: impl IntoIterator<Item = IngressMerkleLeaf>,
+    chain_id: u64,
+    anchor: H256,
+) -> eyre::Result<IngressProof> {
+    let root = generate_ingress_root_from_leaves(leaves)?;
+    generate_ingress_proof_from_root(signer, data_root, H256(root.id), chain_id, anchor)
 }
 
 pub fn verify_ingress_proof<C: AsRef<[u8]>>(
@@ -238,11 +262,46 @@ mod tests {
     use rand::Rng as _;
 
     use crate::{
-        ConsensusConfig, H256, generate_data_root, generate_leaves, hash_sha256,
+        ConsensusConfig, H256, generate_data_root, generate_ingress_data_hash,
+        generate_ingress_leaf_from_data_hash, generate_leaves, hash_sha256,
         ingress::verify_ingress_proof, irys::IrysSigner,
     };
 
-    use super::generate_ingress_proof;
+    use super::{generate_ingress_proof, generate_ingress_proof_from_leaves};
+
+    #[test]
+    fn compact_leaves_match_full_body_proof_with_partial_final_chunk() -> eyre::Result<()> {
+        let config = ConsensusConfig::testing();
+        let signer = IrysSigner::random_signer(&config);
+        let chunks = [vec![1_u8; 32], vec![2_u8; 32], vec![3_u8; 7]];
+        let data = chunks.concat();
+        let regular_leaves = generate_leaves(std::iter::once(Ok(data)), 32)?;
+        let data_root = H256(generate_data_root(regular_leaves)?.id);
+        let anchor = H256::random();
+
+        let full = generate_ingress_proof(
+            &signer,
+            data_root,
+            chunks.iter().map(|chunk| Ok(chunk.as_slice())),
+            17,
+            anchor,
+        )?;
+        let mut boundary = 0_u64;
+        let compact = chunks
+            .iter()
+            .map(|chunk| {
+                boundary += chunk.len() as u64;
+                let persisted_hash = generate_ingress_data_hash(chunk, signer.address());
+                generate_ingress_leaf_from_data_hash(persisted_hash, boundary)
+            })
+            .collect::<eyre::Result<Vec<_>>>()?;
+        let from_compact =
+            generate_ingress_proof_from_leaves(&signer, data_root, compact, 17, anchor)?;
+
+        assert_eq!(from_compact, full);
+        assert!(verify_ingress_proof(&from_compact, &chunks, 17)?);
+        Ok(())
+    }
 
     #[test]
     fn interleave_test() -> eyre::Result<()> {

--- a/crates/types/src/merkle.rs
+++ b/crates/types/src/merkle.rs
@@ -55,12 +55,12 @@ pub fn expected_chunk_byte_range(
     Ok((min, max))
 }
 
-/// Verifies that a validated Merkle path identifies exactly the chunk range
-/// selected by transaction metadata.
+/// Verifies that a validated Merkle path identifies exactly the expected chunk
+/// range. Rightmost status is checked separately because provisional
+/// transaction metadata may understate the size committed by the data root.
 pub fn validate_path_byte_range(
     path: &ValidatePathResult,
     expected: (u64, u64),
-    expected_rightmost: bool,
 ) -> Result<(), Error> {
     let actual = (
         u64::try_from(path.min_byte_range)
@@ -75,10 +75,6 @@ pub fn validate_path_byte_range(
         actual.1,
         expected.0,
         expected.1
-    );
-    eyre::ensure!(
-        path.is_rightmost_chunk == expected_rightmost,
-        "data path rightmost status does not match the chunk position"
     );
     Ok(())
 }
@@ -760,16 +756,13 @@ mod tests {
             max_byte_range: 71,
             is_rightmost_chunk: true,
         };
-        assert!(validate_path_byte_range(&path, (64, 71), true).is_ok());
+        assert!(validate_path_byte_range(&path, (64, 71)).is_ok());
 
         path.min_byte_range = 63;
-        assert!(validate_path_byte_range(&path, (64, 71), true).is_err());
+        assert!(validate_path_byte_range(&path, (64, 71)).is_err());
         path.min_byte_range = 64;
         path.max_byte_range = 70;
-        assert!(validate_path_byte_range(&path, (64, 71), true).is_err());
-        path.max_byte_range = 71;
-        path.is_rightmost_chunk = false;
-        assert!(validate_path_byte_range(&path, (64, 71), true).is_err());
+        assert!(validate_path_byte_range(&path, (64, 71)).is_err());
     }
 
     #[test]

--- a/crates/types/src/merkle.rs
+++ b/crates/types/src/merkle.rs
@@ -4,6 +4,7 @@ use crate::Base64;
 use crate::ChunkBytes;
 use crate::H256;
 use crate::IrysAddress;
+use crate::TxChunkOffset;
 use crate::chunked::ChunkedIterator;
 use borsh::BorshDeserialize as _;
 use borsh_derive::BorshDeserialize;
@@ -22,6 +23,64 @@ pub struct Node {
     pub max_byte_range: usize,
     pub left_child: Option<Box<Self>>,
     pub right_child: Option<Box<Self>>,
+}
+
+/// Minimal in-memory representation of a miner-specific ingress Merkle leaf.
+/// Persisted compact state stores only the ingress data hash; callers derive
+/// this identity and boundary from that hash and authoritative transaction
+/// metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IngressMerkleLeaf {
+    pub id: H256,
+    pub max_byte_range: u64,
+}
+
+/// Returns the exact transaction-relative byte range assigned to a chunk
+/// position under the protocol's fixed-size chunking rule.
+pub fn expected_chunk_byte_range(
+    tx_offset: TxChunkOffset,
+    data_size: u64,
+    chunk_size: u64,
+) -> Result<(u64, u64), Error> {
+    eyre::ensure!(data_size > 0, "data size must be non-zero");
+    eyre::ensure!(chunk_size > 0, "chunk size must be non-zero");
+    let min = u64::from(*tx_offset)
+        .checked_mul(chunk_size)
+        .ok_or_else(|| eyre!("chunk byte range overflow"))?;
+    eyre::ensure!(min < data_size, "chunk offset is past the data size");
+    let max = min
+        .checked_add(chunk_size)
+        .ok_or_else(|| eyre!("chunk byte range overflow"))?
+        .min(data_size);
+    Ok((min, max))
+}
+
+/// Verifies that a validated Merkle path identifies exactly the chunk range
+/// selected by transaction metadata.
+pub fn validate_path_byte_range(
+    path: &ValidatePathResult,
+    expected: (u64, u64),
+    expected_rightmost: bool,
+) -> Result<(), Error> {
+    let actual = (
+        u64::try_from(path.min_byte_range)
+            .map_err(|_| eyre!("validated chunk start boundary exceeds u64"))?,
+        u64::try_from(path.max_byte_range)
+            .map_err(|_| eyre!("validated chunk end boundary exceeds u64"))?,
+    );
+    eyre::ensure!(
+        actual == expected,
+        "data path range {}..{} does not match expected range {}..{}",
+        actual.0,
+        actual.1,
+        expected.0,
+        expected.1
+    );
+    eyre::ensure!(
+        path.is_rightmost_chunk == expected_rightmost,
+        "data path rightmost status does not match the chunk position"
+    );
+    Ok(())
 }
 
 /// Concatenated ids and max byte ranges for full set of nodes for an original data chunk, starting with the root.
@@ -433,14 +492,19 @@ pub fn generate_ingress_leaves<C: AsRef<[u8]>>(
     for chunk in chunks {
         let chunk = chunk?;
         let bytes = chunk.as_ref();
-        let data_hash = hash_ingress_sha256(bytes, address);
         let max_byte_range = min_byte_range + bytes.len();
+        let ingress_data_hash = generate_ingress_data_hash(bytes, address);
+        let compact_leaf = generate_ingress_leaf_from_data_hash(
+            ingress_data_hash,
+            max_byte_range
+                .try_into()
+                .map_err(|_| eyre!("ingress leaf byte range exceeds u64"))?,
+        )?;
         let max_byte_range_bytes = max_byte_range.to_note_vec();
-        let id = hash_all_sha256(vec![&data_hash, &max_byte_range_bytes]);
 
         leaves.push(Node {
-            id,
-            data_hash: Some(data_hash),
+            id: compact_leaf.id.0,
+            data_hash: Some(ingress_data_hash.0),
             min_byte_range,
             max_byte_range,
             left_child: None,
@@ -463,6 +527,73 @@ pub fn generate_ingress_leaves<C: AsRef<[u8]>>(
         min_byte_range += bytes.len();
     }
     Ok((leaves, and_regular.then_some(regular_leaves)))
+}
+
+/// Computes the miner-specific hash that cannot be reconstructed after the
+/// chunk body is reclaimed.
+pub fn generate_ingress_data_hash(chunk: impl AsRef<[u8]>, address: IrysAddress) -> H256 {
+    H256(hash_ingress_sha256(chunk.as_ref(), address))
+}
+
+/// Constructs an ingress leaf from its miner-specific data hash and an
+/// authoritative transaction-relative byte boundary.
+pub fn generate_ingress_leaf_from_data_hash(
+    ingress_data_hash: H256,
+    max_byte_range: u64,
+) -> Result<IngressMerkleLeaf, Error> {
+    let max_byte_range_usize: usize = max_byte_range
+        .try_into()
+        .map_err(|_| eyre!("ingress leaf byte range exceeds usize"))?;
+    let id = hash_all_sha256(vec![
+        &ingress_data_hash.0,
+        &max_byte_range_usize.to_note_vec(),
+    ]);
+    Ok(IngressMerkleLeaf {
+        id: H256(id),
+        max_byte_range,
+    })
+}
+
+/// Rebuilds the existing ingress Merkle root from ordered compact leaves.
+///
+/// Callers that know the transaction size/chunk size must additionally verify
+/// that every expected position is present and has its exact expected byte
+/// boundary before calling this helper. This function still rejects duplicate
+/// or decreasing boundaries so malformed persisted state cannot be folded into
+/// a root silently.
+pub fn generate_ingress_root_from_leaves(
+    leaves: impl IntoIterator<Item = IngressMerkleLeaf>,
+) -> Result<Node, Error> {
+    let mut min_byte_range = 0_usize;
+    let nodes = leaves
+        .into_iter()
+        .map(|leaf| {
+            let max_byte_range: usize = leaf
+                .max_byte_range
+                .try_into()
+                .map_err(|_| eyre!("ingress leaf byte range exceeds usize"))?;
+            if max_byte_range <= min_byte_range {
+                return Err(eyre!(
+                    "ingress leaf boundaries must be strictly increasing: {} then {}",
+                    min_byte_range,
+                    max_byte_range
+                ));
+            }
+            let node = Node {
+                id: leaf.id.0,
+                // Compact leaves intentionally omit the intermediate data hash.
+                // `generate_data_root` only consumes leaf ids and byte ranges.
+                data_hash: None,
+                min_byte_range,
+                max_byte_range,
+                left_child: None,
+                right_child: None,
+            };
+            min_byte_range = max_byte_range;
+            Ok(node)
+        })
+        .collect::<Result<Vec<_>, Error>>()?;
+    generate_data_root(nodes)
 }
 
 pub struct DataRootLeaf {
@@ -603,6 +734,43 @@ pub fn hash_all_sha256(messages: Vec<&[u8]>) -> [u8; 32] {
 mod tests {
     use super::ProofDeserialize as _;
     use super::*;
+
+    #[test]
+    fn expected_chunk_ranges_include_a_partial_tail() {
+        assert_eq!(
+            expected_chunk_byte_range(TxChunkOffset::from(0), 71, 32).unwrap(),
+            (0, 32)
+        );
+        assert_eq!(
+            expected_chunk_byte_range(TxChunkOffset::from(1), 71, 32).unwrap(),
+            (32, 64)
+        );
+        assert_eq!(
+            expected_chunk_byte_range(TxChunkOffset::from(2), 71, 32).unwrap(),
+            (64, 71)
+        );
+        assert!(expected_chunk_byte_range(TxChunkOffset::from(3), 71, 32).is_err());
+    }
+
+    #[test]
+    fn path_range_must_match_chunk_position_exactly() {
+        let mut path = ValidatePathResult {
+            leaf_hash: [0; HASH_SIZE],
+            min_byte_range: 64,
+            max_byte_range: 71,
+            is_rightmost_chunk: true,
+        };
+        assert!(validate_path_byte_range(&path, (64, 71), true).is_ok());
+
+        path.min_byte_range = 63;
+        assert!(validate_path_byte_range(&path, (64, 71), true).is_err());
+        path.min_byte_range = 64;
+        path.max_byte_range = 70;
+        assert!(validate_path_byte_range(&path, (64, 71), true).is_err());
+        path.max_byte_range = 71;
+        path.is_rightmost_chunk = false;
+        assert!(validate_path_byte_range(&path, (64, 71), true).is_err());
+    }
 
     #[test]
     fn validate_is_rightmost_chunk() {


### PR DESCRIPTION
**Describe the changes**

Fixes chunk-cache eviction and ingress-proof generation for Submit-ledger transactions larger than the bounded cache.

- Persist a compact, signer-bound ingress data hash for each validated chunk and reconstruct the existing ingress Merkle leaves from ordered offsets.
- Generate and sign the unchanged ingress-proof protocol from compact leaves instead of rereading every cached chunk body.
- Reclaim each cached body only after both its storage-module write is durable and its compact ingress state is present.
- Preserve write buffering and disk striping: normal paths use threshold/idle flushing rather than per-chunk `force_sync_pending_chunks()` calls.
- Make storage durability receipts, migration retries, restart recovery, duplicate delivery, and data-sync completion idempotent.
- Require an acknowledged compact-leaf commit before a data-sync write receives durable completion credit.
- Recover Publish migration bodies from the durable Submit copy after cache reclamation.
- Backfill compact leaves at startup for pre-upgrade cached bodies, revalidating their Merkle path, exact range, and body hash before crediting them.
- Update the oversized transaction regression to prove successful promotion and Publish availability.

The ingress hash, Merkle construction, signature payload, and verifier are unchanged.

**Related Issue(s)**

No linked issue.

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust style guidelines.

**Diff composition**

Cumulative line-level classification of the implementation and review commits (`041f7b008`, `6639e26ee`, and `752909b96`), counting inline `#[cfg(test)]` modules as test code. This is commit churn, so it includes lines refined by later commits:

| Surface | Additions | Deletions | Changed lines | Share of churn | Net growth |
| --- | ---: | ---: | ---: | ---: | ---: |
| Production | 1,887 | 1,005 | 2,892 | 65% | +882 |
| Tests | 1,283 | 305 | 1,588 | 35% | +978 |
| **Total** | **3,170** | **1,310** | **4,480** | **100%** | **+1,860** |

**Verification**

- `cargo fmt --all --check`
- `cargo clippy --workspace --tests --all-targets`
- `typos`
- 891 current unit tests across `irys-database`, `irys-domain`, and `irys-actors`
- focused Merkle range, compact-leaf equivalence, retry, eviction, durability, and cleanup tests
- `heavy_test_overlapping_data_sizes`
- `heavy_data_promotion_test`
- `spiky_slow_heavy_double_root_data_promotion_test`
- `heavy_test_oversized_tx_cache_eviction_allows_promotion`
- `spiky_slow_heavy4_sync_partition_data_between_peers_test`
- `slow_heavy4_promotion_with_multiple_proofs_test`

**Additional Context**

The new cache table is created automatically when an existing V3 database opens; no consensus database migration or wire-protocol change is required, so mixed-version operation remains compatible.

Operational caveats:

- After a new node has reclaimed a pending upload body, rolling that node back to 4.0.7 can strand that pending upload because 4.0.7 cannot consume compact leaves. Chain compatibility is unaffected, but rollback is lossy for those pending uploads.
- `max_cache_size_bytes` is now a correctness-constrained soft target. Pending or not-yet-durable bodies remain protected even under cache pressure; terminal/expired roots are still cleaned up by the existing lifecycle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ingress proofs can now be generated from persisted compact data, even when chunk bodies have been evicted from cache.
  * Data synchronization now tracks writes until they are durably stored, improving recovery and retry behavior.
* **Bug Fixes**
  * Fixed oversized transactions failing promotion after cache eviction.
  * Improved chunk validation and migration handling for missing or invalid cached data.
  * Cache cleanup now removes only safely durable, reclaimable data.
* **Documentation**
  * Updated snapshot export documentation to include cached ingress data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

