### PR TITLE
fix(metrics): extend chunk latency histograms beyond one second

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ docker/build-output/
 .claude/skills
 .claude/commands
 .agents/local
+/agents/

--- a/crates/actors/src/chunk_ingress_service/metrics.rs
+++ b/crates/actors/src/chunk_ingress_service/metrics.rs
@@ -6,8 +6,8 @@ irys_utils::define_metrics! {
     counter CHUNKS_INGESTED("irys.mempool.chunks.ingested_total", "Chunks successfully ingested into mempool");
     counter BYTES_INGESTED("irys.mempool.chunks.bytes_ingested_total", "Total bytes ingested into mempool");
     counter DUPLICATES("irys.mempool.chunks.duplicates_total", "Duplicate chunks skipped");
-    histogram VALIDATION_MS("irys.mempool.chunks.validation_duration_ms", "Chunk proof validation latency", vec![0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0]);
-    histogram ENQUEUE_MS("irys.mempool.chunks.enqueue_duration_ms", "Chunk write-behind enqueue latency", vec![0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0]);
+    histogram VALIDATION_MS("irys.mempool.chunks.validation_duration_ms", "Chunk proof validation latency", vec![0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0, 10000.0, 30000.0]);
+    histogram ENQUEUE_MS("irys.mempool.chunks.enqueue_duration_ms", "Chunk write-behind enqueue latency", vec![0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0, 10000.0, 30000.0]);
     counter FLUSH_FAILURES("irys.mempool.chunks.flush_failures_total", "Chunk writer flush failures");
     counter ERRORS("irys.mempool.chunks.errors_total", "Chunk processing errors by type");
 }

--- a/crates/api-server/src/metrics.rs
+++ b/crates/api-server/src/metrics.rs
@@ -13,8 +13,8 @@ irys_utils::define_metrics! {
     counter CHUNKS_RECEIVED("irys.api.chunks.received_total", "Total chunks received via API");
     counter BYTES_RECEIVED("irys.api.chunks.bytes_received_total", "Total bytes received in chunk payloads");
     counter CHUNK_ERRORS("irys.api.chunks.errors_total", "Chunk processing errors by type");
-    histogram CHUNK_PROCESSING_MS("irys.api.chunks.processing_duration_ms", "Chunk processing latency in milliseconds", vec![0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0]);
-    histogram REQUEST_DURATION_MS("irys.api.http.request_duration_ms", "HTTP request processing latency in milliseconds", vec![0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0]);
+    histogram CHUNK_PROCESSING_MS("irys.api.chunks.processing_duration_ms", "Chunk processing latency in milliseconds", vec![0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0, 10000.0, 30000.0]);
+    histogram REQUEST_DURATION_MS("irys.api.http.request_duration_ms", "HTTP request processing latency in milliseconds", vec![0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0, 10000.0, 30000.0]);
     counter REQUESTS_TOTAL("irys.api.http.requests_total", "Total HTTP requests by method, path, and status");
 }
 

--- a/crates/p2p/src/metrics.rs
+++ b/crates/p2p/src/metrics.rs
@@ -5,7 +5,7 @@ irys_utils::define_metrics! {
 
     counter CHUNKS_RECEIVED("irys.gossip.chunks.received_total", "Total chunks received via gossip");
     counter BYTES_RECEIVED("irys.gossip.chunks.bytes_received_total", "Total bytes received in gossip chunk payloads");
-    histogram PROCESSING_MS("irys.gossip.chunks.processing_duration_ms", "Gossip chunk processing latency in milliseconds", vec![0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0]);
+    histogram PROCESSING_MS("irys.gossip.chunks.processing_duration_ms", "Gossip chunk processing latency in milliseconds", vec![0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0, 10000.0, 30000.0]);
     counter INBOUND_ERRORS("irys.gossip.inbound.errors_total", "Gossip inbound processing errors by type");
     counter OUTBOUND_ERRORS("irys.gossip.outbound.errors_total", "Gossip outbound send errors by type");
     counter PULL_FAILURES("irys.gossip.pull.failures_total", "Gossip pull failures by request kind and reason");

--- a/docker/observation/configs/grafana/dashboards/detailed/chunk-processing.json
+++ b/docker/observation/configs/grafana/dashboards/detailed/chunk-processing.json
@@ -4,7 +4,7 @@
   "tags": ["irys", "chunks", "ingestion", "gossip"],
   "timezone": "browser",
   "schemaVersion": 38,
-  "version": 2,
+  "version": 3,
   "refresh": "10s",
   "time": {
     "from": "now-1h",
@@ -860,6 +860,66 @@
           }
         }
       }
+    },
+    {
+      "type": "timeseries",
+      "title": "API Chunk POST Latency by Node (p95)",
+      "description": "Application HTTP response latency for POST /v1/chunk, including advisory responses. Finite buckets extend through 30 seconds; quantiles in the overflow bucket remain unresolved. This is separate from the spanmetrics panels above.",
+      "gridPos": { "x": 0, "y": 75, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.95, sum by (job, le) (rate(irys_api_http_request_duration_ms_bucket{job=~\"$node\", method=\"POST\", path=\"/v1/chunk\"}[$__rate_interval])))",
+          "legendFormat": "{{job}} POST p95",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ms", "min": 0 } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Served Ledger Chunk GET 404s",
+      "description": "404 responses served by each node for ledger-offset GETs. These reads bypass chunk-ingress admission but share HTTP workers and storage resources with other requests. A 404 does not identify the caller or prove migration caused the miss.",
+      "gridPos": { "x": 12, "y": 75, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (job) (rate(irys_api_http_requests_total{job=~\"$node\", method=\"GET\", path=\"/v1/chunk/ledger/{ledger_id}/{ledger_offset}\", status=\"404\"}[$__rate_interval]))",
+          "legendFormat": "{{job}} served 404/s",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps", "min": 0 } }
+    },
+    {
+      "type": "timeseries",
+      "title": "API Chunk POST Overload Advisories",
+      "description": "Overloaded results returned to API chunk POST callers, including gateway callers. This node API currently returns these as HTTP 200 advisory bodies; gateway-facing 503s belong to a different metric boundary. Data-sync GET failures do not increment this API counter.",
+      "gridPos": { "x": 0, "y": 81, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (job) (rate(irys_api_chunks_errors_total{job=~\"$node\", error_type=\"overloaded\"}[$__rate_interval]))",
+          "legendFormat": "{{job}} API overload/s",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps", "min": 0 } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Data Sync Fetch Not Found by Requesting Node",
+      "description": "Outbound data-sync fetches classified as not_found, across ledger-offset and data-root fetches. Labels identify the requesting node and ledger. A failed fetch is requeued without entering chunk ingress; successfully fetched bodies share chunk-ingress admission with API POST and gossip bodies.",
+      "gridPos": { "x": 12, "y": 81, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (job, ledger) (rate(irys_data_sync_fetch_failures_total{job=~\"$node\", failure=\"not_found\"}[$__rate_interval]))",
+          "legendFormat": "{{job}} ledger {{ledger}} not-found/s",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps", "min": 0 } }
     }
   ]
 }


### PR DESCRIPTION
**Describe the changes**
**Before**: Histograms capped at 1 second; failure signals lacked dedicated panels.
**After**: Buckets reach 30 seconds; four panels distinguish latency, overloads, and misses.


**Related Issue(s)**
Please link to the issue(s) that will be closed with this PR.

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
