### PR TITLE
fix(data-sync): prevent sparse ledger starvation

### DIFF
--- a/crates/actors/src/data_sync_service.rs
+++ b/crates/actors/src/data_sync_service.rs
@@ -5,10 +5,13 @@ pub mod peer_stats;
 
 use crate::{
     chunk_fetcher::ChunkFetcherFactory,
-    chunk_ingress_service::{ChunkIngressError, facade::ChunkIngressFacadeImpl},
+    chunk_ingress_service::{
+        ChunkIngressError, CriticalChunkIngressError, facade::ChunkIngressFacadeImpl,
+    },
     metrics,
     services::ServiceSenders,
 };
+use chunk_fetcher::ChunkFetchFailureKind;
 use chunk_orchestrator::{ChunkBlockReason, ChunkOrchestrator, ChunkRequestState};
 use irys_database::db::IrysDatabaseExt as _;
 use irys_database::ingress_proofs_by_data_root;
@@ -81,6 +84,19 @@ fn attempt_data_sync_write(
     }
 }
 
+fn ingress_error_is_invalid_peer_data(error: &ChunkIngressError) -> bool {
+    matches!(
+        error,
+        ChunkIngressError::Critical(
+            CriticalChunkIngressError::InvalidProof
+                | CriticalChunkIngressError::InvalidDataHash
+                | CriticalChunkIngressError::InvalidChunkSize
+                | CriticalChunkIngressError::InvalidDataSize
+                | CriticalChunkIngressError::InvalidOffset(_)
+        )
+    )
+}
+
 async fn forward_chunk_to_ingress(
     service_senders: &ServiceSenders,
     unpacked: UnpackedChunk,
@@ -131,6 +147,9 @@ pub struct DataSyncServiceInner {
     rearm_backoff_remaining: u64,
     /// Skip budget applied after the next zero-yield pass (grows, capped).
     rearm_backoff_next_skips: u64,
+    /// Rotates which storage module gets the first opportunity to consume
+    /// shared peer concurrency on each scheduler tick.
+    orchestrator_dispatch_cursor: usize,
 }
 
 /// Re-arm `Blocked(MissingDataRootIndex)` when the local index looks ready.
@@ -149,6 +168,66 @@ const REARM_BACKOFF_INITIAL_SKIPS: u64 = 1;
 
 /// Cap zero-yield skip budget (~16s at 1s re-arm cadence).
 const REARM_BACKOFF_MAX_SKIPS: u64 = 16;
+
+/// Give every storage module one dispatch opportunity per round, rotating the
+/// first module between ticks. The callback returns whether it consumed work.
+/// Rounds stop once no module can use another shared peer permit.
+fn dispatch_round_robin<T: Copy>(
+    ids: &mut [T],
+    cursor: usize,
+    mut dispatch: impl FnMut(T) -> bool,
+) -> usize {
+    if ids.is_empty() {
+        return 0;
+    }
+    let start = cursor % ids.len();
+    ids.rotate_left(start);
+    loop {
+        let mut dispatched = false;
+        for id in ids.iter().copied() {
+            dispatched |= dispatch(id);
+        }
+        if !dispatched {
+            break;
+        }
+    }
+    (cursor + 1) % ids.len()
+}
+
+#[cfg(test)]
+mod scheduler_fairness_tests {
+    use super::dispatch_round_robin;
+
+    #[test]
+    fn shared_capacity_is_round_robin_across_storage_modules() {
+        let mut ids = [0_u8, 1_u8];
+        let mut permits = 3_usize;
+        let mut order = Vec::new();
+        let next_cursor = dispatch_round_robin(&mut ids, 0, |id| {
+            if permits == 0 {
+                return false;
+            }
+            permits -= 1;
+            order.push(id);
+            true
+        });
+        assert_eq!(order, vec![0, 1, 0]);
+        assert_eq!(next_cursor, 1);
+
+        let mut ids = [0_u8, 1_u8];
+        let mut permits = 3_usize;
+        let mut order = Vec::new();
+        let _ = dispatch_round_robin(&mut ids, next_cursor, |id| {
+            if permits == 0 {
+                return false;
+            }
+            permits -= 1;
+            order.push(id);
+            true
+        });
+        assert_eq!(order, vec![1, 0, 1]);
+    }
+}
 
 pub enum DataSyncServiceMessage {
     /// Refresh peer/orchestrator membership for current ledger-assigned SMs.
@@ -169,11 +248,7 @@ pub enum DataSyncServiceMessage {
         storage_module_id: usize,
         chunk_offset: PartitionChunkOffset,
         peer_addr: IrysAddress,
-    },
-    ChunkTimedOut {
-        storage_module_id: usize,
-        chunk_offset: PartitionChunkOffset,
-        peer_address: IrysAddress,
+        failure_kind: ChunkFetchFailureKind,
     },
     PeerListUpdated,
     PeerDisconnected {
@@ -207,6 +282,7 @@ impl DataSyncServiceInner {
             rearm_tick: 0,
             rearm_backoff_remaining: 0,
             rearm_backoff_next_skips: 0,
+            orchestrator_dispatch_cursor: 0,
         };
         data_sync.synchronize_peers_and_orchestrators();
         data_sync
@@ -226,8 +302,6 @@ impl DataSyncServiceInner {
                 peer_address: peer_addr,
                 chunk,
             } => {
-                // Fetch succeeded — record that separately from durable store.
-                metrics::record_data_sync_chunk_fetched();
                 if let Err(e) = self
                     .on_chunk_completed(storage_module_id, chunk_offset, peer_addr, chunk)
                     .await
@@ -244,24 +318,14 @@ impl DataSyncServiceInner {
                 storage_module_id,
                 chunk_offset,
                 peer_addr,
+                failure_kind,
             } => {
                 metrics::record_data_sync_chunk_failure();
-                if let Err(e) = self.on_chunk_failed(storage_module_id, chunk_offset, peer_addr) {
+                if let Err(e) =
+                    self.on_chunk_failed(storage_module_id, chunk_offset, peer_addr, failure_kind)
+                {
                     error!(
                         "Failed to handle chunk failure for storage_module {} chunk_offset {} from peer {}: {e:?}",
-                        storage_module_id, chunk_offset, peer_addr
-                    );
-                }
-            }
-            DataSyncServiceMessage::ChunkTimedOut {
-                storage_module_id,
-                chunk_offset,
-                peer_address: peer_addr,
-            } => {
-                metrics::record_data_sync_chunk_failure();
-                if let Err(e) = self.on_chunk_timeout(storage_module_id, chunk_offset, peer_addr) {
-                    error!(
-                        "Failed to handle chunk timeout for storage_module {} chunk_offset {} from peer {}: {e:?}",
                         storage_module_id, chunk_offset, peer_addr
                     );
                 }
@@ -277,8 +341,38 @@ impl DataSyncServiceInner {
 
     #[tracing::instrument(level = "trace", skip_all, err)]
     pub fn tick(&mut self) -> eyre::Result<()> {
-        for orchestrator in self.chunk_orchestrators.values_mut() {
-            orchestrator.tick()?;
+        let mut orchestrator_ids: Vec<_> = self.chunk_orchestrators.keys().copied().collect();
+        orchestrator_ids.sort_unstable();
+        for id in &orchestrator_ids {
+            if let Some(orchestrator) = self.chunk_orchestrators.get_mut(id) {
+                orchestrator.prepare_tick();
+            }
+        }
+
+        if !orchestrator_ids.is_empty() {
+            // One request per storage module per round. A sparse term ledger
+            // therefore cannot fill every shared peer permit before Publish or
+            // another storage module gets an opportunity to dispatch.
+            self.orchestrator_dispatch_cursor = dispatch_round_robin(
+                &mut orchestrator_ids,
+                self.orchestrator_dispatch_cursor,
+                |id| {
+                    self.chunk_orchestrators
+                        .get_mut(&id)
+                        .is_some_and(ChunkOrchestrator::dispatch_next)
+                },
+            );
+
+            for id in &orchestrator_ids {
+                if let Some(orchestrator) = self.chunk_orchestrators.get(id) {
+                    let state = orchestrator.get_metrics();
+                    metrics::record_data_sync_scheduler_state(
+                        orchestrator.ledger_id(),
+                        *id,
+                        &state,
+                    );
+                }
+            }
         }
         self.optimize_peer_concurrency();
         self.rearm_tick = self.rearm_tick.wrapping_add(1);
@@ -461,11 +555,6 @@ impl DataSyncServiceInner {
         peer_addr: IrysAddress,
         chunk: ChunkFormat,
     ) -> eyre::Result<()> {
-        // Peer delivery success: credit bandwidth stats, leave Requested until write outcome.
-        if let Some(orchestrator) = self.chunk_orchestrators.get_mut(&storage_module_id) {
-            orchestrator.on_chunk_fetched(chunk_offset, peer_addr)?;
-        }
-
         let consensus = &self.config.consensus;
         let unpacked_chunk = match chunk {
             ChunkFormat::Unpacked(u) => u,
@@ -485,11 +574,36 @@ impl DataSyncServiceInner {
             forward_chunk_to_ingress(&self.service_senders, unpacked_chunk.clone()).await
         {
             if let Some(orchestrator) = self.chunk_orchestrators.get_mut(&storage_module_id) {
-                orchestrator.requeue_after_local_write_failure(chunk_offset)?;
+                if ingress_error_is_invalid_peer_data(&error) {
+                    metrics::record_data_sync_chunk_failure();
+                    metrics::record_data_sync_fetch_failure(
+                        orchestrator.ledger_id(),
+                        peer_addr,
+                        "invalid_chunk",
+                    );
+                    orchestrator.on_chunk_failed(
+                        chunk_offset,
+                        peer_addr,
+                        ChunkFetchFailureKind::InvalidResponse,
+                    )?;
+                } else {
+                    // The peer delivered valid bytes as far as the network is
+                    // concerned; local ingress/database pressure must not
+                    // penalize that peer, but the offset remains unresolved.
+                    orchestrator.on_chunk_fetched(chunk_offset, peer_addr)?;
+                    orchestrator.requeue_after_local_write_failure(chunk_offset)?;
+                }
             }
             return Err(eyre::eyre!(
                 "chunk ingress rejected data-sync body before durable write: {error}"
             ));
+        }
+
+        // Validation accepted the body. Credit the fetch separately from the
+        // later storage-module durability transition.
+        metrics::record_data_sync_chunk_fetched();
+        if let Some(orchestrator) = self.chunk_orchestrators.get_mut(&storage_module_id) {
+            orchestrator.on_chunk_fetched(chunk_offset, peer_addr)?;
         }
 
         let sm = storage_module_by_id(&self.storage_modules.read().unwrap(), storage_module_id)
@@ -604,33 +718,21 @@ impl DataSyncServiceInner {
         storage_module_id: usize,
         chunk_offset: PartitionChunkOffset,
         peer_addr: IrysAddress,
+        failure_kind: ChunkFetchFailureKind,
     ) -> eyre::Result<()> {
         if let Some(orchestrator) = self.chunk_orchestrators.get_mut(&storage_module_id) {
-            orchestrator.on_chunk_failed(chunk_offset, peer_addr)?;
+            orchestrator.on_chunk_failed(chunk_offset, peer_addr, failure_kind)?;
 
-            let pa = orchestrator
-                .storage_module
-                .partition_assignment()
-                .expect("A partition assignment present");
-            debug!(
-                "chunk failed: ledger:{:?}, slot_index:{:?} chunk_offset:{} peer:{}",
-                pa.ledger_id, pa.slot_index, chunk_offset, peer_addr
-            );
-        }
-        Ok(())
-    }
-
-    #[tracing::instrument(level = "trace", skip_all, err)]
-    fn on_chunk_timeout(
-        &mut self,
-        storage_module_id: usize,
-        chunk_offset: PartitionChunkOffset,
-        peer_addr: IrysAddress,
-    ) -> eyre::Result<()> {
-        // TODO: Opportunity to do custom timeout tracking/handling here
-        debug!("chunk timed out: {} peer:{}", chunk_offset, peer_addr);
-        if let Some(orchestrator) = self.chunk_orchestrators.get_mut(&storage_module_id) {
-            orchestrator.on_chunk_failed(chunk_offset, peer_addr)?;
+            if failure_kind != ChunkFetchFailureKind::NotFound {
+                let pa = orchestrator
+                    .storage_module
+                    .partition_assignment()
+                    .expect("A partition assignment present");
+                debug!(
+                    "chunk failed: ledger:{:?}, slot_index:{:?} chunk_offset:{} peer:{} kind:{:?}",
+                    pa.ledger_id, pa.slot_index, chunk_offset, peer_addr, failure_kind
+                );
+            }
         }
         Ok(())
     }
@@ -959,7 +1061,7 @@ impl DataSyncServiceInner {
                         })
                     })
                     .count();
-                debug!(
+                tracing::trace!(
                     "data_sync_probe empty_peers sm_id={} ledger={:?} slot={:?} managers={} matching_assignments={}",
                     sm_id,
                     pa.ledger_id,
@@ -1182,7 +1284,8 @@ impl DataSyncService {
 
 #[cfg(test)]
 mod ingress_handoff_tests {
-    use super::forward_chunk_to_ingress;
+    use super::{forward_chunk_to_ingress, ingress_error_is_invalid_peer_data};
+    use crate::chunk_ingress_service::{ChunkIngressError, CriticalChunkIngressError};
     use crate::services::ServiceSenders;
     use irys_types::UnpackedChunk;
 
@@ -1197,6 +1300,16 @@ mod ingress_handoff_tests {
                 .is_err(),
             "data sync must not credit a body that ingress cannot durably acknowledge"
         );
+    }
+
+    #[test]
+    fn only_validation_failures_penalize_the_source_peer() {
+        assert!(ingress_error_is_invalid_peer_data(
+            &ChunkIngressError::Critical(CriticalChunkIngressError::InvalidProof,)
+        ));
+        assert!(!ingress_error_is_invalid_peer_data(
+            &ChunkIngressError::Critical(CriticalChunkIngressError::DatabaseError,)
+        ));
     }
 }
 

--- a/crates/actors/src/data_sync_service/chunk_fetcher.rs
+++ b/crates/actors/src/data_sync_service/chunk_fetcher.rs
@@ -27,6 +27,39 @@ pub enum ChunkFetchError {
     },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChunkFetchFailureKind {
+    NotFound,
+    Timeout,
+    Transport,
+    Server,
+    InvalidResponse,
+}
+
+impl ChunkFetchFailureKind {
+    pub const fn as_metric_label(self) -> &'static str {
+        match self {
+            Self::NotFound => "not_found",
+            Self::Timeout => "timeout",
+            Self::Transport => "transport",
+            Self::Server => "server",
+            Self::InvalidResponse => "invalid_response",
+        }
+    }
+}
+
+impl ChunkFetchError {
+    pub const fn kind(&self) -> ChunkFetchFailureKind {
+        match self {
+            Self::NotFound { .. } => ChunkFetchFailureKind::NotFound,
+            Self::Timeout => ChunkFetchFailureKind::Timeout,
+            Self::NetworkError { .. } => ChunkFetchFailureKind::Transport,
+            Self::ServerError { .. } => ChunkFetchFailureKind::Server,
+            Self::InvalidResponse { .. } => ChunkFetchFailureKind::InvalidResponse,
+        }
+    }
+}
+
 impl std::fmt::Display for ChunkFetchError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/crates/actors/src/data_sync_service/chunk_orchestrator/mod.rs
+++ b/crates/actors/src/data_sync_service/chunk_orchestrator/mod.rs
@@ -1,8 +1,6 @@
 use crate::{
-    DataSyncServiceMessage,
-    chunk_fetcher::{ChunkFetchError, ChunkFetcher},
-    data_sync_service::peer_bandwidth_manager::PeerBandwidthManager,
-    metrics,
+    DataSyncServiceMessage, chunk_fetcher::ChunkFetcher,
+    data_sync_service::peer_bandwidth_manager::PeerBandwidthManager, metrics,
     services::ServiceSenders,
 };
 use irys_domain::{BlockTreeReadGuard, ChunkTimeRecord, ChunkType, CircularBuffer, StorageModule};
@@ -11,22 +9,33 @@ use irys_types::{
     hardfork_config::DataLedgerLookup,
 };
 use std::{
-    collections::{HashMap, HashSet, hash_map},
+    collections::{HashMap, HashSet, VecDeque, hash_map},
     sync::{Arc, RwLock},
     time::{Duration, Instant},
 };
 use tracing::{Instrument as _, debug, warn};
 
-/// `data_sync_probe` diagnostics only fire for chunk offsets below this
-/// threshold. Residual sync stalls manifest as low-offset Entropy holes left
-/// behind while the packing tail (high offsets) is still legitimately Entropy —
-/// gating on low offsets keeps the probes quiet on healthy modules.
+/// Prefer residual holes below the ordinary packing tail when sampling data
+/// roots for ingress-proof signer peer expansion.
 pub(crate) const LOW_OFFSET_PROBE_THRESHOLD: u32 = 20_000;
 
 /// Durability normally follows the five-second idle-tail flush. A much larger
 /// monotonic deadline prevents a stalled write from parking sync forever
 /// without turning ordinary buffered writes into duplicate network requests.
 const DURABILITY_WAIT_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Retry an offset only after other ready work has had an opportunity to run.
+/// The delay is monotonic, doubles after each exhausted peer cycle, and is
+/// capped so data that appears later is eventually rediscovered.
+const RETRY_BACKOFF_INITIAL: Duration = Duration::from_secs(1);
+const RETRY_BACKOFF_MAX: Duration = Duration::from_secs(60);
+
+/// Bound scheduler bookkeeping independently from the partition's Entropy
+/// intervals, which remain the durable source of unresolved work on restart.
+/// When this many delayed entries are retained, the oldest delayed metadata is
+/// discarded; the rotating discovery cursor will encounter that Entropy offset
+/// again after giving the rest of the range an opportunity to run.
+const DELAYED_REQUEST_LIMIT_MULTIPLIER: usize = 1;
 
 /// How to request a missing body from a selected peer.
 ///
@@ -62,7 +71,8 @@ impl ChunkBlockReason {
 
 #[derive(Debug, PartialEq)]
 pub enum ChunkRequestState {
-    /// Chunk needs to be requested.
+    /// Chunk is at the back of the fair dispatch queue. `ChunkRequest::ready_since`
+    /// records its monotonic queue age for observability.
     Pending,
 
     /// Chunk has been requested from the specified peer at the given timestamp.
@@ -81,6 +91,10 @@ pub enum ChunkRequestState {
     /// `reconcile_awaiting_durability`.
     Completed,
 
+    /// Every currently eligible peer has failed this attempt cycle. The offset
+    /// remains unresolved but cannot consume a fetch slot before `retry_at`.
+    Delayed { retry_at: Instant },
+
     /// Locally blocked from hot re-fetch (index gap, etc.). Still retained while
     /// the offset is Entropy so we do not thrash peers. Cleared when the offset
     /// becomes Data, when a re-arm tick finds the local index ready for this
@@ -95,9 +109,14 @@ type ExcludedPeerAddresses = HashSet<IrysAddress>;
 /// assignment, so it is not duplicated per request.
 #[derive(Debug)]
 pub struct ChunkRequest {
-    pub chunk_offset: PartitionChunkOffset,
-    pub excluded: Option<ExcludedPeerAddresses>,
+    pub excluded: ExcludedPeerAddresses,
     pub request_state: ChunkRequestState,
+    /// Number of network attempts during this in-memory scheduler lifetime.
+    pub attempt_count: u32,
+    /// Number of attempt cycles that exhausted every currently eligible peer.
+    pub retry_round: u32,
+    /// Monotonic time this offset most recently joined the FIFO ready queue.
+    pub ready_since: Instant,
 }
 
 /// Orchestrates efficient chunk downloading for a StorageModule's assigned data partition.
@@ -110,6 +129,12 @@ pub struct ChunkRequest {
 #[derive(Debug)]
 pub struct ChunkOrchestrator {
     pub chunk_requests: HashMap<PartitionChunkOffset, ChunkRequest>,
+    /// Explicit FIFO ordering for ready work. Stale entries are skipped when a
+    /// request changes state, keeping state ownership in `chunk_requests`.
+    ready_offsets: VecDeque<PartitionChunkOffset>,
+    /// Next partition-relative offset considered while discovering Entropy.
+    /// This prevents a low sparse prefix from monopolizing queue population.
+    scan_cursor: u32,
     pub current_peers: Vec<IrysAddress>,
     block_tree: BlockTreeReadGuard,
     pub storage_module: Arc<StorageModule>,
@@ -141,6 +166,8 @@ impl ChunkOrchestrator {
         Self {
             storage_module,
             chunk_requests: Default::default(),
+            ready_offsets: Default::default(),
+            scan_cursor: 0,
             recent_chunk_times: CircularBuffer::new(8000),
             current_peers: Default::default(),
             block_tree,
@@ -153,7 +180,14 @@ impl ChunkOrchestrator {
         }
     }
 
-    pub fn tick(&mut self) -> eyre::Result<()> {
+    pub(crate) const fn ledger_id(&self) -> u32 {
+        self.ledger_id
+    }
+
+    /// Refresh local scheduler state. Dispatch is driven separately by
+    /// `DataSyncServiceInner` so storage modules can share peer concurrency in
+    /// round-robin order.
+    pub fn prepare_tick(&mut self) {
         // Only need to tick the Orchestrator if the partition is still assigned to a ledger.
         // Capacity partitions don't need to sync data.
         if self
@@ -162,10 +196,7 @@ impl ChunkOrchestrator {
             .is_some_and(|pa| pa.ledger_id.is_some())
         {
             self.populate_request_queue();
-            self.dispatch_chunk_requests();
         }
-
-        Ok(())
     }
 
     /// Promotes buffered writes the storage module now reports as fsynced, and
@@ -175,6 +206,7 @@ impl ChunkOrchestrator {
     /// notification, so nothing can strand a request and the answer is always
     /// the one restart recovery would reload.
     fn reconcile_awaiting_durability(&mut self, now: Instant, timeout: Duration) {
+        let mut ready = Vec::new();
         for (offset, request) in &mut self.chunk_requests {
             let ChunkRequestState::AwaitingDurability(started) = request.request_state else {
                 continue;
@@ -189,7 +221,9 @@ impl ChunkOrchestrator {
                 );
             } else if now.saturating_duration_since(started) >= timeout {
                 request.request_state = ChunkRequestState::Pending;
-                request.excluded = None;
+                request.ready_since = now;
+                request.excluded.clear();
+                ready.push(*offset);
                 metrics::record_data_sync_durability_stalled();
                 warn!(
                     chunk.offset = %offset,
@@ -198,11 +232,16 @@ impl ChunkOrchestrator {
                 );
             }
         }
+        self.ready_offsets.extend(ready);
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
     fn populate_request_queue(&mut self) {
-        self.reconcile_awaiting_durability(Instant::now(), DURABILITY_WAIT_TIMEOUT);
+        self.populate_request_queue_at(Instant::now());
+    }
+
+    fn populate_request_queue_at(&mut self, now: Instant) {
+        self.reconcile_awaiting_durability(now, DURABILITY_WAIT_TIMEOUT);
 
         // Retain in-flight requests (for telemetry tracking) and pending entropy requests.
         // Remove completed requests and pending requests for chunks that changed type
@@ -226,16 +265,44 @@ impl ChunkOrchestrator {
                 return false;
             }
 
-            // Keep Pending / Blocked while still Entropy. Drop Completed.
+            // Keep Ready / Delayed / Blocked while still Entropy. Drop Completed.
             !matches!(cr.request_state, ChunkRequestState::Completed)
         });
 
-        // Pending only — Blocked offsets intentionally do not consume the
-        // pending budget or get re-dispatched.
-        let pending_count: usize = self
+        // A delayed offset becomes ready only after its monotonic deadline.
+        // Peer exclusions are cleared here, at the beginning of a new attempt
+        // cycle, never in the same transition that handled a 404.
+        let due: Vec<_> = self
+            .chunk_requests
+            .iter()
+            .filter_map(|(&offset, request)| match request.request_state {
+                ChunkRequestState::Delayed { retry_at, .. } if retry_at <= now => Some(offset),
+                _ => None,
+            })
+            .collect();
+        for offset in due {
+            if let Some(request) = self.chunk_requests.get_mut(&offset) {
+                request.excluded.clear();
+                request.request_state = ChunkRequestState::Pending;
+                request.ready_since = now;
+                self.ready_offsets.push_back(offset);
+            }
+        }
+
+        // Ready and in-flight work share the configured hot-work budget.
+        // Delayed entries do not consume it, otherwise a sparse prefix could
+        // prevent discovery of later Entropy forever.
+        let hot_count = self
             .chunk_requests
             .values()
-            .filter(|r| matches!(r.request_state, ChunkRequestState::Pending))
+            .filter(|request| {
+                matches!(
+                    request.request_state,
+                    ChunkRequestState::Pending
+                        | ChunkRequestState::Requested(..)
+                        | ChunkRequestState::AwaitingDurability(..)
+                )
+            })
             .count();
 
         let max_chunk_offset = self.get_max_chunk_offset();
@@ -243,128 +310,191 @@ impl ChunkOrchestrator {
 
         let Some((max_chunk_offset, _)) = max_chunk_offset else {
             // Not requests needed
-            debug!(
+            tracing::trace!(
                 "No chunk requests needed for ledger:{:?} slot_index:{:?}",
-                pa.ledger_id, pa.slot_index
+                pa.ledger_id,
+                pa.slot_index
             );
             return;
         };
 
         let max_requests = self.config.data_sync.max_pending_chunk_requests as usize;
-        let mut requests_to_add = max_requests.saturating_sub(pending_count);
+        let mut requests_to_add = max_requests.saturating_sub(hot_count);
 
+        // Local Entropy intervals do not distinguish a natural term-ledger gap
+        // from a required body that is temporarily unavailable. Keep both
+        // unresolved: fair circular discovery plus delayed retries provides
+        // eventual reconciliation without falsely marking a 404 synchronized.
         let entropy_intervals = self.storage_module.get_intervals(ChunkType::Entropy);
-
-        // data_sync_probe: make empty-peer / residual-hole stalls diagnosable
-        // from DEBUG logs. Only fires when there is low-offset entropy (a hole
-        // below the packing tail) or pending/in-flight work, so healthy modules
-        // whose entropy is all packing tail stay silent on the 250ms tick.
-        let requested = self
-            .chunk_requests
-            .values()
-            .filter(|r| matches!(r.request_state, ChunkRequestState::Requested(..)))
-            .count();
-        let low_entropy: Vec<String> = entropy_intervals
-            .iter()
-            .filter(|iv| *iv.start() < LOW_OFFSET_PROBE_THRESHOLD)
-            .take(4)
-            .map(|iv| format!("{}-{}", *iv.start(), *iv.end()))
-            .collect();
-        if !low_entropy.is_empty() || pending_count > 0 || requested > 0 {
-            debug!(
-                "data_sync_probe ledger={:?} slot={:?} max={} pending={} requested={} peers={} to_add={} low_entropy={:?} map_size={}",
-                pa.ledger_id,
-                pa.slot_index,
-                *max_chunk_offset,
-                pending_count,
-                requested,
-                self.current_peers.len(),
-                requests_to_add,
-                low_entropy,
-                self.chunk_requests.len()
-            );
-        }
 
         if requests_to_add == 0 {
             return;
         }
 
-        for interval in entropy_intervals {
-            for interval_step in *interval.start()..=*interval.end() {
-                let chunk_offset = PartitionChunkOffset::from(interval_step);
+        let max_offset = *max_chunk_offset;
+        self.scan_cursor = self.scan_cursor.min(max_offset);
+        let cursor = self.scan_cursor;
+        let ranges = [(cursor, max_offset), (0, cursor.saturating_sub(1))];
+        let max_probes = max_requests.saturating_mul(4).max(max_requests);
+        let mut probes = 0_usize;
 
-                // Don't try to sync above the maximum amount of data stored in the partition
-                if chunk_offset > max_chunk_offset {
-                    return;
+        'scan: for (range_start, range_end) in ranges {
+            if range_start > range_end {
+                continue;
+            }
+            for interval in &entropy_intervals {
+                let start = (*interval.start()).max(range_start);
+                let end = (*interval.end()).min(range_end).min(max_offset);
+                if start > end {
+                    continue;
                 }
+                for interval_step in start..=end {
+                    probes += 1;
+                    self.scan_cursor = if interval_step == max_offset {
+                        0
+                    } else {
+                        interval_step.saturating_add(1)
+                    };
 
-                if let hash_map::Entry::Vacant(entry) = self.chunk_requests.entry(chunk_offset) {
-                    // Only executes when the entry in the hashmap is vacant
-                    entry.insert(ChunkRequest {
-                        chunk_offset,
-                        excluded: None, // First time chunk requests don't have past failed peer addresses
-                        request_state: ChunkRequestState::Pending,
-                    });
+                    let chunk_offset = PartitionChunkOffset::from(interval_step);
+                    let inserted = if let hash_map::Entry::Vacant(entry) =
+                        self.chunk_requests.entry(chunk_offset)
+                    {
+                        entry.insert(ChunkRequest {
+                            excluded: HashSet::new(),
+                            request_state: ChunkRequestState::Pending,
+                            attempt_count: 0,
+                            retry_round: 0,
+                            ready_since: now,
+                        });
+                        true
+                    } else {
+                        false
+                    };
 
-                    if *chunk_offset < LOW_OFFSET_PROBE_THRESHOLD {
-                        debug!(
-                            "data_sync_probe enqueued offset={} ledger={:?} slot={:?}",
-                            *chunk_offset, pa.ledger_id, pa.slot_index
-                        );
+                    if inserted {
+                        self.ready_offsets.push_back(chunk_offset);
+                        requests_to_add -= 1;
+                        if requests_to_add == 0 {
+                            break 'scan;
+                        }
                     }
-
-                    requests_to_add -= 1;
-                    if requests_to_add == 0 {
-                        return;
+                    if probes >= max_probes {
+                        break 'scan;
                     }
                 }
             }
         }
     }
 
+    /// Dispatch at most one ready offset. Returning `false` lets the service
+    /// stop the current round when this storage module cannot make progress.
     #[tracing::instrument(skip_all)]
-    fn dispatch_chunk_requests(&mut self) {
+    pub fn dispatch_next(&mut self) -> bool {
         if self.should_throttle_requests() {
             debug!("Throttling chunk requests due to storage throughput");
-            return;
+            return false;
         }
 
-        let pending_offsets: Vec<_> = self
-            .chunk_requests
-            .iter()
-            .filter_map(|(&offset, req)| {
-                matches!(req.request_state, ChunkRequestState::Pending).then_some(offset)
-            })
-            .collect();
+        while let Some(chunk_offset) = self.ready_offsets.pop_front() {
+            let Some((excluded, all_peers_exhausted)) = self
+                .chunk_requests
+                .get_mut(&chunk_offset)
+                .and_then(|chunk_request| {
+                    if !matches!(chunk_request.request_state, ChunkRequestState::Pending) {
+                        return None;
+                    }
+                    // Peer churn must not let exclusion bookkeeping grow without bound.
+                    chunk_request
+                        .excluded
+                        .retain(|peer| self.current_peers.contains(peer));
+                    let exhausted = !self.current_peers.is_empty()
+                        && self
+                            .current_peers
+                            .iter()
+                            .all(|peer| chunk_request.excluded.contains(peer));
+                    Some((chunk_request.excluded.clone(), exhausted))
+                })
+            else {
+                continue;
+            };
 
-        for chunk_offset in pending_offsets {
-            // Reset exclusions if all peers are excluded
-            if let Some(chunk_request) = self.chunk_requests.get_mut(&chunk_offset) {
-                chunk_request.excluded = chunk_request
-                    .excluded
-                    .take()
-                    .filter(|ex| ex.len() < self.current_peers.len());
+            if all_peers_exhausted {
+                self.delay_request(chunk_offset, Instant::now());
+                continue;
             }
 
-            // Find best peer and dispatch
-            let Some(chunk_request) = self.chunk_requests.get(&chunk_offset) else {
-                // Was the chunk requests at this offset removed? skip this offset (shouldn't happen)
-                continue;
-            };
-            let Some(peer_address) = self.find_best_peer(chunk_request.excluded.as_ref()) else {
-                // No available peers to request from? skip this offset (can happen)
-                if *chunk_offset < LOW_OFFSET_PROBE_THRESHOLD {
-                    debug!(
-                        "data_sync_probe no_peer offset={} peers={} excluded={:?}",
-                        *chunk_offset,
-                        self.current_peers.len(),
-                        chunk_request.excluded.as_ref().map(HashSet::len)
-                    );
-                }
-                continue;
+            let Some(peer_address) = self.find_best_peer(Some(&excluded)) else {
+                // Eligible peers exist but currently have no concurrency. Keep
+                // FIFO position for the next service tick without spinning.
+                self.ready_offsets.push_back(chunk_offset);
+                return false;
             };
 
-            self.dispatch_chunk_request(chunk_offset, peer_address);
+            if self.dispatch_chunk_request(chunk_offset, peer_address) {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    fn retry_delay(chunk_offset: PartitionChunkOffset, retry_round: u32) -> Duration {
+        let exponent = retry_round.saturating_sub(1).min(6);
+        let base = RETRY_BACKOFF_INITIAL
+            .saturating_mul(1_u32 << exponent)
+            .min(RETRY_BACKOFF_MAX);
+        // Stable per-offset jitter avoids synchronized retry waves without a
+        // random generator or wall-clock dependency. Keep the capped maximum.
+        let jitter_window_ms = (base.as_millis() / 4) as u64;
+        let jitter_ms = if jitter_window_ms == 0 {
+            0
+        } else {
+            u64::from(*chunk_offset).wrapping_mul(0x9e37_79b9) % (jitter_window_ms + 1)
+        };
+        base.saturating_add(Duration::from_millis(jitter_ms))
+            .min(RETRY_BACKOFF_MAX)
+    }
+
+    fn delay_request(&mut self, chunk_offset: PartitionChunkOffset, now: Instant) {
+        let Some(request) = self.chunk_requests.get_mut(&chunk_offset) else {
+            return;
+        };
+        request.retry_round = request.retry_round.saturating_add(1);
+        let retry_round = request.retry_round;
+        let delay = Self::retry_delay(chunk_offset, retry_round);
+        request.request_state = ChunkRequestState::Delayed {
+            retry_at: now + delay,
+        };
+        metrics::record_data_sync_retry_delay(self.ledger_id, delay);
+        metrics::record_data_sync_peers_exhausted(self.ledger_id);
+        self.trim_delayed_requests();
+    }
+
+    fn trim_delayed_requests(&mut self) {
+        let limit = (self.config.data_sync.max_pending_chunk_requests as usize)
+            .saturating_mul(DELAYED_REQUEST_LIMIT_MULTIPLIER)
+            .max(1);
+        let mut delayed_count = self
+            .chunk_requests
+            .values()
+            .filter(|request| matches!(request.request_state, ChunkRequestState::Delayed { .. }))
+            .count();
+        while delayed_count > limit {
+            let Some(offset) = self
+                .chunk_requests
+                .iter()
+                .filter_map(|(&offset, request)| match request.request_state {
+                    ChunkRequestState::Delayed { retry_at, .. } => Some((retry_at, offset)),
+                    _ => None,
+                })
+                .min_by_key(|(retry_at, _)| *retry_at)
+                .map(|(_, offset)| offset)
+            else {
+                break;
+            };
+            self.chunk_requests.remove(&offset);
+            delayed_count -= 1;
         }
     }
 
@@ -514,9 +644,9 @@ impl ChunkOrchestrator {
         &mut self,
         chunk_offset: PartitionChunkOffset,
         peer_addr: IrysAddress,
-    ) {
+    ) -> bool {
         let Some(request) = self.chunk_requests.get_mut(&chunk_offset) else {
-            return;
+            return false;
         };
 
         let slot_index = self
@@ -527,10 +657,10 @@ impl ChunkOrchestrator {
         let (api_addr, use_ledger_offset) = {
             let peers = match self.active_sync_peers.read() {
                 Ok(p) => p,
-                Err(_) => return,
+                Err(_) => return false,
             };
             let Some(peer_manager) = peers.get(&peer_addr) else {
-                return;
+                return false;
             };
             (
                 peer_manager.peer_address.api,
@@ -560,15 +690,14 @@ impl ChunkOrchestrator {
                     tx_offset,
                 },
                 Ok(None) => {
-                    debug!(
+                    tracing::trace!(
                         "data_sync_probe no_data_root_for_proof_peer offset={} peer={}",
-                        chunk_offset, peer_addr
+                        chunk_offset,
+                        peer_addr
                     );
-                    request
-                        .excluded
-                        .get_or_insert_with(HashSet::new)
-                        .insert(peer_addr);
-                    return;
+                    request.excluded.insert(peer_addr);
+                    self.ready_offsets.push_back(chunk_offset);
+                    return false;
                 }
                 Err(e) => {
                     warn!(
@@ -577,11 +706,9 @@ impl ChunkOrchestrator {
                         error = %e,
                         "failed to resolve data_root for proof-signer fetch; excluding peer"
                     );
-                    request
-                        .excluded
-                        .get_or_insert_with(HashSet::new)
-                        .insert(peer_addr);
-                    return;
+                    request.excluded.insert(peer_addr);
+                    self.ready_offsets.push_back(chunk_offset);
+                    return false;
                 }
             }
         };
@@ -594,11 +721,22 @@ impl ChunkOrchestrator {
         }
 
         let start_instant = Instant::now();
+        let attempt_kind = if request.attempt_count == 0 {
+            "fresh"
+        } else {
+            "retry"
+        };
+        if request.attempt_count == 0 {
+            metrics::record_data_sync_unique_offset_attempted(self.ledger_id);
+        }
+        request.attempt_count = request.attempt_count.saturating_add(1);
+        metrics::record_data_sync_attempt(self.ledger_id, attempt_kind);
         request.request_state = ChunkRequestState::Requested(peer_addr, start_instant);
 
         let chunk_fetcher = self.chunk_fetcher.clone();
         let tx = self.service_senders.data_sync.clone();
         let storage_module_id = self.storage_module.id;
+        let ledger_id = self.ledger_id;
         let timeout = self.config.data_sync.chunk_request_timeout;
         let source_label: &'static str = if use_ledger_offset {
             "assigned"
@@ -608,7 +746,7 @@ impl ChunkOrchestrator {
 
         self.runtime_handle.spawn(
             async move {
-                debug!(
+                tracing::trace!(
                     "Fetching chunk {chunk_offset} from {api_addr} via {source_label} ({fetch_mode:?})"
                 );
 
@@ -638,20 +776,22 @@ impl ChunkOrchestrator {
                             chunk,
                         }
                     }
-                    Err(ChunkFetchError::Timeout) => {
-                        metrics::record_data_sync_fetch_by_source(source_label, "fail");
-                        DataSyncServiceMessage::ChunkTimedOut {
-                            storage_module_id,
-                            chunk_offset,
-                            peer_address: peer_addr,
-                        }
-                    }
-                    Err(_) => {
-                        metrics::record_data_sync_fetch_by_source(source_label, "fail");
+                    Err(error) => {
+                        let failure_kind = error.kind();
+                        metrics::record_data_sync_fetch_by_source(
+                            source_label,
+                            failure_kind.as_metric_label(),
+                        );
+                        metrics::record_data_sync_fetch_failure(
+                            ledger_id,
+                            peer_addr,
+                            failure_kind.as_metric_label(),
+                        );
                         DataSyncServiceMessage::ChunkFailed {
                             storage_module_id,
                             chunk_offset,
                             peer_addr,
+                            failure_kind,
                         }
                     }
                 };
@@ -661,6 +801,7 @@ impl ChunkOrchestrator {
             }
             .instrument(tracing::Span::current()),
         );
+        true
     }
 
     /// Peer delivered the chunk body. Credits peer bandwidth stats but leaves
@@ -686,6 +827,7 @@ impl ChunkOrchestrator {
             ref invalid_state @ (ChunkRequestState::Pending
             | ChunkRequestState::AwaitingDurability(..)
             | ChunkRequestState::Completed
+            | ChunkRequestState::Delayed { .. }
             | ChunkRequestState::Blocked(_)) => {
                 return Err(eyre::eyre!(
                     "Invalid state for chunk fetch at offset {}: expected Requested, got {:?}",
@@ -785,7 +927,7 @@ impl ChunkOrchestrator {
         }
         request.request_state = ChunkRequestState::Blocked(reason);
         // Clear peer exclusions — the failure is local, not peer-specific.
-        request.excluded = None;
+        request.excluded.clear();
         Ok(())
     }
 
@@ -823,6 +965,7 @@ impl ChunkOrchestrator {
         }
         offsets.sort_unstable();
         let mut count = 0_usize;
+        let now = Instant::now();
         for (probe_idx, offset) in offsets.into_iter().enumerate() {
             if count >= max || probe_idx >= max_probes {
                 break;
@@ -832,6 +975,10 @@ impl ChunkOrchestrator {
             }
             if let Some(request) = self.chunk_requests.get_mut(&offset) {
                 request.request_state = ChunkRequestState::Pending;
+                request.ready_since = now;
+                request.excluded.clear();
+                request.retry_round = 0;
+                self.ready_offsets.push_back(offset);
                 count += 1;
             }
         }
@@ -866,6 +1013,10 @@ impl ChunkOrchestrator {
             ));
         }
         request.request_state = ChunkRequestState::Pending;
+        request.ready_since = Instant::now();
+        request.excluded.clear();
+        request.retry_round = 0;
+        self.ready_offsets.push_back(chunk_offset);
         // Do not add the delivering peer to `excluded` — they succeeded.
         Ok(())
     }
@@ -878,46 +1029,64 @@ impl ChunkOrchestrator {
         &mut self,
         chunk_offset: PartitionChunkOffset,
         peer_addr: IrysAddress,
+        failure_kind: crate::chunk_fetcher::ChunkFetchFailureKind,
     ) -> eyre::Result<()> {
-        let request = self
-            .chunk_requests
-            .get_mut(&chunk_offset)
-            .ok_or_else(|| eyre::eyre!("Chunk failure for unknown offset: {:?}", chunk_offset))?;
+        let all_peers_exhausted = {
+            let request = self.chunk_requests.get_mut(&chunk_offset).ok_or_else(|| {
+                eyre::eyre!("Chunk failure for unknown offset: {:?}", chunk_offset)
+            })?;
 
-        let expected_peer = match request.request_state {
-            ChunkRequestState::Requested(addr, _) => addr,
-            ChunkRequestState::Pending
-            | ChunkRequestState::AwaitingDurability(..)
-            | ChunkRequestState::Completed
-            | ChunkRequestState::Blocked(_) => {
+            let expected_peer = match request.request_state {
+                ChunkRequestState::Requested(addr, _) => addr,
+                ChunkRequestState::Pending
+                | ChunkRequestState::AwaitingDurability(..)
+                | ChunkRequestState::Completed
+                | ChunkRequestState::Delayed { .. }
+                | ChunkRequestState::Blocked(_) => {
+                    return Err(eyre::eyre!(
+                        "Invalid request state for chunk failure: {:?}",
+                        chunk_offset
+                    ));
+                }
+            };
+
+            if expected_peer != peer_addr {
                 return Err(eyre::eyre!(
-                    "Invalid request state for chunk failure: {:?}",
-                    chunk_offset
+                    "Peer mismatch for chunk failure: {:?} expected peer: {} actual: {}",
+                    chunk_offset,
+                    expected_peer,
+                    peer_addr
                 ));
             }
+
+            request.excluded.insert(expected_peer);
+            !self.current_peers.is_empty()
+                && self
+                    .current_peers
+                    .iter()
+                    .all(|peer| request.excluded.contains(peer))
         };
-
-        if expected_peer != peer_addr {
-            return Err(eyre::eyre!(
-                "Peer mismatch for chunk failure: {:?} expected peer: {} actual: {}",
-                chunk_offset,
-                expected_peer,
-                peer_addr
-            ));
-        }
-
-        debug!("resetting failed chunk to Pending {}", chunk_offset);
-        // Record the peer that was expected to provide this chunk but failed
-        request.request_state = ChunkRequestState::Pending;
-        request
-            .excluded
-            .get_or_insert_with(HashSet::new)
-            .insert(expected_peer);
 
         if let Ok(mut peers) = self.active_sync_peers.write()
             && let Some(peer_manager) = peers.get_mut(&peer_addr)
         {
-            peer_manager.on_chunk_request_failure();
+            match failure_kind {
+                crate::chunk_fetcher::ChunkFetchFailureKind::NotFound => {
+                    peer_manager.on_chunk_not_found()
+                }
+                _ => peer_manager.on_chunk_request_failure(),
+            }
+        }
+
+        let now = Instant::now();
+        if all_peers_exhausted {
+            self.delay_request(chunk_offset, now);
+        } else if let Some(request) = self.chunk_requests.get_mut(&chunk_offset) {
+            // A failed or currently unavailable offset remains unresolved, but
+            // goes to the FIFO tail so other ready offsets and peers run first.
+            request.request_state = ChunkRequestState::Pending;
+            request.ready_since = now;
+            self.ready_offsets.push_back(chunk_offset);
         }
 
         Ok(())
@@ -932,32 +1101,48 @@ impl ChunkOrchestrator {
     pub fn remove_peer(&mut self, peer_addr: IrysAddress) {
         self.current_peers.retain(|&addr| addr != peer_addr);
 
-        for request in self.chunk_requests.values_mut() {
+        let now = Instant::now();
+        let mut ready = Vec::new();
+        for (offset, request) in &mut self.chunk_requests {
             if let ChunkRequestState::Requested(addr, _) = request.request_state
                 && addr == peer_addr
             {
                 request.request_state = ChunkRequestState::Pending;
-                request
-                    .excluded
-                    .get_or_insert_with(HashSet::new)
-                    .insert(addr);
+                request.ready_since = now;
+                request.excluded.insert(addr);
+                ready.push(*offset);
             }
         }
+        self.ready_offsets.extend(ready);
     }
 
     pub fn get_metrics(&self) -> OrchestrationMetrics {
-        let (pending, active, awaiting_durability, completed, blocked) = self
+        let (ready, active, awaiting_durability, completed, delayed, blocked) = self
             .chunk_requests
             .values()
-            .fold((0, 0, 0, 0, 0), |(p, a, d, c, b), request| {
-                match request.request_state {
-                    ChunkRequestState::Pending => (p + 1, a, d, c, b),
-                    ChunkRequestState::Requested(_, _) => (p, a + 1, d, c, b),
-                    ChunkRequestState::AwaitingDurability(..) => (p, a, d + 1, c, b),
-                    ChunkRequestState::Completed => (p, a, d, c + 1, b),
-                    ChunkRequestState::Blocked(_) => (p, a, d, c, b + 1),
+            .fold(
+                (0, 0, 0, 0, 0, 0),
+                |(r, a, w, c, d, b), request| match request.request_state {
+                    ChunkRequestState::Pending => (r + 1, a, w, c, d, b),
+                    ChunkRequestState::Requested(_, _) => (r, a + 1, w, c, d, b),
+                    ChunkRequestState::AwaitingDurability(..) => (r, a, w + 1, c, d, b),
+                    ChunkRequestState::Completed => (r, a, w, c + 1, d, b),
+                    ChunkRequestState::Delayed { .. } => (r, a, w, c, d + 1, b),
+                    ChunkRequestState::Blocked(_) => (r, a, w, c, d, b + 1),
+                },
+            );
+
+        let oldest_ready_age = self
+            .chunk_requests
+            .values()
+            .filter_map(|request| match request.request_state {
+                ChunkRequestState::Pending => {
+                    Some(Instant::now().duration_since(request.ready_since))
                 }
-            });
+                _ => None,
+            })
+            .max()
+            .unwrap_or_default();
 
         let total_throughput_bps = if let Ok(peers) = self.active_sync_peers.read() {
             self.current_peers
@@ -971,11 +1156,14 @@ impl ChunkOrchestrator {
 
         OrchestrationMetrics {
             total_peers: self.current_peers.len(),
-            pending_requests: pending,
+            pending_requests: ready,
             active_requests: active,
             awaiting_durability_requests: awaiting_durability,
             completed_requests: completed,
+            delayed_requests: delayed,
             blocked_requests: blocked,
+            oldest_ready_age,
+            scan_cursor: self.scan_cursor,
             total_throughput_bps,
         }
     }
@@ -988,7 +1176,10 @@ pub struct OrchestrationMetrics {
     pub active_requests: usize,
     pub awaiting_durability_requests: usize,
     pub completed_requests: usize,
+    pub delayed_requests: usize,
     pub blocked_requests: usize,
+    pub oldest_ready_age: Duration,
+    pub scan_cursor: u32,
     pub total_throughput_bps: u64,
 }
 

--- a/crates/actors/src/data_sync_service/chunk_orchestrator/mod.rs
+++ b/crates/actors/src/data_sync_service/chunk_orchestrator/mod.rs
@@ -25,16 +25,19 @@ pub(crate) const LOW_OFFSET_PROBE_THRESHOLD: u32 = 20_000;
 const DURABILITY_WAIT_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Retry an offset only after other ready work has had an opportunity to run.
-/// The delay is monotonic, doubles after each exhausted peer cycle, and is
-/// capped so data that appears later is eventually rediscovered.
+/// While its in-memory request record is retained, the delay is monotonic,
+/// doubles after each exhausted peer cycle, and is capped so data that appears
+/// later is eventually rediscovered.
 const RETRY_BACKOFF_INITIAL: Duration = Duration::from_secs(1);
 const RETRY_BACKOFF_MAX: Duration = Duration::from_secs(60);
 
 /// Bound scheduler bookkeeping independently from the partition's Entropy
 /// intervals, which remain the durable source of unresolved work on restart.
-/// When this many delayed entries are retained, the oldest delayed metadata is
-/// discarded; the rotating discovery cursor will encounter that Entropy offset
-/// again after giving the rest of the range an opportunity to run.
+/// When this many delayed entries are retained, the entry with the soonest
+/// retry deadline is discarded because it has the least suppression left.
+/// This retains the longer backoff for repeat offenders while the rotating
+/// discovery cursor eventually rediscovers the discarded Entropy offset. As
+/// on restart, rediscovery resets that offset's ephemeral backoff.
 const DELAYED_REQUEST_LIMIT_MULTIPLIER: usize = 1;
 
 /// How to request a missing body from a selected peer.
@@ -657,9 +660,15 @@ impl ChunkOrchestrator {
         let (api_addr, use_ledger_offset) = {
             let peers = match self.active_sync_peers.read() {
                 Ok(p) => p,
-                Err(_) => return false,
+                Err(_) => {
+                    self.ready_offsets.push_back(chunk_offset);
+                    return false;
+                }
             };
             let Some(peer_manager) = peers.get(&peer_addr) else {
+                // The peer can disappear between selection and dispatch. Keep
+                // the still-Pending offset in the FIFO for another peer.
+                self.ready_offsets.push_back(chunk_offset);
                 return false;
             };
             (
@@ -1132,13 +1141,12 @@ impl ChunkOrchestrator {
                 },
             );
 
+        let now = Instant::now();
         let oldest_ready_age = self
             .chunk_requests
             .values()
             .filter_map(|request| match request.request_state {
-                ChunkRequestState::Pending => {
-                    Some(Instant::now().duration_since(request.ready_since))
-                }
+                ChunkRequestState::Pending => Some(now.duration_since(request.ready_since)),
                 _ => None,
             })
             .max()

--- a/crates/actors/src/data_sync_service/chunk_orchestrator/tests.rs
+++ b/crates/actors/src/data_sync_service/chunk_orchestrator/tests.rs
@@ -900,23 +900,29 @@ async fn exhausting_all_peers_delays_then_rearms_offset() {
 }
 
 #[test_log::test(tokio::test)]
-async fn delayed_retry_metadata_is_bounded() {
+async fn delayed_retry_metadata_discards_soonest_deadline_within_bound() {
     let tmp = TempDirBuilder::new().with_tracing().build();
     let config = test_config_with_pending_limit(tmp.path().to_path_buf(), 8, 2);
     let sm = packed_sm(&config, 8);
     let mut orch = make_orchestrator(sm, &config);
-    let peer = add_assigned_peer(&mut orch, &config, 51, 9051);
+    let now = Instant::now();
 
     for value in 0..3_u32 {
         let offset = PartitionChunkOffset::from(value);
-        insert_requested(&mut orch, offset, peer);
-        orch.on_chunk_failed(
+        orch.chunk_requests.insert(
             offset,
-            peer,
-            crate::chunk_fetcher::ChunkFetchFailureKind::NotFound,
-        )
-        .unwrap();
+            ChunkRequest {
+                excluded: HashSet::new(),
+                request_state: ChunkRequestState::Delayed {
+                    retry_at: now + Duration::from_secs(u64::from(value) + 1),
+                },
+                attempt_count: 1,
+                retry_round: 1,
+                ready_since: now,
+            },
+        );
     }
+    orch.trim_delayed_requests();
 
     assert_eq!(
         orch.chunk_requests
@@ -929,8 +935,33 @@ async fn delayed_retry_metadata_is_bounded() {
         !orch
             .chunk_requests
             .contains_key(&PartitionChunkOffset::from(0_u32)),
-        "old retry metadata is dropped; Entropy remains the reconciliation source"
+        "the soonest retry has the least suppression left and returns to Entropy reconciliation"
     );
+    assert!(
+        orch.chunk_requests
+            .contains_key(&PartitionChunkOffset::from(2_u32)),
+        "the longest remaining backoff must be retained"
+    );
+}
+
+#[test_log::test(tokio::test)]
+async fn dispatch_restores_pending_offset_when_selected_peer_disappears() {
+    let tmp = TempDirBuilder::new().with_tracing().build();
+    let config = test_config(tmp.path().to_path_buf(), 4);
+    let sm = packed_sm(&config, 4);
+    let mut orch = make_orchestrator(sm, &config);
+    let peer = add_assigned_peer(&mut orch, &config, 52, 9052);
+    let offset = PartitionChunkOffset::from(0_u32);
+    insert_pending(&mut orch, offset);
+    orch.ready_offsets.clear();
+    orch.active_sync_peers.write().unwrap().remove(&peer);
+
+    assert!(!orch.dispatch_chunk_request(offset, peer));
+    assert!(matches!(
+        orch.chunk_requests[&offset].request_state,
+        ChunkRequestState::Pending
+    ));
+    assert_eq!(orch.ready_offsets.front(), Some(&offset));
 }
 
 #[test_log::test(tokio::test)]

--- a/crates/actors/src/data_sync_service/chunk_orchestrator/tests.rs
+++ b/crates/actors/src/data_sync_service/chunk_orchestrator/tests.rs
@@ -4,12 +4,20 @@ use irys_domain::ChunkType;
 use irys_domain::{BlockTree, StorageModuleInfo};
 use irys_testing_utils::TempDirBuilder;
 use irys_types::{
-    Config, ConsensusConfig, DataLedger, H256, IrysAddress, NodeConfig,
+    Config, ConsensusConfig, DataLedger, H256, IrysAddress, NodeConfig, PeerAddress, PeerListItem,
     partition::PartitionAssignment, partition_chunk_offset_ie,
 };
 
 fn test_config(base_directory: std::path::PathBuf, num_chunks: u64) -> Config {
-    let node_config = NodeConfig {
+    test_config_with_pending_limit(base_directory, num_chunks, 1_000)
+}
+
+fn test_config_with_pending_limit(
+    base_directory: std::path::PathBuf,
+    num_chunks: u64,
+    max_pending_chunk_requests: u64,
+) -> Config {
+    let mut node_config = NodeConfig {
         consensus: irys_types::ConsensusOptions::Custom(ConsensusConfig {
             chunk_size: 32,
             num_chunks_in_partition: num_chunks,
@@ -23,12 +31,21 @@ fn test_config(base_directory: std::path::PathBuf, num_chunks: u64) -> Config {
         base_directory,
         ..NodeConfig::testing()
     };
+    node_config.data_sync.max_pending_chunk_requests = max_pending_chunk_requests;
     Config::new_with_random_peer_id(node_config)
 }
 
 fn packed_sm(config: &Config, num_chunks: u64) -> Arc<StorageModule> {
+    packed_sm_for_ledger(config, num_chunks, DataLedger::Publish)
+}
+
+fn packed_sm_for_ledger(
+    config: &Config,
+    num_chunks: u64,
+    ledger: DataLedger,
+) -> Arc<StorageModule> {
     let pa = PartitionAssignment {
-        ledger_id: Some(DataLedger::Publish.into()),
+        ledger_id: Some(ledger.into()),
         slot_index: Some(0),
         miner_address: IrysAddress::from([1_u8; 20]),
         partition_hash: H256::random(),
@@ -63,6 +80,30 @@ fn make_orchestrator(sm: Arc<StorageModule>, config: &Config) -> ChunkOrchestrat
     )
 }
 
+fn make_orchestrator_with_ledger_chunks(
+    sm: Arc<StorageModule>,
+    config: &Config,
+    total_chunks: u64,
+) -> ChunkOrchestrator {
+    use irys_testing_utils::IrysBlockHeaderTestExt as _;
+
+    let mut genesis = irys_testing_utils::new_mock_signed_header();
+    genesis.data_ledgers[DataLedger::Publish].total_chunks = total_chunks;
+    genesis.test_sign();
+    let block_tree = BlockTree::new(&genesis, config.consensus.clone());
+    let block_tree_guard = BlockTreeReadGuard::new(Arc::new(RwLock::new(block_tree)));
+    let (service_senders, _receivers) = build_test_service_senders();
+    ChunkOrchestrator::new(
+        sm,
+        Arc::new(RwLock::new(HashMap::new())),
+        block_tree_guard,
+        &service_senders,
+        Arc::new(MockChunkFetcher::new(DataLedger::Publish as usize)),
+        config.node_config.clone(),
+        tokio::runtime::Handle::current(),
+    )
+}
+
 /// Makes `offset` durably `Data` the way the write path does: buffer, then
 /// flush + fsync. `is_data_chunk_durable_at` only becomes true after the fsync.
 fn store_durable_data(sm: &StorageModule, offset: PartitionChunkOffset, chunk_size: usize) {
@@ -86,11 +127,60 @@ fn insert_requested(orch: &mut ChunkOrchestrator, offset: PartitionChunkOffset, 
     orch.chunk_requests.insert(
         offset,
         ChunkRequest {
-            chunk_offset: offset,
-            excluded: None,
+            excluded: HashSet::new(),
             request_state: ChunkRequestState::Requested(peer, Instant::now()),
+            attempt_count: 1,
+            retry_round: 0,
+            ready_since: Instant::now(),
         },
     );
+}
+
+fn insert_pending(orch: &mut ChunkOrchestrator, offset: PartitionChunkOffset) {
+    let now = Instant::now();
+    orch.chunk_requests.insert(
+        offset,
+        ChunkRequest {
+            excluded: HashSet::new(),
+            request_state: ChunkRequestState::Pending,
+            attempt_count: 0,
+            retry_round: 0,
+            ready_since: now,
+        },
+    );
+    orch.ready_offsets.push_back(offset);
+}
+
+fn add_assigned_peer(
+    orch: &mut ChunkOrchestrator,
+    config: &Config,
+    byte: u8,
+    port: u16,
+) -> IrysAddress {
+    let address = IrysAddress::from([byte; 20]);
+    let api = format!("127.0.0.1:{port}").parse().unwrap();
+    let item = PeerListItem {
+        mining_address: address,
+        address: PeerAddress {
+            api,
+            gossip: api,
+            ..Default::default()
+        },
+        is_online: true,
+        ..Default::default()
+    };
+    let mut manager = PeerBandwidthManager::new(&address, &item, config);
+    manager.partition_assignments.push(
+        orch.storage_module
+            .partition_assignment()
+            .expect("assigned storage module"),
+    );
+    orch.active_sync_peers
+        .write()
+        .unwrap()
+        .insert(address, manager);
+    orch.add_peer(address);
+    address
 }
 
 #[test_log::test(tokio::test)]
@@ -116,9 +206,11 @@ async fn mark_helpers_require_valid_source_state() {
     orch.chunk_requests.insert(
         offset,
         ChunkRequest {
-            chunk_offset: offset,
-            excluded: None,
+            excluded: HashSet::new(),
             request_state: ChunkRequestState::Pending,
+            attempt_count: 0,
+            retry_round: 0,
+            ready_since: Instant::now(),
         },
     );
     assert!(orch.mark_chunk_awaiting_durability(offset).is_err());
@@ -162,7 +254,7 @@ async fn mark_helpers_require_valid_source_state() {
         ChunkRequestState::Pending
     );
     // Requeue must not blame the delivering peer.
-    assert!(orch.chunk_requests[&offset].excluded.is_none());
+    assert!(orch.chunk_requests[&offset].excluded.is_empty());
 }
 
 #[test_log::test(tokio::test)]
@@ -235,7 +327,7 @@ async fn durability_poll_returns_a_stalled_wait_to_pending() {
         "a write that never became durable must be re-fetchable"
     );
     assert!(
-        orch.chunk_requests[&waiting].excluded.is_none(),
+        orch.chunk_requests[&waiting].excluded.is_empty(),
         "a stalled local write must not blame the delivering peer"
     );
 }
@@ -392,9 +484,11 @@ async fn blocked_excluded_from_pending_budget_and_dispatch_selection() {
     orch.chunk_requests.insert(
         offset3,
         ChunkRequest {
-            chunk_offset: offset3,
-            excluded: None,
+            excluded: HashSet::new(),
             request_state: ChunkRequestState::Pending,
+            attempt_count: 0,
+            retry_round: 0,
+            ready_since: Instant::now(),
         },
     );
     let metrics = orch.get_metrics();
@@ -431,9 +525,11 @@ async fn unblock_missing_data_root_index_requeues_only_that_reason() {
     orch.chunk_requests.insert(
         pending,
         ChunkRequest {
-            chunk_offset: pending,
-            excluded: None,
+            excluded: HashSet::new(),
             request_state: ChunkRequestState::Pending,
+            attempt_count: 0,
+            retry_round: 0,
+            ready_since: Instant::now(),
         },
     );
 
@@ -657,5 +753,311 @@ async fn unblock_where_respects_max_probes() {
     assert_eq!(
         orch.chunk_requests[&PartitionChunkOffset::from(5_u32)].request_state,
         ChunkRequestState::Pending
+    );
+}
+
+#[test_log::test(tokio::test)]
+async fn failed_offset_returns_to_fifo_tail_after_other_ready_work() {
+    let tmp = TempDirBuilder::new().with_tracing().build();
+    let config = test_config(tmp.path().to_path_buf(), 8);
+    let sm = packed_sm(&config, 8);
+    let mut orch = make_orchestrator(sm, &config);
+    let peer_a = add_assigned_peer(&mut orch, &config, 21, 9021);
+    let _peer_b = add_assigned_peer(&mut orch, &config, 22, 9022);
+    let failed = PartitionChunkOffset::from(0_u32);
+    let later_a = PartitionChunkOffset::from(6_u32);
+    let later_b = PartitionChunkOffset::from(7_u32);
+
+    insert_pending(&mut orch, later_a);
+    insert_pending(&mut orch, later_b);
+    insert_requested(&mut orch, failed, peer_a);
+    orch.on_chunk_failed(
+        failed,
+        peer_a,
+        crate::chunk_fetcher::ChunkFetchFailureKind::NotFound,
+    )
+    .unwrap();
+
+    assert_eq!(
+        orch.ready_offsets.iter().copied().collect::<Vec<_>>(),
+        vec![later_a, later_b, failed],
+        "a failed sparse-prefix offset must yield to every offset already ready"
+    );
+}
+
+#[test_log::test(tokio::test)]
+async fn not_found_rotates_peer_without_global_health_penalty() {
+    let tmp = TempDirBuilder::new().with_tracing().build();
+    let config = test_config(tmp.path().to_path_buf(), 4);
+    let sm = packed_sm(&config, 4);
+    let mut orch = make_orchestrator(sm, &config);
+    let peer_a = add_assigned_peer(&mut orch, &config, 31, 9031);
+    let peer_b = add_assigned_peer(&mut orch, &config, 32, 9032);
+    let offset = PartitionChunkOffset::from(0_u32);
+    insert_requested(&mut orch, offset, peer_a);
+    orch.active_sync_peers
+        .write()
+        .unwrap()
+        .get_mut(&peer_a)
+        .unwrap()
+        .on_chunk_request_started();
+
+    orch.on_chunk_failed(
+        offset,
+        peer_a,
+        crate::chunk_fetcher::ChunkFetchFailureKind::NotFound,
+    )
+    .unwrap();
+
+    let request = &orch.chunk_requests[&offset];
+    assert!(matches!(request.request_state, ChunkRequestState::Pending));
+    assert!(request.excluded.contains(&peer_a));
+    assert!(!request.excluded.contains(&peer_b));
+    assert_eq!(orch.find_best_peer(Some(&request.excluded)), Some(peer_b));
+    let peers = orch.active_sync_peers.read().unwrap();
+    let peer_a_stats = &peers[&peer_a];
+    assert_eq!(peer_a_stats.active_requests(), 0);
+    assert_eq!(peer_a_stats.total_failures(), 0);
+}
+
+#[test_log::test(tokio::test)]
+async fn transport_failure_releases_concurrency_and_penalizes_peer() {
+    let tmp = TempDirBuilder::new().with_tracing().build();
+    let config = test_config(tmp.path().to_path_buf(), 4);
+    let sm = packed_sm(&config, 4);
+    let mut orch = make_orchestrator(sm, &config);
+    let peer = add_assigned_peer(&mut orch, &config, 33, 9033);
+    let offset = PartitionChunkOffset::from(0_u32);
+    insert_requested(&mut orch, offset, peer);
+    orch.active_sync_peers
+        .write()
+        .unwrap()
+        .get_mut(&peer)
+        .unwrap()
+        .on_chunk_request_started();
+
+    orch.on_chunk_failed(
+        offset,
+        peer,
+        crate::chunk_fetcher::ChunkFetchFailureKind::Transport,
+    )
+    .unwrap();
+
+    let peers = orch.active_sync_peers.read().unwrap();
+    assert_eq!(peers[&peer].active_requests(), 0);
+    assert_eq!(peers[&peer].total_failures(), 1);
+}
+
+#[test_log::test(tokio::test)]
+async fn exhausting_all_peers_delays_then_rearms_offset() {
+    let tmp = TempDirBuilder::new().with_tracing().build();
+    let config = test_config(tmp.path().to_path_buf(), 4);
+    let sm = packed_sm(&config, 4);
+    let mut orch = make_orchestrator(sm, &config);
+    let peer_a = add_assigned_peer(&mut orch, &config, 41, 9041);
+    let peer_b = add_assigned_peer(&mut orch, &config, 42, 9042);
+    let offset = PartitionChunkOffset::from(0_u32);
+
+    insert_requested(&mut orch, offset, peer_a);
+    orch.on_chunk_failed(
+        offset,
+        peer_a,
+        crate::chunk_fetcher::ChunkFetchFailureKind::NotFound,
+    )
+    .unwrap();
+    orch.chunk_requests.get_mut(&offset).unwrap().request_state =
+        ChunkRequestState::Requested(peer_b, Instant::now());
+    orch.on_chunk_failed(
+        offset,
+        peer_b,
+        crate::chunk_fetcher::ChunkFetchFailureKind::NotFound,
+    )
+    .unwrap();
+
+    let retry_at = match orch.chunk_requests[&offset].request_state {
+        ChunkRequestState::Delayed { retry_at } => retry_at,
+        ref state => panic!("expected first delayed retry, got {state:?}"),
+    };
+    assert_eq!(orch.chunk_requests[&offset].retry_round, 1);
+    assert_eq!(orch.chunk_requests[&offset].excluded.len(), 2);
+    orch.populate_request_queue_at(
+        retry_at
+            .checked_sub(Duration::from_millis(1))
+            .expect("retry deadline is at least one second in the future"),
+    );
+    assert!(matches!(
+        orch.chunk_requests[&offset].request_state,
+        ChunkRequestState::Delayed { .. }
+    ));
+
+    orch.populate_request_queue_at(retry_at);
+    assert!(matches!(
+        orch.chunk_requests[&offset].request_state,
+        ChunkRequestState::Pending
+    ));
+    assert!(orch.chunk_requests[&offset].excluded.is_empty());
+    assert_eq!(orch.ready_offsets.back(), Some(&offset));
+}
+
+#[test_log::test(tokio::test)]
+async fn delayed_retry_metadata_is_bounded() {
+    let tmp = TempDirBuilder::new().with_tracing().build();
+    let config = test_config_with_pending_limit(tmp.path().to_path_buf(), 8, 2);
+    let sm = packed_sm(&config, 8);
+    let mut orch = make_orchestrator(sm, &config);
+    let peer = add_assigned_peer(&mut orch, &config, 51, 9051);
+
+    for value in 0..3_u32 {
+        let offset = PartitionChunkOffset::from(value);
+        insert_requested(&mut orch, offset, peer);
+        orch.on_chunk_failed(
+            offset,
+            peer,
+            crate::chunk_fetcher::ChunkFetchFailureKind::NotFound,
+        )
+        .unwrap();
+    }
+
+    assert_eq!(
+        orch.chunk_requests
+            .values()
+            .filter(|request| matches!(request.request_state, ChunkRequestState::Delayed { .. }))
+            .count(),
+        2
+    );
+    assert!(
+        !orch
+            .chunk_requests
+            .contains_key(&PartitionChunkOffset::from(0_u32)),
+        "old retry metadata is dropped; Entropy remains the reconciliation source"
+    );
+}
+
+#[test_log::test(tokio::test)]
+async fn production_shaped_sparse_prefix_yields_to_transaction_range() {
+    let tmp = TempDirBuilder::new().with_tracing().build();
+    let config = test_config(tmp.path().to_path_buf(), 8);
+    let sm = packed_sm_for_ledger(&config, 8, DataLedger::Submit);
+    let mut orch = make_orchestrator(sm, &config);
+    let peer = add_assigned_peer(&mut orch, &config, 61, 9061);
+
+    for value in 0..11_u32 {
+        let offset = PartitionChunkOffset::from(value);
+        insert_requested(&mut orch, offset, peer);
+        orch.on_chunk_failed(
+            offset,
+            peer,
+            crate::chunk_fetcher::ChunkFetchFailureKind::NotFound,
+        )
+        .unwrap();
+    }
+
+    for value in 168_586..=174_797_u32 {
+        insert_pending(&mut orch, PartitionChunkOffset::from(value));
+    }
+
+    let first = orch.ready_offsets.front().copied();
+    let last = orch.ready_offsets.back().copied();
+    assert_eq!(first, Some(PartitionChunkOffset::from(168_586_u32)));
+    assert_eq!(last, Some(PartitionChunkOffset::from(174_797_u32)));
+    assert_eq!(orch.ready_offsets.len(), 6_212);
+    assert_eq!(orch.get_metrics().delayed_requests, 11);
+}
+
+#[test_log::test(tokio::test)]
+async fn delayed_prefix_frees_discovery_budget_for_later_entropy() {
+    let tmp = TempDirBuilder::new().with_tracing().build();
+    let config = test_config_with_pending_limit(tmp.path().to_path_buf(), 8, 2);
+    let sm = packed_sm(&config, 8);
+    let mut orch = make_orchestrator_with_ledger_chunks(sm, &config, 8);
+    let peer = add_assigned_peer(&mut orch, &config, 71, 9071);
+
+    orch.populate_request_queue();
+    assert!(
+        orch.chunk_requests
+            .contains_key(&PartitionChunkOffset::from(0_u32))
+    );
+    assert!(
+        orch.chunk_requests
+            .contains_key(&PartitionChunkOffset::from(1_u32))
+    );
+
+    for value in 0..2_u32 {
+        let offset = PartitionChunkOffset::from(value);
+        orch.chunk_requests.get_mut(&offset).unwrap().request_state =
+            ChunkRequestState::Requested(peer, Instant::now());
+        orch.on_chunk_failed(
+            offset,
+            peer,
+            crate::chunk_fetcher::ChunkFetchFailureKind::NotFound,
+        )
+        .unwrap();
+    }
+
+    orch.populate_request_queue();
+    assert!(
+        orch.chunk_requests
+            .contains_key(&PartitionChunkOffset::from(2_u32))
+            && orch
+                .chunk_requests
+                .contains_key(&PartitionChunkOffset::from(3_u32)),
+        "delayed sparse-prefix work must not consume the hot discovery budget"
+    );
+    assert_eq!(orch.scan_cursor, 4);
+}
+
+#[test]
+fn retry_backoff_is_exponential_jittered_and_capped() {
+    let offset = PartitionChunkOffset::from(17_u32);
+    let delays: Vec<_> = (1..=8)
+        .map(|round| ChunkOrchestrator::retry_delay(offset, round))
+        .collect();
+    assert!(delays.windows(2).all(|pair| pair[1] >= pair[0]));
+    assert!(delays[0] >= RETRY_BACKOFF_INITIAL);
+    assert_eq!(*delays.last().unwrap(), RETRY_BACKOFF_MAX);
+}
+
+#[test_log::test(tokio::test)]
+async fn restart_recovers_from_durable_storage_and_entropy_intervals() {
+    let tmp = TempDirBuilder::new().with_tracing().build();
+    let config = test_config_with_pending_limit(tmp.path().to_path_buf(), 8, 2);
+    let sm = packed_sm(&config, 8);
+    let mut before_restart = make_orchestrator_with_ledger_chunks(Arc::clone(&sm), &config, 8);
+    let peer = add_assigned_peer(&mut before_restart, &config, 81, 9081);
+    before_restart.populate_request_queue();
+
+    let complete = PartitionChunkOffset::from(0_u32);
+    let unresolved = PartitionChunkOffset::from(1_u32);
+    store_durable_data(&sm, complete, 32);
+    before_restart
+        .chunk_requests
+        .get_mut(&unresolved)
+        .unwrap()
+        .request_state = ChunkRequestState::Requested(peer, Instant::now());
+    before_restart
+        .on_chunk_failed(
+            unresolved,
+            peer,
+            crate::chunk_fetcher::ChunkFetchFailureKind::NotFound,
+        )
+        .unwrap();
+    assert!(matches!(
+        before_restart.chunk_requests[&unresolved].request_state,
+        ChunkRequestState::Delayed { .. }
+    ));
+    drop(before_restart);
+
+    let mut after_restart = make_orchestrator_with_ledger_chunks(sm, &config, 8);
+    after_restart.populate_request_queue();
+    assert!(
+        !after_restart.chunk_requests.contains_key(&complete),
+        "durably stored data must remain complete without scheduler metadata"
+    );
+    assert!(after_restart.chunk_requests.contains_key(&unresolved));
+    assert!(
+        after_restart
+            .chunk_requests
+            .contains_key(&PartitionChunkOffset::from(2_u32)),
+        "restart must still discover work after the formerly delayed offset"
     );
 }

--- a/crates/actors/src/data_sync_service/peer_bandwidth_manager.rs
+++ b/crates/actors/src/data_sync_service/peer_bandwidth_manager.rs
@@ -60,6 +60,12 @@ impl PeerBandwidthManager {
         self.peer_stats.record_request_failed();
     }
 
+    /// Release a request that returned 404 without treating a sparse-ledger
+    /// absence as a transport or peer-health failure.
+    pub fn on_chunk_not_found(&mut self) {
+        self.peer_stats.record_request_not_found();
+    }
+
     /// Get max concurrency (upper bound)
     pub fn max_concurrency(&self) -> usize {
         self.peer_stats.max_concurrency as usize

--- a/crates/actors/src/data_sync_service/peer_stats.rs
+++ b/crates/actors/src/data_sync_service/peer_stats.rs
@@ -120,6 +120,13 @@ impl PeerStats {
         self.total_failures += 1;
     }
 
+    /// A 404 is offset-specific negative information, not evidence that the
+    /// peer transport is unhealthy. Release concurrency without penalizing the
+    /// peer's global health score.
+    pub fn record_request_not_found(&mut self) {
+        self.active_requests = self.active_requests.saturating_sub(1);
+    }
+
     pub fn average_completion_time(&self) -> Duration {
         if self.completion_time_samples.is_empty() {
             return Duration::from_millis(100); // Default to 100ms as a baseline

--- a/crates/actors/src/metrics.rs
+++ b/crates/actors/src/metrics.rs
@@ -32,7 +32,17 @@ irys_utils::define_metrics! {
     counter DATA_SYNC_CHUNK_UNBLOCKED("irys.data_sync.chunk_unblocked_total", "Data sync Blocked offsets re-queued after local index-ready probe (MissingDataRootIndex → Pending)");
     counter DATA_SYNC_DURABILITY_STALLED("irys.data_sync.durability_stalled_total", "Data sync writes that did not become durable before the monotonic durability deadline");
     counter DATA_INDEX_HEAL_UNREPAIRED("irys.storage.index_heal_unrepaired_total", "Ledger SMs still gapped/uncertain after a heal pass (labelled by reason)");
-    counter DATA_SYNC_FETCH_BY_SOURCE("irys.data_sync.fetch_by_source_total", "Data sync peer fetches by peer source and outcome (source=assigned|ingress_proof, outcome=success|fail)");
+    counter DATA_SYNC_FETCH_BY_SOURCE("irys.data_sync.fetch_by_source_total", "Data sync peer fetches by source and classified outcome");
+    counter DATA_SYNC_FETCH_FAILURES("irys.data_sync.fetch_failures_total", "Data sync fetch failures by ledger, peer, and failure class");
+    counter DATA_SYNC_ATTEMPTS("irys.data_sync.attempts_total", "Data sync scheduling attempts by ledger and fresh/retry class");
+    counter DATA_SYNC_UNIQUE_OFFSETS_ATTEMPTED("irys.data_sync.unique_offsets_attempted_total", "Offsets attempted for the first time in the current in-memory scheduler lifecycle");
+    counter DATA_SYNC_PEERS_EXHAUSTED("irys.data_sync.peer_cycles_exhausted_total", "Offsets delayed after exhausting all currently eligible peers");
+    gauge DATA_SYNC_READY("irys.data_sync.ready_work", "Ready data sync offsets by ledger and storage module");
+    gauge DATA_SYNC_FETCHING("irys.data_sync.fetching_work", "Fetching data sync offsets by ledger and storage module");
+    gauge DATA_SYNC_DELAYED("irys.data_sync.delayed_work", "Delayed data sync offsets by ledger and storage module");
+    gauge DATA_SYNC_ELIGIBLE_PEERS("irys.data_sync.eligible_peers", "Currently eligible data sync peers by ledger and storage module");
+    gauge DATA_SYNC_OLDEST_READY_AGE_MS("irys.data_sync.oldest_ready_age_ms", "Monotonic age of the oldest ready offset by ledger and storage module");
+    gauge DATA_SYNC_SCAN_CURSOR("irys.data_sync.scan_cursor", "Partition-relative data sync discovery cursor by ledger and storage module");
     gauge DATA_SYNC_ACTIVE_PEERS("irys.data_sync.active_peers", "Number of active data sync peers");
     counter MINING_SOLUTIONS_FOUND("irys.mining.solutions_found_total", "Mining solutions found");
     gauge PACKING_ACTIVE_WORKERS("irys.packing.active_workers", "Number of active packing workers");
@@ -91,6 +101,11 @@ irys_utils::define_metrics! {
         "irys.block_producer.parent_wait_duration_ms",
         "Time the block producer waits for the chosen parent block to be fully validated in milliseconds",
         vec![10.0, 100.0, 500.0, 1000.0, 5000.0, 10000.0, 30000.0, 60000.0, 300000.0, 600000.0]
+    );
+    histogram DATA_SYNC_RETRY_DELAY_MS(
+        "irys.data_sync.retry_delay_ms",
+        "Delay assigned after a data sync offset exhausts all currently eligible peers",
+        vec![1000.0, 2000.0, 4000.0, 8000.0, 16000.0, 32000.0, 60000.0]
     );
 
     counter VALIDATION_RESULTS("irys.validation.results_total", "Validation results by stage and result (labelled)");
@@ -313,7 +328,8 @@ pub(crate) fn record_data_sync_active_peers(count: u64) {
     DATA_SYNC_ACTIVE_PEERS.record(count, &[]);
 }
 
-/// `source`: `assigned` | `ingress_proof`. `outcome`: `success` | `fail`.
+/// `source`: `assigned` | `ingress_proof`. `outcome`: `success` or a
+/// [`crate::chunk_fetcher::ChunkFetchFailureKind`] metric label.
 pub(crate) fn record_data_sync_fetch_by_source(source: &'static str, outcome: &'static str) {
     DATA_SYNC_FETCH_BY_SOURCE.add(
         1,
@@ -322,6 +338,63 @@ pub(crate) fn record_data_sync_fetch_by_source(source: &'static str, outcome: &'
             KeyValue::new("outcome", outcome),
         ],
     );
+}
+
+pub(crate) fn record_data_sync_fetch_failure(
+    ledger_id: u32,
+    peer: irys_types::IrysAddress,
+    failure: &'static str,
+) {
+    DATA_SYNC_FETCH_FAILURES.add(
+        1,
+        &[
+            KeyValue::new("ledger", i64::from(ledger_id)),
+            KeyValue::new("peer", peer.to_string()),
+            KeyValue::new("failure", failure),
+        ],
+    );
+}
+
+pub(crate) fn record_data_sync_attempt(ledger_id: u32, attempt: &'static str) {
+    DATA_SYNC_ATTEMPTS.add(
+        1,
+        &[
+            KeyValue::new("ledger", i64::from(ledger_id)),
+            KeyValue::new("attempt", attempt),
+        ],
+    );
+}
+
+pub(crate) fn record_data_sync_unique_offset_attempted(ledger_id: u32) {
+    DATA_SYNC_UNIQUE_OFFSETS_ATTEMPTED.add(1, &[KeyValue::new("ledger", i64::from(ledger_id))]);
+}
+
+pub(crate) fn record_data_sync_peers_exhausted(ledger_id: u32) {
+    DATA_SYNC_PEERS_EXHAUSTED.add(1, &[KeyValue::new("ledger", i64::from(ledger_id))]);
+}
+
+pub(crate) fn record_data_sync_retry_delay(ledger_id: u32, delay: std::time::Duration) {
+    DATA_SYNC_RETRY_DELAY_MS.record(
+        delay.as_secs_f64() * 1000.0,
+        &[KeyValue::new("ledger", i64::from(ledger_id))],
+    );
+}
+
+pub(crate) fn record_data_sync_scheduler_state(
+    ledger_id: u32,
+    storage_module_id: usize,
+    state: &crate::data_sync_service::chunk_orchestrator::OrchestrationMetrics,
+) {
+    let labels = [
+        KeyValue::new("ledger", i64::from(ledger_id)),
+        KeyValue::new("storage_module", storage_module_id.to_string()),
+    ];
+    DATA_SYNC_READY.record(state.pending_requests as u64, &labels);
+    DATA_SYNC_FETCHING.record(state.active_requests as u64, &labels);
+    DATA_SYNC_DELAYED.record(state.delayed_requests as u64, &labels);
+    DATA_SYNC_ELIGIBLE_PEERS.record(state.total_peers as u64, &labels);
+    DATA_SYNC_OLDEST_READY_AGE_MS.record(state.oldest_ready_age.as_millis() as u64, &labels);
+    DATA_SYNC_SCAN_CURSOR.record(u64::from(state.scan_cursor), &labels);
 }
 
 pub(crate) fn record_mining_solution_found() {


### PR DESCRIPTION
## Summary

- make data-sync discovery and dispatch explicitly fair with FIFO ready work, a rotating partition scan, and round-robin storage-module arbitration
- retain peer-specific 404 exclusions, try other eligible peers, and delay exhausted offsets with bounded monotonic exponential backoff
- classify peer absence, transport failures, invalid remote data, and local persistence failures separately
- bound ephemeral retry metadata and expose scheduler progress, queue state, retry, and failure metrics

## Correctness invariants

- a 404 leaves the offset unresolved and never marks it synchronized or permanently absent
- delayed offsets release concurrency and do not consume the hot discovery budget
- failed work returns behind already-ready work, so persistent old gaps cannot starve later offsets
- a peer-specific 404 does not globally penalize that peer; transport failures and invalid remote data do
- durable Data/Entropy intervals remain the restart source of truth; no second persisted scheduler state is introduced

## Tests

- `cargo xtask local-checks`
- `cargo nextest run -p irys-actors` — 572 passed, 1 skipped
- `cargo nextest run -p irys-actors data_sync_service` — 31 passed
- `cargo nextest run -p irys-actors term_ledger_orchestrator_handles_block_without_ledger_entry`
- `cargo nextest run -p irys-chain-tests spiky_slow_heavy4_sync_partition_data_between_peers_test`

Regression coverage includes sparse-prefix fairness, same-peer 404 exclusion, peer rotation, all-peer backoff and recovery, bounded retry state, cross-storage-module isolation, restart rediscovery, dense-ledger behavior, failure classification, and a production-shaped 6,212-chunk Submit-ledger range.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved data synchronization fairness so storage areas receive balanced processing time.
  * Added more reliable retry handling with backoff when eligible sources are temporarily unavailable.
  * Improved recovery of pending synchronization work after interruptions.
  * Distinguished invalid data responses from network and local failures for more accurate handling.
  * Prevented missing chunks from incorrectly lowering source reliability.

* **Monitoring**
  * Added detailed synchronization metrics for attempts, failures, retries, delays, queue status, and processing age.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->