### PR TITLE
fix(data-sync): fetch term-ledger write heads before Publish backlog

### DIFF
--- a/crates/actors/src/data_sync_service.rs
+++ b/crates/actors/src/data_sync_service.rs
@@ -147,9 +147,10 @@ pub struct DataSyncServiceInner {
     rearm_backoff_remaining: u64,
     /// Skip budget applied after the next zero-yield pass (grows, capped).
     rearm_backoff_next_skips: u64,
-    /// Rotates which storage module gets the first opportunity to consume
-    /// shared peer concurrency on each scheduler tick.
-    orchestrator_dispatch_cursor: usize,
+    /// Rotates which term-ledger storage module is visited first each tick.
+    term_dispatch_cursor: usize,
+    /// Rotates which Publish storage module is visited first each tick.
+    publish_dispatch_cursor: usize,
 }
 
 /// Re-arm `Blocked(MissingDataRootIndex)` when the local index looks ready.
@@ -172,6 +173,7 @@ const REARM_BACKOFF_MAX_SKIPS: u64 = 16;
 /// Give every storage module one dispatch opportunity per round, rotating the
 /// first module between ticks. The callback returns whether it consumed work.
 /// Rounds stop once no module can use another shared peer permit.
+#[cfg(test)]
 fn dispatch_round_robin<T: Copy>(
     ids: &mut [T],
     cursor: usize,
@@ -194,9 +196,52 @@ fn dispatch_round_robin<T: Copy>(
     (cursor + 1) % ids.len()
 }
 
+/// Term-ledger SMs (Submit / OneYear / ThirtyDay) take a turn before Publish
+/// in each inner pass. Publish copies Submit data for promotion; if Submit
+/// replicas stay on the write frontier, Publish has many sources. When shared
+/// peer permits are fewer than the number of SMs, this keeps a busy permanent
+/// backlog from skipping the term write head. Within each group the start
+/// index still rotates so two Submit SMs share fairly.
+fn dispatch_term_then_publish<T: Copy>(
+    term_ids: &mut [T],
+    publish_ids: &mut [T],
+    term_cursor: usize,
+    publish_cursor: usize,
+    mut dispatch: impl FnMut(T) -> bool,
+) -> (usize, usize) {
+    let next_term = if term_ids.is_empty() {
+        0
+    } else {
+        let start = term_cursor % term_ids.len();
+        term_ids.rotate_left(start);
+        (term_cursor + 1) % term_ids.len()
+    };
+    let next_publish = if publish_ids.is_empty() {
+        0
+    } else {
+        let start = publish_cursor % publish_ids.len();
+        publish_ids.rotate_left(start);
+        (publish_cursor + 1) % publish_ids.len()
+    };
+
+    loop {
+        let mut dispatched = false;
+        for id in term_ids.iter().copied() {
+            dispatched |= dispatch(id);
+        }
+        for id in publish_ids.iter().copied() {
+            dispatched |= dispatch(id);
+        }
+        if !dispatched {
+            break;
+        }
+    }
+    (next_term, next_publish)
+}
+
 #[cfg(test)]
 mod scheduler_fairness_tests {
-    use super::dispatch_round_robin;
+    use super::{dispatch_round_robin, dispatch_term_then_publish};
 
     #[test]
     fn shared_capacity_is_round_robin_across_storage_modules() {
@@ -226,6 +271,61 @@ mod scheduler_fairness_tests {
             true
         });
         assert_eq!(order, vec![1, 0, 1]);
+    }
+
+    #[test]
+    fn term_ledgers_take_permits_before_publish_when_capacity_is_scarce() {
+        // 1 Submit + 3 Publish, only 3 shared permits: Submit must not be the
+        // SM left out, or the term write head waits behind a permanent backlog.
+        let mut term = [1_u8];
+        let mut publish = [0_u8, 2_u8, 3_u8];
+        let mut permits = 3_usize;
+        let mut order = Vec::new();
+        let _ = dispatch_term_then_publish(&mut term, &mut publish, 0, 0, |id| {
+            if permits == 0 {
+                return false;
+            }
+            permits -= 1;
+            order.push(id);
+            true
+        });
+        assert_eq!(order, vec![1, 0, 2]);
+        assert!(!order.contains(&3), "a Publish SM is the one that waits");
+    }
+
+    #[test]
+    fn two_term_ledgers_rotate_fairly_ahead_of_publish() {
+        let mut term = [1_u8, 4_u8];
+        let mut publish = [0_u8];
+        let mut permits = 3_usize;
+        let mut order = Vec::new();
+        let (next_term, next_publish) =
+            dispatch_term_then_publish(&mut term, &mut publish, 0, 0, |id| {
+                if permits == 0 {
+                    return false;
+                }
+                permits -= 1;
+                order.push(id);
+                true
+            });
+        assert_eq!(order, vec![1, 4, 0]);
+        assert_eq!(next_term, 1);
+        assert_eq!(next_publish, 0);
+
+        let mut term = [1_u8, 4_u8];
+        let mut publish = [0_u8];
+        let mut permits = 3_usize;
+        let mut order = Vec::new();
+        let _ =
+            dispatch_term_then_publish(&mut term, &mut publish, next_term, next_publish, |id| {
+                if permits == 0 {
+                    return false;
+                }
+                permits -= 1;
+                order.push(id);
+                true
+            });
+        assert_eq!(order, vec![4, 1, 0]);
     }
 }
 
@@ -282,7 +382,8 @@ impl DataSyncServiceInner {
             rearm_tick: 0,
             rearm_backoff_remaining: 0,
             rearm_backoff_next_skips: 0,
-            orchestrator_dispatch_cursor: 0,
+            term_dispatch_cursor: 0,
+            publish_dispatch_cursor: 0,
         };
         data_sync.synchronize_peers_and_orchestrators();
         data_sync
@@ -350,18 +451,38 @@ impl DataSyncServiceInner {
         }
 
         if !orchestrator_ids.is_empty() {
-            // One request per storage module per round. A sparse term ledger
-            // therefore cannot fill every shared peer permit before Publish or
-            // another storage module gets an opportunity to dispatch.
-            self.orchestrator_dispatch_cursor = dispatch_round_robin(
-                &mut orchestrator_ids,
-                self.orchestrator_dispatch_cursor,
+            // Term-ledger SMs (especially Submit) visit first in each pass so
+            // a large Publish backlog cannot consume every shared peer permit
+            // before the term write head is fetched. Publish later copies
+            // Submit data; that path is healthy when Submit replicas are on
+            // the frontier. Within each group, rotate so two Submit SMs still
+            // share fairly.
+            let mut term_ids = Vec::new();
+            let mut publish_ids = Vec::new();
+            for id in orchestrator_ids.iter().copied() {
+                if self
+                    .chunk_orchestrators
+                    .get(&id)
+                    .is_some_and(ChunkOrchestrator::prioritizes_write_frontier)
+                {
+                    term_ids.push(id);
+                } else {
+                    publish_ids.push(id);
+                }
+            }
+            let (next_term, next_publish) = dispatch_term_then_publish(
+                &mut term_ids,
+                &mut publish_ids,
+                self.term_dispatch_cursor,
+                self.publish_dispatch_cursor,
                 |id| {
                     self.chunk_orchestrators
                         .get_mut(&id)
                         .is_some_and(ChunkOrchestrator::dispatch_next)
                 },
             );
+            self.term_dispatch_cursor = next_term;
+            self.publish_dispatch_cursor = next_publish;
 
             for id in &orchestrator_ids {
                 if let Some(orchestrator) = self.chunk_orchestrators.get(id) {

--- a/crates/actors/src/data_sync_service/chunk_orchestrator/mod.rs
+++ b/crates/actors/src/data_sync_service/chunk_orchestrator/mod.rs
@@ -136,7 +136,9 @@ pub struct ChunkOrchestrator {
     /// request changes state, keeping state ownership in `chunk_requests`.
     ready_offsets: VecDeque<PartitionChunkOffset>,
     /// Next partition-relative offset considered while discovering Entropy.
-    /// This prevents a low sparse prefix from monopolizing queue population.
+    /// Publish walks low-to-high from here. Term ledgers walk high-to-low
+    /// (`u32::MAX` means "start at the write head") so abandoned low-offset
+    /// gaps are visited only after the frontier has been scanned.
     scan_cursor: u32,
     pub current_peers: Vec<IrysAddress>,
     block_tree: BlockTreeReadGuard,
@@ -170,7 +172,11 @@ impl ChunkOrchestrator {
             storage_module,
             chunk_requests: Default::default(),
             ready_offsets: Default::default(),
-            scan_cursor: 0,
+            scan_cursor: if Self::ledger_prioritizes_write_frontier(ledger_id) {
+                u32::MAX
+            } else {
+                0
+            },
             recent_chunk_times: CircularBuffer::new(8000),
             current_peers: Default::default(),
             block_tree,
@@ -353,39 +359,71 @@ impl ChunkOrchestrator {
             return;
         }
 
-        self.scan_cursor = self.scan_cursor.min(max_offset);
-        let cursor = self.scan_cursor;
-        let ranges = [(cursor, max_offset), (0, cursor.saturating_sub(1))];
         let max_probes = max_requests.saturating_mul(4).max(max_requests);
         let mut probes = 0_usize;
-
-        'scan: for (range_start, range_end) in ranges {
-            if range_start > range_end {
-                continue;
-            }
-            for interval in &entropy_intervals {
-                let start = (*interval.start()).max(range_start);
-                let end = (*interval.end()).min(range_end).min(max_offset);
-                if start > end {
+        if self.prioritizes_write_frontier() {
+            // High offsets near the write head are live data; low-offset Entropy
+            // on a term ledger is often an abandoned upload. Walk down from the
+            // frontier and only wrap to the prefix after that pass.
+            let cursor = self.scan_cursor.min(max_offset);
+            let ranges: [(u32, u32); 2] = if cursor == max_offset {
+                [(0, max_offset), (1, 0)]
+            } else {
+                [(0, cursor), (cursor.saturating_add(1), max_offset)]
+            };
+            'scan: for (range_start, range_end) in ranges {
+                if range_start > range_end {
                     continue;
                 }
-                for interval_step in start..=end {
-                    probes += 1;
-                    self.scan_cursor = if interval_step == max_offset {
-                        0
-                    } else {
-                        interval_step.saturating_add(1)
-                    };
-
-                    let chunk_offset = PartitionChunkOffset::from(interval_step);
-                    if self.enqueue_pending(chunk_offset, now, false) {
-                        requests_to_add -= 1;
-                        if requests_to_add == 0 {
+                for interval in entropy_intervals.iter().rev() {
+                    let start = (*interval.start()).max(range_start);
+                    let end = (*interval.end()).min(range_end).min(max_offset);
+                    if start > end {
+                        continue;
+                    }
+                    for interval_step in (start..=end).rev() {
+                        if self.note_scan_offset(
+                            interval_step,
+                            max_offset,
+                            true,
+                            now,
+                            &mut probes,
+                            max_probes,
+                            &mut requests_to_add,
+                        ) {
                             break 'scan;
                         }
                     }
-                    if probes >= max_probes {
-                        break 'scan;
+                }
+            }
+        } else {
+            // Publish: older (lower) offsets are more likely already replicated
+            // on Submit/Publish peers, so fill from the start of the slot.
+            self.scan_cursor = self.scan_cursor.min(max_offset);
+            let cursor = self.scan_cursor;
+            let ranges = [(cursor, max_offset), (0, cursor.saturating_sub(1))];
+            'scan: for (range_start, range_end) in ranges {
+                if range_start > range_end {
+                    continue;
+                }
+                for interval in &entropy_intervals {
+                    let start = (*interval.start()).max(range_start);
+                    let end = (*interval.end()).min(range_end).min(max_offset);
+                    if start > end {
+                        continue;
+                    }
+                    for interval_step in start..=end {
+                        if self.note_scan_offset(
+                            interval_step,
+                            max_offset,
+                            false,
+                            now,
+                            &mut probes,
+                            max_probes,
+                            &mut requests_to_add,
+                        ) {
+                            break 'scan;
+                        }
                     }
                 }
             }
@@ -398,10 +436,47 @@ impl ChunkOrchestrator {
     /// these orchestrators before Publish so Submit replicas stay on the
     /// frontier and Publish has many sources to copy from.
     pub(crate) fn prioritizes_write_frontier(&self) -> bool {
+        Self::ledger_prioritizes_write_frontier(self.ledger_id)
+    }
+
+    fn ledger_prioritizes_write_frontier(ledger_id: u32) -> bool {
         matches!(
-            DataLedger::try_from(self.ledger_id),
+            DataLedger::try_from(ledger_id),
             Ok(DataLedger::Submit | DataLedger::OneYear | DataLedger::ThirtyDay)
         )
+    }
+
+    /// Advance `scan_cursor` past `interval_step` and maybe enqueue it.
+    /// Returns true when the scan should stop (budget or probe cap).
+    fn note_scan_offset(
+        &mut self,
+        interval_step: u32,
+        max_offset: u32,
+        reverse: bool,
+        now: Instant,
+        probes: &mut usize,
+        max_probes: usize,
+        requests_to_add: &mut usize,
+    ) -> bool {
+        *probes += 1;
+        self.scan_cursor = if reverse {
+            if interval_step == 0 {
+                u32::MAX
+            } else {
+                interval_step - 1
+            }
+        } else if interval_step == max_offset {
+            0
+        } else {
+            interval_step.saturating_add(1)
+        };
+        if self.enqueue_pending(PartitionChunkOffset::from(interval_step), now, false) {
+            *requests_to_add = requests_to_add.saturating_sub(1);
+            if *requests_to_add == 0 {
+                return true;
+            }
+        }
+        *probes >= max_probes
     }
 
     /// Insert `offset` as Pending if it is not already tracked. `at_front`

--- a/crates/actors/src/data_sync_service/chunk_orchestrator/mod.rs
+++ b/crates/actors/src/data_sync_service/chunk_orchestrator/mod.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use irys_domain::{BlockTreeReadGuard, ChunkTimeRecord, ChunkType, CircularBuffer, StorageModule};
 use irys_types::{
-    IrysAddress, LedgerChunkOffset, NodeConfig, PartitionChunkOffset, SendTraced as _,
+    DataLedger, IrysAddress, LedgerChunkOffset, NodeConfig, PartitionChunkOffset, SendTraced as _,
     hardfork_config::DataLedgerLookup,
 };
 use std::{
@@ -330,11 +330,29 @@ impl ChunkOrchestrator {
         // eventual reconciliation without falsely marking a 404 synchronized.
         let entropy_intervals = self.storage_module.get_intervals(ChunkType::Entropy);
 
+        let max_offset = *max_chunk_offset;
+
+        // Term ledgers (especially Submit) are a small write head on a packed
+        // entropy tail. A low-to-high Entropy walk spends the hot budget on
+        // the prefix, so the newest migrated offset is not even queued — the
+        // replica looks one chunk short of the frontier. Enqueue that write
+        // head first. The service dispatcher also visits term SMs before
+        // Publish so a permanent backlog cannot skip this offset; Publish
+        // later copies Submit data and needs Submit replicas on the frontier.
+        if requests_to_add > 0
+            && self.prioritizes_write_frontier()
+            && entropy_intervals
+                .iter()
+                .any(|interval| *interval.start() <= max_offset && max_offset <= *interval.end())
+            && self.enqueue_pending(PartitionChunkOffset::from(max_offset), now, true)
+        {
+            requests_to_add -= 1;
+        }
+
         if requests_to_add == 0 {
             return;
         }
 
-        let max_offset = *max_chunk_offset;
         self.scan_cursor = self.scan_cursor.min(max_offset);
         let cursor = self.scan_cursor;
         let ranges = [(cursor, max_offset), (0, cursor.saturating_sub(1))];
@@ -360,23 +378,7 @@ impl ChunkOrchestrator {
                     };
 
                     let chunk_offset = PartitionChunkOffset::from(interval_step);
-                    let inserted = if let hash_map::Entry::Vacant(entry) =
-                        self.chunk_requests.entry(chunk_offset)
-                    {
-                        entry.insert(ChunkRequest {
-                            excluded: HashSet::new(),
-                            request_state: ChunkRequestState::Pending,
-                            attempt_count: 0,
-                            retry_round: 0,
-                            ready_since: now,
-                        });
-                        true
-                    } else {
-                        false
-                    };
-
-                    if inserted {
-                        self.ready_offsets.push_back(chunk_offset);
+                    if self.enqueue_pending(chunk_offset, now, false) {
                         requests_to_add -= 1;
                         if requests_to_add == 0 {
                             break 'scan;
@@ -388,6 +390,45 @@ impl ChunkOrchestrator {
                 }
             }
         }
+    }
+
+    /// Submit / OneYear / ThirtyDay: prefer the migrated write head. Publish
+    /// keeps the existing low-to-high walk so a large permanent backlog still
+    /// fills from the start of the slot. The service dispatcher also visits
+    /// these orchestrators before Publish so Submit replicas stay on the
+    /// frontier and Publish has many sources to copy from.
+    pub(crate) fn prioritizes_write_frontier(&self) -> bool {
+        matches!(
+            DataLedger::try_from(self.ledger_id),
+            Ok(DataLedger::Submit | DataLedger::OneYear | DataLedger::ThirtyDay)
+        )
+    }
+
+    /// Insert `offset` as Pending if it is not already tracked. `at_front`
+    /// places it at the dispatch head (term-ledger write head); otherwise it
+    /// joins the FIFO tail.
+    fn enqueue_pending(
+        &mut self,
+        chunk_offset: PartitionChunkOffset,
+        now: Instant,
+        at_front: bool,
+    ) -> bool {
+        let hash_map::Entry::Vacant(entry) = self.chunk_requests.entry(chunk_offset) else {
+            return false;
+        };
+        entry.insert(ChunkRequest {
+            excluded: HashSet::new(),
+            request_state: ChunkRequestState::Pending,
+            attempt_count: 0,
+            retry_round: 0,
+            ready_since: now,
+        });
+        if at_front {
+            self.ready_offsets.push_front(chunk_offset);
+        } else {
+            self.ready_offsets.push_back(chunk_offset);
+        }
+        true
     }
 
     /// Dispatch at most one ready offset. Returning `false` lets the service

--- a/crates/actors/src/data_sync_service/chunk_orchestrator/tests.rs
+++ b/crates/actors/src/data_sync_service/chunk_orchestrator/tests.rs
@@ -1152,3 +1152,70 @@ async fn publish_hot_budget_still_walks_from_the_slot_start() {
         "Publish must not spend its only hot slot on the write head"
     );
 }
+
+/// Term-ledger gaps at low offsets are often abandoned uploads. Discovery
+/// must walk down from the write head so a small hot budget is spent on
+/// frontier Entropy, not on the prefix.
+#[test_log::test(tokio::test)]
+async fn term_ledger_scan_walks_from_the_frontier_downward() {
+    let tmp = TempDirBuilder::new().with_tracing().build();
+    let config = test_config_with_pending_limit(tmp.path().to_path_buf(), 8, 2);
+    let sm = packed_sm_for_ledger(&config, 8, DataLedger::Submit);
+    let mut orch = make_orchestrator_with_ledger_total(sm, &config, DataLedger::Submit, 8);
+    orch.populate_request_queue();
+
+    assert_eq!(
+        orch.ready_offsets.front().copied(),
+        Some(PartitionChunkOffset::from(7_u32))
+    );
+    assert_eq!(
+        orch.ready_offsets.back().copied(),
+        Some(PartitionChunkOffset::from(6_u32))
+    );
+    assert!(
+        !orch
+            .chunk_requests
+            .contains_key(&PartitionChunkOffset::from(0_u32)),
+        "a two-slot budget must not be spent on the abandoned-upload prefix"
+    );
+}
+
+/// After the frontier has been scanned, the reverse walk wraps and still
+/// probes low-offset Entropy — just not first.
+#[test_log::test(tokio::test)]
+async fn term_ledger_reverse_scan_visits_the_prefix_after_the_frontier() {
+    let tmp = TempDirBuilder::new().with_tracing().build();
+    let config = test_config_with_pending_limit(tmp.path().to_path_buf(), 8, 2);
+    let sm = packed_sm_for_ledger(&config, 8, DataLedger::Submit);
+    let mut orch = make_orchestrator_with_ledger_total(sm, &config, DataLedger::Submit, 8);
+    let peer = add_assigned_peer(&mut orch, &config, 91, 9091);
+
+    orch.populate_request_queue();
+    for value in [7_u32, 6_u32] {
+        let offset = PartitionChunkOffset::from(value);
+        orch.chunk_requests.get_mut(&offset).unwrap().request_state =
+            ChunkRequestState::Requested(peer, Instant::now());
+        orch.on_chunk_failed(
+            offset,
+            peer,
+            crate::chunk_fetcher::ChunkFetchFailureKind::NotFound,
+        )
+        .unwrap();
+    }
+
+    orch.populate_request_queue();
+    assert!(
+        orch.chunk_requests
+            .contains_key(&PartitionChunkOffset::from(5_u32))
+            && orch
+                .chunk_requests
+                .contains_key(&PartitionChunkOffset::from(4_u32)),
+        "after the frontier is delayed, reverse discovery must continue downward"
+    );
+    assert!(
+        !orch
+            .chunk_requests
+            .contains_key(&PartitionChunkOffset::from(0_u32)),
+        "the prefix must still wait until higher offsets have been scanned"
+    );
+}

--- a/crates/actors/src/data_sync_service/chunk_orchestrator/tests.rs
+++ b/crates/actors/src/data_sync_service/chunk_orchestrator/tests.rs
@@ -85,10 +85,19 @@ fn make_orchestrator_with_ledger_chunks(
     config: &Config,
     total_chunks: u64,
 ) -> ChunkOrchestrator {
+    make_orchestrator_with_ledger_total(sm, config, DataLedger::Publish, total_chunks)
+}
+
+fn make_orchestrator_with_ledger_total(
+    sm: Arc<StorageModule>,
+    config: &Config,
+    ledger: DataLedger,
+    total_chunks: u64,
+) -> ChunkOrchestrator {
     use irys_testing_utils::IrysBlockHeaderTestExt as _;
 
     let mut genesis = irys_testing_utils::new_mock_signed_header();
-    genesis.data_ledgers[DataLedger::Publish].total_chunks = total_chunks;
+    genesis.data_ledgers[ledger].total_chunks = total_chunks;
     genesis.test_sign();
     let block_tree = BlockTree::new(&genesis, config.consensus.clone());
     let block_tree_guard = BlockTreeReadGuard::new(Arc::new(RwLock::new(block_tree)));
@@ -98,7 +107,7 @@ fn make_orchestrator_with_ledger_chunks(
         Arc::new(RwLock::new(HashMap::new())),
         block_tree_guard,
         &service_senders,
-        Arc::new(MockChunkFetcher::new(DataLedger::Publish as usize)),
+        Arc::new(MockChunkFetcher::new(ledger as usize)),
         config.node_config.clone(),
         tokio::runtime::Handle::current(),
     )
@@ -1090,5 +1099,56 @@ async fn restart_recovers_from_durable_storage_and_entropy_intervals() {
             .chunk_requests
             .contains_key(&PartitionChunkOffset::from(2_u32)),
         "restart must still discover work after the formerly delayed offset"
+    );
+}
+
+/// If the prefix is already Data and the hot budget is one slot, a low-to-high
+/// Entropy walk queues `frontier-1` and never discovers the write head. That
+/// is the "replica is one chunk below the frontier" shape: everything except
+/// the newest migrated offset is durable. Term ledgers must queue the write
+/// head first.
+#[test_log::test(tokio::test)]
+async fn term_ledger_hot_budget_queues_the_write_head_before_the_prefix() {
+    let tmp = TempDirBuilder::new().with_tracing().build();
+    let config = test_config_with_pending_limit(tmp.path().to_path_buf(), 8, 1);
+    let sm = packed_sm_for_ledger(&config, 8, DataLedger::Submit);
+    for value in 0..6_u32 {
+        store_durable_data(&sm, PartitionChunkOffset::from(value), 32);
+    }
+    let mut orch = make_orchestrator_with_ledger_total(sm, &config, DataLedger::Submit, 8);
+    orch.populate_request_queue();
+
+    let frontier = PartitionChunkOffset::from(7_u32);
+    let just_behind = PartitionChunkOffset::from(6_u32);
+    assert_eq!(
+        orch.ready_offsets.front().copied(),
+        Some(frontier),
+        "the term-ledger write head must dispatch before the remaining prefix hole"
+    );
+    assert!(orch.chunk_requests.contains_key(&frontier));
+    assert!(
+        !orch.chunk_requests.contains_key(&just_behind),
+        "a one-slot hot budget must not be spent on frontier-1 while the write head is still Entropy"
+    );
+}
+
+#[test_log::test(tokio::test)]
+async fn publish_hot_budget_still_walks_from_the_slot_start() {
+    let tmp = TempDirBuilder::new().with_tracing().build();
+    let config = test_config_with_pending_limit(tmp.path().to_path_buf(), 8, 1);
+    let sm = packed_sm(&config, 8);
+    let mut orch = make_orchestrator_with_ledger_chunks(sm, &config, 8);
+    orch.populate_request_queue();
+
+    assert_eq!(
+        orch.ready_offsets.front().copied(),
+        Some(PartitionChunkOffset::from(0_u32)),
+        "Publish must keep filling from the start of the slot"
+    );
+    assert!(
+        !orch
+            .chunk_requests
+            .contains_key(&PartitionChunkOffset::from(7_u32)),
+        "Publish must not spend its only hot slot on the write head"
     );
 }


### PR DESCRIPTION
**Describe the changes**

A replica that looks “one chunk below the term-ledger frontier” can be a scheduler artifact, not an off-by-one in `total_chunks`.

**Term ledgers (Submit, OneYear, ThirtyDay)** — live data sits at the write head. Low-offset Entropy is often an abandoned upload that will never fill; we still probe it, but only after the frontier has been scanned. Discovery now:

1. Enqueues the migrated write-head offset first if it is still Entropy.
2. Walks Entropy **high-to-low** from the frontier, wrapping to the prefix only after that pass.
3. Takes a dispatcher turn **before Publish** each pass, so a large permanent backlog cannot consume every shared peer permit first.

**Publish** — the opposite is true. Older / lower offsets are more likely already replicated on Submit or Publish partitions, so Publish still fills from the start of the slot.

Publish copies Submit data for promotion. That path is healthy when Submit replicas stay on the frontier, which is why term work is scheduled first.

**Proof**

- `term_ledger_scan_walks_from_the_frontier_downward`: full Entropy, hot budget 2 → queues **7 then 6**, not 0.
- `term_ledger_reverse_scan_visits_the_prefix_after_the_frontier`: after 7 and 6 404, the next pass queues 5 and 4 — prefix 0 still waits.
- `term_ledger_hot_budget_queues_the_write_head_before_the_prefix`: durable `0..=5`, Entropy at 6 and 7, budget 1 → queues **7**, not 6.
- `publish_hot_budget_still_walks_from_the_slot_start`: Publish with budget 1 still queues offset 0.
- `term_ledgers_take_permits_before_publish_when_capacity_is_scarce`: 1 Submit + 3 Publish, 3 permits → Submit always included.
- `two_term_ledgers_rotate_fairly_ahead_of_publish`: two term SMs rotate in front of Publish.

**Related Issue(s)**
Follow-on to the sparse-term starvation work (#1561). Distinct from #1562 (migrated-block index).

**Checklist**

- [x] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**

Verified locally: `chunk_orchestrator` + `scheduler_fairness` tests, `cargo clippy -p irys-actors --tests --all-targets -- -D warnings`.