### PR TITLE
fix(data-sync): use the migrated block as the replica sync frontier

### DIFF
--- a/crates/actors/src/data_sync_service/chunk_orchestrator/mod.rs
+++ b/crates/actors/src/data_sync_service/chunk_orchestrator/mod.rs
@@ -526,17 +526,25 @@ impl ChunkOrchestrator {
             .get_storage_module_ledger_offsets()
             .expect("storage module should be assigned to a ledger");
 
-        // Fetch the most recently migrated block
-        // We only want to download migrated chunks from other peers
+        // Fetch the most recently migrated block.
+        // We only want to download migrated chunks from other peers — the
+        // index is the same as `tree_safe_height`: `depth` behind the
+        // canonical tip, or genesis while the chain is still shorter than
+        // `block_migration_depth`. `canonical[len - depth]` is one too new
+        // (the tip when depth == 1) and would advertise unmigrated chunks.
         let max_chunk_offset: Option<u64> = {
             let tree = self.block_tree.read();
             let (canonical, _) = tree.get_canonical_chain();
             let block_migration_depth =
                 self.config.consensus_config().block_migration_depth as usize;
 
-            if canonical.len() >= block_migration_depth {
-                let most_recent_migrated_block =
-                    &canonical[canonical.len() - block_migration_depth];
+            if !canonical.is_empty() {
+                let migrated_idx = if canonical.len() > block_migration_depth {
+                    canonical.len() - 1 - block_migration_depth
+                } else {
+                    0
+                };
+                let most_recent_migrated_block = &canonical[migrated_idx];
 
                 let block = most_recent_migrated_block.header();
 
@@ -546,6 +554,9 @@ impl ChunkOrchestrator {
                     .classify_data_ledger(block, self.ledger_id)
                 {
                     DataLedgerLookup::Present(dl) if dl.total_chunks == 0 => None,
+                    // `total_chunks` is the exclusive write frontier (chunk
+                    // count). Convert to the inclusive last offset so the
+                    // entropy scan `start..=max` includes the frontier chunk.
                     DataLedgerLookup::Present(dl) => Some(dl.total_chunks.saturating_sub(1)),
                     // A migrated block that predates this ledger's activation
                     // (e.g. a pre-Cascade block for the OneYear/ThirtyDay term

--- a/crates/actors/src/data_sync_service/chunk_orchestrator/tests.rs
+++ b/crates/actors/src/data_sync_service/chunk_orchestrator/tests.rs
@@ -1,11 +1,15 @@
 use super::*;
 use crate::{chunk_fetcher::MockChunkFetcher, test_helpers::build_test_service_senders};
 use irys_domain::ChunkType;
-use irys_domain::{BlockTree, StorageModuleInfo};
+use irys_domain::{
+    BlockTree, ChainState, CommitmentSnapshot, EpochSnapshot, StorageModuleInfo, dummy_ema_snapshot,
+};
+use irys_testing_utils::IrysBlockHeaderTestExt as _;
 use irys_testing_utils::TempDirBuilder;
 use irys_types::{
-    Config, ConsensusConfig, DataLedger, H256, IrysAddress, NodeConfig, PeerAddress, PeerListItem,
-    partition::PartitionAssignment, partition_chunk_offset_ie,
+    BlockTransactions, Config, ConsensusConfig, DataLedger, H256, IrysAddress, IrysBlockHeader,
+    NodeConfig, PeerAddress, PeerListItem, SealedBlock, U256, partition::PartitionAssignment,
+    partition_chunk_offset_ie,
 };
 
 fn test_config(base_directory: std::path::PathBuf, num_chunks: u64) -> Config {
@@ -1091,4 +1095,127 @@ async fn restart_recovers_from_durable_storage_and_entropy_intervals() {
             .contains_key(&PartitionChunkOffset::from(2_u32)),
         "restart must still discover work after the formerly delayed offset"
     );
+}
+
+fn make_orchestrator_with_tree(
+    sm: Arc<StorageModule>,
+    config: &Config,
+    block_tree: BlockTree,
+) -> ChunkOrchestrator {
+    let block_tree_guard = BlockTreeReadGuard::new(Arc::new(RwLock::new(block_tree)));
+    let (service_senders, _receivers) = build_test_service_senders();
+    ChunkOrchestrator::new(
+        sm,
+        Arc::new(RwLock::new(HashMap::new())),
+        block_tree_guard,
+        &service_senders,
+        Arc::new(MockChunkFetcher::new(DataLedger::Publish as usize)),
+        config.node_config.clone(),
+        tokio::runtime::Handle::current(),
+    )
+}
+
+fn signed_publish_header(
+    height: u64,
+    previous_block_hash: H256,
+    cumulative_diff: u64,
+    publish_total_chunks: u64,
+) -> IrysBlockHeader {
+    let mut header = IrysBlockHeader::new_mock_header();
+    header.height = height;
+    header.previous_block_hash = previous_block_hash;
+    header.cumulative_diff = U256::from(cumulative_diff);
+    header.data_ledgers[DataLedger::Publish].total_chunks = publish_total_chunks;
+    header.test_sign();
+    header
+}
+
+fn insert_onchain(tree: &mut BlockTree, header: &IrysBlockHeader) {
+    let sealed = Arc::new(SealedBlock::new_unchecked(
+        Arc::new(header.clone()),
+        BlockTransactions::default(),
+    ));
+    tree.add_common(
+        header.block_hash,
+        &sealed,
+        Arc::new(CommitmentSnapshot::default()),
+        Arc::new(EpochSnapshot::default()),
+        dummy_ema_snapshot(),
+        ChainState::Onchain,
+    )
+    .expect("onchain block");
+}
+
+#[test_log::test(tokio::test)]
+async fn populate_includes_the_inclusive_frontier_chunk() {
+    let tmp = TempDirBuilder::new().with_tracing().build();
+    let config = test_config(tmp.path().to_path_buf(), 8);
+    let sm = packed_sm(&config, 8);
+
+    // A single-chunk ledger is the classic exclusive-range miss: max offset 0
+    // must still be discovered.
+    let mut orch = make_orchestrator_with_ledger_chunks(Arc::clone(&sm), &config, 1);
+    orch.populate_request_queue();
+    assert!(
+        orch.chunk_requests
+            .contains_key(&PartitionChunkOffset::from(0_u32)),
+        "the sole chunk at the exclusive frontier of 1 must be requested"
+    );
+    assert!(
+        !orch
+            .chunk_requests
+            .contains_key(&PartitionChunkOffset::from(1_u32)),
+        "must not request past the write frontier"
+    );
+
+    // Partial partition: total_chunks=5 → inclusive last offset 4.
+    let mut orch = make_orchestrator_with_ledger_chunks(Arc::clone(&sm), &config, 5);
+    orch.populate_request_queue();
+    for offset in 0..5_u32 {
+        assert!(
+            orch.chunk_requests
+                .contains_key(&PartitionChunkOffset::from(offset)),
+            "entropy scan must include frontier offset {offset} when total_chunks=5"
+        );
+    }
+    assert!(
+        !orch
+            .chunk_requests
+            .contains_key(&PartitionChunkOffset::from(5_u32))
+    );
+
+    // Full partition: last valid offset is num_chunks - 1.
+    let mut orch = make_orchestrator_with_ledger_chunks(sm, &config, 8);
+    orch.populate_request_queue();
+    assert!(
+        orch.chunk_requests
+            .contains_key(&PartitionChunkOffset::from(7_u32)),
+        "a fully written partition must still request its last chunk"
+    );
+}
+
+#[test_log::test(tokio::test)]
+async fn max_chunk_offset_uses_the_migrated_block_not_the_tip() {
+    let tmp = TempDirBuilder::new().with_tracing().build();
+    // depth=1: the tip is not migrated; its parent is.
+    let config = test_config(tmp.path().to_path_buf(), 8);
+    let sm = packed_sm(&config, 8);
+
+    let genesis = signed_publish_header(0, H256::zero(), 1, 3);
+    let block1 = signed_publish_header(1, genesis.block_hash, 2, 5);
+    let tip = signed_publish_header(2, block1.block_hash, 3, 6);
+
+    let mut tree = BlockTree::new(&genesis, config.consensus.clone());
+    insert_onchain(&mut tree, &block1);
+    insert_onchain(&mut tree, &tip);
+
+    let orch = make_orchestrator_with_tree(sm, &config, tree);
+    let (part_max, ledger_max) = orch
+        .get_max_chunk_offset()
+        .expect("migrated block 1 has chunks");
+    assert_eq!(
+        *ledger_max, 4,
+        "must use block 1's exclusive frontier of 5, not the tip's 6"
+    );
+    assert_eq!(*part_max, 4);
 }

--- a/crates/chain-tests/src/data_sync/mod.rs
+++ b/crates/chain-tests/src/data_sync/mod.rs
@@ -1,1 +1,2 @@
 pub(crate) mod sync_partition_data_tests;
+pub(crate) mod term_ledger_replica_sync;

--- a/crates/chain-tests/src/data_sync/term_ledger_replica_sync.rs
+++ b/crates/chain-tests/src/data_sync/term_ledger_replica_sync.rs
@@ -1,0 +1,267 @@
+//! Term-ledger replica data sync must reach the migrated write frontier.
+//!
+//! The Publish/Submit replica-sync test only asserts `data <= N`, so a replica
+//! that stopped one chunk short of the frontier still passed. This test posts
+//! an exact `N`-chunk OneYear transaction, migrates it, and requires every
+//! miner assigned to that slot — the seeder who received the upload *and* the
+//! replica that has to fetch — to store offsets `{0, …, N-1}` as Data.
+
+use std::collections::BTreeSet;
+use std::time::Duration;
+
+use irys_chain::IrysNodeCtx;
+use irys_config::submodules::StorageSubmodulesConfig;
+use irys_domain::ChunkType;
+use irys_testing_utils::initialize_tracing;
+use irys_types::{
+    BoundedFee, DataLedger, IrysAddress, LedgerChunkOffset, NodeConfig, UnixTimestamp,
+    hardfork_config::Cascade, irys::IrysSigner,
+};
+use tracing::info;
+
+use crate::utils::IrysNodeTest;
+
+const CHUNK_SIZE: usize = 32;
+const NUM_CHUNKS_IN_PARTITION: u64 = 10;
+const NUM_DATA_CHUNKS: usize = 5;
+const BLOCKS_PER_EPOCH: u64 = 4;
+const SECONDS_TO_WAIT: usize = 20;
+
+#[test_log::test(tokio::test)]
+async fn slow_heavy_term_ledger_replica_syncs_migrated_frontier() -> eyre::Result<()> {
+    initialize_tracing();
+
+    let mut config = NodeConfig::testing()
+        .with_consensus(|c| {
+            c.chunk_size = CHUNK_SIZE as u64;
+            c.num_chunks_in_partition = NUM_CHUNKS_IN_PARTITION;
+            c.num_partitions_per_slot = 2;
+            c.num_partitions_per_term_ledger_slot = 2;
+            c.epoch.num_blocks_in_epoch = BLOCKS_PER_EPOCH;
+            c.block_migration_depth = 1;
+            c.epoch.submit_ledger_epoch_length = 1000;
+            c.hardforks.cascade = Some(Cascade {
+                activation_timestamp: UnixTimestamp::from_secs(0),
+                one_year_epoch_length: 1000,
+                thirty_day_epoch_length: 1000,
+                annual_cost_per_gb: Cascade::default_annual_cost_per_gb(),
+            });
+        })
+        .with_genesis_peer_discovery_timeout(1000);
+
+    let peer_signer = IrysSigner::random_signer(&config.consensus_config());
+    config.fund_genesis_accounts(vec![&peer_signer]);
+
+    let genesis_test = IrysNodeTest::new_genesis(config.clone());
+    // Cascade-from-genesis: 4 ledgers × 2 replicas. Genesis can occupy only one
+    // replica per slot; extra submodules become capacity pledges.
+    StorageSubmodulesConfig::load_for_test(genesis_test.cfg.base_directory.clone(), 8)?;
+    let genesis_node = genesis_test
+        .start_and_wait_for_packing("GENESIS", SECONDS_TO_WAIT)
+        .await;
+    let genesis_address = genesis_node.node_ctx.config.node_config.miner_address();
+    let peer_address = peer_signer.address();
+
+    // Peer commitments are posted to genesis so the next epoch can fill the
+    // empty second replica of each slot. Stake must land on-chain before
+    // pledges; four pledges match the four empty replicas
+    // (Publish/Submit/OneYear/ThirtyDay).
+    let stake = genesis_node
+        .post_stake_commitment_with_signer(&peer_signer)
+        .await?;
+    genesis_node
+        .wait_for_mempool(stake.id(), SECONDS_TO_WAIT)
+        .await?;
+    genesis_node.mine_block().await?;
+    let mut pledge_ids = Vec::new();
+    for _ in 0..4 {
+        pledge_ids.push(
+            genesis_node
+                .post_pledge_commitment_with_signer(&peer_signer)
+                .await
+                .id(),
+        );
+    }
+    genesis_node
+        .wait_for_mempool_commitment_txs(pledge_ids, SECONDS_TO_WAIT)
+        .await?;
+
+    let mut one_year_owners = Vec::new();
+    for _ in 0..3 {
+        genesis_node.mine_until_next_epoch().await?;
+        one_year_owners = slot_owners(&genesis_node, DataLedger::OneYear, 0);
+        if one_year_owners.len() == 2 {
+            break;
+        }
+    }
+    assert_eq!(
+        one_year_owners.len(),
+        2,
+        "OneYear slot 0 must have both replicas (owners={one_year_owners:?})"
+    );
+    assert!(
+        one_year_owners.contains(&genesis_address) && one_year_owners.contains(&peer_address),
+        "OneYear slot 0 replicas must be genesis and peer (owners={one_year_owners:?})"
+    );
+
+    let peer_config = genesis_node.testing_peer_with_signer(&peer_signer);
+    let peer_test = IrysNodeTest::new(peer_config);
+    StorageSubmodulesConfig::load_for_test(peer_test.cfg.base_directory.clone(), 8)?;
+    let peer_node = peer_test
+        .start_and_wait_for_packing("PEER", SECONDS_TO_WAIT)
+        .await;
+    peer_node
+        .wait_until_height(
+            genesis_node.get_canonical_chain_height().await,
+            SECONDS_TO_WAIT,
+        )
+        .await?;
+
+    let mut chunks = Vec::with_capacity(NUM_DATA_CHUNKS);
+    for i in 0..NUM_DATA_CHUNKS {
+        chunks.push([i as u8; 32]);
+    }
+    let data: Vec<u8> = chunks.concat();
+    let data_size = data.len() as u64;
+    let genesis_signer = genesis_node.node_ctx.config.irys_signer();
+    let price = genesis_node
+        .get_data_price(DataLedger::OneYear, data_size)
+        .await?;
+    let tx = genesis_signer.create_transaction_with_fees(
+        data,
+        genesis_node.get_anchor().await?,
+        DataLedger::OneYear,
+        BoundedFee::new(price.term_fee),
+        None,
+    )?;
+    let tx = genesis_signer.sign_transaction(tx)?;
+    genesis_node.ingest_data_tx(tx.header.clone()).await?;
+    genesis_node
+        .wait_for_mempool(tx.header.id, SECONDS_TO_WAIT)
+        .await?;
+
+    for i in 0..NUM_DATA_CHUNKS {
+        genesis_node.post_chunk_32b(&tx, i, &chunks).await;
+    }
+
+    let inclusion = genesis_node.mine_block().await?;
+    assert_eq!(
+        inclusion.ledger_total_chunks(DataLedger::OneYear),
+        NUM_DATA_CHUNKS as u64,
+        "inclusion block must report the exclusive OneYear frontier"
+    );
+    assert!(
+        inclusion
+            .get_data_ledger_tx_ids()
+            .get(&DataLedger::OneYear)
+            .is_some_and(|ids| ids.contains(&tx.header.id)),
+        "OneYear tx must be included in the mined block"
+    );
+    peer_node
+        .wait_until_height(inclusion.height, SECONDS_TO_WAIT)
+        .await?;
+
+    // depth=1: this block migrates the inclusion block to the seeder SM.
+    let confirm = genesis_node.mine_block().await?;
+    assert_eq!(
+        confirm.ledger_total_chunks(DataLedger::OneYear),
+        NUM_DATA_CHUNKS as u64,
+        "confirmation block must not add OneYear chunks (tip == migrated frontier)"
+    );
+    genesis_node
+        .wait_until_block_index_height(inclusion.height, SECONDS_TO_WAIT)
+        .await?;
+    peer_node
+        .wait_until_height(confirm.height, SECONDS_TO_WAIT)
+        .await?;
+
+    let expected: BTreeSet<u32> = (0..NUM_DATA_CHUNKS as u32).collect();
+    let mut last_genesis = BTreeSet::new();
+    let mut last_peer = BTreeSet::new();
+    let mut synced = false;
+    for attempt in 0..40 {
+        last_genesis = data_offsets(&genesis_node, DataLedger::OneYear, 0);
+        last_peer = data_offsets(&peer_node, DataLedger::OneYear, 0);
+        info!(
+            attempt,
+            genesis = ?last_genesis,
+            peer = ?last_peer,
+            "OneYear slot 0 data offsets"
+        );
+        if last_genesis == expected && last_peer == expected {
+            synced = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    assert_eq!(
+        last_genesis, expected,
+        "seeder must migrate every OneYear chunk through the inclusive frontier"
+    );
+    assert_eq!(
+        last_peer, expected,
+        "replica must sync every OneYear chunk through the inclusive frontier \
+         (a one-chunk-short set is the off-by-one this test exists to catch)"
+    );
+    assert!(synced);
+
+    let last = LedgerChunkOffset::from((NUM_DATA_CHUNKS - 1) as u64);
+    genesis_node
+        .verify_migrated_chunk_32b(
+            DataLedger::OneYear,
+            last,
+            &chunks[NUM_DATA_CHUNKS - 1],
+            data_size,
+        )
+        .await;
+    peer_node
+        .verify_migrated_chunk_32b(
+            DataLedger::OneYear,
+            last,
+            &chunks[NUM_DATA_CHUNKS - 1],
+            data_size,
+        )
+        .await;
+
+    peer_node.stop().await;
+    genesis_node.stop().await;
+    Ok(())
+}
+
+fn slot_owners(
+    node: &IrysNodeTest<IrysNodeCtx>,
+    ledger: DataLedger,
+    slot_index: usize,
+) -> Vec<IrysAddress> {
+    let snapshot = node.get_canonical_epoch_snapshot();
+    let slots = snapshot.ledgers.get_slots(ledger);
+    slots
+        .get(slot_index)
+        .map(|slot| {
+            slot.partitions
+                .iter()
+                .map(|hash| {
+                    snapshot
+                        .partition_assignments
+                        .get_assignment(*hash)
+                        .expect("assigned partition must have an assignment entry")
+                        .miner_address
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn data_offsets(
+    node: &IrysNodeTest<IrysNodeCtx>,
+    ledger: DataLedger,
+    slot_index: usize,
+) -> BTreeSet<u32> {
+    let mut offsets = BTreeSet::new();
+    for interval in node.get_storage_module_intervals(ledger, slot_index, ChunkType::Data) {
+        let start: u32 = interval.start().into();
+        let end: u32 = interval.end().into();
+        offsets.extend(start..=end);
+    }
+    offsets
+}


### PR DESCRIPTION
**Describe the changes**

When term-ledger replicas in the same slot sync from each other, the miner that received the original upload (the seeder) ends up with every migrated chunk on disk, but the other miners in that slot stop one chunk short of the write frontier.

`total_chunks` on a block is an exclusive count: N chunks means valid offsets are `0..=N-1`. Data sync already converts that to an inclusive last offset. The off-by-one was in *which block* it read `total_chunks` from.

Fork choice treats the migrated / confirmed block as `canonical[len - 1 - depth]` (`tree_safe_height`) — `block_migration_depth` behind the tip. Data sync used `canonical[len - depth]`, which is one block too new. With `block_migration_depth = 1` that is the tip itself.

So replicas advertised the tip’s frontier as fetchable. Those extra chunks are not in anyone’s storage module yet (indexes are written at migration; ingress only writes to an SM after that). The fetch 404s, and the replica sits one chunk below the frontier the seeder already migrated from cache.

This change:

1. Selects the same migrated block as `tree_safe_height` (genesis while the chain is still shorter than the migration depth).
2. Documents that `total_chunks - 1` is the inclusive last offset so the entropy scan `start..=max` includes the frontier chunk.
3. Adds unit tests that the last frontier offset is queued (`total_chunks = 1`, `5`, and a full partition) and that a three-block chain with `depth = 1` uses the parent’s frontier, not the tip’s.
4. Adds `slow_heavy_term_ledger_replica_syncs_migrated_frontier`, a two-replica OneYear test that requires exact Data offsets `{0..N-1}` on **both** the seeder and the fetching replica, including a storage read of the last ledger offset. The existing Publish/Submit peer-sync test only asserted `data <= N`, so a one-chunk-short replica still passed.

**Related Issue(s)**
N/A — observed on replica miners in a shared term-ledger slot after the sparse-term data-sync work.

**Checklist**

- [x] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**

Verified locally:

- `chunk_orchestrator` unit tests (27)
- `term_ledger_orchestrator_handles_block_without_ledger_entry`
- `spiky_slow_heavy4_sync_partition_data_between_peers_test`
- `slow_heavy_term_ledger_replica_syncs_migrated_frontier`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected data synchronization frontier calculations to avoid advertising chunks that have not yet been migrated.
  * Ensured synchronization requests use the most recently migrated block rather than the chain tip.

* **Tests**
  * Added coverage for single-chunk, partial, and full ledgers.
  * Added an integration test validating replica synchronization, chunk migration, and stored data contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->