### PR TITLE
fix(chunk-migration): split index path from background body migration

### DIFF
--- a/crates/actors/src/block_migration_service.rs
+++ b/crates/actors/src/block_migration_service.rs
@@ -719,7 +719,32 @@ impl BlockMigrationService {
         // rollback. Crash-safe journaled recovery is the proper fix, tracked for
         // the storage-module rework. Everything above this point is read-only, so
         // its failures propagate normally.
+        /// Holds every module's data writes paused for the rollback; resumes on
+        /// drop, including on the abort path.
+        struct PausedDataWrites(Vec<Arc<StorageModule>>);
+        impl PausedDataWrites {
+            fn pause(modules: Vec<Arc<StorageModule>>) -> Self {
+                for module in &modules {
+                    module.pause_data_writes();
+                }
+                Self(modules)
+            }
+        }
+        impl Drop for PausedDataWrites {
+            fn drop(&mut self) {
+                for module in &self.0 {
+                    module.resume_data_writes();
+                }
+            }
+        }
         let apply_rollback = || -> eyre::Result<()> {
+            // Freeze data writes on every module for the whole rollback. The
+            // body worker, data sync and chunk ingress all write through
+            // `write_data_chunk`; any of them landing a write between
+            // `drop_pending_writes_in_range` and the interval re-mark below
+            // would flush orphaned bytes as `Data` over a cleared index.
+            let _writes_paused =
+                PausedDataWrites::pause(storage_modules_guard.read().iter().cloned().collect());
             // Phase 2: Unassign storage module offsets and clear orphaned index entries
             for info in &rollback_infos {
                 for (ledger, range) in &info.ledger_ranges {
@@ -801,6 +826,13 @@ impl BlockMigrationService {
                             PartitionChunkOffset::from(range_start),
                             PartitionChunkOffset::from(range_end),
                             &info.data_roots,
+                        )?;
+                        // The chunk bodies those placements still owed belong to
+                        // orphaned txs: drop the jobs so the body worker never
+                        // writes them into the re-marked range.
+                        module.purge_pending_body_migrations_in_range(
+                            PartitionChunkOffset::from(range_start),
+                            PartitionChunkOffset::from(range_end),
                         )?;
 
                         // Mark offsets as Uninitialized (not Entropy — on-disk bytes are packed data)
@@ -2718,6 +2750,33 @@ mod tests {
             index.push_item(&submit_index_item(&orphan, 8), 1)?;
         }
 
+        // Body-migration jobs: one for the orphaned tx spanning both modules
+        // (block 1), one for a genesis-range tx that must survive (block 0).
+        let body_job_tx = |data_size: u64| {
+            irys_types::DataTransactionHeader::V1(irys_types::DataTransactionHeaderV1WithMetadata {
+                tx: irys_types::DataTransactionHeaderV1 {
+                    data_root: H256::random(),
+                    data_size,
+                    ..Default::default()
+                },
+                metadata: irys_types::DataTransactionMetadata::new(),
+            })
+        };
+        let chunk_size = config.consensus.chunk_size;
+        let orphan_tx = body_job_tx(5 * chunk_size);
+        let orphan_range =
+            LedgerChunkRange(ii(LedgerChunkOffset::from(3), LedgerChunkOffset::from(7)));
+        for module in &modules {
+            module.index_transaction_data(&orphan_tx, &vec![1, 2, 3], orphan_range, 1)?;
+        }
+        modules[0].index_transaction_data(
+            &body_job_tx(3 * chunk_size),
+            &vec![4, 5, 6],
+            LedgerChunkRange(ii(LedgerChunkOffset::from(0), LedgerChunkOffset::from(2))),
+            0,
+        )?;
+        assert_eq!(modules[0].pending_body_migrations()?.len(), 2);
+        assert_eq!(modules[1].pending_body_migrations()?.len(), 1);
         svc.recover_from_network_partition(0)?;
 
         {
@@ -2725,6 +2784,17 @@ mod tests {
             assert_eq!(index.num_blocks(), 1);
             assert_eq!(index.latest_height(), 0);
         }
+        // The orphaned tx's body jobs are gone from both modules; the genesis
+        // tx's job (partition offset 0 in slot 0) survives.
+        let surviving: Vec<_> = modules[0]
+            .pending_body_migrations()?
+            .into_iter()
+            .map(|(key, job)| (key, job.block_height))
+            .collect();
+        assert_eq!(surviving, vec![(PartitionChunkOffset::from(0), 0)]);
+        assert!(modules[1].pending_body_migrations()?.is_empty());
+        // The write pause is scoped to the rollback: both modules accept data again.
+        assert!(modules.iter().all(|module| !module.data_writes_paused()));
 
         // Each module had exactly its own slice of [3, 7] unassigned: the
         // genesis chunks [0, 2] stay packed in slot 0, and slot 1's offsets

--- a/crates/actors/src/chunk_ingress_service/chunks.rs
+++ b/crates/actors/src/chunk_ingress_service/chunks.rs
@@ -9,6 +9,7 @@ use super::metrics::{
 use irys_database::{
     complete_ingress_leaves, confirm_data_size_for_data_root, db::IrysDatabaseExt as _,
 };
+use irys_domain::WriteDataChunkError;
 use irys_types::gossip::v2::GossipBroadcastMessageV2;
 use irys_types::{
     DataLedger, DataRoot, DatabaseProvider, H256, IngressMerkleLeaf, IngressProof, SendTraced as _,
@@ -565,20 +566,26 @@ impl ChunkIngressServiceInner {
                 .is_empty()
             {
                 info!(target: "irys::mempool::chunk_ingress", "Writing chunk with offset {} for data_root {} to sm {}", &chunk.tx_offset, &chunk.data_root, &sm.id );
-                let result = sm
-                    .write_data_chunk(&chunk)
-                    .map_err(|e| {
+                let result = sm.write_data_chunk(&chunk).map_err(|e| match e {
+                    // Network-partition recovery is rewriting this module's
+                    // ranges. Transient backpressure, not a bad chunk: report it
+                    // the way capacity limits are reported so gossip peers are not
+                    // penalised and HTTP clients retry.
+                    WriteDataChunkError::WritesPaused => {
+                        ChunkIngressError::Advisory(AdvisoryChunkIngressError::Overloaded)
+                    }
+                    e => {
                         error!(
                             "Failed to write chunk data_root {:?} tx_offset {} to storage_module {}: {:?}",
                             chunk.data_root, chunk.tx_offset, sm.id, e
                         );
-                        CriticalChunkIngressError::Other(format!(
-                            "Failed to write chunk to storage_module {}", sm.id
-                        ))
-                    });
-                if let Err(e) = result {
-                    return Err(e.into());
-                }
+                        ChunkIngressError::Critical(CriticalChunkIngressError::Other(format!(
+                            "Failed to write chunk to storage_module {}",
+                            sm.id
+                        )))
+                    }
+                });
+                result?;
             }
         }
 

--- a/crates/actors/src/chunk_ingress_service/chunks.rs
+++ b/crates/actors/src/chunk_ingress_service/chunks.rs
@@ -566,26 +566,25 @@ impl ChunkIngressServiceInner {
                 .is_empty()
             {
                 info!(target: "irys::mempool::chunk_ingress", "Writing chunk with offset {} for data_root {} to sm {}", &chunk.tx_offset, &chunk.data_root, &sm.id );
-                let result = sm.write_data_chunk(&chunk).map_err(|e| match e {
-                    // Network-partition recovery is rewriting this module's
-                    // ranges. Transient backpressure, not a bad chunk: report it
-                    // the way capacity limits are reported so gossip peers are not
-                    // penalised and HTTP clients retry.
-                    WriteDataChunkError::WritesPaused => {
-                        ChunkIngressError::Advisory(AdvisoryChunkIngressError::Overloaded)
-                    }
-                    e => {
+                match sm.write_data_chunk(&chunk) {
+                    Ok(()) => {}
+                    // Cache already committed; the body worker places this after
+                    // recovery resumes. Failing the request would skip gossip,
+                    // and a retry would no-op at `recent_valid_chunks`.
+                    Err(WriteDataChunkError::WritesPaused) => {}
+                    Err(e) => {
                         error!(
                             "Failed to write chunk data_root {:?} tx_offset {} to storage_module {}: {:?}",
                             chunk.data_root, chunk.tx_offset, sm.id, e
                         );
-                        ChunkIngressError::Critical(CriticalChunkIngressError::Other(format!(
-                            "Failed to write chunk to storage_module {}",
-                            sm.id
-                        )))
+                        return Err(ChunkIngressError::Critical(
+                            CriticalChunkIngressError::Other(format!(
+                                "Failed to write chunk to storage_module {}",
+                                sm.id
+                            )),
+                        ));
                     }
-                });
-                result?;
+                }
             }
         }
 

--- a/crates/actors/src/chunk_migration_service.rs
+++ b/crates/actors/src/chunk_migration_service.rs
@@ -6,7 +6,8 @@ use irys_database::{
     tx_header_by_txid,
 };
 use irys_domain::{
-    BlockIndex, StorageModule, StorageModulesReadGuard, get_overlapped_storage_modules,
+    BlockIndex, StorageModule, StorageModulesReadGuard, WriteDataChunkError,
+    get_overlapped_storage_modules,
 };
 use irys_packing::unpack;
 use irys_storage::{InclusiveInterval as _, ie, ii};
@@ -18,8 +19,10 @@ use irys_types::{
 };
 use reth::tasks::shutdown::Shutdown;
 use std::{collections::HashMap, sync::Arc};
-use tokio::sync::{mpsc::UnboundedReceiver, oneshot};
+use tokio::sync::{Notify, mpsc::UnboundedReceiver, oneshot};
 use tracing::{error, instrument};
+
+mod body_worker;
 
 pub struct ChunkMigrationService {
     shutdown: Shutdown,
@@ -27,13 +30,19 @@ pub struct ChunkMigrationService {
     inner: ChunkMigrationServiceInner,
 }
 
-/// Central coordinator for chunk storage operations.
+/// Moves a migrated block's data into the storage modules, in two decoupled
+/// halves:
 ///
-/// Responsibilities:
-/// - Routes chunks to appropriate storage modules
-/// - Maintains chunk location indices
-/// - Coordinates chunk reads/writes
-/// - Manages storage state transitions
+/// - **Index path** (this service, in block order): for every ledger tx,
+///   writes the `tx_path` / `data_root` mappings into each overlapping
+///   submodule's index and, in the same transaction, a
+///   `PendingBodyMigrationsByOffset` row recording that the tx's chunk bodies
+///   are still owed. MDBX only — never touches chunk data — so one huge tx can
+///   never delay the next block's indexes.
+/// - **Body path** (`body_worker`, background): drains those rows at disk
+///   speed, sourcing bodies from the chunk cache or the durable Submit replica,
+///   under a per-pass budget and a pending-write byte ceiling. Whatever it
+///   cannot source locally is left as Entropy for data sync.
 #[derive(Debug)]
 pub struct ChunkMigrationServiceInner {
     /// Tracks block boundaries and offsets for locating chunks in ledgers
@@ -46,6 +55,8 @@ pub struct ChunkMigrationServiceInner {
     pub db: DatabaseProvider,
     /// Service sender channels
     pub service_senders: ServiceSenders,
+    /// Wakes the body-migration worker once a block's indexes have committed.
+    pub body_wakeup: Arc<Notify>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -84,6 +95,7 @@ impl ChunkMigrationServiceInner {
         db: DatabaseProvider,
         service_senders: ServiceSenders,
         config: Config,
+        body_wakeup: Arc<Notify>,
     ) -> Self {
         tracing::info!("service started: chunk_migration");
         Self {
@@ -92,14 +104,25 @@ impl ChunkMigrationServiceInner {
             storage_modules_guard: storage_modules_guard.clone(),
             db,
             service_senders,
+            body_wakeup,
         }
     }
 
-    #[tracing::instrument(level = "trace", skip_all, err)]
-    pub fn handle_message(&mut self, msg: ChunkMigrationServiceMessage) -> eyre::Result<()> {
+    /// Infallible by design: one block whose migration fails must not take the
+    /// service — and every later block's indexes — down with it. The failure is
+    /// logged; index heal re-migrates blocks whose indexes are missing.
+    #[tracing::instrument(level = "trace", skip_all)]
+    pub fn handle_message(&mut self, msg: ChunkMigrationServiceMessage) {
         match msg {
             ChunkMigrationServiceMessage::BlockMigrated(block_header, all_txs) => {
-                self.on_block_migrated(block_header, all_txs)?;
+                if let Err(error) = self.on_block_migrated(block_header.clone(), all_txs) {
+                    tracing::error!(
+                        block.height = block_header.height,
+                        block.hash = %block_header.block_hash,
+                        ?error,
+                        "chunk migration failed for block; continuing with later blocks"
+                    );
+                }
             }
             ChunkMigrationServiceMessage::UpdateStorageModuleIndexes {
                 block_hash,
@@ -115,7 +138,6 @@ impl ChunkMigrationServiceInner {
                 };
             }
         }
-        Ok(())
     }
 
     fn on_update_storage_module_indexes(
@@ -177,7 +199,6 @@ impl ChunkMigrationServiceInner {
         let block_index = self.block_index.clone();
         let config = self.config.clone();
         let storage_modules = Arc::new(self.storage_modules_guard.clone());
-        let db = Arc::new(self.db.clone());
         let service_senders = self.service_senders.clone();
 
         let block_height = block.height;
@@ -226,9 +247,13 @@ impl ChunkMigrationServiceInner {
                 &block_index,
                 &config,
                 &storage_modules,
-                &db,
             )?;
         }
+
+        // This block's indexes are committed; the bodies they describe are now
+        // owed as `PendingBodyMigrationsByOffset` rows. Wake the worker — it
+        // also polls, so a lost wake-up only costs latency, never progress.
+        self.body_wakeup.notify_one();
 
         // forward the finalization message to the cache service for cleanup
         if let Err(e) = service_senders
@@ -246,6 +271,11 @@ impl ChunkMigrationServiceInner {
     }
 }
 
+/// Indexes one ledger's transactions for a migrated block. **Index only**: the
+/// `tx_path` / `data_root` mappings commit here, in block order, and the chunk
+/// bodies they describe are left as `PendingBodyMigrationsByOffset` rows for the
+/// body worker (`body_worker.rs`). Nothing in this path reads or writes chunk
+/// data, so one huge tx can never delay the next block's indexes.
 #[tracing::instrument(level = "trace", skip_all, err)]
 pub fn process_ledger_transactions(
     block: &Arc<IrysBlockHeader>,
@@ -254,7 +284,6 @@ pub fn process_ledger_transactions(
     block_index: &BlockIndex,
     config: &Config,
     storage_modules_guard: &StorageModulesReadGuard,
-    db: &Arc<DatabaseProvider>,
 ) -> Result<(), MigrationError> {
     let path_pairs = get_tx_path_pairs(block, ledger, txs).map_err(|e| {
         MigrationError::Other(format!("tx path merklization failed for {ledger:?}: {e}"))
@@ -285,23 +314,8 @@ pub fn process_ledger_transactions(
             tx_chunk_range,
             ledger,
             storage_modules_guard,
+            block.height,
         )?;
-
-        process_transaction_chunks(
-            tx,
-            num_chunks_in_tx,
-            tx_chunk_range,
-            ledger,
-            storage_modules_guard,
-            db,
-            config,
-        )?;
-
-        for module in storage_modules_guard.read().iter() {
-            if let Err(e) = module.sync_pending_chunks() {
-                tracing::warn!("Failed to sync pending chunks: {:#}", e);
-            }
-        }
 
         prev_chunk_offset += num_chunks_in_tx as u64;
     }
@@ -309,68 +323,14 @@ pub fn process_ledger_transactions(
     Ok(())
 }
 
-fn process_transaction_chunks(
-    tx: &DataTransactionHeader,
-    num_chunks_in_tx: u32,
-    tx_chunk_range: LedgerChunkRange,
-    ledger: DataLedger,
-    storage_modules_guard: &StorageModulesReadGuard,
-    db: &DatabaseProvider,
-    config: &Config,
-) -> Result<(), MigrationError> {
-    for tx_chunk_offset in 0..num_chunks_in_tx {
-        let tx_chunk_offset = TxChunkOffset::from(tx_chunk_offset);
-        // Find which storage module intersects this chunk
-        let ledger_offset = tx_chunk_range.start() + *tx_chunk_offset;
-        let Some(storage_module) =
-            find_storage_module(storage_modules_guard, ledger, ledger_offset.into())
-        else {
-            continue;
-        };
-
-        // Idempotent replay: an already-durable target needs no source body, so
-        // a re-migrated block does not have to re-read or rewrite the chunk.
-        if let Some(target_offsets) = storage_module
-            .partition_offsets_for_data_root_chunk(tx.data_root, tx_chunk_offset)
-            .map_err(|error| {
-                MigrationError::Other(format!("resolving migration target: {error}"))
-            })?
-            && !target_offsets.is_empty()
-            && target_offsets
-                .iter()
-                .all(|offset| storage_module.is_data_chunk_durable_at(*offset))
-        {
-            continue;
-        }
-
-        let Some(chunk) = load_chunk_for_migration(
-            storage_modules_guard,
-            db,
-            ledger,
-            tx,
-            tx_chunk_offset,
-            config,
-        )?
-        else {
-            tracing::warn!(
-                target_ledger = ?ledger,
-                data_root = %tx.data_root,
-                %tx_chunk_offset,
-                "Chunk body unavailable during migration; leaving the target offset for data sync"
-            );
-            continue;
-        };
-
-        write_chunk_to_module(&storage_module, &chunk)?;
-    }
-    Ok(())
-}
-
+/// Source the body for `tx_offset` of `data_root`: the chunk cache first, then
+/// (Publish only) the durable Submit replica. `None` means data sync's problem.
 fn load_chunk_for_migration(
     storage_modules_guard: &StorageModulesReadGuard,
     db: &DatabaseProvider,
     target_ledger: DataLedger,
-    tx: &DataTransactionHeader,
+    data_root: DataRoot,
+    data_size: u64,
     tx_offset: TxChunkOffset,
     config: &Config,
 ) -> Result<Option<UnpackedChunk>, MigrationError> {
@@ -380,13 +340,14 @@ fn load_chunk_for_migration(
             config.consensus.chunk_size
         ))
     })?;
-    match get_cached_chunk(db, tx.data_root, tx_offset) {
+    match get_cached_chunk(db, data_root, tx_offset) {
         Ok(Some((_metadata, cached))) if cached.chunk.is_some() => {
-            match validate_chunk_for_migration(cached, tx, tx_offset, chunk_size) {
+            match validate_chunk_for_migration(cached, data_root, data_size, tx_offset, chunk_size)
+            {
                 Ok(chunk) => return Ok(Some(chunk)),
                 Err(error) => {
                     tracing::warn!(
-                        data_root = %tx.data_root,
+                        data_root = %data_root,
                         %tx_offset,
                         ?error,
                         "Cached chunk failed migration validation; checking durable fallback"
@@ -397,7 +358,7 @@ fn load_chunk_for_migration(
         Ok(_) => {}
         Err(error) => {
             tracing::warn!(
-                data_root = %tx.data_root,
+                data_root = %data_root,
                 %tx_offset,
                 ?error,
                 "Failed to read cached chunk during migration; checking durable fallback"
@@ -425,7 +386,7 @@ fn load_chunk_for_migration(
             continue;
         }
         let Some(partition_offsets) = module
-            .partition_offsets_for_data_root_chunk(tx.data_root, tx_offset)
+            .partition_offsets_for_data_root_chunk(data_root, tx_offset)
             .map_err(|error| {
                 MigrationError::Other(format!("resolving Submit fallback: {error}"))
             })?
@@ -450,9 +411,9 @@ fn load_chunk_for_migration(
                 chunk_size,
                 config.consensus.chain_id,
             );
-            if unpacked.data_root != tx.data_root || unpacked.tx_offset != tx_offset {
+            if unpacked.data_root != data_root || unpacked.tx_offset != tx_offset {
                 tracing::warn!(
-                    data_root = %tx.data_root,
+                    data_root = %data_root,
                     %tx_offset,
                     storage_module.id = module.id,
                     partition.offset = %partition_offset,
@@ -463,14 +424,15 @@ fn load_chunk_for_migration(
             match validate_chunk_parts_for_migration(
                 unpacked.data_path,
                 unpacked.bytes,
-                tx,
+                data_root,
+                data_size,
                 tx_offset,
                 chunk_size,
             ) {
                 Ok(chunk) => return Ok(Some(chunk)),
                 Err(error) => {
                     tracing::warn!(
-                        data_root = %tx.data_root,
+                        data_root = %data_root,
                         %tx_offset,
                         storage_module.id = module.id,
                         partition.offset = %partition_offset,
@@ -578,13 +540,19 @@ fn update_storage_module_indexes(
     tx_chunk_range: LedgerChunkRange,
     ledger: DataLedger,
     storage_modules_guard: &StorageModulesReadGuard,
+    block_height: u64,
 ) -> Result<(), MigrationError> {
     let overlapped_modules =
         get_overlapped_storage_modules(storage_modules_guard, ledger, &tx_chunk_range);
 
     for storage_module in overlapped_modules {
         storage_module
-            .index_transaction_data(data_tx, &tx_path_proof.to_vec(), tx_chunk_range)
+            .index_transaction_data(
+                data_tx,
+                &tx_path_proof.to_vec(),
+                tx_chunk_range,
+                block_height,
+            )
             .map_err(|e| {
                 error!(
                     "Failed to add tx path + data_root + start_offset to index: {}",
@@ -595,6 +563,7 @@ fn update_storage_module_indexes(
     }
     Ok(())
 }
+
 fn get_cached_chunk(
     db: &DatabaseProvider,
     data_root: DataRoot,
@@ -603,61 +572,55 @@ fn get_cached_chunk(
     db.view_eyre(|tx| cached_chunk_by_chunk_offset(tx, data_root, chunk_offset))
 }
 
-fn find_storage_module(
-    storage_modules_guard: &StorageModulesReadGuard,
-    ledger: DataLedger,
-    ledger_offset: u64,
-) -> Option<Arc<StorageModule>> {
-    // Return Arc<StorageModule> (not a reference)
-    let guard = storage_modules_guard.read();
-
-    guard.iter().find_map(|module| {
-        // First check ledger
-        module
-            .partition_assignment()
-            .as_ref()
-            .and_then(|pa| pa.ledger_id)
-            .filter(|&id| id == ledger as u32)
-            // Then check offset range
-            .and_then(|_| module.get_storage_module_ledger_offsets().ok())
-            .filter(|range| range.contains_point(ledger_offset.into()))
-            .map(|_| module.clone()) // Clone the Arc here (it's cheap)
-    })
-}
-
 #[tracing::instrument(level = "trace", skip_all, err)]
 fn write_chunk_to_module(
     storage_module: &Arc<StorageModule>,
     chunk: &UnpackedChunk,
 ) -> Result<(), MigrationError> {
-    storage_module.write_data_chunk(chunk).map_err(|e| {
-        error!(
-            "Failed to write chunk for data_root {:?} chunk_offset {} data_size {}: {:?}",
-            chunk.data_root, chunk.tx_offset, chunk.data_size, e
-        );
-        MigrationError::ChunkDataWrite
+    storage_module.write_data_chunk(chunk).map_err(|e| match e {
+        // Recovery holds the module's data writes; the worker defers, so this
+        // is expected and not an error worth an error-level log.
+        WriteDataChunkError::WritesPaused => {
+            MigrationError::Other("storage module data writes paused for recovery".to_owned())
+        }
+        e => {
+            error!(
+                "Failed to write chunk for data_root {:?} chunk_offset {} data_size {}: {:?}",
+                chunk.data_root, chunk.tx_offset, chunk.data_size, e
+            );
+            MigrationError::ChunkDataWrite
+        }
     })
 }
 
 fn validate_chunk_for_migration(
     cached: CachedChunk,
-    tx: &DataTransactionHeader,
+    data_root: DataRoot,
+    data_size: u64,
     chunk_offset: TxChunkOffset,
     chunk_size: usize,
 ) -> Result<UnpackedChunk, MigrationError> {
     let bytes = cached.chunk.ok_or_else(|| {
         MigrationError::Other(format!(
             "cached chunk body missing for {} offset {}",
-            tx.data_root, chunk_offset
+            data_root, chunk_offset
         ))
     })?;
-    validate_chunk_parts_for_migration(cached.data_path, bytes, tx, chunk_offset, chunk_size)
+    validate_chunk_parts_for_migration(
+        cached.data_path,
+        bytes,
+        data_root,
+        data_size,
+        chunk_offset,
+        chunk_size,
+    )
 }
 
 fn validate_chunk_parts_for_migration(
     data_path: Base64,
     bytes: Base64,
-    tx: &DataTransactionHeader,
+    data_root: DataRoot,
+    data_size: u64,
     chunk_offset: TxChunkOffset,
     chunk_size: usize,
 ) -> Result<UnpackedChunk, MigrationError> {
@@ -668,18 +631,18 @@ fn validate_chunk_parts_for_migration(
         .ok_or_else(|| MigrationError::Other("chunk byte range overflow".to_string()))?;
     let max_byte_range = min_byte_range
         .checked_add(chunk_size_u64)
-        .map_or(tx.data_size, |end| end.min(tx.data_size));
+        .map_or(data_size, |end| end.min(data_size));
     let target_byte_position = max_byte_range.checked_sub(1).ok_or_else(|| {
         MigrationError::Other(format!(
             "chunk has an empty byte range for {} offset {}",
-            tx.data_root, chunk_offset
+            data_root, chunk_offset
         ))
     })?;
-    let validation = validate_path(tx.data_root.0, &data_path, u128::from(target_byte_position))
+    let validation = validate_path(data_root.0, &data_path, u128::from(target_byte_position))
         .map_err(|error| {
             MigrationError::Other(format!(
                 "data path failed revalidation for {} offset {}: {error}",
-                tx.data_root, chunk_offset
+                data_root, chunk_offset
             ))
         })?;
     if validation.min_byte_range != u128::from(min_byte_range)
@@ -687,7 +650,7 @@ fn validate_chunk_parts_for_migration(
     {
         return Err(MigrationError::Other(format!(
             "chunk byte range mismatch for {} offset {}: expected {}..{}, got {}..{}",
-            tx.data_root,
+            data_root,
             chunk_offset,
             min_byte_range,
             max_byte_range,
@@ -701,12 +664,12 @@ fn validate_chunk_parts_for_migration(
     {
         return Err(MigrationError::Other(format!(
             "chunk body failed revalidation for {} offset {}",
-            tx.data_root, chunk_offset
+            data_root, chunk_offset
         )));
     }
     Ok(UnpackedChunk {
-        data_root: tx.data_root,
-        data_size: tx.data_size,
+        data_root,
+        data_size,
         data_path,
         bytes,
         tx_offset: chunk_offset,
@@ -728,6 +691,20 @@ impl ChunkMigrationService {
         let storage_modules_guard = storage_modules_guard.clone();
         let (shutdown_tx, shutdown_rx) = reth::tasks::shutdown::signal();
 
+        // Chunk bodies are written by a separate worker so a slow or busy disk
+        // can never hold up the next block's indexes (see `body_worker.rs`).
+        let body_wakeup = Arc::new(Notify::new());
+        runtime_handle.spawn(
+            body_worker::BodyMigrationWorker::new(
+                storage_modules_guard.clone(),
+                db.clone(),
+                config.clone(),
+                body_wakeup.clone(),
+                shutdown_rx.clone(),
+            )
+            .run(),
+        );
+
         let handle = runtime_handle.spawn(async move {
             let data_sync_service = Self {
                 shutdown: shutdown_rx,
@@ -738,6 +715,7 @@ impl ChunkMigrationService {
                     db,
                     service_senders,
                     config,
+                    body_wakeup,
                 ),
             };
             data_sync_service
@@ -770,7 +748,7 @@ impl ChunkMigrationService {
                     match msg {
                         Some(traced) => {
                             let (msg, _entered) = traced.into_inner();
-                            self.inner.handle_message(msg)?;
+                            self.inner.handle_message(msg);
                         }
                         None => {
                             tracing::warn!("Message channel closed unexpectedly");
@@ -784,10 +762,565 @@ impl ChunkMigrationService {
         // Process remaining messages before shutdown
         while let Ok(traced) = self.msg_rx.try_recv() {
             let (msg, _entered) = traced.into_inner();
-            self.inner.handle_message(msg)?;
+            self.inner.handle_message(msg);
         }
 
         tracing::info!("shutting down DataSync Service gracefully");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::body_worker::{
+        BodyMigrationWorker, MAX_BODY_MIGRATION_ATTEMPTS, PENDING_WRITE_CEILING_BATCHES,
+        PENDING_WRITE_CEILING_MIN_CHUNKS, PassStats, pending_write_ceiling_bytes,
+    };
+    use super::*;
+    use irys_database::{
+        IrysDatabaseArgs as _, cache_chunk, cache_data_root, insert_block_header, insert_tx_header,
+        open_or_create_db, submodule::tables::PendingBodyMigration, tables::IrysTables,
+    };
+    use irys_domain::{ChunkType, StorageModuleInfo};
+    use irys_testing_utils::TempDirBuilder;
+    use irys_types::{
+        BlockIndexItem, ConsensusConfig, DataTransaction, H256List, IrysAddress, LedgerIndexItem,
+        NodeConfig, PartitionChunkOffset, irys::IrysSigner, partition::PartitionAssignment,
+        partition_chunk_offset_ie,
+    };
+    use std::{sync::RwLock, time::Duration};
+
+    struct Fixture {
+        _tmp: irys_testing_utils::utils::tempfile::TempDir,
+        shutdown_signal: Option<reth::tasks::shutdown::Signal>,
+        shutdown: Shutdown,
+        config: Config,
+        sm: Arc<StorageModule>,
+        guard: StorageModulesReadGuard,
+        db: DatabaseProvider,
+        block_index: BlockIndex,
+        block: Arc<IrysBlockHeader>,
+        tx: DataTransaction,
+        data: Vec<u8>,
+    }
+
+    /// One Submit-assigned module (20 chunks, slot 0) and a height-0 block
+    /// carrying a single `num_chunks`-chunk Submit tx. The node DB starts with
+    /// no cached bodies; `seed_cache` adds them. `max_pending_write_bytes` is
+    /// the module's pending-write ceiling (`None` = derived default).
+    fn fixture(num_chunks: u64, max_pending_write_bytes: Option<u64>) -> eyre::Result<Fixture> {
+        let tmp = TempDirBuilder::new().with_tracing().build();
+        let chunk_size = 32_u64;
+        let mut node_config = NodeConfig {
+            consensus: irys_types::ConsensusOptions::Custom(ConsensusConfig {
+                chunk_size,
+                num_chunks_in_partition: 20,
+                num_chunks_in_recall_range: 2,
+                num_partitions_per_slot: 1,
+                entropy_packing_iterations: 1,
+                chain_id: 1,
+                ..ConsensusConfig::testing()
+            }),
+            base_directory: tmp.path().to_path_buf(),
+            ..NodeConfig::testing()
+        };
+        node_config.storage.max_pending_write_bytes = max_pending_write_bytes;
+        let config = Config::new_with_random_peer_id(node_config);
+
+        let sm = Arc::new(StorageModule::new(
+            &StorageModuleInfo {
+                id: 0,
+                partition_assignment: Some(PartitionAssignment {
+                    ledger_id: Some(DataLedger::Submit.into()),
+                    slot_index: Some(0),
+                    miner_address: IrysAddress::from([0xAA; 20]),
+                    partition_hash: H256::random(),
+                }),
+                submodules: vec![(partition_chunk_offset_ie!(0, 20), "hdd0".into())],
+            },
+            &config,
+        )?);
+        let guard = StorageModulesReadGuard::new(Arc::new(RwLock::new(vec![sm.clone()])));
+
+        let db = DatabaseProvider(Arc::new(open_or_create_db(
+            tmp.path().join("irys_db"),
+            IrysTables::ALL,
+            reth_db::mdbx::DatabaseArguments::irys_testing()?,
+        )?));
+        let block_index = BlockIndex::new_for_testing(db.clone());
+
+        let data = vec![7_u8; (chunk_size * num_chunks) as usize];
+        let signer = IrysSigner::random_signer(&config.consensus);
+        let tx = signer.sign_transaction(signer.create_transaction(data.clone(), H256::zero())?)?;
+        let (tx_root, _) =
+            DataTransactionLedger::merklize_tx_root(std::slice::from_ref(&tx.header));
+
+        let mut block = IrysBlockHeader::new_mock_header();
+        block.height = 0;
+        {
+            let submit = &mut block.data_ledgers[DataLedger::Submit];
+            submit.tx_root = tx_root;
+            submit.total_chunks = num_chunks;
+            submit.tx_ids = H256List(vec![tx.header.id]);
+        }
+
+        let (shutdown_signal, shutdown) = reth::tasks::shutdown::signal();
+        Ok(Fixture {
+            _tmp: tmp,
+            shutdown_signal: Some(shutdown_signal),
+            shutdown,
+            config,
+            sm,
+            guard,
+            db,
+            block_index,
+            block: Arc::new(block),
+            tx,
+            data,
+        })
+    }
+
+    impl Fixture {
+        /// The ordered index path, exactly as `on_block_migrated` runs it.
+        fn index(&self) -> Result<(), MigrationError> {
+            process_ledger_transactions(
+                &self.block,
+                DataLedger::Submit,
+                std::slice::from_ref(&self.tx.header),
+                &self.block_index,
+                &self.config,
+                &self.guard,
+            )
+        }
+
+        /// Put every chunk body of the tx into the node's chunk cache.
+        fn seed_cache(&self) -> eyre::Result<()> {
+            self.db.update_eyre(|wtx| {
+                cache_data_root(wtx, &self.tx.header, None)?;
+                for (i, node) in self.tx.chunks.iter().enumerate() {
+                    let chunk = UnpackedChunk {
+                        data_root: self.tx.header.data_root,
+                        data_size: self.tx.header.data_size,
+                        data_path: Base64(self.tx.proofs[i].proof.clone()),
+                        bytes: Base64(self.data[node.min_byte_range..node.max_byte_range].to_vec()),
+                        tx_offset: TxChunkOffset::from(u32::try_from(i)?),
+                    };
+                    cache_chunk(wtx, &chunk)?;
+                }
+                Ok(())
+            })
+        }
+
+        /// A fresh worker over the same modules and DB — also what a restart looks like.
+        fn worker(&self) -> BodyMigrationWorker {
+            BodyMigrationWorker::new(
+                self.guard.clone(),
+                self.db.clone(),
+                self.config.clone(),
+                Arc::new(Notify::new()),
+                self.shutdown.clone(),
+            )
+        }
+
+        fn rows(&self) -> eyre::Result<Vec<(PartitionChunkOffset, PendingBodyMigration)>> {
+            self.sm.pending_body_migrations()
+        }
+
+        fn chunk_type(&self, offset: u32) -> Option<ChunkType> {
+            self.sm.get_chunk_type(&PartitionChunkOffset::from(offset))
+        }
+
+        /// Persist the block the way block migration would have — header and tx
+        /// header in the node DB, item in the block index — so `on_block_migrated`
+        /// (and heal's `UpdateStorageModuleIndexes`) can run against it.
+        fn persist_block(&self) -> eyre::Result<()> {
+            self.db.update_eyre(|tx| {
+                insert_block_header(tx, &self.block)?;
+                insert_tx_header(tx, &self.tx.header)?;
+                Ok(())
+            })?;
+            let submit = &self.block.data_ledgers[DataLedger::Submit];
+            self.block_index.push_item(
+                &BlockIndexItem {
+                    block_hash: self.block.block_hash,
+                    num_ledgers: 1,
+                    ledgers: vec![LedgerIndexItem {
+                        total_chunks: submit.total_chunks,
+                        tx_root: submit.tx_root,
+                        ledger: DataLedger::Submit,
+                    }],
+                },
+                self.block.height,
+            )
+        }
+
+        fn service_inner(&self) -> ChunkMigrationServiceInner {
+            let (service_senders, _receivers) = ServiceSenders::new();
+            ChunkMigrationServiceInner::new(
+                self.block_index.clone(),
+                &self.guard,
+                self.db.clone(),
+                service_senders,
+                self.config.clone(),
+                Arc::new(Notify::new()),
+            )
+        }
+
+        fn migrated_msg(&self, block: Arc<IrysBlockHeader>) -> ChunkMigrationServiceMessage {
+            let mut txs = HashMap::new();
+            txs.insert(DataLedger::Submit, vec![self.tx.header.clone()]);
+            ChunkMigrationServiceMessage::BlockMigrated(block, Arc::new(txs))
+        }
+    }
+
+    /// Index heal's `UpdateStorageModuleIndexes` runs the same index-only path:
+    /// rows appear, no chunk data moves — so a heal pass can never re-create
+    /// the body-write stall it exists to repair.
+    #[test]
+    fn heal_reindex_is_index_only() -> eyre::Result<()> {
+        let f = fixture(3, Some(u64::MAX))?;
+        f.seed_cache()?;
+        f.persist_block()?;
+        let mut inner = f.service_inner();
+
+        inner.on_update_storage_module_indexes(f.block.block_hash)?;
+
+        assert_eq!(f.rows()?.len(), 1);
+        assert!(!f.sm.has_pending_writes());
+        assert_ne!(f.chunk_type(0), Some(ChunkType::Data));
+        assert!(
+            f.sm.partition_offsets_for_data_root_chunk(
+                f.tx.header.data_root,
+                TxChunkOffset::from(0)
+            )?
+            .is_some()
+        );
+        Ok(())
+    }
+
+    /// A block whose migration fails is logged and skipped; the next block is
+    /// still processed. Previously the error unwound `start()` and killed the
+    /// service for the life of the node.
+    #[test]
+    fn failed_block_does_not_stop_later_blocks() -> eyre::Result<()> {
+        let f = fixture(3, Some(u64::MAX))?;
+        f.persist_block()?;
+        let mut inner = f.service_inner();
+
+        // Same hash (passes the block-index guard), corrupted tx_root: merklization fails.
+        let mut bad = (*f.block).clone();
+        bad.data_ledgers[DataLedger::Submit].tx_root = H256::random();
+        inner.handle_message(f.migrated_msg(Arc::new(bad)));
+        assert!(f.rows()?.is_empty(), "failed block must index nothing");
+
+        inner.handle_message(f.migrated_msg(f.block.clone()));
+        assert_eq!(f.rows()?.len(), 1, "later block still migrates");
+        Ok(())
+    }
+
+    /// The ordered path commits the index and the job row and touches no chunk
+    /// data — even when the bodies are sitting in the cache.
+    #[test]
+    fn index_path_writes_index_and_job_row_but_no_bodies() -> eyre::Result<()> {
+        let f = fixture(3, Some(u64::MAX))?;
+        f.seed_cache()?;
+        f.index()?;
+
+        let rows = f.rows()?;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].0, PartitionChunkOffset::from(0));
+        assert_eq!(rows[0].1.data_root, f.tx.header.data_root);
+        assert_eq!(rows[0].1.attempts, 0);
+
+        assert!(!f.sm.has_pending_writes());
+        assert_ne!(f.chunk_type(0), Some(ChunkType::Data));
+        assert_eq!(
+            f.sm.partition_offsets_for_data_root_chunk(
+                f.tx.header.data_root,
+                TxChunkOffset::from(2)
+            )?,
+            Some(vec![PartitionChunkOffset::from(2)])
+        );
+        Ok(())
+    }
+
+    /// The worker sources bodies from the chunk cache and settles the row only
+    /// once the storage module reports them durable (after the flush), so a
+    /// crash between write and fsync cannot lose the job.
+    #[tokio::test]
+    async fn worker_writes_bodies_from_cache_and_settles_after_flush() -> eyre::Result<()> {
+        let f = fixture(3, Some(u64::MAX))?;
+        f.sm.pack_with_zeros();
+        f.seed_cache()?;
+        f.index()?;
+        let worker = f.worker();
+
+        let pass = worker.drain_pass().await;
+        assert_eq!((pass.rows, pass.written, pass.settled), (1, 3, 0));
+        for offset in 0..3 {
+            assert!(f.sm.is_data_write_pending_at(PartitionChunkOffset::from(offset)));
+        }
+        assert_eq!(f.rows()?.len(), 1, "not durable yet: the row must survive");
+
+        // Before the flush everything is in flight: nothing is re-read or re-written.
+        let pass = worker.drain_pass().await;
+        assert_eq!((pass.written, pass.settled), (0, 0));
+        assert_eq!(f.rows()?.len(), 1);
+
+        f.sm.force_sync_pending_chunks()?;
+        let pass = worker.drain_pass().await;
+        assert_eq!(
+            (pass.rows, pass.written, pass.settled, pass.retired),
+            (1, 0, 1, 0)
+        );
+        assert!(f.rows()?.is_empty());
+        for offset in 0..3 {
+            assert_eq!(f.chunk_type(offset), Some(ChunkType::Data));
+        }
+
+        // Idle pass is a no-op.
+        assert_eq!(worker.drain_pass().await, PassStats::default());
+        Ok(())
+    }
+
+    /// With no local source (cold cache, no Submit replica) every pass stalls;
+    /// after `MAX_BODY_MIGRATION_ATTEMPTS` the row is retired and the offsets
+    /// stay Entropy holes for data sync. The index is untouched throughout.
+    #[tokio::test]
+    async fn worker_retires_job_with_no_local_source() -> eyre::Result<()> {
+        let f = fixture(3, Some(u64::MAX))?;
+        f.sm.pack_with_zeros();
+        f.index()?;
+        let worker = f.worker();
+
+        for attempt in 1..MAX_BODY_MIGRATION_ATTEMPTS {
+            let pass = worker.drain_pass().await;
+            assert_eq!((pass.written, pass.settled, pass.retired), (0, 0, 0));
+            assert_eq!(f.rows()?[0].1.attempts, attempt);
+        }
+        let pass = worker.drain_pass().await;
+        assert_eq!(pass.retired, 1);
+        assert!(f.rows()?.is_empty());
+
+        assert_ne!(f.chunk_type(0), Some(ChunkType::Data));
+        assert!(
+            f.sm.partition_offsets_for_data_root_chunk(
+                f.tx.header.data_root,
+                TxChunkOffset::from(0)
+            )?
+            .is_some()
+        );
+        Ok(())
+    }
+
+    /// The per-pass write budget paces, it does not abandon: the row survives a
+    /// partial pass and a *fresh* worker (a restart) continues from the first
+    /// non-durable offset.
+    #[tokio::test]
+    async fn worker_budget_paces_writes_across_passes_and_restarts() -> eyre::Result<()> {
+        let f = fixture(3, Some(u64::MAX))?;
+        f.sm.pack_with_zeros();
+        f.seed_cache()?;
+        f.index()?;
+
+        let pass = f.worker().with_writes_per_pass(2).drain_pass().await;
+        assert_eq!((pass.written, pass.settled), (2, 0));
+        assert!(f.sm.is_data_write_pending_at(PartitionChunkOffset::from(1)));
+        assert!(!f.sm.is_data_write_pending_at(PartitionChunkOffset::from(2)));
+        assert_eq!(
+            f.rows()?[0].1.attempts,
+            0,
+            "a budgeted pass is progress, not a stall"
+        );
+
+        let pass = f.worker().with_writes_per_pass(2).drain_pass().await;
+        assert_eq!((pass.written, pass.settled), (1, 0));
+
+        f.sm.force_sync_pending_chunks()?;
+        assert_eq!(f.worker().drain_pass().await.settled, 1);
+        assert!(f.rows()?.is_empty());
+        Ok(())
+    }
+
+    /// The pending-write ceiling is backpressure, not a budget: once the module
+    /// holds `ceiling` bytes awaiting flush the pass stops writing, the row
+    /// survives with no attempt penalty, and writing resumes only after the
+    /// storage service has flushed. Here nothing flushes until we force it.
+    #[tokio::test]
+    async fn worker_pauses_at_pending_write_ceiling_until_flushed() -> eyre::Result<()> {
+        let chunk_size = 32_u64;
+        let f = fixture(3, Some(2 * chunk_size))?;
+        f.sm.pack_with_zeros();
+        f.sm.force_sync_pending_chunks()?;
+        f.seed_cache()?;
+        f.index()?;
+        let worker = f.worker();
+
+        let pass = worker.drain_pass().await;
+        assert_eq!((pass.written, pass.throttled, pass.settled), (2, 1, 0));
+        assert_eq!(f.sm.pending_write_bytes(), 2 * chunk_size);
+        assert_eq!(f.rows()?[0].1.attempts, 0, "backpressure is not a stall");
+
+        // Still nothing flushed: the worker must not pile more into memory.
+        let pass = worker.drain_pass().await;
+        assert_eq!((pass.written, pass.throttled), (0, 1));
+        assert_eq!(f.sm.pending_write_bytes(), 2 * chunk_size);
+
+        f.sm.force_sync_pending_chunks()?;
+        assert_eq!(f.sm.pending_write_bytes(), 0);
+        let pass = worker.drain_pass().await;
+        assert_eq!((pass.written, pass.throttled), (1, 0));
+
+        f.sm.force_sync_pending_chunks()?;
+        assert_eq!(worker.drain_pass().await.settled, 1);
+        assert!(f.rows()?.is_empty());
+        Ok(())
+    }
+
+    /// Without an explicit ceiling the worker allows two flush batches per
+    /// submodule in memory (one being flushed, one being filled), floored so a
+    /// tiny `num_writes_before_sync` cannot starve it.
+    #[test]
+    fn pending_write_ceiling_defaults_to_two_flush_batches_per_submodule() -> eyre::Result<()> {
+        let f = fixture(1, None)?;
+        let nwbs = f.config.node_config.storage.num_writes_before_sync;
+        assert_eq!(
+            nwbs, 1,
+            "testing config: the floor must be what applies here"
+        );
+        let expected = (PENDING_WRITE_CEILING_BATCHES * nwbs).max(PENDING_WRITE_CEILING_MIN_CHUNKS)
+            * f.config.consensus.chunk_size
+            * f.sm.submodule_count() as u64;
+        assert_eq!(pending_write_ceiling_bytes(&f.config, &f.sm), expected);
+        assert_eq!(
+            expected,
+            PENDING_WRITE_CEILING_MIN_CHUNKS * f.config.consensus.chunk_size,
+            "with num_writes_before_sync = 1 the floor is the ceiling"
+        );
+
+        let g = fixture(1, Some(12_345))?;
+        assert_eq!(pending_write_ceiling_bytes(&g.config, &g.sm), 12_345);
+
+        // A configured ceiling below one flush batch is raised to it: under that
+        // level the threshold flush never fires and migration would crawl.
+        let h = fixture(1, Some(1))?;
+        let one_batch = h.config.node_config.storage.num_writes_before_sync
+            * h.config.consensus.chunk_size
+            * h.sm.submodule_count() as u64;
+        assert_eq!(pending_write_ceiling_bytes(&h.config, &h.sm), one_batch);
+        Ok(())
+    }
+
+    /// Offsets without entropy cannot take a body (`write_data_chunk` writes
+    /// nothing there). The worker must not count those as written — that would
+    /// spin the drain loop and re-read the cache every pass for as long as
+    /// packing takes — but wait, penalty-free, until entropy lands.
+    #[tokio::test]
+    async fn worker_waits_for_entropy_instead_of_spinning() -> eyre::Result<()> {
+        let f = fixture(3, Some(u64::MAX))?;
+        // Deliberately not packed: every offset is Uninitialized.
+        f.seed_cache()?;
+        f.index()?;
+        let worker = f.worker();
+
+        for _ in 0..2 {
+            let pass = worker.drain_pass().await;
+            assert_eq!((pass.written, pass.unwritable, pass.throttled), (0, 3, 0));
+            assert!(
+                !f.sm.has_pending_writes(),
+                "nothing may be queued without entropy"
+            );
+            assert_eq!(
+                f.rows()?[0].1.attempts,
+                0,
+                "waiting on packing is not a stall"
+            );
+        }
+
+        f.sm.pack_with_zeros();
+        f.sm.force_sync_pending_chunks()?;
+        let pass = worker.drain_pass().await;
+        assert_eq!((pass.written, pass.unwritable), (3, 0));
+        Ok(())
+    }
+
+    /// While recovery holds a module's data writes, the worker defers its jobs
+    /// untouched — nothing queued, no attempt counted — and resumes afterwards.
+    #[tokio::test]
+    async fn worker_defers_while_module_writes_are_paused() -> eyre::Result<()> {
+        let f = fixture(3, Some(u64::MAX))?;
+        f.sm.pack_with_zeros();
+        f.seed_cache()?;
+        f.index()?;
+        let worker = f.worker();
+
+        f.sm.pause_data_writes();
+        let pass = worker.drain_pass().await;
+        assert_eq!((pass.written, pass.settled, pass.retired), (0, 0, 0));
+        assert!(!f.sm.has_pending_writes());
+        assert_eq!(f.rows()?[0].1.attempts, 0, "a paused module is not a stall");
+
+        f.sm.resume_data_writes();
+        assert_eq!(worker.drain_pass().await.written, 3);
+        Ok(())
+    }
+
+    /// A job whose index was cleared under it fails on every offset
+    /// (`DataRootNotFound`). Failures count as no-progress passes, so the row
+    /// is retired after the limit instead of erroring every tick forever.
+    #[tokio::test]
+    async fn worker_retires_job_that_keeps_failing() -> eyre::Result<()> {
+        let f = fixture(3, Some(u64::MAX))?;
+        f.sm.pack_with_zeros();
+        f.seed_cache()?;
+        f.index()?;
+        f.sm.clear_data_root_infos_in_range(
+            PartitionChunkOffset::from(0),
+            PartitionChunkOffset::from(2),
+            &[f.tx.header.data_root],
+        )?;
+        let worker = f.worker();
+
+        for attempt in 1..MAX_BODY_MIGRATION_ATTEMPTS {
+            let pass = worker.drain_pass().await;
+            assert_eq!((pass.written, pass.retired), (0, 0));
+            assert_eq!(f.rows()?[0].1.attempts, attempt);
+        }
+        assert_eq!(worker.drain_pass().await.retired, 1);
+        assert!(f.rows()?.is_empty());
+        Ok(())
+    }
+
+    /// `run()` end to end: drains on startup with no wake-up, resumes once the
+    /// storage service (here: us) flushes, and exits on shutdown.
+    #[tokio::test]
+    async fn run_loop_drains_and_exits_on_shutdown() -> eyre::Result<()> {
+        let mut f = fixture(3, Some(u64::MAX))?;
+        f.sm.pack_with_zeros();
+        f.seed_cache()?;
+        f.index()?;
+        let handle = tokio::spawn(f.worker().run());
+
+        // Stand in for the storage-module service's 1s flush tick.
+        tokio::time::timeout(Duration::from_secs(15), async {
+            loop {
+                f.sm.force_sync_pending_chunks().expect("flush");
+                if f.rows().expect("rows").is_empty() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        })
+        .await
+        .expect("worker never settled the job");
+        for offset in 0..3 {
+            assert_eq!(f.chunk_type(offset), Some(ChunkType::Data));
+        }
+
+        f.shutdown_signal.take().expect("signal").fire();
+        tokio::time::timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("worker did not stop on shutdown")?;
         Ok(())
     }
 }

--- a/crates/actors/src/chunk_migration_service.rs
+++ b/crates/actors/src/chunk_migration_service.rs
@@ -1265,6 +1265,31 @@ mod tests {
         Ok(())
     }
 
+    /// After the bodies are durable, pausing still must not settle. Recovery
+    /// may be about to remap those offsets; the next pass after resume settles
+    /// if they are still Data.
+    #[tokio::test]
+    async fn worker_does_not_settle_a_durable_job_while_paused() -> eyre::Result<()> {
+        let f = fixture(3, Some(u64::MAX))?;
+        f.sm.pack_with_zeros();
+        f.seed_cache()?;
+        f.index()?;
+        let worker = f.worker();
+
+        assert_eq!(worker.drain_pass().await.written, 3);
+        f.sm.force_sync_pending_chunks()?;
+
+        f.sm.pause_data_writes();
+        let pass = worker.drain_pass().await;
+        assert_eq!((pass.written, pass.settled, pass.retired), (0, 0, 0));
+        assert_eq!(f.rows()?.len(), 1);
+
+        f.sm.resume_data_writes();
+        assert_eq!(worker.drain_pass().await.settled, 1);
+        assert!(f.rows()?.is_empty());
+        Ok(())
+    }
+
     /// A job whose index was cleared under it fails on every offset
     /// (`DataRootNotFound`). Failures count as no-progress passes, so the row
     /// is retired after the limit instead of erroring every tick forever.

--- a/crates/actors/src/chunk_migration_service/body_worker.rs
+++ b/crates/actors/src/chunk_migration_service/body_worker.rs
@@ -1,0 +1,587 @@
+//! Background drain for `PendingBodyMigrationsByOffset`.
+//!
+//! `on_block_migrated` commits chunk **indexes** in block order and returns. The
+//! chunk **bodies** those indexes describe are copied out of the chunk cache
+//! (or, for Publish, the durable Submit replica) by this worker at whatever
+//! speed the target disk allows. A huge or slow body write therefore never
+//! delays the next block's indexes — the failure that froze n3's Publish
+//! ledger behind a single 4 GiB Submit tx.
+//!
+//! The rows are the backlog of record: they survive restarts and outlive a
+//! dropped wake-up. Every submodule is its own MDBX env and its own IO domain,
+//! so a pass fans out one blocking task per submodule with outstanding rows.
+
+use super::{MigrationError, load_chunk_for_migration, write_chunk_to_module};
+use irys_database::submodule::tables::PendingBodyMigration;
+use irys_domain::{ChunkType, StorageModule, StorageModulesReadGuard};
+use irys_types::{
+    Config, DataLedger, PartitionChunkOffset, TxChunkOffset, app_state::DatabaseProvider,
+};
+use nodit::Interval;
+use reth::tasks::shutdown::Shutdown;
+use std::{
+    collections::HashSet,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use tokio::sync::Notify;
+use tracing::{debug, info, warn};
+
+/// Fallback wake-up so a missed notification only costs latency.
+pub(crate) const BODY_MIGRATION_TICK: Duration = Duration::from_secs(2);
+
+/// Consecutive passes that attempted a job and wrote nothing before it is
+/// retired and its remaining holes left to data sync.
+pub(crate) const MAX_BODY_MIGRATION_ATTEMPTS: u32 = 8;
+
+/// Chunk bodies enqueued per submodule per pass. Pacing, not abandonment: the
+/// row stays and the next pass continues where this one stopped. Bounds
+/// `pending_writes` growth to roughly this × chunk_size per submodule between
+/// storage-service flushes.
+pub(crate) const BODY_WRITES_PER_PASS: usize = 512;
+
+/// Default pending-write ceiling, in flush batches per submodule: one batch
+/// the storage service is flushing plus one the worker is filling. Overridden
+/// by `storage.max_pending_write_bytes`.
+pub(crate) const PENDING_WRITE_CEILING_BATCHES: u64 = 2;
+
+/// Floor on the derived ceiling, in chunks per submodule (64 MiB at 256 KiB).
+/// A small `num_writes_before_sync` (tests use 1) must not throttle the worker
+/// to a couple of chunks per flush tick.
+pub(crate) const PENDING_WRITE_CEILING_MIN_CHUNKS: u64 = 256;
+
+/// Re-check interval after a pass was cut short by the ceiling: the storage
+/// service flushes on a 1s tick, so wait for that rather than a full
+/// [`BODY_MIGRATION_TICK`].
+pub(crate) const BODY_MIGRATION_THROTTLED_TICK: Duration = Duration::from_millis(250);
+
+/// Bytes a storage module may hold in `pending_writes` before the worker stops
+/// writing to it for the rest of the pass. The per-pass budget bounds the
+/// *rate* of enqueueing; this bounds the *level*, so a storage-service flush
+/// tick that falls behind can never let memory grow without limit.
+pub(crate) fn pending_write_ceiling_bytes(config: &Config, sm: &StorageModule) -> u64 {
+    let storage = &config.node_config.storage;
+    let submodules = sm.submodule_count() as u64;
+    // One flush batch per submodule. Below this level the storage service's
+    // threshold flush never fires and only its 5s idle force-flush drains
+    // writes, so a configured ceiling is never allowed under it.
+    let one_batch = storage
+        .num_writes_before_sync
+        .saturating_mul(config.consensus.chunk_size)
+        .saturating_mul(submodules);
+    match storage.max_pending_write_bytes {
+        Some(configured) => configured.max(one_batch),
+        None => PENDING_WRITE_CEILING_BATCHES
+            .saturating_mul(storage.num_writes_before_sync)
+            .max(PENDING_WRITE_CEILING_MIN_CHUNKS)
+            .saturating_mul(config.consensus.chunk_size)
+            .saturating_mul(submodules),
+    }
+}
+
+pub(crate) struct BodyMigrationWorker {
+    storage_modules_guard: StorageModulesReadGuard,
+    db: DatabaseProvider,
+    config: Config,
+    wakeup: Arc<Notify>,
+    shutdown: Shutdown,
+    writes_per_pass: usize,
+    /// Modules already warned that a configured `max_pending_write_bytes` was
+    /// raised to one flush batch, so the warning fires once, not every pass.
+    ceiling_floor_warned: Mutex<HashSet<usize>>,
+}
+
+/// What one pass did, summed over every submodule it touched.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PassStats {
+    /// Rows outstanding when the pass started.
+    pub rows: usize,
+    /// Chunk bodies enqueued to `pending_writes`.
+    pub written: usize,
+    /// Rows deleted because every offset was durable.
+    pub settled: usize,
+    /// Rows deleted after `MAX_BODY_MIGRATION_ATTEMPTS` no-progress passes.
+    pub retired: usize,
+    /// Jobs cut short because their module hit the pending-write ceiling.
+    pub throttled: usize,
+    /// Offsets skipped because they hold no entropy yet (module still packing,
+    /// or a range recovery just re-marked). They wait; they are not failures.
+    pub unwritable: usize,
+}
+
+impl std::ops::AddAssign for PassStats {
+    fn add_assign(&mut self, other: Self) {
+        self.rows += other.rows;
+        self.written += other.written;
+        self.settled += other.settled;
+        self.retired += other.retired;
+        self.throttled += other.throttled;
+        self.unwritable += other.unwritable;
+    }
+}
+
+/// Outcome of one pass over one job's range within one submodule.
+#[derive(Debug)]
+enum JobOutcome {
+    /// Every offset is durable; delete the row.
+    Settled,
+    /// Bodies were enqueued or are awaiting flush; keep the row, no penalty.
+    Progressed { written: usize },
+    /// The pass budget or the pending-write ceiling stopped this job before
+    /// its first write; keep the row.
+    Deferred,
+    /// `unwritable` offsets hold no entropy yet (module packing, or a range
+    /// recovery re-marked), so nothing could be written. Wait for the tick;
+    /// this is not a stall and never counts against the job.
+    Unpacked { unwritable: usize },
+    /// Attempted and nothing was written or in flight: `unavailable` offsets
+    /// had no local source and `failed` errored (last error kept for the log).
+    Stalled {
+        unavailable: usize,
+        failed: usize,
+        last_error: Option<MigrationError>,
+    },
+}
+
+impl BodyMigrationWorker {
+    pub(crate) fn new(
+        storage_modules_guard: StorageModulesReadGuard,
+        db: DatabaseProvider,
+        config: Config,
+        wakeup: Arc<Notify>,
+        shutdown: Shutdown,
+    ) -> Self {
+        Self {
+            storage_modules_guard,
+            db,
+            config,
+            wakeup,
+            shutdown,
+            writes_per_pass: BODY_WRITES_PER_PASS,
+            ceiling_floor_warned: Mutex::new(HashSet::new()),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_writes_per_pass(mut self, writes_per_pass: usize) -> Self {
+        self.writes_per_pass = writes_per_pass;
+        self
+    }
+
+    pub(crate) async fn run(mut self) {
+        info!("service started: chunk_migration body worker");
+        let wakeup = self.wakeup.clone();
+        loop {
+            // Drain back-to-back while passes make progress. The first
+            // iteration is the startup drain of rows a previous process left.
+            // A pass that writes nothing means the backlog is empty, every
+            // outstanding offset is unsourceable for now, or the module is at
+            // its pending-write ceiling and needs the storage service's flush
+            // tick — all of which want a wait, not a spin.
+            let throttled = loop {
+                let stats = self.drain_pass().await;
+                if stats.written == 0 || self.shutdown_requested() {
+                    break stats.throttled > 0;
+                }
+                tokio::task::yield_now().await;
+            };
+            let wait = if throttled {
+                BODY_MIGRATION_THROTTLED_TICK
+            } else {
+                BODY_MIGRATION_TICK
+            };
+            tokio::select! {
+                biased;
+                _ = &mut self.shutdown => break,
+                _ = tokio::time::timeout(wait, wakeup.notified()) => {}
+            }
+        }
+        info!("shutting down chunk_migration body worker");
+    }
+
+    fn shutdown_requested(&mut self) -> bool {
+        use futures::FutureExt as _;
+        (&mut self.shutdown).now_or_never().is_some()
+    }
+
+    /// One pass over every ledger-assigned storage module: each submodule with
+    /// outstanding rows is drained on its own blocking task, in parallel.
+    pub(crate) async fn drain_pass(&self) -> PassStats {
+        let modules: Vec<Arc<StorageModule>> = self.storage_modules_guard.read().clone();
+        let mut tasks = Vec::new();
+        // Lowest block height among the rows this pass starts from: its distance
+        // to the tip is how far the body worker lags the index path.
+        let mut oldest_pending_height: Option<u64> = None;
+        for sm in modules {
+            let Some(ledger) = sm
+                .partition_assignment()
+                .and_then(|pa| pa.ledger_id)
+                .and_then(|id| DataLedger::try_from(id).ok())
+            else {
+                continue;
+            };
+            if sm.data_writes_paused() {
+                // Network-partition recovery is rewriting this module; its rows
+                // wait untouched until writes resume.
+                debug!(
+                    storage_module.id = sm.id,
+                    "body migration skipping module with paused writes"
+                );
+                continue;
+            }
+            let batches = match sm.pending_body_migration_batches() {
+                Ok(batches) => batches,
+                Err(error) => {
+                    warn!(
+                        storage_module.id = sm.id,
+                        ?error,
+                        "failed to read pending body migrations"
+                    );
+                    continue;
+                }
+            };
+            let ceiling = pending_write_ceiling_bytes(&self.config, &sm);
+            if let Some(configured) = self.config.node_config.storage.max_pending_write_bytes
+                && configured < ceiling
+                && self.ceiling_floor_warned.lock().unwrap().insert(sm.id)
+            {
+                warn!(
+                    storage_module.id = sm.id,
+                    configured,
+                    ceiling,
+                    "storage.max_pending_write_bytes is below one flush batch for this module; \
+                     using one flush batch instead (a lower ceiling would stall body migration \
+                     on the storage service's idle flush)"
+                );
+            }
+            for (interval, rows) in batches {
+                if rows.is_empty() {
+                    continue;
+                }
+                if let Some(min) = rows.iter().map(|(_, job)| job.block_height).min() {
+                    oldest_pending_height = Some(oldest_pending_height.map_or(min, |h| h.min(min)));
+                }
+                let drain = SubmoduleDrain {
+                    storage_modules_guard: self.storage_modules_guard.clone(),
+                    db: self.db.clone(),
+                    config: self.config.clone(),
+                    sm: sm.clone(),
+                    ledger,
+                    interval,
+                    rows,
+                    budget: self.writes_per_pass,
+                    ceiling,
+                    throttled_jobs: 0,
+                };
+                tasks.push(tokio::task::spawn_blocking(move || drain.run()));
+            }
+        }
+
+        let mut total = PassStats::default();
+        for joined in futures::future::join_all(tasks).await {
+            match joined {
+                Ok(stats) => total += stats,
+                Err(error) => warn!(?error, "body migration drain task panicked"),
+            }
+        }
+        if total.rows > 0 {
+            debug!(?total, "body migration pass");
+        }
+        crate::metrics::record_body_migration_pass(
+            total.written as u64,
+            total.settled as u64,
+            total.retired as u64,
+            total.throttled as u64,
+            total.rows.saturating_sub(total.settled + total.retired) as u64,
+            oldest_pending_height.unwrap_or(0),
+        );
+        total
+    }
+}
+
+/// Everything one blocking task needs to drain one submodule's rows.
+struct SubmoduleDrain {
+    storage_modules_guard: StorageModulesReadGuard,
+    db: DatabaseProvider,
+    config: Config,
+    sm: Arc<StorageModule>,
+    ledger: DataLedger,
+    interval: Interval<PartitionChunkOffset>,
+    rows: Vec<(PartitionChunkOffset, PendingBodyMigration)>,
+    /// Bodies this task may still enqueue in this pass.
+    budget: usize,
+    /// `pending_write_bytes` level at which this task stops enqueueing.
+    ceiling: u64,
+    /// Jobs this task cut short at the ceiling (for `PassStats::throttled`).
+    throttled_jobs: usize,
+}
+
+impl SubmoduleDrain {
+    fn run(mut self) -> PassStats {
+        let rows = std::mem::take(&mut self.rows);
+        let mut stats = PassStats {
+            rows: rows.len(),
+            ..PassStats::default()
+        };
+        for (key, job) in rows {
+            match self.drain_job(key, &job) {
+                Ok(JobOutcome::Settled) => {
+                    if self.settle(key, &job) {
+                        stats.settled += 1;
+                    }
+                }
+                Ok(JobOutcome::Progressed { written }) => stats.written += written,
+                Ok(JobOutcome::Deferred) => {}
+                Ok(JobOutcome::Unpacked { unwritable }) => {
+                    stats.unwritable += unwritable;
+                    debug!(
+                        storage_module.id = self.sm.id,
+                        partition.offset = %key,
+                        data_root = %job.data_root,
+                        unwritable,
+                        "body migration job is waiting for entropy at its offsets; no penalty"
+                    );
+                }
+                Ok(JobOutcome::Stalled {
+                    unavailable,
+                    failed,
+                    last_error,
+                }) => {
+                    debug!(
+                        storage_module.id = self.sm.id,
+                        partition.offset = %key,
+                        data_root = %job.data_root,
+                        unavailable,
+                        failed,
+                        ?last_error,
+                        "body migration job made no progress; leaving offsets for data sync"
+                    );
+                    self.record_stall(key, &job, &mut stats);
+                }
+                Err(error) => {
+                    warn!(
+                        storage_module.id = self.sm.id,
+                        partition.offset = %key,
+                        data_root = %job.data_root,
+                        ?error,
+                        "body migration job failed; counting as a stalled pass"
+                    );
+                    self.record_stall(key, &job, &mut stats);
+                }
+            }
+        }
+        stats.throttled = self.throttled_jobs;
+        stats
+    }
+
+    /// One no-progress pass on `job`: bump its attempts and retire it once the
+    /// limit is reached, so an unsourceable or persistently failing row cannot
+    /// be retried forever.
+    fn record_stall(
+        &self,
+        key: PartitionChunkOffset,
+        job: &PendingBodyMigration,
+        stats: &mut PassStats,
+    ) {
+        match self
+            .sm
+            .bump_pending_body_migration_attempts(key, job.data_root)
+        {
+            Ok(Some(attempts)) if attempts >= MAX_BODY_MIGRATION_ATTEMPTS => {
+                warn!(
+                    storage_module.id = self.sm.id,
+                    partition.offset = %key,
+                    data_root = %job.data_root,
+                    attempts,
+                    "retiring body migration job after repeated passes without progress; \
+                     remaining holes left to data sync"
+                );
+                if self.settle(key, job) {
+                    stats.retired += 1;
+                }
+            }
+            Ok(_) => {}
+            Err(error) => warn!(
+                storage_module.id = self.sm.id,
+                partition.offset = %key,
+                ?error,
+                "failed to record body migration attempt"
+            ),
+        }
+    }
+
+    fn settle(&self, key: PartitionChunkOffset, job: &PendingBodyMigration) -> bool {
+        match self.sm.settle_pending_body_migration(key, job.data_root) {
+            Ok(removed) => removed,
+            Err(error) => {
+                warn!(
+                    storage_module.id = self.sm.id,
+                    partition.offset = %key,
+                    ?error,
+                    "failed to settle body migration job"
+                );
+                false
+            }
+        }
+    }
+
+    /// Walk the slice of `job` this submodule owns — `[key, min(tx end,
+    /// submodule end)]` — writing every offset that is neither durable nor
+    /// already queued, within the remaining pass budget and the module's
+    /// pending-write ceiling.
+    fn drain_job(
+        &mut self,
+        key: PartitionChunkOffset,
+        job: &PendingBodyMigration,
+    ) -> Result<JobOutcome, MigrationError> {
+        let chunk_size = self.config.consensus.chunk_size;
+        let num_chunks = i64::try_from(job.data_size.div_ceil(chunk_size)).map_err(|_| {
+            MigrationError::Other(format!(
+                "data_size {} exceeds i64 chunk count",
+                job.data_size
+            ))
+        })?;
+        let tx_start = i64::from(*job.start_offset);
+        let first = i64::from(*key);
+        let last = (tx_start + num_chunks - 1).min(i64::from(*self.interval.end()));
+        if last < first {
+            return Ok(JobOutcome::Settled);
+        }
+
+        let (mut durable, mut in_flight, mut written) = (0_usize, 0_usize, 0_usize);
+        let (mut unavailable, mut unwritable, mut failed) = (0_usize, 0_usize, 0_usize);
+        let mut last_error = None;
+        let mut cut_short = false;
+        // Snapshot the module's pending-write level once and track this job's
+        // own additions locally: exact enough for a ceiling, and it keeps the
+        // `pending_writes` lock out of the per-offset loop.
+        let mut pending_bytes = self.sm.pending_write_bytes();
+        for partition_offset in first..=last {
+            let offset =
+                PartitionChunkOffset::from(u32::try_from(partition_offset).map_err(|_| {
+                    MigrationError::Other(format!(
+                        "partition offset {partition_offset} exceeds u32"
+                    ))
+                })?);
+            if self.sm.is_data_chunk_durable_at(offset) {
+                durable += 1;
+                continue;
+            }
+            if self.sm.is_data_write_pending_at(offset) {
+                in_flight += 1;
+                continue;
+            }
+            // Only an Entropy offset — on disk, or queued by packing — can take a
+            // body: `write_data_chunk` silently writes nothing anywhere else
+            // (Uninitialized while packing, Interrupted mid-flush). Skip without
+            // touching the cache and let the tick retry once packing lands.
+            if !matches!(self.sm.get_chunk_type(&offset), Some(ChunkType::Entropy)) {
+                unwritable += 1;
+                continue;
+            }
+            if self.sm.data_writes_paused() {
+                // Recovery took the module mid-pass: stop here, keep the row.
+                cut_short = true;
+                break;
+            }
+            if pending_bytes >= self.ceiling {
+                // Backpressure: the storage service has not flushed what is
+                // already queued. Stop for this pass; the row stays and the
+                // next pass resumes from the first non-durable offset.
+                self.throttled_jobs += 1;
+                cut_short = true;
+                break;
+            }
+            if self.budget == 0 {
+                cut_short = true;
+                break;
+            }
+            let tx_offset =
+                TxChunkOffset::from(u32::try_from(partition_offset - tx_start).map_err(|_| {
+                    MigrationError::Other(format!(
+                        "tx chunk offset for partition offset {partition_offset} is out of range"
+                    ))
+                })?);
+            match self.write_offset(job, offset, tx_offset) {
+                Ok(WriteAttempt::Queued) => {
+                    written += 1;
+                    self.budget -= 1;
+                    pending_bytes += chunk_size;
+                }
+                Ok(WriteAttempt::NoSource) => unavailable += 1,
+                Ok(WriteAttempt::Paused) => {
+                    cut_short = true;
+                    break;
+                }
+                Err(error) => {
+                    failed += 1;
+                    last_error = Some(error);
+                }
+            }
+        }
+
+        let total = usize::try_from(last - first + 1).unwrap_or(usize::MAX);
+        Ok(if durable == total {
+            JobOutcome::Settled
+        } else if written > 0 || in_flight > 0 {
+            JobOutcome::Progressed { written }
+        } else if cut_short {
+            JobOutcome::Deferred
+        } else if unavailable == 0 && failed == 0 {
+            JobOutcome::Unpacked { unwritable }
+        } else {
+            JobOutcome::Stalled {
+                unavailable,
+                failed,
+                last_error,
+            }
+        })
+    }
+
+    /// Source and enqueue one body.
+    fn write_offset(
+        &self,
+        job: &PendingBodyMigration,
+        offset: PartitionChunkOffset,
+        tx_offset: TxChunkOffset,
+    ) -> Result<WriteAttempt, MigrationError> {
+        let Some(chunk) = load_chunk_for_migration(
+            &self.storage_modules_guard,
+            &self.db,
+            self.ledger,
+            job.data_root,
+            job.data_size,
+            tx_offset,
+            &self.config,
+        )?
+        else {
+            return Ok(WriteAttempt::NoSource);
+        };
+        match write_chunk_to_module(&self.sm, &chunk) {
+            Ok(()) => {}
+            // The write raced a recovery pause: not a failure of this job.
+            Err(_) if self.sm.data_writes_paused() => return Ok(WriteAttempt::Paused),
+            Err(error) => return Err(error),
+        }
+        // `write_data_chunk` decides per placement whether anything was
+        // queued; confirm this offset took the body before counting it.
+        Ok(
+            if self.sm.is_data_write_pending_at(offset) || self.sm.is_data_chunk_durable_at(offset)
+            {
+                WriteAttempt::Queued
+            } else {
+                WriteAttempt::NoSource
+            },
+        )
+    }
+}
+
+/// Result of trying to source and enqueue one chunk body.
+enum WriteAttempt {
+    /// The offset now holds a queued (or already durable) data write.
+    Queued,
+    /// No local source for this body; data sync's problem.
+    NoSource,
+    /// The module's data writes were paused by recovery; retry next pass.
+    Paused,
+}

--- a/crates/actors/src/chunk_migration_service/body_worker.rs
+++ b/crates/actors/src/chunk_migration_service/body_worker.rs
@@ -385,7 +385,7 @@ impl SubmoduleDrain {
     ) {
         match self
             .sm
-            .bump_pending_body_migration_attempts(key, job.data_root)
+            .bump_pending_body_migration_attempts(key, job.data_root, job.block_height)
         {
             Ok(Some(attempts)) if attempts >= MAX_BODY_MIGRATION_ATTEMPTS => {
                 warn!(
@@ -411,7 +411,10 @@ impl SubmoduleDrain {
     }
 
     fn settle(&self, key: PartitionChunkOffset, job: &PendingBodyMigration) -> bool {
-        match self.sm.settle_pending_body_migration(key, job.data_root) {
+        match self
+            .sm
+            .settle_pending_body_migration(key, job.data_root, job.block_height)
+        {
             Ok(removed) => removed,
             Err(error) => {
                 warn!(

--- a/crates/actors/src/data_sync_service.rs
+++ b/crates/actors/src/data_sync_service.rs
@@ -1588,6 +1588,7 @@ mod ingress_proof_peer_tests {
             &tx.header,
             &proofs[0].proof,
             LedgerChunkRange(ledger_chunk_offset_ii!(0, 0)),
+            0,
         )
         .expect("index");
 
@@ -1817,6 +1818,7 @@ mod write_outcome_tests {
             }),
             storage: StorageSyncConfig {
                 num_writes_before_sync: num_chunks,
+                max_pending_write_bytes: None,
             },
             base_directory: tmp.path().to_path_buf(),
             ..NodeConfig::testing()

--- a/crates/actors/src/metrics.rs
+++ b/crates/actors/src/metrics.rs
@@ -30,6 +30,12 @@ irys_utils::define_metrics! {
     counter DATA_SYNC_CHUNK_WRITE_FAILED("irys.data_sync.chunk_write_failed_total", "Data sync local write failures after a successful fetch (labelled by reason)");
     counter DATA_SYNC_CHUNK_BLOCKED("irys.data_sync.chunk_blocked_total", "Data sync offsets blocked from hot re-fetch (labelled by reason)");
     counter DATA_SYNC_CHUNK_UNBLOCKED("irys.data_sync.chunk_unblocked_total", "Data sync Blocked offsets re-queued after local index-ready probe (MissingDataRootIndex → Pending)");
+    gauge BODY_MIGRATION_PENDING_JOBS("irys.chunk_migration.body_pending_jobs", "Outstanding chunk-body migration jobs across all storage modules after the last worker pass");
+    gauge BODY_MIGRATION_OLDEST_PENDING_HEIGHT("irys.chunk_migration.body_oldest_pending_height", "Lowest block height with an outstanding chunk-body migration job before the last pass (0 when none); its distance to the tip is the worker's lag");
+    counter BODY_MIGRATION_CHUNKS_WRITTEN("irys.chunk_migration.body_chunks_written_total", "Chunk bodies the body worker enqueued to storage modules");
+    counter BODY_MIGRATION_JOBS_SETTLED("irys.chunk_migration.body_jobs_settled_total", "Body-migration jobs completed with every offset durable");
+    counter BODY_MIGRATION_JOBS_RETIRED("irys.chunk_migration.body_jobs_retired_total", "Body-migration jobs abandoned to data sync after repeated passes with no local source");
+    counter BODY_MIGRATION_THROTTLED("irys.chunk_migration.body_throttled_total", "Body-migration jobs cut short by a storage module's pending-write ceiling");
     counter DATA_SYNC_DURABILITY_STALLED("irys.data_sync.durability_stalled_total", "Data sync writes that did not become durable before the monotonic durability deadline");
     counter DATA_INDEX_HEAL_UNREPAIRED("irys.storage.index_heal_unrepaired_total", "Ledger SMs still gapped/uncertain after a heal pass (labelled by reason)");
     counter DATA_SYNC_FETCH_BY_SOURCE("irys.data_sync.fetch_by_source_total", "Data sync peer fetches by source and classified outcome");
@@ -211,6 +217,23 @@ pub(crate) fn record_validation_concurrent_cancel_repeated() {
 pub(crate) fn record_cache_stats(chunk_count: u64, chunk_size_bytes: u64) {
     CACHE_CHUNK_COUNT.record(chunk_count, &[]);
     CACHE_CHUNK_SIZE_BYTES.record(chunk_size_bytes, &[]);
+}
+
+/// One body-worker pass: counters for what it did, gauges for what is left.
+pub(crate) fn record_body_migration_pass(
+    written: u64,
+    settled: u64,
+    retired: u64,
+    throttled: u64,
+    pending_jobs: u64,
+    oldest_pending_height: u64,
+) {
+    BODY_MIGRATION_CHUNKS_WRITTEN.add(written, &[]);
+    BODY_MIGRATION_JOBS_SETTLED.add(settled, &[]);
+    BODY_MIGRATION_JOBS_RETIRED.add(retired, &[]);
+    BODY_MIGRATION_THROTTLED.add(throttled, &[]);
+    BODY_MIGRATION_PENDING_JOBS.record(pending_jobs, &[]);
+    BODY_MIGRATION_OLDEST_PENDING_HEIGHT.record(oldest_pending_height, &[]);
 }
 
 pub(crate) fn record_block_discovery_error(error_type: &'static str) {

--- a/crates/actors/src/packing_service/mod.rs
+++ b/crates/actors/src/packing_service/mod.rs
@@ -520,6 +520,7 @@ mod tests {
             }),
             storage: StorageSyncConfig {
                 num_writes_before_sync: 1,
+                max_pending_write_bytes: None,
             },
             packing: irys_types::PackingConfig {
                 local: irys_types::LocalPackingConfig {
@@ -929,6 +930,7 @@ mod tests {
             }),
             storage: StorageSyncConfig {
                 num_writes_before_sync: 10,
+                max_pending_write_bytes: None,
             },
             packing: irys_types::PackingConfig {
                 local: irys_types::LocalPackingConfig {

--- a/crates/actors/tests/data_sync_test.rs
+++ b/crates/actors/tests/data_sync_test.rs
@@ -435,6 +435,7 @@ impl TestSetup {
             }),
             storage: StorageSyncConfig {
                 num_writes_before_sync: 1,
+                max_pending_write_bytes: None,
             },
             data_sync: DataSyncServiceConfig {
                 max_pending_chunk_requests: 100,
@@ -662,6 +663,7 @@ impl TestSetup {
                 &data_tx.header,
                 &tx_path,
                 LedgerChunkRange(ledger_chunk_offset_ie!(0, num_chunks as u64)),
+                0,
             )
             .map_err(|e| {
                 error!(

--- a/crates/chain-tests/src/packing/remote_packing.rs
+++ b/crates/chain-tests/src/packing/remote_packing.rs
@@ -74,6 +74,7 @@ pub(crate) async fn packing_worker_full_node_test() -> eyre::Result<()> {
         }),
         storage: StorageSyncConfig {
             num_writes_before_sync: 1,
+            max_pending_write_bytes: None,
         },
         packing: irys_types::PackingConfig {
             local: irys_types::LocalPackingConfig {

--- a/crates/config/templates/mainnet_config.toml
+++ b/crates/config/templates/mainnet_config.toml
@@ -65,8 +65,9 @@ bind_port = 30303
 [storage]
 num_writes_before_sync = 100
 # Bytes of chunk data one storage module may hold in memory awaiting flush before
-# background body migration pauses writing to it. Default derives from
-# num_writes_before_sync × chunk_size × submodules (floored at 256 chunks per submodule).
+# background body migration pauses writing to it. Default is
+# max(2 × num_writes_before_sync, 256) × chunk_size × submodules (two flush
+# batches, floored at 256 chunks per submodule).
 # max_pending_write_bytes = 67108864
 
 [data_sync]

--- a/crates/config/templates/mainnet_config.toml
+++ b/crates/config/templates/mainnet_config.toml
@@ -64,6 +64,10 @@ bind_port = 30303
 
 [storage]
 num_writes_before_sync = 100
+# Bytes of chunk data one storage module may hold in memory awaiting flush before
+# background body migration pauses writing to it. Default derives from
+# num_writes_before_sync × chunk_size × submodules (floored at 256 chunks per submodule).
+# max_pending_write_bytes = 67108864
 
 [data_sync]
 max_storage_throughput_bps = 1047961600

--- a/crates/config/templates/testnet_config.toml
+++ b/crates/config/templates/testnet_config.toml
@@ -35,6 +35,10 @@ bind_port = 30303
 
 [storage]
 num_writes_before_sync = 1
+# Bytes of chunk data one storage module may hold in memory awaiting flush before
+# background body migration pauses writing to it. Default derives from
+# num_writes_before_sync × chunk_size × submodules (floored at 256 chunks per submodule).
+# max_pending_write_bytes = 67108864
 
 [data_sync]
 max_storage_throughput_bps = 1047961600

--- a/crates/config/templates/testnet_config.toml
+++ b/crates/config/templates/testnet_config.toml
@@ -36,8 +36,9 @@ bind_port = 30303
 [storage]
 num_writes_before_sync = 1
 # Bytes of chunk data one storage module may hold in memory awaiting flush before
-# background body migration pauses writing to it. Default derives from
-# num_writes_before_sync × chunk_size × submodules (floored at 256 chunks per submodule).
+# background body migration pauses writing to it. Default is
+# max(2 × num_writes_before_sync, 256) × chunk_size × submodules (two flush
+# batches, floored at 256 chunks per submodule).
 # max_pending_write_bytes = 67108864
 
 [data_sync]

--- a/crates/database/src/submodule/db.rs
+++ b/crates/database/src/submodule/db.rs
@@ -17,7 +17,8 @@ use crate::{
 
 use super::tables::{
     ChunkDataPathByPathHash, ChunkPathHashes, ChunkPathHashesByOffset, DataRootInfos,
-    SubmoduleTables, TxLeafBinding, TxLeafBindingByTxPathHash, TxPathByTxPathHash,
+    PendingBodyMigration, PendingBodyMigrationsByOffset, SubmoduleTables, TxLeafBinding,
+    TxLeafBindingByTxPathHash, TxPathByTxPathHash,
 };
 
 /// Creates or opens a *submodule* MDBX database with the given [`DatabaseArguments`].
@@ -363,6 +364,68 @@ pub fn add_data_root_info<T: DbTxMut + DbTx>(
     Ok(())
 }
 
+/// Record that `data_root`'s placement whose clipped range starts at `offset`
+/// still owes this submodule its chunk bodies.
+///
+/// Must run inside the same txn as the index writes for that tx (see
+/// `StorageModule::index_transaction_data`) so a row can never exist without
+/// its index, nor an index without its row.
+pub fn add_pending_body_migration<T: DbTxMut>(
+    tx: &T,
+    offset: PartitionChunkOffset,
+    job: &PendingBodyMigration,
+) -> eyre::Result<()> {
+    tx.put::<PendingBodyMigrationsByOffset>(offset, job.clone())?;
+    Ok(())
+}
+
+pub fn get_pending_body_migration<T: DbTx>(
+    tx: &T,
+    offset: PartitionChunkOffset,
+) -> eyre::Result<Option<PendingBodyMigration>> {
+    Ok(tx.get::<PendingBodyMigrationsByOffset>(offset)?)
+}
+
+/// Remove a resolved (every offset durable) or retired (unsourceable) job.
+/// Returns whether a row existed at `offset`.
+pub fn del_pending_body_migration<T: DbTxMut>(
+    tx: &T,
+    offset: PartitionChunkOffset,
+) -> eyre::Result<bool> {
+    Ok(tx.delete::<PendingBodyMigrationsByOffset>(offset, None)?)
+}
+
+/// Every outstanding body-migration job at or after `start` (all of them for
+/// `None`), in ascending offset order — the order the body worker drains them so
+/// disk access stays sequential.
+pub fn pending_body_migrations_from<T: DbTx>(
+    tx: &T,
+    start: Option<PartitionChunkOffset>,
+) -> eyre::Result<Vec<(PartitionChunkOffset, PendingBodyMigration)>> {
+    let mut cursor = tx.cursor_read::<PendingBodyMigrationsByOffset>()?;
+    Ok(cursor.walk(start)?.collect::<Result<Vec<_>, _>>()?)
+}
+
+/// Delete every job whose key (clipped tx start) lies in `[start, end]`. Used
+/// by network-partition recovery when those offsets are unassigned: the bodies
+/// they owed belong to txs that are no longer canonical. Returns the number of
+/// rows removed.
+pub fn del_pending_body_migrations_in_range<T: DbTxMut + DbTx>(
+    tx: &T,
+    start: PartitionChunkOffset,
+    end: PartitionChunkOffset,
+) -> eyre::Result<usize> {
+    let orphaned: Vec<PartitionChunkOffset> = pending_body_migrations_from(tx, Some(start))?
+        .into_iter()
+        .map(|(offset, _)| offset)
+        .take_while(|offset| *offset <= end)
+        .collect();
+    for offset in &orphaned {
+        tx.delete::<PendingBodyMigrationsByOffset>(*offset, None)?;
+    }
+    Ok(orphaned.len())
+}
+
 /// clear db
 pub fn clear_submodule_database<T: DbTxMut>(tx: &T) -> eyre::Result<()> {
     tx.clear::<ChunkPathHashesByOffset>()?;
@@ -370,6 +433,7 @@ pub fn clear_submodule_database<T: DbTxMut>(tx: &T) -> eyre::Result<()> {
     tx.clear::<TxPathByTxPathHash>()?;
     tx.clear::<DataRootInfosByDataRoot>()?;
     tx.clear::<TxLeafBindingByTxPathHash>()?;
+    tx.clear::<PendingBodyMigrationsByOffset>()?;
     Ok(())
 }
 
@@ -380,11 +444,17 @@ mod tests {
     use crate::submodule::{
         add_data_root_info, get_data_root_infos_for_data_root, set_data_root_infos_for_data_root,
     };
+    use crate::submodule::{
+        add_pending_body_migration, clear_submodule_database, del_pending_body_migration,
+        del_pending_body_migrations_in_range, get_pending_body_migration,
+        pending_body_migrations_from, tables::PendingBodyMigration,
+    };
     use crate::{
         IrysDatabaseArgs as _, open_or_create_db,
         submodule::tables::{DataRootInfo, SubmoduleTables},
     };
     use irys_types::H256;
+    use irys_types::PartitionChunkOffset;
     use irys_types::RelativeChunkOffset;
     use reth_db::Database as _;
     use reth_db::mdbx::DatabaseArguments;
@@ -455,6 +525,166 @@ mod tests {
             db.view_eyre(|tx| get_data_root_infos_for_data_root(tx, random_data_root))?;
 
         assert!(missing_infos.is_none());
+
+        Ok(())
+    }
+
+    fn open_test_submodule_db(prefix: &str) -> eyre::Result<reth_db::DatabaseEnv> {
+        let tmpdir = irys_testing_utils::utils::TempDirBuilder::new()
+            .prefix(prefix)
+            .build();
+        open_or_create_db(
+            tmpdir,
+            SubmoduleTables::ALL,
+            DatabaseArguments::irys_testing()?,
+        )
+    }
+
+    fn job(data_root: H256, start_offset: i32, block_height: u64) -> PendingBodyMigration {
+        PendingBodyMigration {
+            data_root,
+            data_size: 4_430_000_000, // ~16.9k chunks, the n3 incident size
+            start_offset: RelativeChunkOffset(start_offset),
+            block_height,
+            attempts: 0,
+        }
+    }
+
+    /// Compact round-trip (including a negative unclipped start_offset and the
+    /// extreme values) plus the ascending cursor walk the worker relies on.
+    #[test]
+    fn pending_body_migration_roundtrip_and_ascending_walk() -> eyre::Result<()> {
+        let db = open_test_submodule_db("irys-pending-body-")?;
+
+        let a = job(H256::random(), -20, 29_875);
+        let b = PendingBodyMigration {
+            data_root: H256::random(),
+            data_size: u64::MAX,
+            start_offset: RelativeChunkOffset(i32::MIN),
+            block_height: u64::MAX,
+            attempts: u32::MAX,
+        };
+        let c = job(H256::random(), 0, 29_876);
+
+        // Insert out of order; the walk must come back sorted by key.
+        db.update_eyre(|tx| {
+            add_pending_body_migration(tx, PartitionChunkOffset::from(100), &a)?;
+            add_pending_body_migration(tx, PartitionChunkOffset::from(0), &b)?;
+            add_pending_body_migration(tx, PartitionChunkOffset::from(7), &c)?;
+            Ok(())
+        })?;
+
+        let all = db.view_eyre(|tx| pending_body_migrations_from(tx, None))?;
+        assert_eq!(
+            all,
+            vec![
+                (PartitionChunkOffset::from(0), b),
+                (PartitionChunkOffset::from(7), c.clone()),
+                (PartitionChunkOffset::from(100), a.clone()),
+            ]
+        );
+
+        // Resumable drain: walking from a key starts at that key, inclusive.
+        let from_seven = db.view_eyre(|tx| {
+            pending_body_migrations_from(tx, Some(PartitionChunkOffset::from(7)))
+        })?;
+        assert_eq!(
+            from_seven,
+            vec![
+                (PartitionChunkOffset::from(7), c),
+                (PartitionChunkOffset::from(100), a.clone()),
+            ]
+        );
+
+        assert_eq!(
+            db.view_eyre(|tx| get_pending_body_migration(tx, PartitionChunkOffset::from(100)))?,
+            Some(a)
+        );
+        assert_eq!(
+            db.view_eyre(|tx| get_pending_body_migration(tx, PartitionChunkOffset::from(1)))?,
+            None
+        );
+
+        // Resolve one job; the rest are untouched.
+        db.update_eyre(|tx| del_pending_body_migration(tx, PartitionChunkOffset::from(7)))?;
+        let remaining = db.view_eyre(|tx| pending_body_migrations_from(tx, None))?;
+        assert_eq!(remaining.len(), 2);
+        assert!(
+            remaining
+                .iter()
+                .all(|(offset, _)| *offset != PartitionChunkOffset::from(7))
+        );
+
+        Ok(())
+    }
+
+    /// Partition recovery unassigns an offset range; only jobs keyed inside it go.
+    #[test]
+    fn pending_body_migrations_purged_by_key_range() -> eyre::Result<()> {
+        let db = open_test_submodule_db("irys-pending-body-range-")?;
+        db.update_eyre(|tx| {
+            for offset in [3_u32, 10, 20, 21, 40] {
+                add_pending_body_migration(
+                    tx,
+                    PartitionChunkOffset::from(offset),
+                    &job(H256::random(), offset as i32, 9),
+                )?;
+            }
+            Ok(())
+        })?;
+
+        // Inclusive on both ends; keys outside are untouched.
+        let removed = db.update_eyre(|tx| {
+            del_pending_body_migrations_in_range(
+                tx,
+                PartitionChunkOffset::from(10),
+                PartitionChunkOffset::from(21),
+            )
+        })?;
+        assert_eq!(removed, 3);
+        let remaining: Vec<_> = db
+            .view_eyre(|tx| pending_body_migrations_from(tx, None))?
+            .into_iter()
+            .map(|(offset, _)| *offset)
+            .collect();
+        assert_eq!(remaining, vec![3, 40]);
+
+        // An empty range is a no-op.
+        let removed = db.update_eyre(|tx| {
+            del_pending_body_migrations_in_range(
+                tx,
+                PartitionChunkOffset::from(11),
+                PartitionChunkOffset::from(19),
+            )
+        })?;
+        assert_eq!(removed, 0);
+        Ok(())
+    }
+
+    /// A submodule reset must not leave jobs aimed at offsets that now belong to
+    /// another partition's data.
+    #[test]
+    fn clear_submodule_database_clears_pending_body_migrations() -> eyre::Result<()> {
+        let db = open_test_submodule_db("irys-pending-body-clear-")?;
+
+        db.update_eyre(|tx| {
+            add_pending_body_migration(
+                tx,
+                PartitionChunkOffset::from(1),
+                &job(H256::random(), 1, 1),
+            )
+        })?;
+        assert_eq!(
+            db.view_eyre(|tx| pending_body_migrations_from(tx, None))?
+                .len(),
+            1
+        );
+
+        db.update_eyre(clear_submodule_database)?;
+        assert!(
+            db.view_eyre(|tx| pending_body_migrations_from(tx, None))?
+                .is_empty()
+        );
 
         Ok(())
     }

--- a/crates/database/src/submodule/tables.rs
+++ b/crates/database/src/submodule/tables.rs
@@ -57,6 +57,19 @@ tables! {
     }
 
 
+    /// Body-migration work still owed for a data_root placement in this submodule.
+    ///
+    /// Written in the same txn as the index (`StorageModule::index_transaction_data`)
+    /// so "indexed" and "bytes still owed" can never disagree; deleted by the body
+    /// worker once every offset in the range is durable or the job is retired.
+    /// Keyed on the partition-relative start of the tx range *clipped to this
+    /// submodule's interval*, so a cursor walk drains in ascending disk order.
+    /// Empty on a healthy, caught-up node — this is an intent log, not an index.
+    table PendingBodyMigrationsByOffset {
+        type Key = PartitionChunkOffset;
+        type Value = PendingBodyMigration;
+    }
+
     /// Table to store various metadata, such as the current db schema version
     table Metadata {
         type Key = MetadataKey;
@@ -90,6 +103,28 @@ pub struct DataRootInfo {
 pub struct TxLeafBinding {
     pub data_root: H256,
     pub prefix_hash: H256,
+}
+
+/// One outstanding body-migration job: the chunk bodies a data_root placement
+/// still owes this submodule. See [`PendingBodyMigrationsByOffset`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default, Compact)]
+pub struct PendingBodyMigration {
+    /// Which data_root owes bytes at this placement.
+    pub data_root: H256,
+    /// `data_size` of the paying tx; gives the worker its chunk count without a
+    /// second lookup.
+    pub data_size: u64,
+    /// Mirrors `DataRootInfo::start_offset` — the *unclipped* partition-relative
+    /// tx start (legitimately negative when the data_root begins before this
+    /// module's range). Maps partition offset <-> tx_chunk_offset for the cache
+    /// lookup without re-reading `DataRootInfosByDataRoot`.
+    pub start_offset: RelativeChunkOffset,
+    /// Canonical height whose migration enqueued this job. Lets a reorg purge
+    /// the rows an orphaned block left behind.
+    pub block_height: u64,
+    /// Drain passes that ended with offsets still outstanding. Drives retirement
+    /// so a job whose bodies are gone from the cache is not retried forever.
+    pub attempts: u32,
 }
 
 impl PartialOrd for DataRootInfo {

--- a/crates/database/src/submodule/tables.rs
+++ b/crates/database/src/submodule/tables.rs
@@ -119,8 +119,8 @@ pub struct PendingBodyMigration {
     /// module's range). Maps partition offset <-> tx_chunk_offset for the cache
     /// lookup without re-reading `DataRootInfosByDataRoot`.
     pub start_offset: RelativeChunkOffset,
-    /// Canonical height whose migration enqueued this job. Lets a reorg purge
-    /// the rows an orphaned block left behind.
+    /// Canonical height whose migration enqueued this job. Matched on settle/bump
+    /// so a late drain cannot delete a replacement at the same offset.
     pub block_height: u64,
     /// Drain passes that ended with offsets still outstanding. Drives retirement
     /// so a job whose bodies are gone from the cache is not retried forever.

--- a/crates/database/src/tables.rs
+++ b/crates/database/src/tables.rs
@@ -1,6 +1,6 @@
 use crate::db_cache::{GlobalChunkOffset, PartitionHashes};
 use crate::metadata::MetadataKey;
-use crate::submodule::tables::{DataRootInfos, TxLeafBinding};
+use crate::submodule::tables::{DataRootInfos, PendingBodyMigration, TxLeafBinding};
 use crate::{
     db_cache::{
         CachedChunk, CachedChunkIndexEntry, CachedDataRoot, CachedIngressLeaf, CachedIngressLeafKey,
@@ -103,6 +103,7 @@ impl_compression_for_compact!(
     PartitionHashes,
     DataRootInfos,
     TxLeafBinding,
+    PendingBodyMigration,
     GlobalChunkOffset,
     CompactBase64,
     CompactCachedIngressProof,

--- a/crates/domain/src/models/chunk_provider.rs
+++ b/crates/domain/src/models/chunk_provider.rs
@@ -286,6 +286,7 @@ mod tests {
             &tx.header,
             tx_path,
             LedgerChunkRange(chunk_range),
+            0,
         );
 
         let mut unpacked_chunks = vec![];

--- a/crates/domain/src/models/storage_module.rs
+++ b/crates/domain/src/models/storage_module.rs
@@ -43,12 +43,15 @@ use irys_database::{
     db::IrysDatabaseExt as _,
     submodule::{
         add_data_path_hash_to_offset_index, add_data_root_info, add_full_data_path,
-        add_full_tx_path, add_tx_leaf_binding, add_tx_path_hash_to_offset_index,
-        clear_submodule_database, create_or_open_submodule_db, del_path_hashes_by_offset,
-        get_data_path_by_offset, get_data_root_infos_for_data_root, get_full_data_path,
-        get_full_tx_path, get_path_hashes_by_offset, get_tx_leaf_binding, get_tx_path_by_offset,
-        missing_path_hash_ranges_in_tx, set_data_root_infos_for_data_root,
-        tables::{DataRootInfo, DataRootInfos, TxLeafBinding},
+        add_full_tx_path, add_pending_body_migration, add_tx_leaf_binding,
+        add_tx_path_hash_to_offset_index, clear_submodule_database, create_or_open_submodule_db,
+        del_path_hashes_by_offset, del_pending_body_migration,
+        del_pending_body_migrations_in_range, get_data_path_by_offset,
+        get_data_root_infos_for_data_root, get_full_data_path, get_full_tx_path,
+        get_path_hashes_by_offset, get_pending_body_migration, get_tx_leaf_binding,
+        get_tx_path_by_offset, missing_path_hash_ranges_in_tx, pending_body_migrations_from,
+        set_data_root_infos_for_data_root,
+        tables::{DataRootInfo, DataRootInfos, PendingBodyMigration, TxLeafBinding},
     },
 };
 use irys_packing::{capacity_single::compute_entropy_chunk, packing_xor_vec_u8};
@@ -72,7 +75,7 @@ use std::{
     fs::{self, File, OpenOptions},
     io::{Read as _, Seek as _, SeekFrom, Write as _},
     path::{Path, PathBuf},
-    sync::{Arc, Mutex, RwLock},
+    sync::{Arc, Mutex, RwLock, atomic::AtomicBool},
     time::{Duration, Instant},
 };
 use tracing::{debug, error, info, warn};
@@ -182,6 +185,11 @@ pub struct StorageModule {
     /// data fsync and interval commit both succeed, and therefore serve as the
     /// durability fence themselves.
     sync_in_progress: Mutex<()>,
+    /// Set while network-partition recovery rewrites this module's ranges.
+    /// Data writes re-check it under the `pending_writes` lock at insert time,
+    /// so once it is set no body can be queued behind recovery's
+    /// `drop_pending_writes_in_range`. Entropy (packing) writes are unaffected.
+    data_writes_paused: AtomicBool,
     #[cfg(test)]
     sync_failure: Mutex<Option<SyncFailurePoint>>,
     /// Monotonic instant of the last pending write, used only for idle flushing.
@@ -281,6 +289,10 @@ pub enum WriteDataChunkError {
     /// No `DataRootInfos` entry for this chunk's data_root (needs index rebuild).
     #[error("Chunks data_root not found in storage module")]
     DataRootNotFound,
+    /// Network-partition recovery is rewriting this module's ranges; the write
+    /// was refused and should be retried later.
+    #[error("storage module data writes are paused for recovery")]
+    WritesPaused,
     /// Any other write failure (IO, index update, packing, etc.).
     #[error(transparent)]
     Other(#[from] eyre::Report),
@@ -498,6 +510,7 @@ impl StorageModule {
             partition_assignment: RwLock::new(storage_module_info.partition_assignment),
             pending_writes: RwLock::new(ChunkMap::new()),
             sync_in_progress: Mutex::new(()),
+            data_writes_paused: AtomicBool::new(false),
             #[cfg(test)]
             sync_failure: Mutex::new(None),
             last_pending_write: RwLock::new(Instant::now()),
@@ -568,6 +581,57 @@ impl StorageModule {
 
     pub fn has_pending_writes(&self) -> bool {
         !self.pending_writes.read().unwrap().is_empty()
+    }
+
+    /// True when a *data* write for `offset` is queued but not yet flushed. A
+    /// queued Entropy write does not count: `write_data_chunk` folds data into
+    /// that entry itself, so such an offset is still writable.
+    pub fn is_data_write_pending_at(&self, offset: PartitionChunkOffset) -> bool {
+        self.pending_writes
+            .read()
+            .unwrap()
+            .get(&offset)
+            .is_some_and(|(_, chunk_type)| *chunk_type == ChunkType::Data)
+    }
+
+    /// Bytes of chunk data queued in memory awaiting flush. Background body
+    /// migration pauses writing to this module once this reaches its ceiling
+    /// (`storage.max_pending_write_bytes`).
+    pub fn pending_write_bytes(&self) -> u64 {
+        self.pending_writes
+            .read()
+            .unwrap()
+            .values()
+            .map(|(bytes, _)| bytes.len() as u64)
+            .sum()
+    }
+
+    /// Number of submodules (independent disks) backing this module.
+    pub fn submodule_count(&self) -> usize {
+        self.submodules.len()
+    }
+
+    /// Refuse new data writes until [`Self::resume_data_writes`]. Taken under
+    /// the `pending_writes` write lock so no writer is mid-insert when the flag
+    /// flips: whatever was queued before this call is exactly what
+    /// `drop_pending_writes_in_range` removes, and nothing can be queued after.
+    /// Every data writer — the body worker, data sync, chunk ingress — goes
+    /// through [`Self::write_data_chunk`], so this is the one gate for all of
+    /// them. Entropy (packing) writes are unaffected.
+    pub fn pause_data_writes(&self) {
+        let _pending = self.pending_writes.write().unwrap();
+        self.data_writes_paused
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    pub fn resume_data_writes(&self) {
+        self.data_writes_paused
+            .store(false, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    pub fn data_writes_paused(&self) -> bool {
+        self.data_writes_paused
+            .load(std::sync::atomic::Ordering::SeqCst)
     }
 
     #[cfg(test)]
@@ -1190,11 +1254,17 @@ impl StorageModule {
         chunk_offset: PartitionChunkOffset,
         bytes: Vec<u8>,
         chunk_type: ChunkType,
-    ) {
+    ) -> bool {
         let mut pending = self.pending_writes.write().unwrap();
+        // Checked under the same lock as the insert so a pause taken while a
+        // writer is between its own pre-check and this point still wins.
+        if chunk_type == ChunkType::Data && self.data_writes_paused() {
+            return false;
+        }
         pending.insert(chunk_offset, (bytes, chunk_type));
         *self.last_pending_write.write().unwrap() = Instant::now();
         drop(pending);
+        true
     }
 
     /// Test utility function
@@ -1323,6 +1393,11 @@ impl StorageModule {
     /// Stores three mappings: tx path hashes -> tx_path, chunk offsets -> tx paths, and data roots -> start offset.
     /// Updates all overlapping submodules within the given chunk range.
     ///
+    /// Also records, in the same per-submodule transaction, a
+    /// `PendingBodyMigrationsByOffset` row saying this tx's chunk bodies are still
+    /// owed to that submodule (see [`Self::settle_pending_body_migration`]).
+    /// `block_height` is the canonical block whose migration is indexing the tx.
+    ///
     /// # Errors
     /// Returns error if chunk range doesn't overlap with storage module range.
     pub fn index_transaction_data(
@@ -1330,19 +1405,10 @@ impl StorageModule {
         data_tx: &DataTransactionHeader,
         tx_path: &TxPath,
         chunk_range: LedgerChunkRange,
+        block_height: u64,
     ) -> eyre::Result<()> {
-        let storage_range = self.get_storage_module_ledger_offsets()?;
         let tx_path_hash = H256::from(hash_sha256(tx_path).unwrap());
-
-        let overlap = storage_range
-            .intersection(&chunk_range)
-            .ok_or_else(|| eyre::eyre!("chunk_range does not overlap storage module range"))?;
-
-        // Compute the partition relative overlapping chunk range
-        let partition_overlap = self.make_range_partition_relative(overlap)?;
-        // Compute the Partition relative start offset
-        let start_offset =
-            RelativeChunkOffset::from(self.make_offset_partition_relative(chunk_range.start())?);
+        let (partition_overlap, start_offset) = self.partition_overlap_for(chunk_range)?;
 
         for (interval, submodule) in self.submodules.overlapping(partition_overlap) {
             submodule.db.update_eyre(|tx| -> eyre::Result<()> {
@@ -1372,11 +1438,153 @@ impl StorageModule {
                         data_size: data_tx.data_size,
                     };
                     add_data_root_info(tx, data_tx.data_root, &info)?;
+                    // Same txn as the index, so "indexed" can never be true while
+                    // "bodies owed" is unrecorded. The body worker drains and
+                    // deletes this row; `range.start()` is the key it uses,
+                    // clipped to this submodule (the DataRootInfo above keeps the
+                    // unclipped tx start).
+                    add_pending_body_migration(
+                        tx,
+                        range.start(),
+                        &PendingBodyMigration {
+                            data_root: data_tx.data_root,
+                            data_size: data_tx.data_size,
+                            start_offset,
+                            block_height,
+                            attempts: 0,
+                        },
+                    )?;
                 }
                 Ok(())
             })?;
         }
         Ok(())
+    }
+
+    /// Partition-relative slice of `chunk_range` that lands in this module, plus
+    /// the unclipped partition-relative start of the whole tx (negative when the
+    /// tx began before this module's ledger range).
+    ///
+    /// The `PendingBodyMigrationsByOffset` key for each submodule is the start of
+    /// this slice clipped to that submodule's interval; the body worker recovers
+    /// the same range from the row's `start_offset` + `data_size`.
+    ///
+    /// # Errors
+    /// Returns error if `chunk_range` doesn't overlap the storage module range.
+    fn partition_overlap_for(
+        &self,
+        chunk_range: LedgerChunkRange,
+    ) -> eyre::Result<(PartitionChunkRange, RelativeChunkOffset)> {
+        let storage_range = self.get_storage_module_ledger_offsets()?;
+        let overlap = storage_range
+            .intersection(&chunk_range)
+            .ok_or_else(|| eyre::eyre!("chunk_range does not overlap storage module range"))?;
+        // Compute the partition relative overlapping chunk range
+        let partition_overlap = self.make_range_partition_relative(overlap)?;
+        // Compute the Partition relative start offset
+        let start_offset =
+            RelativeChunkOffset::from(self.make_offset_partition_relative(chunk_range.start())?);
+        Ok((partition_overlap, start_offset))
+    }
+
+    /// Outstanding body-migration jobs grouped by submodule, each group in
+    /// ascending offset order, paired with that submodule's partition interval
+    /// so the worker can clip each job's range to the disk that owns it. Every
+    /// submodule is its own IO domain, so groups may be drained in parallel.
+    pub fn pending_body_migration_batches(
+        &self,
+    ) -> eyre::Result<
+        Vec<(
+            Interval<PartitionChunkOffset>,
+            Vec<(PartitionChunkOffset, PendingBodyMigration)>,
+        )>,
+    > {
+        let mut batches = Vec::with_capacity(self.submodules.len());
+        for (interval, submodule) in self.submodules.iter() {
+            let rows = submodule
+                .db
+                .view_eyre(|tx| pending_body_migrations_from(tx, None))?;
+            batches.push((*interval, rows));
+        }
+        Ok(batches)
+    }
+
+    /// Every outstanding body-migration job across this module's submodules, in
+    /// ascending partition-offset order. Empty on a caught-up node.
+    pub fn pending_body_migrations(
+        &self,
+    ) -> eyre::Result<Vec<(PartitionChunkOffset, PendingBodyMigration)>> {
+        Ok(self
+            .pending_body_migration_batches()?
+            .into_iter()
+            .flat_map(|(_, rows)| rows)
+            .collect())
+    }
+
+    /// Delete the job at `key` once every offset it covers is durable (or the
+    /// job is being retired). Returns whether a row was removed.
+    ///
+    /// Only a row whose `data_root` matches is removed: a late settle from an
+    /// orphaned block's migration must not delete the row the replacement
+    /// block's index wrote at the same offset.
+    pub fn settle_pending_body_migration(
+        &self,
+        key: PartitionChunkOffset,
+        data_root: DataRoot,
+    ) -> eyre::Result<bool> {
+        let (_interval, submodule) = self
+            .submodules
+            .get_key_value_at_point(key)
+            .map_err(|_| eyre::eyre!("No submodule found for Partition Offset {:?}", key))?;
+        submodule
+            .db
+            .update_eyre(|tx| match get_pending_body_migration(tx, key)? {
+                Some(job) if job.data_root == data_root => del_pending_body_migration(tx, key),
+                _ => Ok(false),
+            })
+    }
+
+    /// Delete outstanding body-migration jobs keyed in `[start, end]` (partition
+    /// relative) across the submodules covering that range. Network-partition
+    /// recovery calls this alongside `clear_data_root_infos_in_range`: the
+    /// offsets are being unassigned, so the bodies they owed are moot and the
+    /// worker must not write them. Returns the number of rows removed.
+    pub fn purge_pending_body_migrations_in_range(
+        &self,
+        start: PartitionChunkOffset,
+        end: PartitionChunkOffset,
+    ) -> eyre::Result<usize> {
+        let mut removed = 0;
+        for (_interval, submodule) in self.submodules.overlapping(ii(start, end)) {
+            removed += submodule
+                .db
+                .update_eyre(|tx| del_pending_body_migrations_in_range(tx, start, end))?;
+        }
+        Ok(removed)
+    }
+
+    /// Record one drain pass that attempted the job at `key` and made no
+    /// progress. Returns the new attempt count, or `None` if the row is gone or
+    /// belongs to another data_root.
+    pub fn bump_pending_body_migration_attempts(
+        &self,
+        key: PartitionChunkOffset,
+        data_root: DataRoot,
+    ) -> eyre::Result<Option<u32>> {
+        let (_interval, submodule) = self
+            .submodules
+            .get_key_value_at_point(key)
+            .map_err(|_| eyre::eyre!("No submodule found for Partition Offset {:?}", key))?;
+        submodule
+            .db
+            .update_eyre(|tx| match get_pending_body_migration(tx, key)? {
+                Some(mut job) if job.data_root == data_root => {
+                    job.attempts = job.attempts.saturating_add(1);
+                    add_pending_body_migration(tx, key, &job)?;
+                    Ok(Some(job.attempts))
+                }
+                _ => Ok(None),
+            })
     }
 
     /// Stores the data_path and offset lookups in the correct submodule index
@@ -1432,6 +1640,12 @@ impl StorageModule {
         let data_path = &chunk.data_path.0;
         let data_path_hash = UnpackedChunk::hash_data_path(data_path);
 
+        // Fast path; the authoritative check is under the pending-writes lock
+        // at each insert below.
+        if self.data_writes_paused() {
+            return Err(WriteDataChunkError::WritesPaused);
+        }
+
         let Some(partition_offsets) =
             self.partition_offsets_for_data_root_chunk(chunk.data_root, chunk.tx_offset)?
         else {
@@ -1468,6 +1682,9 @@ impl StorageModule {
         // Process chunk offsets with entropy in pending writes list
         for partition_offset in pending_offsets {
             let mut pending = self.pending_writes.write().unwrap();
+            if self.data_writes_paused() {
+                return Err(WriteDataChunkError::WritesPaused);
+            }
 
             match pending.get(&partition_offset) {
                 Some((entropy_bytes, ChunkType::Entropy)) => {
@@ -1497,7 +1714,9 @@ impl StorageModule {
             // (this also handles cases where the chunk's data isn't the full size, as the entropy will be)
             let packed_data = packing_xor_vec_u8(entropy, &chunk.bytes.0);
 
-            self.write_chunk(partition_offset, packed_data, ChunkType::Data);
+            if !self.write_chunk(partition_offset, packed_data, ChunkType::Data) {
+                return Err(WriteDataChunkError::WritesPaused);
+            }
             self.add_data_path_to_index(data_path_hash, data_path.clone(), partition_offset)?;
         }
 
@@ -2319,6 +2538,246 @@ mod tests {
     };
     use nodit::interval::ii;
 
+    /// Indexing a tx that starts before this module and straddles all three
+    /// submodules must leave one job row per submodule, keyed on that
+    /// submodule's clipped start, all carrying the *unclipped* (negative) tx
+    /// start. Resolve removes exactly those rows, only for the matching
+    /// data_root, and leaves the index itself untouched.
+    #[test]
+    fn index_writes_one_body_job_per_submodule_and_resolve_clears_them() -> eyre::Result<()> {
+        let tmp_dir = TempDirBuilder::new()
+            .prefix("pending_body_index_test")
+            .with_tracing()
+            .build();
+        let node_config = NodeConfig {
+            consensus: irys_types::ConsensusOptions::Custom(ConsensusConfig {
+                chunk_size: 32,
+                num_chunks_in_partition: 20,
+                ..ConsensusConfig::testing()
+            }),
+            base_directory: tmp_dir.path().to_path_buf(),
+            ..NodeConfig::testing()
+        };
+        let config = Config::new_with_random_peer_id(node_config);
+
+        // Slot 1 => this module owns ledger offsets [20, 40).
+        let storage_module = StorageModule::new(
+            &StorageModuleInfo {
+                id: 0,
+                partition_assignment: Some(irys_types::partition::PartitionAssignment {
+                    ledger_id: Some(DataLedger::Submit.into()),
+                    slot_index: Some(1),
+                    miner_address: irys_types::IrysAddress::from([0xAA; 20]),
+                    partition_hash: H256::random(),
+                }),
+                submodules: vec![
+                    (partition_chunk_offset_ii!(0, 4), "hdd0".into()),
+                    (partition_chunk_offset_ii!(5, 9), "hdd1".into()),
+                    (partition_chunk_offset_ii!(10, 19), "hdd2".into()),
+                ],
+            },
+            &config,
+        )?;
+
+        // 17-chunk tx spanning ledger offsets [15, 31]: begins 5 chunks before
+        // this module, ends inside its third submodule.
+        let data_root = H256::random();
+        let data_size = 17 * config.consensus.chunk_size;
+        let data_tx = DataTransactionHeader::V1(irys_types::DataTransactionHeaderV1WithMetadata {
+            tx: DataTransactionHeaderV1 {
+                data_root,
+                data_size,
+                ..Default::default()
+            },
+            metadata: irys_types::DataTransactionMetadata::new(),
+        });
+        let tx_range = LedgerChunkRange(ledger_chunk_offset_ii!(15, 31));
+        let block_height = 29_875;
+
+        storage_module.index_transaction_data(
+            &data_tx,
+            &vec![5, 6, 7, 8],
+            tx_range,
+            block_height,
+        )?;
+
+        let jobs = storage_module.pending_body_migrations()?;
+        let keys: Vec<_> = jobs.iter().map(|(key, _)| *key).collect();
+        assert_eq!(
+            keys,
+            vec![
+                PartitionChunkOffset::from(0),
+                PartitionChunkOffset::from(5),
+                PartitionChunkOffset::from(10),
+            ],
+            "one row per overlapping submodule, keyed on its clipped start"
+        );
+        for (_, job) in &jobs {
+            assert_eq!(
+                *job,
+                PendingBodyMigration {
+                    data_root,
+                    data_size,
+                    start_offset: RelativeChunkOffset(-5),
+                    block_height,
+                    attempts: 0,
+                }
+            );
+        }
+
+        // Batches follow submodule order and carry each submodule's interval.
+        let batches = storage_module.pending_body_migration_batches()?;
+        assert_eq!(batches.len(), 3);
+        assert_eq!(batches[1].0, partition_chunk_offset_ii!(5, 9));
+        assert_eq!(batches[1].1.len(), 1);
+
+        // Wrong data_root: nothing settled, nothing bumped.
+        let key = PartitionChunkOffset::from(5);
+        assert!(!storage_module.settle_pending_body_migration(key, H256::random())?);
+        assert_eq!(
+            storage_module.bump_pending_body_migration_attempts(key, H256::random())?,
+            None
+        );
+        assert_eq!(storage_module.pending_body_migrations()?.len(), 3);
+
+        // A no-progress pass is counted on the row, not by deleting it.
+        assert_eq!(
+            storage_module.bump_pending_body_migration_attempts(key, data_root)?,
+            Some(1)
+        );
+        assert_eq!(storage_module.pending_body_migrations()?[1].1.attempts, 1);
+
+        // Recovery purge is range-scoped: unassigning partition offsets [5, 19]
+        // drops the two rows keyed there and leaves the first submodule's.
+        assert_eq!(
+            storage_module.purge_pending_body_migrations_in_range(
+                PartitionChunkOffset::from(5),
+                PartitionChunkOffset::from(19),
+            )?,
+            2
+        );
+        let keys: Vec<_> = storage_module
+            .pending_body_migrations()?
+            .into_iter()
+            .map(|(key, _)| key)
+            .collect();
+        assert_eq!(keys, vec![PartitionChunkOffset::from(0)]);
+        // Put them back so the settle path below is exercised on all three.
+        storage_module.index_transaction_data(
+            &data_tx,
+            &vec![5, 6, 7, 8],
+            tx_range,
+            block_height,
+        )?;
+        assert_eq!(storage_module.pending_body_migrations()?.len(), 3);
+
+        // Right data_root: each key settles once; index still answers.
+        for key in [0, 5, 10] {
+            assert!(
+                storage_module
+                    .settle_pending_body_migration(PartitionChunkOffset::from(key), data_root)?
+            );
+        }
+        assert!(storage_module.pending_body_migrations()?.is_empty());
+        assert_eq!(
+            storage_module
+                .partition_offsets_for_data_root_chunk(data_root, TxChunkOffset::from(5))?,
+            Some(vec![PartitionChunkOffset::from(0)]),
+            "tx chunk 5 sits at partition offset 0 (start_offset -5); index survives settle"
+        );
+
+        // Settling again is a no-op.
+        assert!(
+            !storage_module
+                .settle_pending_body_migration(PartitionChunkOffset::from(0), data_root)?
+        );
+        Ok(())
+    }
+
+    /// While paused, a data write is refused before anything is queued or
+    /// indexed; packing's entropy writes still land; resuming lets the same
+    /// write through.
+    #[test]
+    fn pause_data_writes_refuses_data_but_not_entropy() -> eyre::Result<()> {
+        let tmp_dir = TempDirBuilder::new()
+            .prefix("pause_data_writes_test")
+            .with_tracing()
+            .build();
+        let node_config = NodeConfig {
+            consensus: irys_types::ConsensusOptions::Custom(ConsensusConfig {
+                chunk_size: 5,
+                num_chunks_in_partition: 5,
+                ..ConsensusConfig::testing()
+            }),
+            base_directory: tmp_dir.path().to_path_buf(),
+            ..NodeConfig::testing()
+        };
+        let config = Config::new_with_random_peer_id(node_config);
+        let storage_module = StorageModule::new(
+            &StorageModuleInfo {
+                id: 0,
+                partition_assignment: Some(irys_types::partition::PartitionAssignment {
+                    ledger_id: Some(DataLedger::Submit.into()),
+                    slot_index: Some(0),
+                    miner_address: irys_types::IrysAddress::from([0xAA; 20]),
+                    partition_hash: H256::random(),
+                }),
+                submodules: vec![(partition_chunk_offset_ii!(0, 4), "hdd0".into())],
+            },
+            &config,
+        )?;
+        storage_module.pack_with_zeros();
+        storage_module.force_sync_pending_chunks()?;
+
+        let data_root = H256::random();
+        let data_tx = DataTransactionHeader::V1(irys_types::DataTransactionHeaderV1WithMetadata {
+            tx: DataTransactionHeaderV1 {
+                data_root,
+                data_size: 5,
+                ..Default::default()
+            },
+            metadata: irys_types::DataTransactionMetadata::new(),
+        });
+        storage_module.index_transaction_data(
+            &data_tx,
+            &vec![5, 6, 7, 8],
+            LedgerChunkRange(ledger_chunk_offset_ii!(0, 0)),
+            0,
+        )?;
+        let chunk = UnpackedChunk {
+            data_root,
+            data_size: 5,
+            data_path: vec![4, 3, 2, 1].into(),
+            bytes: vec![0, 1, 2, 3, 4].into(),
+            tx_offset: TxChunkOffset::from(0),
+        };
+
+        storage_module.pause_data_writes();
+        assert!(storage_module.data_writes_paused());
+        assert!(matches!(
+            storage_module.write_data_chunk(&chunk),
+            Err(WriteDataChunkError::WritesPaused)
+        ));
+        assert!(!storage_module.has_pending_writes());
+        assert!(
+            storage_module.write_chunk(
+                PartitionChunkOffset::from(4),
+                vec![0; 5],
+                ChunkType::Entropy
+            ),
+            "packing is not gated"
+        );
+        assert!(
+            !storage_module.write_chunk(PartitionChunkOffset::from(3), vec![0; 5], ChunkType::Data),
+            "a direct data insert is refused under the lock"
+        );
+
+        storage_module.resume_data_writes();
+        storage_module.write_data_chunk(&chunk)?;
+        assert!(storage_module.is_data_write_pending_at(PartitionChunkOffset::from(0)));
+        Ok(())
+    }
+
     #[test]
     fn storage_module_test() -> eyre::Result<()> {
         let infos = [StorageModuleInfo {
@@ -2791,6 +3250,7 @@ mod tests {
             &tx.header,
             &proofs[0].proof,
             LedgerChunkRange(ledger_chunk_offset_ii!(start, end)),
+            0,
         )?;
 
         // No write_data_chunk: every offset is a residual hole (Entropy, no data_path).
@@ -2943,6 +3403,7 @@ mod tests {
             }),
             storage: StorageSyncConfig {
                 num_writes_before_sync: 10,
+                max_pending_write_bytes: None,
             },
             base_directory: base_path,
             ..NodeConfig::testing()
@@ -3206,6 +3667,7 @@ mod tests {
             &data_tx,
             &tx_path,
             LedgerChunkRange(ledger_chunk_offset_ii!(0, 0)),
+            0,
         );
 
         let chunk = UnpackedChunk {
@@ -3492,6 +3954,7 @@ mod tests {
             base_directory: base_path.clone(),
             storage: StorageSyncConfig {
                 num_writes_before_sync: 1000,
+                max_pending_write_bytes: None,
             },
             ..NodeConfig::testing()
         };
@@ -3536,6 +3999,7 @@ mod tests {
                 &tx.header,
                 &tx_path,
                 LedgerChunkRange(ledger_chunk_offset_ii!(0, 0)),
+                0,
             );
 
             for chunk in tx.data_chunks()? {
@@ -3576,6 +4040,7 @@ mod tests {
             }),
             storage: StorageSyncConfig {
                 num_writes_before_sync: 1,
+                max_pending_write_bytes: None,
             },
             base_directory: tmp_dir.path().to_path_buf(),
             ..NodeConfig::testing()

--- a/crates/domain/src/models/storage_module.rs
+++ b/crates/domain/src/models/storage_module.rs
@@ -1524,14 +1524,19 @@ impl StorageModule {
     /// Delete the job at `key` once every offset it covers is durable (or the
     /// job is being retired). Returns whether a row was removed.
     ///
-    /// Only a row whose `data_root` matches is removed: a late settle from an
-    /// orphaned block's migration must not delete the row the replacement
-    /// block's index wrote at the same offset.
+    /// Only a row whose `data_root` **and** `block_height` match is removed: a
+    /// late settle from an orphaned migration must not delete the replacement
+    /// at the same offset. Refuses while data writes are paused so a mid-pass
+    /// rollback cannot look like a successful drain.
     pub fn settle_pending_body_migration(
         &self,
         key: PartitionChunkOffset,
         data_root: DataRoot,
+        block_height: u64,
     ) -> eyre::Result<bool> {
+        if self.data_writes_paused() {
+            return Ok(false);
+        }
         let (_interval, submodule) = self
             .submodules
             .get_key_value_at_point(key)
@@ -1539,7 +1544,9 @@ impl StorageModule {
         submodule
             .db
             .update_eyre(|tx| match get_pending_body_migration(tx, key)? {
-                Some(job) if job.data_root == data_root => del_pending_body_migration(tx, key),
+                Some(job) if job.data_root == data_root && job.block_height == block_height => {
+                    del_pending_body_migration(tx, key)
+                }
                 _ => Ok(false),
             })
     }
@@ -1564,13 +1571,17 @@ impl StorageModule {
     }
 
     /// Record one drain pass that attempted the job at `key` and made no
-    /// progress. Returns the new attempt count, or `None` if the row is gone or
-    /// belongs to another data_root.
+    /// progress. Returns the new attempt count, or `None` if the row is gone,
+    /// belongs to another job, or data writes are paused.
     pub fn bump_pending_body_migration_attempts(
         &self,
         key: PartitionChunkOffset,
         data_root: DataRoot,
+        block_height: u64,
     ) -> eyre::Result<Option<u32>> {
+        if self.data_writes_paused() {
+            return Ok(None);
+        }
         let (_interval, submodule) = self
             .submodules
             .get_key_value_at_point(key)
@@ -1578,7 +1589,7 @@ impl StorageModule {
         submodule
             .db
             .update_eyre(|tx| match get_pending_body_migration(tx, key)? {
-                Some(mut job) if job.data_root == data_root => {
+                Some(mut job) if job.data_root == data_root && job.block_height == block_height => {
                     job.attempts = job.attempts.saturating_add(1);
                     add_pending_body_migration(tx, key, &job)?;
                     Ok(Some(job.attempts))
@@ -2542,7 +2553,7 @@ mod tests {
     /// submodules must leave one job row per submodule, keyed on that
     /// submodule's clipped start, all carrying the *unclipped* (negative) tx
     /// start. Resolve removes exactly those rows, only for the matching
-    /// data_root, and leaves the index itself untouched.
+    /// data_root and block_height, and leaves the index itself untouched.
     #[test]
     fn index_writes_one_body_job_per_submodule_and_resolve_clears_them() -> eyre::Result<()> {
         let tmp_dir = TempDirBuilder::new()
@@ -2633,16 +2644,48 @@ mod tests {
 
         // Wrong data_root: nothing settled, nothing bumped.
         let key = PartitionChunkOffset::from(5);
-        assert!(!storage_module.settle_pending_body_migration(key, H256::random())?);
+        assert!(!storage_module.settle_pending_body_migration(
+            key,
+            H256::random(),
+            block_height
+        )?);
         assert_eq!(
-            storage_module.bump_pending_body_migration_attempts(key, H256::random())?,
+            storage_module.bump_pending_body_migration_attempts(
+                key,
+                H256::random(),
+                block_height
+            )?,
             None
         );
         assert_eq!(storage_module.pending_body_migrations()?.len(), 3);
 
+        // Wrong block_height: same. A late settle from an orphaned height
+        // must not take the replacement row at this offset.
+        assert!(!storage_module.settle_pending_body_migration(key, data_root, block_height + 1)?);
+        assert_eq!(
+            storage_module.bump_pending_body_migration_attempts(
+                key,
+                data_root,
+                block_height + 1
+            )?,
+            None
+        );
+        assert_eq!(storage_module.pending_body_migrations()?.len(), 3);
+
+        // While paused, even a matching identity is left alone so a mid-pass
+        // rollback cannot look like a successful drain.
+        storage_module.pause_data_writes();
+        assert!(!storage_module.settle_pending_body_migration(key, data_root, block_height)?);
+        assert_eq!(
+            storage_module.bump_pending_body_migration_attempts(key, data_root, block_height)?,
+            None
+        );
+        assert_eq!(storage_module.pending_body_migrations()?.len(), 3);
+        storage_module.resume_data_writes();
+
         // A no-progress pass is counted on the row, not by deleting it.
         assert_eq!(
-            storage_module.bump_pending_body_migration_attempts(key, data_root)?,
+            storage_module.bump_pending_body_migration_attempts(key, data_root, block_height)?,
             Some(1)
         );
         assert_eq!(storage_module.pending_body_migrations()?[1].1.attempts, 1);
@@ -2671,12 +2714,13 @@ mod tests {
         )?;
         assert_eq!(storage_module.pending_body_migrations()?.len(), 3);
 
-        // Right data_root: each key settles once; index still answers.
+        // Right data_root and height: each key settles once; index still answers.
         for key in [0, 5, 10] {
-            assert!(
-                storage_module
-                    .settle_pending_body_migration(PartitionChunkOffset::from(key), data_root)?
-            );
+            assert!(storage_module.settle_pending_body_migration(
+                PartitionChunkOffset::from(key),
+                data_root,
+                block_height
+            )?);
         }
         assert!(storage_module.pending_body_migrations()?.is_empty());
         assert_eq!(
@@ -2687,10 +2731,11 @@ mod tests {
         );
 
         // Settling again is a no-op.
-        assert!(
-            !storage_module
-                .settle_pending_body_migration(PartitionChunkOffset::from(0), data_root)?
-        );
+        assert!(!storage_module.settle_pending_body_migration(
+            PartitionChunkOffset::from(0),
+            data_root,
+            block_height
+        )?);
         Ok(())
     }
 

--- a/crates/domain/tests/storage_module_index_tests.rs
+++ b/crates/domain/tests/storage_module_index_tests.rs
@@ -165,7 +165,7 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
 
     let data_root = tx_headers[0].data_root;
     let data_size = tx_headers[0].data_size;
-    let _ = storage_modules[0].index_transaction_data(&tx_headers[0], tx_path, tx_ledger_range);
+    let _ = storage_modules[0].index_transaction_data(&tx_headers[0], tx_path, tx_ledger_range, 0);
 
     // Get the submodule reference
     let submodule = storage_modules[0]
@@ -196,7 +196,7 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
     let data_root = tx_headers[1].data_root;
     let data_size = tx_headers[1].data_size;
     assert_eq!(data_size, bytes_in_tx);
-    let _ = storage_modules[0].index_transaction_data(&tx_headers[1], tx_path, tx_ledger_range);
+    let _ = storage_modules[0].index_transaction_data(&tx_headers[1], tx_path, tx_ledger_range, 0);
 
     // Get the both submodule references
     let submodule = storage_modules[0]
@@ -239,7 +239,7 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
         bytes_in_tx,
         config.consensus.chunk_size,
     );
-    let _ = storage_modules[0].index_transaction_data(&tx_headers[2], tx_path, tx_ledger_range);
+    let _ = storage_modules[0].index_transaction_data(&tx_headers[2], tx_path, tx_ledger_range, 0);
 
     let submodule3 = storage_modules[0]
         .get_submodule(tx_partition_range.end())
@@ -286,8 +286,8 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
         config.consensus.chunk_size,
     );
     // Update both storage modules with the tx data
-    let _ = storage_modules[0].index_transaction_data(&tx_headers[3], tx_path, tx_ledger_range);
-    let _ = storage_modules[1].index_transaction_data(&tx_headers[3], tx_path, tx_ledger_range);
+    let _ = storage_modules[0].index_transaction_data(&tx_headers[3], tx_path, tx_ledger_range, 0);
+    let _ = storage_modules[1].index_transaction_data(&tx_headers[3], tx_path, tx_ledger_range, 0);
 
     // The first submodule of the second StorageModule/Partition
     let submodule4 = storage_modules[1]
@@ -334,7 +334,7 @@ fn tx_path_overlap_tests() -> eyre::Result<()> {
         config.consensus.chunk_size,
     );
 
-    let _ = storage_modules[1].index_transaction_data(&tx_headers[4], tx_path, tx_ledger_range);
+    let _ = storage_modules[1].index_transaction_data(&tx_headers[4], tx_path, tx_ledger_range, 0);
 
     let tx_path_hash = H256::from(hash_sha256(tx_path).unwrap());
     verify_tx_path_in_submodule(submodule4, tx_path, tx_path_hash);

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -80,6 +80,11 @@ impl Config {
 
     // validate configuration invariants
     pub fn validate(&self) -> eyre::Result<()> {
+        ensure!(
+            self.node_config.storage.max_pending_write_bytes != Some(0),
+            "storage.max_pending_write_bytes must be > 0 (or omitted for the derived default): \
+             a zero ceiling stops chunk-body migration from ever writing"
+        );
         // block_tree_depth must exceed block_migration_depth to prevent premature pruning
         ensure!(
             (self.consensus.block_migration_depth as u64) < self.consensus.block_tree_depth,
@@ -1628,6 +1633,23 @@ mod tests {
             err.contains("overflows u64"),
             "expected the slot-lifetime overflow guard, got: {err}"
         );
+    }
+
+    #[test]
+    fn validate_rejects_zero_pending_write_ceiling() {
+        let mut node_config = NodeConfig::testing();
+        node_config.storage.max_pending_write_bytes = Some(0);
+        let err = Config::new_with_random_peer_id(node_config)
+            .validate()
+            .expect_err("a zero pending-write ceiling would halt body migration")
+            .to_string();
+        assert!(err.contains("max_pending_write_bytes"), "got: {err}");
+
+        let mut node_config = NodeConfig::testing();
+        node_config.storage.max_pending_write_bytes = Some(1);
+        Config::new_with_random_peer_id(node_config)
+            .validate()
+            .expect("any positive ceiling is accepted; the worker floors it");
     }
 
     #[test]

--- a/crates/types/src/config/node.rs
+++ b/crates/types/src/config/node.rs
@@ -470,8 +470,10 @@ pub struct StorageSyncConfig {
     pub num_writes_before_sync: u64,
     /// Ceiling, in bytes, on chunk bodies one storage module may hold in memory
     /// awaiting flush before background body migration pauses writing to it.
-    /// `None` derives `2 × num_writes_before_sync × chunk_size × submodules`
-    /// per module: one flush batch in flight plus one being filled, per disk.
+    /// `None` derives `max(2 × num_writes_before_sync, 256) × chunk_size × submodules`
+    /// per module: one flush batch in flight plus one being filled, per disk,
+    /// floored at 256 chunks so a small `num_writes_before_sync` cannot stall
+    /// the worker on the storage service's idle flush.
     pub max_pending_write_bytes: Option<u64>,
 }
 

--- a/crates/types/src/config/node.rs
+++ b/crates/types/src/config/node.rs
@@ -468,12 +468,18 @@ pub struct StorageSyncConfig {
     /// Number of write operations before forcing a sync to disk
     /// Higher values improve performance but increase data loss risk on crashes
     pub num_writes_before_sync: u64,
+    /// Ceiling, in bytes, on chunk bodies one storage module may hold in memory
+    /// awaiting flush before background body migration pauses writing to it.
+    /// `None` derives `2 × num_writes_before_sync × chunk_size × submodules`
+    /// per module: one flush batch in flight plus one being filled, per disk.
+    pub max_pending_write_bytes: Option<u64>,
 }
 
 impl Default for StorageSyncConfig {
     fn default() -> Self {
         Self {
             num_writes_before_sync: 100,
+            max_pending_write_bytes: None,
         }
     }
 }
@@ -1259,6 +1265,7 @@ impl NodeConfig {
             reward_address,
             storage: StorageSyncConfig {
                 num_writes_before_sync: 1,
+                max_pending_write_bytes: None,
             },
             data_sync: DataSyncServiceConfig {
                 max_pending_chunk_requests: 1000,
@@ -1447,6 +1454,7 @@ impl NodeConfig {
             reward_address,
             storage: StorageSyncConfig {
                 num_writes_before_sync: 1,
+                max_pending_write_bytes: None,
             },
             data_sync: DataSyncServiceConfig {
                 max_pending_chunk_requests: 1000,


### PR DESCRIPTION
## Summary

Migrating the 4.43 GiB Submit tx at block 29875 wrote the storage-module indexes and then tried to copy every chunk body from cache onto the SM. The SM was already saturated with packing writes, so those data chunks sat in cache and never finished migrating. Chunk migration would not start the next block until that tx's bodies were done, so later blocks — including the Publish promotions that grew the ledger from 416,450 to 512,636 chunks — never got indexes. Data sync parked the whole span on `MissingDataRootIndex`.

This splits that work so indexes are not waiting on the body drain.

- **Indexes** stay in block order and MDBX-only. Each overlapping submodule also gets a ~40-byte job row saying the bodies are still owed. No schema bump.
- **Bodies** copy in the background from the chunk cache (or Submit, for Publish). A job is removed only after every offset is durable, and only if `data_root` and `block_height` still match. Missing entropy waits; eight empty passes retire the job to data sync. Writes are paced (512 per pass) and capped by `storage.max_pending_write_bytes`.
- **Recovery** pauses data writes, drops jobs in the ranges it unassigns, then resumes. Once a chunk is in cache, a paused storage-module write is success — gossip still runs.
- A failed block is logged; later blocks still run. Index heal uses the same index-only path.

Bodies now land after `BlockMigrated` returns. Reads in that window come from the chunk cache. `write_chunk` returns `bool`; `write_data_chunk` can return `WritesPaused`; `index_transaction_data` takes `block_height`.

## Test plan

- [x] Job table: one row per overlapping submodule, settle/bump match `data_root` and `block_height`, pause refuses both
- [x] Index path writes no bodies; worker settles only after flush; budget and ceiling; entropy wait; retire; pause defer
- [x] Heal is index-only; a failed block does not stop later blocks; recovery purges jobs and resumes writes
- [x] Config rejects a zero ceiling
- [x] fmt, clippy, typos
- [x] Integration: promotion, cache_service, data_sync, sm_reassignment, data_size, programmable_data, partition_recovery, fork_recovery
- [x] `cargo xtask test -- --no-fail-fast`: 3232 run, 3230 passed. The two failures pass in isolation. `slow_heavy4_promotion_with_multiple_proofs_test` also fails on `master` under the same load (ingress-proof gossip, not this path).
- [ ] Deploy to n3: `body_pending_jobs` / `body_oldest_pending_height` should drain; Publish Data should climb from 416,450 toward 512,636.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added background processing for storage body migrations with retry, throttling, backpressure, and progress metrics.
  - Added configurable limits for pending storage writes, with automatic defaults when unspecified.
  - Added recovery handling that pauses data writes during network-partition rollback and resumes them automatically.

- **Bug Fixes**
  - Prevented stale migration jobs from orphaned ranges from being processed.
  - Improved handling of paused writes without generating unnecessary critical errors.

- **Documentation**
  - Added configuration guidance for pending-write limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->